### PR TITLE
Fix leading comment/header issue in L019.

### DIFF
--- a/src/sqlfluff/core/rules/std.py
+++ b/src/sqlfluff/core/rules/std.py
@@ -2130,11 +2130,15 @@ class Rule_L019(BaseCrawler):
     config_keywords = ["comma_style"]
 
     @staticmethod
-    def _last_code_seg(raw_stack, idx=-1):
-        while True:
-            if raw_stack[idx].is_code or raw_stack[idx].is_type("newline"):
-                return raw_stack[idx]
-            idx -= 1
+    def _last_code_seg(raw_stack):
+        """Trace the raw stack back to the most recent code segment.
+
+        A return value of `None` indicates no code segments preceding the current position.
+        """
+        for segment in raw_stack[::-1]:
+            if segment.is_code or segment.is_type("newline"):
+                return segment
+        return None
 
     def _eval(self, segment, raw_stack, memory, **kwargs):
         """Enforce comma placement.
@@ -2218,6 +2222,9 @@ class Rule_L019(BaseCrawler):
             # A new line preceded by a comma == a trailing comma
             if segment.is_type("newline"):
                 last_seg = self._last_code_seg(raw_stack)
+                # no code precedes the current position: no issue
+                if last_seg is None:
+                    return None
                 if last_seg.is_type("comma"):
                     # Trigger fix routine
                     memory["insert_leading_comma"] = True

--- a/test/core/rules/test_cases/L019.yml
+++ b/test/core/rules/test_cases/L019.yml
@@ -24,6 +24,19 @@ leading_commas_allowed:
       L019:
         comma_style: leading
 
+leading_commas_allowed_with_header:
+  pass_str: |
+    
+    SELECT
+      a
+      , b
+    FROM c
+
+  configs:
+    rules:
+      L019:
+        comma_style: leading
+        
 leading_comma_violations_in_with_statement:
   fail_str: |
     WITH cte_1 as (

--- a/test/core/rules/test_cases/L019.yml
+++ b/test/core/rules/test_cases/L019.yml
@@ -36,7 +36,7 @@ leading_commas_allowed_with_header:
     rules:
       L019:
         comma_style: leading
-        
+
 leading_comma_violations_in_with_statement:
   fail_str: |
     WITH cte_1 as (


### PR DESCRIPTION
Rule L019 (leading/trailing commas) can fail when configured to "leading" commas when the beginning of a query contains one or more non-code lines.

The leading-comma version of the rule currently looks for code segments preceding the current segment. This change handles the case when there are none.
