### PR TITLE
Test upgrading diffcover dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ bench-it
 # oyaml is like pyyaml but preserves orderings
 oyaml
 Jinja2
-diff-cover>=2.5.0,<3.0
+diff-cover>=2.5.0
 # pathspec handles the .sqlfluffignore file
 pathspec
 pytest

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
         "oyaml",
         "Jinja2",
         # Used for diffcover plugin
-        "diff-cover>=2.5.0,<3.0",
+        "diff-cover>=2.5.0",
         # Used for performance profiling
         "bench-it",
         # Used for .sqlfluffignore


### PR DESCRIPTION
We've previously restricted any versions of diffcover post 3.0. This PR relaxes that requirement to see whether this requirement is still necessary.

If tests pass, great. If tests fail, then we can assess the effort required for things to work.