### PR TITLE
BigQuery Except clause refactor

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -15,7 +15,8 @@ https://www.cockroachlabs.com/docs/stable/sql-grammar.html#select_stmt
 from ..parser import (BaseSegment, KeywordSegment, ReSegment, NamedSegment,
                       Sequence, GreedyUntil, StartsWith, ContainsOnly,
                       OneOf, Delimited, Bracketed, AnyNumberOf, Ref, SegmentGenerator,
-                      Anything, LambdaSegment, Indent, Dedent, Nothing)
+                      Anything, LambdaSegment, Indent, Dedent, Nothing,
+                      Checkpoint)
 from .base import Dialect
 from .ansi_keywords import ansi_reserved_keywords, ansi_unreserved_keywords
 
@@ -1204,7 +1205,12 @@ class WithCompoundStatementSegment(BaseSegment):
                 Ref('SingleIdentifierGrammar'),
                 'AS',
                 Bracketed(
-                    Ref('SelectableGrammar')
+                    # Checkpoint here to subdivide the query.
+                    Checkpoint.make(
+                        match_grammar=Anything(),
+                        parse_grammar=Ref('SelectableGrammar'),
+                        name='SelectableGrammar'
+                    )
                 )
             ),
             delimiter=Ref('CommaSegment'),

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -601,15 +601,11 @@ class SelectTargetElementSegment(BaseSegment):
     """An element in the targets of a select statement."""
     type = 'select_target_element'
     # Important to split elements before parsing, otherwise debugging is really hard.
-    match_grammar = OneOf(
-        # *, blah.*, blah.blah.*, etc.
-        Ref('WildcardExpressionSegment'),
-        GreedyUntil(
-            'FROM', 'LIMIT',
-            Ref('CommaSegment'),
-            Ref('SetOperatorSegment'),
-            enforce_whitespace_preceeding_terminator=True
-        )
+    match_grammar = GreedyUntil(
+        'FROM', 'LIMIT',
+        Ref('CommaSegment'),
+        Ref('SetOperatorSegment'),
+        enforce_whitespace_preceeding_terminator=True
     )
 
     parse_grammar = OneOf(
@@ -1235,7 +1231,10 @@ class SetOperatorSegment(BaseSegment):
         ),
         'INTERSECT',
         'EXCEPT',
-        'MINUS'
+        'MINUS',
+        exclude=Sequence(
+            'EXCEPT', Bracketed(Anything())
+        )
     )
 
 

