### PR TITLE
[WIP] Snowflake: Support `COMMENT = <string>` and `CLUSTER BY` statement

### DIFF
--- a/test/dialects/snowflake_test.py
+++ b/test/dialects/snowflake_test.py
@@ -38,6 +38,18 @@ from sqlfluff.core.dialects import dialect_selector
             "create table orders_clone_restore clone orders at (timestamp => to_timestamp_tz('04/05/2013 01:02:03', 'mm/dd/yyyy hh24:mi:ss'));",
         ),
         (
+            "CreateTableStatementSegment",
+            "CREATE TABLE my_table (user_id INTEGER, created TIMESTAMP_TZ)",
+        ),
+        (
+            "CreateTableStatementSegment",
+            "CREATE TABLE my_table (user_id INTEGER, created TIMESTAMP_TZ) COMMENT = 'my_table';",
+        ),
+        (
+            "CreateTableStatementSegment",
+            "CREATE TABLE my_table (user_id INTEGER, created TIMESTAMP_TZ) CLUSTER BY (TO_DATE(created), user_id) COMMENT = 'my_table';",
+        ),
+        (
             "AccessStatementSegment",
             "GRANT OWNERSHIP ON SCHEMA MY_DATABASE.MY_SCHEMA TO ROLE MY_ROLE;",
         ),

--- a/test/fixtures/parser/snowflake/snowflake_create_table.sql
+++ b/test/fixtures/parser/snowflake/snowflake_create_table.sql
@@ -1,0 +1,41 @@
+CREATE TABLE basic_table (
+    column1 VARCHAR,
+    column2 INTEGER
+);
+
+CREATE TABLE basic_table_with_column_comment (
+    column1 VARCHAR COMMENT 'column1 desc',
+    column2 INTEGER
+);
+
+CREATE TABLE table_with_table_comment (
+    column1 VARCHAR,
+    column2 INTEGER
+)
+COMMENT = 'table_with_comments';
+
+CREATE TABLE table_with_table_and_column_comments (
+    column1 VARCHAR COMMENT 'column1 desc',
+    column2 INTEGER
+)
+COMMENT = 'table_with_comments';
+
+CREATE TABLE table_with_cluster_by (
+    column1 VARCHAR,
+    column2 INTEGER
+)
+CLUSTER BY (column1);
+
+CREATE TABLE table_with_cluster_by_and_table_comment (
+    column1 VARCHAR,
+    column2 INTEGER
+)
+CLUSTER BY (column1)
+COMMENT = 'table_with_comments';
+
+CREATE TABLE table_with_cluster_by_and_table_and_column_comments (
+    column1 VARCHAR COMMENT 'column1 desc',
+    column2 INTEGER
+)
+CLUSTER BY (column1)
+COMMENT = 'table_with_comments';

--- a/test/fixtures/parser/snowflake/snowflake_create_table.sql
+++ b/test/fixtures/parser/snowflake/snowflake_create_table.sql
@@ -14,6 +14,13 @@ CREATE TABLE table_with_table_comment (
 )
 COMMENT = 'table_with_comments';
 
+CREATE TABLE table_with_table_comment_before_column_definition
+COMMENT = 'table_with_table_comment_before_column_definition'
+(
+    column1 VARCHAR,
+    column2 INTEGER
+);
+
 CREATE TABLE table_with_table_and_column_comments (
     column1 VARCHAR COMMENT 'column1 desc',
     column2 INTEGER
@@ -39,3 +46,26 @@ CREATE TABLE table_with_cluster_by_and_table_and_column_comments (
 )
 CLUSTER BY (column1)
 COMMENT = 'table_with_comments';
+
+CREATE TABLE table_with_cluster_by_and_table_and_column_comments
+COMMENT = 'table_with_comments'
+(
+    column1 VARCHAR COMMENT 'column1',
+    column2 INTEGER
+)
+CLUSTER BY (column1);
+
+CREATE TABLE table_with_cluster_by_with_function
+(
+    column1 TIMESTAMP COMMENT 'timestamp column',
+    column2 INTEGER
+)
+CLUSTER BY (TO_DATE(column1), column2);
+
+CREATE TABLE table_with_both_comments_and_cluster_by_with_function
+(
+    column1 TIMESTAMP COMMENT 'column comment',
+    column2 INTEGER
+)
+COMMENT = 'table comment'
+CLUSTER BY (TO_DATE(column1), column2);

--- a/test/fixtures/parser/snowflake/snowflake_create_table.yml
+++ b/test/fixtures/parser/snowflake/snowflake_create_table.yml
@@ -56,10 +56,32 @@ file:
         data_type:
           data_type_identifier: INTEGER
     - end_bracket: )
