### PR TITLE
#692: Convert Python relative imports to absolute

### DIFF
--- a/src/sqlfluff/__init__.py
+++ b/src/sqlfluff/__init__.py
@@ -2,7 +2,7 @@
 import sys
 
 # Expose the public API.
-from .api import lint, fix, parse  # noqa: F401
+from src.sqlfluff.api import lint, fix, parse  # noqa: F401
 
 # Check major python version
 if sys.version_info[0] < 3:

--- a/src/sqlfluff/__main__.py
+++ b/src/sqlfluff/__main__.py
@@ -1,5 +1,5 @@
 """Export cli to __main__ for use like python -m sqfluff."""
-from .cli.commands import cli
+from src.sqlfluff.cli.commands import cli
 
 if __name__ == "__main__":
     cli()

--- a/src/sqlfluff/api/__init__.py
+++ b/src/sqlfluff/api/__init__.py
@@ -3,4 +3,4 @@
 # flake8: noqa: F401
 
 # Expose the simple api
-from .simple import lint, fix, parse
+from src.sqlfluff.api.simple import lint, fix, parse

--- a/src/sqlfluff/api/simple.py
+++ b/src/sqlfluff/api/simple.py
@@ -1,6 +1,6 @@
 """The simple public API methods."""
 
-from ..core import Linter
+from src.sqlfluff.core import Linter
 
 
 def _unify_str_or_file(sql):

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -16,7 +16,7 @@ from benchit import BenchIt
 # To enable colour cross platform
 import colorama
 
