### PR TITLE
Tidy rules docs and add sqlfluff fix compatible

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,6 +51,10 @@ exclude_patterns = []
 # Master doc
 master_doc = "index"
 
+# If true, the current module name will be prepended to all description
+# unit titles (such as .. function::).
+add_module_names = False
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -470,8 +470,7 @@ class RuleSet:
         return cls
 
     def document_fix_compatible(self, cls):
-        """Mark the rule as fixable in the documentation
-        """
+        """Mark the rule as fixable in the documentation."""
         cls.__doc__ = "``sqlfluff fix`` compatible.\n\n\n" + cls.__doc__
         return cls
 

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -463,9 +463,16 @@ class RuleSet:
         # docstring by inserting after the first line break, or first period,
         # if there is no line break.
         end_of_class_description = "." if "\n" not in cls.__doc__ else "\n"
+
         cls.__doc__ = cls.__doc__.replace(
-            end_of_class_description, ".\n" + config_doc, 1
+            end_of_class_description, "\n" + config_doc, 1
         )
+        return cls
+
+    def document_fix_compatible(self, cls):
+        """Mark the rule as fixable in the documentation
+        """
+        cls.__doc__ = "``sqlfluff fix`` compatible.\n\n\n" + cls.__doc__
         return cls
 
     def register(self, cls):

--- a/src/sqlfluff/core/rules/std.py
+++ b/src/sqlfluff/core/rules/std.py
@@ -1,5 +1,4 @@
-"""Standard SQL Linting Rules.
-"""
+"""Standard SQL Linting Rules."""
 
 import itertools
 from typing import Tuple, List

--- a/src/sqlfluff/core/rules/std.py
+++ b/src/sqlfluff/core/rules/std.py
@@ -1,10 +1,4 @@
 """Standard SQL Linting Rules.
-
-NB: In docstrings, when marking whitespace, do not use code highlighting
-in any of the examples for that rule. Lexing with fail when encontering the
-explicit '•' amd '->' characters (space and tab respectively) and so
-highglighting will ail for those examples. For consistency, any passing
-examples in the same rule should also be un-highlighted.
 """
 
 import itertools
@@ -16,9 +10,10 @@ from .config_info import STANDARD_CONFIG_INFO_DICT
 std_rule_set = RuleSet(name="standard", config_info=STANDARD_CONFIG_INFO_DICT)
 
 
+@std_rule_set.document_fix_compatible
 @std_rule_set.register
 class Rule_L001(BaseCrawler):
-    """Unneccessary trailing whitespace.
+    """Unnecessary trailing whitespace.
 
     | **Anti-pattern**
     | The • character represents a space.
@@ -120,6 +115,7 @@ class Rule_L002(BaseCrawler):
                     )
 
 
+@std_rule_set.document_fix_compatible
 @std_rule_set.document_configuration
 @std_rule_set.register
 class Rule_L003(BaseCrawler):
@@ -310,7 +306,7 @@ class Rule_L003(BaseCrawler):
         - Any increase in indentation may be _up to_ the number of
           indent characters.
         - Any line must be in line with the previous line which had
-          the same indent balance at it's start.
+          the same indent balance at its start.
         - Apart from "whole" indents, a "hanging" indent is possible
           if the line starts in line with either the indent of the
           previous line or if it starts at the same indent as the *last*
@@ -702,6 +698,7 @@ class Rule_L004(BaseCrawler):
         return LintResult(memory=memory)
 
 
+@std_rule_set.document_fix_compatible
 @std_rule_set.register
 class Rule_L005(BaseCrawler):
     """Commas should not have whitespace directly before them.
@@ -750,6 +747,7 @@ class Rule_L005(BaseCrawler):
         return None
 
 
+@std_rule_set.document_fix_compatible
 @std_rule_set.register
 class Rule_L006(BaseCrawler):
     """Operators should be surrounded by a single whitespace.
@@ -963,6 +961,7 @@ class Rule_L007(BaseCrawler):
             return LintResult(memory=memory)
 
 
