### PR TITLE
Fix linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,14 +85,14 @@ jobs:
   linting:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.9
         environment:
           TOXENV: linting
           UPLOAD_COVERAGE: 0
   doclinting:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.9
         environment:
           TOXENV: doclinting
           UPLOAD_COVERAGE: 0

--- a/src/sqlfluff/core/rules/std/__init__.py
+++ b/src/sqlfluff/core/rules/std/__init__.py
@@ -1,6 +1,6 @@
+# noqa
 # No docstring here as it would appear in the rules docs.
 # Rule definitions for the standard ruleset, dynamically imported from the directory.
-# noqa
 
 import os
 from importlib import import_module

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ commands = mypy src/sqlfluff
 # W503: Line breaks before binary operators
 # D107: Don't require docstrings on __init__
 # D105: Don't require docstrings on magic methods
-ignore = E501, W503, D107, D105
+ignore = E501, W503, D107, D105, D418
 exclude = .git,__pycache__,env,.tox,build,.venv,venv
 max-line-length = 88
 extend-ignore =


### PR DESCRIPTION
For some reason `pydocstyle==6.0.0` released on 18th March is being installed in circle ci but not locally when installing from requirements and requirements dev. The [6.0.0 release adds](pydocstyle==6.0.0):

> Methods, Functions and Nested functions that have a docstring now throw D418 (#511).

I've ignored this rule in tox.ini