### PR TITLE
Issue 839: Lint rules can see file path; other tweaks to the example plugin

### DIFF
--- a/plugins/sqlfluff-plugin-example/setup.py
+++ b/plugins/sqlfluff-plugin-example/setup.py
@@ -5,7 +5,7 @@ setup(
     name="sqlfluff-plugin-example",
     include_package_data=True,
     package_dir={"": "src"},
-    packages=find_packages(),
+    packages=find_packages(where="src"),
     install_requires="sqlfluff>=0.4.0",
     entry_points={"sqlfluff": ["example = example.rules"]},
 )

--- a/plugins/sqlfluff-plugin-example/setup.py
+++ b/plugins/sqlfluff-plugin-example/setup.py
@@ -1,18 +1,24 @@
 """Setup file for example plugin."""
 from setuptools import find_packages, setup
 
-# Change this name in your plugin, e.g. company name or plugin purpose.
-PLUGIN_NAME = "example"
+# Change these names in your plugin, e.g. company name or plugin purpose.
+PLUGIN_LOGICAL_NAME = "example"
+PLUGIN_ROOT_MODULE = "example"
 
 setup(
-    name="sqlfluff-plugin-{plugin_name}".format(plugin_name=PLUGIN_NAME),
+    name="sqlfluff-plugin-{plugin_logical_name}".format(
+        plugin_logical_name=PLUGIN_LOGICAL_NAME
+    ),
     include_package_data=True,
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     install_requires="sqlfluff>=0.4.0",
     entry_points={
         "sqlfluff": [
-            "{plugin_name} = {plugin_name}.rules".format(plugin_name=PLUGIN_NAME)
+            "{plugin_logical_name} = {plugin_root_module}.rules".format(
+                plugin_logical_name=PLUGIN_LOGICAL_NAME,
+                plugin_root_module=PLUGIN_ROOT_MODULE,
+            )
         ]
     },
 )

--- a/plugins/sqlfluff-plugin-example/setup.py
+++ b/plugins/sqlfluff-plugin-example/setup.py
@@ -10,6 +10,9 @@ setup(
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     install_requires="sqlfluff>=0.4.0",
-    entry_points={"sqlfluff": ["{plugin_name} = {plugin_name}.rules".format(
-        plugin_name=PLUGIN_NAME)]},
+    entry_points={
+        "sqlfluff": [
+            "{plugin_name} = {plugin_name}.rules".format(plugin_name=PLUGIN_NAME)
+        ]
+    },
 )

--- a/plugins/sqlfluff-plugin-example/setup.py
+++ b/plugins/sqlfluff-plugin-example/setup.py
@@ -10,5 +10,6 @@ setup(
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     install_requires="sqlfluff>=0.4.0",
-    entry_points={"sqlfluff": ["{plugin_name} = {plugin_name}.rules"]},
+    entry_points={"sqlfluff": ["{plugin_name} = {plugin_name}.rules".format(
+        plugin_name=PLUGIN_NAME)]},
 )

--- a/plugins/sqlfluff-plugin-example/setup.py
+++ b/plugins/sqlfluff-plugin-example/setup.py
@@ -1,11 +1,14 @@
 """Setup file for example plugin."""
 from setuptools import find_packages, setup
 
+# Change this name in your plugin, e.g. company name or plugin purpose.
+PLUGIN_NAME = "example"
+
 setup(
-    name="sqlfluff-plugin-example",
+    name="sqlfluff-plugin-{plugin_name}".format(plugin_name=PLUGIN_NAME),
     include_package_data=True,
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     install_requires="sqlfluff>=0.4.0",
-    entry_points={"sqlfluff": ["example = example.rules"]},
+    entry_points={"sqlfluff": ["{plugin_name} = {plugin_name}.rules"]},
 )

--- a/plugins/sqlfluff-plugin-example/setup.py
+++ b/plugins/sqlfluff-plugin-example/setup.py
@@ -1,15 +1,11 @@
 """Setup file for example plugin."""
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name="sqlfluff-plugin-example",
     include_package_data=True,
     package_dir={"": "src"},
