### PR TITLE
Type Fixes #1049 #1024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,7 +144,7 @@ Contributors:
   related to `dbt`). For more info see [the docs](https://docs.sqlfluff.com/en/latest/configuration.html#dbt-project-configuration). ([#508](https://github.com/sqlfluff/sqlfluff/pull/508))
 - Support for modulo (`%`) operator. ([#447](https://github.com/sqlfluff/sqlfluff/pull/447))
 - A limit in the internal fix routines to catch any infinite loops. ([#494](https://github.com/sqlfluff/sqlfluff/pull/494))
-- Added the `.istype()` method on segments to more intelligently
+- Added the `.is_type()` method on segments to more intelligently
   deal with type matching in rules when inheritance is at play.
 - Added the ability for the user to add their own rules when interacting
   with the `Linter` directly using `user_rules`.

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -140,12 +140,12 @@ class BaseSegment:
     @property
     def _comments(self):
         """Returns only the comment elements of this segment."""
-        return [seg for seg in self.segments if seg.type == "comment"]
+        return [seg for seg in self.segments if seg.is_type("comment")]
 
     @property
     def _non_comments(self):
         """Returns only the non-comment elements of this segment."""
-        return [seg for seg in self.segments if seg.type != "comment"]
+        return [seg for seg in self.segments if not seg.is_type("comment")]
 
     # ################ PUBLIC PROPERTIES
 
@@ -719,11 +719,7 @@ class BaseSegment:
             return [self]
 
         # Are we in the right ballpark?
-        if (
-            not self.get_start_point_marker()
-            <= other.get_start_point_marker()
-            <= self.get_end_point_marker()
-        ):
+        if not self.get_start_loc() <= other.get_start_loc() <= self.get_end_loc():
             return None
 
         # Do we have any child segments at all?

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -719,6 +719,7 @@ class BaseSegment:
             return [self]
 
         # Are we in the right ballpark?
+        # NB: Comparisons have a higher precedence than `not`.
         if not self.get_start_loc() <= other.get_start_loc() <= self.get_end_loc():
             return None
 

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -164,7 +164,14 @@ class RawSegment(BaseSegment):
         Used mostly by fixes.
 
         """
-        return self.__class__(raw=raw, pos_marker=self.pos_marker)
+        return self.__class__(
+            raw=raw,
+            pos_marker=self.pos_marker,
+            type=self._surrogate_type,
+            name=self._surrogate_name,
+            trim_start=self.trim_start,
+            trim_chars=self.trim_chars,
+        )
 
 
 class CodeSegment(RawSegment):

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -253,6 +253,22 @@ class KeywordSegment(CodeSegment):
             name = raw.lower()
         super().__init__(raw=raw, pos_marker=pos_marker, type=type, name=name)
 
+    def edit(self, raw):
+        """Create a new segment, with exactly the same position but different content.
+
+        Returns:
+            A copy of this object with new contents.
+
+        Used mostly by fixes.
+
+        """
+        return self.__class__(
+            raw=raw,
+            pos_marker=self.pos_marker,
+            type=self._surrogate_type,
+            name=self._surrogate_name,
+        )
+
 
 class SymbolSegment(CodeSegment):
     """A segment used for matching single entities which aren't keywords.

--- a/src/sqlfluff/core/rules/analysis/select_crawler.py
+++ b/src/sqlfluff/core/rules/analysis/select_crawler.py
@@ -89,7 +89,7 @@ class SelectCrawler:
                     # It's an external table.
                     yield seg.raw
             else:
-                assert seg.istype("select_statement")
+                assert seg.is_type("select_statement")
                 buff.append(SelectCrawler(seg, dialect))
         if not buff:
             # If we reach here, the SELECT may be querying from a value table

--- a/src/sqlfluff/core/rules/analysis/select_crawler.py
+++ b/src/sqlfluff/core/rules/analysis/select_crawler.py
@@ -78,7 +78,7 @@ class SelectCrawler:
                 # returns the statement itself. Skip that.
                 continue
 
-            if seg.type == "table_reference":
+            if seg.is_type("table_reference"):
                 if not seg.is_qualified() and seg.raw in queries:
                     # It's a CTE.
                     # :TRICKY: Pop the CTE from "queries" to help callers avoid
@@ -89,7 +89,7 @@ class SelectCrawler:
                     # It's an external table.
                     yield seg.raw
             else:
-                assert seg.type == "select_statement"
+                assert seg.istype("select_statement")
                 buff.append(SelectCrawler(seg, dialect))
         if not buff:
             # If we reach here, the SELECT may be querying from a value table

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -412,7 +412,7 @@ class HyphenatedObjectReferenceSegment(ansi_dialect.get_segment("ObjectReference
         # delimiter.
         for is_dot, elems in itertools.groupby(
             self.recursive_crawl("identifier", "binary_operator", "dot"),
-            lambda e: e.type == "dot",
+            lambda e: e.is_type("dot"),
         ):
             if not is_dot:
                 segments = list(elems)

--- a/src/sqlfluff/rules/L010.py
+++ b/src/sqlfluff/rules/L010.py
@@ -174,7 +174,7 @@ class Rule_L010(BaseRule):
         return LintFix(
             "edit",
             segment,
-            segment.__class__(raw=fixed_raw, pos_marker=segment.pos_marker),
+            segment.edit(fixed_raw),
         )
 
     def _init_capitalisation_policy(self):

--- a/src/sqlfluff/rules/L013.py
+++ b/src/sqlfluff/rules/L013.py
@@ -43,7 +43,7 @@ class Rule_L013(BaseRule):
         """
         if segment.is_type("select_clause_element"):
             if not any(e.is_type("alias_expression") for e in segment.segments):
-                types = {e.type for e in segment.segments if e.name != "star"}
+                types = {e.get_type() for e in segment.segments if e.name != "star"}
                 unallowed_types = types - {
                     "whitespace",
                     "newline",

--- a/src/sqlfluff/rules/L033.py
+++ b/src/sqlfluff/rules/L033.py
@@ -33,7 +33,7 @@ class Rule_L033(BaseRule):
         The function does this by looking for a segment of type set_operator
         which has a UNION but no DISTINCT or ALL.
         """
-        if segment.type == "set_operator":
+        if segment.is_type("set_operator"):
             if "UNION" in segment.raw.upper() and not (
                 "ALL" in segment.raw.upper() or "DISTINCT" in segment.raw.upper()
             ):

--- a/src/sqlfluff/rules/L034.py
+++ b/src/sqlfluff/rules/L034.py
@@ -73,7 +73,7 @@ class Rule_L034(BaseRule):
         # If we find a matching target element, we append the element to the corresponding index
         self.seen_band_elements = [[] for i in select_element_order_preference] + [[]]
 
-        if segment.type == "select_clause":
+        if segment.is_type("select_clause"):
             select_target_elements = segment.get_children("select_clause_element")
             if not select_target_elements:
                 return None

--- a/src/sqlfluff/rules/L036.py
+++ b/src/sqlfluff/rules/L036.py
@@ -2,7 +2,7 @@
 
 from typing import List, NamedTuple
 
-from sqlfluff.core.parser import WhitespaceSegment
+from sqlfluff.core.parser import WhitespaceSegment, segments
 
 from sqlfluff.core.parser import BaseSegment, NewlineSegment
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult
@@ -104,8 +104,15 @@ class Rule_L036(BaseRule):
                 == select_target.pos_marker.working_line_no
             ):
                 # Find and delete any whitespace before the select target.
+                start_seg = select_targets_info.select_idx
+                # If any select modifier (e.g. distinct ) is present, start
+                # there rather than at the beginning.
+                modifier = segment.get_child("select_clause_modifier")
+                if modifier:
+                    start_seg = segment.segments.index(modifier)
+
                 ws_to_delete = segment.select_children(
-                    start_seg=segment.segments[select_targets_info.select_idx]
+                    start_seg=segment.segments[start_seg]
                     if not i
                     else select_targets_info.select_targets[i - 1],
                     select_if=lambda s: s.is_type("whitespace"),

--- a/src/sqlfluff/rules/L036.py
+++ b/src/sqlfluff/rules/L036.py
@@ -2,7 +2,7 @@
 
 from typing import List, NamedTuple
 
-from sqlfluff.core.parser import WhitespaceSegment, segments
+from sqlfluff.core.parser import WhitespaceSegment
 
 from sqlfluff.core.parser import BaseSegment, NewlineSegment
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult

--- a/src/sqlfluff/rules/L036.py
+++ b/src/sqlfluff/rules/L036.py
@@ -171,12 +171,12 @@ class Rule_L036(BaseRule):
                         ],
                     ),
                 )
-            if parent_stack and parent_stack[-1].type == "select_statement":
+            if parent_stack and parent_stack[-1].is_type("select_statement"):
                 select_stmt = parent_stack[-1]
                 select_clause_idx = select_stmt.segments.index(select_clause)
                 after_select_clause_idx = select_clause_idx + 1
                 if len(select_stmt.segments) > after_select_clause_idx:
-                    if select_stmt.segments[after_select_clause_idx].type == "newline":
+                    if select_stmt.segments[after_select_clause_idx].is_type("newline"):
                         # The select_clause is immediately followed by a
                         # newline. Delete the newline in order to avoid leaving
                         # behind an empty line after fix.

--- a/test/dialects/ansi_test.py
+++ b/test/dialects/ansi_test.py
@@ -177,5 +177,5 @@ def test__dialect__ansi_is_whitespace():
         parsed = lnt.parse_string(f.read())
     # Check all the segments that *should* be whitespace, ARE
     for raw_seg in parsed.tree.iter_raw_seg():
-        if raw_seg.type in ("whitespace", "newline"):
+        if raw_seg.is_type("whitespace", "newline"):
             assert raw_seg.is_whitespace

--- a/test/fixtures/rules/std_rule_cases/L036.yml
+++ b/test/fixtures/rules/std_rule_cases/L036.yml
@@ -122,3 +122,14 @@ test_cte:
 
     SELECT 1
     FROM cte1
+
+test_distinct:
+  fail_str: |
+    SELECT distinct a, b, c
+    FROM my_table
+  fix_str: |
+    SELECT distinct
+    a,
+    b,
+    c
+    FROM my_table

--- a/test/fixtures/rules/std_rule_cases/L036.yml
+++ b/test/fixtures/rules/std_rule_cases/L036.yml
@@ -123,7 +123,7 @@ test_cte:
     SELECT 1
     FROM cte1
 
-test_distinct:
+test_distinct_many:
   fail_str: |
     SELECT distinct a, b, c
     FROM my_table
@@ -133,3 +133,27 @@ test_distinct:
     b,
     c
     FROM my_table
+
+test_distinct_single_pass:
+  pass_str: |
+    SELECT distinct a
+    FROM my_table
+
+test_distinct_single_fail_a:
+  fail_str: |
+    SELECT distinct
+      a
+    FROM my_table
+  fix_str: |
+    SELECT distinct a
+    FROM my_table
+
+test_distinct_single_fail_b:
+  fail_str: |
+    SELECT
+      distinct a
+    FROM my_table
+  # NOTE: This doesn't yet reflow nicely. We should solve that elsewhere.
+  fix_str: |
+    SELECT distinct a
+       FROM my_table


### PR DESCRIPTION
This solves some type checking issues introduced in 0.5.5 (resolves #1049) and also handles `distinct` clauses in L036 to resolve #1024.

The issue was that in editing new segments, the new `type` wasn't being passed through.