--- a/src/sqlfluff/parser/__init__.py
+++ b/src/sqlfluff/parser/__init__.py
@@ -5,7 +5,7 @@
 from .context import RootParseContext, parser_logger
 from .segments_base import BaseSegment, RawSegment
 from .segments_common import (KeywordSegment, ReSegment, NamedSegment,
-                              LambdaSegment, Indent, Dedent)
+                              LambdaSegment, Indent, Dedent, Checkpoint)
 from .segment_generator import SegmentGenerator
 from .grammar import (Sequence, GreedyUntil, StartsWith, ContainsOnly,
                       OneOf, Delimited, Bracketed, AnyNumberOf, Ref,

--- a/src/sqlfluff/parser/segments_base.py
+++ b/src/sqlfluff/parser/segments_base.py
@@ -309,9 +309,6 @@ class BaseSegment:
         Use the parse setting in the context for testing, mostly to check how deep to go.
         True/False for yes or no, an integer allows a certain number of levels.
         """
-        if not parse_context.dialect:
-            raise RuntimeError("No dialect provided to {0!r}!".format(self))
-
         # Clear the blacklist cache so avoid missteps
         if parse_context:
             parse_context.blacklist.clear()

--- a/src/sqlfluff/parser/segments_common.py
+++ b/src/sqlfluff/parser/segments_common.py
@@ -371,7 +371,7 @@ class Checkpoint(BaseSegment):
 
     def parse(self, parse_context):
         """Use the parse grammar to find subsegments within this segment.
-        
+
         Return the content of the result, rather than itself.
         """
         # Call the ususal parse function
@@ -381,8 +381,11 @@ class Checkpoint(BaseSegment):
 
     @classmethod
     def expected_string(cls, dialect=None, called_from=None):
-        """Return the expected string for this segment."""
-        return "!!TODO!!"
+        """Return the expected string for this segment.
+
+        In this case it's just the expected string of the match grammar.
+        """
+        return cls.match_grammar.expected_string(dialect=None, called_from=None)
 
     @classmethod
     def make(cls, match_grammar, parse_grammar, name):

--- a/src/sqlfluff/parser/segments_common.py
+++ b/src/sqlfluff/parser/segments_common.py
@@ -358,3 +358,42 @@ class Dedent(Indent):
     """
 
     indent_val = -1
+
+
+class Checkpoint(BaseSegment):
+    """A segment acts like a normal segment, but is ephemeral.
+
+    This segment allows grammars to behave like segments. It behaves like
+    a normal segment except that during the `parse` step, it returns its
+    contents rather than itself. This means in the final parsed structure
+    it no longer exists.
+    """
+
+    def parse(self, parse_context):
+        """Use the parse grammar to find subsegments within this segment.
+        
+        Return the content of the result, rather than itself.
+        """
+        # Call the ususal parse function
+        new_self = super().parse(parse_context)
+        # Return the content of that result rather than self
+        return new_self.segments
+
+    @classmethod
+    def expected_string(cls, dialect=None, called_from=None):
+        """Return the expected string for this segment."""
+        return "!!TODO!!"
+
+    @classmethod
+    def make(cls, match_grammar, parse_grammar, name):
+        """Make a subclass of the segment using a method.
+
+        Note: This requires a custom make method, because it's a bit different.
+        """
+        # Now lets make the classname (it indicates the mother class for clarity)
+        classname = "Checkpoint_{name}".format(name=name)
+        # This is the magic, we generate a new class! SORCERY
+        newclass = type(classname, (cls, ),
+                        dict(match_grammar=match_grammar, parse_grammar=parse_grammar))
+        # Now we return that class in the abstract. NOT INSTANTIATED
+        return newclass

--- a/src/sqlfluff/parser/segments_common.py
+++ b/src/sqlfluff/parser/segments_common.py
@@ -361,7 +361,7 @@ class Dedent(Indent):
 
 
 class Checkpoint(BaseSegment):
-    """A segment acts like a normal segment, but is ephemeral.
+    """A segment which acts like a normal segment, but is ephemeral.
 
     This segment allows grammars to behave like segments. It behaves like
     a normal segment except that during the `parse` step, it returns its

--- a/test/fixtures/parser/bigquery/select_multi_except.sql
+++ b/test/fixtures/parser/bigquery/select_multi_except.sql
@@ -1,0 +1,3 @@
+select d.*, r.* except(date_key)
+from my_table as d
+inner join my_other_table as r using(date_key)

--- a/test/parser/grammar_test.py
+++ b/test/parser/grammar_test.py
@@ -133,6 +133,18 @@ def test__parser__grammar_oneof(seg_list, code_only):
         assert not g.match(seg_list[1:], parse_context=ctx)
 
 
+def test__parser__grammar_oneof_exclude(seg_list):
+    """Test the OneOf grammar exclude option."""
+    fs = KeywordSegment.make('foo')
+    bs = KeywordSegment.make('bar')
+    g = OneOf(bs, exclude=Sequence(bs, fs))
+    with RootParseContext(dialect=None) as ctx:
+        # Just against the first alone
+        assert g.match(seg_list[:1], parse_context=ctx)
+        # Now with the bit to exclude invluded
+        assert not g.match(seg_list, parse_context=ctx)
+
+
 def test__parser__grammar_startswith_a(seg_list, fresh_ansi_dialect, caplog):
     """Test the StartsWith grammar simply."""
     baar = KeywordSegment.make('baar')

--- a/test/parser/segments_core_test.py
+++ b/test/parser/segments_core_test.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from sqlfluff.parser import RootParseContext, FilePositionMarker, RawSegment, KeywordSegment
+from sqlfluff.parser import (RootParseContext, FilePositionMarker, RawSegment,
+                             KeywordSegment, Checkpoint)
 
 
 @pytest.fixture(scope="module")
@@ -48,3 +49,30 @@ def test__parser__core_keyword(raw_seg_list):
         assert FooKeyword.match([raw_seg_list[1]], parse_context=ctx)
         # Match it against a list slice and check it still works
         assert FooKeyword.match(raw_seg_list[1:], parse_context=ctx)
+
+
+def test__parser__core_keyword(raw_seg_list):
+    """Test the Mystical KeywordSegment."""
+    # First make a keyword
+    FooKeyword = KeywordSegment.make('foo')
+    BarKeyword = KeywordSegment.make('bar')
+
+    checkpoint = Checkpoint.make(
+        match_grammar=BarKeyword,
+        parse_grammar=BarKeyword,
+        name='foobar'
+    )
+
+    with RootParseContext(dialect=None) as ctx:
+        # Test on a slice containing only the first element
+        m = checkpoint.match(raw_seg_list[:1], parse_context=ctx)
+        assert m
+        # Make sure that it matches as an instance of checkpoint
+        elem = m.matched_segments[0]
+        assert isinstance(elem, checkpoint)
+        # Parse it and make sure we don't get a checkpoint back
+        res = elem.parse(ctx)
+        assert isinstance(res, tuple)
+        elem = res[0]
+        assert not isinstance(elem, checkpoint)
+        assert isinstance(elem, BarKeyword)

--- a/test/parser/segments_core_test.py
+++ b/test/parser/segments_core_test.py
@@ -51,10 +51,9 @@ def test__parser__core_keyword(raw_seg_list):
         assert FooKeyword.match(raw_seg_list[1:], parse_context=ctx)
 
 
-def test__parser__core_keyword(raw_seg_list):
+def test__parser__core_checkpoint(raw_seg_list):
     """Test the Mystical KeywordSegment."""
     # First make a keyword
-    FooKeyword = KeywordSegment.make('foo')
     BarKeyword = KeywordSegment.make('bar')
 
     checkpoint = Checkpoint.make(


### PR DESCRIPTION
This was triggered by #366 .

These fixes don't fix the issue but were necessary to get to properly debugging that issue.

This introduces:
- The `Checkpoint` Segment, which behaves a little like a grammar, but is really a segment so allows dialects to divide up queries during parsing without affecting the eventual structure.
- Adding an `exclude` keyword to the `OneOf` grammar to allow some patterns being matched to prevent the grammar from matching.
- A refactor or `look_ahead_match` to better handle multiple simple matches.