### PR TITLE
[WIP] Snowflake: Support `SET <var> = <expr>;` statement

### DIFF
--- a/test/fixtures/parser/snowflake/snowflake_set_session_variable.sql
+++ b/test/fixtures/parser/snowflake/snowflake_set_session_variable.sql
@@ -1,0 +1,18 @@
+SET var1 = 10;
+
+SET var1 = TRUE;
+
+SET var1 = 'example';
+
+SET var1 = CURRENT_TIMESTAMP;
+
+-- @TODO: Does not work. `pytest dialects_test.py` throws a SQLLexError on this line.
+SET var1 = $var2;
+
+SET var1 = TO_DATE('2021-01-01');
+
+SET var1 = (SELECT 10);
+
+SET var1 = (SELECT AVG(col1) FROM table1 WHERE col2 IS NOT NULL LIMIT 1);
+
+SET var1 = (SELECT AVG(col1) FROM table1 WHERE col2 BETWEEN 10 AND 11 LIMIT 10) / 2;

--- a/test/fixtures/parser/snowflake/snowflake_set_session_variable.yml
+++ b/test/fixtures/parser/snowflake/snowflake_set_session_variable.yml
@@ -1,0 +1,150 @@
+file:
+- statement:
+    set_session_variable_statement:
+      keyword: SET
+      parameter: var1
+      comparison_operator: '='
+      expression:
+        literal: '10'
+- statement_terminator: ;
+- statement:
+    set_session_variable_statement:
+      keyword: SET
+      parameter: var1
+      comparison_operator: '='
+      expression:
+        literal: 'TRUE'
+- statement_terminator: ;
+- statement:
+    set_session_variable_statement:
+      keyword: SET
+      parameter: var1
+      comparison_operator: '='
+      expression:
+        literal: "'example'"
+- statement_terminator: ;
+- statement:
+    set_session_variable_statement:
+      keyword: SET
+      parameter: var1
+      comparison_operator: '='
+      expression:
+        bare_function: CURRENT_TIMESTAMP
+- statement_terminator: ;
+- statement:
+    set_session_variable_statement:
+      keyword: SET
+      parameter: var1
+      comparison_operator: '='
+      expression:
+        variable_reference: $var2
+- statement_terminator: ;
+- statement:
+    set_session_variable_statement:
+      keyword: SET
+      parameter: var1
+      comparison_operator: '='
+      expression:
+        function:
+          function_name: TO_DATE
+          start_bracket: (
+          expression:
+            literal: "'2021-01-01'"
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    set_session_variable_statement:
+      keyword: SET
+      parameter: var1
+      comparison_operator: '='
+      expression:
+        start_bracket: (
+        expression:
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                literal: '10'
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    set_session_variable_statement:
+      keyword: SET
+      parameter: var1
+      comparison_operator: '='
+      expression:
+        start_bracket: (
+        expression:
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                function:
+                  function_name: AVG
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      identifier: col1
+                  end_bracket: )
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      identifier: table1
+            where_clause:
+              keyword: WHERE
+              expression:
+              - column_reference:
+                  identifier: col2
+              - keyword: IS
+              - keyword: NOT
+              - keyword: 'NULL'
+            limit_clause:
+              keyword: LIMIT
+              literal: '1'
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    set_session_variable_statement:
+      keyword: SET
+      parameter: var1
+      comparison_operator: '='
+      expression:
+        start_bracket: (
+        expression:
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                function:
+                  function_name: AVG
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      identifier: col1
+                  end_bracket: )
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      identifier: table1
+            where_clause:
+              keyword: WHERE
+              expression:
+              - column_reference:
+                  identifier: col2
+              - keyword: BETWEEN
+              - literal: '10'
+              - binary_operator: AND
+              - literal: '11'
+            limit_clause:
+              keyword: LIMIT
+              literal: '10'
+        end_bracket: )
+        binary_operator: /
+        literal: '2'
+- statement_terminator: ;


### PR DESCRIPTION
* Added SET session variable support (#996)
* Allow variables, `$varName`, to be used as a Literal in Snowflake.

**TODO**
* [ ] Figure out why `SET var1 = $var2;` causes a SQLLexError