### PR TITLE
Bracket in comment bug

### DIFF
--- a/test/fixtures/parser/ansi/bracket_in_comment.sql
+++ b/test/fixtures/parser/ansi/bracket_in_comment.sql
@@ -1,0 +1,5 @@
+select a
+/*
+)
+*/
+from b


### PR DESCRIPTION
```
if bracket_is_definite:
    # We've found an unexpected end bracket!
    raise SQLParseError(
        f"Found unexpected end bracket!, was expecting one of: {matchers}, but got {matcher}",
        segment=match.matched_segments[0],
    )

sqlfluff.core.errors.SQLParseError: Found unexpected end bracket!, was expecting one of: [<Ref: SemicolonSegment>], but got <class 'sqlfluff.core.parser.segments.raw.end_bracket_SymbolSegment'>

src/sqlfluff/core/parser/grammar/base.py:589: SQLParseError
```

Any ideas on this one @alanmcruickshank? The logic around the error looks rather gnarly 😬