### PR TITLE
Code of conduct + intial project governance

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement via email to
+`admins`@`sqlfluff.com`. All complaints will be reviewed and investigated promptly
+and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,15 @@
 
 :star2: **First** - thanks for being interested in improving sqlfluff! :smiley:
 
-:star2: **Second** - the best way to get started contributing, is to use the
+:star2: **Second** - please read and familiarise yourself with both the content
+of this guide and also our [code of conduct](CODE_OF_CONDUCT.md).
+
+:star2: **Third** - the best way to get started contributing, is to use the
 tool in anger and then to submit bugs and features through github.
 In particular, in helping to develop the parser, examples of queries
 which don't parse as expected are especially helpful.
 
-:star2: **Third** - making sure that our documentation is up to date and useful
+:star2: **Fourth** - making sure that our documentation is up to date and useful
 for new users is really important. If you're a new user, you're in precisely
 the best position to do this. Familiarise yourself with the tool (as per step
 2 above) and familiarise yourself with the current documentation (live version
@@ -17,12 +20,57 @@ folder of the repo). Pull requests are always welcome with documentation
 improvements. Keep in mind that there are linting checks in place for good
 formatting so keep an eye on the tests whenever submitting a PR.
 
-:star2: **Fourth** - if you're so inclined - pull requests on the core codebase
+:star2: **Fifth** - if you're so inclined - pull requests on the core codebase
 are always welcome. Bear in mind that all the tests should pass, and test
 coverage should not decrease unduly as part of the changes which you make.
 You may find it useful to familiarise yourself with the
 [architectural principles here](https://docs.sqlfluff.com/en/latest/architecture.html)
 and with the [current documentation here](https://docs.sqlfluff.com).
+
+## How the community works
+
+SQLfluff is maintained by a community of volunteers, which means we have a
+few processes in place to allow everyone to contribute at a level that suits
+them and at a time that suits them. These aren't meant to be a way of restricting
+development, but a way of allowing the community to agree what to focus on
+and then effectively direct it's focus toward that. Anyone can pipe up in these
+discussions, and the more we hear from users the more we can build a tool
+that's actually useful for the community.
+
+- Large features for consideration will be organised into _Major Releases_.
+  These will usually include significant changes in functionality or backward
+  incompatible changes. As some of these features may require significant
+  coordination, discussion or development work, there is a process for each
+  major release to work out what features will fit into that release.
+  - Each major release will have it's own github issue. For example the link
+    to the issue for [0.4.0 is here](https://github.com/sqlfluff/sqlfluff/issues/470).
+  - Features or issues are organised into a _shortlist_. During the initial
+    discussion for the release, each feature is vetted for enough clarity
+    that someone in the community can pick it up. Issues where we can't
+    reach clarity will be pushed to the next release. Getting this clarity
+    is important before development work progresses so that we know that
+    larger changes are a) in line with the aims of the project and b) are
+    effectively pre-approved changes so that there aren't any suprises
+    when it comes to merging.
+  - Once we reach the deadline for closing the roadmap for a release the
+    focus on development work should be on those features.
+- Small features and bugfixes (assuming no backward compatability issues)
+  don't need to go through the same process and vetting and can be picked
+  up and merged at any time.
+
+### Maintainers
+
+A small group of people volunteer their time to maintain the project and
+share the responsibility for responding to issues and reviewing any proposed
+changes via pull requests. Each one of them will be trying to follow
+the process above and keep development work on the project moving. That
+means for smaller changes and improvements they may review changes as
+individuals and merge them into the project in a very lightweight way.
+For larger changes, especially if not already part of the current major
+release process the expectation is that they will involve other members
+or the maintainer community or the project admins before merging in
+larger changes or giving the green light to major structural project
+changes.
 
 ## Nerdy Details
 ### Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ SQLfluff is maintained by a community of volunteers, which means we have a
 few processes in place to allow everyone to contribute at a level that suits
 them and at a time that suits them. These aren't meant to be a way of restricting
 development, but a way of allowing the community to agree what to focus on
-and then effectively direct it's focus toward that. Anyone can pipe up in these
+and then effectively direct its focus toward that. Anyone can pipe up in these
 discussions, and the more we hear from users the more we can build a tool
 that's actually useful for the community.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ that's actually useful for the community.
   incompatible changes. As some of these features may require significant
   coordination, discussion or development work, there is a process for each
   major release to work out what features will fit into that release.
-  - Each major release will have it's own github issue. For example the link
+  - Each major release will have its own github issue. For example the link
     to the issue for [0.4.0 is here](https://github.com/sqlfluff/sqlfluff/issues/470).
   - Features or issues are organised into a _shortlist_. During the initial
     discussion for the release, each feature is vetted for enough clarity


### PR DESCRIPTION
Closes #444 

For review by @sqlfluff/sqlfluff-maintainers .

Now that we've got a github org and the community is growing, I feel like we should probably should get in place some basic project governance. It's so much easier to get this stuff in place before we run into problems than trying to retro-fit it when something goes wrong.

This PR adds a code of conduct (as per https://opensource.guide/code-of-conduct/) and also adds a basic outline of how I think project process can work going forward.

What do people think?