-    unparsable:
-    - raw: COMMENT
-    - raw: '='
-    - raw: "'table_with_comments'"
+    - comment_clause:
+        keyword: COMMENT
+        comparison_operator: '='
+        literal: "'table_with_comments'"
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_with_table_comment_before_column_definition
+    - comment_clause:
+        keyword: COMMENT
+        comparison_operator: '='
+        literal: "'table_with_table_comment_before_column_definition'"
+    - start_bracket: (
+    - column_definition:
+        identifier: column1
+        data_type:
+          data_type_identifier: VARCHAR
+    - comma: ','
+    - column_definition:
+        identifier: column2
+        data_type:
+          data_type_identifier: INTEGER
+    - end_bracket: )
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -82,10 +104,10 @@ file:
         data_type:
           data_type_identifier: INTEGER
     - end_bracket: )
-    unparsable:
-    - raw: COMMENT
-    - raw: '='
-    - raw: "'table_with_comments'"
+    - comment_clause:
+        keyword: COMMENT
+        comparison_operator: '='
+        literal: "'table_with_comments'"
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -104,12 +126,13 @@ file:
         data_type:
           data_type_identifier: INTEGER
     - end_bracket: )
-    unparsable:
-    - raw: CLUSTER
-    - raw: BY
-    - start_bracket: (
-    - raw: column1
-    - end_bracket: )
+    - cluster_by_segment:
+      - keyword: CLUSTER
+      - keyword: BY
+      - start_bracket: (
+      - column_reference:
+          identifier: column1
+      - end_bracket: )
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -128,15 +151,17 @@ file:
         data_type:
           data_type_identifier: INTEGER
     - end_bracket: )
-    unparsable:
-    - raw: CLUSTER
-    - raw: BY
-    - start_bracket: (
-    - raw: column1
-    - end_bracket: )
-    - raw: COMMENT
-    - raw: '='
-    - raw: "'table_with_comments'"
+    - cluster_by_segment:
+      - keyword: CLUSTER
+      - keyword: BY
+      - start_bracket: (
+      - column_reference:
+          identifier: column1
+      - end_bracket: )
+    - comment_clause:
+        keyword: COMMENT
+        comparison_operator: '='
+        literal: "'table_with_comments'"
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -159,13 +184,128 @@ file:
         data_type:
           data_type_identifier: INTEGER
     - end_bracket: )
-    unparsable:
-    - raw: CLUSTER
-    - raw: BY
+    - cluster_by_segment:
+      - keyword: CLUSTER
+      - keyword: BY
+      - start_bracket: (
+      - column_reference:
+          identifier: column1
+      - end_bracket: )
+    - comment_clause:
+        keyword: COMMENT
+        comparison_operator: '='
+        literal: "'table_with_comments'"
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_with_cluster_by_and_table_and_column_comments
+    - comment_clause:
+        keyword: COMMENT
+        comparison_operator: '='
+        literal: "'table_with_comments'"
     - start_bracket: (
-    - raw: column1
+    - column_definition:
+        identifier: column1
+        data_type:
+          data_type_identifier: VARCHAR
+        column_constraint:
+          comment_clause:
+            keyword: COMMENT
+            literal: "'column1'"
+    - comma: ','
+    - column_definition:
+        identifier: column2
+        data_type:
+          data_type_identifier: INTEGER
     - end_bracket: )
