### PR TITLE
only require dataclasses if installing on Python 3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ pathspec
 pytest
 appdirs
 # dataclasses backport for python 3.6
-dataclasses
+dataclasses; python_version < '3.7'

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
         # Cached property for performance gains
         "cached-property",
         # dataclasses backport for python 3.6
-        "dataclasses",
+        "dataclasses; python_version < '3.7'",
         # better type hints for older python versions
         "typing_extensions",
         # We provide a testing library for plugins in sqlfluff.testing


### PR DESCRIPTION
`dataclasses` is a library which became part of the standard library
from 3.7, so this package only needs to be added in environments with
Python 3.6 and lower

The reason how this cropped up was when I ran `sqlfluff` against our DBT repo running on Python 3.8.8.

And got the following traceback which is associated to having the `dataclasses` backport installed on Python 3.7 or above.

```
Traceback (most recent call last):
  File "/venv/bin/sqlfluff", line 5, in <module>
    from sqlfluff.cli.commands import cli
  File "/venv/lib/python3.8/site-packages/sqlfluff/__init__.py", line 5, in <module>
    from sqlfluff.api import lint, fix, parse, rules, dialects  # noqa: F401
  File "/venv/lib/python3.8/site-packages/sqlfluff/api/__init__.py", line 6, in <module>
    from sqlfluff.api.simple import lint, fix, parse
  File "/venv/lib/python3.8/site-packages/sqlfluff/api/simple.py", line 3, in <module>
    from sqlfluff.core import Linter
  File "/venv/lib/python3.8/site-packages/sqlfluff/core/__init__.py", line 9, in <module>
    from sqlfluff.core.linter import Linter
  File "/venv/lib/python3.8/site-packages/sqlfluff/core/linter.py", line 33, in <module>
    from sqlfluff.core.parser import Lexer, Parser
  File "/venv/lib/python3.8/site-packages/sqlfluff/core/parser/__init__.py", line 29, in <module>
    from sqlfluff.core.parser.lexer import Lexer
  File "/venv/lib/python3.8/site-packages/sqlfluff/core/parser/lexer.py", line 17, in <module>
    from sqlfluff.core.templaters import TemplatedFile
  File "/venv/lib/python3.8/site-packages/sqlfluff/core/templaters/__init__.py", line 12, in <module>
    from sqlfluff.core.templaters.dbt import DbtTemplater
  File "/venv/lib/python3.8/site-packages/sqlfluff/core/templaters/dbt.py", line 21, in <module>
    class DbtConfigArgs:
  File "/venv/lib/python3.8/site-packages/dataclasses.py", line 958, in dataclass
    return wrap(_cls)
  File "/venv/lib/python3.8/site-packages/dataclasses.py", line 950, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash, frozen)
  File "/venv/lib/python3.8/site-packages/dataclasses.py", line 800, in _process_class
    cls_fields = [_get_field(cls, name, type)
  File "/venv/lib/python3.8/site-packages/dataclasses.py", line 800, in <listcomp>
    cls_fields = [_get_field(cls, name, type)
  File "/venv/lib/python3.8/site-packages/dataclasses.py", line 659, in _get_field
    if (_is_classvar(a_type, typing)
  File "/venv/lib/python3.8/site-packages/dataclasses.py", line 550, in _is_classvar
    return type(a_type) is typing._ClassVar
AttributeError: module 'typing' has no attribute '_ClassVar'
```