### PR TITLE
Issue 735: Fix some remaining issues with named windows

### DIFF
--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -650,8 +650,8 @@ class OverClauseSegment(BaseSegment):
             Ref("SingleIdentifierGrammar"),  # Window name
             Bracketed(
                 Ref("WindowSpecificationSegment"),
-            )
-        )
+            ),
+        ),
     )
 
 

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -646,12 +646,12 @@ class OverClauseSegment(BaseSegment):
     type = "over_clause"
     match_grammar = Sequence(
         "OVER",
-        Bracketed(
-            OneOf(
+        OneOf(
+            Ref("SingleIdentifierGrammar"),  # Window name
+            Bracketed(
                 Ref("WindowSpecificationSegment"),
-                Ref("SingleIdentifierGrammar"),  # Window name
             )
-        ),
+        )
     )
 
 

--- a/test/fixtures/parser/ansi/select_named_window_no_parentheses.sql
+++ b/test/fixtures/parser/ansi/select_named_window_no_parentheses.sql
@@ -1,0 +1,10 @@
+SELECT
+    NTH_VALUE(bar, 1) OVER w1 AS baz
+FROM t
+WINDOW w1 AS (
+    PARTITION BY
+        x,
+        y,
+        z
+    ORDER BY abc DESC
+)

--- a/test/fixtures/parser/ansi/select_named_window_no_parentheses.yml
+++ b/test/fixtures/parser/ansi/select_named_window_no_parentheses.yml
@@ -1,0 +1,57 @@
+file:
+  statement:
+    select_statement:
+    - select_clause:
+        keyword: SELECT
+        select_target_element:
+          function:
+          - function_name: NTH_VALUE
+          - start_bracket: (
+          - expression:
+              column_reference:
+                identifier: bar
+          - comma: ','
+          - expression:
+              literal: '1'
+          - end_bracket: )
+          - over_clause:
+              keyword: OVER
+              identifier: w1
+          alias_expression:
+            keyword: AS
+            identifier: baz
+    - from_clause:
+        keyword: FROM
+        table_expression:
+          main_table_expression:
+            table_reference:
+              identifier: t
+    - named_window:
+        keyword: WINDOW
+        named_window_expression:
+        - identifier: w1
+        - keyword: AS
+        - start_bracket: (
+        - window_specification:
+            partitionby_clause:
+            - keyword: PARTITION
+            - keyword: BY
+            - expression:
+                column_reference:
+                  identifier: x
+            - comma: ','
+            - expression:
+                column_reference:
+                  identifier: y
+            - comma: ','
+            - expression:
+                column_reference:
+                  identifier: z
+            orderby_clause:
+            - keyword: ORDER
+            - keyword: BY
+            - column_reference:
+                identifier: abc
+            - keyword: DESC
+        - end_bracket: )
+

--- a/test/fixtures/parser/ansi/select_named_window_with_parentheses.sql
+++ b/test/fixtures/parser/ansi/select_named_window_with_parentheses.sql
@@ -1,0 +1,10 @@
+SELECT
+    NTH_VALUE(bar, 1) OVER(w1) AS baz
+FROM t
+WINDOW w1 AS (
+    PARTITION BY
+        x,
+        y,
+        z
+    ORDER BY abc DESC
+)


### PR DESCRIPTION
Resolves #735 

Although the issue mentions linting errors, this was really a parsing issue. Once those were addressed, `sqlfluff lint` and `sqlfluff fix` are both happy with the test query "as is" (other than a benign, seemingly legit warning about indentation.