### PR TITLE
New rule: keys instead of using for joins

### DIFF
--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -2894,7 +2894,7 @@ class Rule_L031(BaseCrawler):
 
 @std_rule_set.register
 class Rule_L032(BaseCrawler):
-    """Prefer specifying join keys instead of using "USING"
+    """Prefer specifying join keys instead of using "USING".
 
     | **Anti-pattern**
 

--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -2930,6 +2930,6 @@ class Rule_L032(BaseCrawler):
                     return [LintResult(
                         # Reference the element, not the string.
                         anchor=seg,
-                        description=("Specified join keys expected instead of USING.")
+                        description=("Found USING statement. Expected only ON statements.")
                     )]
         return None

--- a/src/sqlfluff/rules/std.py
+++ b/src/sqlfluff/rules/std.py
@@ -2890,3 +2890,46 @@ class Rule_L031(BaseCrawler):
             )
 
         return violation_buff or None
+
+
+@std_rule_set.register
+class Rule_L032(BaseCrawler):
+    """Prefer specifying join keys instead of using "USING"
+
+    | **Anti-pattern**
+
+    .. code-block:: sql
+
+        SELECT
+            table_a.field_1,
+            table_b.field_2
+        FROM
+            table_a
+        INNER JOIN table_b USING (id)
+
+    | **Best practice**
+    |  Specify the keys directly
+
+    .. code-block:: sql
+
+        SELECT
+            table_a.field_1,
+            table_b.field_2
+        FROM
+            table_a
+        INNER JOIN table_b
+            ON table_a.id = table_b.id
+
+    """
+
+    def _eval(self, segment, **kwargs):
+        """Look for USING in a join clause."""
+        if segment.type == 'join_clause':
+            for seg in segment.segments:
+                if seg.type == 'keyword' and seg.name == 'USING':
+                    return [LintResult(
+                        # Reference the element, not the string.
+                        anchor=seg,
+                        description=("Specified join keys expected instead of USING.")
+                    )]
+        return None

--- a/test/fixtures/cli/passing_b.sql
+++ b/test/fixtures/cli/passing_b.sql
@@ -8,7 +8,7 @@ SELECT
     d.something,    -- Which a comment after it
     a.foo
 FROM tbl AS a
-INNER JOIN b USING (common_id)
+INNER JOIN b ON (a.common_id = b.common_id)
 JOIN c ON (a.id = c.id)
 LEFT JOIN d ON (a.id = d.other_id)
 ORDER BY a.name ASC

--- a/test/rules_std_test.py
+++ b/test/rules_std_test.py
@@ -222,7 +222,10 @@ def assert_rule_pass_in_sql(code, sql, configs=None):
      'SELECT u.id, customers.first_name, customers.last_name, COUNT(orders.user_id) FROM users as u JOIN customers on u.id = customers.user_id JOIN orders on u.id = orders.user_id;', None),
     # Fix for https://github.com/sqlfluff/sqlfluff/issues/476
     ('L010', 'fail', 'SELECT * FROM MOO ORDER BY dt DESC',
-     'select * from MOO order by dt desc', {'rules': {'L010': {'capitalisation_policy': 'lower'}}})
+     'select * from MOO order by dt desc', {'rules': {'L010': {'capitalisation_policy': 'lower'}}}),
+    ('L032', 'pass', 'select x.a from x inner join y on x.id = y.id', None, None),
+    ('L032', 'fail', 'select x.a from x inner join y using (id)', None, None),
+    ('L032', 'fail', 'select x.a from x inner join y on x.id = y.id inner join z using (id)', None, None),
 ])
 def test__rules__std_string(rule, pass_fail, qry, fixed, configs):
     """Test that a rule passes/fails on a given string.


### PR DESCRIPTION
Addresses #467

Hi folks, I've been poking around with sqlfluff at work some (it's 👍 btw, awesome work!), figured I'd try and put a contribution in.  Please let me know any feedback!  Couple of things I'm unsure on that I could use a hand with:

- For adding a new rule, is there anything to do to default configs, or do you just accept the new rule as adding to the default behaviour?  Any numbering schemes to think about, other than just incrementing the latest rule by one?
- I couldn't get all the versions up and running through tox locally (too many competing environment setups 😬) but tests pass when calling `pytest` directly in 3.7.9 on my machine.  Is tox run in CI too to validate against other versions?
- For this rule if there's just two tables I _think_ it could be auto-fixed by grabbing aliases and replacing a `using (id)` with a `alias_1.id = alias_2.id`.  But if there's more than two tables I think you wouldn't be able to auto-fix.  I didn't include any auto-fixing, any thoughts on implementing this as part of the rule?
- I updated `test/fixtures/cli/passing_b.sql` since it was using (heh) a `using` clause.  That ok?