### PR TITLE
Fixed typo in README and added instructions on how to virtualenv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,16 @@ tox -e cov-init,py36,cov-report,linting
 ### Using your local version
 
 To trial using your local development branch of sqlfluff, I recommend you use a virtual
-environment. __(TODO: Insert a link here to the python docs for `virtualenv`)__
+environment. e.g:
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+```
+> `python3 -m venv .venv` creates a new virtual environment (in current working
+> directory) called `.venv`.
+> `source .venv/bin/activate` activates the virtual environment so that packages
+> can be installed/uninstalled into it. [More info on venv](https://docs.python.org/3/library/venv.html).
 
 Once you're in a virtual environment, run:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CircleCI](https://img.shields.io/circleci/build/gh/sqlfluff/sqlfluff/master?style=flat-square&logo=CircleCI)](https://circleci.com/gh/sqlfluff/sqlfluff/tree/master)
 [![ReadTheDocs](https://img.shields.io/readthedocs/sqlfluff?style=flat-square&logo=Read%20the%20Docs)](https://sqlfluff.readthedocs.io)
 
-Bored of not having a good SQL linter that works with whichever dialiect you're
+Bored of not having a good SQL linter that works with whichever dialect you're
 working with? Fluff is an extensible and modular linter designed to help you write
 good SQL and catch errors and bad SQL before it hits your database.
 

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ commands = doc8 docs/source --file-encoding utf8
 # D107: Don't require docstrings on __init__
 # D105: Don't require docstrings on magic methods
 ignore = E501, W503, D107, D105
-exclude = .git,__pycache__,env,.tox,build
+exclude = .git,__pycache__,env,.tox,build,.venv,venv
 # sqlfluff uses flake8-docstrings https://pypi.org/project/flake8-docstrings/
 # this is to assist with the sphinx based autodoc
 docstring-convention = google


### PR DESCRIPTION
This looks like a really great open source project. I'd like to contribute to its development so I started reading your docs. I noticed a couple of small issues there so here's a PR to fix them. 

With regards to instructions on `virtualenv`, I'm open to feedback on whether I should include more detail. Also, my improvement only recommends python's `venv` module rather than the independent [virtualenv](https://virtualenv.pypa.io/en/stable/) package. I believe in recommending a single tool and and python's `venv` module is best because it doesn't required additional installation. 

Let me know how I could improve this PR. 