### PR TITLE
Clearout to support refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `BaseSegment.grammar`, `BaseSegment._match_grammar()` and
   `BaseSegment._parse_grammar()` instead preferring references directly
   to `BaseSegment.match_grammar` and `BaseSegment.parse_grammar`.
+- Removed `EmptySegmentGrammar` and replaced with better non-code handling
+  in the `FileSegment` itself.
 
 ## [0.3.6] - 2020-09-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `EmptySegmentGrammar` and replaced with better non-code handling
   in the `FileSegment` itself.
 - Remove the `ContainsOnly` grammar as it remained only as an anti-pattern.
+- Removed the `expected_string()` functionality from grammars and segments
+  as it was poorly supported.
 
 ## [0.3.6] - 2020-09-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to `BaseSegment.match_grammar` and `BaseSegment.parse_grammar`.
 - Removed `EmptySegmentGrammar` and replaced with better non-code handling
   in the `FileSegment` itself.
+- Remove the `ContainsOnly` grammar as it remained only as an anti-pattern.
 
 ## [0.3.6] - 2020-09-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Internally added an `EphemeralSegment` to aid with parsing efficiency
   without altering the end structure of the query.
 
+### Removed
+- Removed `BaseSegment.grammar`, `BaseSegment._match_grammar()` and
+  `BaseSegment._parse_grammar()` instead preferring references directly
+  to `BaseSegment.match_grammar` and `BaseSegment.parse_grammar`.
+
 ## [0.3.6] - 2020-09-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove the `ContainsOnly` grammar as it remained only as an anti-pattern.
 - Removed the `expected_string()` functionality from grammars and segments
   as it was poorly supported.
+- Removed `BaseSegment.as_optional()` as now this functionality happens
+  mostly in grammars (including `Ref`).
 
 ## [0.3.6] - 2020-09-24
 

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -1297,7 +1297,7 @@ class EmptyStatementSegment(BaseSegment):
     """A placeholder for a statement containing nothing but whitespace and comments."""
 
     type = "empty_statement"
-    grammar = ContainsOnly("comment", "newline")
+    match_grammar = ContainsOnly("comment", "newline")
     # TODO: At some point - we should lint that these are only
     # allowed at the END - otherwise it's probably a parsing error
 

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -326,7 +326,7 @@ class ColumnExpressionSegment(BaseSegment):
 
     type = "column_expression"
     match_grammar = OneOf(
-        Ref("SingleIdentifierGrammar"), code_only=False
+        Ref("SingleIdentifierGrammar"), allow_gaps=False
     )  # QuotedIdentifierSegment
 
 
@@ -349,7 +349,7 @@ class ObjectReferenceSegment(BaseSegment):
             Ref("ColonSegment"),
             Ref("SemicolonSegment"),
         ),
-        code_only=False,
+        allow_gaps=False,
     )
 
     @staticmethod
@@ -437,7 +437,7 @@ class ShorthandCastSegment(BaseSegment):
 
     type = "cast_expression"
     match_grammar = Sequence(
-        Ref("CastOperatorSegment"), Ref("DatatypeSegment"), code_only=False
+        Ref("CastOperatorSegment"), Ref("DatatypeSegment"), allow_gaps=False
     )
 
 
@@ -455,7 +455,7 @@ class QualifiedNumericLiteralSegment(BaseSegment):
     match_grammar = Sequence(
         OneOf(Ref("PlusSegment"), Ref("MinusSegment")),
         Ref("NumericLiteralSegment"),
-        code_only=False,
+        allow_gaps=False,
     )
 
 
@@ -642,10 +642,10 @@ class WildcardIdentifierSegment(ObjectReferenceSegment):
     match_grammar = Sequence(
         # *, blah.*, blah.blah.*, etc.
         AnyNumberOf(
-            Sequence(Ref("SingleIdentifierGrammar"), Ref("DotSegment"), code_only=True)
+            Sequence(Ref("SingleIdentifierGrammar"), Ref("DotSegment"), allow_gaps=True)
         ),
         Ref("StarSegment"),
-        code_only=False,
+        allow_gaps=False,
     )
 
     def iter_raw_references(self):
