### PR TITLE
Fix test on master branch now L036 added

### DIFF
--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -108,7 +108,7 @@ def test__linter__lint_string_vs_file(path):
 
 
 @pytest.mark.parametrize(
-    "rules,num_violations", [(None, 6), ("L010", 2), (("L001", "L009", "L031"), 2)]
+    "rules,num_violations", [(None, 7), ("L010", 2), (("L001", "L009", "L031"), 2)]
 )
 def test__linter__get_violations_filter_rules(rules, num_violations):
     """Test filtering violations by which rules were violated."""


### PR DESCRIPTION
New L036 rule was causing this test to fail.

```
L:   1 | P:   1 | L036 | Select targets should be on a new line unless there is
                       | only one select target.
L:   1 | P:  13 | L010 | Inconsistent capitalisation of keywords.
L:   1 | P:  22 | L011 | Implicit aliasing of table not allowed. Use explicit
                       | `AS` clause.
L:   1 | P:  22 | L025 | Alias 'c' is never used in SELECT statement.
L:   1 | P:  22 | L031 | Avoid using aliases in join condition
L:   1 | P:  30 | L010 | Inconsistent capitalisation of keywords.
L:   1 | P:  33 | L009 | Files must end with a trailing newline.
```