### PR TITLE
Issue 356: Rules that fail when using BigQuery UNNEST() with alias

### DIFF
--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -11,8 +11,6 @@ labs full sql grammar. In particular their way for dividing up the expression
 grammar. Check out their docs, they're awesome.
 https://www.cockroachlabs.com/docs/stable/sql-grammar.html#select_stmt
 """
-from _collections import OrderedDict
-
 from ..parser import (
     Matchable,
     BaseSegment,
@@ -148,9 +146,7 @@ ansi_dialect.sets("bracket_pairs").update(
 # apparently only BigQuery has this concept, but it's included in ANSI because
 # it impacts core linter rules and how they interpret the contents of
 # table_expressions.
-ansi_dialect.sets("value_table_functions").update(
-    []
-)
+ansi_dialect.sets("value_table_functions").update([])
 
 
 ansi_dialect.add(

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -933,20 +933,6 @@ class FromClauseSegment(BaseSegment):
             buff.append((clause, ref))
         return buff
 
-    def get_eventual_aliases(self):
-        """List the eventual aliases of this from clause.
-
-        Comes as a list of tuples (string, segment).
-        """
-        temp_buff = self.get_table_expressions_and_eventual_aliases()
-        buff = []
-        for table_expr, alias in temp_buff:
-            # Only append if non null. A None reference, may
-            # indicate a generator expression or similar.
-            if alias:
-                buff.append(alias)
-        return buff
-
 
 @ansi_dialect.segment()
 class CaseExpressionSegment(BaseSegment):

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -944,7 +944,7 @@ class FromClauseSegment(BaseSegment):
         """
         temp_buff = self.get_table_expressions_and_eventual_aliases()
         buff = []
-        for clause, alias in temp_buff:
+        for table_expr, alias in temp_buff:
             # Only append if non null. A None reference, may
             # indicate a generator expression or similar.
             if alias:

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -11,6 +11,7 @@ labs full sql grammar. In particular their way for dividing up the expression
 grammar. Check out their docs, they're awesome.
 https://www.cockroachlabs.com/docs/stable/sql-grammar.html#select_stmt
 """
+
 from ..parser import (
     Matchable,
     BaseSegment,
@@ -142,10 +143,13 @@ ansi_dialect.sets("bracket_pairs").update(
 )
 
 # Set the value table functions. These are functions that, if they appear as
-# an item in "FROM', are treated as returning a COLUMN, not a TABLE. Currently,
-# apparently only BigQuery has this concept, but it's included in ANSI because
-# it impacts core linter rules and how they interpret the contents of
-# table_expressions.
+# an item in "FROM', are treated as returning a COLUMN, not a TABLE. Among
+# Apparently, among dialects supported by SQLFluff, only BigQuery has this
+# concept, but this set is defined in the ANSI dialect because:
+# - It impacts core linter rules (see L020 and several other rules that subclass
+#   from it) and how they interpret the contents of table_expressions
+# - At least one other database (DB2) has the same value table function,
+#   UNNEST(), as BigQuery. DB2 is not currently supported by BigQuery.
 ansi_dialect.sets("value_table_functions").update([])
 
 
@@ -919,8 +923,8 @@ class FromClauseSegment(BaseSegment):
         Dedent.when(indented_joins=True),
     )
 
-    def get_table_expressions_and_eventual_aliases(self):
-        """List the table expressions and eventual aliases of this from clause.
+    def get_eventual_aliases(self):
+        """List the eventual aliases of this from clause.
 
         Comes as a list of tuples (table expr, tuple (string, segment, bool)).
         """

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -922,7 +922,7 @@ class FromClauseSegment(BaseSegment):
     def get_table_expressions_and_eventual_aliases(self):
         """List the table expressions and eventual aliases of this from clause.
 
-        Comes as a list of tuples (table expr, tuples (string, segment)).
+        Comes as a list of tuples (table expr, tuple (string, segment, bool)).
         """
         buff = []
         direct_table_children = self.get_children("table_expression")
@@ -930,7 +930,13 @@ class FromClauseSegment(BaseSegment):
         # Iterate through the potential sources of aliases
         for clause in (*direct_table_children, *join_clauses):
             ref = clause.get_eventual_alias()
