### PR TITLE
Issue 963: Fix bug where L045 recurses forever if a CTE references itself

### DIFF
--- a/src/sqlfluff/core/rules/analysis/select_crawler.py
+++ b/src/sqlfluff/core/rules/analysis/select_crawler.py
@@ -81,7 +81,10 @@ class SelectCrawler:
             if seg.type == "table_reference":
                 if not seg.is_qualified() and seg.raw in queries:
                     # It's a CTE.
-                    yield queries[seg.raw]
+                    # :TRICKY: Pop the CTE from "queries" to help callers avoid
+                    # infinite recursion. We could make this behavior optional
+                    # someday, if necessary.
+                    yield queries.pop(seg.raw)
                 else:
                     # It's an external table.
                     yield seg.raw

--- a/src/sqlfluff/core/rules/std/L045.py
+++ b/src/sqlfluff/core/rules/std/L045.py
@@ -51,24 +51,11 @@ class Rule_L045(BaseRule):
         queries: Dict[str, List[SelectCrawler]],
     ):
         for select_info in select_info_list:
-            # Process nested SELECTs.
             for source in SelectCrawler.crawl(
                 select_info.select_statement, queries, dialect
             ):
                 if isinstance(source, list):
                     cls._visit_sources(source, dialect, queries)
-
-            # Process the query's sources.
-            for alias_info in select_info.select_info.table_aliases:
-                # Does the query read from a CTE? If so, visit the CTE.
-                for target_segment in alias_info.from_expression_element.get_children(
-                    "table_expression", "join_clause"
-                ):
-                    target = target_segment.raw
-                    if target in queries:
-                        select_info_target = queries.pop(target)
-                        if isinstance(select_info_target, list):
-                            cls._visit_sources(select_info_target, dialect, queries)
 
     def _eval(self, segment, dialect, **kwargs):
         if segment.is_type("statement"):

--- a/test/fixtures/rules/std_rule_cases/L045.yml
+++ b/test/fixtures/rules/std_rule_cases/L045.yml
@@ -108,3 +108,52 @@ test_10:
 
     SELECT stuff
     FROM uses_max_date_cte
+
+test_11:
+  # Issue 963: Infinite recursion when a CTE references itself
+  pass_str: |
+    with pages_xf as (
+      select pages.received_at
+      from pages
+      where pages.received_at > (select max(received_at) from pages_xf )
+    ),
+    final as (
+      select pages_xf.received_at
+      from pages_xf
+    )
+
+    select * from final
+
+test_12:
+  # Variant on test_11 where there *is* an unused CTE
+  fail_str: |
+    with pages_xf as (
+      select pages.received_at
+      from pages
+      where pages.received_at > (select max(received_at) from pages_xf )
+    ),
+    final as (
+      select pages_xf.received_at
+      from pages_xf
+    ),
+    unused as (
+      select pages.received_at from pages
+    )
+
+    select * from final
+
+test_13:
+  # Variant on test_11 where the CTE references itself indirectly
+  pass_str: |
+    with pages_xf as (
+      select pages.received_at
+      from pages
+      where pages.received_at > (select max(received_at) from final )
+    ),
+
+    final as (
+      select pages_xf.received_at
+      from pages_xf
+    )
+
+    select * from final


### PR DESCRIPTION
Resolves #963.

Fixes another bug similar to the one addressed in #938 -- infinite recursion in one of the new CTE analysis rules.