@@ -1016,7 +1016,7 @@ ansi_dialect.add(
         ),
         Ref("Accessor_Grammar", optional=True),
         Ref("ShorthandCastSegment", optional=True),
-        code_only=False,
+        allow_gaps=False,
     ),
     Accessor_Grammar=AnyNumberOf(Ref("ArrayAccessorSegment")),
 )

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -20,7 +20,6 @@ from ..parser import (
     Sequence,
     GreedyUntil,
     StartsWith,
-    ContainsOnly,
     OneOf,
     Delimited,
     Bracketed,

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -1293,16 +1293,6 @@ class InsertStatementSegment(BaseSegment):
 
 
 @ansi_dialect.segment()
-class EmptyStatementSegment(BaseSegment):
-    """A placeholder for a statement containing nothing but whitespace and comments."""
-
-    type = "empty_statement"
-    match_grammar = ContainsOnly("comment", "newline")
-    # TODO: At some point - we should lint that these are only
-    # allowed at the END - otherwise it's probably a parsing error
-
-
-@ansi_dialect.segment()
 class TransactionStatementSegment(BaseSegment):
     """A `COMMIT` or `ROLLBACK` statement."""
 
@@ -1814,7 +1804,6 @@ class StatementSegment(BaseSegment):
     parse_grammar = OneOf(
         Ref("SelectableGrammar"),
         Ref("InsertStatementSegment"),
-        Ref("EmptyStatementSegment"),
         Ref("TransactionStatementSegment"),
         Ref("DropStatementSegment"),
         Ref("AccessStatementSegment"),

--- a/src/sqlfluff/core/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/core/dialects/dialect_snowflake.py
@@ -259,13 +259,13 @@ class SemiStructuredAccessorSegment(BaseSegment):
                 ),
                 Ref("ArrayAccessorSegment", optional=True),
                 # No extra whitespace
-                code_only=False,
+                allow_gaps=False,
             ),
             # No extra whitespace
-            code_only=False,
+            allow_gaps=False,
         ),
         # No extra whitespace
-        code_only=False,
+        allow_gaps=False,
     )
 
 

