### PR TITLE
Fix docs version to match current release

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ copyright = "2019, Alan Cruickshank"
 author = "Alan Cruickshank"
 
 # The full version, including alpha/beta/rc tags
-release = "0.1.5"
+release = "0.3.6"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Just noticed that on https://docs.sqlfluff.com/en/latest/rules.html the page title specifies sqlfluff 0.1.5, this fixes that.

I also realised that the docs reflect the most recent push to master, not the most recent release on pypi. I'll make an issue to sort that out