### PR TITLE
Add mypy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,6 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV=bench
-  # Benchmarking task
   mypy:
     <<: *common
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,13 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV=bench
+  # Benchmarking task
+  mypy:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV=mypy
 
 
 ### Workflows which call the different tox jobs
@@ -114,6 +121,7 @@ workflows:
     jobs:
       - linting
       - doclinting
+      - mypy
       - py35
       - py36
       - py37

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,22 @@
+[mypy]
+warn_unused_configs = True
+warn_unused_ignores = True
+
+# skip type checking for 3rd party packages for which stubs are not available
+[mypy-benchit.*]
+ignore_missing_imports = True
+
+[mypy-cdifflib.*]
+ignore_missing_imports = True
+
+[mypy-pathspec.*]
+ignore_missing_imports = True
+
+[mypy-appdirs.*]
+ignore_missing_imports = True
+
+[mypy-oyaml.*]
+ignore_missing_imports = True
+
+[mypy-diff_cover.*]
+ignore_missing_imports = True

--- a/src/sqlfluff/errors.py
+++ b/src/sqlfluff/errors.py
@@ -1,9 +1,10 @@
 """Errors - these are closely linked to what used to be called violations."""
+from typing import Optional
 
 
 class SQLBaseError(ValueError):
     """Base Error Class for all violations."""
-    _code = None
+    _code: Optional[str] = None
     _identifier = 'base'
 
     def __init__(self, *args, **kwargs):

--- a/src/sqlfluff/parser/segments_base.py
+++ b/src/sqlfluff/parser/segments_base.py
@@ -15,8 +15,11 @@ These are the fundamental building blocks of the rest of the parser.
 import logging
 
 from io import StringIO
+from typing import Optional
+
 from benchit import BenchIt
 
+from .grammar import BaseGrammar
 from .match import MatchResult, curtail_string, join_segments_raw
 from ..errors import SQLLintError
 
@@ -177,9 +180,9 @@ class BaseSegment:
 
     # `type` should be the *category* of this kind of segment
     type = 'base'
-    parse_grammar = None
-    match_grammar = None
-    grammar = None
+    parse_grammar: Optional[BaseGrammar] = None
+    match_grammar: Optional[BaseGrammar] = None
+    grammar: Optional[BaseGrammar] = None
     comment_seperate = False
     is_whitespace = False
     optional = False  # NB: See the seguence grammar for details

--- a/src/sqlfluff/parser/segments_base.py
+++ b/src/sqlfluff/parser/segments_base.py
@@ -15,13 +15,16 @@ These are the fundamental building blocks of the rest of the parser.
 import logging
 
 from io import StringIO
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from benchit import BenchIt
 
-from .grammar import BaseGrammar
 from .match import MatchResult, curtail_string, join_segments_raw
 from ..errors import SQLLintError
+
+
+if TYPE_CHECKING:
+    from .grammar import BaseGrammar
 
 
 def verbosity_logger(msg, verbosity=0, level='info', v_level=3):
@@ -180,9 +183,9 @@ class BaseSegment:
 
     # `type` should be the *category* of this kind of segment
     type = 'base'
-    parse_grammar: Optional[BaseGrammar] = None
-    match_grammar: Optional[BaseGrammar] = None
-    grammar: Optional[BaseGrammar] = None
+    parse_grammar: Optional['BaseGrammar'] = None
+    match_grammar: Optional['BaseGrammar'] = None
+    grammar: Optional['BaseGrammar'] = None
     comment_seperate = False
     is_whitespace = False
     optional = False  # NB: See the seguence grammar for details

--- a/src/sqlfluff/templaters.py
+++ b/src/sqlfluff/templaters.py
@@ -10,7 +10,7 @@ import jinja2.nodes
 from .errors import SQLTemplaterError
 from .parser import FilePositionMarker
 
-_templater_lookup = {}
+_templater_lookup = {} # type: ignore
 
 
 def templater_selector(s=None, **kwargs):

--- a/src/sqlfluff/templaters.py
+++ b/src/sqlfluff/templaters.py
@@ -2,6 +2,7 @@
 
 import os.path
 import ast
+from typing import Dict
 
 from jinja2.sandbox import SandboxedEnvironment
 from jinja2 import meta
@@ -10,7 +11,7 @@ import jinja2.nodes
 from .errors import SQLTemplaterError
 from .parser import FilePositionMarker
 
-_templater_lookup = {} # type: ignore
+_templater_lookup: Dict[str, 'RawTemplateInterface'] = {}
 
 
 def templater_selector(s=None, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = linting, doclinting, cov-init, py35, py36, py37, py38, py39, cov-report, bench
+envlist = linting, doclinting, cov-init, py35, py36, py37, py38, py39, cov-report, bench, mypy
 
 [testenv]
 passenv = CI CIRCLECI CIRCLE_*
@@ -55,6 +55,11 @@ deps =
     doc8
     pygments
 commands = doc8 docs/source --file-encoding utf8
+
+[testenv:mypy]
+deps = mypy
+
+commands = mypy src/sqlfluff
 
 [flake8]
 # Ignore:


### PR DESCRIPTION
Gradually introduce type checking and static analysis to the project by adding `mypy` as a build step in tox. 

Addresses #378 

Running `mypy` for the first time without any changes yielded `79 errors in 12 files`

I addressed all the straight forward errors (mostly by adding type hints indicate optional types). 

I am left with 2 errors (3 occurrences) that are actual issues that needs looking at: 

```
src/sqlfluff/rules/std.py:1345: error: Incompatible types in assignment (expression has type "Tuple[Tuple[str, str]]", base class "Rule_L010" defined the type as "Tuple[Tuple[str, str], Tuple[str, str]]")
```


```
src/sqlfluff/dialects/dialect_ansi.py:559: error: Incompatible types in assignment (expression has type "Sequence", base class "ObjectReferenceSegment" defined the type as "Delimited")
```