### PR TITLE
Remove fixing loop from test suite.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A limit in the internal fix routines to catch any infinite loops.
 - Added the `.istype()` method on segments to more intelligently
   deal with type matching in rules when inheritance is at play.
+- Added the ability for the user to add their own rules when interacting
+  with the `Linter` directly using `user_rules`.
 
 ### Changed
 

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -7,6 +7,7 @@ rules = None
 exclude_rules = None
 recurse = 0
 output_line_length = 80
+runaway_limit = 10
 
 [sqlfluff:indentation]
 indented_joins = False

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -589,7 +589,13 @@ class Linter:
     """The interface class to interact with the linter."""
 
     def __init__(
-        self, sql_exts=(".sql",), config=None, formatter=None, dialect=None, rules=None
+        self,
+        sql_exts=(".sql",),
+        config=None,
+        formatter=None,
+        dialect=None,
+        rules=None,
+        user_rules=None,
     ):
         if (dialect or rules) and config:
             raise ValueError(
@@ -615,10 +621,15 @@ class Linter:
         self.config = config
         # Store the formatter for output
         self.formatter = formatter
+        # Store references to user rule classes
+        self.user_rules = user_rules or []
 
     def get_ruleset(self, config=None):
         """Get hold of a set of rules."""
         rs = get_ruleset()
+        # Register any user rules
+        for rule in self.user_rules:
+            rs.register(rule)
         cfg = config or self.config
         return rs.get_rulelist(config=cfg)
 
@@ -801,7 +812,7 @@ class Linter:
                 linting_errors = []
                 last_fixes = None
                 fix_loop_idx = 0
-                loop_limit = 20
+                loop_limit = 10
                 while True:
                     fix_loop_idx += 1
                     if fix_loop_idx > loop_limit:

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -571,6 +571,19 @@ class LintingResult:
             ]
         )
 
+    @property
+    def tree(self):
+        """A convenience method for when there is only one file and we want the tree."""
+        if len(self.paths) > 1:
+            raise ValueError(
+                ".tree() cannot be called when a LintingResult contains more than one path."
+            )
+        if len(self.paths[0].files) > 1:
+            raise ValueError(
+                ".tree() cannot be called when a LintingResult contains more than one file."
+            )
+        return self.paths[0].files[0].tree
+
 
 class Linter:
     """The interface class to interact with the linter."""

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -812,7 +812,7 @@ class Linter:
                 linting_errors = []
                 last_fixes = None
                 fix_loop_idx = 0
-                loop_limit = 10
+                loop_limit = config.get("runaway_limit")
                 while True:
                     fix_loop_idx += 1
                     if fix_loop_idx > loop_limit:

--- a/src/sqlfluff/core/rules/__init__.py
+++ b/src/sqlfluff/core/rules/__init__.py
@@ -7,4 +7,5 @@ from .base import rules_logger  # noqa
 def get_ruleset(name="standard"):
     """Get a ruleset by name."""
     lookup = {std_rule_set.name: std_rule_set}
-    return lookup[name]
+    # Return a copy in case someone modifies the register.
+    return lookup[name].copy()

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -14,6 +14,7 @@ should flag on the segment FOLLOWING, the place that the desired element is
 missing.
 """
 
+import copy
 import logging
 from collections import namedtuple
 
@@ -573,3 +574,9 @@ class RuleSet:
 
         # Instantiate in the final step
         return [self._register[k]["cls"](**rule_kwargs[k]) for k in keylist]
+
+    def copy(self):
+        """Return a copy of self with a seperate register."""
+        new_ruleset = copy.copy(self)
+        new_ruleset._register = self._register.copy()
+        return new_ruleset

--- a/test/core/rules/std_test.py
+++ b/test/core/rules/std_test.py
@@ -15,7 +15,7 @@ def get_rule_from_set(code, config):
     raise ValueError("{0!r} not in {1!r}".format(code, std_rule_set))
 
 
-def assert_rule_fail_in_sql(code, sql, configs=None, runaway_limit=20):
+def assert_rule_fail_in_sql(code, sql, configs=None):
     """Assert that a given rule does fail on the given sql."""
     # Set up the config to only use the rule we are testing.
     cfg = FluffConfig(configs=configs, overrides={"rules": code})

--- a/test/core/rules/std_test.py
+++ b/test/core/rules/std_test.py
@@ -576,9 +576,10 @@ def test__rules__user_rules():
 
 def test__rules__runaway_fail_catch():
     """Test that we catch runaway rules."""
+    runaway_limit = 5
     my_query = "SELECT * FROM foo"
     # Set up the config to only use the rule we are testing.
-    cfg = FluffConfig(overrides={"rules": "T001"})
+    cfg = FluffConfig(overrides={"rules": "T001", "runaway_limit": runaway_limit})
     # Lint it using the current config (while in fix mode)
     linter = Linter(config=cfg, user_rules=[Rule_T001])
     # In theory this step should result in an infinite
@@ -586,7 +587,7 @@ def test__rules__runaway_fail_catch():
     linted = linter.lint_string(my_query, fix=True)
     # We should have a lot of newlines in there.
     # The number should equal the runaway limit
-    assert linted.tree.raw.count("\n") == 10
+    assert linted.tree.raw.count("\n") == runaway_limit
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This half addresses #499 . 

This removes the custom code from the test suite and uses the `Linter()` fix routines instead. Adding a custom runaway rule is proving harder!