### PR TITLE
Wrapped CTE slicing bug

### DIFF
--- a/test/core/templaters/dbt_test.py
+++ b/test/core/templaters/dbt_test.py
@@ -90,7 +90,6 @@ select * from a
 -- NB This test is an excellent test
 select * from {{ ref('test__historics') }}
 where total_costs not between -100000000 and 100000000
-
 """,
             """
 with dbt__CTE__INTERNAL_test as (
@@ -100,17 +99,19 @@ with dbt__CTE__INTERNAL_test as (
 select * from analytics_test.test__historics
 where total_costs not between -100000000 and 100000000
 )select count(*) from dbt__CTE__INTERNAL_test""",
-            # The unwrapper should trim the ends. The below slices are the ones currently returned and are incorrect.
+            # The unwrapper should trim the ends.
             [
                 ("literal", slice(0, 79, None), slice(0, 79, None)),
-                ("templated", slice(79, 164, None), slice(79, 210, None)),
+                ("templated", slice(79, 107, None), slice(79, 109, None)),
+                ("literal", slice(107, 163, None), slice(109, 165, None)),
             ],
-            # The slice_file function should remove the wrapped CTE part of the query, like so:
+            # The slice_file function removes the wrapped CTE part of the query:
             """-- This is a thorough test
 
 -- NB This test is an excellent test
 select * from analytics_test.test__historics
-where total_costs not between -100000000 and 100000000""",
+where total_costs not between -100000000 and 100000000
+""",
         ),
     ],
     ids=[1,2]

--- a/test/core/templaters/dbt_test.py
+++ b/test/core/templaters/dbt_test.py
@@ -113,6 +113,7 @@ select * from analytics_test.test__historics
 where total_costs not between -100000000 and 100000000""",
         ),
     ],
+    ids=[1,2]
 )
 def test__templater_dbt_slice_file_wrapped_test(
     test_raw_str, test_templated_str, test_slices, test_new_templated_str, caplog

--- a/test/core/templaters/dbt_test.py
+++ b/test/core/templaters/dbt_test.py
@@ -139,8 +139,8 @@ def test__templater_dbt_slice_file_wrapped_test(
     ],
 )
 def test__templater_dbt_templating_test_lex(
-    in_dbt_project_dir, dbt_templater, fname, source_str, templated_str
-):  # noqa
+    in_dbt_project_dir, dbt_templater, fname, source_str, templated_str # noqa
+):
     """A test to demonstrate that tests are stripped of their wrapped CTE before parsing."""
     lexer = Lexer(config=FluffConfig(configs=DBT_FLUFF_CONFIG))
     templated_file, _ = dbt_templater.process(

--- a/test/core/templaters/dbt_test.py
+++ b/test/core/templaters/dbt_test.py
@@ -114,7 +114,7 @@ where total_costs not between -100000000 and 100000000
 """,
         ),
     ],
-    ids=[1,2]
+    ids=[1, 2],
 )
 def test__templater_dbt_slice_file_wrapped_test(
     test_raw_str, test_templated_str, test_slices, test_new_templated_str, caplog
@@ -141,7 +141,7 @@ def test__templater_dbt_slice_file_wrapped_test(
     ],
 )
 def test__templater_dbt_templating_test_lex(
-    in_dbt_project_dir, dbt_templater, fname, source_str, templated_str # noqa
+    in_dbt_project_dir, dbt_templater, fname, source_str, templated_str  # noqa
 ):
     """A test to demonstrate that tests are stripped of their wrapped CTE before parsing."""
     lexer = Lexer(config=FluffConfig(configs=DBT_FLUFF_CONFIG))


### PR DESCRIPTION
This PR just introduces an additional test case. It came about due to an error I was seeing with a dbt test in my work codebase. There's an inconsistency in dbt which is leading to errors in slicing dbt tests. If there is more than one new line at the end of a raw test file, the additional new lines are removed in the templated file, as so:

```
raw_str
"-- This is a thorough test\n\n-- NB This test is an excellent test\nselect * from {{ ref('test__historics') }}\nwhere total_costs not between -100000000 and 100000000\n\n"
```

```
templated_str
'\nwith dbt__CTE__INTERNAL_test as (\n-- This is a thorough test\n\n-- NB This test is an excellent test\nselect * from analytics_test.test__historics\nwhere total_costs not between -100000000 and 100000000\n)select count(*) from dbt__CTE__INTERNAL_test'
```

Note there is only one newline after `100000000` vs two in the raw.

Our literals here are:
```
literals
['-- This is a thorough test\n\n-- NB This test is an excellent test\nselect * from ', '\nwhere total_costs not between -100000000 and 100000000\n\n']
```

But because the two newlines aren't present in the templated string, `_substring_occurances` can't find the second literal in the templated string:

```
templated_occurances
{'-- This is a thorough test\n\n-- NB This test is an excellent test\nselect * from ': [35], '\nwhere total_costs not between -100000000 and 100000000\n\n': []}
```

And so the slicing fails. I don't think is something we fix in an elegant way in SQLFluff, so I'll raise a PR in dbt to resolve this behaviour of removing newlines.

The test case I've added only has one newline at the end so doesn't fail anymore, but is probably worth merging just for more coverage anyway. The solution for now is just avoid having more than one newline at the end of a dbt test.


--edit not the problem 🤔