+@std_rule_set.document_fix_compatible
 @std_rule_set.register
 class Rule_L008(BaseCrawler):
     """Commas should be followed by a single whitespace unless followed by a comment.
@@ -1013,6 +1012,7 @@ class Rule_L008(BaseCrawler):
         return None
 
 
+@std_rule_set.document_fix_compatible
 @std_rule_set.register
 class Rule_L009(BaseCrawler):
     """Files must end with a trailing newline."""
@@ -1052,6 +1052,7 @@ class Rule_L009(BaseCrawler):
         )
 
 
+@std_rule_set.document_fix_compatible
 @std_rule_set.document_configuration
 @std_rule_set.register
 class Rule_L010(BaseCrawler):
@@ -1187,6 +1188,7 @@ class Rule_L010(BaseCrawler):
         return LintResult(memory=memory)
 
 
+@std_rule_set.document_fix_compatible
 @std_rule_set.register
 class Rule_L011(BaseCrawler):
     """Implicit aliasing of table not allowed. Use explicit `AS` clause.
@@ -1216,7 +1218,7 @@ class Rule_L011(BaseCrawler):
     def _eval(self, segment, parent_stack, raw_stack, **kwargs):
         """Implicit aliasing of table/column not allowed. Use explicit `AS` clause.
 
-        We look for the alias segment, and then evaluate it's parent and whether
+        We look for the alias segment, and then evaluate its parent and whether
         it contains an AS keyword. This is the _eval function for both L011 and L012.
 
         The use of `raw_stack` is just for working out how much whitespace to add.
@@ -1264,7 +1266,7 @@ class Rule_L011(BaseCrawler):
 class Rule_L012(Rule_L011):
     """Implicit aliasing of column not allowed. Use explicit `AS` clause.
 
-    NB: This rule inherits it's functionality from obj:`Rule_L011` but is
+    NB: This rule inherits its functionality from obj:`Rule_L011` but is
     seperate so that they can be enabled and disabled seperately.
 
     """
@@ -1388,6 +1390,7 @@ class Rule_L015(BaseCrawler):
         return LintResult()
 
 
+@std_rule_set.document_fix_compatible
 @std_rule_set.document_configuration
 @std_rule_set.register
 class Rule_L016(Rule_L003):
@@ -1808,6 +1811,7 @@ class Rule_L016(Rule_L003):
             return LintResult(anchor=segment)
 
 
+@std_rule_set.document_fix_compatible
 @std_rule_set.register
 class Rule_L017(BaseCrawler):
     """Function name not immediately followed by bracket.
@@ -1861,6 +1865,7 @@ class Rule_L017(BaseCrawler):
         return LintResult()
 
 
+@std_rule_set.document_fix_compatible
 @std_rule_set.register
 class Rule_L018(BaseCrawler):
     """WITH clause closing bracket should be aligned with WITH keyword.
@@ -2262,6 +2267,7 @@ class Rule_L021(BaseCrawler):
         return None
 
 
+@std_rule_set.document_fix_compatible
 @std_rule_set.register
 class Rule_L022(BaseCrawler):
     """Blank line expected but not found after CTE definition.
@@ -2446,6 +2452,7 @@ class Rule_L022(BaseCrawler):
         return error_buffer or None
 
 
+@std_rule_set.document_fix_compatible
 @std_rule_set.register
 class Rule_L023(BaseCrawler):
     """Single whitespace expected after AS in WITH clause.
@@ -2878,6 +2885,7 @@ class Rule_L030(Rule_L010):
     _target_elems: List[Tuple[str, str]] = [("name", "function_name")]
 
 
+@std_rule_set.document_fix_compatible
 @std_rule_set.register
 class Rule_L031(BaseCrawler):
     """Avoid table aliases in from clauses and join conditions.
@@ -3102,6 +3110,7 @@ class Rule_L033(BaseCrawler):
         return LintResult()
 
 
+@std_rule_set.document_fix_compatible
 @std_rule_set.register
 class Rule_L034(BaseCrawler):
     """Use wildcards then simple select targets before calculations and aggregates.


### PR DESCRIPTION
Resolves #549 

- Removes the module path from the rule docs which is distracting
- Adds a decorator for showing if a rule returns LintFixes
- Minor copy fixes

Before:
![image](https://user-images.githubusercontent.com/23722609/99130820-535b8500-2609-11eb-95d4-decd51a02c2c.png)

After:
![image](https://user-images.githubusercontent.com/23722609/99130824-5a829300-2609-11eb-8074-5bc5a275ca2b.png)
