### PR TITLE
483 Ignore file passed explictly if matched in "ignore file config"

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -275,12 +275,12 @@ def dialects(**kwargs):
     ),
 )
 @click.option(
-    "--not-ignore-files",
+    "--disregard-sqlfluffignores",
     is_flag=True,
-    help=("If set, files will not be ignored by configuration files"),
+    help=("Perform the operation regardless of .sqlfluffignore configurations"),
 )
 @click.argument("paths", nargs=-1)
-def lint(paths, format, nofail, not_ignore_files, logger=None, **kwargs):
+def lint(paths, format, nofail, disregard_sqlfluffignores, logger=None, **kwargs):
     """Lint SQL files via passing a list of files or using stdin.
 
     PATH is the path to a sql file or directory to lint. This can be either a
@@ -320,7 +320,7 @@ def lint(paths, format, nofail, not_ignore_files, logger=None, **kwargs):
             result = lnt.lint_paths(
                 paths,
                 ignore_non_existent_files=False,
-                ignore_files=not not_ignore_files,
+                ignore_files=not disregard_sqlfluffignores,
             )
         except IOError:
             click.echo(

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -274,8 +274,11 @@ def dialects(**kwargs):
         "found. This is potentially useful during rollout."
     ),
 )
-@click.option('--not-ignore-files', is_flag=True,
-              help=('If set, files will not be ignored by configuration files'))
+@click.option(
+    "--not-ignore-files",
+    is_flag=True,
+    help=("If set, files will not be ignored by configuration files"),
+)
 @click.argument("paths", nargs=-1)
 def lint(paths, format, nofail, not_ignore_files, logger=None, **kwargs):
     """Lint SQL files via passing a list of files or using stdin.

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -274,8 +274,10 @@ def dialects(**kwargs):
         "found. This is potentially useful during rollout."
     ),
 )
+@click.option('--not-ignore-files', is_flag=True,
+              help=('If set, files will not be ignored by configuration files'))
 @click.argument("paths", nargs=-1)
-def lint(paths, format, nofail, logger=None, **kwargs):
+def lint(paths, format, nofail, not_ignore_files, logger=None, **kwargs):
     """Lint SQL files via passing a list of files or using stdin.
 
     PATH is the path to a sql file or directory to lint. This can be either a
@@ -312,7 +314,11 @@ def lint(paths, format, nofail, logger=None, **kwargs):
             click.echo(format_linting_result_header())
         try:
             # TODO: Remove verbose
-            result = lnt.lint_paths(paths, ignore_non_existent_files=False)
+            result = lnt.lint_paths(
+                paths,
+                ignore_non_existent_files=False,
+                ignore_files=not not_ignore_files,
+            )
         except IOError:
             click.echo(
                 colorize(

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -283,7 +283,6 @@ class ConfigLoader:
 
     def find_config_up_to_path(self, path, working_path=os.getcwd()):
         """Finds files from both the path and it's parent paths."""
-
         given_path = os.path.abspath(path)
         working_path = os.path.abspath(working_path)
 

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -298,11 +298,7 @@ class ConfigLoader:
         if not given_path.is_dir():
             given_path = given_path.parent
 
-        if hasattr(os.path, "commonpath"):
-            common_path = Path(os.path.commonpath([working_path, given_path]))
-        else:
-            # Compatabilty with pre python 3.5
-            common_path = Path(os.path.commonprefix([working_path, given_path]))
+        common_path = Path(os.path.commonpath([working_path, given_path]))
 
         # we have a sub path! We can load nested paths
         path_to_visit = common_path

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -268,8 +268,9 @@ class ConfigLoader:
         config_stack = [self.load_config_at_path(p) for p in config_paths]
         return nested_combine(user_appdir_config, user_config, *config_stack)
 
+    @classmethod
     def find_ignore_config_files(
-        self, path, working_path=os.getcwd(), ignore_file_name=".sqlfluffignore"
+        cls, path, working_path=os.getcwd(), ignore_file_name=".sqlfluffignore"
     ):
         """Finds sqlfluff ignore files from both the path and its parent paths."""
         return set(
@@ -277,14 +278,15 @@ class ConfigLoader:
                 os.path.isfile,
                 map(
                     lambda x: os.path.join(x, ignore_file_name),
-                    self.iter_config_locations_up_to_path(
+                    cls.iter_config_locations_up_to_path(
                         path=path, working_path=working_path
                     ),
                 ),
             )
         )
 
