### PR TITLE
Allow ignoring comment lines

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -45,5 +45,8 @@ capitalisation_policy = consistent
 [sqlfluff:rules:L014]
 capitalisation_policy = consistent
 
+[sqlfluff:rules:L016]
+ignore_comment_lines = False
+
 [sqlfluff:rules:L030]
 capitalisation_policy = consistent

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -58,4 +58,11 @@ STANDARD_CONFIG_INFO_DICT = {
             " such as `{{blah}}` have their indentation linted."
         ),
     },
+    "ignore_comment_lines": {
+        "validation": [True, False],
+        "definition": (
+            "Should lines that contain only whitespace and comments"
+            " be ignored when linting line lengths."
+        ),
+    },
 }

--- a/src/sqlfluff/core/rules/std/L016.py
+++ b/src/sqlfluff/core/rules/std/L016.py
@@ -14,7 +14,12 @@ from sqlfluff.core.rules.std.L003 import Rule_L003
 class Rule_L016(Rule_L003):
     """Line is too long."""
 
-    config_keywords = ["max_line_length", "tab_space_size", "indent_unit"]
+    config_keywords = [
+        "max_line_length",
+        "tab_space_size",
+        "indent_unit",
+        "ignore_comment_lines",
+    ]
 
     def _eval_line_for_breaks(self, segments):
         """Evaluate the line for break points.
@@ -395,7 +400,10 @@ class Rule_L016(Rule_L003):
                     self.logger.info(
                         "Unfixable inline comment, alone on line: %s", this_line[-1]
                     )
-                    return LintResult(anchor=segment)
+                    if self.ignore_comment_lines:
+                        return LintResult()
+                    else:
+                        return LintResult(anchor=segment)
 
                 self.logger.info(
                     "Attempting move of inline comment at end of line: %s",

--- a/test/core/rules/test_cases/L016.yml
+++ b/test/core/rules/test_cases/L016.yml
@@ -32,7 +32,7 @@ test_4:
       max_line_length: 20
 
 test_5:
-   # Check we handle indents nicely
+  # Check we handle indents nicely
   fail_str: "SELECT 12345\n"
   fix_str: "SELECT\n    12345\n"
   configs:
@@ -40,9 +40,27 @@ test_5:
       max_line_length: 10
 
 test_6:
-   # Check priority of fixes
+  # Check priority of fixes
   fail_str: "SELECT COUNT(*) FROM tbl -- Some Comment\n"
   fix_str: "-- Some Comment\nSELECT\n    COUNT(*)\nFROM tbl\n"
   configs:
     rules:
       max_line_length: 18
+
+test_7:
+  # Check we can ignore comments if we want
+  pass_str: "SELECT 1\n-- Some long comment over 10 characters\n"
+  configs:
+    rules:
+      max_line_length: 10
+      L016:
+        ignore_comment_lines: True
+
+test_8:
+  # Check we still pick up long comments if we don't want to ignore
+  fail_str: "SELECT 1\n-- Some long comment over 10 characters\n"
+  configs:
+    rules:
+      max_line_length: 10
+      L016:
+        ignore_comment_lines: False


### PR DESCRIPTION
This addresses #299 .

@barrywhart - was this what you had in mind?

It will still flag up lines that *end* with comments, but if it's a line with only comments on it, then it will be ignored if this config value is set. I've set the default so that it's not set, but it should show up in the docs as an option.