### PR TITLE
Refactor wildcard expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Created new Github Organisation (https://github.com/sqlfluff) and
   migrated from https://github.com/alanmcruickshank/sqlfluff to
   https://github.com/sqlfluff/sqlfluff.
+- Changed the handling of `*` and `a.b.*` expressions to have their
+  own expressions. Any dependencies on this structure downstream
+  will be broken. This also fixes the linting of both kinds of expressions
+  with regard to L013 and L025.
 
 ## [0.3.6] - 2020-09-24
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -6,7 +6,7 @@ and
 https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#string_and_bytes_literals
 """
 
-from ..parser import (BaseSegment, NamedSegment, OneOf, Ref, Sequence, Bracketed, Delimited, AnyNumberOf)
+from ..parser import (BaseSegment, NamedSegment, OneOf, Ref, Sequence, Bracketed, Delimited)
 
 from .dialect_ansi import ansi_dialect
 
@@ -80,25 +80,22 @@ bigquery_dialect.replace(
             Ref('SingleIdentifierGrammar'),
             optional=True
         )
-    ),
-    WildcardSelectTargetElementGrammar=Sequence(
+    )
+)
+
+
+@bigquery_dialect.segment(replace=True)
+class WildcardExpressionSegment(BaseSegment):
+    """An extension of the star expression for Bigquery."""
+    type = 'wildcard_expression'
+    match_grammar = Sequence(
         # *, blah.*, blah.blah.*, etc.
-        Sequence(
-            AnyNumberOf(
-                Sequence(
-                    Ref('SingleIdentifierGrammar'),
-                    Ref('DotSegment'),
-                    code_only=True
-                )
-            ),
-            Ref('StarSegment'), code_only=False
-        ),
+        Ref('WildcardIdentifierSegment'),
         # Optional EXCEPT or REPLACE clause
         # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_replace
         Ref('ExceptClauseSegment', optional=True),
         Ref('ReplaceClauseSegment', optional=True)
-    ),
-)
+    )
 
 
 @bigquery_dialect.segment()

--- a/src/sqlfluff/parser/segments_base.py
+++ b/src/sqlfluff/parser/segments_base.py
@@ -949,9 +949,15 @@ class BaseSegment:
         return buff
 
     def recursive_crawl(self, seg_type):
-        """Recursively crawl for segments of a given type."""
+        """Recursively crawl for segments of a given type.
+
+        Args:
+            seg_type: :obj:`str` or :obj:`tuple` of :obj:`str`: which specifies
+                the type of elements to look for."""
         # Check this segment
-        if self.type == seg_type:
+        if isinstance(seg_type, str) and self.type == seg_type:
+            yield self
+        elif isinstance(seg_type, tuple) and self.type in seg_type:
             yield self
         # Recurse
         for seg in self.segments:

--- a/src/sqlfluff/parser/segments_base.py
+++ b/src/sqlfluff/parser/segments_base.py
@@ -953,7 +953,8 @@ class BaseSegment:
 
         Args:
             seg_type: :obj:`str` or :obj:`tuple` of :obj:`str`: which specifies
-                the type of elements to look for."""
+                the type of elements to look for.
+        """
         # Check this segment
         if isinstance(seg_type, str) and self.type == seg_type:
             yield self

--- a/test/fixtures/parser/ansi/select_simple_b.yml
+++ b/test/fixtures/parser/ansi/select_simple_b.yml
@@ -5,7 +5,9 @@ file:
       select_clause:
         keyword: select
         select_target_element:
-          keyword: '*'
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
       from_clause:
         keyword: from
         table_expression:

--- a/test/fixtures/parser/bigquery/select_replace_2.yml
+++ b/test/fixtures/parser/bigquery/select_replace_2.yml
@@ -4,24 +4,26 @@ file:
       select_clause:
         keyword: SELECT
         select_target_element:
-          keyword: '*'
-          select_replace_clause:
-            keyword: REPLACE
-            start_bracket: (
-            select_target_element:
-              function:
-                function_name: CAST
-                start_bracket: (
-                expression:
-                  literal: '1'
-                keyword: AS
-                data_type:
-                  data_type_identifier: BOOLEAN
-                end_bracket: )
-              alias_expression:
-                keyword: AS
-                identifier: foo
-            end_bracket: )
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_replace_clause:
+              keyword: REPLACE
+              start_bracket: (
+              select_target_element:
+                function:
+                  function_name: CAST
+                  start_bracket: (
+                  expression:
+                    literal: '1'
+                  keyword: AS
+                  data_type:
+                    data_type_identifier: BOOLEAN
+                  end_bracket: )
+                alias_expression:
+                  keyword: AS
+                  identifier: foo
+              end_bracket: )
       from_clause:
         keyword: FROM
         table_expression:

--- a/test/fixtures/parser/snowflake/snowflake_pivot.yml
+++ b/test/fixtures/parser/snowflake/snowflake_pivot.yml
@@ -4,7 +4,9 @@ file:
       select_clause:
         keyword: SELECT
         select_target_element:
-          keyword: '*'
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
       from_clause:
         keyword: FROM
         table_expression:

--- a/test/fixtures/templater/jinja_g_macros/jinja.yml
+++ b/test/fixtures/templater/jinja_g_macros/jinja.yml
@@ -50,7 +50,9 @@ file:
             select_clause:
               keyword: select
               select_target_element:
-                keyword: '*'
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
             from_clause:
               keyword: from
               table_expression:


### PR DESCRIPTION
Fixes #449 . This introduces a backward incompatible change to the handling of `*` segments but I think it's for the best.

