### PR TITLE
Sort cli dialects output

### DIFF
--- a/src/sqlfluff/core/dialects/__init__.py
+++ b/src/sqlfluff/core/dialects/__init__.py
@@ -45,7 +45,7 @@ class DialectTuple(NamedTuple):
 
 def dialect_readout():
     """Generate a readout of available dialects."""
-    for dialect_label in _dialect_lookup:
+    for dialect_label in sorted(_dialect_lookup):
         dialect = load_raw_dialect(dialect_label)
         yield DialectTuple(
             label=dialect_label,


### PR DESCRIPTION
Sort sqlfluff cli `dialects` output

before
```bash
(sqlfluff) ➜  sqlfluff git:(cli_sort_dialect) ✗ sqlfluff dialects
==== sqlfluff - dialects ====
ansi:                 ansi dialect [inherits from 'nothing']
bigquery:            bigquery dialect [inherits from 'ansi']
mysql:                  mysql dialect [inherits from 'ansi']
teradata:            teradata dialect [inherits from 'ansi']
postgres:            postgres dialect [inherits from 'ansi']
snowflake:      snowflake dialect [inherits from 'postgres']
exasol:                exasol dialect [inherits from 'ansi']
exasol_fs:        exasol_fs dialect [inherits from 'exasol']
```

after
```bash
(sqlfluff) ➜  sqlfluff git:(cli_sort_dialect) ✗ sqlfluff dialects
==== sqlfluff - dialects ====
ansi:                 ansi dialect [inherits from 'nothing']
bigquery:            bigquery dialect [inherits from 'ansi']
exasol:                exasol dialect [inherits from 'ansi']
exasol_fs:        exasol_fs dialect [inherits from 'exasol']
mysql:                  mysql dialect [inherits from 'ansi']
postgres:            postgres dialect [inherits from 'ansi']
snowflake:      snowflake dialect [inherits from 'postgres']
teradata:            teradata dialect [inherits from 'ansi']
```