### PR TITLE
Extract runner selection logic

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -1,6 +1,5 @@
 """Defines the linter class."""
 
-import sys
 import os
 import time
 import logging
@@ -51,6 +50,9 @@ linter_logger: logging.Logger = logging.getLogger("sqlfluff.linter")
 
 class Linter:
     """The interface class to interact with the linter."""
+
+    # Default to allowing process parallelism
+    allow_process_parallelism = True
 
     def __init__(
         self,
@@ -638,9 +640,6 @@ class Linter:
         result.add(linted_path)
         return result
 
-    MIN_THRESHOLD_PARALLEL = 2
-    PARALLEL_CLS = runner_module.MultiProcessRunner
-
     def lint_path(
         self,
         path: str,
@@ -660,21 +659,12 @@ class Linter:
                 ignore_files=ignore_files,
             )
         )
-        runner: runner_module.BaseRunner
-        if parallel >= self.MIN_THRESHOLD_PARALLEL and sys.version_info > (3, 7):
-            runner = self.PARALLEL_CLS(
-                type(self), self, self.config, self.dialect.name, parallel
-            )
-        else:
-            if parallel > 1:
-                linter_logger.warning(
-                    "Parallel linting is not supported in Python %s.%s.",
-                    sys.version_info.major,
-                    sys.version_info.minor,
-                )
-            runner = runner_module.SequentialRunner(
-                type(self), self, self.config, self.dialect.name
-            )
+        runner = runner_module.get_runner(
+            self,
+            self.config,
+            parallel=parallel,
+            allow_process_parallelism=self.allow_process_parallelism,
+        )
         for linted_file in runner.run(fnames, fix):
             linted_path.add(linted_file)
             # If any fatal errors, then stop iteration.

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -30,7 +30,7 @@ from sqlfluff.core.rules import get_ruleset
 from sqlfluff.core.config import FluffConfig, ConfigLoader
 
 # Classes needed only for type checking
-from sqlfluff.core.linter import runner as runner_module
+from sqlfluff.core.linter.runner import get_runner
 from sqlfluff.core.parser.segments.base import BaseSegment
 from sqlfluff.core.parser.segments.meta import MetaSegment
 from sqlfluff.core.parser.segments.raw import RawSegment
@@ -659,7 +659,7 @@ class Linter:
                 ignore_files=ignore_files,
             )
         )
-        runner = runner_module.get_runner(
+        runner = get_runner(
             self,
             self.config,
             parallel=parallel,

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -210,11 +210,9 @@ def test__linter__linting_parallel_thread(force_error, monkeypatch):
     tests capture code coverage information for the backend parts of parallel
     execution without having to jump through hoops.
     """
-    monkeypatch.setattr(Linter, "MIN_THRESHOLD_PARALLEL", 1)
-
     if not force_error:
 
-        monkeypatch.setattr(Linter, "PARALLEL_CLS", runner.MultiThreadRunner)
+        monkeypatch.setattr(Linter, "allow_process_parallelism", False)
 
     else:
 
@@ -236,7 +234,7 @@ def test__linter__linting_parallel_thread(force_error, monkeypatch):
     lntr = Linter(formatter=CallbackFormatter(callback=lambda m: None, verbosity=0))
     result = lntr.lint_paths(
         ("test/fixtures/linter/comma_errors.sql",),
-        parallel=1,
+        parallel=2,
     )
 
     all([type(v) == SQLLintError for v in result.get_violations()])


### PR DESCRIPTION
As suggested in #1101 and to support #1088, this extracts runner selection logic into the `runner` module.