### PR TITLE
Rip out BenchIt and replace with TimingSummary

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -3,9 +3,6 @@ warn_unused_configs = True
 warn_unused_ignores = True
 
 # skip type checking for 3rd party packages for which stubs are not available
-[mypy-benchit.*]
-ignore_missing_imports = True
-
 [mypy-pathspec.*]
 ignore_missing_imports = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@ click>=7.1
 colorama>=0.3
 configparser
 cached-property
-# bench-it is used while profiling
-bench-it
 # oyaml is like pyyaml but preserves orderings
 oyaml
 Jinja2

--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,6 @@ setup(
         "Jinja2",
         # Used for diffcover plugin
         "diff-cover>=2.5.0",
-        # Used for performance profiling
-        "bench-it",
         # Used for .sqlfluffignore
         "pathspec",
         # Used for finding os-specific application config dirs

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -333,14 +333,12 @@ def lint(
     set_logging_level(verbosity=verbose, logger=logger, stderr_output=non_human_output)
     # add stdin if specified via lone '-'
     if ("-",) == paths:
-        # TODO: Remove verbose
         result = lnt.lint_string_wrapped(sys.stdin.read(), fname="stdin")
     else:
         # Output the results as we go
         if verbose >= 1:
             click.echo(format_linting_result_header())
         try:
-            # TODO: Remove verbose
             result = lnt.lint_paths(
                 paths,
                 ignore_non_existent_files=False,
@@ -440,7 +438,6 @@ def fix(force, paths, parallel, bench=False, fixed_suffix="", logger=None, **kwa
     # handle stdin case. should output formatted sql to stdout and nothing else.
     if fixing_stdin:
         stdin = sys.stdin.read()
-        # TODO: Remove verbose
         result = lnt.lint_string_wrapped(stdin, fname="stdin", fix=True)
         stdout = result.paths[0].files[0].fix_string()[0]
         click.echo(stdout, nl=False)
@@ -474,7 +471,6 @@ def fix(force, paths, parallel, bench=False, fixed_suffix="", logger=None, **kwa
         )
         if force:
             click.echo(colorize("FORCE MODE", "red") + ": Attempting fixes...")
-            # TODO: Remove verbose
             success = do_fixes(
                 lnt,
                 result,
@@ -492,7 +488,6 @@ def fix(force, paths, parallel, bench=False, fixed_suffix="", logger=None, **kwa
             click.echo("...")
             if c in ("y", "\r", "\n"):
                 click.echo("Attempting fixes...")
-                # TODO: Remove verbose
                 success = do_fixes(
                     lnt,
                     result,
@@ -520,8 +515,11 @@ def fix(force, paths, parallel, bench=False, fixed_suffix="", logger=None, **kwa
         click.echo("All Finished 📜 🎉!")
 
     if bench:
-        click.echo("\n\n==== bencher stats ====")
-        # TODO
+        click.echo("==== overall timings ====")
+        timing_summary = result.timing_summary()
+        for step in timing_summary:
+            click.echo(f"=== {step} ===")
+            click.echo(cli_table(timing_summary[step].items()))
 
     sys.exit(0)
 
@@ -608,7 +606,6 @@ def parse(path, code_only, format, profiler, bench, nofail, logger=None, **kwarg
             ]
         else:
             # A single path must be specified for this command
-            # TODO: Remove verbose
             result = lnt.parse_path(path, recurse=recurse)
 
         # iterative print for human readout

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -11,7 +11,6 @@ import click
 # For the profiler
 import pstats
 from io import StringIO
-from benchit import BenchIt
 
 # To enable colour cross platform
 import colorama
@@ -418,8 +417,6 @@ def fix(force, paths, parallel, bench=False, fixed_suffix="", logger=None, **kwa
     lnt, formatter = get_linter_and_formatter(c, silent=fixing_stdin)
     verbose = c.get("verbose")
 
-    bencher = BenchIt()
-
     formatter.dispatch_config(lnt)
 
     # Set up logging.
@@ -509,7 +506,7 @@ def fix(force, paths, parallel, bench=False, fixed_suffix="", logger=None, **kwa
 
     if bench:
         click.echo("\n\n==== bencher stats ====")
-        bencher.display()
+        # TODO
 
     sys.exit(0)
 
@@ -561,8 +558,6 @@ def parse(path, code_only, format, profiler, bench, nofail, logger=None, **kwarg
     character to indicate reading from *stdin* or a dot/blank ('.'/' ') which will
     be interpreted like passing the current working directory as a path argument.
     """
-    # Initialise the benchmarker
-    bencher = BenchIt()  # starts the timer
     c = get_config(**kwargs)
     # We don't want anything else to be logged if we want json or yaml output
     non_human_output = format in ("json", "yaml")
@@ -587,7 +582,6 @@ def parse(path, code_only, format, profiler, bench, nofail, logger=None, **kwarg
         pr = cProfile.Profile()
         pr.enable()
 
-    bencher("Parse setup")
     try:
         # handle stdin if specified via lone '-'
         if "-" == path:
@@ -623,7 +617,6 @@ def parse(path, code_only, format, profiler, bench, nofail, logger=None, **kwarg
                 if verbose >= 2:
                     click.echo("==== timings ====")
                     click.echo(cli_table(parsed_string.time_dict.items()))
-                bencher("Output details for file")
         else:
             # collect result and print as single payload
             # will need to zip in the file paths
@@ -665,7 +658,7 @@ def parse(path, code_only, format, profiler, bench, nofail, logger=None, **kwarg
 
     if bench:
         click.echo("\n\n==== bencher stats ====")
-        bencher.display()
+        # TODO
 
     if nv > 0 and not nofail:
         sys.exit(66)

--- a/src/sqlfluff/core/__init__.py
+++ b/src/sqlfluff/core/__init__.py
@@ -22,6 +22,9 @@ from sqlfluff.core.errors import (
     SQLLintError,
 )
 
+# Timing objects
+from sqlfluff.core.timing import TimingSummary
+
 
 # This is for "sqlfluff lint" and "sqlfluff fix" multiprocessing (--parallel)
 # support. If an exception (i.e. runtime error) occurs in a worker process, we

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -19,8 +19,6 @@ from typing import (
     Type,
 )
 
-from benchit import BenchIt
-
 from sqlfluff.core.errors import (
     SQLBaseError,
     SQLLintError,
@@ -240,9 +238,6 @@ class LintedFile(NamedTuple):
         completely dialect agnostic. A Segment is determined by the
         Lexer from portions of strings after templating.
         """
-        bencher = BenchIt()
-        bencher("fix_string: start")
-
         linter_logger.debug("Original Tree: %r", self.templated_file.templated_str)
         assert self.tree
         linter_logger.debug("Fixed Tree: %r", self.tree.raw)
@@ -477,7 +472,6 @@ class LintedFile(NamedTuple):
                 )
                 str_buff += self.templated_file.source_str[source_slice]
 
-        bencher("fix_string: Fixing loop done")
         # The success metric here is whether anything ACTUALLY changed.
         return str_buff, str_buff != original_source
 

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -16,7 +16,6 @@ from typing import (
     Iterable,
 )
 
-from benchit import BenchIt
 import pathspec
 
 from sqlfluff.core.errors import (
@@ -190,13 +189,6 @@ class Linter:
                 linter_logger.info(unparsable.stringify())
         return parsed, violations
 
-    @staticmethod
-    def _generate_short_fname(fname: Optional[str] = None):
-        # Handle nulls gracefully
-        if not fname:
-            return None
-        return os.path.basename(fname)
-
     def render_string(self, in_str: str, fname: Optional[str], config: FluffConfig):
         """Template the file."""
         linter_logger.info("TEMPLATING RAW [%s] (%s)", self.templater.name, fname)
@@ -225,9 +217,6 @@ class Linter:
         """Parse a string."""
         violations: List[SQLBaseError] = []
         t0 = time.monotonic()
-        bencher = BenchIt()  # starts the timer
-        short_fname = self._generate_short_fname(fname)
-        bencher("Staring parse_string for {0!r}".format(short_fname))
 
         # Dispatch the output for the template header (including the config diff)
         if self.formatter:
@@ -243,7 +232,6 @@ class Linter:
         violations += templater_violations
 
         t1 = time.monotonic()
-        bencher("Templating {0!r}".format(short_fname))
 
         # Dispatch the output for the parse header
         if self.formatter:
@@ -257,7 +245,6 @@ class Linter:
             tokens = None
 
         t2 = time.monotonic()
-        bencher("Lexing {0!r}".format(short_fname))
         linter_logger.info("PARSING (%s)", fname)
 
         if tokens:
@@ -268,7 +255,6 @@ class Linter:
 
         t3 = time.monotonic()
         time_dict = {"templating": t1 - t0, "lexing": t2 - t1, "parsing": t3 - t2}
-        bencher("Finish parsing {0!r}".format(short_fname))
         return ParsedString(parsed, violations, time_dict, templated_file, config)
 
     @classmethod

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -14,6 +14,7 @@ from sqlfluff.core.errors import (
     CheckTuple,
 )
 
+from sqlfluff.core.timing import TimingSummary
 
 # Classes needed only for type checking
 from sqlfluff.core.parser.segments.base import BaseSegment
@@ -118,6 +119,14 @@ class LintingResult:
         all_stats["exit code"] = 65 if all_stats["violations"] > 0 else 0
         all_stats["status"] = "FAIL" if all_stats["violations"] > 0 else "PASS"
         return all_stats
+
+    def timing_summary(self) -> Dict[str, Dict[str, float]]:
+        """Return a timing summary."""
+        timing = TimingSummary()
+        for dir in self.paths:
+            for file in dir.files:
+                timing.add(file.time_dict)
+        return timing.summary()
 
     def as_records(self) -> List[dict]:
         """Return the result as a list of dictionaries.

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -9,7 +9,6 @@ Here we define:
 """
 
 from io import StringIO
-from benchit import BenchIt
 from cached_property import cached_property
 from typing import Any, Callable, Optional, List, Tuple, NamedTuple, Iterator
 import logging
@@ -838,9 +837,6 @@ class BaseSegment:
                     )
                     + post_nc
                 )
-
-        bencher = BenchIt()  # starts the timer
-        bencher("Parse complete of {0!r}".format(self.__class__.__name__))
 
         # Recurse if allowed (using the expand method to deal with the expansion)
         parse_context.logger.debug(

--- a/src/sqlfluff/core/timing.py
+++ b/src/sqlfluff/core/timing.py
@@ -1,0 +1,40 @@
+"""Timing summary class."""
+
+from typing import Optional, List, Dict
+from collections import defaultdict
+
+
+class TimingSummary:
+    """An object for tracking the timing of similar steps across many files."""
+
+    def __init__(self, steps: Optional[List[str]] = None):
+        self.steps = steps
+        self._timings: List[Dict[str, float]] = []
+
+    def add(self, timing_dict: Dict[str, float]):
+        """Add a timing dictionary to the summary."""
+        self._timings.append(timing_dict)
+        if not self.steps:
+            self.steps = list(timing_dict.keys())
+
+    def summary(self) -> Dict[str, Dict[str, float]]:
+        """Generate a summary for display."""
+        vals: Dict[str, List[float]] = defaultdict(list)
+        if not self.steps:
+            return {}
+
+        for timing_dict in self._timings:
+            for step in self.steps:
+                if step in timing_dict:
+                    vals[step].append(timing_dict[step])
+        summary = {}
+        for step in self.steps:
+            if vals[step]:
+                summary[step] = {
+                    "cnt": len(vals[step]),
+                    "sum": sum(vals[step]),
+                    "min": min(vals[step]),
+                    "max": max(vals[step]),
+                    "avg": sum(vals[step]) / len(vals[step]),
+                }
+        return summary


### PR DESCRIPTION
The procedural nature of `BenchIt` was causing issues with the changes I'd like to make to the `Linter` class to support #1088 . I asked on the slack thread and nobody voted to keep the exiting `BenchIt` implementation, but I think there's still value in profiling and benchmarking tools.

This PR removes the `BenchIt` library and replaces the functionality with a `TimingSummary` object which displays more useful descriptive stats about where time was spent during the operation.