-            buff.append((clause, ref))
+            # Only append if non null. A None reference, may
+            # indicate a generator expression or similar.
+            table_expr = clause \
+                if clause in direct_table_children \
+                else clause.get_child("table_expression")
+            if ref:
+                buff.append((table_expr, ref))
         return buff
 
 

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -932,9 +932,11 @@ class FromClauseSegment(BaseSegment):
             ref = clause.get_eventual_alias()
             # Only append if non null. A None reference, may
             # indicate a generator expression or similar.
-            table_expr = clause \
-                if clause in direct_table_children \
+            table_expr = (
+                clause
+                if clause in direct_table_children
                 else clause.get_child("table_expression")
+            )
             if ref:
                 buff.append((table_expr, ref))
         return buff

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -143,13 +143,13 @@ ansi_dialect.sets("bracket_pairs").update(
 )
 
 # Set the value table functions. These are functions that, if they appear as
-# an item in "FROM', are treated as returning a COLUMN, not a TABLE. Among
-# Apparently, among dialects supported by SQLFluff, only BigQuery has this
-# concept, but this set is defined in the ANSI dialect because:
+# an item in "FROM', are treated as returning a COLUMN, not a TABLE. Apparently,
+# among dialects supported by SQLFluff, only BigQuery has this concept, but this
+# set is defined in the ANSI dialect because:
 # - It impacts core linter rules (see L020 and several other rules that subclass
 #   from it) and how they interpret the contents of table_expressions
 # - At least one other database (DB2) has the same value table function,
-#   UNNEST(), as BigQuery. DB2 is not currently supported by BigQuery.
+#   UNNEST(), as BigQuery. DB2 is not currently supported by SQLFluff.
 ansi_dialect.sets("value_table_functions").update([])
 
 

--- a/src/sqlfluff/core/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/core/dialects/dialect_bigquery.py
@@ -82,6 +82,11 @@ bigquery_dialect.sets("unreserved_keywords").add("STRUCT")
 # Reserved Keywords
 bigquery_dialect.sets("reserved_keywords").add("FOR")
 