-from .formatters import (
+from src.sqlfluff.cli.formatters import (
     format_rules,
     format_violation,
     format_linting_result_header,
@@ -26,10 +26,10 @@ from .formatters import (
     format_dialects,
     CallbackFormatter,
 )
-from .helpers import cli_table, get_package_version
+from src.sqlfluff.cli.helpers import cli_table, get_package_version
 
 # Import from sqlfluff core.
-from ..core import Linter, FluffConfig, SQLLintError, dialect_selector, dialect_readout
+from src.sqlfluff.core import Linter, FluffConfig, SQLLintError, dialect_selector, dialect_readout
 
 
 class RedWarningsFilter(logging.Filter):

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -3,7 +3,7 @@
 
 from io import StringIO
 
-from .helpers import (
+from src.sqlfluff.cli.helpers import (
     colorize,
     cli_table,
     get_package_version,
@@ -11,7 +11,7 @@ from .helpers import (
     pad_line,
 )
 
-from ..core import SQLBaseError
+from src.sqlfluff.core import SQLBaseError
 
 
 def format_filename(filename, success=False, success_text="PASS"):

--- a/src/sqlfluff/cli/helpers.py
+++ b/src/sqlfluff/cli/helpers.py
@@ -5,7 +5,7 @@ import sys
 import textwrap
 from colorama import Fore, Style
 
-from .. import __version__ as pkg_version
+from src.sqlfluff import __version__ as pkg_version
 
 
 color_lookup = {

--- a/src/sqlfluff/core/__init__.py
+++ b/src/sqlfluff/core/__init__.py
@@ -3,14 +3,14 @@
 # flake8: noqa: F401
 
 # Config objects
-from .config import FluffConfig
+from src.sqlfluff.core.config import FluffConfig
 
 # Public classes
-from .linter import Linter
-from .parser import Lexer, Parser
+from src.sqlfluff.core.linter import Linter
+from src.sqlfluff.core.parser import Lexer, Parser
 
 # All of the errors.
-from .errors import (
+from src.sqlfluff.core.errors import (
     SQLBaseError,
     SQLTemplaterError,
     SQLLexError,
@@ -20,4 +20,4 @@ from .errors import (
 
 # Dialect introspection.
 # TODO: This feels untidy, maybe refactor into a class.
-from .dialects import dialect_selector, dialect_readout
+from src.sqlfluff.core.dialects import dialect_selector, dialect_readout

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -370,8 +370,8 @@ class FluffConfig:
 
         # Dialect and Template selection.
         # NB: We import here to avoid a circular references.
-        from .dialects import dialect_selector
-        from .templaters import templater_selector
+        from src.sqlfluff.core.dialects import dialect_selector
+        from src.sqlfluff.core.templaters import templater_selector
 
         self._configs["core"]["dialect_obj"] = dialect_selector(
             self._configs["core"]["dialect"]

--- a/src/sqlfluff/core/dialects/__init__.py
+++ b/src/sqlfluff/core/dialects/__init__.py
@@ -1,13 +1,13 @@
 """Contains SQL Dialects."""
 
-from .dialect_ansi import ansi_dialect
-from .dialect_bigquery import bigquery_dialect
-from .dialect_mysql import mysql_dialect
-from .dialect_teradata import teradata_dialect
-from .dialect_postgres import postgres_dialect
-from .dialect_snowflake import snowflake_dialect
-from .dialect_exasol import exasol_dialect
-from .dialect_exasol_fs import exasol_fs_dialect
+from src.sqlfluff.core.dialects.dialect_ansi import ansi_dialect
+from src.sqlfluff.core.dialects.dialect_bigquery import bigquery_dialect
+from src.sqlfluff.core.dialects.dialect_mysql import mysql_dialect
+from src.sqlfluff.core.dialects.dialect_teradata import teradata_dialect
+from src.sqlfluff.core.dialects.dialect_postgres import postgres_dialect
+from src.sqlfluff.core.dialects.dialect_snowflake import snowflake_dialect
+from src.sqlfluff.core.dialects.dialect_exasol import exasol_dialect
+from src.sqlfluff.core.dialects.dialect_exasol_fs import exasol_fs_dialect
 
 
 _dialect_lookup = {

--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -1,6 +1,6 @@
 """Defines the base dialect class."""
 
-from ..parser import KeywordSegment, SegmentGenerator
+from src.sqlfluff.core.parser import KeywordSegment, SegmentGenerator
 
 
 class Dialect:

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -12,7 +12,7 @@ grammar. Check out their docs, they're awesome.
 https://www.cockroachlabs.com/docs/stable/sql-grammar.html#select_stmt
 """
 
-from ..parser import (
+from src.sqlfluff.core.parser import (
     Matchable,
     BaseSegment,
     KeywordSegment,
@@ -34,8 +34,8 @@ from ..parser import (
     Nothing,
 )
 
-from .base import Dialect
-from .ansi_keywords import ansi_reserved_keywords, ansi_unreserved_keywords
+from src.sqlfluff.core.dialects.base import Dialect
+from src.sqlfluff.core.dialects.ansi_keywords import ansi_reserved_keywords, ansi_unreserved_keywords
 
 
 ansi_dialect = Dialect("ansi", root_segment_name="FileSegment")

--- a/src/sqlfluff/core/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/core/dialects/dialect_bigquery.py
@@ -6,7 +6,7 @@ and
 https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#string_and_bytes_literals
 """
 
-from ..parser import (
+from src.sqlfluff.core.parser import (
     Anything,
     BaseSegment,
     NamedSegment,
@@ -21,7 +21,7 @@ from ..parser import (
     Indent,
 )
 
-from .dialect_ansi import (
+from src.sqlfluff.core.dialects.dialect_ansi import (
     ansi_dialect,
     SelectTargetElementSegment as AnsiSelectTargetElementSegment,
     SelectClauseSegment as AnsiSelectClauseSegment,

--- a/src/sqlfluff/core/dialects/dialect_exasol.py
+++ b/src/sqlfluff/core/dialects/dialect_exasol.py
@@ -4,7 +4,7 @@ https://docs.exasol.com
 https://docs.exasol.com/sql_references/sqlstandardcompliance.htm
 """
 
-from ..parser import (
+from src.sqlfluff.core.parser import (
     AnyNumberOf,
     BaseSegment,
     Bracketed,
@@ -22,8 +22,8 @@ from ..parser import (
     Sequence,
     StartsWith,
 )
-from .dialect_ansi import ObjectReferenceSegment, ansi_dialect
-from .exasol_keywords import BARE_FUNCTIONS, RESERVED_KEYWORDS, UNRESERVED_KEYWORDS
+from src.sqlfluff.core.dialects.dialect_ansi import ObjectReferenceSegment, ansi_dialect
+from src.sqlfluff.core.dialects.exasol_keywords import BARE_FUNCTIONS, RESERVED_KEYWORDS, UNRESERVED_KEYWORDS
 
 exasol_dialect = ansi_dialect.copy_as("exasol")
 

--- a/src/sqlfluff/core/dialects/dialect_exasol_fs.py
+++ b/src/sqlfluff/core/dialects/dialect_exasol_fs.py
@@ -12,7 +12,7 @@ https://docs.exasol.com
 #       e.g. LUA: local _stmt = [[SOME ASSIGNMENT WITH OPEN BRACKET ( ]]
 #                 ...do some stuff ...
 #                 local _stmt = _stmt .. [[ ) ]]
-from ..parser import (
+from src.sqlfluff.core.parser import (
     AnyNumberOf,
     Anything,
     BaseSegment,
@@ -27,7 +27,7 @@ from ..parser import (
     StartsWith,
     SymbolSegment,
 )
-from .dialect_exasol import ObjectReferenceSegment, exasol_dialect
+from src.sqlfluff.core.dialects.dialect_exasol import ObjectReferenceSegment, exasol_dialect
 
 exasol_fs_dialect = exasol_dialect.copy_as("exasol_fs")
 exasol_fs_dialect.sets("unreserved_keywords").add("ROWCOUNT")

--- a/src/sqlfluff/core/dialects/dialect_mysql.py
+++ b/src/sqlfluff/core/dialects/dialect_mysql.py
@@ -4,9 +4,9 @@ For now the only change is the parsing of comments.
 https://dev.mysql.com/doc/refman/8.0/en/differences-from-ansi.html
 """
 
-from ..parser import NamedSegment, OneOf, Ref
+from src.sqlfluff.core.parser import NamedSegment, OneOf, Ref
 
-from .dialect_ansi import ansi_dialect
+from src.sqlfluff.core.dialects.dialect_ansi import ansi_dialect
 
 mysql_dialect = ansi_dialect.copy_as("mysql")
 

--- a/src/sqlfluff/core/dialects/dialect_postgres.py
+++ b/src/sqlfluff/core/dialects/dialect_postgres.py
@@ -1,6 +1,6 @@
 """The PostgreSQL dialect."""
 
-from ..parser import (
+from src.sqlfluff.core.parser import (
     OneOf,
     Ref,
     Sequence,
@@ -11,7 +11,7 @@ from ..parser import (
     Delimited,
 )
 
-from .dialect_ansi import ansi_dialect
+from src.sqlfluff.core.dialects.dialect_ansi import ansi_dialect
 
 # At the moment this is just a placeholder. Unique syntax to be added later.
 postgres_dialect = ansi_dialect.copy_as("postgres")

--- a/src/sqlfluff/core/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/core/dialects/dialect_snowflake.py
@@ -5,9 +5,9 @@ Inherits from Postgres.
 Based on https://docs.snowflake.com/en/sql-reference-commands.html
 """
 
-from .dialect_postgres import postgres_dialect
-from .dialect_ansi import SelectClauseSegment as ansi_SelectClauseSegment
-from ..parser import (
+from src.sqlfluff.core.dialects.dialect_postgres import postgres_dialect
+from src.sqlfluff.core.dialects.dialect_ansi import SelectClauseSegment as ansi_SelectClauseSegment
+from src.sqlfluff.core.parser import (
     BaseSegment,
     NamedSegment,
     OneOf,

--- a/src/sqlfluff/core/dialects/dialect_teradata.py
+++ b/src/sqlfluff/core/dialects/dialect_teradata.py
@@ -8,8 +8,8 @@ Teradata Database SQL Data Definition Language Syntax and Examples
 
 """
 
-from .dialect_ansi import ansi_dialect
-from ..parser import (
+from src.sqlfluff.core.dialects.dialect_ansi import ansi_dialect
+from src.sqlfluff.core.parser import (
     BaseSegment,
     Sequence,
     GreedyUntil,

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -23,24 +23,24 @@ from typing_extensions import Literal
 from benchit import BenchIt
 import pathspec
 
-from .errors import (
+from src.sqlfluff.core.errors import (
     SQLBaseError,
     SQLLexError,
     SQLLintError,
     SQLParseError,
     CheckTuple,
 )
-from .parser import Lexer, Parser
-from .string_helpers import findall
-from .templaters import TemplatedFile
-from .rules import get_ruleset
-from .config import FluffConfig, ConfigLoader
+from src.sqlfluff.core.parser import Lexer, Parser
+from src.sqlfluff.core.string_helpers import findall
+from src.sqlfluff.core.templaters import TemplatedFile
+from src.sqlfluff.core.rules import get_ruleset
+from src.sqlfluff.core.config import FluffConfig, ConfigLoader
 
 # Classes needed only for type checking
-from .parser.segments.base import BaseSegment, FixPatch
-from .parser.segments.indent import MetaSegment
-from .parser.segments.raw import RawSegment
-from .rules.base import BaseCrawler
+from src.sqlfluff.core.parser.segments.base import BaseSegment, FixPatch
+from src.sqlfluff.core.parser.segments.indent import MetaSegment
+from src.sqlfluff.core.parser.segments.raw import RawSegment
+from src.sqlfluff.core.rules.base import BaseCrawler
 
 # Instantiate the linter logger
 linter_logger: logging.Logger = logging.getLogger("sqlfluff.linter")

--- a/src/sqlfluff/core/parser/__init__.py
+++ b/src/sqlfluff/core/parser/__init__.py
@@ -2,7 +2,7 @@
 
 # flake8: noqa: F401
 
-from .segments import (
+from src.sqlfluff.core.parser.segments import (
     BaseSegment,
     RawSegment,
     KeywordSegment,
@@ -13,7 +13,7 @@ from .segments import (
     Dedent,
     SegmentGenerator,
 )
-from .grammar import (
+from src.sqlfluff.core.parser.grammar import (
     Sequence,
     GreedyUntil,
     StartsWith,
@@ -25,7 +25,7 @@ from .grammar import (
     Anything,
     Nothing,
 )
-from .markers import FilePositionMarker
-from .lexer import Lexer
-from .parser import Parser
-from .matchable import Matchable
+from src.sqlfluff.core.parser.markers import FilePositionMarker
+from src.sqlfluff.core.parser.lexer import Lexer
+from src.sqlfluff.core.parser.parser import Parser
+from src.sqlfluff.core.parser.matchable import Matchable

--- a/src/sqlfluff/core/parser/grammar/__init__.py
+++ b/src/sqlfluff/core/parser/grammar/__init__.py
@@ -2,8 +2,8 @@
 
 # flake8: noqa: F401
 
-from .base import Ref, Anything, Nothing
-from .anyof import AnyNumberOf, OneOf
-from .delimited import Delimited
-from .greedy import GreedyUntil, StartsWith
-from .sequence import Sequence, Bracketed
+from src.sqlfluff.core.parser.grammar.base import Ref, Anything, Nothing
+from src.sqlfluff.core.parser.grammar.anyof import AnyNumberOf, OneOf
+from src.sqlfluff.core.parser.grammar.delimited import Delimited
+from src.sqlfluff.core.parser.grammar.greedy import GreedyUntil, StartsWith
+from src.sqlfluff.core.parser.grammar.sequence import Sequence, Bracketed

--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -2,14 +2,14 @@
 
 from typing import List, Optional, Tuple
 
-from ..helpers import trim_non_code_segments
-from ..match_result import MatchResult
-from ..match_wrapper import match_wrapper
-from ..match_logging import parse_match_logging
-from ..context import ParseContext
-from ..segments import BaseSegment
+from src.sqlfluff.core.parser.helpers import trim_non_code_segments
+from src.sqlfluff.core.parser.match_result import MatchResult
+from src.sqlfluff.core.parser.match_wrapper import match_wrapper
+from src.sqlfluff.core.parser.match_logging import parse_match_logging
+from src.sqlfluff.core.parser.context import ParseContext
+from src.sqlfluff.core.parser.segments import BaseSegment
 
-from .base import BaseGrammar, MatchableType, cached_method_for_parse_context
+from src.sqlfluff.core.parser.grammar.base import BaseGrammar, MatchableType, cached_method_for_parse_context
 
 
 class AnyNumberOf(BaseGrammar):

--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -3,19 +3,19 @@
 import copy
 from typing import List, NamedTuple, Optional, Union, Type, Tuple
 
-from ...errors import SQLParseError
-from ...string_helpers import curtail_string
+from src.sqlfluff.core.errors import SQLParseError
+from src.sqlfluff.core.string_helpers import curtail_string
 
-from ..segments import BaseSegment, EphemeralSegment
-from ..helpers import trim_non_code_segments
-from ..match_result import MatchResult
-from ..match_logging import (
+from src.sqlfluff.core.parser.segments import BaseSegment, EphemeralSegment
+from src.sqlfluff.core.parser.helpers import trim_non_code_segments
+from src.sqlfluff.core.parser.match_result import MatchResult
+from src.sqlfluff.core.parser.match_logging import (
     parse_match_logging,
     LateBoundJoinSegmentsCurtailed,
 )
-from ..match_wrapper import match_wrapper
-from ..matchable import Matchable
-from ..context import ParseContext
+from src.sqlfluff.core.parser.match_wrapper import match_wrapper
+from src.sqlfluff.core.parser.matchable import Matchable
+from src.sqlfluff.core.parser.context import ParseContext
 
 # Either a Grammar or a Segment CLASS
 MatchableType = Union[Matchable, Type[BaseSegment]]

--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -2,14 +2,14 @@
 
 from typing import Tuple, List
 
-from ..grammar import Ref
-from ..segments import BaseSegment
-from ..match_result import MatchResult
-from ..match_wrapper import match_wrapper
-from ..context import ParseContext
+from src.sqlfluff.core.parser.grammar import Ref
+from src.sqlfluff.core.parser.segments import BaseSegment
+from src.sqlfluff.core.parser.match_result import MatchResult
+from src.sqlfluff.core.parser.match_wrapper import match_wrapper
+from src.sqlfluff.core.parser.context import ParseContext
 
-from .noncode import NonCodeMatcher
-from .anyof import OneOf
+from src.sqlfluff.core.parser.grammar.noncode import NonCodeMatcher
+from src.sqlfluff.core.parser.grammar.anyof import OneOf
 
 
 class Delimited(OneOf):

--- a/src/sqlfluff/core/parser/grammar/greedy.py
+++ b/src/sqlfluff/core/parser/grammar/greedy.py
@@ -2,12 +2,12 @@
 
 from typing import Optional, List
 
-from ..helpers import trim_non_code_segments
-from ..match_result import MatchResult
-from ..match_wrapper import match_wrapper
-from ..context import ParseContext
+from src.sqlfluff.core.parser.helpers import trim_non_code_segments
+from src.sqlfluff.core.parser.match_result import MatchResult
+from src.sqlfluff.core.parser.match_wrapper import match_wrapper
+from src.sqlfluff.core.parser.context import ParseContext
 
-from .base import BaseGrammar, cached_method_for_parse_context
+from src.sqlfluff.core.parser.grammar.base import BaseGrammar, cached_method_for_parse_context
 
 
 class GreedyUntil(BaseGrammar):

--- a/src/sqlfluff/core/parser/grammar/noncode.py
+++ b/src/sqlfluff/core/parser/grammar/noncode.py
@@ -6,10 +6,10 @@ terminator or similar alongside other matchers.
 
 from typing import Optional, List
 
-from ..match_wrapper import match_wrapper
-from ..match_result import MatchResult
-from ..matchable import Matchable
-from ..context import ParseContext
+from src.sqlfluff.core.parser.match_wrapper import match_wrapper
+from src.sqlfluff.core.parser.match_result import MatchResult
+from src.sqlfluff.core.parser.matchable import Matchable
+from src.sqlfluff.core.parser.context import ParseContext
 
 
 class NonCodeMatcher(Matchable):

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -2,15 +2,15 @@
 
 from typing import Optional, List, Tuple
 
-from ...errors import SQLParseError
+from src.sqlfluff.core.errors import SQLParseError
 
-from ..segments import BaseSegment, Indent, Dedent
-from ..helpers import trim_non_code_segments, check_still_complete
-from ..match_result import MatchResult
-from ..match_wrapper import match_wrapper
-from ..context import ParseContext
+from src.sqlfluff.core.parser.segments import BaseSegment, Indent, Dedent
+from src.sqlfluff.core.parser.helpers import trim_non_code_segments, check_still_complete
+from src.sqlfluff.core.parser.match_result import MatchResult
+from src.sqlfluff.core.parser.match_wrapper import match_wrapper
+from src.sqlfluff.core.parser.context import ParseContext
 
-from .base import BaseGrammar, cached_method_for_parse_context
+from src.sqlfluff.core.parser.grammar.base import BaseGrammar, cached_method_for_parse_context
 
 
 class Sequence(BaseGrammar):

--- a/src/sqlfluff/core/parser/helpers.py
+++ b/src/sqlfluff/core/parser/helpers.py
@@ -2,10 +2,10 @@
 
 from typing import Tuple, TYPE_CHECKING
 
-from ..string_helpers import curtail_string
+from src.sqlfluff.core.string_helpers import curtail_string
 
 if TYPE_CHECKING:
-    from .segments import BaseSegment
+    from src.sqlfluff.core.parser.segments import BaseSegment
 
 
 def join_segments_raw(segments: Tuple["BaseSegment", ...]) -> str:

--- a/src/sqlfluff/core/parser/lexer.py
+++ b/src/sqlfluff/core/parser/lexer.py
@@ -5,11 +5,11 @@ from typing import Optional, List, Tuple, Union
 from collections import namedtuple
 import re
 
-from .markers import FilePositionMarker, EnrichedFilePositionMarker
-from .segments import BaseSegment, RawSegment, Indent, Dedent, TemplateSegment
-from ..errors import SQLLexError
-from ..templaters import TemplatedFile
-from ..config import FluffConfig
+from src.sqlfluff.core.parser.markers import FilePositionMarker, EnrichedFilePositionMarker
+from src.sqlfluff.core.parser.segments import BaseSegment, RawSegment, Indent, Dedent, TemplateSegment
+from src.sqlfluff.core.errors import SQLLexError
+from src.sqlfluff.core.templaters import TemplatedFile
+from src.sqlfluff.core.config import FluffConfig
 
 # Instantiate the lexer logger
 lexer_logger = logging.getLogger("sqlfluff.lexer")

--- a/src/sqlfluff/core/parser/match_logging.py
+++ b/src/sqlfluff/core/parser/match_logging.py
@@ -1,6 +1,6 @@
 """Classes to help with match logging."""
 
-from .helpers import join_segments_raw_curtailed
+from src.sqlfluff.core.parser.helpers import join_segments_raw_curtailed
 
 
 class LateLoggingObject(object):

--- a/src/sqlfluff/core/parser/match_result.py
+++ b/src/sqlfluff/core/parser/match_result.py
@@ -6,10 +6,10 @@ This should be the default response from any `match` method.
 from typing import Tuple, TYPE_CHECKING
 from collections import namedtuple
 
-from .helpers import join_segments_raw
+from src.sqlfluff.core.parser.helpers import join_segments_raw
 
 if TYPE_CHECKING:
-    from .segments import BaseSegment
+    from src.sqlfluff.core.parser.segments import BaseSegment
 
 
 def is_segment(other):

--- a/src/sqlfluff/core/parser/match_wrapper.py
+++ b/src/sqlfluff/core/parser/match_wrapper.py
@@ -1,8 +1,8 @@
 """Defined the `match_wrapper` which adds validation and logging to match methods."""
 
-from .match_logging import ParseMatchLogObject
-from .match_result import MatchResult
-from .helpers import join_segments_raw_curtailed
+from src.sqlfluff.core.parser.match_logging import ParseMatchLogObject
+from src.sqlfluff.core.parser.match_result import MatchResult
+from src.sqlfluff.core.parser.helpers import join_segments_raw_curtailed
 
 
 class WrapParseMatchLogObject(ParseMatchLogObject):

--- a/src/sqlfluff/core/parser/matchable.py
+++ b/src/sqlfluff/core/parser/matchable.py
@@ -5,8 +5,8 @@ from typing import List, Optional, TYPE_CHECKING
 
 
 if TYPE_CHECKING:
-    from .context import ParseContext
-    from .match_result import MatchResult
+    from src.sqlfluff.core.parser.context import ParseContext
+    from src.sqlfluff.core.parser.match_result import MatchResult
 
 
 class Matchable(ABC):

--- a/src/sqlfluff/core/parser/parser.py
+++ b/src/sqlfluff/core/parser/parser.py
@@ -2,11 +2,11 @@
 
 from typing import Optional, Tuple, TYPE_CHECKING
 
-from .context import RootParseContext
-from ..config import FluffConfig
+from src.sqlfluff.core.parser.context import RootParseContext
+from src.sqlfluff.core.config import FluffConfig
 
 if TYPE_CHECKING:
-    from .segments import BaseSegment
+    from src.sqlfluff.core.parser.segments import BaseSegment
 
 
 class Parser:

--- a/src/sqlfluff/core/parser/segments/__init__.py
+++ b/src/sqlfluff/core/parser/segments/__init__.py
@@ -2,12 +2,12 @@
 
 # flake8: noqa: F401
 
-from .base import BaseSegment, UnparsableSegment
-from .generator import SegmentGenerator
-from .raw import RawSegment
-from .ephemeral import EphemeralSegment
-from .indent import Indent, Dedent, TemplateSegment
-from .keyword import (
+from src.sqlfluff.core.parser.segments.base import BaseSegment, UnparsableSegment
+from src.sqlfluff.core.parser.segments.generator import SegmentGenerator
+from src.sqlfluff.core.parser.segments.raw import RawSegment
+from src.sqlfluff.core.parser.segments.ephemeral import EphemeralSegment
+from src.sqlfluff.core.parser.segments.indent import Indent, Dedent, TemplateSegment
+from src.sqlfluff.core.parser.segments.keyword import (
     KeywordSegment,
     SymbolSegment,
     ReSegment,

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -15,21 +15,21 @@ from cached_property import cached_property
 from typing import Optional, List, Tuple, NamedTuple, Iterator
 import logging
 
-from ...string_helpers import (
+from src.sqlfluff.core.string_helpers import (
     frame_msg,
     curtail_string,
 )
 
-from ..match_result import MatchResult
-from ..match_logging import parse_match_logging
-from ..match_wrapper import match_wrapper
-from ..helpers import (
+from src.sqlfluff.core.parser.match_result import MatchResult
+from src.sqlfluff.core.parser.match_logging import parse_match_logging
+from src.sqlfluff.core.parser.match_wrapper import match_wrapper
+from src.sqlfluff.core.parser.helpers import (
     check_still_complete,
     trim_non_code_segments,
 )
-from ..matchable import Matchable
-from ..markers import EnrichedFilePositionMarker
-from ..context import ParseContext
+from src.sqlfluff.core.parser.matchable import Matchable
+from src.sqlfluff.core.parser.markers import EnrichedFilePositionMarker
+from src.sqlfluff.core.parser.context import ParseContext
 
 # Instantiate the linter logger (only for use in methods involved with fixing.)
 linter_logger = logging.getLogger("sqlfluff.linter")

--- a/src/sqlfluff/core/parser/segments/ephemeral.py
+++ b/src/sqlfluff/core/parser/segments/ephemeral.py
@@ -1,6 +1,6 @@
 """Ephemeral segment definitions."""
 
-from .base import BaseSegment
+from src.sqlfluff.core.parser.segments.base import BaseSegment
 
 
 class EphemeralSegment(BaseSegment):

--- a/src/sqlfluff/core/parser/segments/indent.py
+++ b/src/sqlfluff/core/parser/segments/indent.py
@@ -1,9 +1,9 @@
 """Indent and Dedent classes."""
 
-from ..match_wrapper import match_wrapper
-from ..markers import FilePositionMarker
+from src.sqlfluff.core.parser.match_wrapper import match_wrapper
+from src.sqlfluff.core.parser.markers import FilePositionMarker
 
-from .raw import RawSegment
+from src.sqlfluff.core.parser.segments.raw import RawSegment
 
 
 class MetaSegment(RawSegment):

--- a/src/sqlfluff/core/parser/segments/keyword.py
+++ b/src/sqlfluff/core/parser/segments/keyword.py
@@ -14,12 +14,12 @@ we use, and will be common between all of them.
 import re
 from typing import Optional, List
 
-from ..match_result import MatchResult
-from ..match_wrapper import match_wrapper
-from ..context import ParseContext
+from src.sqlfluff.core.parser.match_result import MatchResult
+from src.sqlfluff.core.parser.match_wrapper import match_wrapper
+from src.sqlfluff.core.parser.context import ParseContext
 
-from .base import BaseSegment
-from .raw import RawSegment
+from src.sqlfluff.core.parser.segments.base import BaseSegment
+from src.sqlfluff.core.parser.segments.raw import RawSegment
 
 
 class _ProtoKeywordSegment(RawSegment):

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -4,7 +4,7 @@ This is designed to be the root segment, without
 any children, and the output of the lexer.
 """
 
-from .base import BaseSegment
+from src.sqlfluff.core.parser.segments.base import BaseSegment
 
 
 class RawSegment(BaseSegment):

--- a/src/sqlfluff/core/rules/__init__.py
+++ b/src/sqlfluff/core/rules/__init__.py
@@ -1,8 +1,8 @@
 """Register all the rule classes with their corresponding rulesets (just std currently)."""
 
-from .base import RuleSet
-from .config_info import STANDARD_CONFIG_INFO_DICT
-from .std import rules as std_rules  # Import the standard ruleset list
+from src.sqlfluff.core.rules.base import RuleSet
+from src.sqlfluff.core.rules.config_info import STANDARD_CONFIG_INFO_DICT
+from src.sqlfluff.core.rules.std import rules as std_rules  # Import the standard ruleset list
 
 
 std_rule_set = RuleSet(name="standard", config_info=STANDARD_CONFIG_INFO_DICT)

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -18,8 +18,8 @@ import copy
 import logging
 from collections import namedtuple
 
-from ..parser import RawSegment, KeywordSegment, BaseSegment
-from ..errors import SQLLintError
+from src.sqlfluff.core.parser import RawSegment, KeywordSegment, BaseSegment
+from src.sqlfluff.core.errors import SQLLintError
 
 # The ghost of a rule (mostly used for testing)
 RuleGhost = namedtuple("RuleGhost", ["code", "description"])

--- a/src/sqlfluff/core/rules/doc_decorators.py
+++ b/src/sqlfluff/core/rules/doc_decorators.py
@@ -1,7 +1,7 @@
 """A collection of decorators to modify rule docstrings for Sphinx."""
 
-from .config_info import STANDARD_CONFIG_INFO_DICT
-from .base import rules_logger  # noqa
+from src.sqlfluff.core.rules.config_info import STANDARD_CONFIG_INFO_DICT
+from src.sqlfluff.core.rules.base import rules_logger  # noqa
 
 
 def document_fix_compatible(cls):

--- a/src/sqlfluff/core/rules/std/L001.py
+++ b/src/sqlfluff/core/rules/std/L001.py
@@ -1,6 +1,6 @@
 """Implementation of Rule L001."""
-from ..base import BaseCrawler, LintResult, LintFix
-from ..doc_decorators import document_fix_compatible
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult, LintFix
+from src.sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
 @document_fix_compatible

--- a/src/sqlfluff/core/rules/std/L002.py
+++ b/src/sqlfluff/core/rules/std/L002.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L002."""
 
-from ..base import BaseCrawler, LintResult, LintFix
-from ..doc_decorators import document_configuration
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult, LintFix
+from src.sqlfluff.core.rules.doc_decorators import document_configuration
 
 
 @document_configuration

--- a/src/sqlfluff/core/rules/std/L003.py
+++ b/src/sqlfluff/core/rules/std/L003.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L003."""
 
-from ..base import BaseCrawler, LintResult, LintFix
-from ..doc_decorators import (
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult, LintFix
+from src.sqlfluff.core.rules.doc_decorators import (
     document_fix_compatible,
     document_configuration,
 )

--- a/src/sqlfluff/core/rules/std/L004.py
+++ b/src/sqlfluff/core/rules/std/L004.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L004."""
 
-from ..base import BaseCrawler, LintResult, LintFix
-from ..doc_decorators import (
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult, LintFix
+from src.sqlfluff.core.rules.doc_decorators import (
     document_fix_compatible,
     document_configuration,
 )

--- a/src/sqlfluff/core/rules/std/L005.py
+++ b/src/sqlfluff/core/rules/std/L005.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L005."""
 
-from ..base import BaseCrawler, LintResult, LintFix
-from ..doc_decorators import document_fix_compatible
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult, LintFix
+from src.sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
 @document_fix_compatible

--- a/src/sqlfluff/core/rules/std/L006.py
+++ b/src/sqlfluff/core/rules/std/L006.py
@@ -1,8 +1,8 @@
 """Implementation of Rule L006."""
 
 
-from ..base import BaseCrawler, LintResult, LintFix
-from ..doc_decorators import document_fix_compatible
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult, LintFix
+from src.sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
 @document_fix_compatible

--- a/src/sqlfluff/core/rules/std/L007.py
+++ b/src/sqlfluff/core/rules/std/L007.py
@@ -1,6 +1,6 @@
 """Implementation of Rule L007."""
 
-from ..base import BaseCrawler, LintResult
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult
 
 
 class Rule_L007(BaseCrawler):

--- a/src/sqlfluff/core/rules/std/L008.py
+++ b/src/sqlfluff/core/rules/std/L008.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L008."""
 
-from ..base import BaseCrawler, LintResult, LintFix
-from ..doc_decorators import document_fix_compatible
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult, LintFix
+from src.sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
 @document_fix_compatible

--- a/src/sqlfluff/core/rules/std/L009.py
+++ b/src/sqlfluff/core/rules/std/L009.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L009."""
 
-from ..base import BaseCrawler, LintResult, LintFix
-from ..doc_decorators import document_fix_compatible
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult, LintFix
+from src.sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
 @document_fix_compatible

--- a/src/sqlfluff/core/rules/std/L010.py
+++ b/src/sqlfluff/core/rules/std/L010.py
@@ -1,8 +1,8 @@
 """Implementation of Rule L010."""
 
 from typing import Tuple, List
-from ..base import BaseCrawler, LintResult, LintFix
-from ..doc_decorators import (
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult, LintFix
+from src.sqlfluff.core.rules.doc_decorators import (
     document_fix_compatible,
     document_configuration,
 )

--- a/src/sqlfluff/core/rules/std/L011.py
+++ b/src/sqlfluff/core/rules/std/L011.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L011."""
 
-from ..base import BaseCrawler, LintResult, LintFix
-from ..doc_decorators import document_fix_compatible
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult, LintFix
+from src.sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
 @document_fix_compatible

--- a/src/sqlfluff/core/rules/std/L013.py
+++ b/src/sqlfluff/core/rules/std/L013.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L013."""
 
-from ..base import BaseCrawler, LintResult
-from ..doc_decorators import document_configuration
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult
+from src.sqlfluff.core.rules.doc_decorators import document_configuration
 
 
 @document_configuration

--- a/src/sqlfluff/core/rules/std/L014.py
+++ b/src/sqlfluff/core/rules/std/L014.py
@@ -2,7 +2,7 @@
 
 from typing import Tuple, List
 
-from ..doc_decorators import document_configuration
+from src.sqlfluff.core.rules.doc_decorators import document_configuration
 from sqlfluff.core.rules.std.L010 import Rule_L010
 
 

--- a/src/sqlfluff/core/rules/std/L015.py
+++ b/src/sqlfluff/core/rules/std/L015.py
@@ -1,6 +1,6 @@
 """Implementation of Rule L015."""
 
-from ..base import BaseCrawler, LintFix, LintResult
+from src.sqlfluff.core.rules.base import BaseCrawler, LintFix, LintResult
 
 
 class Rule_L015(BaseCrawler):

--- a/src/sqlfluff/core/rules/std/L016.py
+++ b/src/sqlfluff/core/rules/std/L016.py
@@ -1,8 +1,8 @@
 """Implementation of Rule L016."""
 
 
-from ..base import LintFix, LintResult
-from ..doc_decorators import (
+from src.sqlfluff.core.rules.base import LintFix, LintResult
+from src.sqlfluff.core.rules.doc_decorators import (
     document_fix_compatible,
     document_configuration,
 )

--- a/src/sqlfluff/core/rules/std/L017.py
+++ b/src/sqlfluff/core/rules/std/L017.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L017."""
 
-from ..base import BaseCrawler, LintFix, LintResult
-from ..doc_decorators import document_fix_compatible
+from src.sqlfluff.core.rules.base import BaseCrawler, LintFix, LintResult
+from src.sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
 @document_fix_compatible

--- a/src/sqlfluff/core/rules/std/L018.py
+++ b/src/sqlfluff/core/rules/std/L018.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L018."""
 
-from ..base import BaseCrawler, LintFix, LintResult
-from ..doc_decorators import document_fix_compatible
+from src.sqlfluff.core.rules.base import BaseCrawler, LintFix, LintResult
+from src.sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
 @document_fix_compatible

--- a/src/sqlfluff/core/rules/std/L019.py
+++ b/src/sqlfluff/core/rules/std/L019.py
@@ -2,8 +2,8 @@
 
 from typing import Dict, Any
 
-from ..base import BaseCrawler, LintFix, LintResult
-from ..doc_decorators import (
+from src.sqlfluff.core.rules.base import BaseCrawler, LintFix, LintResult
+from src.sqlfluff.core.rules.doc_decorators import (
     document_fix_compatible,
     document_configuration,
 )

--- a/src/sqlfluff/core/rules/std/L020.py
+++ b/src/sqlfluff/core/rules/std/L020.py
@@ -2,7 +2,7 @@
 
 import itertools
 
-from ..base import BaseCrawler, LintResult
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult
 
 
 class Rule_L020(BaseCrawler):

--- a/src/sqlfluff/core/rules/std/L021.py
+++ b/src/sqlfluff/core/rules/std/L021.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L021."""
 
 
-from ..base import BaseCrawler, LintResult
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult
 
 
 class Rule_L021(BaseCrawler):

--- a/src/sqlfluff/core/rules/std/L022.py
+++ b/src/sqlfluff/core/rules/std/L022.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L022."""
 
-from ..base import BaseCrawler, LintFix, LintResult
-from ..doc_decorators import document_fix_compatible
+from src.sqlfluff.core.rules.base import BaseCrawler, LintFix, LintResult
+from src.sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
 @document_fix_compatible

--- a/src/sqlfluff/core/rules/std/L023.py
+++ b/src/sqlfluff/core/rules/std/L023.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L023."""
 
-from ..base import BaseCrawler, LintFix, LintResult
-from ..doc_decorators import document_fix_compatible
+from src.sqlfluff.core.rules.base import BaseCrawler, LintFix, LintResult
+from src.sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
 @document_fix_compatible

--- a/src/sqlfluff/core/rules/std/L025.py
+++ b/src/sqlfluff/core/rules/std/L025.py
@@ -1,6 +1,6 @@
 """Implementation of Rule L025."""
 
-from ..base import LintResult
+from src.sqlfluff.core.rules.base import LintResult
 from sqlfluff.core.rules.std.L020 import Rule_L020
 
 

--- a/src/sqlfluff/core/rules/std/L026.py
+++ b/src/sqlfluff/core/rules/std/L026.py
@@ -1,6 +1,6 @@
 """Implementation of Rule L026."""
 
-from ..base import LintResult
+from src.sqlfluff.core.rules.base import LintResult
 from sqlfluff.core.rules.std.L025 import Rule_L025
 
 

--- a/src/sqlfluff/core/rules/std/L027.py
+++ b/src/sqlfluff/core/rules/std/L027.py
@@ -1,6 +1,6 @@
 """Implementation of Rule L027."""
 
-from ..base import LintResult
+from src.sqlfluff.core.rules.base import LintResult
 from sqlfluff.core.rules.std.L025 import Rule_L025
 
 

--- a/src/sqlfluff/core/rules/std/L028.py
+++ b/src/sqlfluff/core/rules/std/L028.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L028."""
 
-from ..base import LintResult
-from ..doc_decorators import document_configuration
+from src.sqlfluff.core.rules.base import LintResult
+from src.sqlfluff.core.rules.doc_decorators import document_configuration
 from sqlfluff.core.rules.std.L025 import Rule_L025
 
 

--- a/src/sqlfluff/core/rules/std/L029.py
+++ b/src/sqlfluff/core/rules/std/L029.py
@@ -1,8 +1,8 @@
 """Implementation of Rule L029."""
 
 
-from ..base import BaseCrawler, LintResult
-from ..doc_decorators import document_configuration
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult
+from src.sqlfluff.core.rules.doc_decorators import document_configuration
 
 
 @document_configuration

--- a/src/sqlfluff/core/rules/std/L030.py
+++ b/src/sqlfluff/core/rules/std/L030.py
@@ -2,7 +2,7 @@
 
 from typing import List, Tuple
 
-from ..doc_decorators import document_configuration
+from src.sqlfluff.core.rules.doc_decorators import document_configuration
 from sqlfluff.core.rules.std.L010 import Rule_L010
 
 

--- a/src/sqlfluff/core/rules/std/L031.py
+++ b/src/sqlfluff/core/rules/std/L031.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L031."""
 
-from ..base import BaseCrawler, LintFix, LintResult
-from ..doc_decorators import document_fix_compatible
+from src.sqlfluff.core.rules.base import BaseCrawler, LintFix, LintResult
+from src.sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
 @document_fix_compatible

--- a/src/sqlfluff/core/rules/std/L032.py
+++ b/src/sqlfluff/core/rules/std/L032.py
@@ -1,6 +1,6 @@
 """Implementation of Rule L032."""
 
-from ..base import BaseCrawler, LintResult
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult
 
 
 class Rule_L032(BaseCrawler):

--- a/src/sqlfluff/core/rules/std/L033.py
+++ b/src/sqlfluff/core/rules/std/L033.py
@@ -1,6 +1,6 @@
 """Implementation of Rule L033."""
 
-from ..base import BaseCrawler, LintResult
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult
 
 
 class Rule_L033(BaseCrawler):

--- a/src/sqlfluff/core/rules/std/L034.py
+++ b/src/sqlfluff/core/rules/std/L034.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L034."""
 
-from ..base import BaseCrawler, LintFix, LintResult
-from ..doc_decorators import document_fix_compatible
+from src.sqlfluff.core.rules.base import BaseCrawler, LintFix, LintResult
+from src.sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
 @document_fix_compatible

--- a/src/sqlfluff/core/rules/std/L035.py
+++ b/src/sqlfluff/core/rules/std/L035.py
@@ -1,7 +1,7 @@
 """Implementation of Rule L035."""
 
-from ..base import BaseCrawler, LintFix, LintResult
-from ..doc_decorators import document_fix_compatible
+from src.sqlfluff.core.rules.base import BaseCrawler, LintFix, LintResult
+from src.sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
 @document_fix_compatible

--- a/src/sqlfluff/core/rules/std/L036.py
+++ b/src/sqlfluff/core/rules/std/L036.py
@@ -2,7 +2,7 @@
 
 from collections import namedtuple
 
-from ..base import BaseCrawler, LintResult
+from src.sqlfluff.core.rules.base import BaseCrawler, LintResult
 
 
 class Rule_L036(BaseCrawler):

--- a/src/sqlfluff/core/rules/std/L037.py
+++ b/src/sqlfluff/core/rules/std/L037.py
@@ -2,9 +2,9 @@
 
 from typing import NamedTuple, Optional, List
 
-from ..base import BaseCrawler, LintFix, LintResult
+from src.sqlfluff.core.rules.base import BaseCrawler, LintFix, LintResult
 from sqlfluff.core.parser import BaseSegment
-from ..doc_decorators import document_fix_compatible
+from src.sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
 class OrderByColumnInfo(NamedTuple):

--- a/src/sqlfluff/core/templaters/__init__.py
+++ b/src/sqlfluff/core/templaters/__init__.py
@@ -2,11 +2,11 @@
 
 # flake8: noqa: F401
 
-from .base import templater_selector, TemplatedFile
+from src.sqlfluff.core.templaters.base import templater_selector, TemplatedFile
 
 # Although these shouldn't usually be instantiated from here
 # we import them to make sure they get registered.
-from .base import RawTemplater
-from .jinja import JinjaTemplater
-from .python import PythonTemplater
-from .dbt import DbtTemplater
+from src.sqlfluff.core.templaters.base import RawTemplater
+from src.sqlfluff.core.templaters.jinja import JinjaTemplater
+from src.sqlfluff.core.templaters.python import PythonTemplater
+from src.sqlfluff.core.templaters.dbt import DbtTemplater

--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -8,10 +8,10 @@ from dataclasses import dataclass
 from cached_property import cached_property
 from functools import partial
 
-from ..errors import SQLTemplaterError
+from src.sqlfluff.core.errors import SQLTemplaterError
 
-from .base import register_templater, TemplatedFile
-from .jinja import JinjaTemplater
+from src.sqlfluff.core.templaters.base import register_templater, TemplatedFile
+from src.sqlfluff.core.templaters.jinja import JinjaTemplater
 
 # Instantiate the templater logger
 templater_logger = logging.getLogger("sqlfluff.templater")

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -8,11 +8,11 @@ from jinja2.sandbox import SandboxedEnvironment
 from jinja2 import meta, TemplateSyntaxError, TemplateError
 import jinja2.nodes
 
-from ..errors import SQLTemplaterError
-from ..parser import FilePositionMarker
+from src.sqlfluff.core.errors import SQLTemplaterError
+from src.sqlfluff.core.parser import FilePositionMarker
 
-from .base import register_templater, TemplatedFile, RawFileSlice
-from .python import PythonTemplater
+from src.sqlfluff.core.templaters.base import register_templater, TemplatedFile, RawFileSlice
+from src.sqlfluff.core.templaters.python import PythonTemplater
 
 # Instantiate the templater logger
 templater_logger = logging.getLogger("sqlfluff.templater")

--- a/src/sqlfluff/core/templaters/python.py
+++ b/src/sqlfluff/core/templaters/python.py
@@ -4,10 +4,10 @@ import ast
 from string import Formatter
 from typing import Iterable, Dict, Tuple, List, Iterator, Optional, NamedTuple
 
-from ..errors import SQLTemplaterError
-from ..string_helpers import findall
+from src.sqlfluff.core.errors import SQLTemplaterError
+from src.sqlfluff.core.string_helpers import findall
 
-from .base import (
+from src.sqlfluff.core.templaters.base import (
     RawTemplater,
     register_templater,
     TemplatedFile,

--- a/src/sqlfluff/diff_quality_plugin.py
+++ b/src/sqlfluff/diff_quality_plugin.py
@@ -2,7 +2,7 @@
 from diff_cover.hook import hookimpl as diff_cover_hookimpl
 from diff_cover.violationsreporters.base import BaseViolationReporter, Violation
 
-from .core import FluffConfig, Linter
+from src.sqlfluff.core import FluffConfig, Linter
 
 
 class SQLFluffViolationReporter(BaseViolationReporter):

--- a/test/core/rules/rule_test_cases_test.py
+++ b/test/core/rules/rule_test_cases_test.py
@@ -5,7 +5,7 @@ from glob import glob
 import pytest
 import oyaml as yaml
 
-from .std_test import rules__test_helper, RuleTestCase
+from test.core.rules.std_test import rules__test_helper, RuleTestCase
 
 ids = []
 test_cases = []


### PR DESCRIPTION
Resolves #692.

I ran a tool called [`absolute_imports`](https://pypi.org/project/abs-imports/), which updated the imports automatically. It seems to work correctly. I noticed that many (but not all) of the files show in `git diff` and GitHub as **every line changed**. I suspect but have not confirmed that these files were using Windows line endings.

**Because of this, if we merge the PR, the file history (`git diff`, `git blame`) will be a bit weird. For the affected files, it'll look as if I changed every line.** If this is a concern, I can look at generating a version of this PR that does not have this behavior (probably hacking some fancier whitespace/newline handling into the `absolute_imports` tool).

For the same reason, I recommend reviewing this PR using the GitHub option that [hides whitespace changes](https://github.blog/2018-05-01-ignore-white-space-in-code-review/).