--- a/src/sqlfluff/core/dialects/dialect_teradata.py
+++ b/src/sqlfluff/core/dialects/dialect_teradata.py
@@ -540,7 +540,6 @@ class StatementSegment(BaseSegment):
     parse_grammar = OneOf(
         Ref("SelectableGrammar"),
         Ref("InsertStatementSegment"),
-        Ref("EmptyStatementSegment"),
         Ref("TransactionStatementSegment"),
         Ref("DropStatementSegment"),
         Ref("AccessStatementSegment"),

--- a/src/sqlfluff/core/parser/__init__.py
+++ b/src/sqlfluff/core/parser/__init__.py
@@ -17,7 +17,6 @@ from .grammar import (
     Sequence,
     GreedyUntil,
     StartsWith,
-    ContainsOnly,
     OneOf,
     Delimited,
     Bracketed,

--- a/src/sqlfluff/core/parser/segments_base.py
+++ b/src/sqlfluff/core/parser/segments_base.py
@@ -339,9 +339,7 @@ class BaseSegment:
                     + (
                         UnparsableSegment(
                             segments=segments,
-                            expected=self.parse_grammar.expected_string(
-                                dialect=parse_context.dialect
-                            ),
+                            expected=self.type,
                         ),  # NB: tuple
                     )
                     + post_nc
@@ -672,18 +670,6 @@ class BaseSegment:
     def is_raw(self):
         """Return True if this segment has no children."""
         return len(self.segments) == 0
-
-    @classmethod
-    def expected_string(cls, dialect=None, called_from=None):
-        """Return the expected string for this segment.
-
-        This is never going to be called on an _instance_
-        but rather on the class, as part of a grammar, and therefore
-        as part of the matching phase. So we use the match grammar.
-        """
-        return cls.match_grammar.expected_string(
-            dialect=dialect, called_from=called_from
-        )
 
     @classmethod
     def as_optional(cls):

--- a/src/sqlfluff/core/parser/segments_base.py
+++ b/src/sqlfluff/core/parser/segments_base.py
@@ -316,21 +316,6 @@ class BaseSegment:
         return elem
 
     @classmethod
-    def as_optional(cls):
-        """Construct a copy of this class, but with the optional flag set true.
-
-        Used in constructing grammars, will make an identical class
-        but with the optional argument set to true. Used in constructing
-        sequences.
-        """
-        # Now lets make the classname (it indicates the mother class for clarity)
-        classname = "Optional_{0}".format(cls.__name__)
-        # This is the magic, we generate a new class! SORCERY
-        newclass = type(classname, (cls,), dict(optional=True))
-        # Now we return that class in the abstract. NOT INSTANTIATED
-        return newclass
-
-    @classmethod
     @match_wrapper(v_level=4)
     def match(cls, segments, parse_context):
         """Match a list of segments against this segment.

--- a/src/sqlfluff/core/parser/segments_base.py
+++ b/src/sqlfluff/core/parser/segments_base.py
@@ -91,9 +91,9 @@ class BaseSegment:
     _func = None  # Available for use by subclasses (e.g. the LambdaSegment)
     is_meta = False
     # Are we able to have non-code at the start or end?
-    _can_start_end_non_code = False
+    can_start_end_non_code = False
     # Can we allow it to be empty? Usually used in combination
-    # with the _can_start_end_non_code.
+    # with the can_start_end_non_code.
     allow_empty = False
     # What should we trim off the ends to get to content
     trim_chars = None
@@ -277,7 +277,7 @@ class BaseSegment:
             # at the start or end of the segments. They should always in the middle,
             # or in the parent expression.
             segments = self.segments
-            if self._can_start_end_non_code:
+            if self.can_start_end_non_code:
                 pre_nc, segments, post_nc = trim_non_code(segments)
             else:
                 pre_nc = ()

--- a/src/sqlfluff/core/parser/segments_base.py
+++ b/src/sqlfluff/core/parser/segments_base.py
@@ -380,7 +380,7 @@ class BaseSegment:
             modifier="[META] " if self.is_meta else "",
             type=self.type + ":",
         )
-        preface = "{pos:17}|{padded_type:60}  {suffix}".format(
+        preface = "{pos:20}|{padded_type:60}  {suffix}".format(
             pos=str(self.pos_marker) if self.pos_marker else "-",
             padded_type=padded_type,
             suffix=self._suffix() or "",

--- a/src/sqlfluff/core/parser/segments_common.py
+++ b/src/sqlfluff/core/parser/segments_common.py
@@ -86,11 +86,6 @@ class KeywordSegment(RawSegment):
             )
         return MatchResult.from_unmatched(segments)
 
-    @classmethod
-    def expected_string(cls, dialect=None, called_from=None):
-        """Return the expected string for this segment."""
-        return cls._template
-
 
 class ReSegment(KeywordSegment):
     """A more flexible matching segment which uses of regexes.
@@ -158,11 +153,6 @@ class ReSegment(KeywordSegment):
                     return MatchResult(m, segments[1:])
         return MatchResult.from_unmatched(segments)
 
-    @classmethod
-    def expected_string(cls, dialect=None, called_from=None):
-        """Return the expected string for this segment."""
-        return cls.type
-
 
 class NamedSegment(KeywordSegment):
     """A segment which matches based on the `name` property of segments.
@@ -225,11 +215,6 @@ class NamedSegment(KeywordSegment):
             )
         return MatchResult.from_unmatched(segments)
 
-    @classmethod
-    def expected_string(cls, dialect=None, called_from=None):
-        """Return the expected string for this segment."""
-        return "[" + cls._template + "]"
-
 
 class LambdaSegment(BaseSegment):
     """A segment which when the given lambda is applied to it returns true.
@@ -269,11 +254,6 @@ class LambdaSegment(BaseSegment):
             else:
                 # Got buffer but no match
                 return MatchResult(matched_segs, seg_buff)
-
-    @classmethod
-    def expected_string(cls, dialect=None, called_from=None):
-        """Return the expected string for this segment."""
-        return "!!TODO!!"
 
     @classmethod
     def make(cls, func, name, **kwargs):
@@ -364,11 +344,6 @@ class Indent(RawSegment):
             )
         )
 
