### PR TITLE
Split ObjectReference into ColumnReference and TableReference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   information.
 - Support for modulo (`%`) operator.
 - A limit in the internal fix routines to catch any infinite loops.
+- Added the `.istype()` method on segments to more intelligently
+  deal with type matching in rules when inheritance is at play.
 
 ### Changed
 
@@ -32,6 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor of L022 to handle poorly formatted CTEs better.
 - Internally added an `EphemeralSegment` to aid with parsing efficiency
   without altering the end structure of the query.
+- Split `ObjectReference` into `ColumnReference` and `TableReference`
+  for more useful API access to the underlying structure.
+- `KeywordSegment` and the new `SymbolSegment` both now inherit
+  from `_ProtoKeywordSegment` which allows symbols to match in a very
+  similar way to keywords without later appearing with the `type` of
+  `keyword`.
 
 ## [0.3.6] - 2020-09-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   similar way to keywords without later appearing with the `type` of
   `keyword`.
 
+### Removed
+
+- Removed `ColumnExpressionSegment` in favour of `ColumnReference`.
+
 ## [0.3.6] - 2020-09-24
 
 ### Added

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -18,3 +18,16 @@ Simple API commands
 
 .. automodule:: sqlfluff
    :members: lint, fix, parse
+
+
+Advanced API usage
+------------------
+
+The simple API presents only a fraction of the functionality present
+within the core sqlfluff library. For more advanced use cases, users
+can import the :code:`Linter()` and :code:`FluffConfig()` classes from
+:code:`sqlfluff.core`. As of version 0.4.0 this is considered as
+*experimental only* as the internals may change without warning in any
+future release. If you come to rely on the internals of sqlfluff, please
+post an issue on github to share what you're up to. This will help shape
+a more reliable, tidy and well documented public API for use.

--- a/examples/basic_api_usage.py
+++ b/examples/basic_api_usage.py
@@ -46,3 +46,5 @@ structure = parsed.to_tuple(show_raw=True, code_only=True)
 # Extract certain elements
 keywords = [keyword.raw for keyword in parsed.recursive_crawl("keyword")]
 # keywords = ['SeLEct', 'as', 'from']
+tbl_refs = [tbl_ref.raw for tbl_ref in parsed.recursive_crawl("table_reference")]
+# tbl_refs == ["myTable"]

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -656,7 +656,7 @@ class WildcardIdentifierSegment(ObjectReferenceSegment):
         will only appear once.
         """
         # Extract the references from those identifiers (because some may be quoted)
-        for elem in self.recursive_crawl(("identifier", "star")):
+        for elem in self.recursive_crawl("identifier", "star"):
             yield from self._iter_reference_parts(elem)
 
 

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -324,16 +324,6 @@ class DatatypeSegment(BaseSegment):
 
 
 @ansi_dialect.segment()
-class ColumnExpressionSegment(BaseSegment):
-    """A reference to a column."""
-
-    type = "column_expression"
-    match_grammar = OneOf(
-        Ref("SingleIdentifierGrammar"), code_only=False
-    )  # QuotedIdentifierSegment
-
-
-@ansi_dialect.segment()
 class ObjectReferenceSegment(BaseSegment):
     """A reference to an object."""
 
@@ -1727,7 +1717,7 @@ class SetClauseSegment(BaseSegment):
     type = "set_clause"
 
     match_grammar = Sequence(
-        Ref("ColumnExpressionSegment"),
+        Ref("ColumnReferenceSegment"),
         Ref("EqualsSegment"),
         OneOf(
             Ref("LiteralGrammar"),

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -15,6 +15,7 @@ https://www.cockroachlabs.com/docs/stable/sql-grammar.html#select_stmt
 from ..parser import (
     BaseSegment,
     KeywordSegment,
+    SymbolSegment,
     ReSegment,
     NamedSegment,
     Sequence,
@@ -131,51 +132,53 @@ ansi_dialect.add(
         lambda x: not x.is_code, is_code=False, name="non_code"
     ),
     # Real segments
-    SemicolonSegment=KeywordSegment.make(";", name="semicolon"),
-    ColonSegment=KeywordSegment.make(":", name="colon"),
-    SliceSegment=KeywordSegment.make(":", name="slice"),
-    StartBracketSegment=KeywordSegment.make(
+    SemicolonSegment=SymbolSegment.make(
+        ";", name="semicolon", type="statement_terminator"
+    ),
+    ColonSegment=SymbolSegment.make(":", name="colon", type="colon"),
+    SliceSegment=SymbolSegment.make(":", name="slice", type="slice"),
+    StartBracketSegment=SymbolSegment.make(
         "(", name="start_bracket", type="start_bracket"
     ),
-    EndBracketSegment=KeywordSegment.make(")", name="end_bracket", type="end_bracket"),
-    StartSquareBracketSegment=KeywordSegment.make(
+    EndBracketSegment=SymbolSegment.make(")", name="end_bracket", type="end_bracket"),
+    StartSquareBracketSegment=SymbolSegment.make(
         "[", name="start_square_bracket", type="start_square_bracket"
     ),
-    EndSquareBracketSegment=KeywordSegment.make(
+    EndSquareBracketSegment=SymbolSegment.make(
         "]", name="end_square_bracket", type="end_square_bracket"
     ),
-    CommaSegment=KeywordSegment.make(",", name="comma", type="comma"),
-    DotSegment=KeywordSegment.make(".", name="dot", type="dot"),
-    StarSegment=KeywordSegment.make("*", name="star", type="star"),
-    TildeSegment=KeywordSegment.make("~", name="tilde"),
-    CastOperatorSegment=KeywordSegment.make(
+    CommaSegment=SymbolSegment.make(",", name="comma", type="comma"),
+    DotSegment=SymbolSegment.make(".", name="dot", type="dot"),
+    StarSegment=SymbolSegment.make("*", name="star", type="star"),
+    TildeSegment=SymbolSegment.make("~", name="tilde", type="tilde"),
+    CastOperatorSegment=SymbolSegment.make(
         "::", name="casting_operator", type="casting_operator"
     ),
-    PlusSegment=KeywordSegment.make("+", name="plus", type="binary_operator"),
-    MinusSegment=KeywordSegment.make("-", name="minus", type="binary_operator"),
-    PositiveSegment=KeywordSegment.make("+", name="positive", type="sign_indicator"),
-    NegativeSegment=KeywordSegment.make("-", name="negative", type="sign_indicator"),
-    DivideSegment=KeywordSegment.make("/", name="divide", type="binary_operator"),
-    MultiplySegment=KeywordSegment.make("*", name="multiply", type="binary_operator"),
-    ModuloSegment=KeywordSegment.make("%", name="modulo", type="binary_operator"),
-    ConcatSegment=KeywordSegment.make("||", name="concatenate", type="binary_operator"),
-    EqualsSegment=KeywordSegment.make("=", name="equals", type="comparison_operator"),
-    GreaterThanSegment=KeywordSegment.make(
+    PlusSegment=SymbolSegment.make("+", name="plus", type="binary_operator"),
+    MinusSegment=SymbolSegment.make("-", name="minus", type="binary_operator"),
+    PositiveSegment=SymbolSegment.make("+", name="positive", type="sign_indicator"),
+    NegativeSegment=SymbolSegment.make("-", name="negative", type="sign_indicator"),
+    DivideSegment=SymbolSegment.make("/", name="divide", type="binary_operator"),
+    MultiplySegment=SymbolSegment.make("*", name="multiply", type="binary_operator"),
+    ModuloSegment=SymbolSegment.make("%", name="modulo", type="binary_operator"),
+    ConcatSegment=SymbolSegment.make("||", name="concatenate", type="binary_operator"),
+    EqualsSegment=SymbolSegment.make("=", name="equals", type="comparison_operator"),
+    GreaterThanSegment=SymbolSegment.make(
         ">", name="greater_than", type="comparison_operator"
     ),
-    LessThanSegment=KeywordSegment.make(
+    LessThanSegment=SymbolSegment.make(
         "<", name="less_than", type="comparison_operator"
     ),
-    GreaterThanOrEqualToSegment=KeywordSegment.make(
+    GreaterThanOrEqualToSegment=SymbolSegment.make(
         ">=", name="greater_than_equal_to", type="comparison_operator"
     ),
-    LessThanOrEqualToSegment=KeywordSegment.make(
+    LessThanOrEqualToSegment=SymbolSegment.make(
         "<=", name="less_than_equal_to", type="comparison_operator"
     ),
-    NotEqualToSegment_a=KeywordSegment.make(
+    NotEqualToSegment_a=SymbolSegment.make(
         "!=", name="not_equal_to", type="comparison_operator"
     ),
-    NotEqualToSegment_b=KeywordSegment.make(
+    NotEqualToSegment_b=SymbolSegment.make(
         "<>", name="not_equal_to", type="comparison_operator"
     ),
     # The following functions can be called without parentheses per ANSI specification

--- a/src/sqlfluff/core/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/core/dialects/dialect_snowflake.py
@@ -225,7 +225,7 @@ class NamedParameterExpressionSegment(BaseSegment):
         Ref("ParameterAssignerSegment"),
         OneOf(
             Ref("LiteralGrammar"),
-            Ref("ObjectReferenceSegment"),
+            Ref("ColumnReferenceSegment"),
             Ref("ExpressionSegment"),
         ),
     )

--- a/src/sqlfluff/core/dialects/dialect_teradata.py
+++ b/src/sqlfluff/core/dialects/dialect_teradata.py
@@ -190,12 +190,12 @@ class TdRenameStatementSegment(BaseSegment):
     match_grammar = Sequence(
         "RENAME",
         "TABLE",
-        Ref("ObjectReferenceSegment"),
+        Ref("TableReferenceSegment"),
         OneOf(
             "TO",
             "AS",
         ),
-        Ref("ObjectReferenceSegment"),
+        Ref("TableReferenceSegment"),
     )
 
 
@@ -259,7 +259,7 @@ class ColumnDefinitionSegment(BaseSegment):
 
     type = "column_definition"
     match_grammar = Sequence(
-        Ref("ObjectReferenceSegment"),  # Column name
+        Ref("ColumnReferenceSegment"),  # Column name
         Ref("DatatypeSegment"),  # Column type
         Bracketed(Anything(), optional=True),  # For types like VARCHAR(100)
         AnyNumberOf(
@@ -436,7 +436,7 @@ class TdTableConstraints(BaseSegment):
                 Ref.keyword("ALL", optional=True),
                 Bracketed(  # Columns making up  constraint
                     Delimited(
-                        Ref("ObjectReferenceSegment"), delimiter=Ref("CommaSegment")
+                        Ref("ColumnReferenceSegment"), delimiter=Ref("CommaSegment")
                     ),
                 ),
             ),
@@ -457,7 +457,7 @@ class CreateTableStatementSegment(BaseSegment):
         OneOf(Sequence("GLOBAL", "TEMPORARY"), "VOLATILE", optional=True),
         "TABLE",
         Sequence("IF", "NOT", "EXISTS", optional=True),
-        Ref("ObjectReferenceSegment"),
+        Ref("TableReferenceSegment"),
         # , NO FALLBACK, NO BEFORE JOURNAL, NO AFTER JOURNAL
         OneOf(Ref("TdCreateTableOptions"), optional=True),
         OneOf(
@@ -479,7 +479,7 @@ class CreateTableStatementSegment(BaseSegment):
             # Create AS syntax:
             Sequence("AS", Ref("SelectableGrammar")),
             # Create like syntax
-            Sequence("LIKE", Ref("ObjectReferenceSegment")),
+            Sequence("LIKE", Ref("TableReferenceSegment")),
         ),
         # PRIMARY INDEX( COD_TARJETA, COD_EST, IND_TIPO_TARJETA, FEC_ANIO_MES )
         OneOf(Ref("TdTableConstraints"), optional=True),
@@ -498,15 +498,15 @@ class UpdateStatementSegment(BaseSegment):
     SET <set clause list> [ WHERE <search condition> ]
     """
 
