### PR TITLE
Assume yes if prompted to attempt to fix

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -449,7 +449,7 @@ def fix(force, paths, bench=False, fixed_suffix="", logger=None, **kwargs):
             )
             c = click.getchar().lower()
             click.echo("...")
-            if c == "y":
+            if c in ("y", "\r", "\n"):
                 click.echo("Attempting fixes...")
                 # TODO: Remove verbose
                 success = do_fixes(

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -464,7 +464,7 @@ def fix(force, paths, bench=False, fixed_suffix="", logger=None, **kwargs):
             elif c == "n":
                 click.echo("Aborting...")
             else:
-                click.echo("Invalid input :(")
+                click.echo("Invalid input, please enter 'Y' or 'N'")
                 click.echo("Aborting...")
     else:
         click.echo("==== no fixable linting violations found ====")


### PR DESCRIPTION
If the user responds with "Enter" to the question "Are you sure you wish to attempt to fix these? [Y/n]", assume the default selection **Y**es.

Also makes the error when hitting a wrong key more explicit.

Fixes #638