### PR TITLE
Make warnings red, and clear up old print statements

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -31,6 +31,16 @@ from ..config import FluffConfig
 from ..errors import SQLLintError
 
 
+class RedWarningsFilter(logging.Filter):
+    """This filter makes all warnings or above red."""
+
+    def filter(self, record):
+        """Filter any warnings (or above) to turn them red."""
+        if record.levelno >= logging.WARNING:
+            record.msg = colorize(record.msg, "red")
+        return True
+
+
 def set_logging_level(verbosity, logger=None):
     """Set up logging for the CLI.
 
@@ -51,6 +61,8 @@ def set_logging_level(verbosity, logger=None):
     # Set up the log handler to log to stdout
     handler = logging.StreamHandler(stream=sys.stdout)
     handler.setFormatter(logging.Formatter("%(levelname)-10s %(message)s"))
+    # Set up a handler to colour warnings red.
+    handler.addFilter(RedWarningsFilter())
     if logger:
         focus_logger = logging.getLogger("sqlfluff.{0}".format(logger))
         focus_logger.addHandler(handler)

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -267,8 +267,8 @@ class LintedFile(
                     else:
                         # We're not at the end point yet, continue to fast forward through.
                         if fixed_block[0] != "equal":
-                            print(
-                                "WARNING: Skipping edit block: {0}".format(fixed_block)
+                            linter_logger.warning(
+                                "Skipping edit block: {0}".format(fixed_block)
                             )
                         if diff_fix_codes:
                             fixed_block = diff_fix_codes.pop(0)
@@ -292,10 +292,8 @@ class LintedFile(
                         # TODO: We're trying to move through an templated section, but end up
                         # in a fixed section. We've lost track of indexes.
                         # We might need to panic if this happens...
-                        print("UMMMMMM!")
-                        print(new_templ_idx)
-                        print(fixed_block)
-                        raise NotImplementedError("ABC")
+                        linter_logger.warning("UMMMMMM!\n%s\n%s", new_templ_idx, fixed_block)
+                        raise NotImplementedError("PANIC. Index position confused. Report this error.")
                 write_buff += buff
                 # consume template block
                 templ_block = None

--- a/src/sqlfluff/linter.py
+++ b/src/sqlfluff/linter.py
@@ -292,8 +292,12 @@ class LintedFile(
                         # TODO: We're trying to move through an templated section, but end up
                         # in a fixed section. We've lost track of indexes.
                         # We might need to panic if this happens...
-                        linter_logger.warning("UMMMMMM!\n%s\n%s", new_templ_idx, fixed_block)
-                        raise NotImplementedError("PANIC. Index position confused. Report this error.")
+                        linter_logger.warning(
+                            "UMMMMMM!\n%s\n%s", new_templ_idx, fixed_block
+                        )
+                        raise NotImplementedError(
+                            "PANIC. Index position confused. Report this error."
+                        )
                 write_buff += buff
                 # consume template block
                 templ_block = None

--- a/src/sqlfluff/parser/grammar.py
+++ b/src/sqlfluff/parser/grammar.py
@@ -365,7 +365,6 @@ class BaseGrammar:
 
         # Have we been passed an empty list?
         if len(segments) == 0:
-            print("e")
             return ((), MatchResult.from_empty(), None)
 
         # Here we enable a performance optimisation. Most of the time in this cycle

--- a/util.py
+++ b/util.py
@@ -7,7 +7,6 @@ NB: This is not part of the core sqlfluff code.
 """
 
 from __future__ import absolute_import
-from __future__ import print_function
 
 # This contains various utility scripts
 


### PR DESCRIPTION
As brought up in #486 , we've had some stray print statements lying around.

This PR also makes Warnings or above red so that they're easier to find.