### PR TITLE
Macros Defined in Config take Precedence over Path Macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+
+- Macros defined within the .sqlfluff config will take precedence over the macros defined in the
+  path that is defined with config value `sqlfluff:templater:jinja:load_macros_from_path`.
+
 ## [0.4.0] - 2021-02-14
 ### Added
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -194,7 +194,8 @@ path specified on this variable. The path is interpreted *relative to the
 config file*, and therefore if the config file above was found at
 :code:`/home/my_project/.sqlfluff` then SQLFluff will look for macros in the
 folder :code:`/home/my_project/my_macros/`. Alternatively the path can also
-be a :code:`.sql` itself.
+be a :code:`.sql` itself. Any macros defined in the config will always take
+precedence over a macro defined in the path.
 
 
 .. note::

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -223,21 +223,23 @@ class JinjaTemplater(PythonTemplater):
                 if name not in live_context:
                     live_context[name] = dbt_builtins[name]
 
-        # Load config macros
         env = self._get_jinja_env()
-        ctx = self._extract_macros_from_config(config=config, env=env, ctx=live_context)
+
         # Load macros from path (if applicable)
         macros_path = config.get_section(
             (self.templater_selector, self.name, "load_macros_from_path")
         )
         if macros_path:
-            ctx.update(
+            live_context.update(
                 self._extract_macros_from_path(macros_path, env=env, ctx=live_context)
             )
 
-        ctx.update(self._extract_libraries_from_config(config=config))
+        # Load config macros, these will take precedence over macros from the path
+        live_context.update(
+            self._extract_macros_from_config(config=config, env=env, ctx=live_context)
+        )
 
-        live_context.update(ctx)
+        live_context.update(self._extract_libraries_from_config(config=config))
 
         # Load the template, passing the global context.
         try:

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -91,6 +91,8 @@ def assert_structure(yaml_loader, path, code_only=True):
         ("jinja_i_raw/raw_tag_2", True),
         # Library Loading from a folder
         ("jinja_j_libraries/jinja", True),
+        # Priority of macros
+        ("jinja_k_config_override_path_macros/jinja", True),
     ],
 )
 def test__templater_full(subpath, code_only, yaml_loader, caplog):

--- a/test/fixtures/templater/jinja_k_config_override_path_macros/.sqlfluff
+++ b/test/fixtures/templater/jinja_k_config_override_path_macros/.sqlfluff
@@ -1,0 +1,6 @@
+[sqlfluff:templater:jinja]
+load_macros_from_path=macros
+
+[sqlfluff:templater:jinja:macros]
+foo2_def={%- macro foo2() -%}202{%- endmacro -%}
+foo3_def={%- macro foo3() -%}203{%- endmacro -%}

--- a/test/fixtures/templater/jinja_k_config_override_path_macros/jinja.sql
+++ b/test/fixtures/templater/jinja_k_config_override_path_macros/jinja.sql
@@ -1,0 +1,5 @@
+select
+    {{ foo1() }},
+    {{ foo2() }},
+    {{ foo3() }}
+from my_table

--- a/test/fixtures/templater/jinja_k_config_override_path_macros/jinja.yml
+++ b/test/fixtures/templater/jinja_k_config_override_path_macros/jinja.yml
@@ -1,0 +1,19 @@
+file:
+  statement:
+    select_statement:
+      select_clause:
+        - keyword: select
+        - select_target_element:
+            literal: 101
+        - comma: ","
+        - select_target_element:
+            literal: 202
+        - comma: ","
+        - select_target_element:
+            literal: 203
+      from_clause:
+        keyword: from
+        table_expression:
+          main_table_expression:
+            table_reference:
+              identifier: my_table

--- a/test/fixtures/templater/jinja_k_config_override_path_macros/macros/foo.sql
+++ b/test/fixtures/templater/jinja_k_config_override_path_macros/macros/foo.sql
@@ -1,0 +1,3 @@
+{%- macro foo1() -%}101{%- endmacro -%}
+
+{%- macro foo2() -%}102{%- endmacro -%}


### PR DESCRIPTION
If I define a path in my config where all my macros live,
and then define a few specific macros in the config file, the config
file macros will take precedent over the one defined in the path.
This allows the user to generally use most of their macros that
are being used in prod, and then just mock out the non compliant ones.