### PR TITLE
Logging and output improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Logging and readout now includes more detail and a notification of dbt compilation.
+
 ## [0.5.1] - 2021-04-09
 ### Changed
 - Parsing improvements around optional brackets.

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -245,7 +245,7 @@ class CallbackFormatter:
                     )
                 )
             if self._verbosity > 1:
-                text_buffer.write("== Raw Config:\n")
+                text_buffer.write("\n== Raw Config:\n")
                 text_buffer.write(format_config_vals(linter.config.iter_vals()))
         return text_buffer.getvalue()
 

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -857,9 +857,9 @@ class Linter:
             short_fname = fname
         bencher("Staring parse_string for {0!r}".format(short_fname))
 
-        # Dispatch the output for the parse header (including the config diff)
+        # Dispatch the output for the template header (including the config diff)
         if self.formatter:
-            self.formatter.dispatch_parse_header(fname, self.config, config)
+            self.formatter.dispatch_template_header(fname, self.config, config)
 
         # Just use the local config from here:
         config = config or self.config
@@ -872,7 +872,7 @@ class Linter:
 
         linter_logger.info("TEMPLATING RAW [%s] (%s)", self.templater.name, fname)
         templated_file, templater_violations = self.templater.process(
-            in_str=in_str, fname=fname, config=config
+            in_str=in_str, fname=fname, config=config, formatter=self.formatter
         )
         violations += templater_violations
         # Detect the case of a catastrophic templater fail. In this case
@@ -883,6 +883,10 @@ class Linter:
 
         t1 = time.monotonic()
         bencher("Templating {0!r}".format(short_fname))
+
+        # Dispatch the output for the parse header
+        if self.formatter:
+            self.formatter.dispatch_parse_header(fname)
 
         if templated_file:
             linter_logger.info("LEXING RAW (%s)", fname)
@@ -1062,6 +1066,10 @@ class Linter:
 
         # If we are fixing then we want to loop up to the runaway_limit, otherwise just once for linting.
         loop_limit = config.get("runaway_limit") if fix else 1
+
+        # Dispatch the output for the lint header
+        if self.formatter:
+            self.formatter.dispatch_lint_header(fname)
 
         for loop in range(loop_limit):
             changed = False

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -371,7 +371,7 @@ class RawTemplater:
         """
 
     def process(
-        self, *, in_str: str, fname: Optional[str] = None, config=None
+        self, *, in_str: str, fname: Optional[str] = None, config=None, formatter=None
     ) -> Tuple[Optional[TemplatedFile], list]:
         """Process a string and return a TemplatedFile.
 
@@ -389,6 +389,7 @@ class RawTemplater:
                 mostly for loading config files at runtime.
             config (:obj:`FluffConfig`): A specific config to use for this
                 templating operation. Only necessary for some templaters.
+            formatter (:obj:`CallbackFormatter`): Optional object for output.
 
         """
         return TemplatedFile(in_str, fname=fname), []
@@ -399,3 +400,7 @@ class RawTemplater:
         NB: This is useful in comparing configs.
         """
         return isinstance(other, self.__class__)
+
+    def config_pairs(self):
+        """Returns info about the given templater for output by the cli."""
+        return [("templater", self.name)]

--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -34,7 +34,12 @@ class DbtTemplater(JinjaTemplater):
 
     def __init__(self, **kwargs):
         self.sqlfluff_config = None
+        self.formatter = None
         super().__init__(**kwargs)
+
+    def config_pairs(self):
+        """Returns info about the given templater for output by the cli."""
+        return [("templater", self.name), ("dbt", self.dbt_version)]
 
     @cached_property
     def dbt_version(self):
@@ -104,6 +109,11 @@ class DbtTemplater(JinjaTemplater):
     @cached_property
     def dbt_selector_method(self):
         """Loads the dbt selector method."""
+        if self.formatter:
+            self.formatter.dispatch_compilation_header(
+                "dbt templater", "Compiling dbt project..."
+            )
+
         if "0.17" in self.dbt_version:
             from dbt.graph.selector import PathSelector
 
@@ -169,7 +179,7 @@ class DbtTemplater(JinjaTemplater):
                 "please install dbt dependencies through `pip install sqlfluff[dbt]`"
             ) from e
 
