### PR TITLE
Modify supported python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
   py39:
     <<: *common
     docker:
-      - image: circleci/python:3.9-rc
+      - image: circleci/python:3.9
         environment:
           TOXENV=py39
   # Benchmarking task

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,12 +68,6 @@ jobs:
         environment:
           - TOXENV=doclinting
           - UPLOAD_COVERAGE=0
-  py35:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV=py35
   py36:
     <<: *common
     docker:
@@ -114,7 +108,6 @@ workflows:
     jobs:
       - linting
       - doclinting
-      - py35
       - py36
       - py37
       - py38

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ good SQL and catch errors and bad SQL before it hits your database.
 * **0.3.x** drops support for python 2.7 and 3.4, and also reworks the
   handling of indentation linting in a potentially not backward
   compatable way.
+* **0.4.x** (ongoing development) drops support for python 3.5, and more...
 
 # Getting Started
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     author='Alan Cruickshank',
     author_email='alan@designingoverload.com',
     url='https://github.com/sqlfluff/sqlfluff',
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     keywords=['sqlfluff', 'sql', 'linter'],
     project_urls={
         # Homepage not ready yet.

--- a/src/sqlfluff/__init__.py
+++ b/src/sqlfluff/__init__.py
@@ -1,8 +1,17 @@
 """Sqlfluff is a SQL linter for humans."""
 import sys
 
+# Check major python version
 if sys.version_info[0] < 3:
     raise Exception("Sqlfluff does not support Python 2. Please upgrade to Python 3.")
+# Check minor python version
+elif sys.version[1] < 6:
+    raise Exception(
+        (
+            "Sqlfluff 0.4.0 only supports Python 3.6 and beyond. "
+            "Use an earlier version of sqlfluff or a later version of Python"
+        )
+    )
 
 import pkg_resources
 import configparser

--- a/src/sqlfluff/__init__.py
+++ b/src/sqlfluff/__init__.py
@@ -5,7 +5,7 @@ import sys
 if sys.version_info[0] < 3:
     raise Exception("Sqlfluff does not support Python 2. Please upgrade to Python 3.")
 # Check minor python version
-elif sys.version[1] < 6:
+elif sys.version_info[1] < 6:
     raise Exception(
         (
             "Sqlfluff 0.4.0 only supports Python 3.6 and beyond. "

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = linting, doclinting, cov-init, py35, py36, py37, py38, py39, cov-report, bench
+envlist = linting, doclinting, cov-init, py36, py37, py38, py39, cov-report, bench
 
 [testenv]
 passenv = CI CIRCLECI CIRCLE_*


### PR DESCRIPTION
Drop support for python 3.5 (related to #459)
Use 3.9 python 3.9 stable release in CI (Closes #461)