### PR TITLE
Freeze dbt_utils in dbt fixture to 0.6.3 🥶

### DIFF
--- a/test/fixtures/dbt_project/packages.yml
+++ b/test/fixtures/dbt_project/packages.yml
@@ -1,3 +1,3 @@
 packages:
     - package: fishtown-analytics/dbt_utils
-      version: [">=0.6.0"]
+      version: ["0.6.3"]


### PR DESCRIPTION
Resolves #674 

Newly released 0.6.4 is not compatible with dbt017