-    def iter_config_locations_up_to_path(self, path, working_path=Path.cwd()):
+    @staticmethod
+    def iter_config_locations_up_to_path(path, working_path=Path.cwd()):
         """Finds config locations from both the path and it's parent paths.
 
         The lowest priority is the user appdir, then home dir, then increasingly

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -936,15 +936,23 @@ class Linter:
         is_exact_file = not os.path.isdir(path)
 
         if is_exact_file:
+            # When the exact file to lint is passed, we
+            # fill path_walk with an input that follows
+            # the structure of `os.walk`:
+            #   (root, directories, files)
             dirpath = os.path.dirname(path)
             files = [os.path.basename(path)]
             ignore_file_paths = ConfigLoader.find_ignore_config_files(
                 path=path, working_path=working_path, ignore_file_name=ignore_file_name
             )
+            # Add paths that could contain "ignore files"
+            # to the path_walk list
             path_walk_ignore_file = [
                 (
                     os.path.dirname(ignore_file_path),
                     None,
+                    # Only one possible file, since we only
+                    # have one "ignore file name"
                     [os.path.basename(ignore_file_path)],
                 )
                 for ignore_file_path in ignore_file_paths

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -18,7 +18,7 @@ import pathspec
 from .errors import SQLLexError, SQLParseError
 from .parser import Lexer, Parser
 from .rules import get_ruleset
-from .config import FluffConfig
+from .config import FluffConfig, ConfigLoader
 
 
 # Instantiate the linter logger

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -990,8 +990,8 @@ class Linter:
             if os.path.abspath(fpath) not in ignore_set:
                 filtered_buffer.append(os.path.normpath(fpath))
             elif is_exact_file:
-                print(
-                    "WARNING: Exact file path %s was given but "
+                linter_logger.warning(
+                    "Exact file path %s was given but "
                     "it was ignored by a %s pattern, "
                     "re-run with `--not-ignore-files` to "
                     "skip %s"

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -933,7 +933,7 @@ class Linter:
             for f in files:
                 # Handle potential .sqlfluffignore files
                 if f.name == ignore_file_name:
-                    with open(f, 'r') as fh:
+                    with open(str(f), 'r') as fh:
                         spec = pathspec.PathSpec.from_lines('gitwildmatch', fh)
                     matches = spec.match_tree(abs_dir)
                     for m in matches:

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -938,8 +938,7 @@ class Linter:
         if is_exact_file:
             dirpath = os.path.dirname(path)
             files = [os.path.basename(path)]
-            loader = ConfigLoader.get_global()
-            ignore_file_paths = loader.find_ignore_config_files(
+            ignore_file_paths = ConfigLoader.find_ignore_config_files(
                 path=path, working_path=working_path, ignore_file_name=ignore_file_name
             )
             path_walk_ignore_file = [

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -1,7 +1,6 @@
 """Defines the linter class."""
 
 import os
-from pathlib import Path
 import time
 from collections import namedtuple
 import logging
@@ -943,7 +942,7 @@ class Linter:
             ignore_file_paths = loader.find_ignore_config_files(
                 path=path, working_path=working_path, ignore_file_name=ignore_file_name
             )
-            path_walk = [(dirpath, None, files),] + [
+            path_walk_ignore_file = [
                 (
                     os.path.dirname(ignore_file_path),
                     None,
@@ -951,6 +950,7 @@ class Linter:
                 )
                 for ignore_file_path in ignore_file_paths
             ]
+            path_walk = [(dirpath, None, files)] + path_walk_ignore_file
         else:
             path_walk = os.walk(path)
 

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -906,7 +906,9 @@ class Linter:
 
         return linted_file
 
-    def _get_potential_ignore_file_locations_for_file(self, path, ignore_file_name='.sqlfluffignore', current_dir=Path.cwd()):
+    def _get_potential_ignore_file_locations_for_file(
+        self, path, ignore_file_name=".sqlfluffignore", current_dir=Path.cwd()
+    ):
         """Returns a set of potential paths for ignore files based on file to be linted.
 
         When a path to a file to be linted is explicitly passed
