### PR TITLE
Fail fast on fatal errors

### DIFF
--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -10,7 +10,17 @@ class SQLBaseError(ValueError):
     _code: Optional[str] = None
     _identifier = "base"
 
-    def __init__(self, *args, pos=None, line_no=0, line_pos=0, ignore=False, **kwargs):
+    def __init__(
+        self,
+        *args,
+        pos=None,
+        line_no=0,
+        line_pos=0,
+        ignore=False,
+        fatal=False,
+        **kwargs
+    ):
+        self.fatal = fatal
         self.ignore = ignore
         if pos:
             self.line_no, self.line_pos = pos.source_position()

--- a/src/sqlfluff/core/linter.py
+++ b/src/sqlfluff/core/linter.py
@@ -1417,11 +1417,16 @@ class Linter:
                 fname, "r", encoding="utf8", errors="backslashreplace"
             ) as target_file:
                 try:
-                    linted_path.add(
-                        self.lint_string(
-                            target_file.read(), fname=fname, fix=fix, config=config
-                        )
+                    linted_file = self.lint_string(
+                        target_file.read(), fname=fname, fix=fix, config=config
                     )
+                    linted_path.add(linted_file)
+                    # If any fatal errors, then stop iteration.
+                    if any(v.fatal for v in linted_file.violations):
+                        linter_logger.error(
+                            "Fatal linting error. Halting further linting." ""
+                        )
+                        break
                 except IOError as e:  # IOErrors caught in commands.py, so still raise it
                     raise (e)
                 except Exception:

--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -203,7 +203,8 @@ class DbtTemplater(JinjaTemplater):
         except DbtCompilationException as e:
             return None, [
                 SQLTemplaterError(
-                    f"dbt compilation error on file '{e.node.original_file_path}', {e.msg}"
+                    f"dbt compilation error on file '{e.node.original_file_path}', {e.msg}",
+                    fatal=True,
                 )
             ]
         except DbtFailedToConnectException as e:
@@ -211,7 +212,8 @@ class DbtTemplater(JinjaTemplater):
                 SQLTemplaterError(
                     "dbt tried to connect to the database and failed: "
                     "you could use 'execute' https://docs.getdbt.com/reference/dbt-jinja-functions/execute/ "
-                    f"to skip the database calls. Error: {e.msg}"
+                    f"to skip the database calls. Error: {e.msg}",
+                    fatal=True,
                 )
             ]
         # If a SQLFluff error is raised, just pass it through


### PR DESCRIPTION
We're currently having an issue where SQLFluff takes ages to fail, but results in the same failure on every file. Specifically it's where the dbt templater fails to compile and then keeps attempting (This clearly takes a LONG time).

This adds a `fatal` flag to some errors which enables them to terminate linting entirely, to return an error to the user faster.