### PR TITLE
Postgres Syntax Gaps

### DIFF
--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -426,7 +426,17 @@ class DatatypeSegment(BaseSegment):
 
     type = "data_type"
     match_grammar = Sequence(
-        Ref("DatatypeIdentifierSegment"),
+        Sequence(
+            # Some dialects allow optional qualification of data types with schemas
+            Sequence(
+                Ref("SingleIdentifierGrammar"),
+                Ref("DotSegment"),
+                allow_gaps=False,
+                optional=True
+            ),
+            Ref("DatatypeIdentifierSegment"),
+            allow_gaps=False
+        ),
         Bracketed(
             OneOf(
                 Delimited(Ref("ExpressionSegment")),

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -2371,6 +2371,41 @@ class CreateModelStatementSegment(BaseSegment):
 
 
 @ansi_dialect.segment()
+class CreateTypeStatementSegment(BaseSegment):
+    """A `CREATE TYPE` statement.
+    
+    This is based around the Postgres syntax.
+    https://www.postgresql.org/docs/current/sql-createtype.html
+
+    Note: This is relatively permissive currently
+    and does not lint the syntax strictly, to allow
+    for some deviation between dialects.
+    """
+
+    type = "create_type_statement"
+    match_grammar = Sequence(
+        "CREATE",
+        "TYPE",
+        Ref("ObjectReferenceSegment"),
+        Sequence(
+            "AS",
+            OneOf(
+                "ENUM",
+                "RANGE",
+                optional=True
+            ),
+            optional=True
+        ),
+        Bracketed(
+            Delimited(
+                Anything()
+            ),
+            optional=True
+        )
+    )
+
+
+@ansi_dialect.segment()
 class DropModelStatementSegment(BaseSegment):
     """A `DROP MODEL` statement."""
 
@@ -2424,6 +2459,7 @@ class StatementSegment(BaseSegment):
         Ref("DropStatementSegment"),
         Ref("AccessStatementSegment"),
         Ref("CreateTableStatementSegment"),
+        Ref("CreateTypeStatementSegment"),
         Ref("AlterTableStatementSegment"),
         Ref("CreateSchemaStatementSegment"),
         Ref("CreateDatabaseStatementSegment"),

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -432,10 +432,10 @@ class DatatypeSegment(BaseSegment):
                 Ref("SingleIdentifierGrammar"),
                 Ref("DotSegment"),
                 allow_gaps=False,
-                optional=True
+                optional=True,
             ),
             Ref("DatatypeIdentifierSegment"),
-            allow_gaps=False
+            allow_gaps=False,
         ),
         Bracketed(
             OneOf(
@@ -2383,7 +2383,7 @@ class CreateModelStatementSegment(BaseSegment):
 @ansi_dialect.segment()
 class CreateTypeStatementSegment(BaseSegment):
     """A `CREATE TYPE` statement.
-    
+
     This is based around the Postgres syntax.
     https://www.postgresql.org/docs/current/sql-createtype.html
 
@@ -2397,21 +2397,8 @@ class CreateTypeStatementSegment(BaseSegment):
         "CREATE",
         "TYPE",
         Ref("ObjectReferenceSegment"),
-        Sequence(
-            "AS",
-            OneOf(
-                "ENUM",
-                "RANGE",
-                optional=True
-            ),
-            optional=True
-        ),
-        Bracketed(
-            Delimited(
-                Anything()
-            ),
-            optional=True
-        )
+        Sequence("AS", OneOf("ENUM", "RANGE", optional=True), optional=True),
+        Bracketed(Delimited(Anything()), optional=True),
     )
 
 

--- a/test/fixtures/parser/postgres/postgres_create_table.sql
+++ b/test/fixtures/parser/postgres/postgres_create_table.sql
@@ -1,0 +1,4 @@
+-- Test qualifying datatype with schema
+CREATE TABLE counters (
+    my_type public.MY_TYPE
+)

--- a/test/fixtures/parser/postgres/postgres_create_table.yml
+++ b/test/fixtures/parser/postgres/postgres_create_table.yml
@@ -1,0 +1,15 @@
+file:
+  statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: counters
+    - start_bracket: (
+    - column_definition:
+        identifier: my_type
+        data_type:
+          identifier: public
+          dot: .
+          data_type_identifier: MY_TYPE
+    - end_bracket: )

--- a/test/fixtures/parser/postgres/postgres_create_type.sql
+++ b/test/fixtures/parser/postgres/postgres_create_type.sql
@@ -1,0 +1,6 @@
+-- https://www.postgresql.org/docs/current/sql-createtype.html
+CREATE TYPE foo;
+CREATE TYPE bar AS ENUM ('foo', 'bar');
+CREATE TYPE foobar AS RANGE (SUBTYPE = FLOAT);
+CREATE TYPE barbar AS (INPUT = foo, OUTPUT = bar);
+CREATE TYPE foofoo AS (foo varchar collate utf8);

--- a/test/fixtures/parser/postgres/postgres_create_type.yml
+++ b/test/fixtures/parser/postgres/postgres_create_type.yml
@@ -1,0 +1,67 @@
+file:
+- statement:
+    create_type_statement:
+    - keyword: CREATE
+    - keyword: TYPE
+    - object_reference:
+        identifier: foo
+- statement_terminator: ;
+- statement:
+    create_type_statement:
+    - keyword: CREATE
+    - keyword: TYPE
+    - object_reference:
+        identifier: bar
+    - keyword: AS
+    - keyword: ENUM
+    - start_bracket: (
+    - raw: "'foo'"
+    - comma: ','
+    - raw: "'bar'"
+    - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_type_statement:
+    - keyword: CREATE
+    - keyword: TYPE
+    - object_reference:
+        identifier: foobar
+    - keyword: AS
+    - keyword: RANGE
+    - start_bracket: (
+    - raw: SUBTYPE
+    - raw: '='
+    - raw: FLOAT
+    - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_type_statement:
+    - keyword: CREATE
+    - keyword: TYPE
+    - object_reference:
+        identifier: barbar
+    - keyword: AS
+    - start_bracket: (
+    - raw: INPUT
+    - raw: '='
+    - raw: foo
+    - comma: ','
+    - raw: OUTPUT
+    - raw: '='
+    - raw: bar
+    - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_type_statement:
+    - keyword: CREATE
+    - keyword: TYPE
+    - object_reference:
+        identifier: foofoo
+    - keyword: AS
+    - start_bracket: (
+    - raw: foo
+    - raw: varchar
+    - raw: collate
+    - raw: utf8
+    - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
This resolves #341 and resolves #343.

I've added both to the ansi dialect, because they're additive and don't conflict with anything already there. Plus there may be other dialects beyond postgres with a similar syntax.