### PR TITLE
Silence the Indent balance test failed warning

### DIFF
--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -840,7 +840,7 @@ class Linter:
                     for elem in cast(Tuple[BaseSegment, ...], tokens)
                 )
                 if indent_balance != 0:
-                    linter_logger.warning(
+                    linter_logger.debug(
                         "Indent balance test failed for %r. Template indents will not be linted for this file.",
                         fname,
                     )


### PR DESCRIPTION
This has been raised by several users now. As it isn't actionable by the end-user, it seems that it should be at the debug level.

https://sqlfluff.slack.com/archives/C01GX4L213J/p1614615362024600
