### PR TITLE
Now raising error when old capitalisation_policy config is used

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,3 +15,5 @@ pytest-sugar
 # MyPy
 mypy
 typing_extensions
+# Common use cases
+dbt

--- a/src/sqlfluff/core/rules/std/L010.py
+++ b/src/sqlfluff/core/rules/std/L010.py
@@ -63,6 +63,17 @@ class Rule_L010(BaseRule):
         cap_policy_name = next(
             k for k in self.config_keywords if k.endswith("capitalisation_policy")
         )
+        # Make sure the user hasn't provided the wrong name
+        try:
+            wrong_keyword = next(
+                k for k in dir(self) if k.endswith("capitalisation_policy")
+                and k != cap_policy_name and getattr(self, k) != None
+            )
+            raise ValueError("Capitalisation policy provided via configuration "
+                             f"'{wrong_keyword}', but must be provided via "
+                             f"configuration '{cap_policy_name}'")
+        except StopIteration:
+            pass
         cap_policy = getattr(self, cap_policy_name)
         cap_policy_opts = [
             opt

--- a/src/sqlfluff/core/rules/std/L010.py
+++ b/src/sqlfluff/core/rules/std/L010.py
@@ -51,7 +51,7 @@ class Rule_L010(BaseRule):
         """Inconsistent capitalisation of keywords.
 
         We use the `memory` feature here to keep track of cases known to be
-        INconsistent with what we've seen so far as well as the top choice
+        *inconsistent* with what we've seen so far as well as the top choice
         for what the possible case is.
 
         """
@@ -100,22 +100,22 @@ class Rule_L010(BaseRule):
         # Skip if no inconsistencies, otherwise compute a concrete policy
         # to convert to.
         if cap_policy == "consistent":
-            possible_cases = [c for c in cap_policy_opts if c not in refuted_cases]
-            self.logger.debug(
-                f"Possible cases after segment '{segment.raw}': {possible_cases}"
-            )
-            if possible_cases:
-                # Save the latest possible case and skip
-                memory["latest_possible_case"] = possible_cases[0]
-                self.logger.debug(
-                    f"Consistent capitalization, returning with memory: {memory}"
+            try:
+                memory["latest_possible_case"] = next(
+                    c for c in cap_policy_opts if c not in refuted_cases
                 )
-                return LintResult(memory=memory)
-            else:
+            except StopIteration:
                 concrete_policy = memory.get("latest_possible_case", "upper")
                 self.logger.debug(
                     f"Getting concrete policy '{concrete_policy}' from memory"
                 )
+            else:
+                self.logger.debug(
+                    f"Latest possible case after segment '{segment.raw}': "
+                    f"{memory['latest_possible_case']}. Still consistent..."
+                )
+                return LintResult(memory=memory)
+
         else:
             if cap_policy not in refuted_cases:
                 # Skip

--- a/test/fixtures/rules/std_rule_cases/L014.yml
+++ b/test/fixtures/rules/std_rule_cases/L014.yml
@@ -31,6 +31,11 @@ test_consistency_8:
   # Single-word ambiguity: Pascal vs Capitalise
   pass_str: SELECT AppleFritter, Banana
 
+test_consistency_9:
+  # Test that UPPER case is chosen first in case of ambiguity
+  fail_str: SELECT U, what_Is_This_Case
+  fix_str: SELECT U, WHAT_IS_THIS_CASE
+
 # PascalCase tests are based on this comment by @alanmcruickshank:
 # https://github.com/sqlfluff/sqlfluff/issues/820#issuecomment-787050507
 test_pascal_1:

--- a/test/fixtures/rules/std_rule_cases/L014.yml
+++ b/test/fixtures/rules/std_rule_cases/L014.yml
@@ -36,6 +36,11 @@ test_consistency_9:
   fail_str: SELECT U, what_Is_This_Case
   fix_str: SELECT U, WHAT_IS_THIS_CASE
 
+test_consistency_10:
+  # Ensure that the latest known case is used
+  fail_str: SELECT l, what_Is_This_Case, WasPascal
+  fix_str: SELECT l, what_is_this_case, was_pascal
+
 # PascalCase tests are based on this comment by @alanmcruickshank:
 # https://github.com/sqlfluff/sqlfluff/issues/820#issuecomment-787050507
 test_pascal_1:


### PR DESCRIPTION
Fixes #966. I also added some things I didn't get around to from the code review of #838. **Don't merge until all of the below tasks are checked off.**

- [ ] Please advise how to test that a class Rule_LXX throws errors when an unexpected configuration was provided
- [x] @GClunies please validate that you get a bunch of `ValueError`s now when you try to run sqlfluff from this branch with your existing config. Also validate that the output when you run it with `extended_capitalisation_policy` instead now matches your expectations.
- [ ] @barrywhart Would it be worthwhile to invest a little more time and create a general rule that throws errors whenever extraneous configurations are provided in any rule class?