### PR TITLE
#801: API .get_tables_references() Snowflake Dialect Bug

### DIFF
--- a/src/sqlfluff/core/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/core/dialects/dialect_snowflake.py
@@ -8,6 +8,7 @@ Based on https://docs.snowflake.com/en/sql-reference-commands.html
 from sqlfluff.core.dialects.dialect_postgres import postgres_dialect
 from sqlfluff.core.dialects.dialect_ansi import (
     SelectClauseSegment as ansi_SelectClauseSegment,
+    StatementSegment as ansi_StatementSegment,
 )
 from sqlfluff.core.parser import (
     BaseSegment,
@@ -139,7 +140,7 @@ snowflake_dialect.replace(
 
 
 @snowflake_dialect.segment(replace=True)
-class StatementSegment(BaseSegment):
+class StatementSegment(ansi_StatementSegment):
     """A generic segment, to any of its child subsegments."""
 
     type = "statement"

--- a/test/api/util_test.py
+++ b/test/api/util_test.py
@@ -16,14 +16,14 @@ INNER JOIN ban USING (user_id)
 
 
 @pytest.mark.parametrize(
-    "sql,table_refs",
+    "sql,table_refs,dialect",
     [
-        (my_bad_query, {"myTable"}),
-        (query_with_ctes, {"bar.bar", "bap", "ban"}),
+        (my_bad_query, {"myTable"}, None),
+        (query_with_ctes, {"bar.bar", "bap", "ban"}, "snowflake"),
     ],
 )
-def test__api__util_get_table_references(sql, table_refs):
+def test__api__util_get_table_references(sql, table_refs, dialect):
     """Basic checking of lint functionality."""
-    parsed = sqlfluff.parse(sql)
+    parsed = sqlfluff.parse(sql, dialect=dialect)
     external_tables = parsed.tree.get_table_references()
     assert external_tables == table_refs


### PR DESCRIPTION
Issue [801](https://github.com/sqlfluff/sqlfluff/issues/801)
Using the new `.get_table_references()` util fails when specifying the "snowflake" dialect.

Test results:

```
============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.8.3, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/kp/Projects/sqlfluff, configfile: pytest.ini
plugins: cov-2.11.1, hypothesis-6.3.0
collected 13 items

test/api/classes_test.py ....                                                                                                                                              [ 30%]
test/api/simple_test.py .......                                                                                                                                            [ 84%]
test/api/util_test.py .F                                                                                                                                                   [100%]

==================================================================================== FAILURES ====================================================================================
_ test__api__util_get_table_references[\nWITH foo AS (SELECT * FROM bar.bar),\nbaz AS (SELECT * FROM bap)\nSELECT * FROM foo\nINNER JOIN baz USING (user_id)\nINNER JOIN ban USING (user_id)\n-table_refs1-snowflake] _

sql = '\nWITH foo AS (SELECT * FROM bar.bar),\nbaz AS (SELECT * FROM bap)\nSELECT * FROM foo\nINNER JOIN baz USING (user_id)\nINNER JOIN ban USING (user_id)\n'
table_refs = {'ban', 'bap', 'bar.bar'}, dialect = 'snowflake'

    @pytest.mark.parametrize(
        "sql,table_refs,dialect",
        [
            (my_bad_query, {"myTable"}, None),
            (query_with_ctes, {"bar.bar", "bap", "ban"}, "snowflake"),
        ],
    )
    def test__api__util_get_table_references(sql, table_refs, dialect):
        """Basic checking of lint functionality."""
        parsed = sqlfluff.parse(sql, dialect=dialect)
>       external_tables = parsed.tree.get_table_references()

test/api/util_test.py:28:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <FileSegment: ([0](1, 1, 1))>

    def get_table_references(self):
        """Use parsed tree to extract table references."""
        references = set()
        for stmt in self.get_children("statement"):
>           references |= stmt.get_table_references()
E           AttributeError: 'StatementSegment' object has no attribute 'get_table_references'

src/sqlfluff/core/dialects/dialect_ansi.py:389: AttributeError
============================================================================ short test summary info =============================================================================
FAILED test/api/util_test.py::test__api__util_get_table_references[\nWITH foo AS (SELECT * FROM bar.bar),\nbaz AS (SELECT * FROM bap)\nSELECT * FROM foo\nINNER JOIN baz USING (user_id)\nINNER JOIN ban USING (user_id)\n-table_refs1-snowflake]
========================================================================== 1 failed, 12 passed in 0.73s ==========================================================================
```