-    type = "delete_statement"
+    type = "update_statement"
     match_grammar = StartsWith("UPDATE")
     parse_grammar = Sequence(
         "UPDATE",
         OneOf(
-            Ref("ObjectReferenceSegment"),
+            Ref("TableReferenceSegment"),
             Ref("FromUpdateClauseSegment"),
             Sequence(
-                Ref("ObjectReferenceSegment"),
+                Ref("TableReferenceSegment"),
                 Ref("FromUpdateClauseSegment"),
             ),
         ),

--- a/src/sqlfluff/core/parser/__init__.py
+++ b/src/sqlfluff/core/parser/__init__.py
@@ -6,6 +6,7 @@ from .context import RootParseContext, parser_logger
 from .segments_base import BaseSegment, RawSegment
 from .segments_common import (
     KeywordSegment,
+    SymbolSegment,
     ReSegment,
     NamedSegment,
     LambdaSegment,

--- a/src/sqlfluff/core/parser/grammar.py
+++ b/src/sqlfluff/core/parser/grammar.py
@@ -1079,7 +1079,7 @@ class GreedyUntil(BaseGrammar):
                         if elem.is_meta:
                             idx += 1
                             continue
-                        elif elem.type in ("whitespace", "newline"):
+                        elif elem.is_type("whitespace", "newline"):
                             allow = True
                             break
                         else:
@@ -1098,7 +1098,7 @@ class GreedyUntil(BaseGrammar):
                             if pre[idx].is_meta:
                                 idx -= 1
                                 continue
-                            elif pre[idx].type in ("whitespace", "newline"):
+                            elif pre[idx].is_type("whitespace", "newline"):
                                 allow = True
                                 break
                             else:
@@ -1564,7 +1564,7 @@ class ContainsOnly(BaseGrammar):
                 # Try and match it
                 for opt in self._elements:
                     if isinstance(opt, str):
-                        if forward_buffer[0].type == opt:
+                        if forward_buffer[0].is_type(opt):
                             matched_buffer += (forward_buffer[0],)
                             forward_buffer = forward_buffer[1:]
                             break

--- a/src/sqlfluff/core/parser/segments_base.py
+++ b/src/sqlfluff/core/parser/segments_base.py
@@ -408,12 +408,12 @@ class BaseSegment:
     @property
     def _comments(self):
         """Returns only the comment elements of this segment."""
-        return [seg for seg in self.segments if seg.type == "comment"]
+        return [seg for seg in self.segments if seg.is_type("comment")]
 
     @property
     def _non_comments(self):
         """Returns only the non-comment elements of this segment."""
-        return [seg for seg in self.segments if seg.type != "comment"]
+        return [seg for seg in self.segments if not seg.is_type("comment")]
 
     def stringify(self, ident=0, tabsize=4, pos_idx=60, raw_idx=80, code_only=False):
         """Use indentation to render this segment and it's children as a string."""
@@ -840,7 +840,7 @@ class BaseSegment:
     def get_child(self, seg_type):
         """Retrieve the first of the children of this segment with matching type."""
         for seg in self.segments:
-            if seg.type == seg_type:
+            if seg.is_type(seg_type):
                 return seg
         return None
 
@@ -848,7 +848,7 @@ class BaseSegment:
         """Retrieve the all of the children of this segment with matching type."""
         buff = []
         for seg in self.segments:
-            if seg.type == seg_type:
+            if seg.is_type(seg_type):
                 buff.append(seg)
         return buff
 
@@ -860,9 +860,9 @@ class BaseSegment:
                 the type of elements to look for.
         """
         # Check this segment
-        if isinstance(seg_type, str) and self.type == seg_type:
+        if isinstance(seg_type, str) and self.is_type(seg_type):
             yield self
-        elif isinstance(seg_type, tuple) and self.type in seg_type:
+        elif isinstance(seg_type, tuple) and self.is_type(*seg_type):
             yield self
         # Recurse
         for seg in self.segments:

--- a/src/sqlfluff/core/parser/segments_base.py
+++ b/src/sqlfluff/core/parser/segments_base.py
@@ -73,6 +73,21 @@ class BaseSegment:
     trim_chars = None
     trim_start = None
 
+    @classmethod
+    def is_type(cls, *reference_types):
+        """Is this segment (or it's parent) of the given type."""
+        # Do we match on the type of _this_ class.
+        if cls.type in reference_types:
+            return True
+        # Have we reached the bottom?
+        elif cls.type == "base":
+            return False
+        # If not, check parent classes.
+        else:
+            return any(
+                base_class.is_type(*reference_types) for base_class in cls.__bases__
+            )
+
     @property
     def name(self):
         """The name of this segment.

--- a/src/sqlfluff/core/parser/segments_base.py
+++ b/src/sqlfluff/core/parser/segments_base.py
@@ -74,10 +74,10 @@ class BaseSegment:
     trim_start = None
 
     @classmethod
-    def is_type(cls, *reference_types):
+    def is_type(cls, *seg_type):
         """Is this segment (or it's parent) of the given type."""
         # Do we match on the type of _this_ class.
-        if cls.type in reference_types:
+        if cls.type in seg_type:
             return True
         # Have we reached the bottom?
         elif cls.type == "base":
@@ -85,7 +85,7 @@ class BaseSegment:
         # If not, check parent classes.
         else:
             return any(
-                base_class.is_type(*reference_types) for base_class in cls.__bases__
+                base_class.is_type(*seg_type) for base_class in cls.__bases__
             )
 
     @property
@@ -837,18 +837,18 @@ class BaseSegment:
         # Create a new version of this class with the new details
         return self.__class__(segments=tuple(seg_buffer), pos_marker=self.pos_marker)
 
-    def get_child(self, seg_type):
+    def get_child(self, *seg_type):
         """Retrieve the first of the children of this segment with matching type."""
         for seg in self.segments:
-            if seg.is_type(seg_type):
+            if seg.is_type(*seg_type):
                 return seg
         return None
 
-    def get_children(self, seg_type):
+    def get_children(self, *seg_type):
         """Retrieve the all of the children of this segment with matching type."""
         buff = []
         for seg in self.segments:
-            if seg.is_type(seg_type):
+            if seg.is_type(*seg_type):
                 buff.append(seg)
         return buff
 

--- a/src/sqlfluff/core/parser/segments_base.py
+++ b/src/sqlfluff/core/parser/segments_base.py
@@ -852,21 +852,19 @@ class BaseSegment:
                 buff.append(seg)
         return buff
 
-    def recursive_crawl(self, seg_type):
+    def recursive_crawl(self, *seg_type):
         """Recursively crawl for segments of a given type.
 
         Args:
-            seg_type: :obj:`str` or :obj:`tuple` of :obj:`str`: which specifies
-                the type of elements to look for.
+            seg_type: :obj:`str`: one or more type of segment
+                to look for.
         """
         # Check this segment
-        if isinstance(seg_type, str) and self.is_type(seg_type):
-            yield self
-        elif isinstance(seg_type, tuple) and self.is_type(*seg_type):
+        if self.is_type(*seg_type):
             yield self
         # Recurse
         for seg in self.segments:
-            yield from seg.recursive_crawl(seg_type=seg_type)
+            yield from seg.recursive_crawl(*seg_type)
 
     def path_to(self, other):
         """Given a segment which is assumed within self, get the intermediate segments.

--- a/src/sqlfluff/core/parser/segments_base.py
+++ b/src/sqlfluff/core/parser/segments_base.py
@@ -84,9 +84,7 @@ class BaseSegment:
             return False
         # If not, check parent classes.
         else:
-            return any(
-                base_class.is_type(*seg_type) for base_class in cls.__bases__
-            )
+            return any(base_class.is_type(*seg_type) for base_class in cls.__bases__)
 
     @property
     def name(self):

--- a/src/sqlfluff/core/parser/segments_common.py
+++ b/src/sqlfluff/core/parser/segments_common.py
@@ -18,16 +18,21 @@ from .match_logging import parse_match_logging
 from .match_wrapper import match_wrapper
 
 
-class KeywordSegment(RawSegment):
+class _ProtoKeywordSegment(RawSegment):
     """A segment used for matching single words or entities.
 
-    The Keyword Segment is a bit special, because while it
+    The _ProtoKeywordSegment Segment is a bit special, because while it
     can be instantiated directly, we mostly generate them on the
     fly for convenience. The `make` method is defined on RawSegment
     instead of here, but can be used here too.
+
+    This is distinct from KeywordSegment so that we can inherit
+    from this class (which mostly provides common functionality)
+    without inheriting the type `keyword` which rules and modules
+    may depend on later.
     """
 
-    type = "keyword"
+    type = "_proto_keyword"
     _is_code = True
     _template = "<unset>"
     _case_sensitive = False
@@ -92,11 +97,33 @@ class KeywordSegment(RawSegment):
         return cls._template
 
 
-class ReSegment(KeywordSegment):
+class KeywordSegment(_ProtoKeywordSegment):
+    """A segment used for matching single words.
+
+    We rename the segment class here so that decendents of
+    _ProtoKeywordSegment can use the same functionality
+    but don't end up being labelled as a `keyword` later.
+    """
+
+    type = "keyword"
+
+
+class SymbolSegment(_ProtoKeywordSegment):
+    """A segment used for matching single entities which aren't keywords.
+
+    We rename the segment class here so that decendents of
+    _ProtoKeywordSegment can use the same functionality
+    but don't end up being labelled as a `keyword` later.
+    """
+
+    type = "symbol"
+
+
+class ReSegment(_ProtoKeywordSegment):
     """A more flexible matching segment which uses of regexes.
 
-    This is more flexible that the `KeywordSegment` but also more complicated
-    and so the `KeywordSegment` should be used instead wherever possible.
+    This is more flexible that the `_ProtoKeywordSegment` but also more complicated
+    and so the `_ProtoKeywordSegment` should be used instead wherever possible.
     """
 
     _anti_template = None
@@ -164,7 +191,7 @@ class ReSegment(KeywordSegment):
         return cls.type
 
 
-class NamedSegment(KeywordSegment):
+class NamedSegment(_ProtoKeywordSegment):
     """A segment which matches based on the `name` property of segments.
 
     Useful for matching quoted segments, or anything else which
@@ -324,7 +351,7 @@ class Indent(RawSegment):
                     cls, kwargs
                 )
             )
-        # Sorcery (but less to than on KeywordSegment)
+        # Sorcery (but less to than on _ProtoKeywordSegment)
         return type(cls.__name__, (cls,), dict(_config_rules=kwargs))
 
     @classmethod

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -257,7 +257,7 @@ class BaseCrawler:
 
         # First, check whether we're looking at an unparsable and whether
         # this rule will still operate on that.
-        if not self._works_on_unparsable and segment.type == "unparsable":
+        if not self._works_on_unparsable and segment.is_type("unparsable"):
             # Abort here if it doesn't. Otherwise we'll get odd results.
             return vs, raw_stack, [], memory
 

--- a/src/sqlfluff/core/rules/std.py
+++ b/src/sqlfluff/core/rules/std.py
@@ -46,15 +46,15 @@ class Rule_L001(BaseCrawler):
         """
         # We only trigger on newlines
         if (
-            segment.type == "newline"
+            segment.is_type("newline")
             and len(raw_stack) > 0
-            and raw_stack[-1].type == "whitespace"
+            and raw_stack[-1].is_type("whitespace")
         ):
             # If we find a newline, which is preceeded by whitespace, then bad
             deletions = []
             idx = -1
             while True:
-                if raw_stack[idx].type == "whitespace":
+                if raw_stack[idx].is_type("whitespace"):
                     deletions.append(raw_stack[idx])
                     idx -= 1
                 else:
@@ -118,14 +118,14 @@ class Rule_L002(BaseCrawler):
                 ],
             )
 
-        if segment.type == "whitespace":
+        if segment.is_type("whitespace"):
             if " " in segment.raw and "\t" in segment.raw:
-                if len(raw_stack) == 0 or raw_stack[-1].type == "newline":
+                if len(raw_stack) == 0 or raw_stack[-1].is_type("newline"):
                     # We've got a single whitespace at the beginning of a line.
                     # It's got a mix of spaces and tabs. Replace each tab with
                     # a multiple of spaces
                     return construct_response()
-                elif raw_stack[-1].type == "whitespace":
+                elif raw_stack[-1].is_type("whitespace"):
                     # It's preceeded by more whitespace!
                     # We shouldn't worry about correcting those
                     # segments, because those will be caught themselves, but we
@@ -134,13 +134,13 @@ class Rule_L002(BaseCrawler):
                     while True:
                         # pop something off the end
                         seg = buff.pop()
-                        if seg.type == "whitespace":
+                        if seg.is_type("whitespace"):
                             if len(buff) == 0:
                                 # Found start of file
                                 return construct_response()
                             else:
                                 continue
-                        elif seg.type == "newline":
+                        elif seg.is_type("newline"):
                             # we're at the start of a line
                             return construct_response()
                         else:
@@ -222,7 +222,7 @@ class Rule_L003(BaseCrawler):
 
         for elem in raw_stack:
             line_buffer.append(elem)
-            if elem.type == "newline":
+            if elem.is_type("newline"):
                 result_buffer[line_no] = {
                     "line_no": line_no,
                     # Using slicing to copy line_buffer here to be py2 compliant
@@ -254,7 +254,7 @@ class Rule_L003(BaseCrawler):
                         clean_indent = True
                     break
             elif in_indent:
-                if elem.type == "whitespace":
+                if elem.is_type("whitespace"):
                     indent_buffer.append(elem)
                 elif elem.is_meta and elem.indent_val != 0:
                     indent_balance += elem.indent_val
@@ -369,12 +369,12 @@ class Rule_L003(BaseCrawler):
                 "comment_lines": [],
             }
 
-        if segment.type == "newline":
+        if segment.is_type("newline"):
             memory["in_indent"] = True
             # We're not going to flag on empty lines so we can safely proceed
             return LintResult(memory=memory)
         elif memory["in_indent"]:
-            if segment.type == "whitespace":
+            if segment.is_type("whitespace"):
                 # it's whitespace, carry on
                 return LintResult(memory=memory)
             elif segment.segments or segment.is_meta:
@@ -577,7 +577,7 @@ class Rule_L003(BaseCrawler):
                             b_idx += 1
                             continue
                         else:
-                            if elem.type in ["end_bracket", "end_square_bracket"]:
+                            if elem.is_type("end_bracket", "end_square_bracket"):
                                 b_idx += 1
                                 b_num += 1
                                 continue
@@ -666,7 +666,7 @@ class Rule_L003(BaseCrawler):
                     # Find the anchor first.
                     anchor = None
                     for seg in prev_line["line_buffer"]:
-                        if seg.type == "comment":
+                        if seg.is_type("comment"):
                             anchor = seg
                             break
                     # Check we found a comment, bail out if not.
@@ -734,8 +734,8 @@ class Rule_L004(BaseCrawler):
 
         """
         indents_seen = memory.get("indents_seen", set())
-        if segment.type == "whitespace":
-            if len(raw_stack) == 0 or raw_stack[-1].type == "newline":
+        if segment.is_type("whitespace"):
+            if len(raw_stack) == 0 or raw_stack[-1].is_type("newline"):
                 indents_here = set(segment.raw)
                 indents_union = indents_here | indents_seen
                 memory["indents_seen"] = indents_union
@@ -785,8 +785,8 @@ class Rule_L005(BaseCrawler):
         if len(raw_stack) >= 1:
             cm1 = raw_stack[-1]
             if (
-                segment.type == "comma"
-                and cm1.type == "whitespace"
+                segment.is_type("comma")
+                and cm1.is_type("whitespace")
                 and cm1.pos_marker.line_pos > 1
             ):
                 anchor = cm1
@@ -847,7 +847,7 @@ class Rule_L006(BaseCrawler):
                     )
                 )
             elif len(segments_since_code) > 1 or any(
-                elem.type == "newline" for elem in segments_since_code
+                elem.is_type("newline") for elem in segments_since_code
             ):
                 # TODO: This is a case we should deal with, but there are probably
                 # some cases that SHOULDNT apply here (like comments and newlines)