-    packages=[
-        "example",
-    ],
-    # TODO: Change me to the first release
-    # that includes the pluggy work.
-    install_requires="sqlfluff>=0.4.0a3",
+    packages=find_packages(),
+    install_requires="sqlfluff>=0.4.0",
     entry_points={"sqlfluff": ["example = example.rules"]},
 )

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -860,7 +860,9 @@ class TableExpressionSegment(BaseSegment):
             # Return the last element of the reference, which
             # will already be a tuple.
             penultimate_ref = list(ref.iter_raw_references())[-1]
-            return AliasInfo(penultimate_ref[0], penultimate_ref[1], False, self, None, ref)
+            return AliasInfo(
+                penultimate_ref[0], penultimate_ref[1], False, self, None, ref
+            )
         # No references or alias, return None
         return None
 

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -814,6 +814,7 @@ class AliasInfo(NamedTuple):
     aliased: bool
     table_expression: BaseSegment
     alias_expression: Optional[BaseSegment]
+    object_reference: Optional[BaseSegment]
 
 
 @ansi_dialect.segment()
@@ -847,19 +848,19 @@ class TableExpressionSegment(BaseSegment):
 
         """
         alias_expression = self.get_child("alias_expression")
+        ref = self.get_child("main_table_expression").get_child("object_reference")
         if alias_expression:
             # If it has an alias, return that
             segment = alias_expression.get_child("identifier")
-            return AliasInfo(segment.raw, segment, True, self, alias_expression)
+            return AliasInfo(segment.raw, segment, True, self, alias_expression, ref)
 
         # If not return the object name (or None if there isn't one)
         # ref = self.get_child("object_reference")
-        ref = self.get_child("main_table_expression").get_child("object_reference")
         if ref:
             # Return the last element of the reference, which
             # will already be a tuple.
             penultimate_ref = list(ref.iter_raw_references())[-1]
-            return AliasInfo(penultimate_ref[0], penultimate_ref[1], False, self, None)
+            return AliasInfo(penultimate_ref[0], penultimate_ref[1], False, self, None, ref)
         # No references or alias, return None
         return None
 

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -935,7 +935,11 @@ class Linter:
         )
 
     def lint_fix(
-        self, tree: BaseSegment, config: Optional[FluffConfig] = None, fix: bool = False, fname: Optional[str] = None
+        self,
+        tree: BaseSegment,
+        config: Optional[FluffConfig] = None,
+        fix: bool = False,
+        fname: Optional[str] = None,
     ) -> Tuple[BaseSegment, List[SQLLintError]]:
         """Lint and optionally fix a tree object."""
         config = config or self.config
@@ -1017,14 +1021,20 @@ class Linter:
         return linting_errors
 
     def fix(
-        self, tree: BaseSegment, config: Optional[FluffConfig] = None, fname: Optional[str] = None
+        self,
+        tree: BaseSegment,
+        config: Optional[FluffConfig] = None,
+        fname: Optional[str] = None,
     ) -> Tuple[BaseSegment, List[SQLLintError]]:
         """Return the fixed tree and violations from lintfix when we're fixing."""
         fixed_tree, violations = self.lint_fix(tree, config, fix=True, fname=fname)
         return fixed_tree, violations
 
     def lint(
-        self, tree: BaseSegment, config: Optional[FluffConfig] = None, fname: Optional[str] = None
+        self,
+        tree: BaseSegment,
+        config: Optional[FluffConfig] = None,
+        fname: Optional[str] = None,
     ) -> List[SQLLintError]:
         """Return just the violations from lintfix when we're only linting."""
         _, violations = self.lint_fix(tree, config, fix=False, fname=fname)
@@ -1070,7 +1080,9 @@ class Linter:
             linter_logger.info("LINTING (%s)", fname)
 
             if fix:
