### PR TITLE
Issue 930: L044 -- Max Recursion Depth

### DIFF
--- a/src/sqlfluff/core/rules/analysis/select_crawler.py
+++ b/src/sqlfluff/core/rules/analysis/select_crawler.py
@@ -120,6 +120,8 @@ class SelectCrawler:
                             seg,
                             [
                                 alias_info.ref_str
+                                if alias_info.aliased
+                                else alias_info.from_expression_element.raw
                                 for alias_info in self.select_info.table_aliases
                             ],
                         )

--- a/src/sqlfluff/core/rules/std/L044.py
+++ b/src/sqlfluff/core/rules/std/L044.py
@@ -104,7 +104,7 @@ class Rule_L044(BaseRule):
                             if wildcard_table in queries:
                                 # Wildcard refers to a CTE. Analyze it.
                                 self._analyze_result_columns(
-                                    queries[wildcard_table], dialect, queries
+                                    queries.pop(wildcard_table), dialect, queries
                                 )
                             else:
                                 # Not CTE, not table alias. Presumably an

--- a/src/sqlfluff/testing/rules.py
+++ b/src/sqlfluff/testing/rules.py
@@ -59,6 +59,9 @@ def assert_rule_fail_in_sql(code, sql, configs=None, line_numbers=None):
     linted = Linter(config=cfg).lint_string(sql, fix=True)
     lerrs = linted.get_violations()
     print("Errors Found: {0}".format(lerrs))
+    for e in lerrs:
+        if e.desc().startswith("Unexpected exception"):
+            pytest.fail(f"Linter failed with {e.desc()}")
     parse_errors = list(filter(lambda v: type(v) == SQLParseError, lerrs))
     if parse_errors:
         pytest.fail(f"Found the following parse errors in test case: {parse_errors}")

--- a/test/fixtures/rules/std_rule_cases/L044.yml
+++ b/test/fixtures/rules/std_rule_cases/L044.yml
@@ -292,9 +292,10 @@ test_31:
 
 test_32:
   # Issue 930: Infinite recursion if CTE queries itself.
-  fail_str: with
-    hubspot__engagement_calls as (
-      select * from hubspot__engagement_calls
-    )
+  fail_str: |
+    with
+      hubspot__engagement_calls as (
+        select * from hubspot__engagement_calls
+      )
 
-    select * from hubspot__engagement_calls
+      select * from hubspot__engagement_calls

--- a/test/fixtures/rules/std_rule_cases/L044.yml
+++ b/test/fixtures/rules/std_rule_cases/L044.yml
@@ -289,3 +289,12 @@ test_30:
 test_31:
   # Issue 915: Crash on statements that don't have a SELECT
   pass_str: CREATE TABLE my_table (id INTEGER)
+
+test_32:
+  # Issue 930: Infinite recursion if CTE queries itself.
+  fail_str: with
+    hubspot__engagement_calls as (
+      select * from hubspot__engagement_calls
+    )
+
+    select * from hubspot__engagement_calls

--- a/test/fixtures/rules/std_rule_cases/L044.yml
+++ b/test/fixtures/rules/std_rule_cases/L044.yml
@@ -299,3 +299,18 @@ test_32:
       )
 
       select * from hubspot__engagement_calls
+
+test_33:
+  # Another test for issue #930
+  fail_str: |
+    with
+    hubspot__contacts as (
+      select * from ANALYTICS.PUBLIC_intermediate.hubspot__contacts
+    ),
+    final as (
+      select *
+      from
+        hubspot__contacts
+        where not coalesce(_fivetran_deleted, false)
+    )
+    select * from final


### PR DESCRIPTION
Resolves #930 

The coverage report is failing, but only because I added code to detect when linter tests cause unexpected exceptions -- I think the PR is ready for review and potential merge, unless we feel strongly about adding tests for the test framework.