### PR TITLE
L031 bug

### DIFF
--- a/src/sqlfluff/core/rules/std.py
+++ b/src/sqlfluff/core/rules/std.py
@@ -2950,7 +2950,10 @@ class Rule_L031(BaseCrawler):
 
             return (
                 self._lint_aliases_in_join(
-                    base_table, table_expression_segments, column_reference_segments, segment
+                    base_table,
+                    table_expression_segments,
+                    column_reference_segments,
+                    segment,
                 )
                 or None
             )

--- a/src/sqlfluff/core/rules/std.py
+++ b/src/sqlfluff/core/rules/std.py
@@ -2991,10 +2991,14 @@ class Rule_L031(BaseCrawler):
                 if used_alias_ref.raw == alias_identifier_ref.raw:
                     ids_refs.append(used_alias_ref)
 
-            # Find all references to alias in join clauses
+            # Find all references to alias in column references
             for exp_ref in column_reference_segments:
                 used_alias_ref = exp_ref.get_child("identifier")
-                if used_alias_ref.raw == alias_identifier_ref.raw:
+                # exp_ref.get_child('dot') ensures that the column reference includes a table reference
+                if (
+                    used_alias_ref.raw == alias_identifier_ref.raw
+                    and exp_ref.get_child("dot")
+                ):
                     ids_refs.append(used_alias_ref)
 
             # Fixes for deleting ` as sth` and for editing references to aliased tables

--- a/test/core/rules/std_test.py
+++ b/test/core/rules/std_test.py
@@ -439,12 +439,20 @@ def assert_rule_pass_in_sql(code, sql, configs=None):
             "SELECT users.id, customers.first_name, customers.last_name, COUNT(orders.user_id) FROM users JOIN customers on users.id = customers.user_id JOIN orders on users.id = orders.user_id;",
             None,
         ),
-        # L031 bug
+        # L031 order by
         (
             "L031",
             "fail",
             "SELECT u.id, c.first_name, c.last_name, COUNT(o.user_id) FROM users as u JOIN customers as c on u.id = c.user_id JOIN orders as o on u.id = o.user_id order by o.user_id desc",
             "SELECT users.id, customers.first_name, customers.last_name, COUNT(orders.user_id) FROM users JOIN customers on users.id = customers.user_id JOIN orders on users.id = orders.user_id order by orders.user_id desc",
+            None,
+        ),
+        # L031 order by identifier which is the same raw as an alias but refers to a column
+        (
+            "L031",
+            "fail",
+            "SELECT u.id, c.first_name, c.last_name, COUNT(o.user_id) FROM users as u JOIN customers as c on u.id = c.user_id JOIN orders as o on u.id = o.user_id order by o desc",
+            "SELECT users.id, customers.first_name, customers.last_name, COUNT(orders.user_id) FROM users JOIN customers on users.id = customers.user_id JOIN orders on users.id = orders.user_id order by o desc",
             None,
         ),
         # Fix for https://github.com/sqlfluff/sqlfluff/issues/476

--- a/test/core/rules/std_test.py
+++ b/test/core/rules/std_test.py
@@ -439,6 +439,14 @@ def assert_rule_pass_in_sql(code, sql, configs=None):
             "SELECT u.id, customers.first_name, customers.last_name, COUNT(orders.user_id) FROM users as u JOIN customers on u.id = customers.user_id JOIN orders on u.id = orders.user_id;",
             None,
         ),
+        # L031 bug
+        (
+            "L031",
+            "fail",
+            "SELECT u.id, c.first_name, c.last_name, COUNT(o.user_id) FROM users as u JOIN customers as c on u.id = c.user_id JOIN orders as o on u.id = o.user_id order by o.user_id desc",
+            "SELECT u.id, customers.first_name, customers.last_name, COUNT(orders.user_id) FROM users as u JOIN customers on u.id = customers.user_id JOIN orders on u.id = orders.user_id order by orders.user_id desc",
+            None,
+        ),
         # Fix for https://github.com/sqlfluff/sqlfluff/issues/476
         (
             "L010",

--- a/test/core/rules/std_test.py
+++ b/test/core/rules/std_test.py
@@ -444,7 +444,7 @@ def assert_rule_pass_in_sql(code, sql, configs=None):
             "L031",
             "fail",
             "SELECT u.id, c.first_name, c.last_name, COUNT(o.user_id) FROM users as u JOIN customers as c on u.id = c.user_id JOIN orders as o on u.id = o.user_id order by o.user_id desc",
-            "SELECT u.id, customers.first_name, customers.last_name, COUNT(orders.user_id) FROM users as u JOIN customers on u.id = customers.user_id JOIN orders on u.id = orders.user_id order by orders.user_id desc",
+            "SELECT users.id, customers.first_name, customers.last_name, COUNT(orders.user_id) FROM users JOIN customers on users.id = customers.user_id JOIN orders on users.id = orders.user_id order by orders.user_id desc",
             None,
         ),
         # Fix for https://github.com/sqlfluff/sqlfluff/issues/476


### PR DESCRIPTION
```
SELECT u.id, c.first_name, c.last_name, COUNT(o.user_id) FROM users as u JOIN customers as c on u.id = c.user_id JOIN orders as o on u.id = o.user_id order by o.user_id desc
```

should be fixed to

```
SELECT users.id, customers.first_name, customers.last_name, COUNT(orders.user_id) FROM users JOIN customers on users.id = customers.user_id JOIN orders on users.id = orders.user_id order by orders.user_id desc
```

But the L031 lint fix is not fixing the alias in the order by clause, so the fix currently results in

```
SELECT users.id, customers.first_name, customers.last_name, COUNT(orders.user_id) FROM users JOIN customers on users.id = customers.user_id JOIN orders on users.id = orders.user_id order by o.user_id desc
```

order by **o**.user_id desc instead of order by **orders**.user_id desc