### PR TITLE
Like operators

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -88,6 +88,7 @@ ansi_dialect.set_lexer_struct(
             dict(is_code=True),
         ),
         ("not_equal", "regex", r"!=|<>", dict(is_code=True)),
+        ("like_operator", "regex", r"!?~~?\*?", dict(is_code=True)),
         ("greater_than_or_equal", "regex", r">=", dict(is_code=True)),
         ("less_than_or_equal", "regex", r"<=", dict(is_code=True)),
         ("newline", "regex", r"\r\n|\n", dict(type="newline", is_whitespace=True)),
@@ -99,7 +100,6 @@ ansi_dialect.set_lexer_struct(
         ("dot", "singleton", ".", dict(is_code=True)),
         ("comma", "singleton", ",", dict(is_code=True, type="comma")),
         ("plus", "singleton", "+", dict(is_code=True)),
-        ("tilde", "singleton", "~", dict(is_code=True)),
         ("minus", "singleton", "-", dict(is_code=True)),
         ("divide", "singleton", "/", dict(is_code=True)),
         ("percent", "singleton", "%", dict(is_code=True)),
@@ -208,6 +208,9 @@ ansi_dialect.add(
     ModuloSegment=SymbolSegment.make("%", name="modulo", type="binary_operator"),
     ConcatSegment=SymbolSegment.make("||", name="concatenate", type="binary_operator"),
     EqualsSegment=SymbolSegment.make("=", name="equals", type="comparison_operator"),
+    LikeOperatorSegment=NamedSegment.make(
+        "like_operator", name="like_operator", type="comparison_operator"
+    ),
     GreaterThanSegment=SymbolSegment.make(
         ">", name="greater_than", type="comparison_operator"
     ),
@@ -305,6 +308,7 @@ ansi_dialect.add(
         Ref("LessThanOrEqualToSegment"),
         Ref("NotEqualToSegment_a"),
         Ref("NotEqualToSegment_b"),
+        Ref("LikeOperatorSegment"),
     ),
     # hookpoint for other dialects
     # e.g. EXASOL str to date cast with DATE '2021-01-01'

--- a/test/fixtures/parser/ansi/like_operators.sql
+++ b/test/fixtures/parser/ansi/like_operators.sql
@@ -1,0 +1,9 @@
+-- https://github.com/sqlfluff/sqlfluff/issues/828
+-- https://github.com/sqlfluff/sqlfluff/issues/842
+-- https://www.postgresql.org/docs/9.0/functions-matching.html#FUNCTIONS-LIKE
+SELECT *
+FROM my_tbl
+WHERE a !~ '[a-z]'
+AND d !~~* '[a-z]'
+AND b LIKE 'Spec\'s%'
+AND c !~* '^([0-9]){1,}(\.)([0-9]{1,})$'

--- a/test/fixtures/parser/ansi/like_operators.yml
+++ b/test/fixtures/parser/ansi/like_operators.yml
@@ -1,0 +1,38 @@
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: my_tbl
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            identifier: a
+        - comparison_operator: '!~'
+        - literal: "'[a-z]'"
+        - binary_operator: AND
+        - column_reference:
+            identifier: d
+        - comparison_operator: '!~~*'
+        - literal: "'[a-z]'"
+        - binary_operator: AND
+        - column_reference:
+            identifier: b
+        - keyword: LIKE
+        - literal: "'Spec\\'s%'"
+        - binary_operator: AND
+        - column_reference:
+            identifier: c
+        - comparison_operator: '!~*'
+        - literal: "'^([0-9]){1,}(\\.)([0-9]{1,})$'"


### PR DESCRIPTION
This resolves #828 and #842.

I thought the issue was with regex strings, but it's actually just a lack of the `LIKE` style operators. This adds a relatively fully featured set based on on Postgres. I dithered a bit about whether this should go in the `ansi` dialect, or just in `postgres` but for now I don't think it's doing any harm here.

In mysql this might conflict with the bitwise negation operator `~`, but we don't seem to have many mysql users so far.