### PR TITLE
Speed up L010, allow invoking sqlfluff.cli.commands as a module to simplify profiling

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -651,5 +651,5 @@ def parse(path, code_only, format, profiler, bench, nofail, logger=None, **kwarg
 # This "__main__" handler allows invoking SQLFluff using "python -m", which
 # simplifies the use of cProfile, e.g.:
 # python -m cProfile -s cumtime -m sqlfluff.cli.commands lint slow_file.sql
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli.main(sys.argv[1:])

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -646,3 +646,10 @@ def parse(path, code_only, format, profiler, bench, nofail, logger=None, **kwarg
         sys.exit(66)
     else:
         sys.exit(0)
+
+
+# This "__main__" handler allows invoking SQLFluff using "python -m", which
+# simplifies the use of cProfile, e.g.:
+# python -m cProfile -s cumtime -m sqlfluff.cli.commands lint slow_file.sql
+if __name__ == '__main__':
+    cli.main(sys.argv[1:])

--- a/src/sqlfluff/core/rules/std/L010.py
+++ b/src/sqlfluff/core/rules/std/L010.py
@@ -172,8 +172,7 @@ class Rule_L010(BaseRule):
     def _init_capitalisation_policy(self):
         """Called first time rule is evaluated to fetch & cache the policy."""
         cap_policy_name = next(
-            k for k in self.config_keywords if
-            k.endswith("capitalisation_policy")
+            k for k in self.config_keywords if k.endswith("capitalisation_policy")
         )
         self.cap_policy = getattr(self, cap_policy_name)
         self.cap_policy_opts = [

--- a/src/sqlfluff/core/rules/std/L010.py
+++ b/src/sqlfluff/core/rules/std/L010.py
@@ -59,11 +59,13 @@ class Rule_L010(BaseRule):
         if not self.matches_target_tuples(segment, self._target_elems):
             return LintResult(memory=memory)
 
-        # Get the capitalisation policy configuration
+        # Get the capitalisation policy configuration.
         try:
             cap_policy = self.cap_policy
             cap_policy_opts = self.cap_policy_opts
         except AttributeError:
+            # First-time only, read the settings from configuration. This is
+            # very slow.
             cap_policy, cap_policy_opts = self._init_capitalisation_policy()
 
         refuted_cases = memory.get("refuted_cases", set())

--- a/src/sqlfluff/core/rules/std/L010.py
+++ b/src/sqlfluff/core/rules/std/L010.py
@@ -60,19 +60,11 @@ class Rule_L010(BaseRule):
             return LintResult(memory=memory)
 
         # Get the capitalisation policy configuration
-        cap_policy_name = next(
-            k for k in self.config_keywords if k.endswith("capitalisation_policy")
-        )
-        cap_policy = getattr(self, cap_policy_name)
-        cap_policy_opts = [
-            opt
-            for opt in get_config_info()[cap_policy_name]["validation"]
-            if opt != "consistent"
-        ]
-        self.logger.debug(
-            f"Selected '{cap_policy_name}': '{cap_policy}' from options "
-            f"{cap_policy_opts}"
-        )
+        try:
+            cap_policy = self.cap_policy
+            cap_policy_opts = self.cap_policy_opts
+        except AttributeError:
+            cap_policy, cap_policy_opts = self._init_capitalisation_policy()
 
         refuted_cases = memory.get("refuted_cases", set())
 
@@ -176,3 +168,23 @@ class Rule_L010(BaseRule):
                 ],
                 memory=memory,
             )
+
+    def _init_capitalisation_policy(self):
+        """Called first time rule is evaluated to fetch & cache the policy."""
+        cap_policy_name = next(
+            k for k in self.config_keywords if
+            k.endswith("capitalisation_policy")
+        )
+        self.cap_policy = getattr(self, cap_policy_name)
+        self.cap_policy_opts = [
+            opt
+            for opt in get_config_info()[cap_policy_name]["validation"]
+            if opt != "consistent"
+        ]
+        self.logger.debug(
+            f"Selected '{cap_policy_name}': '{self.cap_policy}' from options "
+            f"{self.cap_policy_opts}"
+        )
+        cap_policy = self.cap_policy
+        cap_policy_opts = self.cap_policy_opts
+        return cap_policy, cap_policy_opts


### PR DESCRIPTION
This PR speeds up L010 and L014 **a lot**. We can consider closing #962 as a result, or maybe we want to do more performance analysis and/or tuning?

Besides speeding up the two rules, this PR also makes a small change to the CLI to simplify the process for users profiling the performance of SQLFluff commands (e.g. lint, fix) on their own machines. In many cases, this means the maintainers can get performance insights without having to ask users to upload their confidential SQL code.

To generate a function-level performance report, the user would run:
```
python -m cProfile -s cumtime -m sqlfluff.cli.commands lint my_query.sql > output.txt
```