### PR TITLE
Fix issue 646: Rule L036 misbehaves when there's trailing whitespace after "SELECT"

### DIFF
--- a/src/sqlfluff/core/rules/std.py
+++ b/src/sqlfluff/core/rules/std.py
@@ -3467,7 +3467,7 @@ class Rule_L036(BaseCrawler):
             if seg.is_type("newline") and first_new_line_idx == -1:
                 first_new_line_idx = fname_idx
             # TRICKY: Ignore whitespace prior to the first newline, e.g. if
-            # the line with "SELECT" (before any selct targets) has trailing
+            # the line with "SELECT" (before any select targets) has trailing
             # whitespace.
             if (
                 seg.is_type("whitespace")

--- a/src/sqlfluff/core/rules/std.py
+++ b/src/sqlfluff/core/rules/std.py
@@ -3462,11 +3462,14 @@ class Rule_L036(BaseCrawler):
                 cnt_select_targets += 1
                 if first_select_target_idx == -1:
                     first_select_target_idx = fname_idx
-            if seg.is_type("keyword") and seg.name == "SELECT" and select_idx - 1:
+            if seg.is_type("keyword") and seg.name == "SELECT" and select_idx == -1:
                 select_idx = fname_idx
             if seg.is_type("newline") and first_new_line_idx == -1:
                 first_new_line_idx = fname_idx
-            if seg.is_type("whitespace") and first_whitespace_idx == -1:
+            # TRICKY: Ignore whitespace prior to the first newline, e.g. if
+            # the line with "SELECT" (before any selct targets) has trailing
+            # whitespace.
+            if seg.is_type("whitespace") and first_new_line_idx != -1 and first_whitespace_idx == -1:
                 first_whitespace_idx = fname_idx
 
         eval_result = EvalResult(

--- a/src/sqlfluff/core/rules/std.py
+++ b/src/sqlfluff/core/rules/std.py
@@ -3469,7 +3469,11 @@ class Rule_L036(BaseCrawler):
             # TRICKY: Ignore whitespace prior to the first newline, e.g. if
             # the line with "SELECT" (before any selct targets) has trailing
             # whitespace.
-            if seg.is_type("whitespace") and first_new_line_idx != -1 and first_whitespace_idx == -1:
+            if (
+                seg.is_type("whitespace")
+                and first_new_line_idx != -1
+                and first_whitespace_idx == -1
+            ):
                 first_whitespace_idx = fname_idx
 
         eval_result = EvalResult(

--- a/test/core/rules/test_cases/L036.yml
+++ b/test/core/rules/test_cases/L036.yml
@@ -22,7 +22,11 @@ test_single_select_target_and_new_line_between_select_and_select_target:
         *
     from x
 
-test_mulitple_select_targets_all_on_the_same_line:
+test_multiple_select_targets_all_on_the_same_line:
   fail_str: |
     select a, b, c
     from x
+
+test_multiple_select_targets_trailing_whitespace_after_select:
+  # TRICKY: Use explicit newlines to preserve the trailing space after "SELECT".
+  pass_str: "SELECT \n    a,\n    b\nFROM t\n"


### PR DESCRIPTION
Addresses #646 