### PR TITLE
Issue 357: Rule L027 fails when using BigQuery date parts

### DIFF
--- a/src/sqlfluff/core/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/core/dialects/dialect_bigquery.py
@@ -50,6 +50,27 @@ bigquery_dialect.add(
     )
 )
 
+# Add additional bare functions. These are not *quite* bare functions, because
+# they can only be used as parameters to a handful of date functions, but this
+# is a simple way to allow these keywords without SQLFluff having to know about
+# all the BigQuery date/time function signaatures.
+bigquery_dialect.sets("bare_functions").update(
+    [
+        "MICROSECOND",
+        "MILLISECOND",
+        "SECOND",
+        "MINUTE",
+        "HOUR",
+        "DAY",
+        "WEEK",
+        "ISOWEEKMONTH",
+        "MONTH",
+        "QUARTER",
+        "YEAR",
+        "ISOYEAR",
+    ]
+)
+
 # Add additional datetime units
 # https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions#extract
 bigquery_dialect.sets("datetime_units").update(

--- a/test/core/rules/test_cases/L027.yml
+++ b/test/core/rules/test_cases/L027.yml
@@ -1,0 +1,13 @@
+rule: L027
+
+test_1:
+  # Allow use of BigQuery date parts (which are not quoted and were previously
+  # mistaken for column references and flagged by this rule).
+  pass_str: |
+    SELECT timestamp_trunc(a.ts, month) AS t
+    FROM a
+    JOIN b ON a.id = b.id
+
+  configs:
+    core:
+      dialect: bigquery


### PR DESCRIPTION
I'm creating this PR as a _possible_ way to address #357. On that issue, @alanmcruickshank [commented](https://github.com/sqlfluff/sqlfluff/issues/357#issuecomment-631741312) that this is a tricky design issue, saying:

>I don't really want to start hard coding function signatures into the parser, but I'm not sure how we can always conclusively know whether to expect a date-part or whether to expect a reference.

This proposed solution addresses the issue reasonably well, I think, albeit with some tradeoffs. It does so by "stretching" the notion of "bare functions" a bit. Normally, bare functions can be used as standalone expressions. This PR extends the BigQuery dialect's bare functions to include date parts. This addresses #357. The tradeoff is that the grammar becomes a bit lenient by allowing date parts as standalone expressions, even though they are really only allowed at specific places in BigQuery date functions. However, as @alanmcruickshank mentioned (same comment as above):

>occasionally mistaking identifiers for date-parts feels better than the other way around

I'd like to hear some opinions on this approach. I'm happy to tweak it or close it if it seems horrible 😄 , but I believe it may be a pragmatic way forward for now.

If this approach seems too loose, another possibility might be to tweak the `FunctionContentsGrammar`, somehow allowing date parts as "expressions" only when used as function parameters (i.e. inside parentheses). The tradeoff for this "plus" is that it involves slightly more changes to the grammar.