### PR TITLE
Null Literal instead of "keyword"

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -42,17 +42,20 @@ only_aliases = True
 [sqlfluff:rules:L003]
 lint_templated_tokens = True
 
-[sqlfluff:rules:L010]
+[sqlfluff:rules:L010]  # Keywords
 capitalisation_policy = consistent
 
-[sqlfluff:rules:L014]
+[sqlfluff:rules:L014]  # Unquoted identifiers
 capitalisation_policy = consistent
 
 [sqlfluff:rules:L016]
 ignore_comment_lines = False
 
-[sqlfluff:rules:L030]
+[sqlfluff:rules:L030]  # Function names
 capitalisation_policy = consistent
 
 [sqlfluff:rules:L038]
 select_clause_trailing_comma = forbid
+
+[sqlfluff:rules:L040]  # Null & Boolean Literals
+capitalisation_policy = consistent

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -267,6 +267,8 @@ ansi_dialect.add(
     NumericLiteralSegment=NamedSegment.make(
         "numeric_literal", name="numeric_literal", type="literal"
     ),
+    # NullSegment is defined seperately to the keyword so we can give it a different type
+    NullLiteralSegment=KeywordSegment.make("null", name="null_literal", type="literal"),
     TrueSegment=KeywordSegment.make("true", name="boolean_literal", type="literal"),
     FalseSegment=KeywordSegment.make("false", name="boolean_literal", type="literal"),
     # We use a GRAMMAR here not a Segment. Otherwise we get an unnecessary layer
@@ -306,7 +308,7 @@ ansi_dialect.add(
         Ref("QualifiedNumericLiteralSegment"),
         # NB: Null is included in the literals, because it is a keyword which
         # can otherwise be easily mistaken for an identifier.
-        Ref("NullKeywordSegment"),
+        Ref("NullLiteralSegment"),
         Ref("DateTimeLiteralGrammar"),
     ),
     AndKeywordSegment=KeywordSegment.make("and", type="binary_operator"),
@@ -2248,7 +2250,6 @@ class SetClauseSegment(BaseSegment):
             Ref("BareFunctionSegment"),
             Ref("FunctionSegment"),
             Ref("ColumnReferenceSegment"),
-            "NULL",
             "DEFAULT",
         ),
     )

--- a/src/sqlfluff/core/rules/std/L040.py
+++ b/src/sqlfluff/core/rules/std/L040.py
@@ -1,0 +1,23 @@
+"""Implementation of Rule L040."""
+
+from typing import Tuple, List
+
+from sqlfluff.core.rules.doc_decorators import (
+    document_configuration,
+    document_fix_compatible,
+)
+from sqlfluff.core.rules.std.L010 import Rule_L010
+
+
+@document_configuration
+@document_fix_compatible
+class Rule_L040(Rule_L010):
+    """Inconsistent capitalisation of boolean/null literal.
+
+    The functionality for this rule is inherited from :obj:`Rule_L010`.
+    """
+
+    _target_elems: List[Tuple[str, str]] = [
+        ("name", "null_literal"),
+        ("name", "boolean_literal")
+    ]

--- a/src/sqlfluff/core/rules/std/L040.py
+++ b/src/sqlfluff/core/rules/std/L040.py
@@ -19,5 +19,5 @@ class Rule_L040(Rule_L010):
 
     _target_elems: List[Tuple[str, str]] = [
         ("name", "null_literal"),
-        ("name", "boolean_literal")
+        ("name", "boolean_literal"),
     ]

--- a/test/core/rules/test_cases/L010.yml
+++ b/test/core/rules/test_cases/L010.yml
@@ -1,9 +1,5 @@
 rule: L010
 
-test_1:
-  fail_str: SELECT null,   a
-  fix_str: SELECT NULL,   a
-
 test_2:
   # Test that we don't have the "inconsistent" bug
   fail_str: SeLeCt 1

--- a/test/core/rules/test_cases/L040.yml
+++ b/test/core/rules/test_cases/L040.yml
@@ -1,0 +1,5 @@
+rule: L040
+
+test_1:
+  fail_str: SeLeCt true, FALSE, NULL
+  fix_str: SeLeCt true, false, null

--- a/test/fixtures/linter/autofix/ansi/009_keyword_capitalisation/test-config.yml
+++ b/test/fixtures/linter/autofix/ansi/009_keyword_capitalisation/test-config.yml
@@ -1,3 +1,4 @@
 test-config:
   rules:
     - L010
+    - L040

--- a/test/fixtures/parser/ansi/select_g.yml
+++ b/test/fixtures/parser/ansi/select_g.yml
@@ -5,7 +5,7 @@ file:
       - keyword: SELECT
       - select_target_element:
           expression:
-            keyword: 'NULL'
+            literal: 'NULL'
             cast_expression:
               casting_operator: '::'
               data_type:
@@ -16,7 +16,7 @@ file:
       - comma: ','
       - select_target_element:
           expression:
-            keyword: 'NULL'
+            literal: 'NULL'
             cast_expression:
               casting_operator: '::'
               data_type:

--- a/test/fixtures/parser/ansi/select_p.yml
+++ b/test/fixtures/parser/ansi/select_p.yml
@@ -19,7 +19,7 @@ file:
             function_name: SAFE_CAST
             start_bracket: (
             expression:
-              keyword: 'NULL'
+              literal: 'NULL'
             keyword: AS
             data_type:
               data_type_identifier: STRING


### PR DESCRIPTION
I noticed that `null` was behaving differently to `true` and `false` and being classed as a keyword in some cases instead of a literal.

- This adds an additional `NullLiteralSegment` so that we can parse null differently in different situations.
- It also adds a new variant on the capitalisation rule (`L040`) which is a rule for capitalising literals like `true`, `false` and `null`.