### PR TITLE
Mask linting errors around templated sections.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Ignore IDE files
 .vscode
 .idea
-.sqlfluff
+/.sqlfluff
 
 # Ignore Python cache and prebuilt things
 .cache

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -445,9 +445,11 @@ class FluffConfig:
         """
         return dict_diff(self._configs, other._configs)
 
-    def get(self, val: str, section: Union[str, Iterable[str]] = "core"):
+    def get(
+        self, val: str, section: Union[str, Iterable[str]] = "core", default: Any = None
+    ):
         """Get a particular value from the config."""
-        return self._configs[section].get(val, None)
+        return self._configs[section].get(val, default)
 
     def get_section(self, section: Union[str, Iterable[str]]) -> Union[dict, None]:
         """Return a whole section of config as a dict.

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -8,6 +8,7 @@ exclude_rules = None
 recurse = 0
 output_line_length = 80
 runaway_limit = 10
+ignore_templated_areas = True
 
 [sqlfluff:indentation]
 indented_joins = False

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -932,6 +932,16 @@ class Linter:
         for crawler in self.get_ruleset(config=config):
             lerrs, _, _, _ = crawler.crawl(parsed, dialect=config.get("dialect_obj"))
             linting_errors += lerrs
+
+        # Filter out any linting errors in templated sections if relevant.
+        if config.get("ignore_templated_areas", default=True):
+            linting_errors = list(
+                filter(
+                    lambda e: getattr(e.segment.pos_marker, "is_literal", True),
+                    linting_errors,
+                )
+            )
+
         return linting_errors
 
     def fix(self, parsed: BaseSegment, config: Optional[FluffConfig] = None):

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -221,7 +221,7 @@ def test__linter__empty_file():
         ),
     ],
 )
-def test__linter__mast_templated_violations(ignore_templated_areas, check_tuples):
+def test__linter__mask_templated_violations(ignore_templated_areas, check_tuples):
     """Test linter masks files properly around templated content."""
     lntr = Linter(
         config=FluffConfig(

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -201,3 +201,34 @@ def test__linter__empty_file():
     # Make sure no exceptions raised and no violations found in empty file.
     parsed = lntr.parse_string("")
     assert not parsed.violations
+
+
+@pytest.mark.parametrize(
+    "ignore_templated_areas,check_tuples",
+    [
+        (True, [("L006", 3, 27), ("L006", 3, 28)]),
+        (
+            False,
+            [
+                ("L006", 3, 17),
+                ("L006", 3, 18),
+                ("L006", 3, 19),
+                ("L006", 3, 20),
+                ("L006", 3, 27),
+                ("L006", 3, 28),
+            ],
+        ),
+    ],
+)
+def test__linter__mast_templated_violations(ignore_templated_areas, check_tuples):
+    """Test linter masks files properly around templated content."""
+    lntr = Linter(
+        config=FluffConfig(
+            overrides={
+                "rules": "L006",
+                "ignore_templated_areas": ignore_templated_areas,
+            }
+        )
+    )
+    linted = lntr.lint_path(path="test/fixtures/templater/jinja_h_macros/jinja.sql")
+    assert linted.check_tuples() == check_tuples

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -85,6 +85,7 @@ def assert_structure(yaml_loader, path, code_only=True):
         ("jinja_f/jinja", True),
         # Macro loading from a folder
         ("jinja_g_macros/jinja", True),
+        ("jinja_h_macros/jinja", True),
     ],
 )
 def test__templater_full(subpath, code_only, yaml_loader, caplog):

--- a/test/fixtures/templater/jinja_h_macros/.sqlfluff
+++ b/test/fixtures/templater/jinja_h_macros/.sqlfluff
@@ -1,0 +1,2 @@
+[sqlfluff:templater:jinja]
+load_macros_from_path=macros

--- a/test/fixtures/templater/jinja_h_macros/jinja.sql
+++ b/test/fixtures/templater/jinja_h_macros/jinja.sql
@@ -1,0 +1,4 @@
+-- Spacing errors inside and outside of the macro.
+-- This test make
+select 1 + 2 + {{ bad_macro() }} + 999+101
+from my_table

--- a/test/fixtures/templater/jinja_h_macros/jinja.yml
+++ b/test/fixtures/templater/jinja_h_macros/jinja.yml
@@ -1,0 +1,26 @@
+file:
+  statement:
+    select_statement:
+      select_clause:
+        - keyword: select
+        - select_target_element:
+            expression:
+              - literal: 1
+              - binary_operator: +
+              - literal: 2
+              - binary_operator: +
+              - literal: 5
+              - binary_operator: +
+              - literal: 6
+              - binary_operator: +
+              - literal: 7
+              - binary_operator: +
+              - literal: 999
+              - binary_operator: +
+              - literal: 101
+      from_clause:
+        keyword: from
+        table_expression:
+          main_table_expression:
+            table_reference:
+              identifier: my_table

--- a/test/fixtures/templater/jinja_h_macros/macros/bad_macro.sql
+++ b/test/fixtures/templater/jinja_h_macros/macros/bad_macro.sql
@@ -1,0 +1,1 @@
+{% macro bad_macro() %}5+6+7{% endmacro %}


### PR DESCRIPTION
I think this addresses #713 and relates to the conversation we had with @sqlfluff/sqlfluff-maintainers earlier this week.

This enables masking of linting errors within templated sections using the new source mapping code.