-    - raw: COMMENT
-    - raw: '='
-    - raw: "'table_with_comments'"
+    - cluster_by_segment:
+      - keyword: CLUSTER
+      - keyword: BY
+      - start_bracket: (
+      - column_reference:
+          identifier: column1
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_with_cluster_by_with_function
+    - start_bracket: (
+    - column_definition:
+        identifier: column1
+        data_type:
+          data_type_identifier: TIMESTAMP
+        column_constraint:
+          comment_clause:
+            keyword: COMMENT
+            literal: "'timestamp column'"
+    - comma: ','
+    - column_definition:
+        identifier: column2
+        data_type:
+          data_type_identifier: INTEGER
+    - end_bracket: )
+    - cluster_by_segment:
+      - keyword: CLUSTER
+      - keyword: BY
+      - start_bracket: (
+      - expression:
+          function:
+            function_name: TO_DATE
+            start_bracket: (
+            expression:
+              column_reference:
+                identifier: column1
+            end_bracket: )
+      - comma: ','
+      - column_reference:
+          identifier: column2
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_with_both_comments_and_cluster_by_with_function
+    - start_bracket: (
+    - column_definition:
+        identifier: column1
+        data_type:
+          data_type_identifier: TIMESTAMP
+        column_constraint:
+          comment_clause:
+            keyword: COMMENT
+            literal: "'column comment'"
+    - comma: ','
+    - column_definition:
+        identifier: column2
+        data_type:
+          data_type_identifier: INTEGER
+    - end_bracket: )
+    - comment_clause:
+        keyword: COMMENT
+        comparison_operator: '='
+        literal: "'table comment'"
+    - cluster_by_segment:
+      - keyword: CLUSTER
+      - keyword: BY
+      - start_bracket: (
+      - expression:
+          function:
+            function_name: TO_DATE
+            start_bracket: (
+            expression:
+              column_reference:
+                identifier: column1
+            end_bracket: )
+      - comma: ','
+      - column_reference:
+          identifier: column2
+      - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/parser/snowflake/snowflake_create_table.yml
+++ b/test/fixtures/parser/snowflake/snowflake_create_table.yml
@@ -1,0 +1,171 @@
+file:
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: basic_table
+    - start_bracket: (
+    - column_definition:
+        identifier: column1
+        data_type:
+          data_type_identifier: VARCHAR
+    - comma: ','
+    - column_definition:
+        identifier: column2
+        data_type:
+          data_type_identifier: INTEGER
+    - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: basic_table_with_column_comment
+    - start_bracket: (
+    - column_definition:
+        identifier: column1
+        data_type:
+          data_type_identifier: VARCHAR
+        column_constraint:
+          comment_clause:
+            keyword: COMMENT
+            literal: "'column1 desc'"
+    - comma: ','
+    - column_definition:
+        identifier: column2
+        data_type:
+          data_type_identifier: INTEGER
+    - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_with_table_comment
+    - start_bracket: (
+    - column_definition:
+        identifier: column1
+        data_type:
+          data_type_identifier: VARCHAR
+    - comma: ','
+    - column_definition:
+        identifier: column2
+        data_type:
+          data_type_identifier: INTEGER
+    - end_bracket: )
+    unparsable:
+    - raw: COMMENT
+    - raw: '='
+    - raw: "'table_with_comments'"
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_with_table_and_column_comments
+    - start_bracket: (
+    - column_definition:
+        identifier: column1
+        data_type:
+          data_type_identifier: VARCHAR
+        column_constraint:
+          comment_clause:
+            keyword: COMMENT
+            literal: "'column1 desc'"
+    - comma: ','
+    - column_definition:
+        identifier: column2
+        data_type:
+          data_type_identifier: INTEGER
+    - end_bracket: )
+    unparsable:
+    - raw: COMMENT
+    - raw: '='
+    - raw: "'table_with_comments'"
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_with_cluster_by
+    - start_bracket: (
+    - column_definition:
+        identifier: column1
+        data_type:
+          data_type_identifier: VARCHAR
+    - comma: ','
+    - column_definition:
+        identifier: column2
+        data_type:
+          data_type_identifier: INTEGER
+    - end_bracket: )
+    unparsable:
+    - raw: CLUSTER
+    - raw: BY
+    - start_bracket: (
+    - raw: column1
+    - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_with_cluster_by_and_table_comment
+    - start_bracket: (
+    - column_definition:
+        identifier: column1
+        data_type:
+          data_type_identifier: VARCHAR
+    - comma: ','
+    - column_definition:
+        identifier: column2
+        data_type:
+          data_type_identifier: INTEGER
+    - end_bracket: )
+    unparsable:
+    - raw: CLUSTER
+    - raw: BY
+    - start_bracket: (
+    - raw: column1
+    - end_bracket: )
+    - raw: COMMENT
+    - raw: '='
+    - raw: "'table_with_comments'"
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_with_cluster_by_and_table_and_column_comments
+    - start_bracket: (
+    - column_definition:
+        identifier: column1
+        data_type:
+          data_type_identifier: VARCHAR
+        column_constraint:
+          comment_clause:
+            keyword: COMMENT
+            literal: "'column1 desc'"
+    - comma: ','
+    - column_definition:
+        identifier: column2
+        data_type:
+          data_type_identifier: INTEGER
+    - end_bracket: )
+    unparsable:
+    - raw: CLUSTER
+    - raw: BY
+    - start_bracket: (
+    - raw: column1
+    - end_bracket: )
+    - raw: COMMENT
+    - raw: '='
+    - raw: "'table_with_comments'"
+- statement_terminator: ;

--- a/test/fixtures/parser/snowflake/snowflake_select_transient_table.yml
+++ b/test/fixtures/parser/snowflake/snowflake_select_transient_table.yml
@@ -1,25 +1,14 @@
 file:
   statement:
-    create_table_statement:
-    - keyword: CREATE
-    - binary_operator: OR
-    - keyword: REPLACE
-    - keyword: TRANSIENT
-    - keyword: TABLE
-    - table_reference:
-        identifier: new_tab
-    - keyword: AS
-    - select_statement:
-        select_clause:
-          keyword: SELECT
-          select_clause_element:
-            wildcard_expression:
-              wildcard_identifier:
-                star: '*'
-        from_clause:
-          keyword: FROM
-          from_expression:
-            from_expression_element:
-              table_expression:
-                table_reference:
-                  identifier: tab
+    unparsable:
+    - raw: CREATE
+    - raw: OR
+    - raw: REPLACE
+    - raw: TRANSIENT
+    - raw: TABLE
+    - raw: new_tab
+    - raw: AS
+    - raw: SELECT
+    - raw: '*'
+    - raw: FROM
+    - raw: tab


### PR DESCRIPTION
* Support Snowflake style table comment (With an `=` sign between COMMENT and the string literal)
* Support `CLUSTER BY ( col1, <col2>)` syntax in Snowflake