### PR TITLE
.gitignore conda environment.yml and .envrc used by other contributors to manage python environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ test-reports
 /test*.sql
 /test*.py
 /.hypothesis/
+
+# Ignore conda environment.yml and .envrc used by other contributors to
+# manage python environments. The contirbuting docs suggest venv, but others be
+# more comfrotable with conda.
+environment.yml
+.envrc


### PR DESCRIPTION
## Purpose
The [CONTRIBUTING](https://github.com/sqlfluff/sqlfluff/blob/master/CONTRIBUTING.md) docs suggest using `venv` to manage the python virtual environment for contributions, but other contributors (like me) may prefer to use `conda` to manage their environments.

## This PR
- Ignores `environment.yml` files from being committed to the repo.
- Ignores `.envrc` files from being committed to the repo. This is used by [`direnv`](https://direnv.net/) to automatically activate a specific `conda` environment when navigating inside a repo - in my case when I navigate inside my local `sqlfluff` repo a `sqlfluff-dev` conda environment activates.

This does not effect the `sqlfluff` code in any way. This PR is mainly to make sure the repo does not get cluttered with files used for different virtual environment approaches.