-    @classmethod
-    def expected_string(cls, dialect=None, called_from=None):
-        """Return the expected string for this segment."""
-        return ""
-
     def __init__(self, pos_marker):
         """For the indent we override the init method.
 
@@ -416,14 +391,6 @@ class EphemeralSegment(BaseSegment):
         new_self = super().parse(parse_context)
         # Return the content of that result rather than self
         return new_self.segments
-
-    @classmethod
-    def expected_string(cls, dialect=None, called_from=None):
-        """Return the expected string for this segment.
-
-        In this case it's just the expected string of the match grammar.
-        """
-        return cls.match_grammar.expected_string(dialect=None, called_from=None)
 
     @classmethod
     def make(cls, match_grammar, parse_grammar, name):

--- a/src/sqlfluff/core/parser/segments_file.py
+++ b/src/sqlfluff/core/parser/segments_file.py
@@ -17,6 +17,8 @@ class FileSegment(BaseSegment):
     type = "file"
     # The file segment is the only one which can start or end with non-code
     _can_start_end_non_code = True
+    # A file can be empty!
+    allow_empty = True
 
     # NB: We don't need a match_grammar here because we're
     # going straight into instantiating it directly ususually.

--- a/src/sqlfluff/core/parser/segments_file.py
+++ b/src/sqlfluff/core/parser/segments_file.py
@@ -18,7 +18,9 @@ class FileSegment(BaseSegment):
     # The file segment is the only one which can start or end with non-code
     _can_start_end_non_code = True
 
-    grammar = Delimited(
+    # NB: We don't need a match_grammar here because we're
+    # going straight into instantiating it directly ususually.
+    parse_grammar = Delimited(
         Ref("StatementSegment"),
         delimiter=Ref("SemicolonSegment"),
         code_only=True,

--- a/src/sqlfluff/core/parser/segments_file.py
+++ b/src/sqlfluff/core/parser/segments_file.py
@@ -23,7 +23,7 @@ class FileSegment(BaseSegment):
     parse_grammar = Delimited(
         Ref("StatementSegment"),
         delimiter=Ref("SemicolonSegment"),
-        code_only=True,
+        allow_gaps=True,
         allow_trailing=True,
     )
 

--- a/src/sqlfluff/core/parser/segments_file.py
+++ b/src/sqlfluff/core/parser/segments_file.py
@@ -16,7 +16,7 @@ class FileSegment(BaseSegment):
 
     type = "file"
     # The file segment is the only one which can start or end with non-code
-    _can_start_end_non_code = True
+    can_start_end_non_code = True
     # A file can be empty!
     allow_empty = True
 

--- a/test/core/parser/conftest.py
+++ b/test/core/parser/conftest.py
@@ -1,0 +1,27 @@
+"""Test fixtures for parser tests."""
+
+import pytest
+
+from sqlfluff.core.dialects import ansi_dialect
+
+
+@pytest.fixture(scope="function")
+def fresh_ansi_dialect():
+    """Expand the ansi dialect for use."""
+    dialect = ansi_dialect
+    dialect.expand()
+    return dialect
+
+
+@pytest.fixture(scope="function")
+def seg_list(generate_test_segments):
+    """A preset list of segments for testing."""
+    return generate_test_segments(["bar", " \t ", "foo", "baar", " \t "])
+
+
+@pytest.fixture(scope="function")
+def bracket_seg_list(generate_test_segments):
+    """Another preset list of segments for testing."""
+    return generate_test_segments(
+        ["bar", " \t ", "(", "foo", "    ", ")", "baar", " \t ", "foo"]
+    )

--- a/test/core/parser/grammar_test.py
+++ b/test/core/parser/grammar_test.py
@@ -3,7 +3,8 @@
 import pytest
 import logging
 
-from sqlfluff.core.parser import RootParseContext
+from sqlfluff.core.parser import RootParseContext, KeywordSegment
+from sqlfluff.core.parser.segments_common import EphemeralSegment
 from sqlfluff.core.parser.grammar import (
     OneOf,
     Sequence,
@@ -12,33 +13,11 @@ from sqlfluff.core.parser.grammar import (
     Delimited,
     BaseGrammar,
     StartsWith,
+    Anything,
+    Nothing,
 )
-from sqlfluff.core.parser.segments_common import KeywordSegment, EphemeralSegment
-from sqlfluff.core.dialects import ansi_dialect
 
 # NB: All of these tests depend somewhat on the KeywordSegment working as planned
-
-
-@pytest.fixture(scope="function")
-def seg_list(generate_test_segments):
-    """A preset list of segments for testing."""
-    return generate_test_segments(["bar", " \t ", "foo", "baar", " \t "])
-
-
-@pytest.fixture(scope="function")
-def bracket_seg_list(generate_test_segments):
-    """Another preset list of segments for testing."""
-    return generate_test_segments(
-        ["bar", " \t ", "(", "foo", "    ", ")", "baar", " \t ", "foo"]
-    )
-
-
-@pytest.fixture(scope="function")
-def fresh_ansi_dialect():
-    """Expand the ansi dialect for use."""
-    dialect = ansi_dialect
-    dialect.expand()
-    return dialect
 
 
 def test__parser__grammar__base__code_only_sensitive_match(seg_list):
@@ -365,3 +344,15 @@ def test__parser__grammar_containsonly(seg_list):
         )
         # When we consider mode than code then it shouldn't work
         assert not g3.match(seg_list, parse_context=ctx)
+
+
+def test__parser__grammar_anything(seg_list, fresh_ansi_dialect):
+    """Test the Anything grammar."""
+    with RootParseContext(dialect=fresh_ansi_dialect) as ctx:
+        assert Anything().match(seg_list, parse_context=ctx)
+
+
+def test__parser__grammar_nothing(seg_list, fresh_ansi_dialect):
+    """Test the Nothing grammar."""
+    with RootParseContext(dialect=fresh_ansi_dialect) as ctx:
+        assert not Nothing().match(seg_list, parse_context=ctx)

--- a/test/core/parser/grammar_test.py
+++ b/test/core/parser/grammar_test.py
@@ -45,17 +45,6 @@ def test__parser__grammar__base__code_only_sensitive_match(seg_list):
         assert m.matched_segments == (bs("bar", seg_list[0].pos_marker), seg_list[1])
 
 
-def test__parser__grammar__base__trim_non_code(seg_list):
-    """Test the _trim_non_code method of the BaseGrammar."""
-    assert BaseGrammar._trim_non_code(seg_list) == ((), seg_list[:4], (seg_list[4],))
-    assert BaseGrammar._trim_non_code(seg_list, allow_gaps=False) == ((), seg_list, ())
-    assert BaseGrammar._trim_non_code(seg_list[1:]) == (
-        (seg_list[1],),
-        seg_list[2:4],
-        (seg_list[4],),
-    )
-
-
 def test__parser__grammar__base__look_ahead_match(seg_list):
     """Test the _look_ahead_match method of the BaseGrammar."""
     fs = KeywordSegment.make("foo")

--- a/test/core/parser/grammar_test.py
+++ b/test/core/parser/grammar_test.py
@@ -9,7 +9,6 @@ from sqlfluff.core.parser.grammar import (
     OneOf,
     Sequence,
     GreedyUntil,
-    ContainsOnly,
     Delimited,
     BaseGrammar,
     StartsWith,
@@ -307,32 +306,6 @@ def test__parser__grammar_greedyuntil_bracketed(bracket_seg_list, fresh_ansi_dia
     with RootParseContext(dialect=fresh_ansi_dialect) as ctx:
         # Check that we can make it past the brackets
         assert len(g.match(bracket_seg_list, parse_context=ctx)) == 7
-
-
-def test__parser__grammar_containsonly(seg_list):
-    """Test the ContainsOnly grammar."""
-    fs = KeywordSegment.make("foo")
-    bs = KeywordSegment.make("bar")
-    bas = KeywordSegment.make("baar")
-    g0 = ContainsOnly(bs, bas)
-    g1 = ContainsOnly("raw")
-    g2 = ContainsOnly(fs, bas, bs)
-    g3 = ContainsOnly(fs, bas, bs, allow_gaps=False)
-    with RootParseContext(dialect=None) as ctx:
-        # Contains only, without matches for all shouldn't match
-        assert not g0.match(seg_list, parse_context=ctx)
-        # Contains only, with just the type should return the list as is
-        assert g1.match(seg_list, parse_context=ctx) == seg_list
-        # Contains only with matches for all should, as the matched versions
-        assert g2.match(seg_list, parse_context=ctx).matched_segments == (
-            bs("bar", seg_list[0].pos_marker),
-            seg_list[1],  # This will be the whitespace segment
-            fs("foo", seg_list[2].pos_marker),
-            bas("baar", seg_list[3].pos_marker),
-            seg_list[4],  # This will be the whitespace segment
-        )
-        # When we consider mode than code then it shouldn't work
-        assert not g3.match(seg_list, parse_context=ctx)
 
 
 def test__parser__grammar_anything(seg_list, fresh_ansi_dialect):

--- a/test/core/parser/parse_test.py
+++ b/test/core/parser/parse_test.py
@@ -1,0 +1,61 @@
+"""The Test file for The New Parser (Grammar Classes)."""
+
+import logging
+
+from sqlfluff.core.parser import BaseSegment, KeywordSegment, Anything, RootParseContext
+
+BarKeyword = KeywordSegment.make("bar")
+
+
+class BasicSegment(BaseSegment):
+    """A basic segment for testing parse and expand."""
+
+    type = "basic"
+    match_grammar = Anything()
+    parse_grammar = BarKeyword
+
+
+def test__parser__parse_match(seg_list):
+    """Test match method on a real segment."""
+    with RootParseContext(dialect=None) as ctx:
+        # This should match and have consumed everything, which should
+        # now be part of a BasicSegment.
+        m = BasicSegment.match(seg_list[:1], parse_context=ctx)
+        assert m
+        assert len(m.matched_segments) == 1
+        assert isinstance(m.matched_segments[0], BasicSegment)
+        assert m.matched_segments[0].segments[0].type == "raw"
+
+
+def test__parser__parse_parse(seg_list, caplog):
+    """Test parse method on a real segment."""
+    with RootParseContext(dialect=None) as ctx:
+        # Match the segment, and get the inner segment
+        seg = BasicSegment.match(seg_list[:1], parse_context=ctx).matched_segments[0]
+        # Remind ourselves that this should be an unparsed BasicSegment
+        assert isinstance(seg, BasicSegment)
+
+        # Now parse that segment, with debugging because this is
+        # where we'll need to debug if things fail.
+        with caplog.at_level(logging.DEBUG):
+            res = seg.parse(parse_context=ctx)
+        # Check it's still a BasicSegment
+        assert isinstance(res, BasicSegment)
+        # Check that we now have a keyword inside
+        assert isinstance(res.segments[0], BarKeyword)
+
+
+def test__parser__parse_expand(seg_list):
+    """Test expand method on a real segment."""
+    with RootParseContext(dialect=None) as ctx:
+        # Match the segment, and get the matched segments
+        segments = BasicSegment.match(seg_list[:1], parse_context=ctx).matched_segments
+        # Remind ourselves that this should be tuple containing a BasicSegment
+        assert isinstance(segments[0], BasicSegment)
+
+        # Now expand those segments, using the base class version (not that it should matter)
+        res = BasicSegment.expand(segments, parse_context=ctx)
+        # Check we get an iterable containing a BasicSegment
+        assert isinstance(res[0], BasicSegment)
+        # Check that we now have a keyword inside
+        assert isinstance(res[0].segments[0], BarKeyword)

--- a/test/core/parser/segments_base_test.py
+++ b/test/core/parser/segments_base_test.py
@@ -51,7 +51,7 @@ def test__parser__base_segments_raw(raw_seg):
     assert str(raw_seg) == repr(raw_seg) == "<RawSegment: ([3](1, 1, 4)) 'foobar'>"
     assert (
         raw_seg.stringify(ident=1, tabsize=2)
-        == "[3](1, 1, 4)     |  raw:                                                        'foobar'\n"
+        == "[3](1, 1, 4)        |  raw:                                                        'foobar'\n"
     )
     # Check tuple
     assert raw_seg.to_tuple() == ("raw", ())
@@ -77,9 +77,9 @@ def test__parser__base_segments_base(raw_seg_list):
     # Check Formatting and Stringification
     assert str(base_seg) == repr(base_seg) == "<DummySegment: ([3](1, 1, 4))>"
     assert base_seg.stringify(ident=1, tabsize=2) == (
-        "[3](1, 1, 4)     |  dummy:\n"
-        "[3](1, 1, 4)     |    raw:                                                      'foobar'\n"
-        "[9](1, 1, 10)    |    raw:                                                      '.barfoo'\n"
+        "[3](1, 1, 4)        |  dummy:\n"
+        "[3](1, 1, 4)        |    raw:                                                      'foobar'\n"
+        "[9](1, 1, 10)       |    raw:                                                      '.barfoo'\n"
     )
 
 

--- a/test/core/parser/segments_base_test.py
+++ b/test/core/parser/segments_base_test.py
@@ -8,6 +8,7 @@ from sqlfluff.core.parser import (
     RawSegment,
     BaseSegment,
 )
+from sqlfluff.core.parser.segments_base import trim_non_code
 from sqlfluff.core.dialects import ansi_dialect
 
 
@@ -34,6 +35,16 @@ class DummyAuxSegment(BaseSegment):
     """A different dummy segment for testing with no grammar."""
 
     type = "dummy_aux"
+
+
+def test__parser__base_segments__trim_non_code(seg_list):
+    """Test the _trim_non_code method of the BaseGrammar."""
+    assert trim_non_code(seg_list) == ((), seg_list[:4], (seg_list[4],))
+    assert trim_non_code(seg_list[1:]) == (
+        (seg_list[1],),
+        seg_list[2:4],
+        (seg_list[4],),
+    )
 
 
 def test__parser__base_segments_raw_init():


### PR DESCRIPTION
With a few performance gains in mind I've gone through and removed several older sections of code which had been hanging around. I've also renamed and reorganized a few parts which had got convoluted.

### Added
- Extra test cases for the parser

### Removed
- Removed `BaseSegment.grammar`, `BaseSegment._match_grammar()` and `BaseSegment._parse_grammar()` instead preferring references directly to `BaseSegment.match_grammar` and `BaseSegment.parse_grammar`.
- Removed `EmptySegmentGrammar` and replaced with better non-code handling in the `FileSegment` itself.
- Remove the `ContainsOnly` grammar as it remained only as an anti-pattern.
- Removed the `expected_string()` functionality from grammars and segments as it was poorly supported.
- Removed `BaseSegment.as_optional()` as now this functionality happens mostly in grammars (including `Ref`).