-    def process(self, *, fname, in_str=None, config=None):
+    def process(self, *, fname, in_str=None, config=None, formatter=None):
         """Compile a dbt model and return the compiled SQL.
 
         Args:
@@ -177,7 +187,11 @@ class DbtTemplater(JinjaTemplater):
             in_str (:obj:`str`, optional): This is ignored for dbt
             config (:obj:`FluffConfig`, optional): A specific config to use for this
                 templating operation. Only necessary for some templaters.
+            formatter (:obj:`CallbackFormatter`): Optional object for output.
         """
+        # Stash the formatter if provided to use in cached methods.
+        self.formatter = formatter
+
         self._check_dbt_installed()
         from dbt.exceptions import (
             CompilationException as DbtCompilationException,

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -182,7 +182,7 @@ class JinjaTemplater(PythonTemplater):
         )
 
     def process(
-        self, *, in_str: str, fname: Optional[str] = None, config=None
+        self, *, in_str: str, fname: Optional[str] = None, config=None, formatter=None
     ) -> Tuple[Optional[TemplatedFile], list]:
         """Process a string and return the new string.
 
@@ -200,6 +200,7 @@ class JinjaTemplater(PythonTemplater):
                 mostly for loading config files at runtime.
             config (:obj:`FluffConfig`): A specific config to use for this
                 templating operation. Only necessary for some templaters.
+            formatter (:obj:`CallbackFormatter`): Optional object for output.
 
         """
         if not config:

--- a/src/sqlfluff/core/templaters/python.py
+++ b/src/sqlfluff/core/templaters/python.py
@@ -200,7 +200,7 @@ class PythonTemplater(RawTemplater):
         return live_context
 
     def process(
-        self, *, in_str: str, fname: Optional[str] = None, config=None
+        self, *, in_str: str, fname: Optional[str] = None, config=None, formatter=None
     ) -> Tuple[Optional[TemplatedFile], list]:
         """Process a string and return a TemplatedFile.
 
@@ -218,6 +218,7 @@ class PythonTemplater(RawTemplater):
                 mostly for loading config files at runtime.
             config (:obj:`FluffConfig`): A specific config to use for this
                 templating operation. Only necessary for some templaters.
+            formatter (:obj:`CallbackFormatter`): Optional object for output.
 
         """
         live_context = self.get_context(fname=fname, config=config)


### PR DESCRIPTION
This improves output UX, in particular for using the dbt templater. I think this resolves #645 too.

# Config header
... now includes the templater and dbt version (if using the dbt templater)

```
==== sqlfluff ====
sqlfluff:           0.5.1 python:             3.8.5
dialect:        snowflake verbosity:              1
templater:            dbt dbt:              =0.19.1
rules:       L004, L010, L011, L014, L025
```

# Compilation warning
When running at the first verbose level (or above), there's now an output to show when model compilation is happening.

```
==== sqlfluff ====
sqlfluff:           0.5.1 python:             3.8.5
dialect:        snowflake verbosity:              1
templater:            dbt dbt:              =0.19.1
rules:       L004, L010, L011, L014, L025
==== readout ====

=== [ path: /root/data_warehouse ] ===

=== [dbt templater] Compiling dbt project...
== [/root/data_warehouse/a.sql] PASS
== [/root/data_warehouse/b.sql] PASS
...
```

# Linting steps readout.
When running at level two verbosity (or above) `-vv` there is now a seperate readout for templating, parsing and linting. This allows deeper introspection of where the time is being spent (which made me notice that I think that linting is now the bottleneck!).

```
...
=== [ path: /root/data_warehouse ] ===

== [/root/data_warehouse/models/a.sql] TEMPLATING
=== [dbt templater] Compiling dbt project...
== [/root/data_warehouse/models/a.sql] PARSING
== [/root/data_warehouse/models/a.sql] LINTING
== [/root/data_warehouse/models/a.sql] PASS
== [/root/data_warehouse/models/b.sql] TEMPLATING
== [/root/data_warehouse/models/b.sql] PARSING
== [/root/data_warehouse/models/b.sql] LINTING
== [/root/data_warehouse/models/b.sql] PASS
...
```

# Config Diff Logging.
There was a stub showing config diffs because of the dialect obj, which is now ignored and so that unnecessary stub no longer appears.
