### PR TITLE
Handle exceptions applying rules as violations

### DIFF
--- a/test/core/rules/std_test.py
+++ b/test/core/rules/std_test.py
@@ -895,3 +895,18 @@ def test_rules_configs_are_dynamically_documented():
         pass
 
     assert "Configuration" not in RuleWithoutConfig.__doc__
+
+
+def test_rule_exception_is_caught_to_validation():
+    """Assert that a rule that throws an exception on _eval returns it as a validation."""
+
+    @std_rule_set.register
+    class Rule_LXXX(BaseCrawler):
+        """Rule that throws an exception."""
+
+        def _eval(self, segment, parent_stack, **kwargs):
+            raise Exception("Catch me or I'll deny any linting results from you")
+
+    linter = Linter(config=FluffConfig(overrides=dict(rules="LXXX")))
+
+    assert linter.lint_string("select 1").check_tuples() == [("LXXX", 1, 1)]


### PR DESCRIPTION
## Handle Rule exceptions as violations

I am currently trying to turn ON sqlfluff for our dbt project at Earnest

I have at least two rules that fail on edge cases and throw Exceptions that simply **halt sqlfluff's execution**. This is actually hard to debug as well because the SQL file in question is not present in the stack trace.

I would like to:
* Be defensive about potential Exceptions in applying rules, handling them as violations
* Give the users useful information when a rule throws an Exception, and a way for the user to silence that specific Exception (instead of having to ignore the file)

## In practice:

I have the following file, that generates a table with dates:

```sql
with

date_generator as (

    select
        dateadd(
            day,
            seq4(),
            date '2010-01-01'
        ) as date
    from table(
        generator(
            -- Number of days since start date
            rowcount=>10000
        )
    )
),

us_holidays as (
    select * from utils_db.us_holidays
)

select
    dg.date,
    year(dg.date) as year,
    month(dg.date) as month,
    monthname(dg.date) as month_name,
    weekiso(dg.date) as week_of_year,
    day(dg.date) as day,
    dayname(dg.date) as day_name,
    dayofweekiso(dg.date) as day_of_week,
    dayofyear(dg.date) as day_of_year,
    dayofweekiso(dg.date) > 5 as is_weekend,
    uh.date is not null as is_us_holiday
from date_generator as dg
left join us_holidays as uh
    on dg.date = uh.date
```

### With this PR:

```bash
🚀 sqlfluff lint --rules L031 /tmp/dim_date.sql
CRITICAL   [L031] Applying rule L031 threw and Exception: 'NoneType' object has no attribute 'raw'
Traceback (most recent call last):
  File "/Users/dmpires/code/tmp-worktrees/sqlfluff/src/sqlfluff/core/rules/base.py", line 267, in crawl
    res = self._eval(
  File "/Users/dmpires/code/tmp-worktrees/sqlfluff/src/sqlfluff/core/rules/std.py", line 2959, in _eval
    self._lint_aliases_in_join(
  File "/Users/dmpires/code/tmp-worktrees/sqlfluff/src/sqlfluff/core/rules/std.py", line 2980, in _lint_aliases_in_join
    if base_table.raw == table_ref.raw and base_table != table_ref:
AttributeError: 'NoneType' object has no attribute 'raw'
== [/tmp/dim_date.sql] FAIL
L:   5 | P:   5 | L031 | Unexpected exception: 'NoneType' object has no attribute
                       | 'raw'; Could you open an issue at
                       | https://github.com/sqlfluff/sqlfluff/issues ? You can
                       | ignore this exception for now, by adding '--noqa: L031'
                       | at the end of line 5
L:   9 | P:  17 |  PRS | Found unparsable section: " '2010-01-01'"
L:  14 | P:  21 |  PRS | Found unparsable section: '=>10000'
L:  35 | P:  24 | L031 | Avoid using aliases in join condition
L:  36 | P:  26 | L031 | Avoid using aliases in join condition
```