### PR TITLE
MyPy - round 2.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV=bench
+  mypy:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV=mypy
 
 
 ### Workflows which call the different tox jobs
@@ -108,6 +114,7 @@ workflows:
     jobs:
       - linting
       - doclinting
+      - mypy
       - py36
       - py37
       - py38

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,25 @@
+[mypy]
+warn_unused_configs = True
+warn_unused_ignores = True
+
+# skip type checking for 3rd party packages for which stubs are not available
+[mypy-benchit.*]
+ignore_missing_imports = True
+
+[mypy-cdifflib.*]
+ignore_missing_imports = True
+
+[mypy-pathspec.*]
+ignore_missing_imports = True
+
+[mypy-appdirs.*]
+ignore_missing_imports = True
+
+[mypy-oyaml.*]
+ignore_missing_imports = True
+
+[mypy-diff_cover.*]
+ignore_missing_imports = True
+
+[mypy-colorama.*]
+ignore_missing_imports = True

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,3 +10,5 @@ Pygments
 coverage
 pytest
 pytest-cov
+# MyPy
+mypy

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -13,6 +13,7 @@ https://www.cockroachlabs.com/docs/stable/sql-grammar.html#select_stmt
 """
 
 from ..parser import (
+    Matchable,
     BaseSegment,
     KeywordSegment,
     SymbolSegment,
@@ -32,6 +33,7 @@ from ..parser import (
     Dedent,
     Nothing,
 )
+
 from .base import Dialect
 from .ansi_keywords import ansi_reserved_keywords, ansi_unreserved_keywords
 
@@ -348,7 +350,7 @@ class ObjectReferenceSegment(BaseSegment):
 
     type = "object_reference"
     # match grammar (don't allow whitespace)
-    match_grammar = Delimited(
+    match_grammar: Matchable = Delimited(
         Ref("SingleIdentifierGrammar"),
         delimiter=OneOf(Ref("DotSegment"), Sequence(Ref("DotSegment"))),
         terminator=OneOf(

--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -1,10 +1,11 @@
 """Errors - these are closely linked to what used to be called violations."""
+from typing import Optional
 
 
 class SQLBaseError(ValueError):
     """Base Error Class for all violations."""
 
-    _code = None
+    _code: Optional[str] = None
     _identifier = "base"
 
     def __init__(self, *args, **kwargs):

--- a/src/sqlfluff/core/parser/__init__.py
+++ b/src/sqlfluff/core/parser/__init__.py
@@ -28,3 +28,4 @@ from .grammar import (
 from .markers import FilePositionMarker
 from .lexer import Lexer
 from .parser import Parser
+from .matchable import Matchable

--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -12,9 +12,10 @@ from ..match_logging import (
     LateBoundJoinSegmentsCurtailed,
 )
 from ..match_wrapper import match_wrapper
+from ..matchable import Matchable
 
 
-class BaseGrammar:
+class BaseGrammar(Matchable):
     """Grammars are a way of composing match statements.
 
     Any grammar must implment the `match` function. Segments can also be

--- a/src/sqlfluff/core/parser/grammar/noncode.py
+++ b/src/sqlfluff/core/parser/grammar/noncode.py
@@ -6,9 +6,10 @@ terminator or similar alongside other matchers.
 
 from ..match_wrapper import match_wrapper
 from ..match_result import MatchResult
+from ..matchable import Matchable
 
 
-class NonCodeMatcher:
+class NonCodeMatcher(Matchable):
     """An object which behaves like a matcher to match non-code."""
 
     def simple(self, parse_context):

--- a/src/sqlfluff/core/parser/match_logging.py
+++ b/src/sqlfluff/core/parser/match_logging.py
@@ -3,7 +3,34 @@
 from .helpers import join_segments_raw_curtailed
 
 
