### PR TITLE
Fix broken pathing issues

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -579,14 +579,13 @@ def parse(path, code_only, format, profiler, bench, nofail, logger=None, **kwarg
         # handle stdin if specified via lone '-'
         if "-" == path:
             # put the parser result in a list to iterate later
-            config = lnt.config.make_child_from_path("stdin")
             result = [
                 (
                     # TODO: Remove verbose
                     *lnt.parse_string(
-                        sys.stdin.read(), "stdin", recurse=recurse, config=config
+                        sys.stdin.read(), "stdin", recurse=recurse, config=lnt.config
                     ),
-                    config,
+                    lnt.config,
                 )
             ]
         else:

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -54,8 +54,9 @@ def test__cli__command_directed():
     check_b = "Indentation"
     assert check_a in result.output
     assert check_b in result.output
-    # Finally check the WHOLE output to make sure that unexpected newlines are not added
-    assert result.output == expected_output
+    # Finally check the WHOLE output to make sure that unexpected newlines are not added.
+    # The replace command just accounts for cross platform testing.
+    assert result.output.replace("\\", "/") == expected_output
 
 
 def test__cli__command_dialect():


### PR DESCRIPTION
For some reason two tests were failing on master for me. One is related to UNIX/Windows path handling. The other relates to an issue when trying to make a config object from the path `stdin` which would have no effect, except was causing a conflict error in trying to use both absolute and relative paths.

This PR fixes both.