### PR TITLE
Refactor L006 & L039, introduce L048

### DIFF
--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -18,7 +18,7 @@ import copy
 import logging
 import pathlib
 import re
-from typing import Optional, List, TYPE_CHECKING
+from typing import Optional, List, Tuple, TYPE_CHECKING
 from collections import namedtuple
 
 from sqlfluff.core.parser import RawSegment, KeywordSegment, BaseSegment, SymbolSegment
@@ -453,6 +453,15 @@ class BaseRule:
         )
         # At the moment we let the rule dictate *case* here.
         return symbol_seg(raw=raw, pos_marker=pos_marker)
+
+    @staticmethod
+    def matches_target_tuples(seg: BaseSegment, target_tuples: List[Tuple[str, str]]):
+        """Does the given segment match any of the given type tuples."""
+        if seg.name in [elem[1] for elem in target_tuples if elem[0] == "name"]:
+            return True
+        elif seg.is_type(*[elem[1] for elem in target_tuples if elem[0] == "type"]):
+            return True
+        return False
 
 
 class RuleSet:

--- a/src/sqlfluff/core/rules/std/L006.py
+++ b/src/sqlfluff/core/rules/std/L006.py
@@ -47,7 +47,6 @@ class Rule_L006(BaseRule):
 
         NOTE: We also allow bracket characters either side.
         """
-
         # Iterate through children of this segment looking for any of the
         # target types. We also check for whether any of the children start
         # or end with the targets.
@@ -116,11 +115,23 @@ class Rule_L006(BaseRule):
                         break
 
                 if (
+                    # There is a previous segment
                     prev_seg
+                    # And it's not whitespace
                     and not prev_seg.is_whitespace
+                    # And it's not an opening bracket
                     and not (
                         prev_seg.name.endswith("_bracket")
                         and prev_seg.name.startswith("start_")
+                    )
+                    # And it's not a placeholder that itself ends with whitespace.
+                    # NOTE: This feels convoluted but handles the case of '-%}' modifiers.
+                    and not (
+                        prev_seg.is_meta
+                        and (
+                            prev_seg.source_str.endswith(" ")
+                            or prev_seg.source_str.endswith("\n")
+                        )
                     )
                 ):
                     self.logger.debug(
@@ -159,11 +170,23 @@ class Rule_L006(BaseRule):
                         break
 
                 if (
+                    # There is a next segment
                     next_seg
+                    # It's not whitespace
                     and not next_seg.is_whitespace
+                    # It's not a closeing bracket
                     and not (
                         next_seg.name.endswith("_bracket")
                         and next_seg.name.startswith("end_")
+                    )
+                    # And it's not a placeholder that itself starts with whitespace.
+                    # NOTE: This feels convoluted but handles the case of '{%-' modifiers.
+                    and not (
+                        next_seg.is_meta
+                        and (
+                            next_seg.source_str.startswith(" ")
+                            or next_seg.source_str.startswith("\n")
+                        )
                     )
                 ):
                     self.logger.debug(

--- a/src/sqlfluff/core/rules/std/L010.py
+++ b/src/sqlfluff/core/rules/std/L010.py
@@ -56,9 +56,7 @@ class Rule_L010(BaseRule):
 
         """
         # Skip if not an element of the specified type/name
-        if (("type", segment.type) not in self._target_elems) and (
-            ("name", segment.name) not in self._target_elems
-        ):
+        if not self.matches_target_tuples(segment, self._target_elems):
             return LintResult(memory=memory)
 
         # Get the capitalisation policy configuration

--- a/src/sqlfluff/core/rules/std/L039.py
+++ b/src/sqlfluff/core/rules/std/L039.py
@@ -32,6 +32,7 @@ class Rule_L039(BaseRule):
         # For the given segment, lint whitespace directly within it.
         prev_newline = True
         prev_whitespace = None
+        violations = []
         for seg in segment.segments:
             if seg.is_type("newline"):
                 prev_newline = True
@@ -47,18 +48,22 @@ class Rule_L039(BaseRule):
             else:
                 if prev_whitespace:
                     if prev_whitespace.raw != " ":
