### PR TITLE
Allow an underscore as the first char in a semi structured element key

### DIFF
--- a/src/sqlfluff/core/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/core/dialects/dialect_snowflake.py
@@ -73,7 +73,7 @@ snowflake_dialect.add(
         "=>", name="parameter_assigner", type="parameter_assigner"
     ),
     NakedSemiStructuredElementSegment=ReSegment.make(
-        r"[A-Z][A-Z0-9_]*",
+        r"[A-Z0-9_]*",
         name="naked_semi_structured_element",
         type="semi_structured_element",
     ),

--- a/test/fixtures/parser/snowflake/snowflake_json_underscore_key.sql
+++ b/test/fixtures/parser/snowflake/snowflake_json_underscore_key.sql
@@ -1,0 +1,1 @@
+select x.y:_z::string from x


### PR DESCRIPTION
Picked this one up from my work codebase. Had a parse error on the `_z` as the regex didn't match. Does anyone know why the regex was like that to start with? Don't want to have missed something.