### PR TITLE
flake8 ignore=E501 and --max-line-length are mutually exclusive

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,7 @@ commands = mypy src/sqlfluff
 # D105: Don't require docstrings on magic methods
 ignore = W503, D107, D105, D418
 exclude = .git,__pycache__,env,.tox,build,.venv,venv
-max-line-length = 88
+max-line-length = 154
 extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
     E203,

--- a/tox.ini
+++ b/tox.ini
@@ -60,11 +60,10 @@ commands = mypy src/sqlfluff
 
 [flake8]
 # Ignore:
-# E501: Long lines
 # W503: Line breaks before binary operators
 # D107: Don't require docstrings on __init__
 # D105: Don't require docstrings on magic methods
-ignore = E501, W503, D107, D105, D418
+ignore = W503, D107, D105, D418
 exclude = .git,__pycache__,env,.tox,build,.venv,venv
 max-line-length = 88
 extend-ignore =

--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,7 @@ commands = mypy src/sqlfluff
 # D105: Don't require docstrings on magic methods
 ignore = W503, D107, D105, D418
 exclude = .git,__pycache__,env,.tox,build,.venv,venv
-max-line-length = 154
+max-line-length = 196
 extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
     E203,


### PR DESCRIPTION
These two settings are about the same thing: The length of long lines.

Setting `max-line-length = 196` avoids all flake8 E501 errors and allows us to:
1. Flag attempts to add of even longer lines
2. Wrap long lines and lower max-line-length toward the recommended 88 chars per line.