### PR TITLE
Add pre commit hooks for `lint` and `fix`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,20 @@
+
+- id: sqlfluff-lint
+  name: sqlfluff-lint
+  entry: sqlfluff
+  language: python
+  description: 'Lints sql files with `sqlfluff`'
+  types: [sql]
+  args: [lint]
+  require_serial: false
+  additional_dependencies: []
+
+- id: sqlfluff-fix
+  name: sqlfluff-fix
+  entry: sqlfluff
+  language: python
+  description: 'Fixes sql lint errors with `sqlfluff`'
+  types: [sql]
+  args: [fix]
+  require_serial: false
+  additional_dependencies: []

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,7 +9,8 @@
 
 - id: sqlfluff-fix
   name: sqlfluff-fix
-  entry: sqlfluff fix
+  # Needs to use "--force" to disable confirmation
+  entry: sqlfluff fix --force
   language: python
   description: 'Fixes sql lint errors with `sqlfluff`'
   types: [sql]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   language: python
   description: 'Lints sql files with `sqlfluff`'
   types: [sql]
-  require_serial: false
+  require_serial: true
   additional_dependencies: []
 
 - id: sqlfluff-fix
@@ -13,5 +13,5 @@
   language: python
   description: 'Fixes sql lint errors with `sqlfluff`'
   types: [sql]
-  require_serial: false
+  require_serial: true
   additional_dependencies: []

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,20 +1,17 @@
-
 - id: sqlfluff-lint
   name: sqlfluff-lint
-  entry: sqlfluff
+  entry: sqlfluff lint
   language: python
   description: 'Lints sql files with `sqlfluff`'
   types: [sql]
-  args: [lint]
   require_serial: false
   additional_dependencies: []
 
 - id: sqlfluff-fix
   name: sqlfluff-fix
-  entry: sqlfluff
+  entry: sqlfluff fix
   language: python
   description: 'Fixes sql lint errors with `sqlfluff`'
   types: [sql]
-  args: [fix]
   require_serial: false
   additional_dependencies: []

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,6 +10,7 @@
 - id: sqlfluff-fix
   name: sqlfluff-fix
   # Needs to use "--force" to disable confirmation
+  # By default all the rules are applied
   entry: sqlfluff fix --force
   language: python
   description: 'Fixes sql lint errors with `sqlfluff`'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,19 +92,22 @@ html_theme_options = {
     "codecov_button": True,
 }
 
-# Replacement variables in code-blocks
-# do not work, so we use these functions
-# from: https://github.com/sphinx-doc/sphinx/issues/4054#issuecomment-329097229
-def ultimateReplace(app, docname, source):
+
+def ultimate_replace(app, docname, source):
+    """Replaces variables in docs, including code blocks.
+
+    From: https://github.com/sphinx-doc/sphinx/issues/4054#issuecomment-329097229
+    """
     result = source[0]
     for key in app.config.ultimate_replacements:
         result = result.replace(key, app.config.ultimate_replacements[key])
     source[0] = result
 
-ultimate_replacements = {
-    "|release|" : release
-}
+
+ultimate_replacements = {"|release|": release}
+
 
 def setup(app):
-   app.add_config_value('ultimate_replacements', {}, True)
-   app.connect('source-read', ultimateReplace)
+    """Configures the documentation app."""
+    app.add_config_value("ultimate_replacements", {}, True)
+    app.connect("source-read", ultimate_replace)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,6 +5,8 @@ list see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
+import configparser
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -15,6 +17,11 @@ https://www.sphinx-doc.org/en/master/usage/configuration.html
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+# Get the global config info as currently stated
+# (we use the config file to avoid actually loading any python here)
+config = configparser.ConfigParser()
+config.read(["../../src/sqlfluff/config.ini"])
+stable_version = config.get("sqlfluff", "stable_version")
 
 # -- Project information -----------------------------------------------------
 
@@ -23,7 +30,7 @@ copyright = "2019, Alan Cruickshank"
 author = "Alan Cruickshank"
 
 # The full version, including alpha/beta/rc tags
-release = "0.3.6"
+release = stable_version
 
 
 # -- General configuration ---------------------------------------------------
@@ -84,3 +91,20 @@ html_theme_options = {
     # Codecov button
     "codecov_button": True,
 }
+
+# Replacement variables in code-blocks
+# do not work, so we use these functions
+# from: https://github.com/sphinx-doc/sphinx/issues/4054#issuecomment-329097229
+def ultimateReplace(app, docname, source):
+    result = source[0]
+    for key in app.config.ultimate_replacements:
+        result = result.replace(key, app.config.ultimate_replacements[key])
+    source[0] = result
+
+ultimate_replacements = {
+    "|release|" : release
+}
+
+def setup(app):
+   app.add_config_value('ultimate_replacements', {}, True)
+   app.connect('source-read', ultimateReplace)

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -240,6 +240,8 @@ projects. In particular it provides mock objects for:
 .. _`dbt`: https://www.getdbt.com/
 .. _`github`: https://www.github.com/sqlfluff/sqlfluff
 
