### PR TITLE
Update dbt versions for testing.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ deps =
     plugins/sqlfluff-plugin-example
     # Define dbt versions
     dbt017: dbt==0.17.2
-    dbt018: dbt==0.18.1
-    dbt019: dbt==0.19.0
+    dbt018: dbt==0.18.2
+    dbt019: dbt==0.19.1
 # Include any other steps necessary for testing below.
 # {posargs} is there to allow us to specify specific tests, which
 # can then be invoked from tox by calling e.g.


### PR DESCRIPTION
requires.io picked up that our version dependencies are out of date. This bumps dbt versions to the latest for each stream.