### PR TITLE
Fix auto documentation for rules, broken by plugin PR

### DIFF
--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -12,7 +12,7 @@ for the rule itself, with all the other mechanics abstracted away.
 Specific Rules
 --------------
 
-.. automodule:: sqlfluff.core.rules.std
+.. automodule:: sqlfluff.core.rules
    :members:
    :member-order: alphabetical
 

--- a/plugins/sqlfluff-plugin-example/src/example/rules.py
+++ b/plugins/sqlfluff-plugin-example/src/example/rules.py
@@ -37,8 +37,10 @@ def get_configs_info() -> dict:
     }
 
 
-@document_fix_compatible
+# These two decorators allow plugins
+# to be displayed in the sqlfluff docs
 @document_configuration
+@document_fix_compatible
 class Rule_Example_L001(BaseCrawler):
     """ORDER BY on these columns is forbidden!
 

--- a/plugins/sqlfluff-plugin-example/src/example/rules.py
+++ b/plugins/sqlfluff-plugin-example/src/example/rules.py
@@ -39,8 +39,8 @@ def get_configs_info() -> dict:
 
 # These two decorators allow plugins
 # to be displayed in the sqlfluff docs
-@document_configuration
 @document_fix_compatible
+@document_configuration
 class Rule_Example_L001(BaseCrawler):
     """ORDER BY on these columns is forbidden!
 

--- a/src/sqlfluff/core/rules/__init__.py
+++ b/src/sqlfluff/core/rules/__init__.py
@@ -6,10 +6,24 @@ from sqlfluff.core.plugin.host import get_plugin_manager
 
 std_rule_set = RuleSet(name="standard", config_info=STANDARD_CONFIG_INFO_DICT)
 
+# Sphinx effectively runs an import * from this module in rules.rst, so initialise
+# __all__ with an empty list before we populate it with the rule names.
+__all__ = []
+
 # Iterate through the rules list and register each rule with the std_rule_set
 for plugin_rules in get_plugin_manager().hook.get_rules():
     for rule in plugin_rules:
         std_rule_set.register(rule)
+
+        if not rule.__name__.startswith("Rule_Example"):
+            # Add the Rule classes to the module namespace with globals() so that they can
+            # be found by Sphinx automodule documentation in rules.rst
+            # The result is the same as declaring the classes in this file.
+            # Rules coming from the "Example" plugin are excluded from the
+            # documentation.
+            globals()[rule.__name__] = rule
+            # Add the rule class names to __all__ for Sphinx automodule discovery
+            __all__.append(rule.__name__)
 
 
 def get_ruleset(name: str = "standard") -> RuleSet:

--- a/src/sqlfluff/core/rules/__init__.py
+++ b/src/sqlfluff/core/rules/__init__.py
@@ -15,15 +15,14 @@ for plugin_rules in get_plugin_manager().hook.get_rules():
     for rule in plugin_rules:
         std_rule_set.register(rule)
 
-        if not rule.__name__.startswith("Rule_Example"):
-            # Add the Rule classes to the module namespace with globals() so that they can
-            # be found by Sphinx automodule documentation in rules.rst
-            # The result is the same as declaring the classes in this file.
-            # Rules coming from the "Example" plugin are excluded from the
-            # documentation.
-            globals()[rule.__name__] = rule
-            # Add the rule class names to __all__ for Sphinx automodule discovery
-            __all__.append(rule.__name__)
+        # Add the Rule classes to the module namespace with globals() so that they can
+        # be found by Sphinx automodule documentation in rules.rst
+        # The result is the same as declaring the classes in this file.
+        # Rules coming from the "Example" plugin are excluded from the
+        # documentation.
+        globals()[rule.__name__] = rule
+        # Add the rule class names to __all__ for Sphinx automodule discovery
+        __all__.append(rule.__name__)
 
 
 def get_ruleset(name: str = "standard") -> RuleSet:

--- a/src/sqlfluff/core/rules/std/L039.py
+++ b/src/sqlfluff/core/rules/std/L039.py
@@ -18,7 +18,7 @@ class Rule_L039(BaseCrawler):
 
     | **Best practice**
     | Unless an indent or preceeding a comment, whitespace should
-    be a single space.
+    | be a single space.
 
     .. code-block::
 

--- a/src/sqlfluff/core/rules/std/__init__.py
+++ b/src/sqlfluff/core/rules/std/__init__.py
@@ -16,10 +16,6 @@ def get_rules_from_path(
     # Create a rules dictionary for importing in sqlfluff/src/sqlfluff/core/rules/__init__.py
     rules = []
 
-    # Sphinx effectively runs an import * from this module in rules.rst, so initialise
-    # __all__ with an empty list before we populate it with the rule names.
-    __all__ = []
-
     for module in sorted(glob(rules_path)):
         # Manipulate the module path to extract the filename without the .py
         rule_id = os.path.splitext(os.path.basename(module))[0]
@@ -35,11 +31,5 @@ def get_rules_from_path(
             ) from e
         # Add the rules to the rules dictionary for sqlfluff/src/sqlfluff/core/rules/__init__.py
         rules.append(rule_class)
-        # Add the rule_classes to the module namespace with globals() so that they can
-        # be found by Sphinx automodule documentation in rules.rst
-        # The result is the same as declaring the classes in this file.
-        globals()[rule_class_name] = rule_class
-        # Add the rule class names to __all__ for Sphinx automodule discovery
-        __all__.append(rule_class_name)
 
     return rules


### PR DESCRIPTION
Right now the auto documentation for rules is broken! I actually introduced the bug on my pluggy PR.

@NiallRees brought it to my attention on Slack and I'm adding the bug fix

(see current issue: https://docs.sqlfluff.com/en/latest/rules.html#module-sqlfluff.core.rules.std)