### PR TITLE
Use API to extract table references

### DIFF
--- a/examples/03_extracting_references.py
+++ b/examples/03_extracting_references.py
@@ -1,0 +1,27 @@
+"""This is an example of how to extract table names."""
+
+import sqlfluff
+
+query_with_ctes = """
+WITH foo AS (SELECT * FROM bar.bar),
+baz AS (SELECT * FROM bap)
+SELECT * FROM foo
+INNER JOIN baz USING (user_id)
+INNER JOIN ban USING (user_id)
+"""
+
+#  -------- PARSING ----------
+parsed = sqlfluff.parse(query_with_ctes)
+
+#  -------- EXTRACTION ----------
+# Note that this is still outline functionality and this
+# logic may eventually be brough into more convenient
+# helper methods. For now the recommendation is for
+# libraries to use the low level abstractions to extract
+# elements they need for their own purposes.
+tbl_refs = set(tbl_ref.raw for tbl_ref in parsed.tree.recursive_crawl("table_reference"))
+# tbl_refs == {'bap', 'ban', 'baz', 'foo', 'bar.bar'}
+cte_refs = set(cte_def.get_identifier().raw for cte_def in parsed.tree.recursive_crawl("common_table_expression"))
+# cte_refs == {'baz', 'foo'}
+external_tables = tbl_refs - cte_refs
+# external_tables == {'bar.bar', 'bap', 'ban'}

--- a/examples/03_extracting_references.py
+++ b/examples/03_extracting_references.py
@@ -14,14 +14,7 @@ INNER JOIN ban USING (user_id)
 parsed = sqlfluff.parse(query_with_ctes)
 
 #  -------- EXTRACTION ----------
