### PR TITLE
Failing test with empty file

### DIFF
--- a/src/sqlfluff/core/parser/parser.py
+++ b/src/sqlfluff/core/parser/parser.py
@@ -21,6 +21,8 @@ class Parser:
 
     def parse(self, segments: Tuple["BaseSegment", ...], recurse=True) -> "BaseSegment":
         """Parse a series of lexed tokens using the current dialect."""
+        if not segments:
+            raise ValueError("Cannot parse an empty iterable of segments.")
         # Instantiate the root segment
         root_segment = self.RootSegment(segments=segments)
         # Call .parse() on that segment

--- a/test/core/dialects/dialects_test.py
+++ b/test/core/dialects/dialects_test.py
@@ -64,14 +64,21 @@ def test__dialect__base_file_parse(dialect, file):
     # Do the parse WITHOUT lots of logging
     # The logs get too long here to be useful. We should use
     # specfic segment tests if we want to debug logs.
-    parsed = Parser(config=config).parse(tokens)
-    print("Post-parse structure: {0}".format(parsed.to_tuple(show_raw=True)))
-    print("Post-parse structure: {0}".format(parsed.stringify()))
-    # Check we're all there.
-    assert parsed.raw == raw
-    # Check that there's nothing un parsable
-    typs = parsed.type_set()
-    assert "unparsable" not in typs
+    if raw:
+        parsed = Parser(config=config).parse(tokens)
+        print("Post-parse structure: {0}".format(parsed.to_tuple(show_raw=True)))
+        print("Post-parse structure: {0}".format(parsed.stringify()))
+        # Check we're all there.
+        assert parsed.raw == raw
+        # Check that there's nothing un parsable
+        typs = parsed.type_set()
+        assert "unparsable" not in typs
+    else:
+        # If it's an empty file, check that we get a value exception
+        # here. The linter handles this by *not* parsing the file,
+        # but in this case, we explicitly want an error.
+        with pytest.raises(ValueError):
+            Parser(config=config).parse(tokens)
 
 
 @pytest.mark.parametrize("dialect,sqlfile,code_only,yamlfile", parse_structure_examples)

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -127,3 +127,11 @@ def test__linter__linting_result__combine_dicts():
     assert lr.combine_dicts(a, b, r) == dict(
         a=3, b=123, f=876.321, h=19, i=321.0, j=23478, z=22
     )
+
+
+def test__linter__empty_file():
+    """Test linter behaves nicely with an empty string."""
+    lntr = Linter()
+    # Make sure no exceptions raised and no violations found in empty file.
+    parsed = lntr.parse_string("")
+    assert not parsed.violations


### PR DESCRIPTION
Reproduces the error from #587


```
sqlfluff lint /Users/niallwoodward/dev/pull_requests/sqlfluff/test/fixtures/parser/ansi/empty_file.sql
Traceback (most recent call last):
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff_venv/bin/sqlfluff", line 11, in <module>
    load_entry_point('sqlfluff', 'console_scripts', 'sqlfluff')()
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff_venv/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff_venv/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff_venv/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff_venv/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff_venv/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff/src/sqlfluff/cli/commands.py", line 323, in lint
    ignore_files=not disregard_sqlfluffignores,
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff/src/sqlfluff/core/linter.py", line 1158, in lint_paths
    ignore_files=ignore_files,
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff/src/sqlfluff/core/linter.py", line 1136, in lint_path
    target_file.read(), fname=fname, fix=fix, config=config
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff/src/sqlfluff/core/linter.py", line 936, in lint_string
    parsed = self.parse_string(in_str=in_str, fname=fname, config=config)
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff/src/sqlfluff/core/linter.py", line 748, in parse_string
    indent_balance = sum(getattr(elem, "indent_val", 0) for elem in tokens)
TypeError: 'NoneType' object is not iterable
```