-                        return LintResult(
-                            anchor=prev_whitespace,
-                            fixes=[
-                                LintFix(
-                                    "edit",
-                                    prev_whitespace,
-                                    self.make_whitespace(
-                                        raw=" ", pos_marker=prev_whitespace.pos_marker
-                                    ),
-                                )
-                            ],
+                        violations.append(
+                            LintResult(
+                                anchor=prev_whitespace,
+                                fixes=[
+                                    LintFix(
+                                        "edit",
+                                        prev_whitespace,
+                                        self.make_whitespace(
+                                            raw=" ",
+                                            pos_marker=prev_whitespace.pos_marker,
+                                        ),
+                                    )
+                                ],
+                            )
                         )
                 prev_newline = False
                 prev_whitespace = None
-        return None
+        if violations:
+            return violations

--- a/src/sqlfluff/core/rules/std/L048.py
+++ b/src/sqlfluff/core/rules/std/L048.py
@@ -1,0 +1,37 @@
+"""Implementation of Rule L048."""
+
+from typing import Tuple, List
+
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+
+from sqlfluff.core.rules.std.L006 import Rule_L006
+
+
+@document_fix_compatible
+class Rule_L048(Rule_L006):
+    """Quoted literals should be surrounded by a single whitespace.
+
+    | **Anti-pattern**
+    | In this example, there is a space missing space between the string 'foo'
+    | and the keyword AS.
+
+    .. code-block:: sql
+
+        SELECT
+            'foo'AS bar
+        FROM foo
+
+
+    | **Best practice**
+    | Keep a single space.
+
+    .. code-block:: sql
+
+        SELECT
+            'foo' AS bar
+        FROM foo
+    """
+
+    _target_elems: List[Tuple[str, str]] = [
+        ("name", "quoted_literal"),
+    ]

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -235,7 +235,7 @@ def test__linter__empty_file():
 @pytest.mark.parametrize(
     "ignore_templated_areas,check_tuples",
     [
-        (True, [("L006", 3, 39), ("L006", 3, 40)]),
+        (True, [("L006", 3, 39), ("L006", 3, 39)]),
         (
             False,
             [
@@ -244,7 +244,7 @@ def test__linter__empty_file():
                 ("L006", 3, 16),
                 ("L006", 3, 16),
                 ("L006", 3, 39),
-                ("L006", 3, 40),
+                ("L006", 3, 39),
             ],
         ),
     ],

--- a/test/core/rules/std_test.py
+++ b/test/core/rules/std_test.py
@@ -96,14 +96,24 @@ def test__rules__runaway_fail_catch():
         (
             "L006",
             "operator_errors.sql",
-            [(3, 8), (4, 10), (7, 6), (7, 7), (7, 9), (7, 10), (7, 12), (7, 13)],
+            [(7, 6), (7, 9), (7, 12)],
+        ),
+        (
+            "L039",
+            "operator_errors.sql",
+            [(3, 8), (4, 10)],
         ),
         ("L007", "operator_errors.sql", [(5, 9)]),
-        # Check we DO get a violation on line 2 but NOT on line 3
+        # Check we DO get a violation on line 2 but NOT on line 3 (between L006 & L039)
         (
             "L006",
             "operator_errors_negative.sql",
-            [(2, 6), (2, 9), (5, 6), (5, 7)],
+            [(5, 6)],
+        ),
+        (
+            "L039",
+            "operator_errors_negative.sql",
+            [(2, 6), (2, 9)],
         ),
         # Hard indentation errors
         (
@@ -128,7 +138,7 @@ def test__rules__runaway_fail_catch():
         # Distinct and Group by
         ("L021", "select_distinct_group_by.sql", [(1, 8)]),
         # Make sure that ignoring works as expected
-        ("L006", "operator_errors_ignore.sql", [(10, 8), (10, 9)]),
+        ("L006", "operator_errors_ignore.sql", [(10, 8)]),
         (
             "L031",
             "aliases_in_join_error.sql",

--- a/test/fixtures/linter/operator_errors_ignore.sql
+++ b/test/fixtures/linter/operator_errors_ignore.sql
@@ -5,7 +5,7 @@ are still present. No errors should be found on line 8 at all. */
 
 SELECT
     a.a + a.b AS good,
-    a.a  - a.b AS bad_1,  -- noqa
-    a.a *  a.b AS bad_2,  -- noqa: L007, L006
+    a.a-a.b AS bad_1,  -- noqa
+    a.a*a.b AS bad_2,  -- noqa: L007, L006
     a.a*a.b AS bad_3  -- noqa: L007
 FROM tbl AS a

--- a/test/fixtures/rules/std_rule_cases/L006.yml
+++ b/test/fixtures/rules/std_rule_cases/L006.yml
@@ -1,12 +1,25 @@
 rule: L006
 
-test_1:
+test_pass_brackets:
   # Test that we don't fail * operators in brackets
   pass_str: "SELECT COUNT(*) FROM tbl\n\n"
 
-test_2:
+test_pass_expression:
   # Github Bug #207
   pass_str: |
+    select
+        field,
+        date(field_1) - date(field_2) as diff
+    from table
+
+test_fail_expression:
+  # Github Bug #207
+  fail_str: |
+    select
+        field,
+        date(field_1)-date(field_2) as diff
+    from table
+  fix_str: |
     select
         field,
         date(field_1) - date(field_2) as diff
@@ -16,23 +29,31 @@ test_2:
 # Check we don't get false alarms with newlines, or sign indicators
 # -------------------
 
-test_3:
+test_pass_newline_1:
   pass_str: |
     SELECT 1
 
     + 2
 
-test_4:
+test_pass_newline_2:
   pass_str: |
     SELECT 1
     	+ 2
 
-test_5:
+test_pass_newline_£:
   pass_str: |
     SELECT 1
         + 2
 
-test_6:
+test_pass_sign_indicators:
   pass_str: SELECT 1, +2, -4
 
 # -------------------
+
+fail_simple:
+  fail_str: "SELECT 1+2"
+  fix_str: "SELECT 1 + 2"
+
+dont_fail_on_too_much_whitespace:
+  # Too much whitespace should be caught by L039
+  pass_str: "SELECT 1   +   2"

--- a/test/fixtures/rules/std_rule_cases/L048.yml
+++ b/test/fixtures/rules/std_rule_cases/L048.yml
@@ -1,14 +1,9 @@
 rule: L048
 
 test_pass_1:
-  # Test that we don't fail * operators in brackets
   pass_str: "SELECT 'foo'"
 
 test_pass_2:
-  # Test that we don't fail * operators in brackets
-  pass_str: "SELECT 'foo'"
-
-test_pass_3:
   # Test that brackets don't trigger it
   pass_str: "SELECT ('foo' || 'bar') as buzz"
 

--- a/test/fixtures/rules/std_rule_cases/L048.yml
+++ b/test/fixtures/rules/std_rule_cases/L048.yml
@@ -1,0 +1,17 @@
+rule: L048
+
+test_pass_1:
+  # Test that we don't fail * operators in brackets
+  pass_str: "SELECT 'foo'"
+
+test_pass_2:
+  # Test that we don't fail * operators in brackets
+  pass_str: "SELECT 'foo'"
+
+test_pass_3:
+  # Test that brackets don't trigger it
+  pass_str: "SELECT ('foo' || 'bar') as buzz"
+
+test_fail_simple:
+  fail_str: "SELECT ('foo'||'bar') as buzz"
+  fix_str: "SELECT ('foo' || 'bar') as buzz"


### PR DESCRIPTION
This resolves #360 .

It also refactors L006. Since the introduction of L039 (excessive whitespace), L006 no longer needs to lint for _too much_ whitespace. This PR applies that fix and also make the logic more reusable so that it can be used for L048 (missing whitespace around quoted literal). The refactor also improves the error message to be more explanatory (e.g. "Missing whitespace before *").

In implementing these I noted that L039 was only flagging on the first issue found and not all occurrences. This PR also extends that rule to fix that issue.

NB: L006 and L048 check for whitespace before *and* after (as before) but the anchor point for both is now the same. This means in comparing sets of check_tuples it appears as though the same error has appeared at the same position and therefore only once. This is just an effect of comparing `set` objects. In real use, the effect is still the same except that the position of the second linting issue has been moved back by one. This feels like a more appropriate positioning for the error.