### PR TITLE
L012 bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow whitespace before a shorthand cast. ([#544](https://github.com/sqlfluff/sqlfluff/pull/544))
 - Silenced warnings when fixing from stdin. ([#522](https://github.com/sqlfluff/sqlfluff/pull/522))
 - Allow an underscore as the first char in a semi structured element key. ([#596](https://github.com/sqlfluff/sqlfluff/pull/596))
+- Fix PostFunctionGrammar in the Snowflake dialect which was causing strange behaviour in L012. ([#619](https://github.com/sqlfluff/sqlfluff/pull/619/files))
 
 ### Removed
 - Dropped support for python 3.5. ([#482](https://github.com/sqlfluff/sqlfluff/pull/482))

--- a/src/sqlfluff/core/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/core/dialects/dialect_snowflake.py
@@ -114,10 +114,8 @@ snowflake_dialect.replace(
     ),
     PostFunctionGrammar=Sequence(
         Ref("WithinGroupClauseSegment", optional=True),
-        Sequence(
-            Sequence(OneOf("IGNORE", "RESPECT"), "NULLS", optional=True),
-            Ref("OverClauseSegment"),
-        ),
+        Sequence(OneOf("IGNORE", "RESPECT"), "NULLS", optional=True),
+        Ref("OverClauseSegment"),
     ),
 )
 

--- a/src/sqlfluff/core/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/core/dialects/dialect_snowflake.py
@@ -112,6 +112,13 @@ snowflake_dialect.replace(
         Ref("QuotedIdentifierSegment"),
         Ref("ColumnIndexIdentifierSegment"),
     ),
+    PostFunctionGrammar=Sequence(
+        Ref("WithinGroupClauseSegment", optional=True),
+        Sequence(
+            Sequence(OneOf("IGNORE", "RESPECT"), "NULLS", optional=True),
+            Ref("OverClauseSegment"),
+        ),
+    ),
 )
 
 

--- a/test/core/rules/test_cases/L012.yml
+++ b/test/core/rules/test_cases/L012.yml
@@ -1,7 +1,7 @@
 rule: L012
 
-test_1:
-  # Add whitespace when fixing implicit aliasing
+issue_561:
+  # Test for https://github.com/sqlfluff/sqlfluff/issues/561
   pass_str: |
     select
       array_agg(catalog_item_id) within group

--- a/test/core/rules/test_cases/L012.yml
+++ b/test/core/rules/test_cases/L012.yml
@@ -10,4 +10,5 @@ test_1:
     from x
 
   configs:
-    dialect: snowflake
+    core:
+      dialect: snowflake

--- a/test/core/rules/test_cases/L012.yml
+++ b/test/core/rules/test_cases/L012.yml
@@ -1,0 +1,13 @@
+rule: L012
+
+test_1:
+  # Add whitespace when fixing implicit aliasing
+  pass_str: |
+    select
+      array_agg(catalog_item_id) within group
+        (order by product_position asc) over (partition by (event_id, shelf_position))
+      as shelf_catalog_items
+    from x
+
+  configs:
+    dialect: snowflake


### PR DESCRIPTION
Resolves #561 

Implements the window function grammar from https://docs.snowflake.com/en/sql-reference/functions/array_agg.html#syntax.

I think this is subtly different to the postgres grammar, which I believe still to be correct:

https://github.com/sqlfluff/sqlfluff/blob/master/src/sqlfluff/core/dialects/dialect_postgres.py#L49-L55
https://www.postgresql.org/docs/9.4/functions-aggregate.html#FUNCTIONS-ORDEREDSET-TABLE