-class ParseMatchLogObject:
+class LateLoggingObject(object):
+    """A basic late binding log object for parse_match_logging.
+
+    This allows us to defer the string manipulation involved
+    until actually required by the logger.
+    """
+
+    __slots__ = "v_level", "logger", "msg"
+
+    def __init__(self, logger, msg, v_level=3):
+        self.v_level = v_level
+        self.logger = logger
+        self.msg = msg
+
+    def __str__(self):
+        """Actually materialise the string."""
+        return self.msg
+
+    def log(self):
+        """Actually log this object."""
+        # Otherwise carry on...
+        if self.v_level == 3:
+            self.logger.info(self)
+        elif self.v_level == 4:
+            self.logger.debug(self)
+
+
+class ParseMatchLogObject(LateLoggingObject):
     """A late binding log object for parse_match_logging.
 
     This allows us to defer the string manipulation involved
@@ -11,46 +38,26 @@ class ParseMatchLogObject:
     """
 
     __slots__ = [
-        "parse_depth",
-        "match_depth",
-        "match_segment",
+        "context",
         "grammar",
         "func",
-        "msg",
         "kwargs",
     ]
 
-    def __init__(
-        self, parse_depth, match_depth, match_segment, grammar, func, msg, **kwargs
-    ):
-        self.parse_depth = parse_depth
-        self.match_depth = match_depth
-        self.match_segment = match_segment
+    def __init__(self, parse_context, grammar, func, msg, v_level=3, **kwargs):
+        super().__init__(v_level=v_level, logger=parse_context.logger, msg=msg)
+        self.context = parse_context
         self.grammar = grammar
         self.func = func
-        self.msg = msg
         self.kwargs = kwargs
-
-    @classmethod
-    def from_context(cls, parse_context, grammar, func, msg, **kwargs):
-        """Create a ParseMatchLogObject given a parse_context."""
-        return cls(
-            parse_context.parse_depth,
-            parse_context.match_depth,
-            parse_context.match_segment,
-            grammar,
-            func,
-            msg,
-            **kwargs
-        )
 
     def __str__(self):
         """Actually materialise the string."""
         symbol = self.kwargs.pop("symbol", "")
         s = "[PD:{0:<2} MD:{1:<2}]\t{2:<50}\t{3:<20}\t{4:<4}".format(
-            self.parse_depth,
-            self.match_depth,
-            ("." * self.match_depth) + str(self.match_segment),
+            self.context.parse_depth,
+            self.context.match_depth,
+            ("." * self.context.match_depth) + str(self.context.match_segment),
             "{0:.5}.{1} {2}".format(self.grammar, self.func, self.msg),
             symbol,
         )
@@ -64,17 +71,12 @@ class ParseMatchLogObject:
         return s
 
 
-def parse_match_logging(grammar, func, msg, parse_context, v_level, **kwargs):
+def parse_match_logging(grammar, func, msg, parse_context, v_level=3, **kwargs):
     """Log in a particular consistent format for use while matching."""
     # Make a late bound log object so we only do the string manipulation when we need to.
-    log_obj = ParseMatchLogObject.from_context(
-        parse_context, grammar, func, msg, **kwargs
-    )
-    # Otherwise carry on...
-    if v_level == 3:
-        parse_context.logger.info(log_obj)
-    elif v_level == 4:
-        parse_context.logger.debug(log_obj)
+    ParseMatchLogObject(
+        parse_context, grammar, func, msg, v_level=v_level, **kwargs
+    ).log()
 
 
 class LateBoundJoinSegmentsCurtailed:

--- a/src/sqlfluff/core/parser/matchable.py
+++ b/src/sqlfluff/core/parser/matchable.py
@@ -1,0 +1,19 @@
+"""The definition of a matchable interface."""
+
+from abc import ABC
+
+
+class Matchable(ABC):
+    """A base object defining the matching interface."""
+
+    def is_optional(self):
+        """Return whether this element is optional."""
+        pass
+
+    def simple(self, parse_context):
+        """Try to obtain a simple response from the matcher."""
+        pass
+
+    def match(self, segments, parse_context):
+        """Match against this matcher."""
+        pass

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -10,11 +10,13 @@ Here we define:
 
 from io import StringIO
 from benchit import BenchIt