-# Note that this is still outline functionality and this
-# logic may eventually be brough into more convenient
-# helper methods. For now the recommendation is for
-# libraries to use the low level abstractions to extract
-# elements they need for their own purposes.
-tbl_refs = set(tbl_ref.raw for tbl_ref in parsed.tree.recursive_crawl("table_reference"))
-# tbl_refs == {'bap', 'ban', 'baz', 'foo', 'bar.bar'}
-cte_refs = set(cte_def.get_identifier().raw for cte_def in parsed.tree.recursive_crawl("common_table_expression"))
-# cte_refs == {'baz', 'foo'}
-external_tables = tbl_refs - cte_refs
+# Under the hood we look for all of the table references
+# which aren't also CTE aliases.
+external_tables = parsed.tree.get_table_references()
 # external_tables == {'bar.bar', 'bap', 'ban'}

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -1532,7 +1532,7 @@ class CTEDefinitionSegment(BaseSegment):
 
     def get_identifier(self) -> BaseSegment:
         """Gets the identifier of this CTE.
-        
+
         Note: it blindly get the first identifier it finds
         which given the structure of a CTE definition is
         usually the right one.

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -1532,7 +1532,7 @@ class CTEDefinitionSegment(BaseSegment):
         ),
         "AS",
         Bracketed(
-            # Checkpoint here to subdivide the query.
+            # Ephemeral here to subdivide the query.
             Ref("SelectableGrammar", ephemeral_name="SelectableGrammar")
         ),
     )

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -620,6 +620,16 @@ class BaseSegment:
         for s in self.segments:
             yield from s.iter_raw_seg()
 
+    def iter_segments(self, expanding=None, pass_through=False):
+        """Iterate raw segments, optionally expanding some chldren."""
+        for s in self.segments:
+            if expanding and s.is_type(*expanding):
+                yield from s.iter_segments(
+                    expanding=expanding if pass_through else None
+                )
+            else:
+                yield s
+
     def iter_unparsables(self):
         """Iterate through any unparsables this segment may contain."""
         for s in self.segments:

--- a/src/sqlfluff/core/rules/std/L018.py
+++ b/src/sqlfluff/core/rules/std/L018.py
@@ -79,7 +79,7 @@ class Rule_L018(BaseCrawler):
 
             balance = 0
             with_indent, with_indent_str = indent_size_up_to(raw_stack_buff)
-            for seg in segment.segments:
+            for seg in segment.iter_segments(expanding=["common_table_expression"]):
                 if seg.name == "start_bracket":
                     balance += 1
                 elif seg.name == "end_bracket":
@@ -109,7 +109,9 @@ class Rule_L018(BaseCrawler):
                             # Is it all whitespace before the bracket on this line?
                             prev_segs_on_line = [
                                 elem
-                                for elem in segment.segments
+                                for elem in segment.iter_segments(
+                                    expanding=["common_table_expression"]
+                                )
                                 if elem.pos_marker.line_no == seg.pos_marker.line_no
                                 and elem.pos_marker.line_pos < seg.pos_marker.line_pos
                             ]

--- a/src/sqlfluff/core/rules/std/L022.py
+++ b/src/sqlfluff/core/rules/std/L022.py
@@ -43,13 +43,16 @@ class Rule_L022(BaseCrawler):
 
             # Find all the closing brackets. They are our anchor points.
             bracket_indices = []
-            for idx, seg in enumerate(segment.segments):
+            expanded_segments = list(
+                segment.iter_segments(expanding=["common_table_expression"])
+            )
+            for idx, seg in enumerate(expanded_segments):
                 if seg.is_type("end_bracket"):
                     bracket_indices.append(idx)
 
             # Work through each point and deal with it individually
             for bracket_idx in bracket_indices:
-                forward_slice = segment.segments[bracket_idx:]
+                forward_slice = expanded_segments[bracket_idx:]
                 seg_idx = 1
                 line_idx = 0
                 comma_seg_idx = None

--- a/src/sqlfluff/core/rules/std/L023.py
+++ b/src/sqlfluff/core/rules/std/L023.py
@@ -37,6 +37,7 @@ class Rule_L023(BaseCrawler):
     pre_segment_identifier = ("name", "AS")
     post_segment_identifier = ("type", "start_bracket")
     allow_newline = False
+    expand_children = ["common_table_expression"]
 
     def _eval(self, segment, **kwargs):
         """Single whitespace expected in mother segment between pre and post segments."""
@@ -44,7 +45,7 @@ class Rule_L023(BaseCrawler):
         if segment.is_type(self.expected_mother_segment_type):
             last_code = None
             mid_segs = []
-            for seg in segment.segments:
+            for seg in segment.iter_segments(expanding=self.expand_children):
                 if seg.is_code:
                     if (
                         last_code

--- a/src/sqlfluff/core/rules/std/L023.py
+++ b/src/sqlfluff/core/rules/std/L023.py
@@ -1,5 +1,7 @@
 """Implementation of Rule L023."""
 
+from typing import Optional, List
+
 from ..base import BaseCrawler, LintFix, LintResult
 from ..doc_decorators import document_fix_compatible
 
@@ -37,7 +39,7 @@ class Rule_L023(BaseCrawler):
     pre_segment_identifier = ("name", "AS")
     post_segment_identifier = ("type", "start_bracket")
     allow_newline = False
-    expand_children = ["common_table_expression"]
+    expand_children: Optional[List[str]] = ["common_table_expression"]
 
     def _eval(self, segment, **kwargs):
         """Single whitespace expected in mother segment between pre and post segments."""

--- a/src/sqlfluff/core/rules/std/L024.py
+++ b/src/sqlfluff/core/rules/std/L024.py
@@ -31,4 +31,5 @@ class Rule_L024(Rule_L023):
     expected_mother_segment_type = "join_clause"
     pre_segment_identifier = ("name", "USING")
     post_segment_identifier = ("type", "start_bracket")
+    expand_children = None
     allow_newline = True

--- a/test/api/util_test.py
+++ b/test/api/util_test.py
@@ -1,0 +1,29 @@
+"""Test using sqlfluff to extract elements of queries."""
+
+import pytest
+
+import sqlfluff
+
+my_bad_query = "SeLEct  *, 1, blah as  fOO  from myTable"
+
+query_with_ctes = """
+WITH foo AS (SELECT * FROM bar.bar),
+baz AS (SELECT * FROM bap)
+SELECT * FROM foo
+INNER JOIN baz USING (user_id)
+INNER JOIN ban USING (user_id)
+"""
+
+
+@pytest.mark.parametrize(
+    "sql,table_refs",
+    [
+        (my_bad_query, {"myTable"}),
+        (query_with_ctes, {"bar.bar", "bap", "ban"}),
+    ],
+)
+def test__api__util_get_table_references(sql, table_refs):
+    """Basic checking of lint functionality."""
+    parsed = sqlfluff.parse(sql)
+    external_tables = parsed.tree.get_table_references()
+    assert external_tables == table_refs

--- a/test/fixtures/parser/ansi/multi_statement_b.yml
+++ b/test/fixtures/parser/ansi/multi_statement_b.yml
@@ -64,23 +64,24 @@ file:
 - statement:
     with_compound_statement:
     - keyword: with
-    - identifier: tmp
-    - keyword: as
-    - start_bracket: (
-    - select_statement:
-        select_clause:
-          keyword: select
-          select_target_element:
-            wildcard_expression:
-              wildcard_identifier:
-                star: '*'
-        from_clause:
-          keyword: from
-          table_expression:
-            main_table_expression:
-              table_reference:
-                identifier: blah
-    - end_bracket: )
+    - common_table_expression:
+      - identifier: tmp
+      - keyword: as
+      - start_bracket: (
+      - select_statement:
+          select_clause:
+            keyword: select
+            select_target_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: from
+            table_expression:
+              main_table_expression:
+                table_reference:
+                  identifier: blah
+      - end_bracket: )
     - select_statement:
         select_clause:
         - keyword: select

--- a/test/fixtures/parser/ansi/multi_statement_c.yml
+++ b/test/fixtures/parser/ansi/multi_statement_c.yml
@@ -17,29 +17,30 @@ file:
 - statement:
     with_compound_statement:
     - keyword: WITH
-    - identifier: blah
-    - keyword: AS
-    - start_bracket: (
-    - select_statement:
-        select_clause:
-        - keyword: select
-        - select_target_element:
-            column_reference:
-              identifier: x
-        - comma: ','
-        - select_target_element:
-            column_reference:
-              identifier: y
-        - comma: ','
-        - select_target_element:
-            literal: '4.567'
-        from_clause:
-          keyword: FROM
-          table_expression:
-            main_table_expression:
-              table_reference:
-                identifier: foo
-    - end_bracket: )
+    - common_table_expression:
+      - identifier: blah
+      - keyword: AS
+      - start_bracket: (
+      - select_statement:
+          select_clause:
+          - keyword: select
+          - select_target_element:
+              column_reference:
+                identifier: x
+          - comma: ','
+          - select_target_element:
+              column_reference:
+                identifier: y
+          - comma: ','
+          - select_target_element:
+              literal: '4.567'
+          from_clause:
+            keyword: FROM
+            table_expression:
+              main_table_expression:
+                table_reference:
+                  identifier: foo
+      - end_bracket: )
     - select_statement:
         select_clause:
         - keyword: select

--- a/test/fixtures/parser/ansi/select_r.yml
+++ b/test/fixtures/parser/ansi/select_r.yml
@@ -2,44 +2,45 @@ file:
 - statement:
     with_compound_statement:
     - keyword: WITH
-    - identifier: result
-    - keyword: AS
-    - start_bracket: (
-    - set_expression:
-      - select_statement:
-          select_clause:
-            keyword: SELECT
-            select_target_element:
-              column_reference:
-                identifier: customer
-          from_clause:
-            keyword: FROM
-            table_expression:
-              main_table_expression:
-                table_reference:
-                  identifier: sales_eu
-              alias_expression:
-                keyword: AS
-                identifier: s
-      - set_operator:
-        - keyword: UNION
-        - keyword: ALL
-      - select_statement:
-          select_clause:
-            keyword: SELECT
-            select_target_element:
-              column_reference:
-                identifier: customer
-          from_clause:
-            keyword: FROM
-            table_expression:
-              main_table_expression:
-                table_reference:
-                  identifier: sales_us
-              alias_expression:
-                keyword: AS
-                identifier: s2
-    - end_bracket: )
+    - common_table_expression:
+      - identifier: result
+      - keyword: AS
+      - start_bracket: (
+      - set_expression:
+        - select_statement:
+            select_clause:
+              keyword: SELECT
+              select_target_element:
+                column_reference:
+                  identifier: customer
+            from_clause:
+              keyword: FROM
+              table_expression:
+                main_table_expression:
+                  table_reference:
+                    identifier: sales_eu
+                alias_expression:
+                  keyword: AS
+                  identifier: s
+        - set_operator:
+          - keyword: UNION
+          - keyword: ALL
+        - select_statement:
+            select_clause:
+              keyword: SELECT
+              select_target_element:
+                column_reference:
+                  identifier: customer
+            from_clause:
+              keyword: FROM
+              table_expression:
+                main_table_expression:
+                  table_reference:
+                    identifier: sales_us
+                alias_expression:
+                  keyword: AS
+                  identifier: s2
+      - end_bracket: )
     - select_statement:
         select_clause:
           keyword: SELECT

--- a/test/fixtures/parser/ansi/select_v.yml
+++ b/test/fixtures/parser/ansi/select_v.yml
@@ -2,38 +2,40 @@ file:
 - statement:
     with_compound_statement:
     - keyword: WITH
-    - identifier: counter
-    - keyword: AS
-    - start_bracket: (
-    - with_compound_statement:
-      - keyword: WITH
-      - identifier: ladder
+    - common_table_expression:
+      - identifier: counter
       - keyword: AS
       - start_bracket: (
-      - select_statement:
-          select_clause:
-            keyword: SELECT
-            select_target_element:
-              literal: '1'
+      - with_compound_statement:
+        - keyword: WITH
+        - common_table_expression:
+          - identifier: ladder
+          - keyword: AS
+          - start_bracket: (
+          - select_statement:
+              select_clause:
+                keyword: SELECT
+                select_target_element:
+                  literal: '1'
+          - end_bracket: )
+        - select_statement:
+          - select_clause:
+              keyword: SELECT
+              select_target_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+          - from_clause:
+              keyword: FROM
+              table_expression:
+                main_table_expression:
+                  table_reference:
+                    identifier: ladder
+          - orderby_clause:
+            - keyword: ORDER
+            - keyword: BY
+            - literal: '1'
       - end_bracket: )
-      - select_statement:
-        - select_clause:
-            keyword: SELECT
-            select_target_element:
-              wildcard_expression:
-                wildcard_identifier:
-                  star: '*'
-        - from_clause:
-            keyword: FROM
-            table_expression:
-              main_table_expression:
-                table_reference:
-                  identifier: ladder
-        - orderby_clause:
-          - keyword: ORDER
-          - keyword: BY
-          - literal: '1'
-    - end_bracket: )
     - select_statement:
         select_clause:
           keyword: SELECT

--- a/test/fixtures/parser/ansi/select_with_a.yml
+++ b/test/fixtures/parser/ansi/select_with_a.yml
@@ -2,22 +2,23 @@ file:
   statement:
     with_compound_statement:
     - keyword: WITH
-    - identifier: cte
-    - keyword: as
-    - start_bracket: (
-    - select_statement:
-        select_clause:
-          keyword: select
-          select_target_element:
-            column_reference:
-              identifier: a
-        from_clause:
-          keyword: from
-          table_expression:
-            main_table_expression:
-              table_reference:
-                identifier: tbla
-    - end_bracket: )
+    - common_table_expression:
+      - identifier: cte
+      - keyword: as
+      - start_bracket: (
+      - select_statement:
+          select_clause:
+            keyword: select
+            select_target_element:
+              column_reference:
+                identifier: a
+          from_clause:
+            keyword: from
+            table_expression:
+              main_table_expression:
+                table_reference:
+                  identifier: tbla
+      - end_bracket: )
     - select_statement:
         select_clause:
           keyword: select

--- a/test/fixtures/parser/ansi/select_with_b.yml
+++ b/test/fixtures/parser/ansi/select_with_b.yml
@@ -2,30 +2,31 @@ file:
   statement:
     with_compound_statement:
     - keyword: WITH
-    - identifier: blah
-    - keyword: AS
-    - start_bracket: (
-    - select_statement:
-        select_clause:
-        - keyword: select
-        - select_target_element:
-            column_reference:
-              identifier: x
-        - comma: ','
-        - select_target_element:
-            column_reference:
-              identifier: y
-        - comma: ','
-        - select_target_element:
-            column_reference:
-              identifier: z
-        from_clause:
-          keyword: FROM
-          table_expression:
-            main_table_expression:
-              table_reference:
-                identifier: foo
-    - end_bracket: )
+    - common_table_expression:
+      - identifier: blah
+      - keyword: AS
+      - start_bracket: (
+      - select_statement:
+          select_clause:
+          - keyword: select
+          - select_target_element:
+              column_reference:
+                identifier: x
+          - comma: ','
+          - select_target_element:
+              column_reference:
+                identifier: y
+          - comma: ','
+          - select_target_element:
+              column_reference:
+                identifier: z
+          from_clause:
+            keyword: FROM
+            table_expression:
+              main_table_expression:
+                table_reference:
+                  identifier: foo
+      - end_bracket: )
     - select_statement:
         select_clause:
         - keyword: select

--- a/test/fixtures/parser/bigquery/select_example.yml
+++ b/test/fixtures/parser/bigquery/select_example.yml
@@ -2,209 +2,211 @@ file:
 - statement:
     with_compound_statement:
     - keyword: WITH
-    - identifier: age_buckets_bit_array
-    - keyword: AS
-    - start_bracket: (
-    - select_statement:
-        select_clause:
-        - keyword: SELECT
-        - select_target_element:
-            column_reference:
-              identifier: bucket_id
-        - comma: ','
-        - select_target_element:
-            column_reference:
-              identifier: num_ranges
-        - comma: ','
-        - select_target_element:
-            column_reference:
-              identifier: min_age
-        - comma: ','
-        - select_target_element:
-            function:
-              function_name: ARRAY
-              start_bracket: (
-              expression:
-                select_statement:
-                  select_clause:
-                    keyword: SELECT
-                    select_target_element:
-                      function:
-                      - function_name: CAST
-                      - start_bracket: (
-                      - expression:
-                          column_reference:
-                            identifier: num
-                      - keyword: AS
-                      - data_type:
-                          data_type_identifier: INT64
-                      - end_bracket: )
-                  from_clause:
-                    keyword: FROM
-                    table_expression:
-                      main_table_expression:
-                        function:
-                          function_name: UNNEST
-                          start_bracket: (
-                          expression:
-                            function:
-                            - function_name: SPLIT
-                            - start_bracket: (
-                            - expression:
-                                column_reference:
-                                  identifier: binary
-                            - comma: ','
-                            - expression:
-                                literal: "''"
-                            - end_bracket: )
-                          end_bracket: )
-                      alias_expression:
-                        keyword: AS
-                        identifier: num
-              end_bracket: )
-            alias_expression:
-              keyword: AS
-              identifier: bits
-        - comma: ','
-        - select_target_element:
-            column_reference:
-              identifier: age_label
-        from_clause:
-          keyword: FROM
-          table_expression:
-            main_table_expression:
-              table_reference:
-                identifier: age_buckets
-    - end_bracket: )
-    - comma: ','
-    - identifier: bucket_abundance
-    - keyword: AS
-    - start_bracket: (
-    - select_statement:
-        select_clause:
-          keyword: SELECT
-          select_target_element:
-            expression:
-            - function:
-                function_name: bucket_id
+    - common_table_expression:
+      - identifier: age_buckets_bit_array
+      - keyword: AS
+      - start_bracket: (
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_target_element:
+              column_reference:
+                identifier: bucket_id
+          - comma: ','
+          - select_target_element:
+              column_reference:
+                identifier: num_ranges
+          - comma: ','
+          - select_target_element:
+              column_reference:
+                identifier: min_age
+          - comma: ','
+          - select_target_element:
+              function:
+                function_name: ARRAY
                 start_bracket: (
                 expression:
-                - column_reference:
-                    identifier: count_18_24
-                - binary_operator: '*'
-                - column_reference:
-                    identifier: bits
-                - array_accessor:
-                    start_square_bracket: '['
-                    expression:
-                      function:
-                        function_name: OFFSET
-                        start_bracket: (
-                        expression:
-                          literal: '0'
-                        end_bracket: )
-                    end_square_bracket: ']'
-                - binary_operator: +
-                - column_reference:
-                    identifier: count_25_34
-                - binary_operator: '*'
-                - column_reference:
-                    identifier: bits
-                - array_accessor:
-                    start_square_bracket: '['
-                    expression:
-                      function:
-                        function_name: OFFSET
-                        start_bracket: (
-                        expression:
-                          literal: '1'
-                        end_bracket: )
-                    end_square_bracket: ']'
-                - binary_operator: +
-                - column_reference:
-                    identifier: count_35_44
-                - binary_operator: '*'
-                - column_reference:
-                    identifier: bits
-                - array_accessor:
-                    start_square_bracket: '['
-                    expression:
-                      function:
-                        function_name: OFFSET
-                        start_bracket: (
-                        expression:
-                          literal: '2'
-                        end_bracket: )
-                    end_square_bracket: ']'
-                - binary_operator: +
-                - column_reference:
-                    identifier: count_45_54
-                - binary_operator: '*'
-                - column_reference:
-                    identifier: bits
-                - array_accessor:
-                    start_square_bracket: '['
-                    expression:
-                      function:
-                        function_name: OFFSET
-                        start_bracket: (
-                        expression:
-                          literal: '3'
-                        end_bracket: )
-                    end_square_bracket: ']'
-                - binary_operator: +
-                - column_reference:
-                    identifier: count_55_64
-                - binary_operator: '*'
-                - column_reference:
-                    identifier: bits
-                - array_accessor:
-                    start_square_bracket: '['
-                    expression:
-                      function:
-                        function_name: OFFSET
-                        start_bracket: (
-                        expression:
-                          literal: '4'
-                        end_bracket: )
-                    end_square_bracket: ']'
-                - binary_operator: +
-                - column_reference:
-                    identifier: count_65_plus
-                - binary_operator: '*'
-                - column_reference:
-                    identifier: bits
-                - array_accessor:
-                    start_square_bracket: '['
-                    expression:
-                      function:
-                        function_name: OFFSET
-                        start_bracket: (
-                        expression:
-                          literal: '5'
-                        end_bracket: )
-                    end_square_bracket: ']'
+                  select_statement:
+                    select_clause:
+                      keyword: SELECT
+                      select_target_element:
+                        function:
+                        - function_name: CAST
+                        - start_bracket: (
+                        - expression:
+                            column_reference:
+                              identifier: num
+                        - keyword: AS
+                        - data_type:
+                            data_type_identifier: INT64
+                        - end_bracket: )
+                    from_clause:
+                      keyword: FROM
+                      table_expression:
+                        main_table_expression:
+                          function:
+                            function_name: UNNEST
+                            start_bracket: (
+                            expression:
+                              function:
+                              - function_name: SPLIT
+                              - start_bracket: (
+                              - expression:
+                                  column_reference:
+                                    identifier: binary
+                              - comma: ','
+                              - expression:
+                                  literal: "''"
+                              - end_bracket: )
+                            end_bracket: )
+                        alias_expression:
+                          keyword: AS
+                          identifier: num
                 end_bracket: )
-            - binary_operator: /
-            - column_reference:
-                identifier: audience_size
-            alias_expression:
-              keyword: AS
-              identifier: relative_abundance
-        from_clause:
-        - keyword: FROM
-        - table_expression:
-            main_table_expression:
-              table_reference:
-                identifier: audience_counts_gender_age
-        - join_clause:
-          - keyword: CROSS
-          - keyword: JOIN
+              alias_expression:
+                keyword: AS
+                identifier: bits
+          - comma: ','
+          - select_target_element:
+              column_reference:
+                identifier: age_label
+          from_clause:
+            keyword: FROM
+            table_expression:
+              main_table_expression:
+                table_reference:
+                  identifier: age_buckets
+      - end_bracket: )
+    - comma: ','
+    - common_table_expression:
+      - identifier: bucket_abundance
+      - keyword: AS
+      - start_bracket: (
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_target_element:
+              expression:
+              - function:
+                  function_name: bucket_id
+                  start_bracket: (
+                  expression:
+                  - column_reference:
+                      identifier: count_18_24
+                  - binary_operator: '*'
+                  - column_reference:
+                      identifier: bits
+                  - array_accessor:
+                      start_square_bracket: '['
+                      expression:
+                        function:
+                          function_name: OFFSET
+                          start_bracket: (
+                          expression:
+                            literal: '0'
+                          end_bracket: )
+                      end_square_bracket: ']'
+                  - binary_operator: +
+                  - column_reference:
+                      identifier: count_25_34
+                  - binary_operator: '*'
+                  - column_reference:
+                      identifier: bits
+                  - array_accessor:
+                      start_square_bracket: '['
+                      expression:
+                        function:
+                          function_name: OFFSET
+                          start_bracket: (
+                          expression:
+                            literal: '1'
+                          end_bracket: )
+                      end_square_bracket: ']'
+                  - binary_operator: +
+                  - column_reference:
+                      identifier: count_35_44
+                  - binary_operator: '*'
+                  - column_reference:
+                      identifier: bits
+                  - array_accessor:
+                      start_square_bracket: '['
+                      expression:
+                        function:
+                          function_name: OFFSET
+                          start_bracket: (
+                          expression:
+                            literal: '2'
+                          end_bracket: )
+                      end_square_bracket: ']'
+                  - binary_operator: +
+                  - column_reference:
+                      identifier: count_45_54
+                  - binary_operator: '*'
+                  - column_reference:
+                      identifier: bits
+                  - array_accessor:
+                      start_square_bracket: '['
+                      expression:
+                        function:
+                          function_name: OFFSET
+                          start_bracket: (
+                          expression:
+                            literal: '3'
+                          end_bracket: )
+                      end_square_bracket: ']'
+                  - binary_operator: +
+                  - column_reference:
+                      identifier: count_55_64
+                  - binary_operator: '*'
+                  - column_reference:
+                      identifier: bits
+                  - array_accessor:
+                      start_square_bracket: '['
+                      expression:
+                        function:
+                          function_name: OFFSET
+                          start_bracket: (
+                          expression:
+                            literal: '4'
+                          end_bracket: )
+                      end_square_bracket: ']'
+                  - binary_operator: +
+                  - column_reference:
+                      identifier: count_65_plus
+                  - binary_operator: '*'
+                  - column_reference:
+                      identifier: bits
+                  - array_accessor:
+                      start_square_bracket: '['
+                      expression:
+                        function:
+                          function_name: OFFSET
+                          start_bracket: (
+                          expression:
+                            literal: '5'
+                          end_bracket: )
+                      end_square_bracket: ']'
+                  end_bracket: )
+              - binary_operator: /
+              - column_reference:
+                  identifier: audience_size
+              alias_expression:
+                keyword: AS
+                identifier: relative_abundance
+          from_clause:
+          - keyword: FROM
           - table_expression:
               main_table_expression:
                 table_reference:
-                  identifier: age_buckets_bit_array
-    - end_bracket: )
+                  identifier: audience_counts_gender_age
+          - join_clause:
+            - keyword: CROSS
+            - keyword: JOIN
+            - table_expression:
+                main_table_expression:
+                  table_reference:
+                    identifier: age_buckets_bit_array
+      - end_bracket: )
     - select_statement:
         select_clause:
           keyword: SELECT


### PR DESCRIPTION
This moves us closer to #289.

@NiallRees @kgpayne - this adds the details to do easy table reference extraction using sqlfluff.

@sqlfluff/sqlfluff-maintainers this adjusts the parse structure of WITH statements so that this kind of information is easier to extract. It does change quite a few of the test cases, but I think the simplicity in using the eventual structure is worth it.

Take a look at `examples/03_extracting_references.py` which hopefully should illustrate this use case well.