### PR TITLE
Add short option for parallel

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -286,6 +286,7 @@ def dialects(**kwargs):
     help=("Perform the operation regardless of .sqlfluffignore configurations"),
 )
 @click.option(
+    "-p",
     "--parallel",
     type=int,
     default=1,


### PR DESCRIPTION
This enables `sqlfluff lint -p 4` rather than just `sqlfluff lint --parallel 4`.