@@ -933,8 +935,8 @@ class Linter:
             for f in files:
                 # Handle potential .sqlfluffignore files
                 if f.name == ignore_file_name:
-                    with open(f, 'r') as fh:
-                        spec = pathspec.PathSpec.from_lines('gitwildmatch', fh)
+                    with open(f, "r") as fh:
+                        spec = pathspec.PathSpec.from_lines("gitwildmatch", fh)
                     matches = spec.match_tree(abs_dir)
                     for m in matches:
                         ignore_path = abs_dir / m
@@ -943,7 +945,14 @@ class Linter:
                     continue
         return ignore_set
 
-    def paths_from_path(self, path, ignore_file_name='.sqlfluffignore', ignore_non_existent_files=False, ignore_files=True, current_dir=Path.cwd()):
+    def paths_from_path(
+        self,
+        path,
+        ignore_file_name=".sqlfluffignore",
+        ignore_non_existent_files=False,
+        ignore_files=True,
+        current_dir=Path.cwd(),
+    ):
         """Return a set of sql file paths from a potentially more ambigious path string.
 
         Here we also deal with the .sqlfluffignore file if present.
@@ -963,9 +972,7 @@ class Linter:
         if is_exact_file:
             dirpath = os.path.dirname(path)
             files = [os.path.basename(path)]
-            path_walk = [
-                (dirpath, None, files)
-            ]
+            path_walk = [(dirpath, None, files)]
             ignore_set = self._get_potential_ignore_file_locations_for_file(
                 path=path,
                 ignore_file_name=ignore_file_name,
@@ -981,8 +988,8 @@ class Linter:
                 fpath = os.path.join(dirpath, fname)
                 # Handle potential .sqlfluffignore files
                 if ignore_files and fname == ignore_file_name:
-                    with open(fpath, 'r') as fh:
-                        spec = pathspec.PathSpec.from_lines('gitwildmatch', fh)
+                    with open(fpath, "r") as fh:
+                        spec = pathspec.PathSpec.from_lines("gitwildmatch", fh)
                     matches = spec.match_tree(dirpath)
                     for m in matches:
                         ignore_path = os.path.join(dirpath, m)
@@ -1013,7 +1020,8 @@ class Linter:
                     "WARNING: Exact file path %s was given but "
                     "it was ignored by a %s pattern, "
                     "re-run with `--not-ignore-files` to "
-                    "skip %s" % (
+                    "skip %s"
+                    % (
                         path,
                         ignore_file_name,
                         ignore_file_name,
@@ -1031,12 +1039,18 @@ class Linter:
         result.add(linted_path)
         return result
 
-    def lint_path(self, path, fix=False, ignore_non_existent_files=False, ignore_files=True):
+    def lint_path(
+        self, path, fix=False, ignore_non_existent_files=False, ignore_files=True
+    ):
         """Lint a path."""
         linted_path = LintedPath(path)
         if self.formatter:
             self.formatter.dispatch_path(path)
-        for fname in self.paths_from_path(path, ignore_non_existent_files=ignore_non_existent_files, ignore_files=ignore_files):
+        for fname in self.paths_from_path(
+            path,
+            ignore_non_existent_files=ignore_non_existent_files,
+            ignore_files=ignore_files,
+        ):
             config = self.config.make_child_from_path(fname)
             # Handle unicode issues gracefully
             with open(
@@ -1049,7 +1063,9 @@ class Linter:
                 )
         return linted_path
 
-    def lint_paths(self, paths, fix=False, ignore_non_existent_files=False, ignore_files=True):
+    def lint_paths(
+        self, paths, fix=False, ignore_non_existent_files=False, ignore_files=True
+    ):
         """Lint an iterable of paths."""
         # If no paths specified - assume local
         if len(paths) == 0:
@@ -1059,8 +1075,14 @@ class Linter:
         for path in paths:
             # Iterate through files recursively in the specified directory (if it's a directory)
             # or read the file directly if it's not
-            result.add(self.lint_path(path, fix=fix,
-                                      ignore_non_existent_files=ignore_non_existent_files, ignore_files=ignore_files))
+            result.add(
+                self.lint_path(
+                    path,
+                    fix=fix,
+                    ignore_non_existent_files=ignore_non_existent_files,
+                    ignore_files=ignore_files,
+                )
+            )
         return result
 
     def parse_path(self, path, recurse=True):

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -935,7 +935,7 @@ class Linter:
                 if f.name == ignore_file_name:
                     with open(str(f), 'r') as fh:
                         spec = pathspec.PathSpec.from_lines('gitwildmatch', fh)
-                    matches = spec.match_tree(abs_dir)
+                    matches = spec.match_tree(str(abs_dir))
                     for m in matches:
                         ignore_path = abs_dir / m
                         ignore_set.add(str(ignore_path))

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -943,7 +943,6 @@ class Linter:
                     continue
         return ignore_set
 
-
     def paths_from_path(self, path, ignore_file_name='.sqlfluffignore', ignore_non_existent_files=False, ignore_files=True, current_dir=Path.cwd()):
         """Return a set of sql file paths from a potentially more ambigious path string.
 

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -1000,7 +1000,7 @@ class Linter:
                 linter_logger.warning(
                     "Exact file path %s was given but "
                     "it was ignored by a %s pattern, "
-                    "re-run with `--not-ignore-files` to "
+                    "re-run with `--disregard-sqlfluffignores` to "
                     "skip %s"
                     % (
                         path,

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -933,9 +933,9 @@ class Linter:
             for f in files:
                 # Handle potential .sqlfluffignore files
                 if f.name == ignore_file_name:
-                    with open(str(f), 'r') as fh:
+                    with open(f, 'r') as fh:
                         spec = pathspec.PathSpec.from_lines('gitwildmatch', fh)
-                    matches = spec.match_tree(str(abs_dir))
+                    matches = spec.match_tree(abs_dir)
                     for m in matches:
                         ignore_path = abs_dir / m
                         ignore_set.add(str(ignore_path))

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -221,13 +221,13 @@ def test__cli__command_lint_warning_explicit_file_ignored():
 
 
 def test__cli__command_lint_skip_ignore_files():
-    """Check "ignore file" is skipped when --not-ignore-files flag is set."""
+    """Check "ignore file" is skipped when --disregard-sqlfluffignores flag is set."""
     runner = CliRunner()
     result = runner.invoke(
         lint,
         [
             "test/fixtures/linter/sqlfluffignore/path_b/query_c.sql",
-            "--not-ignore-files",
+            "--disregard-sqlfluffignores",
         ],
     )
     assert result.exit_code == 65

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -210,10 +210,14 @@ def test__cli__command_lint_parse(command):
 def test__cli__command_lint_warning_explicit_file_ignored():
     """Check ignoring file works when passed explicitly and ignore file is in the same directory."""
     runner = CliRunner()
-    result = runner.invoke(lint, ['test/fixtures/linter/sqlfluffignore/path_b/query_c.sql'])
+    result = runner.invoke(
+        lint, ["test/fixtures/linter/sqlfluffignore/path_b/query_c.sql"]
+    )
     assert result.exit_code == 0
-    assert ("WARNING: Exact file path test/fixtures/linter/sqlfluffignore/path_b/query_c.sql "
-            "was given but it was ignored") in result.output.strip()
+    assert (
+        "WARNING: Exact file path test/fixtures/linter/sqlfluffignore/path_b/query_c.sql "
+        "was given but it was ignored"
+    ) in result.output.strip()
 
 
 def test__cli__command_lint_skip_ignore_files():
@@ -222,9 +226,10 @@ def test__cli__command_lint_skip_ignore_files():
     result = runner.invoke(
         lint,
         [
-            'test/fixtures/linter/sqlfluffignore/path_b/query_c.sql',
-            '--not-ignore-files'
-        ])
+            "test/fixtures/linter/sqlfluffignore/path_b/query_c.sql",
+            "--not-ignore-files",
+        ],
+    )
     assert result.exit_code == 65
     assert "L009" in result.output.strip()
 

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -215,7 +215,7 @@ def test__cli__command_lint_warning_explicit_file_ignored():
     )
     assert result.exit_code == 0
     assert (
-        "WARNING: Exact file path test/fixtures/linter/sqlfluffignore/path_b/query_c.sql "
+        "Exact file path test/fixtures/linter/sqlfluffignore/path_b/query_c.sql "
         "was given but it was ignored"
     ) in result.output.strip()
 

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -207,6 +207,28 @@ def test__cli__command_lint_parse(command):
     invoke_assert_code(args=command)
 
 
