### PR TITLE
Bump Click Version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     ],
     install_requires=[
         # Core
-        "click>=2.0",
+        "click>=7.1",
         "colorama>=0.3",
         "configparser",
         "oyaml",


### PR DESCRIPTION
Fixing https://github.com/sqlfluff/sqlfluff/issues/241, https://github.com/sqlfluff/sqlfluff/pull/244

Hi I got same issue as https://github.com/sqlfluff/sqlfluff/issues/241, and I have noticed that you updated click version in requirments.txt file but in `setup.py` the click package version was not modified. Thus, I got the same issue continuously so I upgraded the click version

```
pip install sqlfluff==0.3.6
Requirement already satisfied: sqlfluff==0.3.6 in /opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages (0.3.6)
Requirement already satisfied: click>=2.0 in /opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages (from sqlfluff==0.3.6) (6.7)

...

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.9/x64/bin/sqlfluff", line 11, in <module>
    load_entry_point('sqlfluff==0.3.6', 'console_scripts', 'sqlfluff')()
  File "/opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages/pkg_resources/__init__.py", line 490, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2862, in load_entry_point
    return ep.load()
  File "/opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2462, in load
    return self.resolve()
  File "/opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2468, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/opt/hostedtoolcache/Python/3.7.9/x64/lib/python3.7/site-packages/sqlfluff/cli/commands.py", line 132, in <module>
    type=click.Choice(['human', 'json', 'yaml'], case_sensitive=False),
TypeError: __init__() got an unexpected keyword argument 'case_sensitive'
make: *** [sql-lint] Error 123
```