### PR TITLE
Allow more complex offset structures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignore IDE files
 .vscode
 .idea
+.sqlfluff
 
 # Ignore Python cache and prebuilt things
 .cache

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -1235,8 +1235,22 @@ class LimitClauseSegment(BaseSegment):
     """A `LIMIT` clause like in `SELECT`."""
 
     type = "limit_clause"
-    match_grammar = Sequence("LIMIT", Ref("NumericLiteralSegment"))
-
+    match_grammar = Sequence(
+        "LIMIT",
+        OneOf(
+            Ref("NumericLiteralSegment"),
+            Sequence(
+                Ref("NumericLiteralSegment"),
+                "OFFSET",
+                Ref("NumericLiteralSegment")
+            ),
+            Sequence(
+                Ref("NumericLiteralSegment"),
+                Ref("CommaSegment"),
+                Ref("NumericLiteralSegment")
+            )
+        )
+    )
 
 @ansi_dialect.segment()
 class ValuesClauseSegment(BaseSegment):

--- a/test/fixtures/parser/ansi/select_with_limit_and_offset.sql
+++ b/test/fixtures/parser/ansi/select_with_limit_and_offset.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM counter
+LIMIT 10 OFFSET 10

--- a/test/fixtures/parser/ansi/select_with_offset_limit.sql
+++ b/test/fixtures/parser/ansi/select_with_offset_limit.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM counter
+LIMIT 10, 10

--- a/test/fixtures/parser/ansi/select_with_simple_limit.sql
+++ b/test/fixtures/parser/ansi/select_with_simple_limit.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM counter
+LIMIT 10


### PR DESCRIPTION
This pull request allows you to specify offsets in the format of `LIMIT 10, 10` and `LIMIT 10 OFFSET 10`.

This isn't quite ANSI, but neither is LIMIT in the first place it appears.