+def test__cli__command_lint_warning_explicit_file_ignored():
+    """Check ignoring file works when passed explicitly and ignore file is in the same directory"""
+    runner = CliRunner()
+    result = runner.invoke(lint, ['test/fixtures/linter/sqlfluffignore/path_b/query_c.sql'])
+    assert result.exit_code == 0
+    assert ("WARNING: Exact file path test/fixtures/linter/sqlfluffignore/path_b/query_c.sql "
+            "was given but it was ignored") in result.output.strip()
+
+
+def test__cli__command_lint_skip_ignore_files():
+    """Check "ignore file" is skipped when --not-ignore-files flag is set"""
+    runner = CliRunner()
+    result = runner.invoke(
+        lint,
+        [
+            'test/fixtures/linter/sqlfluffignore/path_b/query_c.sql',
+            '--not-ignore-files'
+        ])
+    assert result.exit_code == 65
+    assert "L009" in result.output.strip()
+
+
 def test__cli__command_versioning():
     """Check version command."""
     # Get the package version info

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -208,7 +208,7 @@ def test__cli__command_lint_parse(command):
 
 
 def test__cli__command_lint_warning_explicit_file_ignored():
-    """Check ignoring file works when passed explicitly and ignore file is in the same directory"""
+    """Check ignoring file works when passed explicitly and ignore file is in the same directory."""
     runner = CliRunner()
     result = runner.invoke(lint, ['test/fixtures/linter/sqlfluffignore/path_b/query_c.sql'])
     assert result.exit_code == 0