+.. _dbt-project-configuration:
+
 Dbt Project Configuration
 -------------------------
 

--- a/docs/source/production.rst
+++ b/docs/source/production.rst
@@ -89,28 +89,48 @@ such as:
 Using `pre-commit`_
 ^^^^^^^^^^^^^^^^^^^
 
+`pre-commit`_ is a framework to manage git "hooks"
+triggered right before a commit is made.
+
+A `git hook`_ is a git feature to "fire off custom scripts"
+when specific actions occur.
+
+Using `pre-commit`_ with SQLFluff is a good way
+to provide automated linting to SQL developers.
+
+With `pre-commit`_, you also get the benefit of
+only linting/fixing the files that changed.
+
 SQLFluff comes with two `pre-commit`_ hooks:
 
 * sqlfluff-lint: returns linting errors.
 * sqlfluff-fix: attempts to fix rule violations.
 
-Running with `pre-commit`_, you get the benefit of
-only linting/fixing the files that changed.
-
-Your `.pre-commit-config.yaml` should look like this:
+You should create a file named `.pre-commit-config.yaml`
+at the root of your git project, which should look
+like this:
 
 .. code-block:: yaml
 
   repos:
   - repo: https://github.com/sqlfluff/sqlfluff
-    rev: v0.4.0
+    rev: v|release|
     hooks:
       - id: sqlfluff-lint
         # For dbt projects, this installs the dbt "extras":
         # additional_dependencies: ['.[dbt]']
       - id: sqlfluff-fix
-        # Fixes indentation and inconsistent capitalisation
-        args: [--rules, "L003,L014"]
+        # Arbitrary arguments to show an example
+        # args: [--rules, "L003,L014"]
         # additional_dependencies: ['.[dbt]']
 
+When trying to use the `dbt templater`_, uncomment the
+``additional_dependencies`` to install the extras.
+This is equivalent to running ``pip install sqlfluff[dbt]``.
+
+Note that you can pass the same arguments available
+through the CLI using ``args:``.
+
 .. _`pre-commit`: https://pre-commit.com/
+.. _`git hook`: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
+.. _`dbt templater`: `dbt-project-configuration`

--- a/docs/source/production.rst
+++ b/docs/source/production.rst
@@ -85,3 +85,32 @@ such as:
   lines). The default is `origin/master`.
 * Configuring `diff-quality` to return an error code if the quality is too low
 * Troubleshooting
+
+Using `pre-commit`_
+^^^^^^^^^^^^^^^^^^^
+
+SQLFluff comes with two `pre-commit`_ hooks:
+
+* sqlfluff-lint: returns linting errors.
+* sqlfluff-fix: attempts to fix rule violations.
+
+Running with `pre-commit`_, you get the benefit of
+only linting/fixing the files that changed.
+
+Your `.pre-commit-config.yaml` should look like this:
+
+.. code-block:: yaml
+
+  repos:
+  - repo: https://github.com/sqlfluff/sqlfluff
+    rev: v0.4.0
+    hooks:
+      - id: sqlfluff-lint
+        # For dbt projects, this installs the dbt "extras":
+        # additional_dependencies: ['.[dbt]']
+      - id: sqlfluff-fix
+        # Fixes indentation and inconsistent capitalisation
+        args: [--rules, "L003,L014"]
+        # additional_dependencies: ['.[dbt]']
+
+.. _`pre-commit`: https://pre-commit.com/

--- a/src/sqlfluff/config.ini
+++ b/src/sqlfluff/config.ini
@@ -1,4 +1,4 @@
 # Config file for sqlfluff, mostly for version info for now
 [sqlfluff]
 version=0.4.0a1
-stable_version=0.4.0
+stable_version=0.3.6

--- a/src/sqlfluff/config.ini
+++ b/src/sqlfluff/config.ini
@@ -1,3 +1,4 @@
 # Config file for sqlfluff, mostly for version info for now
 [sqlfluff]
 version=0.4.0a1
+stable_version=0.4.0


### PR DESCRIPTION
Test it out :)

```yaml
repos:
- repo: https://github.com/dmateusp/sqlfluff
  rev: 9cb4a120ed877a3abdfbef054d00763997e73069
  hooks:
    - id: sqlfluff-lint
      # For dbt projects, this installs the dbt "extras"
      # additional_dependencies: ['.[dbt]']
    - id: sqlfluff-fix
      args: [--rules, "L003,L014"]
      # additional_dependencies: ['.[dbt]']
```

Related: https://github.com/sqlfluff/sqlfluff/issues/523