### PR TITLE
Fix L017 window function bug.

### DIFF
--- a/src/sqlfluff/rules/L017.py
+++ b/src/sqlfluff/rules/L017.py
@@ -43,7 +43,7 @@ class Rule_L017(BaseRule):
 
             # Look for the start bracket
             for bracket_idx, seg in enumerate(segment.segments):
-                if seg.name == "start_bracket":
+                if seg.is_type("bracketed"):
                     break
 
             if bracket_idx != fname_idx + 1:

--- a/test/fixtures/rules/std_rule_cases/L017.yml
+++ b/test/fixtures/rules/std_rule_cases/L017.yml
@@ -3,6 +3,9 @@ rule: L017
 passing_example:
   pass_str: SELECT SUM(1)
 
+passing_example_window_function:
+  pass_str: SELECT AVG(c) OVER (PARTITION BY a)
+  
 simple_fail:
   fail_str: SELECT SUM (1)
   fix_str: SELECT SUM(1)


### PR DESCRIPTION
### Bug fix checklist
- [X] I have identified the root cause of the bug.
- I have fixed:
  - [X] All cases affected by the bug.
  - [ ] Some cases affected by the bug, but others still remain.
  - [ ] No cases, this PR just adds a failing test case.
- [X] This PR includes test cases to demonstrate the fix. Specifically:
  - [X] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [ ] `.sql`/`.yml` parser test cases in `test/fixtures/parser`.
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [ ] Other.
- [ ] This PR updates the [CHANGELOG.md](https://github.com/sqlfluff/sqlfluff/blob/master/CHANGELOG.md).

### What was the root cause of this bug?
Comparison in line 46 was wrong. Segment _start_bracket_ is nested a _bracketed_ segment, so it was never falling in the condition and was working accidentally for normal cases, but not working for window functions.