@@ -217,7 +217,7 @@ def test__cli__command_lint_warning_explicit_file_ignored():
 
 
 def test__cli__command_lint_skip_ignore_files():
-    """Check "ignore file" is skipped when --not-ignore-files flag is set"""
+    """Check "ignore file" is skipped when --not-ignore-files flag is set."""
     runner = CliRunner()
     result = runner.invoke(
         lint,

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -67,6 +67,23 @@ def test__config__load_nested():
     }
 
 
+def test__config__find_sqlfluffignore_in_same_directory():
+    """Test find ignore file in the same directory as sql file."""
+    c = ConfigLoader()
+    ignore_files = c.find_ignore_config_files(
+        path="test/fixtures/linter/sqlfluffignore/path_b/query_b.sql",
+        working_path="test/fixtures/linter/sqlfluffignore/",
+    )
+    assert ignore_files == set(
+        [
+            os.path.abspath(
+                "test/fixtures/linter/sqlfluffignore/path_b/.sqlfluffignore"
+            ),
+            os.path.abspath("test/fixtures/linter/sqlfluffignore/.sqlfluffignore"),
+        ]
+    )
+
+
 def test__config__nested_config_tests():
     """Test linting with overriden config in nested paths.
 

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -91,8 +91,7 @@ def test__config__iter_config_paths_right_order():
 
 def test__config__find_sqlfluffignore_in_same_directory():
     """Test find ignore file in the same directory as sql file."""
-    c = ConfigLoader()
-    ignore_files = c.find_ignore_config_files(
+    ignore_files = ConfigLoader.find_ignore_config_files(
         path="test/fixtures/linter/sqlfluffignore/path_b/query_b.sql",
         working_path="test/fixtures/linter/sqlfluffignore/",
     )

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -5,6 +5,8 @@ import os
 from sqlfluff.core.config import ConfigLoader, nested_combine, dict_diff
 from sqlfluff.core import Linter, FluffConfig
 
+from pathlib import Path
+
 
 config_a = {
     "core": {"testing_val": "foobar", "testing_int": 4},
@@ -65,6 +67,26 @@ def test__config__load_nested():
         "bar": {"foo": "foobar"},
         "fnarr": {"fnarr": {"foo": "foobar"}},
     }
+
+
+def test__config__iter_config_paths_right_order():
+    """Test that config paths are fetched ordered by priority."""
+    c = ConfigLoader()
+    cfg_paths = c.iter_config_locations_up_to_path(
+        os.path.join(
+            "test", "fixtures", "config", "inheritance_a", "nested", "blah.sql"
+        ),
+        working_path="test/fixtures",
+    )
+    assert list(cfg_paths) == [
+        str(Path(p).resolve())
+        for p in [
+            "test/fixtures",
+            "test/fixtures/config",
+            "test/fixtures/config/inheritance_a",
+            "test/fixtures/config/inheritance_a/nested",
+        ]
+    ]
 
 
 def test__config__find_sqlfluffignore_in_same_directory():

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -55,7 +55,7 @@ def test__linter__path_from_paths__explicit_ignore():
         "test/fixtures/linter/sqlfluffignore/path_a/query_a.sql",
         ignore_non_existent_files=True,
         ignore_files=True,
-        current_dir=Path("test/fixtures/linter/sqlfluffignore/"),
+        working_path="test/fixtures/linter/sqlfluffignore/",
     )
     assert len(paths) == 0
 

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -51,7 +51,12 @@ def test__linter__path_from_paths__not_exist_ignore():
 def test__linter__path_from_paths__explicit_ignore():
     """Test ignoring files that were passed explicitly."""
     lntr = Linter(config=FluffConfig())
-    paths = lntr.paths_from_path('test/fixtures/linter/sqlfluffignore/path_a/query_a.sql', ignore_non_existent_files=True, ignore_files=True, current_dir=Path("test/fixtures/linter/sqlfluffignore/"))
+    paths = lntr.paths_from_path(
+        "test/fixtures/linter/sqlfluffignore/path_a/query_a.sql",
+        ignore_non_existent_files=True,
+        ignore_files=True,
+        current_dir=Path("test/fixtures/linter/sqlfluffignore/"),
+    )
     assert len(paths) == 0
 
 

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from sqlfluff.core import Linter
-from sqlfluff.core.linter import LintingResult
+from sqlfluff.linter import Linter, LintingResult
+from sqlfluff.config import FluffConfig
 from pathlib import Path
 
 

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -2,9 +2,8 @@
 
 import pytest
 
-from sqlfluff.linter import Linter, LintingResult
-from sqlfluff.config import FluffConfig
-from pathlib import Path
+from sqlfluff.core import Linter, FluffConfig
+from sqlfluff.core.linter import LintingResult
 
 
 def normalise_paths(paths):

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from sqlfluff.core import Linter
 from sqlfluff.core.linter import LintingResult
+from pathlib import Path
 
 
 def normalise_paths(paths):
@@ -44,6 +45,13 @@ def test__linter__path_from_paths__not_exist_ignore():
     """Test extracting paths from a file path."""
     lntr = Linter()
     paths = lntr.paths_from_path("asflekjfhsakuefhse", ignore_non_existent_files=True)
+    assert len(paths) == 0
+
+
+def test__linter__path_from_paths__explicit_ignore():
+    """Test ignoring files that were passed explicitly."""
+    lntr = Linter(config=FluffConfig())
+    paths = lntr.paths_from_path('test/fixtures/linter/sqlfluffignore/path_a/query_a.sql', ignore_non_existent_files=True, ignore_files=True, current_dir=Path("test/fixtures/linter/sqlfluffignore/"))
     assert len(paths) == 0
 
 


### PR DESCRIPTION
Closes #483 

## New lint flag

`--not-ignore-files` skips ignore file patterns, by default it is false and ignore file patterns are respected

## New behavior for passing paths explicitly

When a path to a file to be linted is explicitly passed we look for ignore files in all directories that are parents of the file, up to the current directory.

If the current directory is not a parent of the file we only look for an ignore file in the direct parent of the file.