+# In BigQuery, UNNEST() returns a "value table".
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#value_tables
+bigquery_dialect.sets("value_table_functions").update(
+    ["unnest"]
+)
 
 # Bracket pairs (a set of tuples)
 bigquery_dialect.sets("bracket_pairs").update(

--- a/src/sqlfluff/core/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/core/dialects/dialect_bigquery.py
@@ -84,9 +84,7 @@ bigquery_dialect.sets("reserved_keywords").add("FOR")
 
 # In BigQuery, UNNEST() returns a "value table".
 # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#value_tables
-bigquery_dialect.sets("value_table_functions").update(
-    ["unnest"]
-)
+bigquery_dialect.sets("value_table_functions").update(["unnest"])
 
 # Bracket pairs (a set of tuples)
 bigquery_dialect.sets("bracket_pairs").update(

--- a/src/sqlfluff/core/rules/std/L020.py
+++ b/src/sqlfluff/core/rules/std/L020.py
@@ -35,8 +35,13 @@ class Rule_L020(BaseCrawler):
         return None
 
     @staticmethod
-    def _has_value_table_function(clause, dialect):
-        function = clause.get_child('function')
+    def _has_value_table_function(table_expr, dialect):
+        if not dialect:
+            # We need the dialect to get the value table function names. If
+            # we don't have it, assume the clause does not have one.
+            return False
+
+        function = table_expr.get_child('function')
         if not function:
             return False
 
@@ -59,12 +64,12 @@ class Rule_L020(BaseCrawler):
         # * None values
         # * Aliases for table value functions
         result = []
-        for clause, alias in aliases:
-            if alias and not cls._has_value_table_function(clause, dialect):
+        for table_expr, alias in aliases:
+            if alias and not cls._has_value_table_function(table_expr, dialect):
                 result.append(alias)
         return result
 
-    def _eval(self, segment, parent_stack, dialect, **kwargs):
+    def _eval(self, segment, parent_stack, **kwargs):
         """Get References and Aliases and allow linting.
 
         This rule covers a lot of potential cases of odd usages of
@@ -74,7 +79,7 @@ class Rule_L020(BaseCrawler):
         `_lint_references_and_aliases` method.
         """
         if segment.is_type("select_statement"):
-            aliases = self._get_aliases_from_select(segment, dialect)
+            aliases = self._get_aliases_from_select(segment, kwargs.get('dialect'))
             if not aliases:
                 return None
 

--- a/src/sqlfluff/core/rules/std/L020.py
+++ b/src/sqlfluff/core/rules/std/L020.py
@@ -44,7 +44,8 @@ class Rule_L020(BaseCrawler):
     def _has_value_table_function(table_expr, dialect):
         if not dialect:
             # We need the dialect to get the value table function names. If
-            # we don't have it, assume the clause does not have one.
+            # we don't have it, assume the clause does not have a value table
+            # function.
             return False
 
         function = table_expr.get_child("function")
@@ -62,17 +63,16 @@ class Rule_L020(BaseCrawler):
 
         Returns a tuple of two lists:
         - Table aliases
-        - Value table aliases
+        - Value table function aliases
         """
         fc = segment.get_child("from_clause")
         if not fc:
             # If there's no from clause then just abort.
             return None, None
-        aliases = fc.get_table_expressions_and_eventual_aliases()
+        aliases = fc.get_eventual_aliases()
 
-        # We only want table aliases, so filter out:
-        # * None values
-        # * Aliases for table value functions
+        # We only want table aliases, so filter out aliases for value table
+        # functions.
         table_aliases = []
         value_table_function_aliases = []
         for table_expr, alias_info in aliases:

--- a/src/sqlfluff/core/rules/std/L020.py
+++ b/src/sqlfluff/core/rules/std/L020.py
@@ -41,11 +41,11 @@ class Rule_L020(BaseCrawler):
             # we don't have it, assume the clause does not have one.
             return False
 
-        function = table_expr.get_child('function')
+        function = table_expr.get_child("function")
         if not function:
             return False
 
-        function_name = function.get_child('function_name')
+        function_name = function.get_child("function_name")
         if not function_name:
             return False
 
@@ -79,7 +79,7 @@ class Rule_L020(BaseCrawler):
         `_lint_references_and_aliases` method.
         """
         if segment.is_type("select_statement"):
-            aliases = self._get_aliases_from_select(segment, kwargs.get('dialect'))
+            aliases = self._get_aliases_from_select(segment, kwargs.get("dialect"))
             if not aliases:
                 return None
 

--- a/src/sqlfluff/core/rules/std/L020.py
+++ b/src/sqlfluff/core/rules/std/L020.py
@@ -46,10 +46,8 @@ class Rule_L020(BaseCrawler):
             return False
 
         function_name = function.get_child("function_name")
-        if not function_name:
-            return False
-
-        return function_name.raw in dialect.sets("value_table_functions")
+        return function_name and \
+            function_name.raw in dialect.sets("value_table_functions")
 
     @classmethod
     def _get_aliases_from_select(cls, segment, dialect=None):

--- a/src/sqlfluff/core/rules/std/L020.py
+++ b/src/sqlfluff/core/rules/std/L020.py
@@ -67,12 +67,11 @@ class Rule_L020(BaseCrawler):
         # * Aliases for table value functions
         table_aliases = []
         value_table_function_aliases = []
-        for table_expr, alias in aliases:
-            if alias:
-                if not cls._has_value_table_function(table_expr, dialect):
-                    table_aliases.append(alias)
-                else:
-                    value_table_function_aliases.append(alias)
+        for table_expr, alias_info in aliases:
+            if not cls._has_value_table_function(table_expr, dialect):
+                table_aliases.append(alias_info)
+            else:
+                value_table_function_aliases.append(alias_info)
         return table_aliases, value_table_function_aliases
 
     def _eval(self, segment, parent_stack, **kwargs):

--- a/src/sqlfluff/core/rules/std/L020.py
+++ b/src/sqlfluff/core/rules/std/L020.py
@@ -52,7 +52,7 @@ class Rule_L020(BaseCrawler):
         return function_name.raw in dialect.sets("value_table_functions")
 
     @classmethod
-    def _get_aliases_from_select(cls, segment, dialect):
+    def _get_aliases_from_select(cls, segment, dialect=None):
         # Get the aliases referred to in the clause
         fc = segment.get_child("from_clause")
         if not fc:

--- a/src/sqlfluff/core/rules/std/L020.py
+++ b/src/sqlfluff/core/rules/std/L020.py
@@ -52,7 +52,7 @@ class Rule_L020(BaseCrawler):
             return False
 
         function_name = function.get_child("function_name")
-        return function_name and function_name.raw in dialect.sets(
+        return function_name and function_name.raw.lower() in dialect.sets(
             "value_table_functions"
         )
 

--- a/src/sqlfluff/core/rules/std/L020.py
+++ b/src/sqlfluff/core/rules/std/L020.py
@@ -8,8 +8,15 @@ from ..base import BaseCrawler, LintResult
 class Rule_L020(BaseCrawler):
     """Table aliases should be unique within each clause."""
 
-    def _lint_references_and_aliases(self, table_aliases, value_table_function_aliases, references,
-                                     col_aliases, using_cols, parent_select):
+    def _lint_references_and_aliases(
+        self,
+        table_aliases,
+        value_table_function_aliases,
+        references,
+        col_aliases,
+        using_cols,
+        parent_select,
+    ):
         """Check whether any aliases are duplicates.
 
         NB: Subclasses of this error should override this function.
@@ -45,14 +52,15 @@ class Rule_L020(BaseCrawler):
             return False
 
         function_name = function.get_child("function_name")
-        return function_name and \
-            function_name.raw in dialect.sets("value_table_functions")
+        return function_name and function_name.raw in dialect.sets(
+            "value_table_functions"
+        )
 
     @classmethod
     def _get_aliases_from_select(cls, segment, dialect=None):
-        """
-        Gets the aliases referred to in the FROM clause. Returns a tuple of two
-        lists:
+        """Gets the aliases referred to in the FROM clause.
+
+        Returns a tuple of two lists:
         - Table aliases
         - Value table aliases
         """
@@ -84,8 +92,9 @@ class Rule_L020(BaseCrawler):
         `_lint_references_and_aliases` method.
         """
         if segment.is_type("select_statement"):
-            table_aliases, value_table_function_aliases = \
-                self._get_aliases_from_select(segment, kwargs.get("dialect"))
+            table_aliases, value_table_function_aliases = self._get_aliases_from_select(
+                segment, kwargs.get("dialect")
+            )
             if not table_aliases and not value_table_function_aliases:
                 return None
 
@@ -156,9 +165,12 @@ class Rule_L020(BaseCrawler):
 
             # Pass them all to the function that does all the work.
             # NB: Subclasses of this rules should override the function below
-            return self._lint_references_and_aliases(table_aliases,
-                                                     value_table_function_aliases,
-                                                     reference_buffer,
-                                                     col_aliases, using_cols,
-                                                     parent_select)
+            return self._lint_references_and_aliases(
+                table_aliases,
+                value_table_function_aliases,
+                reference_buffer,
+                col_aliases,
+                using_cols,
+                parent_select,
+            )
         return None

--- a/src/sqlfluff/core/rules/std/L025.py
+++ b/src/sqlfluff/core/rules/std/L025.py
@@ -33,9 +33,8 @@ class Rule_L025(Rule_L020):
 
     """
 
-    def _lint_references_and_aliases(
-        self, aliases, references, col_aliases, using_cols, parent_select
-    ):
+    def _lint_references_and_aliases(self, table_aliases, value_table_function_aliases, references,
+                                     col_aliases, using_cols, parent_select):
         """Check all aliased references against tables referenced in the query."""
         # A buffer to keep any violations.
         violation_buff = []
@@ -46,7 +45,7 @@ class Rule_L025(Rule_L020):
             if tbl_ref:
                 tbl_refs.add(tbl_ref[0])
 
-        for ref_str, seg, aliased in aliases:
+        for ref_str, seg, aliased in table_aliases:
             if aliased and ref_str not in tbl_refs:
                 violation_buff.append(
                     LintResult(

--- a/src/sqlfluff/core/rules/std/L025.py
+++ b/src/sqlfluff/core/rules/std/L025.py
@@ -33,8 +33,15 @@ class Rule_L025(Rule_L020):
 
     """
 
-    def _lint_references_and_aliases(self, table_aliases, value_table_function_aliases, references,
-                                     col_aliases, using_cols, parent_select):
+    def _lint_references_and_aliases(
+        self,
+        table_aliases,
+        value_table_function_aliases,
+        references,
+        col_aliases,
+        using_cols,
+        parent_select,
+    ):
         """Check all aliased references against tables referenced in the query."""
         # A buffer to keep any violations.
         violation_buff = []

--- a/src/sqlfluff/core/rules/std/L026.py
+++ b/src/sqlfluff/core/rules/std/L026.py
@@ -27,9 +27,8 @@ class Rule_L026(Rule_L025):
 
     """
 
-    def _lint_references_and_aliases(
-        self, aliases, references, col_aliases, using_cols, parent_select
-    ):
+    def _lint_references_and_aliases(self, table_aliases, value_table_function_aliases, references,
+                                     col_aliases, using_cols, parent_select):
         # A buffer to keep any violations.
         violation_buff = []
 
@@ -37,10 +36,10 @@ class Rule_L026(Rule_L025):
         for r in references:
             tbl_ref = r.extract_reference(level=2)
             # Check whether the string in the list of strings
-            if tbl_ref and tbl_ref[0] not in [a[0] for a in aliases]:
+            if tbl_ref and tbl_ref[0] not in [a[0] for a in table_aliases]:
                 # Last check, this *might* be a correlated subquery reference.
                 if parent_select:
-                    parent_aliases = self._get_aliases_from_select(parent_select)
+                    parent_aliases, _ = self._get_aliases_from_select(parent_select)
                     if parent_aliases and tbl_ref[0] in [a[0] for a in parent_aliases]:
                         continue
 

--- a/src/sqlfluff/core/rules/std/L026.py
+++ b/src/sqlfluff/core/rules/std/L026.py
@@ -27,8 +27,15 @@ class Rule_L026(Rule_L025):
 
     """
 
-    def _lint_references_and_aliases(self, table_aliases, value_table_function_aliases, references,
-                                     col_aliases, using_cols, parent_select):
+    def _lint_references_and_aliases(
+        self,
+        table_aliases,
+        value_table_function_aliases,
+        references,
+        col_aliases,
+        using_cols,
+        parent_select,
+    ):
         # A buffer to keep any violations.
         violation_buff = []
 

--- a/src/sqlfluff/core/rules/std/L027.py
+++ b/src/sqlfluff/core/rules/std/L027.py
@@ -29,8 +29,15 @@ class Rule_L027(Rule_L025):
         LEFT JOIN vee ON vee.a = foo.a
     """
 
-    def _lint_references_and_aliases(self, table_aliases, value_table_function_aliases, references,
-                                     col_aliases, using_cols, parent_select):
+    def _lint_references_and_aliases(
+        self,
+        table_aliases,
+        value_table_function_aliases,
+        references,
+        col_aliases,
+        using_cols,
+        parent_select,
+    ):
         # Do we have more than one? If so, all references should be qualified.
         if len(table_aliases) <= 1:
             return None

--- a/src/sqlfluff/core/rules/std/L027.py
+++ b/src/sqlfluff/core/rules/std/L027.py
@@ -29,11 +29,10 @@ class Rule_L027(Rule_L025):
         LEFT JOIN vee ON vee.a = foo.a
     """
 
-    def _lint_references_and_aliases(
-        self, aliases, references, col_aliases, using_cols, parent_select
-    ):
+    def _lint_references_and_aliases(self, table_aliases, value_table_function_aliases, references,
+                                     col_aliases, using_cols, parent_select):
         # Do we have more than one? If so, all references should be qualified.
-        if len(aliases) <= 1:
+        if len(table_aliases) <= 1:
             return None
         # A buffer to keep any violations.
         violation_buff = []

--- a/src/sqlfluff/core/rules/std/L028.py
+++ b/src/sqlfluff/core/rules/std/L028.py
@@ -40,8 +40,15 @@ class Rule_L028(Rule_L025):
 
     config_keywords = ["single_table_references"]
 
-    def _lint_references_and_aliases(self, table_aliases, value_table_function_aliases, references,
-                                     col_aliases, using_cols, parent_select):
+    def _lint_references_and_aliases(
+        self,
+        table_aliases,
+        value_table_function_aliases,
+        references,
+        col_aliases,
+        using_cols,
+        parent_select,
+    ):
         """Iterate through references and check consistency."""
         # How many aliases are there? If more than one then abort.
         if len(table_aliases) > 1:

--- a/src/sqlfluff/core/rules/std/L028.py
+++ b/src/sqlfluff/core/rules/std/L028.py
@@ -53,8 +53,6 @@ class Rule_L028(Rule_L025):
         # How many aliases are there? If more than one then abort.
         if len(table_aliases) > 1:
             return None
-        # Oddball case: Column aliases provided via function calls in by FROM or
-        # JOIN. References to these should not be qualified.
         standalone_aliases = [t[0] for t in value_table_function_aliases]
         # A buffer to keep any violations.
         violation_buff = []
@@ -64,6 +62,11 @@ class Rule_L028(Rule_L025):
             # We skip any unqualified wildcard references (i.e. *). They shouldn't count.
             if not ref.is_qualified() and ref.is_type("wildcard_identifier"):
                 continue
+            # Oddball case: Column aliases provided via function calls in by
+            # FROM or JOIN. References to these don't need to be qualified.
+            # Note there could be a table with a column by the same name as
+            # this alias, so avoid bogus warnings by just skipping them
+            # entirely rather than trying to enforce anything.
             if ref.raw in standalone_aliases:
                 continue
             this_ref_type = ref.qualification()

--- a/src/sqlfluff/core/rules/std/L028.py
+++ b/src/sqlfluff/core/rules/std/L028.py
@@ -53,6 +53,9 @@ class Rule_L028(Rule_L025):
         # How many aliases are there? If more than one then abort.
         if len(table_aliases) > 1:
             return None
+        # Oddball case: Column aliases provided via function calls in by FROM or
+        # JOIN. References to these should not be qualified.
+        standalone_aliases = [t[0] for t in value_table_function_aliases]
         # A buffer to keep any violations.
         violation_buff = []
         # Check all the references that we have.
@@ -60,6 +63,8 @@ class Rule_L028(Rule_L025):
         for ref in references:
             # We skip any unqualified wildcard references (i.e. *). They shouldn't count.
             if not ref.is_qualified() and ref.is_type("wildcard_identifier"):
+                continue
+            if ref.raw in standalone_aliases:
                 continue
             this_ref_type = ref.qualification()
             if self.single_table_references == "consistent":

--- a/src/sqlfluff/core/rules/std/L028.py
+++ b/src/sqlfluff/core/rules/std/L028.py
@@ -40,12 +40,11 @@ class Rule_L028(Rule_L025):
 
     config_keywords = ["single_table_references"]
 
-    def _lint_references_and_aliases(
-        self, aliases, references, col_aliases, using_cols, parent_select
-    ):
+    def _lint_references_and_aliases(self, table_aliases, value_table_function_aliases, references,
+                                     col_aliases, using_cols, parent_select):
         """Iterate through references and check consistency."""
         # How many aliases are there? If more than one then abort.
-        if len(aliases) > 1:
+        if len(table_aliases) > 1:
             return None
         # A buffer to keep any violations.
         violation_buff = []

--- a/test/core/rules/test_cases/L020.yml
+++ b/test/core/rules/test_cases/L020.yml
@@ -3,3 +3,12 @@ rule: L020
 test_1:
   # duplicate aliases
   fail_str: select 1 from table_1 as a join table_2 as a using(pk)
+
+test_ignore_value_table_functions:
+  pass_str: |
+    select *
+    from unnest(generate_timestamp_array(
+        '2020-01-01', '2020-01-30', interval 1 day)) as ts
+  configs:
+    core:
+      dialect: bigquery

--- a/test/core/rules/test_cases/L020.yml
+++ b/test/core/rules/test_cases/L020.yml
@@ -3,12 +3,3 @@ rule: L020
 test_1:
   # duplicate aliases
   fail_str: select 1 from table_1 as a join table_2 as a using(pk)
-
-test_ignore_value_table_functions:
-  pass_str: |
-    select *
-    from unnest(generate_timestamp_array(
-        '2020-01-01', '2020-01-30', interval 1 day)) as ts
-  configs:
-    core:
-      dialect: bigquery

--- a/test/core/rules/test_cases/L025.yml
+++ b/test/core/rules/test_cases/L025.yml
@@ -10,3 +10,13 @@ test_2:
 test_3:
   # L025 fix with https://github.com/sqlfluff/sqlfluff/issues/449
   pass_str: select ps.*, pandgs.blah from ps join pandgs using(moo)
+
+test_ignore_value_table_functions:
+  # L025 fix with https://github.com/sqlfluff/sqlfluff/issues/356
+  pass_str: |
+    select *
+    from unnest(generate_timestamp_array(
+        '2020-01-01', '2020-01-30', interval 1 day)) as ts
+  configs:
+    core:
+      dialect: bigquery

--- a/test/core/rules/test_cases/L027.yml
+++ b/test/core/rules/test_cases/L027.yml
@@ -24,10 +24,6 @@ test_allow_date_parts_as_function_parameter_snowflake:
 
 test_ignore_value_table_functions:
   pass_str: |
-    with a as (
-        select 1
-    )
-
     select
         a.*,
         _t_start

--- a/test/core/rules/test_cases/L027.yml
+++ b/test/core/rules/test_cases/L027.yml
@@ -21,3 +21,20 @@ test_allow_date_parts_as_function_parameter_snowflake:
   configs:
     core:
       dialect: snowflake
+
+test_ignore_value_table_functions:
+  pass_str: |
+    with a as (
+        select 1
+    )
+
+    select
+        a.*,
+        _t_start
+    from a
+    left join unnest(generate_timestamp_array(
+            '2020-01-01', '2020-01-30', interval 1 day)) as _t_start
+        on true
+  configs:
+    core:
+      dialect: bigquery

--- a/test/core/rules/test_cases/L028.yml
+++ b/test/core/rules/test_cases/L028.yml
@@ -31,3 +31,13 @@ test_6:
   pass_str: |
     SELECT * FROM db.sc.tbl2
     WHERE a NOT IN (SELECT a FROM db.sc.tbl1)
+
+test_value_table_functions_do_not_require_qualification:
+  pass_str: |
+    select
+        a.*,
+        _t_start
+    from a
+    left join unnest(generate_timestamp_array(
+            '2020-01-01', '2020-01-30', interval 1 day)) as _t_start
+        on true

--- a/test/core/rules/test_cases/L028.yml
+++ b/test/core/rules/test_cases/L028.yml
@@ -41,3 +41,6 @@ test_value_table_functions_do_not_require_qualification:
     left join unnest(generate_timestamp_array(
             '2020-01-01', '2020-01-30', interval 1 day)) as _t_start
         on true
+  configs:
+    core:
+      dialect: bigquery


### PR DESCRIPTION
Addresses #356. This PR adds a new ANSI-level set called `value_table_functions`. It's empty at the ANSI level, but BigQuery updates it to add `UNNEST`. This set is not used in the grammars, but when there is a `table_expression` with an alias, affected rules use this set to determine the nature of that alias: Is it a table alias or a column alias? This is a weird concept, but that's essentially what BigQuery does.

Context: `UNNEST()` is usually, but not always, used to unpack an array of scalar values. In this case, it returns a "table" with only one column. BigQuery has the concept of ["value tables"](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#value_tables):
>In BigQuery, a value table is a table where the row type is a single value. In a regular table, each row is made up of columns, each of which has a name and a type. In a value table, the row type is just a single value, and there are no column names.

In this situation, BugQuery seems to sort of treat the "table" and its single column as the same thing, allowing the alias for the value table to be used directly as a column. It's fairly natural for users of `UNNEST()`, but it's pretty weird from a SQLFluff perspective, since the nature of the alias has to be deduced with more complex logic. And, as you'll see in some of my comments on the issue (#356), it's probably not perfect for two reasons, both covered in the BigQuery docs [here](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#value_tables):
* While `UNNEST()` is usually used with scalar arrays, BigQuery also supports arrays of `STRUCT`, which return regular tables, not value tables, when unnested.
* BigQuery supports **implicit** unnesting of array columns, in which case, the `UNNEST()` function does not appear in the query.

This PR makes no attempt to address either of these last two challenges, but it does address all the issues initially raised in #356, which I think will cover the majority of array unnesting use cases.