### PR TITLE
Off by one error fix in working locations

### DIFF
--- a/src/sqlfluff/core/parser/markers.py
+++ b/src/sqlfluff/core/parser/markers.py
@@ -165,13 +165,17 @@ class PositionMarker:
 
     @staticmethod
     def infer_next_position(raw: str, line_no: int, line_pos: int) -> Tuple[int, int]:
-        """Using the raw string provided to infer the position of the next."""
+        """Using the raw string provided to infer the position of the next.
+
+        NB: Line position in 1-indexed.
+        """
+        # No content?
         if not raw:
             return line_no, line_pos
         split = raw.split("\n")
         return (
             line_no + len(split) - 1,
-            line_pos + len(raw) if len(split) == 1 else len(split[-1]),
+            line_pos + len(raw) if len(split) == 1 else len(split[-1]) + 1,
         )
 
     def with_working_position(self, line_no: int, line_pos: int):

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -526,7 +526,7 @@ class BaseSegment:
 
     def get_start_loc(self):
         """Get a location tuple at the start of this segment."""
-        return self.pos_marker.working_loc()
+        return self.pos_marker.working_loc
 
     def get_end_loc(self):
         """Get a location tuple at the end of this segment."""

--- a/test/core/parser/markers_test.py
+++ b/test/core/parser/markers_test.py
@@ -11,10 +11,11 @@ from sqlfluff.core.parser.markers import PositionMarker
     [
         ("fsaljk", (0, 0), (0, 6)),
         ("", (2, 2), (2, 2)),
-        ("\n", (2, 2), (3, 0)),
-        ("boo\n", (2, 2), (3, 0)),
-        ("boo\nfoo", (2, 2), (3, 3)),
-        ("\nfoo", (2, 2), (3, 3)),
+        # NB: 1 indexed, not 0 indexed.
+        ("\n", (2, 2), (3, 1)),
+        ("boo\n", (2, 2), (3, 1)),
+        ("boo\nfoo", (2, 2), (3, 4)),
+        ("\nfoo", (2, 2), (3, 4)),
     ],
 )
 def test_markers__infer_next_position(raw, start_pos, end_pos):


### PR DESCRIPTION
Resolves #1047 .

Some of the code was written expecting line positions to be zero-indexed, and some expecting them to be 1-indexed. This resolves all to be 1-indexed, fixing the off-by-one error being caused during repositioning.

I'll do a bugfix release to 0.5.4 once this is merged