### PR TITLE
OneOf add tests to show that longest match is taken, but in case of same length, first is taken

### DIFF
--- a/test/core/parser/grammar_test.py
+++ b/test/core/parser/grammar_test.py
@@ -255,6 +255,26 @@ def test__parser__grammar_oneof_take_longest_match(seg_list):
         )
 
 
+def test__parser__grammar_oneof_take_first(seg_list):
+    """Test that the OneOf grammar takes first match in case they are of same length."""
+    fooRegex = ReSegment.make(r"fo{2}")
+    foo = KeywordSegment.make(
+        "foo",
+    )
+
+    # Both segments would match "foo"
+    # so we test that order matters
+    g1 = OneOf(fooRegex, foo)
+    g2 = OneOf(foo, fooRegex)
+    with RootParseContext(dialect=None) as ctx:
+        assert g1.match(seg_list[2:], parse_context=ctx).matched_segments == (
+            fooRegex("foo", seg_list[2].pos_marker),
+        )
+        assert g2.match(seg_list[2:], parse_context=ctx).matched_segments == (
+            foo("foo", seg_list[2].pos_marker),
+        )
+
+
 @pytest.mark.parametrize(
     "keyword,match_truthy",
     [


### PR DESCRIPTION
Added two tests to show the OneOf behavior. Per https://github.com/sqlfluff/sqlfluff/pull/719#discussion_r567145572, I wasn't sure exactly how OneOf worked, and after reading the OneOf docs: https://github.com/sqlfluff/sqlfluff/blob/7f1880ba4449310200d0ee5e6c0a19cc883db63d/src/sqlfluff/core/parser/grammar/anyof.py#L214, I just wanted to make sure I understood correctly.

> If it matches multiple, it returns the longest, and if any are the same
    length it returns the first (unless we explicitly just match first).