### PR TITLE
Fix infinite recursion issue with many operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Macros defined within the .sqlfluff config will take precedence over the macros defined in the
   path that is defined with config value `sqlfluff:templater:jinja:load_macros_from_path`.
+- Fixed bug in expression parsing leading to recursion errors.
 
 ## [0.4.0] - 2021-02-14
 ### Added

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -1193,10 +1193,10 @@ ansi_dialect.add(
                         )
                         # We need to add a lot more here...
                     ),
-                    Ref("Expression_A_Grammar"),
+                    Ref("Expression_C_Grammar"),
                     Sequence(
                         Ref.keyword("ESCAPE"),
-                        Ref("Expression_A_Grammar"),
+                        Ref("Expression_C_Grammar"),
                         optional=True,
                     ),
                 ),

--- a/test/fixtures/parser/ansi/expression_recursion.sql
+++ b/test/fixtures/parser/ansi/expression_recursion.sql
@@ -1,0 +1,51 @@
+ -- This test checks for recursion errors. If the expression
+ -- is not parsed correctly it can lead to very deep recursion.
+
+ -- If this test is failing, then check the structure of expression
+ -- parsing.
+ 
+ select
+        1
+    from
+        test_table
+    where
+        test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%' --5
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%' -- 10
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%' -- 15
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%' -- 20
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%' --30
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%'
+        or test_table.string_field like 'some string%' -- 40

--- a/test/fixtures/parser/ansi/expression_recursion.yml
+++ b/test/fixtures/parser/ansi/expression_recursion.yml
@@ -1,0 +1,295 @@
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_target_element:
+          literal: '1'
+      from_clause:
+        keyword: from
+        table_expression:
+          main_table_expression:
+            table_reference:
+              identifier: test_table
+      where_clause:
+        keyword: where
+        expression:
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"
+        - binary_operator: or
+        - column_reference:
+          - identifier: test_table
+          - dot: .
+          - identifier: string_field
+        - keyword: like
+        - literal: "'some string%'"

--- a/test/fixtures/parser/ansi/expression_recursion_2.sql
+++ b/test/fixtures/parser/ansi/expression_recursion_2.sql
@@ -1,0 +1,8 @@
+ -- This test checks for recursion errors. If the expression
+ -- is not parsed correctly it can lead to very deep recursion.
+
+ -- If this test is failing, then check the structure of expression
+ -- parsing.
+ 
+ SELECT * FROM t WHERE a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b AND a < b
+ 

--- a/test/fixtures/parser/ansi/expression_recursion_2.yml
+++ b/test/fixtures/parser/ansi/expression_recursion_2.yml
@@ -1,0 +1,221 @@
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_target_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        table_expression:
+          main_table_expression:
+            table_reference:
+              identifier: t
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b
+        - binary_operator: AND
+        - column_reference:
+            identifier: a
+        - comparison_operator: <
+        - column_reference:
+            identifier: b


### PR DESCRIPTION
This resolves #641 and resolves #669.

The way that the expression segment was parsing expressions with lots of operators was leading to recursion errors. This was because it was effectively parsing `a+b+c+d` as `a+(b+(c+d))`. This PR adjusts that parsing so that it parses as originally intended.