@@ -880,10 +880,10 @@ class Rule_L006(BaseCrawler):
         description = None
 
         # The parent stack tells us whether we're in an expression or not.
-        if parent_stack and parent_stack[-1].type == "expression":
+        if parent_stack and parent_stack[-1].is_type("expression"):
             if segment.is_code:
                 # This is code, what kind?
-                if segment.type in ["binary_operator", "comparison_operator"]:
+                if segment.is_type("binary_operator", "comparison_operator"):
                     # It's an operator, we can evaluate whitespace before it.
                     anchor, fixes = _handle_previous_segments(
                         memory["since_code"],
@@ -896,10 +896,10 @@ class Rule_L006(BaseCrawler):
                 else:
                     # It's not an operator, we can evaluate what happened after an
                     # operator if that's the last code we saw.
-                    if memory["last_code"] and memory["last_code"].type in [
+                    if memory["last_code"] and memory["last_code"].is_type(
                         "binary_operator",
                         "comparison_operator",
-                    ]:
+                    ):
                         # Evaluate whitespace AFTER the operator
                         anchor, fixes = _handle_previous_segments(
                             memory["since_code"],
@@ -974,16 +974,16 @@ class Rule_L007(BaseCrawler):
         anchor = None
 
         # The parent stack tells us whether we're in an expression or not.
-        if parent_stack and parent_stack[-1].type == "expression":
+        if parent_stack and parent_stack[-1].is_type("expression"):
             if segment.is_code:
                 # This is code, what kind?
-                if segment.type in ["binary_operator", "comparison_operator"]:
+                if segment.is_type("binary_operator", "comparison_operator"):
                     # We only trigger if the last was an operator, not if this is.
                     pass
-                elif memory["last_code"] and memory["last_code"].type in [
+                elif memory["last_code"] and memory["last_code"].is_type(
                     "binary_operator",
                     "comparison_operator",
-                ]:
+                ):
                     # It's not an operator, but the last code was. Now check to see
                     # there is a newline between us and the last operator.
                     for s in memory["since_code"]:
@@ -1269,8 +1269,8 @@ class Rule_L011(BaseCrawler):
         The use of `raw_stack` is just for working out how much whitespace to add.
 
         """
-        if segment.type == "alias_expression":
-            if parent_stack[-1].type in self._target_elems:
+        if segment.is_type("alias_expression"):
+            if parent_stack[-1].is_type(*self._target_elems):
                 if not any(e.name.lower() == "as" for e in segment.segments):
                     insert_buff = []
                     insert_str = ""
@@ -1357,8 +1357,8 @@ class Rule_L013(BaseCrawler):
         elements there are.
 
         """
-        if segment.type == "select_target_element":
-            if not any(e.type == "alias_expression" for e in segment.segments):
+        if segment.is_type("select_target_element"):
+            if not any(e.is_type("alias_expression") for e in segment.segments):
                 types = {e.type for e in segment.segments if e.name != "star"}
                 unallowed_types = types - {
                     "whitespace",
@@ -1374,7 +1374,7 @@ class Rule_L013(BaseCrawler):
                         # statement. If this is the only one, then we won't
                         # report an error.
                         num_elements = sum(
-                            e.type == "select_target_element"
+                            e.is_type("select_target_element")
                             for e in parent_stack[-1].segments
                         )
                         if num_elements > 1:
@@ -1543,14 +1543,14 @@ class Rule_L016(Rule_L003):
 
                     # NOTE: Deal with commas and binary operators differently here.
                     # Maybe only deal with commas to start with?
-                    if any(seg.type == "binary_operator" for seg in self.segments):
+                    if any(seg.is_type("binary_operator") for seg in self.segments):
                         raise NotImplementedError(
                             "Don't know how to deal with binary operators here yet!!"
                         )
 
                     # Remove any existing whitespace
                     for elem in self.segments:
-                        if not elem.is_meta and elem.type == "whitespace":
+                        if not elem.is_meta and elem.is_type("whitespace"):
                             fixes.append(LintFix("delete", elem))
 
                     # Create a newline and a similar indent
@@ -1600,7 +1600,7 @@ class Rule_L016(Rule_L003):
 
         for seg in segments:
             if indent_section is None:
-                if seg.type == "whitespace" or seg.is_meta:
+                if seg.is_type("whitespace") or seg.is_meta:
                     whitespace_buff += (seg,)
                 else:
                     indent_section = Section(
@@ -1611,7 +1611,7 @@ class Rule_L016(Rule_L003):
                     whitespace_buff = ()
                     segment_buff = (seg,)
             else:
-                if seg.type == "whitespace" or seg.is_meta:
+                if seg.is_type("whitespace") or seg.is_meta:
                     whitespace_buff += (seg,)
                     if seg.is_meta:
                         indent_impulse += seg.indent_val
@@ -1646,7 +1646,7 @@ class Rule_L016(Rule_L003):
                     # Did we think we were in a pause?
                     # TODO: Renable binary operator breaks some time in future.
                     if is_pause:
-                        if seg.name == "comma":  # or seg.type == 'binary_operator'
+                        if seg.name == "comma":  # or seg.is_type('binary_operator')
                             # Having a double comma/operator should be impossible
                             # but let's deal with that case regardless.
                             segment_buff += whitespace_buff + (seg,)
@@ -1667,7 +1667,7 @@ class Rule_L016(Rule_L003):
                             is_pause = False
                     else:
                         # We're not in a pause (or not in a pause yet)
-                        if seg.name == "comma":  # or seg.type == 'binary_operator'
+                        if seg.name == "comma":  # or seg.is_type('binary_operator')
                             if segment_buff:
                                 # End the previous section, start a comma/operator.
                                 # Any whitespace is added to the segment
@@ -1909,10 +1909,10 @@ class Rule_L017(BaseCrawler):
         function name before brackets
         """
         # We only trigger on start_bracket (open parenthesis)
-        if segment.type == "function":
+        if segment.is_type("function"):
             # Look for the function name
             for fname_idx, seg in enumerate(segment.segments):
-                if seg.type == "function_name":
+                if seg.is_type("function_name"):
                     break
             else:
                 # This shouldn't happen, but let's not worry
@@ -1981,7 +1981,7 @@ class Rule_L018(BaseCrawler):
         Look for a with clause and evaluate the position of closing brackets.
         """
         # We only trigger on start_bracket (open parenthesis)
-        if segment.type == "with_compound_statement":
+        if segment.is_type("with_compound_statement"):
             raw_stack_buff = list(raw_stack)
             # Look for the with keyword
             for seg in segment.segments:
@@ -1993,7 +1993,7 @@ class Rule_L018(BaseCrawler):
             else:
                 # This *could* happen if the with statement is unparsable,
                 # in which case then the user will have to fix that first.
-                if any(s.type == "unparsable" for s in segment.segments):
+                if any(s.is_type("unparsable") for s in segment.segments):
                     return LintResult()
                 # If it's parsable but we still didn't find a with, then
                 # we should raise that.
@@ -2003,7 +2003,7 @@ class Rule_L018(BaseCrawler):
                 seg_buff = []
                 # Get any segments running up to the WITH
                 for elem in reversed(segs):
-                    if elem.type == "newline":
+                    if elem.is_type("newline"):
                         break
                     elif elem.is_meta:
                         continue
@@ -2055,7 +2055,7 @@ class Rule_L018(BaseCrawler):
                                 and elem.pos_marker.line_pos < seg.pos_marker.line_pos
                             ]
                             if all(
-                                elem.type == "whitespace" for elem in prev_segs_on_line
+                                elem.is_type("whitespace") for elem in prev_segs_on_line
                             ):
                                 # We can move it back, it's all whitespace
                                 fixes = [
@@ -2144,7 +2144,7 @@ class Rule_L019(BaseCrawler):
         while True:
             if -idx > len(raw_stack):
                 return None
-            if raw_stack[idx].is_code or raw_stack[idx].type == "newline":
+            if raw_stack[idx].is_code or raw_stack[idx].is_type("newline"):
                 return raw_stack[idx]
             idx -= 1
 
@@ -2157,19 +2157,19 @@ class Rule_L019(BaseCrawler):
         """
         if len(raw_stack) >= 1:
             if self.comma_style == "leading":
-                if segment.type == "newline":
+                if segment.is_type("newline"):
                     # work back and find the last code segment, was it a comma?
                     last_seg = self._last_code_seg(raw_stack)
-                    if last_seg.type == "comma":
+                    if last_seg.is_type("comma"):
                         return LintResult(
                             anchor=last_seg,
                             description="Found trailing comma. Expected only leading.",
                         )
             elif self.comma_style == "trailing":
-                if segment.type == "comma":
+                if segment.is_type("comma"):
                     # work back and find the last interesting thing, is the comma the first element?
                     last_seg = self._last_code_seg(raw_stack)
-                    if last_seg.type == "newline":
+                    if last_seg.is_type("newline"):
                         return LintResult(
                             anchor=segment,
                             description="Found leading comma. Expected only trailing.",
@@ -2226,7 +2226,7 @@ class Rule_L020(BaseCrawler):
         Subclasses of this rule should override the
         `_lint_references_and_aliases` method.
         """
-        if segment.type == "select_statement":
+        if segment.is_type("select_statement"):
             aliases = self._get_aliases_from_select(segment)
             if not aliases:
                 return None
@@ -2251,7 +2251,7 @@ class Rule_L020(BaseCrawler):
                 ref_path = segment.path_to(ref)
                 # is it in a subselect? i.e. a select which isn't this one.
                 if any(
-                    seg.type == "select_statement" and seg is not segment
+                    seg.is_type("select_statement") and seg is not segment
                     for seg in ref_path
                 ):
                     reference_buffer.remove(ref)
@@ -2260,7 +2260,7 @@ class Rule_L020(BaseCrawler):
             col_aliases = []
             for col_seg in list(sc.recursive_crawl("alias_expression")):
                 for seg in col_seg.segments:
-                    if seg.type == "identifier":
+                    if seg.is_type("identifier"):
                         col_aliases.append(seg.raw)
 
             # Get any columns referred to in a using clause, and extract anything
@@ -2272,18 +2272,18 @@ class Rule_L020(BaseCrawler):
                 seen_using = False
                 seen_on = False
                 for seg in join_clause.segments:
-                    if seg.type == "keyword" and seg.name == "USING":
+                    if seg.is_type("keyword") and seg.name == "USING":
                         seen_using = True
-                    elif seg.type == "keyword" and seg.name == "ON":
+                    elif seg.is_type("keyword") and seg.name == "ON":
                         seen_on = True
-                    elif seen_using and seg.type == "start_bracket":
+                    elif seen_using and seg.is_type("start_bracket"):
                         in_using_brackets = True
-                    elif seen_using and seg.type == "end_bracket":
+                    elif seen_using and seg.is_type("end_bracket"):
                         in_using_brackets = False
                         seen_using = False
-                    elif in_using_brackets and seg.type == "identifier":
+                    elif in_using_brackets and seg.is_type("identifier"):
                         using_cols.append(seg.raw)
-                    elif seen_on and seg.type == "expression":
+                    elif seen_on and seg.is_type("expression"):
                         # Deal with expressions
                         reference_buffer += list(
                             seg.recursive_crawl("object_reference")
@@ -2292,7 +2292,7 @@ class Rule_L020(BaseCrawler):
             # Work out if we have a parent select function
             parent_select = None
             for seg in reversed(parent_stack):
-                if seg.type == "select_statement":
+                if seg.is_type("select_statement"):
                     parent_select = seg
                     break
 
@@ -2330,7 +2330,7 @@ class Rule_L021(BaseCrawler):
 
     def _eval(self, segment, **kwargs):
         """Ambiguous use of DISTINCT in select statement with GROUP BY."""
-        if segment.type == "select_statement":
+        if segment.is_type("select_statement"):
             # Do we have a group by clause
             group_clause = segment.get_child("groupby_clause")
             if not group_clause:
@@ -2381,14 +2381,14 @@ class Rule_L022(BaseCrawler):
     def _eval(self, segment, **kwargs):
         """Blank line expected but not found after CTE definition."""
         error_buffer = []
-        if segment.type == "with_compound_statement":
+        if segment.is_type("with_compound_statement"):
             # First we need to find all the commas, the end brackets, the
             # things that come after that and the blank lines in between.
 
             # Find all the closing brackets. They are our anchor points.
             bracket_indices = []
             for idx, seg in enumerate(segment.segments):
-                if seg.type == "end_bracket":
+                if seg.is_type("end_bracket"):
                     bracket_indices.append(idx)
 
             # Work through each point and deal with it individually
@@ -2413,21 +2413,21 @@ class Rule_L022(BaseCrawler):
 
                 # Work forward to map out the following segments.
                 while (
-                    forward_slice[seg_idx].type == "comma"
+                    forward_slice[seg_idx].is_type("comma")
                     or not forward_slice[seg_idx].is_code
                 ):
-                    if forward_slice[seg_idx].type == "newline":
+                    if forward_slice[seg_idx].is_type("newline"):
                         if line_blank:
                             # It's a blank line!
                             blank_lines += 1
                         line_blank = True
                         line_idx += 1
                         line_starts[line_idx] = seg_idx + 1
-                    elif forward_slice[seg_idx].type == "comment":
+                    elif forward_slice[seg_idx].is_type("comment"):
                         # Lines with comments aren't blank
                         line_blank = False
                         comment_lines.append(line_idx)
-                    elif forward_slice[seg_idx].type == "comma":
+                    elif forward_slice[seg_idx].is_type("comma"):
                         # Keep track of where the comma is.
                         # We'll evaluate it later.
                         comma_line_idx = line_idx
@@ -2477,7 +2477,7 @@ class Rule_L022(BaseCrawler):
                             fix_point = forward_slice[comma_seg_idx + 1]
                             # Optionally here, if the segment we've landed on is
                             # whitespace then we REPLACE it rather than inserting.
-                            if forward_slice[comma_seg_idx + 1].type == "whitespace":
+                            if forward_slice[comma_seg_idx + 1].is_type("whitespace"):
                                 fix_type = "edit"
                         elif self.comma_style == "leading":
                             # Add a blank line before the comma
@@ -2494,7 +2494,7 @@ class Rule_L022(BaseCrawler):
                                 # Detected an existing trailing comma or it's a final CTE,
                                 # OR the comma isn't leading or trailing.
                                 # If the preceeding segment is whitespace, replace it
-                                if forward_slice[seg_idx - 1].type == "whitespace":
+                                if forward_slice[seg_idx - 1].is_type("whitespace"):
                                     fix_point = forward_slice[seg_idx - 1]
                                     fix_type = "edit"
                                 else:
@@ -2569,7 +2569,7 @@ class Rule_L023(BaseCrawler):
     def _eval(self, segment, **kwargs):
         """Single whitespace expected in mother segment between pre and post segments."""
         error_buffer = []
-        if segment.type == self.expected_mother_segment_type:
+        if segment.is_type(self.expected_mother_segment_type):
             last_code = None
             mid_segs = []
             for seg in segment.segments:
@@ -2858,7 +2858,7 @@ class Rule_L028(Rule_L025):
         seen_ref_types = set()
         for r in references:
             # We skip any unqualified wildcard references (i.e. *). They shouldn't count.
-            if not r.is_qualified() and r.type == "wildcard_reference":
+            if not r.is_qualified() and r.is_type("wildcard_reference"):
                 continue
             this_ref_type = r.qualification()
             if self.single_table_references == "consistent":
@@ -2918,7 +2918,7 @@ class Rule_L029(BaseCrawler):
             # If self.only_aliases is true, we're a bit pickier here
             if self.only_aliases:
                 # Aliases are ok (either directly, or in column definitions or in with statements)
-                if parent_stack[-1].type in (
+                if parent_stack[-1].is_type(
                     "alias_expression",
                     "column_definition",
                     "with_compound_statement",
@@ -3008,7 +3008,7 @@ class Rule_L031(BaseCrawler):
         Find base table, table expressions in join, and other expressions in select clause
         and decide if it's needed to report them.
         """
-        if segment.type == "select_statement":
+        if segment.is_type("select_statement"):
             # A buffer for all table expressions in join conditions
             table_expressions_in_join = []
             expressions_in_join = []
@@ -3027,9 +3027,9 @@ class Rule_L031(BaseCrawler):
 
             for join_clause in fc.recursive_crawl("join_clause"):
                 for seg in join_clause.segments:
-                    if seg.type == "table_expression":
+                    if seg.is_type("table_expression"):
                         table_expressions_in_join.append(seg)
-                    elif seg.type == "expression":
+                    elif seg.is_type("expression"):
                         expressions_in_join.append(seg)
 
             return (
@@ -3131,9 +3131,9 @@ class Rule_L032(BaseCrawler):
 
     def _eval(self, segment, **kwargs):
         """Look for USING in a join clause."""
-        if segment.type == "join_clause":
+        if segment.is_type("join_clause"):
             for seg in segment.segments:
-                if seg.type == "keyword" and seg.name == "USING":
+                if seg.is_type("keyword") and seg.name == "USING":
                     return [
                         LintResult(
                             # Reference the element, not the string.

--- a/src/sqlfluff/core/rules/std.py
+++ b/src/sqlfluff/core/rules/std.py
@@ -1363,7 +1363,7 @@ class Rule_L013(BaseCrawler):
                 unallowed_types = types - {
                     "whitespace",
                     "newline",
-                    "object_reference",
+                    "column_reference",
                     "wildcard_expression",
                 }
                 if len(unallowed_types) > 0:

--- a/test/api/simple_test.py
+++ b/test/api/simple_test.py
@@ -93,3 +93,9 @@ def test__api__parse_string():
     # Check we can iterate objects within it
     keywords = [keyword.raw for keyword in parsed.recursive_crawl("keyword")]
     assert keywords == ["SeLEct", "as", "from"]
+    # Check we can get columns from it
+    col_refs = [col_ref.raw for col_ref in parsed.recursive_crawl("column_reference")]
+    assert col_refs == ["blah"]
+    # Check we can get table from it
+    tbl_refs = [tbl_ref.raw for tbl_ref in parsed.recursive_crawl("table_reference")]
+    assert tbl_refs == ["myTable"]

--- a/test/core/parser/segments_base_test.py
+++ b/test/core/parser/segments_base_test.py
@@ -42,6 +42,16 @@ def test__parser__base_segments_raw_init():
     RawSegment("foobar", fp)
 
 
+def test__parser__base_segments_type():
+    """Test the .is_type() method."""
+    assert BaseSegment.is_type("base")
+    assert not BaseSegment.is_type("foo")
+    assert not BaseSegment.is_type("foo", "bar")
+    assert DummySegment.is_type("dummy")
+    assert DummySegment.is_type("base")
+    assert DummySegment.is_type("base", "foo", "bar")
+
+
 def test__parser__base_segments_raw(raw_seg):
     """Test raw segments behave as expected."""
     # Check Segment Return

--- a/test/fixtures/parser/ansi/multi_statement_a_nc.yml
+++ b/test/fixtures/parser/ansi/multi_statement_a_nc.yml
@@ -18,7 +18,7 @@ file:
   - whitespace: '  '
   - comment: /*comment here*/
   - whitespace: ' '
-  - keyword: ;
+  - statement_terminator: ;
   - whitespace: '  '
   - comment: /*and here*/
   - whitespace: '  '
@@ -37,7 +37,7 @@ file:
           table_expression:
             object_reference:
               identifier: tbl2
-  - keyword: ;
+  - statement_terminator: ;
   - whitespace: '   '
   - comment: -- trailling ending comment
   - newline: "\n"

--- a/test/fixtures/parser/ansi/multi_statement_a_nc.yml
+++ b/test/fixtures/parser/ansi/multi_statement_a_nc.yml
@@ -6,14 +6,14 @@ file:
           keyword: select
           whitespace: ' '
           select_target_element:
-            object_reference:
+            column_reference:
               identifier: a
         whitespace: ' '
         from_clause:
           keyword: from
           whitespace: ' '
           table_expression:
-            object_reference:
+            table_reference:
               identifier: tbl1
   - whitespace: '  '
   - comment: /*comment here*/
@@ -28,14 +28,14 @@ file:
           keyword: select
           whitespace: ' '
           select_target_element:
-            object_reference:
+            column_reference:
               identifier: b
         whitespace: ' '
         from_clause:
           keyword: from
           whitespace: ' '
           table_expression:
-            object_reference:
+            table_reference:
               identifier: tbl2
   - statement_terminator: ;
   - whitespace: '   '

--- a/test/fixtures/parser/ansi/select_a.yml
+++ b/test/fixtures/parser/ansi/select_a.yml
@@ -5,20 +5,20 @@ file:
       select_clause:
       - keyword: select
       - select_target_element:
-          object_reference:
+          column_reference:
             identifier: a
       - comma: ','
       - select_target_element:
-          object_reference:
+          column_reference:
             identifier: b
       - comma: ','
       - select_target_element:
-          object_reference:
+          column_reference:
             identifier: c
       from_clause:
         keyword: from
         table_expression:
-          object_reference:
+          table_reference:
           - identifier: sch
           - dot: '.'
           - identifier: '"blah"'

--- a/test/fixtures/parser/ansi/select_e.yml
+++ b/test/fixtures/parser/ansi/select_e.yml
@@ -5,7 +5,7 @@ file:
           select_clause:
             keyword: SELECT
             select_target_element:
-              object_reference:
+              column_reference:
                 identifier: col_a
               alias_expression:
                 keyword: as
@@ -13,7 +13,7 @@ file:
           from_clause:
             keyword: FROM
             table_expression:
-              object_reference:
+              table_reference:
                 identifier: some_table
       - set_operator:
           keyword: UNION
@@ -21,7 +21,7 @@ file:
           select_clause:
             keyword: SELECT
             select_target_element:
-              object_reference:
+              column_reference:
                 identifier: col_b
               alias_expression:
                 keyword: as
@@ -29,7 +29,7 @@ file:
           from_clause:
             keyword: FROM
             table_expression:
-              object_reference:
+              table_reference:
                 identifier: another_table
       - set_operator:
         - keyword: UNION
@@ -38,7 +38,7 @@ file:
           select_clause:
             keyword: SELECT
             select_target_element:
-              object_reference:
+              column_reference:
                 identifier: col_c
               alias_expression:
                 keyword: as
@@ -46,7 +46,7 @@ file:
           from_clause:
             keyword: FROM
             table_expression:
-              object_reference:
+              table_reference:
                 identifier: this_other_table
       - set_operator:
           keyword: INTERSECT
@@ -54,7 +54,7 @@ file:
           select_clause:
             keyword: SELECT
             select_target_element:
-              object_reference:
+              column_reference:
                 identifier: col_d
               alias_expression:
                 keyword: as
@@ -62,5 +62,5 @@ file:
           from_clause:
             keyword: FROM
             table_expression:
-              object_reference:
+              table_reference:
                 identifier: the_last_table

--- a/test/fixtures/parser/ansi/select_simple_b.yml
+++ b/test/fixtures/parser/ansi/select_simple_b.yml
@@ -11,5 +11,5 @@ file:
       from_clause:
         keyword: from
         table_expression:
-          object_reference:
+          table_reference:
             identifier: blah

--- a/test/fixtures/parser/ansi/select_simple_e.yml
+++ b/test/fixtures/parser/ansi/select_simple_e.yml
@@ -6,7 +6,7 @@ file:
       - keyword: SELECT
       - select_target_element:
           expression:
-            object_reference:
+            column_reference:
               identifier: my_var
             cast_expression:
               casting_operator: '::'
@@ -29,5 +29,5 @@ file:
       from_clause:
         keyword: FROM
         table_expression:
-          object_reference:
+          table_reference:
             identifier: boo

--- a/test/fixtures/parser/ansi/select_simple_e_nc.yml
+++ b/test/fixtures/parser/ansi/select_simple_e_nc.yml
@@ -8,7 +8,7 @@ file:
                 - whitespace: '    '
                 - select_target_element:
                     expression:
-                        object_reference:
+                        column_reference:
                             identifier: my_var
                         cast_expression:
                             casting_operator: '::'
@@ -39,6 +39,6 @@ file:
                 keyword: FROM
                 whitespace: ' '
                 table_expression:
-                    object_reference:
+                    table_reference:
                         identifier: boo
     newline: "\n"

--- a/test/fixtures/parser/ansi/select_simple_j.yml
+++ b/test/fixtures/parser/ansi/select_simple_j.yml
@@ -1,27 +1,26 @@
-# Test that casting works as expected
 file:
   statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_target_element:
-          object_reference:
+          column_reference:
             identifier: count_correctly_substituted
       from_clause:
         - keyword: FROM
         - table_expression:
-            object_reference:
+            table_reference:
               identifier: correctly_substituted
         - join_clause:
           - keyword: CROSS
           - keyword: JOIN
           - table_expression:
-              object_reference:
+              table_reference:
                 identifier: needs_substitution
         - join_clause:
           - keyword: LEFT
           - keyword: OUTER
           - keyword: JOIN
           - table_expression:
-              object_reference:
+              table_reference:
                 identifier: some_other_table

--- a/test/fixtures/parser/ansi/select_with_a.yml
+++ b/test/fixtures/parser/ansi/select_with_a.yml
@@ -1,4 +1,3 @@
-# Possibly the simplest query
 file:
   statement:
     with_compound_statement:
@@ -10,22 +9,22 @@ file:
       - select_clause:
           keyword: select
           select_target_element:
-            object_reference:
+            column_reference:
               identifier: a
       - from_clause:
           keyword: from
           table_expression:
-            object_reference:
+            table_reference:
               identifier: tbla
     - end_bracket: )
     - select_statement:
       - select_clause:
           keyword: select
           select_target_element:
-            object_reference:
+            column_reference:
               identifier: a
       - from_clause:
           keyword: from
           table_expression:
-            object_reference:
+            table_reference:
               identifier: cte

--- a/test/fixtures/parser/snowflake/snowflake_pivot.yml
+++ b/test/fixtures/parser/snowflake/snowflake_pivot.yml
@@ -10,7 +10,7 @@ file:
       from_clause:
         keyword: FROM
         table_expression:
-          object_reference:
+          table_reference:
             identifier: my_tbl
         from_pivot_expression:
         - keyword: PIVOT
@@ -19,7 +19,7 @@ file:
             function_name: min
             start_bracket: (
             expression:
-              object_reference:
+              column_reference:
                 identifier: f_val
             end_bracket: )
         - keyword: FOR

--- a/test/fixtures/parser/snowflake/snowflake_semi_structured.yml
+++ b/test/fixtures/parser/snowflake/snowflake_semi_structured.yml
@@ -4,12 +4,12 @@ file:
       select_clause:
       - keyword: SELECT
       - select_target_element:
-          object_reference:
+          column_reference:
             identifier: ticket_id
       - comma: ','
       - select_target_element:
           expression:
-            object_reference:
+            column_reference:
               identifier: value
             snowflake_semi_structured_expression:
               colon: ':'
@@ -20,7 +20,7 @@ file:
       - comma: ','
       - select_target_element:
           expression:
-            object_reference:
+            column_reference:
               identifier: value
             snowflake_semi_structured_expression:
               colon: ':'
@@ -35,7 +35,7 @@ file:
       - comma: ','
       - select_target_element:
           expression:
-            object_reference:
+            column_reference:
               identifier: value
             snowflake_semi_structured_expression:
               colon: ':'
@@ -50,7 +50,7 @@ file:
       - comma: ','
       - select_target_element:
           expression:
-            object_reference:
+            column_reference:
               identifier: value
             snowflake_semi_structured_expression:
             - colon: ':'
@@ -67,7 +67,7 @@ file:
       - comma: ','
       - select_target_element:
           expression:
-            object_reference:
+            column_reference:
               identifier: value
             snowflake_semi_structured_expression:
             - colon: ':'
@@ -96,7 +96,7 @@ file:
       from_clause:
       - keyword: FROM
       - table_expression:
-          object_reference:
+          table_reference:
             identifier: raw_tickets
       - comma: ','
       - table_expression:
@@ -107,6 +107,6 @@ file:
             snowflake_keyword_expression:
               parameter: INPUT
               parameter_assigner: =>
-              object_reference:
+              column_reference:
                 identifier: custom_fields
             end_bracket: )

--- a/test/fixtures/parser/snowflake/snowflake_semi_structured.yml
+++ b/test/fixtures/parser/snowflake/snowflake_semi_structured.yml
@@ -12,7 +12,7 @@ file:
             object_reference:
               identifier: value
             snowflake_semi_structured_expression:
-              keyword: ':'
+              colon: ':'
               semi_structured_element: value
           alias_expression:
             keyword: AS
@@ -23,7 +23,7 @@ file:
             object_reference:
               identifier: value
             snowflake_semi_structured_expression:
-              keyword: ':'
+              colon: ':'
               semi_structured_element: id
             cast_expression:
               casting_operator: '::'
@@ -38,7 +38,7 @@ file:
             object_reference:
               identifier: value
             snowflake_semi_structured_expression:
-              keyword: ':'
+              colon: ':'
               semi_structured_element: value
             cast_expression:
               casting_operator: '::'
@@ -53,7 +53,7 @@ file:
             object_reference:
               identifier: value
             snowflake_semi_structured_expression:
-            - keyword: ':'
+            - colon: ':'
             - semi_structured_element: thing
             - array_accessor:
                 start_square_bracket: '['
@@ -70,7 +70,7 @@ file:
             object_reference:
               identifier: value
             snowflake_semi_structured_expression:
-            - keyword: ':'
+            - colon: ':'
             - semi_structured_element: thing
             - array_accessor:
                 start_square_bracket: '['

--- a/test/fixtures/templater/jinja_a/jinja.yml
+++ b/test/fixtures/templater/jinja_a/jinja.yml
@@ -8,7 +8,7 @@ file:
       from_clause:
         keyword: FROM
         table_expression:
-          object_reference:
+          table_reference:
           - identifier: sch1
           - dot: '.'
           - identifier: tbl2

--- a/test/fixtures/templater/jinja_b/jinja.yml
+++ b/test/fixtures/templater/jinja_b/jinja.yml
@@ -36,6 +36,6 @@ file:
         keyword: FROM
         whitespace: ' '
         table_expression:
-          object_reference:
+          table_reference:
           - identifier: some_table
   newline: "\n"

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins.yml
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins.yml
@@ -4,14 +4,14 @@ file:
       select_clause:
       - keyword: SELECT
       - select_target_element:
-          object_reference:
+          column_reference:
             identifier: col1
       - comma: ','
       - select_target_element:
-          object_reference:
+          column_reference:
             identifier: col2
       from_clause:
         keyword: FROM
         table_expression:
-          object_reference:
+          table_reference:
             identifier: my_table

--- a/test/fixtures/templater/jinja_f/jinja.yml
+++ b/test/fixtures/templater/jinja_f/jinja.yml
@@ -4,7 +4,7 @@ file:
     - select_clause:
       - keyword: SELECT
       - select_target_element:
-          object_reference:
+          column_reference:
             identifier: job_id
       - comma: ','
       - select_target_element:
@@ -16,7 +16,7 @@ file:
               - keyword: CASE
               - keyword: WHEN
               - expression:
-                - object_reference:
+                - column_reference:
                     identifier: word
                 - comparison_operator: '='
                 - literal: '''shop'''
@@ -41,7 +41,7 @@ file:
               - keyword: CASE
               - keyword: WHEN
               - expression:
-                - object_reference:
+                - column_reference:
                     identifier: word
                 - comparison_operator: '='
                 - literal: '''products'''
@@ -66,7 +66,7 @@ file:
               - keyword: CASE
               - keyword: WHEN
               - expression:
-                - object_reference:
+                - column_reference:
                     identifier: word
                 - comparison_operator: '='
                 - literal: '''code'''
@@ -87,7 +87,7 @@ file:
           - function_name: safe_cast
           - start_bracket: (
           - expression:
-              object_reference:
+              column_reference:
                 identifier: vector_array
               array_accessor:
                 start_square_bracket: '['
@@ -112,7 +112,7 @@ file:
           - function_name: safe_cast
           - start_bracket: (
           - expression:
-              object_reference:
+              column_reference:
                 identifier: vector_array
               array_accessor:
                 start_square_bracket: '['
@@ -134,7 +134,7 @@ file:
     - from_clause:
         keyword: FROM
         table_expression:
-          object_reference:
+          table_reference:
             identifier: tbl
     - limit_clause:
         keyword: LIMIT

--- a/test/fixtures/templater/jinja_g_macros/jinja.yml
+++ b/test/fixtures/templater/jinja_g_macros/jinja.yml
@@ -8,13 +8,13 @@ file:
         - keyword: 'on'
         - start_bracket: (
         - expression:
-            object_reference:
+            column_reference:
               identifier: id
         - end_bracket: )
       - select_target_element:
           expression:
           - start_bracket: (
-          - object_reference:
+          - column_reference:
               identifier: json
           - binary_operator: ->
           - literal: "'type'"
@@ -32,7 +32,7 @@ file:
       - select_target_element:
           expression:
           - start_bracket: (
-          - object_reference:
+          - column_reference:
               identifier: json
           - binary_operator: ->
           - literal: "'type'"
@@ -56,7 +56,7 @@ file:
             from_clause:
               keyword: from
               table_expression:
-                object_reference:
+                table_reference:
                   identifier: sb_route_events
                 alias_expression:
                   keyword: as
@@ -65,7 +65,7 @@ file:
               keyword: where
               expression:
               - start_bracket: (
-              - object_reference:
+              - column_reference:
                 - identifier: s
                 - dot: .
                 - identifier: match_id
@@ -78,12 +78,12 @@ file:
                     select_clause_modifier:
                       keyword: distinct
                     select_target_element:
-                      object_reference:
+                      column_reference:
                         identifier: match_id
                   from_clause:
                     keyword: from
                     table_expression:
-                      object_reference:
+                      table_reference:
                         identifier: this_model
               - end_bracket: )
               - end_bracket: )


### PR DESCRIPTION
This builds on #501 and relates to #289  . That PR should be merged and reviewed first. Until then, this is to be considered *draft*.

- Added the `.istype()` method on segments to more intelligently deal with type matching in rules when inheritance is at play.
- Split `ObjectReference` into `ColumnReference` and `TableReference` for more useful API access to the underlying structure.
- `KeywordSegment` and the new `SymbolSegment` both now inherit from `_ProtoKeywordSegment` which allows symbols to match in a very similar way to keywords without later appearing with the `type` of `keyword`.

This is quite a backward incompatible change if anyone depends on the internal parse structure of queries (hence the updates to so many of the test cases). I'm glad this coincides with an upcoming major release!