### PR TITLE
Support DBT subprojects

### DIFF
--- a/src/sqlfluff/exceptions.py
+++ b/src/sqlfluff/exceptions.py
@@ -1,19 +1,18 @@
-"""
-    These Exceptions are for unexpected errors relating to configuration and
-    the sqlfluff context (macros, variables).
+"""These Exceptions are for unexpected errors relating to configuration and the sqlfluff context (macros, variables).
 
-    For "violations", or "common usage errors" such as parsing errors, refer
-    to sqlfluff/errors.py
+For "violations", or "common usage errors" such as parsing errors, refer
+to sqlfluff/errors.py
 """
 
 
 class MacroExtractError(Exception):
-    """When loading macros fails"""
+    """When loading macros fails."""
     def __init__(self, message=None):
         Exception.__init__(self, message)
 
     @property
     def message(self):
+        """Error details."""
         if self.args:
             message = self.args[0]
             if message is not None:

--- a/src/sqlfluff/exceptions.py
+++ b/src/sqlfluff/exceptions.py
@@ -1,0 +1,20 @@
+"""
+    These Exceptions are for unexpected errors relating to configuration and
+    the sqlfluff context (macros, variables).
+
+    For "violations", or "common usage errors" such as parsing errors, refer
+    to sqlfluff/errors.py
+"""
+
+
+class MacroExtractError(Exception):
+    """When loading macros fails"""
+    def __init__(self, message=None):
+        Exception.__init__(self, message)
+
+    @property
+    def message(self):
+        if self.args:
+            message = self.args[0]
+            if message is not None:
+                return message

--- a/src/sqlfluff/templaters.py
+++ b/src/sqlfluff/templaters.py
@@ -3,7 +3,6 @@
 import os.path
 import ast
 from fnmatch import fnmatch
-from copy import deepcopy
 import collections
 
 from .errors import SQLTemplaterError
@@ -15,14 +14,14 @@ _templater_lookup = {}
 
 
 def update_macro_context(ctx, updated_ctx):
-    """
-        Update 2 macro contexts by overwriting the first
-        context with the second for all keys except
-        for top-level dictionaries which are merged
+    """Merge 2 macro contexts.
 
-        This is to support dbt_modules
+    Overwrites the first context with the second for all keys except
+    for top-level dictionaries which are merged
 
-        inspired from https://gist.github.com/angstwad/bf22d1822c38a92ec0a9
+    This is to support dbt_modules
+
+    inspired from https://gist.github.com/angstwad/bf22d1822c38a92ec0a9
     """
     for k, v in updated_ctx.items():
         if (k in ctx and isinstance(ctx[k], dict)
@@ -193,7 +192,7 @@ class JinjaTemplateInterface(PythonTemplateInterface):
         context = {}
         macro_template = env.from_string(template, globals=ctx)
         if dbt_project:
-            context[dbt_project] =  {}
+            context[dbt_project] = {}
         # This is kind of low level and hacky but it works
         for k in macro_template.module.__dict__:
             attr = getattr(macro_template.module, k)


### PR DESCRIPTION
* Support comma delimited list of directories in Configuration `load_macros_from_path`
* Support new comma delimited list of wildcard patterns to ignore in Configuration `load_macros_exclude_path_patterns`
* Check if macro sub-directories contain `dbt_project.yml`, in which case, import macros in dictionary `{<project_name>: ...}`

My configuration looks like this:

```
[sqlfluff:templater:jinja]
load_macros_from_path=macros,dbt_modules
load_macros_exclude_path_patterns=*integration_tests*,*materializations
```

TODO:
- [ ] Tests
- [ ] Do not assume directories after first project found are always inside a project
- [ ] Edge case: file with only macro code fails with "dbt_utils is undefined"
- [ ] Support DBT extensions https://github.com/fishtown-analytics/dbt/blob/3e8414e259b92e57d883c1f54492a3b7ed0e3853/core/dbt/clients/jinja.py#L353, should we optionally inherit from `dbt_core` ?
- [ ] Support DBT projects that do not match their root directory name
- [ ] Support silencing linting issues coming from imported macros

Closes:
* #371 