### PR TITLE
Demonstrate BigQuery parse errors

### DIFF
--- a/test/fixtures/parser/bigquery/select_case.sql
+++ b/test/fixtures/parser/bigquery/select_case.sql
@@ -1,0 +1,7 @@
+select
+  case fruit_code
+    when 0 then 'apple'
+    when 1 then 'banana'
+    when 2 then 'cashew'
+  end as fruit
+from some_table

--- a/test/fixtures/parser/bigquery/select_except.sql
+++ b/test/fixtures/parser/bigquery/select_except.sql
@@ -5,4 +5,17 @@ FROM my_tbl;
 -- Catch potential bugs in unions
 select * except (foo) from some_table
 union all
-select * from another_table
+select * from another_table;
+
+-- Except is allowed after other fields
+select
+  1 + 2 as calculated,
+  * except (irrelevant)
+from my_tbl;
+
+-- This might be redundant with the example above.
+-- Demonstrates using multiple except clauses.
+select
+  foo.* except (some_column),
+  bar.* except (other_column)
+from my_tbl;

--- a/test/fixtures/parser/bigquery/select_except_replace.sql
+++ b/test/fixtures/parser/bigquery/select_except_replace.sql
@@ -1,0 +1,5 @@
+-- We can call functions when replacing a field
+select
+  * except(foo)
+    replace (concat(fruit, 'berry') as fruit)
+from some_table

--- a/test/fixtures/parser/bigquery/select_struct.sql
+++ b/test/fixtures/parser/bigquery/select_struct.sql
@@ -1,3 +1,4 @@
+-- Example of "select as struct *" syntax.
 select
   some_table.foo_id,
   array(
@@ -6,3 +7,12 @@ select
     where another_table.foo_id = some_table.foo_id
   )
 from another_table
+
+-- Example of explicitly building a struct in a select clause.
+select
+  struct(
+    bar.bar_id as id,
+    bar.bar_name as bar
+  ) as bar
+from foo
+left join bar on bar.foo_id = foo.foo_id

--- a/test/fixtures/parser/bigquery/select_struct.sql
+++ b/test/fixtures/parser/bigquery/select_struct.sql
@@ -1,0 +1,8 @@
+select
+  some_table.foo_id,
+  array(
+    select as struct *
+    from another_table
+    where another_table.foo_id = some_table.foo_id
+  )
+from another_table


### PR DESCRIPTION
I was quite excited to see that https://github.com/alanmcruickshank/sqlfluff/pull/332 fixed several bugs I filed. 

However, when I ran…

```console
$ sqlfluff lint --ignore=templating --rules=L001 models/
== [models/adjust/adjust_view.sql] FAIL
L:  18 | P:   4 |  PRS | Found unparsable section: ' except
                       | (partner_parameters)\nfrom\n adju...'
== [models/braze/custom_user_attributes.sql] FAIL
L:  18 | P:   5 |  PRS | Found unparsable section: 'STRUCT(\n username,\n
                       | email,\n ...'
L: 103 | P:  17 |  PRS | Found unparsable section: ' except (user_id, updateable,
                       | watermark,...'
== [models/braze/user_subscription.sql] FAIL
L:  11 | P:   3 |  PRS | Found unparsable section: "CASE subscription_type\n WHEN
                       | 0 THEN '..."
== [models/jira/stg_epics.sql] FAIL
L:  11 | P:  25 |  PRS | Found unparsable section: ' *'
== [models/jira/stg_issues.sql] FAIL
L:  31 | P:   5 |  PRS | Found unparsable section: 'STRUCT(\n status.status_id AS
                       | id,\n...'
L:  42 | P:   5 |  PRS | Found unparsable section: 'ARRAY(\n SELECT AS STRUCT\n
                       | ...'
L:  59 | P:   5 |  PRS | Found unparsable section: 'ARRAY(\n SELECT AS STRUCT\n
                       | ...'
L: 108 | P:   7 |  PRS | Found unparsable section: 'CASE
                       | LOWER(show_on_pipeline_board.name)\n...'
== [models/legacy_models/segment_users.sql] FAIL
L:   7 | P:   4 |  PRS | Found unparsable section: ' except (\n id,\n
                       | context_library_na...'
== [models/legacy_models/subscription_logs_history_view.sql] FAIL
L:  51 | P:  15 |  PRS | Couldn't find closing bracket for opening bracket.
== [models/reports/tech/_pipeline_build_epics.sql] FAIL
L:  28 | P:   5 |  PRS | Found unparsable section: 'ARRAY(\n SELECT AS STRUCT\n
                       | ...'
```

(Note: the `--rules=L001` is a hack to suppress any linter warnings, so I just get parser errors).

… against our code, I still had quite a few parse errors for what I know to be valid BigQuery SQL code.

Rather than file one bug per error, I thought it might be better to submit a PR that adds tests that demonstrate the problem. I'd really love to dig in and fix these issues, but I'm very unlikely to have the time. If you would prefer me to file bugs, I can definitely do that. 

Thank you so much for looking into this! sqlfluff is very promising. 

## Failing tests

- [ ] FAILED test/dialects_test.py::test__dialect__base_file_parse[bigquery-select_except_replace.sql]
- [ ] FAILED test/dialects_test.py::test__dialect__base_file_parse[bigquery-select_except.sql]
- [x] FAILED test/dialects_test.py::test__dialect__base_file_parse[bigquery-select_case.sql] (fixed by #364)
- [ ] FAILED test/dialects_test.py::test__dialect__base_file_parse[bigquery-select_struct.sql]