### PR TITLE
Include undeclared dependency "typing_extensions"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,8 @@ setup(
         "cached-property",
         # dataclasses backport for python 3.6
         "dataclasses",
+        # better type hints for older python versions
+        "typing_extensions",
     ],
     extras_require={
         "dbt": ["dbt>=0.17"],


### PR DESCRIPTION
Introduced by #580 (AKA me 😢 )

Added `typing_extensions` but didn't add it to `setup.py` thinking it was std lib, when it's not 🤦‍♂️

To recreate the current issue:
```
$ python -m venv .venv
$ source .venv/Scripts/activate
$ pip install --pre sqlfluff
$ sqlfluff --version
...
ModuleNotFoundError: No module named 'typing_extensions'
```

FWIW I think we should do another alpha release after this PR