### PR TITLE
Add a little fun on lint/fix CLI exit

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -361,12 +361,7 @@ def lint(
 
     if not nofail:
         if not non_human_output:
-            fun_string = "\nThat's some nice looking SQL 🎉! "
-            if result.num_violations() > 0:
-                fun_string += "But you could clean it up a little 😉."
-            else:
-                fun_string += "It's clean as a whistle- Don't change a thing 👍."
-            click.echo(fun_string)
+            click.echo("All Finished 📜 🎉!")
         sys.exit(result.stats()["exit code"])
     else:
         sys.exit(0)
@@ -496,9 +491,7 @@ def fix(force, paths, parallel, bench=False, fixed_suffix="", logger=None, **kwa
                 if not success:
                     sys.exit(1)
                 else:
-                    fun_string = "\nThat was some nice looking SQL 🎉! "
-                    fun_string += "But we made a few minor changes 😉."
-                    click.echo(fun_string)
+                    click.echo("All Finished 📜 🎉!")
             elif c == "n":
                 click.echo("Aborting...")
             else:
@@ -512,13 +505,7 @@ def fix(force, paths, parallel, bench=False, fixed_suffix="", logger=None, **kwa
                     result.num_violations(types=SQLLintError, fixable=False)
                 )
             )
-            fun_string = "\nThat's some nice looking SQL 🎉! "
-            fun_string += "But you might want to look at a few things 😉."
-            click.echo(fun_string)
-        else:
-            fun_string = "\nThat's some nice looking SQL 🎉! "
-            fun_string += "We wouldn't change a thing 👍."
-            click.echo(fun_string)
+        click.echo("All Finished 📜 🎉!")
 
     if bench:
         click.echo("\n\n==== bencher stats ====")

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -360,6 +360,13 @@ def lint(
         click.echo(yaml.dump(result.as_records()))
 
     if not nofail:
+        if not non_human_output:
+            fun_string = "\nThat's some nice looking SQL 🎉! "
+            if result.num_violations() > 0:
+                fun_string += "But you could clean it up a little 😉."
+            else:
+                fun_string += "It's clean as a whistle- Don't change a thing 👍."
+            click.echo(fun_string)
         sys.exit(result.stats()["exit code"])
     else:
         sys.exit(0)
@@ -488,6 +495,10 @@ def fix(force, paths, parallel, bench=False, fixed_suffix="", logger=None, **kwa
                 )
                 if not success:
                     sys.exit(1)
+                else:
+                    fun_string = "\nThat was some nice looking SQL 🎉! "
+                    fun_string += "But we made a few minor changes 😉."
+                    click.echo(fun_string)
             elif c == "n":
                 click.echo("Aborting...")
             else:
@@ -501,6 +512,13 @@ def fix(force, paths, parallel, bench=False, fixed_suffix="", logger=None, **kwa
                     result.num_violations(types=SQLLintError, fixable=False)
                 )
             )
+            fun_string = "\nThat's some nice looking SQL 🎉! "
+            fun_string += "But you might want to look at a few things 😉."
+            click.echo(fun_string)
+        else:
+            fun_string = "\nThat's some nice looking SQL 🎉! "
+            fun_string += "We wouldn't change a thing 👍."
+            click.echo(fun_string)
 
     if bench:
         click.echo("\n\n==== bencher stats ====")

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -58,7 +58,7 @@ def test__cli__command_directed():
     assert check_b in result.output
     # Finally check the WHOLE output to make sure that unexpected newlines are not added.
     # The replace command just accounts for cross platform testing.
-    assert result.output.replace("\\", "/") == expected_output
+    assert result.output.replace("\\", "/").startswith(expected_output)
 
 
 def test__cli__command_dialect():


### PR DESCRIPTION
Fixes #1043 

Echos some strings describing the way SQLFluff felt about the SQL it saw. This is mostly a proposal for the _copy_ of the strings. I'm fairly agnostic about it and realize the way it's written right now is very much of my vibe (which may not be shared by others!).

I'm also agnostic on how deeply this should be tested. Ought we be testing on the CLI output being an exact string match? if so, we can add cases to `test__cli__command_directed` and so on.

## Examples

```
➜ sqlfluff lint test/fixtures/cli/passing_a.sql

All Finished 📜 🎉!
```

```
➜ sqlfluff lint test/fixtures/cli/fail_many.sql
== [test/fixtures/cli/fail_many.sql] FAIL
L:   3 | P:   8 |  TMP | Undefined jinja template variable: 'something'
L:   3 | P:  21 |  PRS | Line 3, Position 6: Found unparsable section: 'as
                       | trailing_space'
L:   3 | P:  21 | L013 | Column expression without alias. Use explicit `AS`
                       | clause.
L:   3 | P:  21 | L034 | Use wildcards then simple select targets before
                       | calculations and aggregates.
L:   3 | P:  38 | L005 | Commas should not have whitespace directly before them.
L:   3 | P:  38 | L039 | Unnecessary whitespace found.
L:   3 | P:  41 | L003 | Line over-indented compared to line #2
L:   4 | P:   5 | L013 | Column expression without alias. Use explicit `AS`
                       | clause.
L:   4 | P:   6 |  PRS | Line 4, Position 6: Found unparsable section: ' +'
L:   4 | P:   9 |  PRS | Line 4, Position 9: Found unparsable section: 'FROM
                       | SELECT FROM'
WARNING: Parsing errors found and dialect is set to 'ansi'. Have you configured your dialect?
All Finished 📜 🎉!
```

```
➜ sqlfluff fix test/fixtures/cli/passing_b.sql 
==== finding fixable violations ====
==== no fixable linting violations found ====
All Finished 📜 🎉!
```

```
➜ sqlfluff fix test/fixtures/cli/fail_many.sql 
==== finding fixable violations ====
== [test/fixtures/cli/fail_many.sql] FAIL
L:   3 | P:  21 | L034 | Use wildcards then simple select targets before
                       | calculations and aggregates.
L:   3 | P:  41 | L003 | Line over-indented compared to line #2
==== fixing violations ====
2 fixable linting violations found
Are you sure you wish to attempt to fix these? [Y/n] ...
Attempting fixes...
Persisting Changes...
== [test/fixtures/cli/fail_many.sql] PASS
Done. Please check your files to confirm.
All Finished 📜 🎉!
```