### PR TITLE
Allow whitespace before shorthand cast

### DIFF
--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -1051,7 +1051,7 @@ ansi_dialect.add(
         ),
         Ref("Accessor_Grammar", optional=True),
         Ref("ShorthandCastSegment", optional=True),
-        allow_gaps=False,
+        allow_gaps=True,
     ),
     Accessor_Grammar=AnyNumberOf(Ref("ArrayAccessorSegment")),
 )

--- a/test/fixtures/parser/ansi/shorthand_cast.sql
+++ b/test/fixtures/parser/ansi/shorthand_cast.sql
@@ -1,0 +1,4 @@
+select
+    '1'    ::   INT as id1,
+    '2'::int as id2
+from table_a


### PR DESCRIPTION
Previously resulted in a parse error:

```
---test.sql---
select '1' ::INT as id
```

```
(sqlfluff_venv) ➜  sqlfluff git:(master) sqlfluff lint test.sql
== [test.sql] FAIL
L:   1 | P:  11 |  PRS | Found unparsable section: ' ::INT as id'
WARNING: Parsing errors found and dialect is set to 'ansi'. Have you configured your dialect?
```