### PR TITLE
Update setup.py to fix imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,10 +55,13 @@ setup(
     # Specify all the seperate packages, modules come automatically
     packages=[
         "sqlfluff",
+        "sqlfluff.api",
         "sqlfluff.cli",
         "sqlfluff.core",
         "sqlfluff.core.dialects",
         "sqlfluff.core.parser",
+        "sqlfluff.core.parser.segments",
+        "sqlfluff.core.parser.grammar",
         "sqlfluff.core.rules",
     ],
     package_dir={"": "src"},


### PR DESCRIPTION
This fixes #511 

After the new module structure, the `setup.py` structure hadn't been updated. This means that during docs builds, the autodoc step was failing and therefore nuking the rules page. This fixes that.