+from typing import Optional
 
 from ..match_result import MatchResult
 from ..match_logging import parse_match_logging
 from ..match_wrapper import match_wrapper
 from ..helpers import frame_msg, check_still_complete, trim_non_code, curtail_string
+from ..matchable import Matchable
 
 
 class BaseSegment:
@@ -37,8 +39,8 @@ class BaseSegment:
 
     # `type` should be the *category* of this kind of segment
     type = "base"
-    parse_grammar = None
-    match_grammar = None
+    parse_grammar: Optional[Matchable] = None
+    match_grammar: Optional[Matchable] = None
     comment_seperate = False
     is_whitespace = False
     optional = False  # NB: See the sequence grammar for details

--- a/src/sqlfluff/core/rules/std.py
+++ b/src/sqlfluff/core/rules/std.py
@@ -8,6 +8,7 @@ examples in the same rule should also be un-highlighted.
 """
 
 import itertools
+from typing import Tuple, List
 
 from .base import BaseCrawler, LintFix, LintResult, RuleSet
 from .config_info import STANDARD_CONFIG_INFO_DICT
@@ -1082,7 +1083,10 @@ class Rule_L010(BaseCrawler):
     """
 
     # Binary operators behave like keywords too.
-    _target_elems = (("type", "keyword"), ("type", "binary_operator"))
+    _target_elems: List[Tuple[str, str]] = [
+        ("type", "keyword"),
+        ("type", "binary_operator"),
+    ]
     config_keywords = ["capitalisation_policy"]
 
     def _eval(self, segment, memory, **kwargs):
@@ -1344,7 +1348,7 @@ class Rule_L014(Rule_L010):
     The functionality for this rule is inherited from :obj:`Rule_L010`.
     """
 
-    _target_elems = (("name", "naked_identifier"),)
+    _target_elems: List[Tuple[str, str]] = [("name", "naked_identifier")]
 
 
 @std_rule_set.register
@@ -2871,7 +2875,7 @@ class Rule_L030(Rule_L010):
 
     """
 
-    _target_elems = (("name", "function_name"),)
+    _target_elems: List[Tuple[str, str]] = [("name", "function_name")]
 
 
 @std_rule_set.register

--- a/src/sqlfluff/core/templaters.py
+++ b/src/sqlfluff/core/templaters.py
@@ -2,6 +2,7 @@
 
 import os.path
 import ast
+from typing import Dict
 
 from jinja2.sandbox import SandboxedEnvironment
 from jinja2 import meta
@@ -10,7 +11,7 @@ import jinja2.nodes
 from .errors import SQLTemplaterError
 from .parser import FilePositionMarker
 
-_templater_lookup = {}
+_templater_lookup: Dict[str, "RawTemplateInterface"] = {}
 
 
 def templater_selector(s=None, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = linting, doclinting, cov-init, py36, py37, py38, py39, cov-report, bench
+envlist = linting, doclinting, cov-init, py36, py37, py38, py39, cov-report, bench, mypy
 
 [testenv]
 passenv = CI CIRCLECI CIRCLE_*
@@ -47,6 +47,9 @@ commands = flake8
 
 [testenv:doclinting]
 commands = doc8 docs/source --file-encoding utf8
+
+[testenv:mypy]
+commands = mypy src/sqlfluff
 
 [flake8]
 # Ignore:


### PR DESCRIPTION
Based on the excellent work by @dnshio in #459 , this takes things the last mile and gets mypy into action.

It resolves the two outstanding issues, mostly by creating an abstract base class (`Matchable`) which `BaseGrammar` and a few other things inherit from. This base class does not depend on the rest of the library and so has no circular dependency issues.

This PR doesn't implement all of the checks I would like to introduce with mypy, but it does get it into CI so we can start building on it.