### PR TITLE
fix indexerror when lint API surfaces no errors

### DIFF
--- a/src/sqlfluff/api/simple.py
+++ b/src/sqlfluff/api/simple.py
@@ -33,7 +33,7 @@ def lint(sql, dialect="ansi", rules=None):
     result = linter.lint_string_wrapped(sql)
     result_records = result.as_records()
     # Return just the violations for this file
-    return result_records[0]["violations"]
+    return [] if not result_records else result_records[0]["violations"]
 
 
 def fix(sql, dialect="ansi", rules=None):

--- a/test/api/simple_test.py
+++ b/test/api/simple_test.py
@@ -3,7 +3,6 @@
 import io
 
 import sqlfluff
-
 from sqlfluff.core.linter import ParsedString
 
 my_bad_query = "SeLEct  *, 1, blah as  fOO  from myTable"
@@ -64,6 +63,12 @@ lint_result = [
         "description": "Inconsistent capitalisation of unquoted identifiers.",
     },
 ]
+
+
+def test__api__lint_string_without_violations():
+    """Check lint functionality when there is no violation."""
+    result = sqlfluff.lint("select column from table\n")
+    assert result == []
 
 
 def test__api__lint_string():


### PR DESCRIPTION
Fixes #761.

Checks if there are any violations before accessing `result[0]`. Also adds a test for this tiny edge case. First bug of 0.4.0???