### PR TITLE
EphemeralSegment rework (#1019)

### DIFF
--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -7,7 +7,7 @@ from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.match_wrapper import match_wrapper
 from sqlfluff.core.parser.match_logging import parse_match_logging
 from sqlfluff.core.parser.context import ParseContext
-from sqlfluff.core.parser.segments import BaseSegment
+from sqlfluff.core.parser.segments import BaseSegment, allow_ephemeral
 from sqlfluff.core.parser.grammar.base import (
     BaseGrammar,
     MatchableType,
@@ -149,6 +149,7 @@ class AnyNumberOf(BaseGrammar):
         return match
 
     @match_wrapper()
+    @allow_ephemeral
     def match(
         self, segments: Tuple[BaseSegment, ...], parse_context: ParseContext
     ) -> MatchResult:

--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -3,7 +3,7 @@
 from typing import Tuple, List
 
 from sqlfluff.core.parser.grammar import Ref
-from sqlfluff.core.parser.segments import BaseSegment
+from sqlfluff.core.parser.segments import BaseSegment, allow_ephemeral
 from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.match_wrapper import match_wrapper
 from sqlfluff.core.parser.context import ParseContext
@@ -39,6 +39,7 @@ class Delimited(OneOf):
         super().__init__(*args, **kwargs)
 
     @match_wrapper()
+    @allow_ephemeral
     def match(
         self, segments: Tuple[BaseSegment, ...], parse_context: ParseContext
     ) -> MatchResult:

--- a/src/sqlfluff/core/parser/grammar/greedy.py
+++ b/src/sqlfluff/core/parser/grammar/greedy.py
@@ -6,6 +6,7 @@ from sqlfluff.core.parser.helpers import trim_non_code_segments
 from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.match_wrapper import match_wrapper
 from sqlfluff.core.parser.context import ParseContext
+from sqlfluff.core.parser.segments import allow_ephemeral
 
 from sqlfluff.core.parser.grammar.base import (
     BaseGrammar,
@@ -35,6 +36,7 @@ class GreedyUntil(BaseGrammar):
             )
 
     @match_wrapper()
+    @allow_ephemeral
     def match(self, segments, parse_context):
         """Matching for GreedyUntil works just how you'd expect."""
         return self.greedy_match(

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -4,7 +4,7 @@ from typing import Optional, List, Tuple
 
 from sqlfluff.core.errors import SQLParseError
 
-from sqlfluff.core.parser.segments import BaseSegment, Indent, Dedent
+from sqlfluff.core.parser.segments import BaseSegment, Indent, Dedent, allow_ephemeral
 from sqlfluff.core.parser.helpers import trim_non_code_segments, check_still_complete
 from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.match_wrapper import match_wrapper
@@ -39,6 +39,7 @@ class Sequence(BaseGrammar):
         return simple_buff
 
     @match_wrapper()
+    @allow_ephemeral
     def match(self, segments, parse_context):
         """Match a specific sequence of elements."""
         if isinstance(segments, BaseSegment):
@@ -210,6 +211,7 @@ class Bracketed(Sequence):
         return start_bracket, end_bracket
 
     @match_wrapper()
+    @allow_ephemeral
     def match(
         self, segments: Tuple["BaseSegment", ...], parse_context: ParseContext
     ) -> MatchResult:

--- a/src/sqlfluff/core/parser/match_wrapper.py
+++ b/src/sqlfluff/core/parser/match_wrapper.py
@@ -45,15 +45,8 @@ def match_wrapper(v_level=3):
 
         def wrapped_match_method(self_cls, segments: tuple, parse_context):
             """A wrapper on the match function to do some basic validation."""
-            # Use the ephemeral_segment if present. This should only
-            # be the case for grammars where `ephemeral_name` is defined.
-            ephemeral_segment = getattr(self_cls, "ephemeral_segment", None)
-            if ephemeral_segment:
-                # We're going to return as though it's a full match, similar to Anything().
-                m = MatchResult.from_matched(ephemeral_segment(segments=segments))
-            else:
-                # Otherwise carry on through with wrapping the function.
-                m = func(self_cls, segments, parse_context=parse_context)
+            # Do the match
+            m = func(self_cls, segments, parse_context=parse_context)
 
             # Validate result
             if not isinstance(m, MatchResult):

--- a/src/sqlfluff/core/parser/segments/__init__.py
+++ b/src/sqlfluff/core/parser/segments/__init__.py
@@ -14,5 +14,5 @@ from sqlfluff.core.parser.segments.raw import (
     KeywordSegment,
     SymbolSegment,
 )
-from sqlfluff.core.parser.segments.ephemeral import EphemeralSegment
+from sqlfluff.core.parser.segments.ephemeral import EphemeralSegment, allow_ephemeral
 from sqlfluff.core.parser.segments.meta import Indent, Dedent, TemplateSegment

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -154,7 +154,7 @@ class BaseSegment:
         """The name of this segment.
 
         The reason for three routes for names is that some subclasses
-        might want to override the name rather than just getting it
+        might want to override the name rather than just getting
         the class name. Instances may also override this with the
         _surrogate_name.
 

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -78,9 +78,11 @@ class BaseSegment:
     # with the can_start_end_non_code.
     allow_empty = False
 
-    def __init__(self, segments, pos_marker=None):
+    def __init__(self, segments, pos_marker=None, name: Optional[str] = None):
         # A cache variable for expandable
         self._is_expandable = None
+        # Surrogate name option.
+        self._surrogate_name = name
         if len(segments) == 0:
             raise RuntimeError(
                 "Setting {0} with a zero length segment set. This shouldn't happen.".format(
@@ -100,18 +102,17 @@ class BaseSegment:
                 "Unexpected type passed to BaseSegment: {0}".format(type(segments))
             )
 
-        if pos_marker:
-            self.pos_marker = pos_marker
-        else:
+        if not pos_marker:
             # If no pos given, it's the pos of the first segment.
             if isinstance(segments, (tuple, list)):
-                self.pos_marker = PositionMarker.from_child_markers(
+                pos_marker = PositionMarker.from_child_markers(
                     *(seg.pos_marker for seg in segments)
                 )
             else:
                 raise TypeError(
                     "Unexpected type passed to BaseSegment: {0}".format(type(segments))
                 )
+        self.pos_marker: PositionMarker = pos_marker
 
     def __eq__(self, other):
         # NB: this should also work for RawSegment
@@ -152,16 +153,17 @@ class BaseSegment:
     def name(self):
         """The name of this segment.
 
-        The reason for two routes for names is that some subclasses
+        The reason for three routes for names is that some subclasses
         might want to override the name rather than just getting it
-        the class name.
+        the class name. Instances may also override this with the
+        _surrogate_name.
 
         Name should be specific to this kind of segment, while `type`
         should be a higher level descriptor of the kind of segment.
         For example, the name of `+` is 'plus' but the type might be
         'binary_operator'.
         """
-        return self._name or self.__class__.__name__
+        return self._surrogate_name or self._name or self.__class__.__name__
 
     @property
     def is_expandable(self):
@@ -735,13 +737,17 @@ class BaseSegment:
                 return [self] + res
         return None
 
-    def parse(self, parse_context=None):
+    def parse(self, parse_context=None, parse_grammar=None):
         """Use the parse grammar to find subsegments within this segment.
 
         A large chunk of the logic around this can be found in the `expand` method.
 
         Use the parse setting in the context for testing, mostly to check how deep to go.
         True/False for yes or no, an integer allows a certain number of levels.
+
+        Optionally, this method allows a custom parse grammar to be
+        provided which will override any existing parse grammar
+        on the segment.
         """
         # Clear the blacklist cache so avoid missteps
         if parse_context:
@@ -753,7 +759,8 @@ class BaseSegment:
             return self
 
         # Check the Parse Grammar
-        if self.parse_grammar is None:
+        parse_grammar = parse_grammar or self.parse_grammar
+        if parse_grammar is None:
             # No parse grammar, go straight to expansion
             parse_context.logger.debug(
                 "{0}.parse: no grammar. Going straight to expansion".format(
@@ -785,7 +792,7 @@ class BaseSegment:
 
             # NOTE: No match_depth kwarg, because this is the start of the matching.
             with parse_context.matching_segment(self.__class__.__name__) as ctx:
-                m = self.parse_grammar.match(segments=segments, parse_context=ctx)
+                m = parse_grammar.match(segments=segments, parse_context=ctx)
 
             if not isinstance(m, MatchResult):
                 raise TypeError(

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -41,8 +41,10 @@ class RawSegment(BaseSegment):
         else:
             self._raw = self._default_raw
         self._raw_upper = self._raw.upper()
-        # pos marker is required here
-        self.pos_marker = pos_marker
+        # pos marker is required here. We ignore the typing initially
+        # because it might *initially* be unset, but it will be reset
+        # later.
+        self.pos_marker: PositionMarker = pos_marker  # type: ignore
         # if a surrogate type is provided, store it for later.
         self._surrogate_type = type
         self._surrogate_name = name
@@ -96,16 +98,6 @@ class RawSegment(BaseSegment):
         This is in case something tries to iterate on this segment.
         """
         return []
-
-    @property
-    def name(self):
-        """The name of this segment.
-
-        In addition to the options defined by BaseSegment, subclasses
-        of RawSegment may also define a _surrogate_name which is also
-        take into account here.
-        """
-        return self._surrogate_name or super().name
 
     # ################ INSTANCE METHODS
 

--- a/test/core/parser/grammar_test.py
+++ b/test/core/parser/grammar_test.py
@@ -10,7 +10,7 @@ from sqlfluff.core.parser import (
     RegexParser,
 )
 from sqlfluff.core.parser.context import RootParseContext
-from sqlfluff.core.parser.segments import EphemeralSegment
+from sqlfluff.core.parser.segments import EphemeralSegment, BaseSegment
 from sqlfluff.core.parser.grammar.base import BaseGrammar
 from sqlfluff.core.parser.grammar.noncode import NonCodeMatcher
 from sqlfluff.core.parser.grammar import (
@@ -156,11 +156,13 @@ def test__parser__grammar__base__look_ahead_match(
 
 
 def test__parser__grammar__base__ephemeral_segment(seg_list):
-    """Test the ephemeral features BaseGrammar.
+    """Test the ephemeral features on BaseGrammar.
 
     Normally you cant call .match() on a BaseGrammar, but
     if things are set up right, then it should be possible
     in the case that the ephemeral_name is set.
+
+    This indirectly tests the allow_ephemeral decorator.
     """
     g = BaseGrammar(ephemeral_name="TestGrammar")
 
@@ -168,9 +170,35 @@ def test__parser__grammar__base__ephemeral_segment(seg_list):
         m = g.match(seg_list, ctx)
         # Check we get an ephemeral segment
         assert isinstance(m.matched_segments[0], EphemeralSegment)
+        assert len(m.matched_segments) == 1
         chkpoint = m.matched_segments[0]
         # Check it's got the same content.
         assert chkpoint.segments == seg_list
+
+
+def test__parser__grammar__oneof__ephemeral_segment(seg_list):
+    """A realistic full test of ephemeral segments."""
+
+    class TestSegment(BaseSegment):
+        match_grammar = OneOf(
+            StringParser("bar", KeywordSegment), ephemeral_name="foofoo"
+        )
+
+    with RootParseContext(dialect=None) as ctx:
+        m = TestSegment.match(seg_list[:1], ctx)
+        # Make sure we've matched
+        assert m
+        seg = m.matched_segments[0]
+        assert isinstance(seg, TestSegment)
+        # Check the content is ephemeral
+        assert isinstance(seg.segments[0], EphemeralSegment)
+        assert seg.segments[0].name == "foofoo"
+        # Expand the segment
+        res = seg.parse(ctx)
+        # Check we still have a test segment
+        assert isinstance(res, TestSegment)
+        # But that it contains a keyword segment now
+        assert isinstance(res.segments[0], KeywordSegment)
 
 
 def test__parser__grammar__base__bracket_sensitive_look_ahead_match(

--- a/test/core/parser/segments_common_test.py
+++ b/test/core/parser/segments_common_test.py
@@ -42,20 +42,17 @@ def test__parser__core_ephemeral_segment(raw_seg_list):
     # First make a keyword
     BarKeyword = StringParser("bar", KeywordSegment)
 
-    ephemeral_segment = EphemeralSegment.make(
-        match_grammar=BarKeyword, parse_grammar=BarKeyword, name="foobar"
+    ephemeral_segment = EphemeralSegment(
+        segments=raw_seg_list[:1],
+        pos_marker=None,
+        parse_grammar=BarKeyword,
+        name="foobar",
     )
 
     with RootParseContext(dialect=None) as ctx:
-        # Test on a slice containing only the first element
-        m = ephemeral_segment.match(raw_seg_list[:1], parse_context=ctx)
-        assert m
-        # Make sure that it matches as an instance of EphemeralSegment
-        elem = m.matched_segments[0]
-        assert isinstance(elem, ephemeral_segment)
         # Parse it and make sure we don't get an EphemeralSegment back
-        res = elem.parse(ctx)
+        res = ephemeral_segment.parse(ctx)
         assert isinstance(res, tuple)
         elem = res[0]
-        assert not isinstance(elem, ephemeral_segment)
+        assert not isinstance(elem, EphemeralSegment)
         assert isinstance(elem, KeywordSegment)


### PR DESCRIPTION
This follows on from #1034, and should be reviewed after that is merged. It relates to #1019,

This addresses ephemeral segments so that they don't involve dynamic class generation. Specifically.
- `EphemeralSegment` now accepts a `parse_grammar` so that instances can act as the dynamic classes before.
- Creation of `EphemeralSegment` has been moved from the `@match()` decorator to a seperate decorator `@allow_ephemeral` which is then only attached to the `.match()` methods of grammars and not segments. This simplifies the code path and also avoids a circular reference.
- As we now only create the `EphemeralSegment` on `match()`, all the code which created the custom class can be removed from the `__init__` method of `BaseGrammar`.
- Extra test cases added to test the full lifecycle of an ephemeral segment.