### PR TITLE
Explicitly nest expressions when bracketed.

### DIFF
--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -1072,10 +1072,9 @@ class JoinOnConditionSegment(BaseSegment):
     match_grammar = Sequence(
         "ON",
         Indent,
-        OneOf(
-            # This is a great case for "optionally bracketed"
-            Bracketed(Ref("ExpressionSegment", ephemeral_name="JoinCondition")),
+        OptionallyBracketed(
             Ref("ExpressionSegment"),
+            ephemeral_name="JoinCondition"
         ),
         Dedent,
     )

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -1073,8 +1073,9 @@ class JoinOnConditionSegment(BaseSegment):
         "ON",
         Indent,
         OneOf(
-            Ref("ExpressionSegment"),
+            # This is a great case for "optionally bracketed"
             Bracketed(Ref("ExpressionSegment", ephemeral_name="JoinCondition")),
+            Ref("ExpressionSegment"),
         ),
         Dedent,
     )
@@ -1285,7 +1286,9 @@ ansi_dialect.add(
             Ref("FunctionSegment"),
             Bracketed(
                 OneOf(
-                    Ref("Expression_A_Grammar"),
+                    # We're using the expression segment here rather than the grammar so
+                    # that in the parsed structure we get nested elements.
+                    Ref("ExpressionSegment"),
                     Ref("SelectableGrammar"),
                     Delimited(
                         Ref(

--- a/src/sqlfluff/core/dialects/dialect_ansi.py
+++ b/src/sqlfluff/core/dialects/dialect_ansi.py
@@ -1072,10 +1072,7 @@ class JoinOnConditionSegment(BaseSegment):
     match_grammar = Sequence(
         "ON",
         Indent,
-        OptionallyBracketed(
-            Ref("ExpressionSegment"),
-            ephemeral_name="JoinCondition"
-        ),
+        OptionallyBracketed(Ref("ExpressionSegment")),
         Dedent,
     )
 

--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -224,7 +224,16 @@ class OneOf(AnyNumberOf):
 
 
 class OptionallyBracketed(OneOf):
-    """Hybrid of Bracketed and Sequence: allows brackets but they aren't required."""
+    """Hybrid of Bracketed and Sequence: allows brackets but they aren't required.
+
+    NOTE: This class is greedy on brackets so if they *can* be claimed, then
+    they will be.
+    """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(Sequence(*args), Bracketed(*args, **kwargs))
+        super().__init__(
+            Bracketed(*args),
+            # In the case that there is only one argument, no sequence is required.
+            args[0] if len(args) == 1 else Sequence(*args),
+            **kwargs
+        )

--- a/test/fixtures/parser/ansi/arithmetic_a.yml
+++ b/test/fixtures/parser/ansi/arithmetic_a.yml
@@ -8,9 +8,10 @@ file:
           - literal: '1'
           - binary_operator: +
           - start_bracket: (
-          - literal: '2'
-          - binary_operator: '*'
-          - literal: '3'
+          - expression:
+            - literal: '2'
+            - binary_operator: '*'
+            - literal: '3'
           - end_bracket: )
           - comparison_operator: '>='
           - literal: '4'

--- a/test/fixtures/parser/ansi/create_view_a.yml
+++ b/test/fixtures/parser/ansi/create_view_a.yml
@@ -26,9 +26,9 @@ file:
                   table_reference:
                     identifier: table2
             - join_on_condition:
-                keyword: 'ON'
-                expression:
-                - start_bracket: (
+              - keyword: 'ON'
+              - start_bracket: (
+              - expression:
                 - column_reference:
                   - identifier: table1
                   - dot: .
@@ -38,4 +38,4 @@ file:
                   - identifier: table2
                   - dot: .
                   - identifier: id
-                - end_bracket: )
+              - end_bracket: )

--- a/test/fixtures/parser/ansi/modulo.yml
+++ b/test/fixtures/parser/ansi/modulo.yml
@@ -10,28 +10,30 @@ file:
             - keyword: WHEN
             - expression:
               - start_bracket: (
-              - column_reference:
-                  identifier: year_number
-              - binary_operator: '%'
-              - literal: '400'
-              - comparison_operator: '='
-              - literal: '0'
+              - expression:
+                - column_reference:
+                    identifier: year_number
+                - binary_operator: '%'
+                - literal: '400'
+                - comparison_operator: '='
+                - literal: '0'
               - end_bracket: )
               - binary_operator: OR
               - start_bracket: (
-              - column_reference:
-                  identifier: year_number
-              - binary_operator: '%'
-              - literal: '4'
-              - comparison_operator: '='
-              - literal: '0'
-              - binary_operator: AND
-              - column_reference:
-                  identifier: year_number
-              - binary_operator: '%'
-              - literal: '100'
-              - comparison_operator: '!='
-              - literal: '0'
+              - expression:
+                - column_reference:
+                    identifier: year_number
+                - binary_operator: '%'
+                - literal: '4'
+                - comparison_operator: '='
+                - literal: '0'
+                - binary_operator: AND
+                - column_reference:
+                    identifier: year_number
+                - binary_operator: '%'
+                - literal: '100'
+                - comparison_operator: '!='
+                - literal: '0'
               - end_bracket: )
             - keyword: THEN
             - expression:

--- a/test/fixtures/parser/ansi/select_b.yml
+++ b/test/fixtures/parser/ansi/select_b.yml
@@ -20,9 +20,9 @@ file:
                 table_reference:
                   identifier: bar
             join_on_condition:
-              keyword: 'ON'
-              expression:
-              - start_bracket: (
+            - keyword: 'ON'
+            - start_bracket: (
+            - expression: 
               - column_reference:
                 - identifier: foo
                 - dot: .
@@ -32,4 +32,4 @@ file:
                 - identifier: bar
                 - dot: .
                 - identifier: a
-              - end_bracket: )
+            - end_bracket: )

--- a/test/fixtures/parser/ansi/select_j.yml
+++ b/test/fixtures/parser/ansi/select_j.yml
@@ -6,49 +6,50 @@ file:
         select_target_element:
           expression:
           - start_bracket: (
-          - function:
-            - function_name: POW
-            - start_bracket: (
-            - expression:
-                column_reference:
-                  identifier: sd2
-            - comma: ','
-            - expression:
-                literal: '2'
-            - end_bracket: )
-          - binary_operator: +
-          - function:
-            - function_name: POW
-            - start_bracket: (
-            - expression:
-                column_reference:
-                  identifier: sd3
-            - comma: ','
-            - expression:
-                literal: '2'
-            - end_bracket: )
-          - binary_operator: +
-          - function:
-            - function_name: POW
-            - start_bracket: (
-            - expression:
-                column_reference:
-                  identifier: sd4
-            - comma: ','
-            - expression:
-                literal: '2'
-            - end_bracket: )
-          - binary_operator: +
-          - function:
-            - function_name: POW
-            - start_bracket: (
-            - expression:
-                column_reference:
-                  identifier: sd4
-            - comma: ','
-            - expression:
-                literal: '2'
-            - end_bracket: )
+          - expression:
+            - function:
+              - function_name: POW
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    identifier: sd2
+              - comma: ','
+              - expression:
+                  literal: '2'
+              - end_bracket: )
+            - binary_operator: +
+            - function:
+              - function_name: POW
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    identifier: sd3
+              - comma: ','
+              - expression:
+                  literal: '2'
+              - end_bracket: )
+            - binary_operator: +
+            - function:
+              - function_name: POW
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    identifier: sd4
+              - comma: ','
+              - expression:
+                  literal: '2'
+              - end_bracket: )
+            - binary_operator: +
+            - function:
+              - function_name: POW
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    identifier: sd4
+              - comma: ','
+              - expression:
+                  literal: '2'
+              - end_bracket: )
           - end_bracket: )
           alias_expression:
             identifier: w1

--- a/test/fixtures/parser/ansi/select_l.yml
+++ b/test/fixtures/parser/ansi/select_l.yml
@@ -19,9 +19,10 @@ file:
             identifier: c
           comparison_operator: '>='
           start_bracket: (
-          select_statement:
-            select_clause:
-              keyword: SELECT
-              select_target_element:
-                literal: '1'
+          expression:
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_target_element:
+                  literal: '1'
           end_bracket: )

--- a/test/fixtures/parser/ansi/select_m.yml
+++ b/test/fixtures/parser/ansi/select_m.yml
@@ -55,24 +55,26 @@ file:
               keyword: 'ON'
               expression:
               - start_bracket: (
-              - column_reference:
-                  identifier: business_type
-              - comparison_operator: '='
-              - column_reference:
-                  identifier: low_business_type
+              - expression:
+                - column_reference:
+                    identifier: business_type
+                - comparison_operator: '='
+                - column_reference:
+                    identifier: low_business_type
               - end_bracket: )
               - binary_operator: AND
               - start_bracket: (
-              - column_reference:
-                  identifier: business_type
-              - comparison_operator: '='
-              - column_reference:
-                  identifier: low_business_type
-              - binary_operator: OR
-              - column_reference:
-                  identifier: size_label
-              - comparison_operator: '='
-              - column_reference:
-                  identifier: low_size_label
+              - expression:
+                - column_reference:
+                    identifier: business_type
+                - comparison_operator: '='
+                - column_reference:
+                    identifier: low_business_type
+                - binary_operator: OR
+                - column_reference:
+                    identifier: size_label
+                - comparison_operator: '='
+                - column_reference:
+                    identifier: low_size_label
               - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/parser/ansi/select_s.yml
+++ b/test/fixtures/parser/ansi/select_s.yml
@@ -14,101 +14,102 @@ file:
       - select_target_element:
           expression:
           - start_bracket: (
-          - column_reference:
-              identifier: count_18_24
-          - binary_operator: '*'
-          - column_reference:
-              identifier: bits
-          - array_accessor:
-              start_square_bracket: '['
-              expression:
-                function:
-                  function_name: OFFSET
-                  start_bracket: (
-                  expression:
-                    literal: '0'
-                  end_bracket: )
-              end_square_bracket: ']'
-          - binary_operator: +
-          - column_reference:
-              identifier: count_25_34
-          - binary_operator: '*'
-          - column_reference:
-              identifier: bits
-          - array_accessor:
-              start_square_bracket: '['
-              expression:
-                function:
-                  function_name: OFFSET
-                  start_bracket: (
-                  expression:
-                    literal: '1'
-                  end_bracket: )
-              end_square_bracket: ']'
-          - binary_operator: +
-          - column_reference:
-              identifier: count_35_44
-          - binary_operator: '*'
-          - column_reference:
-              identifier: bits
-          - array_accessor:
-              start_square_bracket: '['
-              expression:
-                function:
-                  function_name: OFFSET
-                  start_bracket: (
-                  expression:
-                    literal: '2'
-                  end_bracket: )
-              end_square_bracket: ']'
-          - binary_operator: +
-          - column_reference:
-              identifier: count_45_54
-          - binary_operator: '*'
-          - column_reference:
-              identifier: bits
-          - array_accessor:
-              start_square_bracket: '['
-              expression:
-                function:
-                  function_name: OFFSET
-                  start_bracket: (
-                  expression:
-                    literal: '3'
-                  end_bracket: )
-              end_square_bracket: ']'
-          - binary_operator: +
-          - column_reference:
-              identifier: count_55_64
-          - binary_operator: '*'
-          - column_reference:
-              identifier: bits
-          - array_accessor:
-              start_square_bracket: '['
-              expression:
-                function:
-                  function_name: OFFSET
-                  start_bracket: (
-                  expression:
-                    literal: '4'
-                  end_bracket: )
-              end_square_bracket: ']'
-          - binary_operator: +
-          - column_reference:
-              identifier: count_65_plus
-          - binary_operator: '*'
-          - column_reference:
-              identifier: bits
-          - array_accessor:
-              start_square_bracket: '['
-              expression:
-                function:
-                  function_name: OFFSET
-                  start_bracket: (
-                  expression:
-                    literal: '5'
-                  end_bracket: )
-              end_square_bracket: ']'
+          - expression:
+            - column_reference:
+                identifier: count_18_24
+            - binary_operator: '*'
+            - column_reference:
+                identifier: bits
+            - array_accessor:
+                start_square_bracket: '['
+                expression:
+                  function:
+                    function_name: OFFSET
+                    start_bracket: (
+                    expression:
+                      literal: '0'
+                    end_bracket: )
+                end_square_bracket: ']'
+            - binary_operator: +
+            - column_reference:
+                identifier: count_25_34
+            - binary_operator: '*'
+            - column_reference:
+                identifier: bits
+            - array_accessor:
+                start_square_bracket: '['
+                expression:
+                  function:
+                    function_name: OFFSET
+                    start_bracket: (
+                    expression:
+                      literal: '1'
+                    end_bracket: )
+                end_square_bracket: ']'
+            - binary_operator: +
+            - column_reference:
+                identifier: count_35_44
+            - binary_operator: '*'
+            - column_reference:
+                identifier: bits
+            - array_accessor:
+                start_square_bracket: '['
+                expression:
+                  function:
+                    function_name: OFFSET
+                    start_bracket: (
+                    expression:
+                      literal: '2'
+                    end_bracket: )
+                end_square_bracket: ']'
+            - binary_operator: +
+            - column_reference:
+                identifier: count_45_54
+            - binary_operator: '*'
+            - column_reference:
+                identifier: bits
+            - array_accessor:
+                start_square_bracket: '['
+                expression:
+                  function:
+                    function_name: OFFSET
+                    start_bracket: (
+                    expression:
+                      literal: '3'
+                    end_bracket: )
+                end_square_bracket: ']'
+            - binary_operator: +
+            - column_reference:
+                identifier: count_55_64
+            - binary_operator: '*'
+            - column_reference:
+                identifier: bits
+            - array_accessor:
+                start_square_bracket: '['
+                expression:
+                  function:
+                    function_name: OFFSET
+                    start_bracket: (
+                    expression:
+                      literal: '4'
+                    end_bracket: )
+                end_square_bracket: ']'
+            - binary_operator: +
+            - column_reference:
+                identifier: count_65_plus
+            - binary_operator: '*'
+            - column_reference:
+                identifier: bits
+            - array_accessor:
+                start_square_bracket: '['
+                expression:
+                  function:
+                    function_name: OFFSET
+                    start_bracket: (
+                    expression:
+                      literal: '5'
+                    end_bracket: )
+                end_square_bracket: ']'
           - end_bracket: )
           - binary_operator: /
           - column_reference:

--- a/test/fixtures/parser/bigquery/create_temp_function_with_select.yml
+++ b/test/fixtures/parser/bigquery/create_temp_function_with_select.yml
@@ -19,36 +19,37 @@ file:
         start_bracket: (
         expression:
           start_bracket: (
-          select_statement:
-            select_clause:
-              keyword: SELECT
-              select_target_element:
-                literal: '1'
-            from_clause:
-              keyword: FROM
-              table_expression:
-              - main_table_expression:
-                  function:
-                    function_name: UNNEST
-                    start_bracket: (
-                    expression:
-                      function:
-                      - function_name: REGEXP_EXTRACT_ALL
-                      - start_bracket: (
-                      - expression:
-                          column_reference:
-                            identifier: url
-                      - comma: ','
-                      - expression:
-                          literal: r"%[0-9a-fA-F]{2}|[^%]+"
-                      - end_bracket: )
-                    end_bracket: )
-              - alias_expression:
-                  keyword: AS
-                  identifier: y
-              - keyword: WITH
-              - keyword: OFFSET
-              - keyword: AS
-              - identifier: i
+          expression:
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_target_element:
+                  literal: '1'
+              from_clause:
+                keyword: FROM
+                table_expression:
+                - main_table_expression:
+                    function:
+                      function_name: UNNEST
+                      start_bracket: (
+                      expression:
+                        function:
+                        - function_name: REGEXP_EXTRACT_ALL
+                        - start_bracket: (
+                        - expression:
+                            column_reference:
+                              identifier: url
+                        - comma: ','
+                        - expression:
+                            literal: r"%[0-9a-fA-F]{2}|[^%]+"
+                        - end_bracket: )
+                      end_bracket: )
+                - alias_expression:
+                    keyword: AS
+                    identifier: y
+                - keyword: WITH
+                - keyword: OFFSET
+                - keyword: AS
+                - identifier: i
           end_bracket: )
         end_bracket: )

--- a/test/fixtures/parser/bigquery/select_1_gt_0.yml
+++ b/test/fixtures/parser/bigquery/select_1_gt_0.yml
@@ -6,7 +6,8 @@ file:
         select_target_element:
           expression:
           - start_bracket: (
-          - literal: '1'
-          - comparison_operator: '>'
-          - literal: '0'
+          - expression:
+            - literal: '1'
+            - comparison_operator: '>'
+            - literal: '0'
           - end_bracket: )

--- a/test/fixtures/parser/bigquery/select_1_lt_0.yml
+++ b/test/fixtures/parser/bigquery/select_1_lt_0.yml
@@ -6,7 +6,8 @@ file:
         select_target_element:
           expression:
           - start_bracket: (
-          - literal: '1'
-          - comparison_operator: <
-          - literal: '0'
+          - expression:
+            - literal: '1'
+            - comparison_operator: <
+            - literal: '0'
           - end_bracket: )

--- a/test/fixtures/parser/bigquery/select_gt_lt.yml
+++ b/test/fixtures/parser/bigquery/select_gt_lt.yml
@@ -6,11 +6,12 @@ file:
         select_target_element:
           expression:
           - start_bracket: (
-          - literal: '1'
-          - comparison_operator: '>'
-          - literal: '0'
-          - binary_operator: AND
-          - literal: '0'
-          - comparison_operator: <
-          - literal: '1'
+          - expression:
+            - literal: '1'
+            - comparison_operator: '>'
+            - literal: '0'
+            - binary_operator: AND
+            - literal: '0'
+            - comparison_operator: <
+            - literal: '1'
           - end_bracket: )

--- a/test/fixtures/parser/bigquery/select_lt_gt.yml
+++ b/test/fixtures/parser/bigquery/select_lt_gt.yml
@@ -6,11 +6,12 @@ file:
         select_target_element:
           expression:
           - start_bracket: (
-          - literal: '0'
-          - comparison_operator: <
-          - literal: '1'
-          - binary_operator: AND
-          - literal: '1'
-          - comparison_operator: '>'
-          - literal: '0'
+          - expression:
+            - literal: '0'
+            - comparison_operator: <
+            - literal: '1'
+            - binary_operator: AND
+            - literal: '1'
+            - comparison_operator: '>'
+            - literal: '0'
           - end_bracket: )

--- a/test/fixtures/parser/postgres/postgres_join_no_space.yml
+++ b/test/fixtures/parser/postgres/postgres_join_no_space.yml
@@ -25,9 +25,9 @@ file:
                 - dot: .
                 - identifier: '"my_table"'
           - join_on_condition:
-              keyword: 'ON'
-              expression:
-              - start_bracket: (
+            - keyword: 'ON'
+            - start_bracket: (
+            - expression:
               - column_reference:
                 - identifier: '"my_table2"'
                 - dot: .
@@ -37,4 +37,4 @@ file:
                 - identifier: '"my_table"'
                 - dot: .
                 - identifier: foo
-              - end_bracket: )
+            - end_bracket: )

--- a/test/fixtures/parser/snowflake/snowflake_lateral_flatten_after_join.yml
+++ b/test/fixtures/parser/snowflake/snowflake_lateral_flatten_after_join.yml
@@ -66,9 +66,9 @@ file:
                 table_reference:
                   identifier: b
           - join_on_condition:
-              keyword: 'on'
-              expression:
-              - start_bracket: (
+            - keyword: 'on'
+            - start_bracket: (
+            - expression:
               - column_reference:
                 - identifier: b
                 - dot: .
@@ -78,7 +78,7 @@ file:
                 - identifier: a
                 - dot: .
                 - identifier: c_id
-              - end_bracket: )
+            - end_bracket: )
       - comma: ','
       - table_expression:
           keyword: lateral

--- a/test/fixtures/templater/jinja_g_macros/jinja.yml
+++ b/test/fixtures/templater/jinja_g_macros/jinja.yml
@@ -14,12 +14,13 @@ file:
         - select_target_element:
             expression:
               - start_bracket: (
-              - column_reference:
-                  identifier: json
-              - binary_operator: ->
-              - literal: "'type'"
-              - binary_operator: ->>
-              - literal: "'id'"
+              - expression:
+                - column_reference:
+                    identifier: json
+                - binary_operator: ->
+                - literal: "'type'"
+                - binary_operator: ->>
+                - literal: "'id'"
               - end_bracket: )
               - cast_expression:
                   casting_operator: "::"
@@ -32,12 +33,13 @@ file:
         - select_target_element:
             expression:
               - start_bracket: (
-              - column_reference:
-                  identifier: json
-              - binary_operator: ->
-              - literal: "'type'"
-              - binary_operator: ->>
-              - literal: "'name'"
+              - expression:
+                - column_reference:
+                    identifier: json
+                - binary_operator: ->
+                - literal: "'type'"
+                - binary_operator: ->>
+                - literal: "'name'"
               - end_bracket: )
             alias_expression:
               keyword: as


### PR DESCRIPTION
This is related to #870 .

In expression parsing, I noticed two parts not functioning correctly.

1. In `JoinOnConditionSegment` an additional `expression` layer was being added when it should just be _optionally bracketed_.
2. Nested expressions were being parsed as one big expression, because we we referring to an expression _grammar_ when brackets were present rather than an expression _segment_.

This addresses both.