### PR TITLE
#643: Fix snowflake indent

### DIFF
--- a/src/sqlfluff/core/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/core/dialects/dialect_snowflake.py
@@ -386,6 +386,9 @@ class SelectStatementSegment(ansi_SelectClauseSegment):
 
     parse_grammar = Sequence(
         Ref("SelectClauseSegment"),
+        # Dedent for the indent in the select clause.
+        # It's here so that it can come AFTER any whitespace.
+        Dedent,
         Ref("FromClauseSegment", optional=True),
         Ref("WhereClauseSegment", optional=True),
         Ref("GroupByClauseSegment", optional=True),

--- a/test/core/rules/test_cases/L003.yml
+++ b/test/core/rules/test_cases/L003.yml
@@ -139,3 +139,31 @@ test_12:
         t1
     -- Comment
     JOIN t2 USING (user_id)
+
+# https://github.com/sqlfluff/sqlfluff/issues/643
+snowflake_with_indent:
+  pass_str: |
+    with source_data as (
+        select * from {{ source('source_name', 'xxx_yyy_zzz') }}   
+    )
+
+    select *
+    from source_data
+  
+  configs:
+    core:
+      dialect: snowflake
+
+# https://github.com/sqlfluff/sqlfluff/issues/643
+bigquery_with_indent:
+  pass_str: |
+    with source_data as (
+        select * from {{ source('source_name', 'xxx_yyy_zzz') }}   
+    )
+
+    select *
+    from source_data
+  
+  configs:
+    core:
+      dialect: bigquery


### PR DESCRIPTION
This resolves #643 

The dedent segment which was moved in the `ansi` dialect wasn't moved in the `snowflake` dialect leading to odd indent behaviour.