### PR TITLE
Set statement parsing

### DIFF
--- a/src/sqlfluff/core/parser/helpers.py
+++ b/src/sqlfluff/core/parser/helpers.py
@@ -63,7 +63,22 @@ def trim_non_code_segments(
 
 
 def iter_indices(seq: List, val: Any) -> Iterator[int]:
-    """Iterate all indices in a list that val occurs at."""
+    """Iterate all indices in a list that val occurs at.
+
+    Args:
+        seq (list): A list to look for indices in.
+        val: What to look for.
+
+    Yields:
+        int: The index of val in seq.
+
+    Examples:
+        The function works like str.index() but iterates all
+        the results rather than returning the first.
+
+        >>> print([i for i in iter_indices([1, 0, 2, 3, 2], 2)])
+        [2, 4]
+    """
     idx = 0
     while val in seq[idx:]:
         idx = seq.index(val, idx) + 1

--- a/src/sqlfluff/core/parser/helpers.py
+++ b/src/sqlfluff/core/parser/helpers.py
@@ -1,6 +1,6 @@
 """Helpers for the parser module."""
 
-from typing import Tuple, List, Any, TYPE_CHECKING
+from typing import Tuple, List, Any, Iterator, TYPE_CHECKING
 
 from sqlfluff.core.string_helpers import curtail_string
 
@@ -62,7 +62,7 @@ def trim_non_code_segments(
     return segments[:pre_idx], segments[pre_idx:post_idx], segments[post_idx:]
 
 
-def iter_indices(seq: List, val: Any) -> int:
+def iter_indices(seq: List, val: Any) -> Iterator[int]:
     """Iterate all indices in a list that val occurs at."""
     idx = 0
     while val in seq[idx:]:

--- a/src/sqlfluff/core/parser/helpers.py
+++ b/src/sqlfluff/core/parser/helpers.py
@@ -1,6 +1,6 @@
 """Helpers for the parser module."""
 
-from typing import Tuple, TYPE_CHECKING
+from typing import Tuple, List, Any, TYPE_CHECKING
 
 from sqlfluff.core.string_helpers import curtail_string
 
@@ -60,3 +60,11 @@ def trim_non_code_segments(
             post_idx -= 1
 
     return segments[:pre_idx], segments[pre_idx:post_idx], segments[post_idx:]
+
+
+def iter_indices(seq: List, val: Any) -> int:
+    """Iterate all indices in a list that val occurs at."""
+    idx = 0
+    while val in seq[idx:]:
+        idx = seq.index(val, idx) + 1
+        yield idx - 1

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -955,9 +955,9 @@ class SelectClauseElementSegment(BaseSegment):
     # Important to split elements before parsing, otherwise debugging is really hard.
     match_grammar = GreedyUntil(
         "FROM",
-        "LIMIT",
-        "ORDER",
         "WHERE",
+        "ORDER",
+        "LIMIT",
         Ref("CommaSegment"),
         Ref("SetOperatorSegment"),
         enforce_whitespace_preceeding_terminator=True,
@@ -1000,9 +1000,9 @@ class SelectClauseSegment(BaseSegment):
         Sequence("SELECT", Ref("WildcardExpressionSegment", optional=True)),
         terminator=OneOf(
             "FROM",
-            "LIMIT",
             "WHERE",
             "ORDER",
+            "LIMIT",
             Ref("SetOperatorSegment"),
         ),
         enforce_whitespace_preceeding_terminator=True,

--- a/test/core/parser/helpers_test.py
+++ b/test/core/parser/helpers_test.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from sqlfluff.core.parser.helpers import trim_non_code_segments
+from sqlfluff.core.parser.helpers import trim_non_code_segments, iter_indices
 
 
 @pytest.mark.parametrize(
@@ -30,3 +30,18 @@ def test__parser__helper_trim_non_code_segments(
     assert [elem.raw for elem in pre] == list(token_list[:pre_len])
     assert [elem.raw for elem in mid] == list(token_list[pre_len : pre_len + mid_len])
     assert [elem.raw for elem in post] == list(token_list[len(seg_list) - post_len :])
+
+
+@pytest.mark.parametrize(
+    "seq,val,indices",
+    [
+        ([], 1, []),
+        ([0, 1, 0], 2, []),
+        ([0, 1, 0], 1, [1]),
+        ([0, 1, 0], 0, [0, 2]),
+    ],
+)
+def test__parser__helper_iter_indices(seq, val, indices):
+    """Test iter_indices."""
+    res = list(iter_indices(seq, val))
+    assert res == indices

--- a/test/dialects/ansi_test.py
+++ b/test/dialects/ansi_test.py
@@ -152,7 +152,12 @@ def test__dialect__ansi_specific_segment_not_match(
     [
         # Missing Closing bracket. Error should be raised
         # on the starting bracket.
-        ("SELECT 1 + (2 ", [(1, 12)])
+        ("SELECT 1 + (2 ", [(1, 12)]),
+        # Set expression with inappropriate ORDER BY or LIMIT. Error
+        # raised on the UNION.
+        ("SELECT * FROM a ORDER BY 1 UNION SELECT * FROM b", [(1, 27)]),
+        ("SELECT * FROM a LIMIT 1 UNION SELECT * FROM b", [(1, 24)]),
+        ("SELECT * FROM a ORDER BY 1 LIMIT 1 UNION SELECT * FROM b", [(1, 35)]),
     ],
 )
 def test__dialect__ansi_specific_segment_not_parse(raw, err_locations, caplog):
@@ -160,6 +165,7 @@ def test__dialect__ansi_specific_segment_not_parse(raw, err_locations, caplog):
     lnt = Linter()
     parsed = lnt.parse_string(raw)
     assert len(parsed.violations) > 0
+    print(parsed.violations)
     locs = [(v.line_no(), v.line_pos()) for v in parsed.violations]
     assert locs == err_locations
 

--- a/test/fixtures/parser/ansi/set_order_by.sql
+++ b/test/fixtures/parser/ansi/set_order_by.sql
@@ -1,0 +1,5 @@
+-- https://github.com/sqlfluff/sqlfluff/issues/852
+SELECT 1 AS a
+UNION ALL
+SELECT 1 AS a
+ORDER BY a

--- a/test/fixtures/parser/ansi/set_order_by.yml
+++ b/test/fixtures/parser/ansi/set_order_by.yml
@@ -1,0 +1,27 @@
+file:
+  statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            literal: '1'
+            alias_expression:
+              keyword: AS
+              identifier: a
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            literal: '1'
+            alias_expression:
+              keyword: AS
+              identifier: a
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          identifier: a

--- a/test/fixtures/parser/ansi/set_order_by_complex.sql
+++ b/test/fixtures/parser/ansi/set_order_by_complex.sql
@@ -1,0 +1,6 @@
+-- https://github.com/sqlfluff/sqlfluff/issues/852
+-- ORDER BY and LIMIT are allowed when bracketed. Otherwise not.
+(SELECT * FROM a ORDER BY 1 LIMIT 1)
+UNION ALL
+(SELECT * FROM b ORDER BY 1 LIMIT 1)
+ORDER BY 1 LIMIT 1

--- a/test/fixtures/parser/ansi/set_order_by_complex.yml
+++ b/test/fixtures/parser/ansi/set_order_by_complex.yml
@@ -1,0 +1,59 @@
+file:
+  statement:
+    set_expression:
+    - start_bracket: (
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: a
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - literal: '1'
+        limit_clause:
+          keyword: LIMIT
+          literal: '1'
+    - end_bracket: )
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - start_bracket: (
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: b
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - literal: '1'
+        limit_clause:
+          keyword: LIMIT
+          literal: '1'
+    - end_bracket: )
+    - orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - literal: '1'
+    - limit_clause:
+        keyword: LIMIT
+        literal: '1'


### PR DESCRIPTION
This resolves #852 . This works by altering the `SelectableGrammar` and distinguishing between _ordered_ and _unordered_ select statements. For ease, they both have the same name, but only the former may contain `ORDER` or `LIMIT` clauses.

In solving this I've solved two other bugs:
1. In the `_look_ahead_match` heuristic, if there were multiple simple matches for a single matcher (e.g. multiple opened and closed brackets), then only one was being considered. This PR now iterates through all of them.
2. In `_bracket_sensitive_look_ahead_match` a critical error was thrown if we found an unmatched closed bracket. We could however get into this situation during terminator matching. In this case it's not a problem and is simply the signal that we should stop matching. Rather than raising an exception this now logs and returns no match. In the event that a query should parse because of a stray bracket, it should still be flagged, but now just as an unparsable end section.