### PR TITLE
Fix false alarm on test with windows-style paths.

### DIFF
--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -181,7 +181,7 @@ def test__linter__linting_unexpected_error_handled_gracefully(
     assert (
         "Unable to lint test/fixtures/linter/passing.sql due to an internal error."
         # NB: Replace is to handle windows-style paths.
-        in patched_logger.warning.call_args[0][0].replace('\\', '/')
+        in patched_logger.warning.call_args[0][0].replace("\\", "/")
         and "Exception: Something unexpected happened"
         in patched_logger.warning.call_args[0][0]
     )

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -180,7 +180,8 @@ def test__linter__linting_unexpected_error_handled_gracefully(
     lntr.lint_paths(["test/fixtures/linter/passing.sql"])
     assert (
         "Unable to lint test/fixtures/linter/passing.sql due to an internal error."
-        in patched_logger.warning.call_args[0][0]
+        # NB: Replace is to handle windows-style paths.
+        in patched_logger.warning.call_args[0][0].replace('\\', '/')
         and "Exception: Something unexpected happened"
         in patched_logger.warning.call_args[0][0]
     )


### PR DESCRIPTION
This addresses a test which is not current cross-platform friendly. The fix makes the test not raise a false alarm with windows style paths.