### PR TITLE
Look deeper for function names (table_expression parse tree structure…

### DIFF
--- a/src/sqlfluff/core/rules/std/L020.py
+++ b/src/sqlfluff/core/rules/std/L020.py
@@ -48,14 +48,10 @@ class Rule_L020(BaseCrawler):
             # function.
             return False
 
-        function = table_expr.get_child("function")
-        if not function:
-            return False
-
-        function_name = function.get_child("function_name")
-        return function_name and function_name.raw.lower() in dialect.sets(
-            "value_table_functions"
-        )
+        for function_name in table_expr.recursive_crawl("function_name"):
+            if function_name.raw.lower() in dialect.sets("value_table_functions"):
+                return True
+        return False
 
     @classmethod
     def _get_aliases_from_select(cls, segment, dialect=None):

--- a/test/core/dialects/bigquery_test.py
+++ b/test/core/dialects/bigquery_test.py
@@ -12,7 +12,7 @@ from sqlfluff.core import FluffConfig
     st.lists(
         st.tuples(st.sampled_from(["<", "=", ">"]), st.sampled_from(["AND", "OR"])),
         min_size=1,
-        max_size=33,
+        max_size=30,
     )
 )
 @example(data=[("<", "AND")])


### PR DESCRIPTION
Fixes failing tests in master (replaces PR #723)

These are the affected tests:
* `test/core/rules/rule_test_cases_test.py::test__rule_test_case[L025_test_ignore_value_table_functions]`
* `test/core/rules/rule_test_cases_test.py::test__rule_test_case[L027_test_ignore_value_table_functions]`