-                tree, initial_linting_errors = self.fix(tree, config=config, fname=fname)
+                tree, initial_linting_errors = self.fix(
+                    tree, config=config, fname=fname
+                )
             else:
                 lint = self.lint(tree, config=config, fname=fname)
                 initial_linting_errors = lint

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -935,7 +935,7 @@ class Linter:
         )
 
     def lint_fix(
-        self, tree: BaseSegment, config: Optional[FluffConfig] = None, fix: bool = False
+        self, tree: BaseSegment, config: Optional[FluffConfig] = None, fix: bool = False, fname: Optional[str] = None
     ) -> Tuple[BaseSegment, List[SQLLintError]]:
         """Lint and optionally fix a tree object."""
         config = config or self.config
@@ -958,7 +958,7 @@ class Linter:
                 # "anchor", the segment to look for either to edit or to insert BEFORE.
                 # The second is the element to insert or create.
                 linting_errors, _, fixes, _ = crawler.crawl(
-                    tree, dialect=config.get("dialect_obj")
+                    tree, dialect=config.get("dialect_obj"), fname=fname
                 )
                 all_linting_errors += linting_errors
 
@@ -1017,17 +1017,17 @@ class Linter:
         return linting_errors
 
     def fix(
-        self, tree: BaseSegment, config: Optional[FluffConfig] = None
+        self, tree: BaseSegment, config: Optional[FluffConfig] = None, fname: Optional[str] = None
     ) -> Tuple[BaseSegment, List[SQLLintError]]:
         """Return the fixed tree and violations from lintfix when we're fixing."""
-        fixed_tree, violations = self.lint_fix(tree, config, fix=True)
+        fixed_tree, violations = self.lint_fix(tree, config, fix=True, fname=fname)
         return fixed_tree, violations
 
     def lint(
-        self, tree: BaseSegment, config: Optional[FluffConfig] = None
+        self, tree: BaseSegment, config: Optional[FluffConfig] = None, fname: Optional[str] = None
     ) -> List[SQLLintError]:
         """Return just the violations from lintfix when we're only linting."""
-        _, violations = self.lint_fix(tree, config, fix=False)
+        _, violations = self.lint_fix(tree, config, fix=False, fname=fname)
         return violations
 
     def lint_string(
@@ -1070,9 +1070,10 @@ class Linter:
             linter_logger.info("LINTING (%s)", fname)
 
             if fix:
-                tree, initial_linting_errors = self.fix(tree, config=config)
+                tree, initial_linting_errors = self.fix(tree, config=config, fname=fname)
             else:
-                initial_linting_errors = self.lint(tree, config=config)
+                lint = self.lint(tree, config=config, fname=fname)
+                initial_linting_errors = lint
 
             # Update the timing dict
             t1 = time.monotonic()

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -16,6 +16,7 @@ missing.
 
 import copy
 import logging
+import pathlib
 import re
 from collections import namedtuple
 
@@ -251,6 +252,7 @@ class BaseCrawler:
         siblings_post=None,
         raw_stack=None,
         memory=None,
+        fname=None,
     ):
         """Recursively perform the crawl operation on a given segment.
 
@@ -287,6 +289,7 @@ class BaseCrawler:
                 raw_stack=raw_stack,
                 memory=memory,
                 dialect=dialect,
+                path=pathlib.Path(fname) if fname else None,
             )
         # Any exception at this point would halt the linter and
         # cause the user to get no results
@@ -353,6 +356,7 @@ class BaseCrawler:
                 raw_stack=raw_stack,
                 memory=memory,
                 dialect=dialect,
+                fname=fname,
             )
             vs += dvs
             fixes += child_fixes


### PR DESCRIPTION
Resolves #839 

I'm working on a real-world plugin for my employer. This PR addresses the noted issue. It also includes some othersmall changes I think will streamline plugin creation a bit. 

- [X] Update the `install_requires` SQLFluff version to an official (not alpha) release
- [X] Template the plugin name (`example`) to make it easier to change
- [X] Use `find_packages()` so deeper module directory structures will "just work"