### PR TITLE
Handle internal errors elegantly and report the triggering sql file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
 
 - Public API to enable people to import `sqlfluff` as a python module
@@ -59,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#632](https://github.com/sqlfluff/sqlfluff/pull/632) Handle internal errors elegantly, reporting the stacktrace and the error-surfacing file.
 - Big refactor of logging internally. `Linter` is now decoupled from
   logging so that it can be imported directly by subprojects without
   needing to worry about weird output or without the log handing getting

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -3,6 +3,7 @@
 import os
 import time
 import logging
+import traceback
 from typing import (
     Any,
     Dict,
@@ -1270,14 +1271,25 @@ class Linter:
         for path in paths:
             # Iterate through files recursively in the specified directory (if it's a directory)
             # or read the file directly if it's not
-            result.add(
-                self.lint_path(
-                    path,
-                    fix=fix,
-                    ignore_non_existent_files=ignore_non_existent_files,
-                    ignore_files=ignore_files,
+            try:
+                result.add(
+                    self.lint_path(
+                        path,
+                        fix=fix,
+                        ignore_non_existent_files=ignore_non_existent_files,
+                        ignore_files=ignore_files,
+                    )
                 )
-            )
+            except IOError as e:  # IOErrors caught in commands.py, so still raise it
+                raise (e)
+            except Exception:
+                linter_logger.warning(
+                    f"""
+Unable to lint {path} due to an internal error. Please report this as an issue with the stacktrace below!
+If you'd like to hide this warning, add the failing file to .sqlfluffignore
+{traceback.format_exc()}
+                    """,
+                )
         return result
 
     def parse_path(

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -1285,7 +1285,7 @@ class Linter:
             except Exception:
                 linter_logger.warning(
                     f"""
-Unable to lint {path} due to an internal error. Please report this as an issue with the stacktrace below!
+Unable to lint {path} due to an internal error. Please report this as an issue with your query's contents and stacktrace below!
 If you'd like to hide this warning, add the failing file to .sqlfluffignore
 {traceback.format_exc()}
                     """,

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -170,12 +170,12 @@ def test__linter__linting_result_get_violations():
 
 
 @patch("sqlfluff.core.linter.linter_logger")
-@patch("sqlfluff.core.Linter.lint_path")
+@patch("sqlfluff.core.Linter.lint_string")
 def test__linter__linting_unexpected_error_handled_gracefully(
-    patched_lint_path, patched_logger
+    patched_lint_string, patched_logger
 ):
     """Test that an unexpected internal error is handled gracefully and returns the issue-surfacing file."""
-    patched_lint_path.side_effect = Exception("Something unexpected happened")
+    patched_lint_string.side_effect = Exception("Something unexpected happened")
     lntr = Linter()
     lntr.lint_paths(["test/fixtures/linter/passing.sql"])
     assert (

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -177,7 +177,7 @@ def test__linter__linting_unexpected_error_handled_gracefully(
     """Test that an unexpected internal error is handled gracefully and returns the issue-surfacing file."""
     patched_lint_path.side_effect = Exception("Something unexpected happened")
     lntr = Linter()
-    result = lntr.lint_paths(["test/fixtures/linter/passing.sql"])
+    lntr.lint_paths(["test/fixtures/linter/passing.sql"])
     assert (
         "Unable to lint test/fixtures/linter/passing.sql due to an internal error."
         in patched_logger.warning.call_args[0][0]

--- a/test/fixtures/linter/passing.sql
+++ b/test/fixtures/linter/passing.sql
@@ -1,0 +1,1 @@
+select a from b


### PR DESCRIPTION
At present, if an attempt to lint a file fails due to an unhandled internal error, the linting process quits and doesn't report which file is causing the issue. This makes it hard to identify what file has surfaced the internal error, which you need to do in order to .sqlfluffignore the file and work around it. This PR prints the exception as a warning with the file that has surfaced the issue.

Outcome:

```
WARNING    Unable to lint /Users/niallwoodward/dev/.../models/reporting/query.sql due to an internal error. Please report this as an issue with your query's contents and stacktrace below!
To hide this warning, add the failing file to .sqlfluffignore
Traceback (most recent call last):
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff/src/sqlfluff/core/linter.py", line 1254, in lint_path
    target_file.read(), fname=fname, fix=fix, config=config
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff/src/sqlfluff/core/linter.py", line 1044, in lint_string
    parsed = self.parse_string(in_str=in_str, fname=fname, config=config)
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff/src/sqlfluff/core/linter.py", line 816, in parse_string
    tokens, lex_vs = lexer.lex(templated_file)
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff/src/sqlfluff/core/parser/lexer.py", line 343, in lex
    return self.enrich_segments(segment_buff, raw), violations
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff/src/sqlfluff/core/parser/lexer.py", line 373, in enrich_segments
    templated_slice
  File "/Users/niallwoodward/dev/pull_requests/sqlfluff/src/sqlfluff/core/templaters/base.py", line 289, in templated_slice_to_source_slice
    if stop_slices[-1][0] == "literal":
IndexError: list index out of range

WARNING    Indent balance test failed for '/Users/niallwoodward/dev/.../models/reporting/query2.sql'. Template indents will not be linted for this file.
WARNING    Indent balance test failed for '/Users/niallwoodward/dev/.../models/reporting/query3.sql'. Template indents will not be linted for this file.
==== summary ====
violations:        0 status:         PASS
______________________________________________________________________________________________________________ summary _______________________________________________________________________________________________________________
  sqlfluff: commands succeeded
  congratulations :)
```