### PR TITLE
Issue 1022: When L036 moves single select target to another line, remove whitespace

### DIFF
--- a/src/sqlfluff/rules/L036.py
+++ b/src/sqlfluff/rules/L036.py
@@ -157,6 +157,25 @@ class Rule_L036(BaseRule):
                     select_clause.segments[select_targets_info.first_select_target_idx],
                 ),
             ]
+            if (
+                select_targets_info.first_select_target_idx
+                - select_targets_info.first_new_line_idx
+                == 2
+                and select_clause.segments[
+                    select_targets_info.first_new_line_idx + 1
+                ].is_whitespace
+            ):
+                # If the select target is preceded by a single whitespace
+                # segment, delete that as well. This addresses the bug fix
+                # tested in L036.yml's "test_cte" scenario.
+                fixes.append(
+                    LintFix(
+                        "delete",
+                        select_clause.segments[
+                            select_targets_info.first_new_line_idx + 1
+                        ],
+                    ),
+                )
             if parent_stack and parent_stack[-1].type == "select_statement":
                 select_stmt = parent_stack[-1]
                 select_clause_idx = select_stmt.segments.index(select_clause)

--- a/test/fixtures/rules/std_rule_cases/L036.yml
+++ b/test/fixtures/rules/std_rule_cases/L036.yml
@@ -13,11 +13,9 @@ test_single_select_target_and_new_line_before_select_target:
       select
           a
       from x
-  # In a normal "sqlfluff fix" run, the extra spaces in fix_str would be removed
-  # by a different rule, L039.
   fix_str: |
     select a
-        from x
+    from x
 
 test_multiple_select_targets_on_new_lines_and_new_line_after_select:
   pass_str: |

--- a/test/fixtures/rules/std_rule_cases/L036.yml
+++ b/test/fixtures/rules/std_rule_cases/L036.yml
@@ -101,3 +101,26 @@ test_multiple_select_targets_some_newlines_missing_2:
     g,
       h
     from x
+
+test_cte:
+  fail_str: |
+    WITH
+    cte1 AS (
+        SELECT
+            c1 AS c
+        FROM
+            t
+    )
+
+    SELECT 1
+    FROM cte1
+  fix_str: |
+    WITH
+    cte1 AS (
+        SELECT c1 AS c
+        FROM
+            t
+    )
+
+    SELECT 1
+    FROM cte1


### PR DESCRIPTION
Resolves #1022 

This PR relates to the formatting discussion on PR #905, which led to us creating issue #946. This PR does not attempt to address the larger issues raised there. Rather, it addresses a particular case where L036 left behind poor formatting that, for some reason, was not addressed by other indentation rules such as L003.