### PR TITLE
Don't build additional docs formats

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,8 +9,8 @@ version: 2
 sphinx:
   configuration: docs/source/conf.py
 
-# Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+# Don't build any additional formats
+formats: []
 
 # Optionally set the version of Python and requirements required to build your docs.
 # In our case we need both the docs requirements and the package itself.


### PR DESCRIPTION
Docs have been failing fairly regularly for the pdf and latex builds. This updates the config to just not build those versions.