### PR TITLE
Draft: Resolve parallel dbt templating issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Contributors:
 - Fix bug [#1037](https://github.com/sqlfluff/sqlfluff/issues/1037), in which fix 
   logging had been sent to stdout when reading data from stdin.
 - Add a little bit of fun on CLI exit 🎉!
+- Disabled models in the dbt templater are now skipped enitrely rather than
+  returning an untemplated file.
 
 ## [0.6.0a1] - 2021-05-15
 ### Added

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -366,6 +366,7 @@ def lint(
 
     if bench:
         click.echo("==== overall timings ====")
+        click.echo(cli_table([("Clock time", result.total_time)]))
         timing_summary = result.timing_summary()
         for step in timing_summary:
             click.echo(f"=== {step} ===")
@@ -516,6 +517,7 @@ def fix(force, paths, parallel, bench=False, fixed_suffix="", logger=None, **kwa
 
     if bench:
         click.echo("==== overall timings ====")
+        click.echo(cli_table([("Clock time", result.total_time)]))
         timing_summary = result.timing_summary()
         for step in timing_summary:
             click.echo(f"=== {step} ===")
@@ -633,6 +635,7 @@ def parse(path, code_only, format, profiler, bench, nofail, logger=None, **kwarg
                     click.echo(cli_table(parsed_string.time_dict.items()))
             if verbose >= 2 or bench:
                 click.echo("==== overall timings ====")
+                click.echo(cli_table([("Clock time", result.total_time)]))
                 timing_summary = timing.summary()
                 for step in timing_summary:
                     click.echo(f"=== {step} ===")

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -3,6 +3,7 @@
 import sys
 import json
 import logging
+import time
 
 import oyaml as yaml
 
@@ -598,6 +599,7 @@ def parse(path, code_only, format, profiler, bench, nofail, logger=None, **kwarg
         pr.enable()
 
     try:
+        t0 = time.monotonic()
         # handle stdin if specified via lone '-'
         if "-" == path:
             # put the parser result in a list to iterate later
@@ -609,6 +611,7 @@ def parse(path, code_only, format, profiler, bench, nofail, logger=None, **kwarg
         else:
             # A single path must be specified for this command
             result = lnt.parse_path(path, recurse=recurse)
+        total_time = time.monotonic() - t0
 
         # iterative print for human readout
         if format == "human":
@@ -635,7 +638,7 @@ def parse(path, code_only, format, profiler, bench, nofail, logger=None, **kwarg
                     click.echo(cli_table(parsed_string.time_dict.items()))
             if verbose >= 2 or bench:
                 click.echo("==== overall timings ====")
-                click.echo(cli_table([("Clock time", result.total_time)]))
+                click.echo(cli_table([("Clock time", total_time)]))
                 timing_summary = timing.summary()
                 for step in timing_summary:
                     click.echo(f"=== {step} ===")

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -648,7 +648,7 @@ def parse(path, code_only, format, profiler, bench, nofail, logger=None, **kwarg
                     if parsed
                     else None,
                 )
-                for filepath, (parsed, _, _, _, _) in zip(filepaths, result)
+                for filepath, (parsed, _, _, _, _, _) in zip(filepaths, result)
             ]
 
             if format == "yaml":

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -644,17 +644,16 @@ def parse(path, code_only, format, profiler, bench, nofail, logger=None, **kwarg
                     click.echo(f"=== {step} ===")
                     click.echo(cli_table(timing_summary[step].items()))
         else:
-            # collect result and print as single payload
-            # will need to zip in the file paths
-            filepaths = ["stdin"] if "-" == path else lnt.paths_from_path(path)
             result = [
                 dict(
-                    filepath=filepath,
-                    segments=parsed.as_record(code_only=code_only, show_raw=True)
-                    if parsed
+                    filepath=linted_result.fname,
+                    segments=linted_result.tree.as_record(
+                        code_only=code_only, show_raw=True
+                    )
+                    if linted_result.tree
                     else None,
                 )
-                for filepath, (parsed, _, _, _, _, _) in zip(filepaths, result)
+                for linted_result in result
             ]
 
             if format == "yaml":

--- a/src/sqlfluff/core/linter/common.py
+++ b/src/sqlfluff/core/linter/common.py
@@ -40,6 +40,7 @@ class RenderedFile(NamedTuple):
     templater_violations: List[SQLTemplaterError]
     config: FluffConfig
     time_dict: Dict[str, float]
+    fname: str
 
 
 class ParsedString(NamedTuple):
@@ -62,6 +63,7 @@ class ParsedString(NamedTuple):
     time_dict: dict
     templated_file: TemplatedFile
     config: FluffConfig
+    fname: str
 
 
 class EnrichedFixPatch(NamedTuple):

--- a/src/sqlfluff/core/linter/common.py
+++ b/src/sqlfluff/core/linter/common.py
@@ -33,7 +33,7 @@ class RenderedFile(NamedTuple):
     """An object to store the result of a templated file/string.
 
     This is notable as it's the intermediate state between what happens
-    in the main thread and the child threads when running in parallel mode.
+    in the main process and the child processes when running in parallel mode.
     """
 
     templated_file: TemplatedFile

--- a/src/sqlfluff/core/linter/common.py
+++ b/src/sqlfluff/core/linter/common.py
@@ -5,9 +5,10 @@ from typing import (
     NamedTuple,
     Optional,
     Tuple,
+    Dict,
 )
 
-from sqlfluff.core.errors import SQLBaseError
+from sqlfluff.core.errors import SQLBaseError, SQLTemplaterError
 from sqlfluff.core.templaters import TemplatedFile
 from sqlfluff.core.config import FluffConfig
 from sqlfluff.core.parser.segments.base import BaseSegment
@@ -26,6 +27,19 @@ class NoQaDirective(NamedTuple):
     line_no: int  # Source line number
     rules: Optional[Tuple[str, ...]]  # Affected rule names
     action: Optional[str]  # "enable", "disable", or "None"
+
+
+class RenderedFile(NamedTuple):
+    """An object to store the result of a templated file/string.
+
+    This is notable as it's the intermediate state between what happens
+    in the main thread and the child threads when running in parallel mode.
+    """
+
+    templated_file: TemplatedFile
+    templater_violations: List[SQLTemplaterError]
+    config: FluffConfig
+    time_dict: Dict[str, float]
 
 
 class ParsedString(NamedTuple):

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -30,7 +30,7 @@ from sqlfluff.core.rules import get_ruleset
 from sqlfluff.core.config import FluffConfig, ConfigLoader
 
 # Classes needed only for type checking
-from sqlfluff.core.linter import runner as runner_module
+from sqlfluff.core.linter.runner import get_runner
 from sqlfluff.core.parser.segments.base import BaseSegment
 from sqlfluff.core.parser.segments.meta import MetaSegment
 from sqlfluff.core.parser.segments.raw import RawSegment
@@ -659,7 +659,7 @@ class Linter:
                 ignore_files=ignore_files,
             )
         )
-        runner = runner_module.get_runner(
+        runner = get_runner(
             self,
             self.config,
             parallel=parallel,

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -484,6 +484,18 @@ class Linter:
 
         return linted_file
 
+    @classmethod
+    def lint_rendered(
+        cls,
+        rendered: RenderedFile,
+        rule_set: List[BaseRule],
+        fix: bool = False,
+        formatter: Any = None,
+    ) -> LintedFile:
+        """Take a RenderedFile and return a LintedFile."""
+        parsed = cls.parse_rendered(rendered)
+        return cls.lint_parsed(parsed, rule_set=rule_set, fix=fix, formatter=formatter)
+
     # ### Instance Methods
     # These are tied to a specific instance and so are not necessarily
     # safe to use in parallel operations.

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -751,6 +751,7 @@ class Linter:
         linted_path = LintedDir(fname)
         linted_path.add(self.lint_string(string, fname=fname, fix=fix))
         result.add(linted_path)
+        result.stop_timer()
         return result
 
     def lint_path(
@@ -812,6 +813,7 @@ class Linter:
                     parallel=parallel,
                 )
             )
+        result.stop_timer()
         return result
 
     def parse_path(

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -528,8 +528,6 @@ class Linter:
 
     def render_file(self, fname: str, root_config: FluffConfig) -> RenderedFile:
         """Load and render a file with relevant config."""
-        if self.formatter:
-            self.formatter.dispatch_path(fname)
         # Load the raw file.
         raw_file, config = self._load_raw_file_and_config(fname, root_config)
         # Render the file

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -766,12 +766,8 @@ class Linter:
         for fname in self.paths_from_path(path):
             if self.formatter:
                 self.formatter.dispatch_path(path)
-
-            config = self.config.make_child_from_path(fname)
-            # Handle unicode issues gracefully
-            with open(
-                fname, "r", encoding="utf8", errors="backslashreplace"
-            ) as target_file:
-                yield self.parse_string(
-                    target_file.read(), fname=fname, recurse=recurse, config=config
-                )
+            # Load the file with the config and yield the result.
+            raw_file, config = self._load_raw_file_and_config(fname, self.config)
+            yield self.parse_string(
+                raw_file, fname=fname, recurse=recurse, config=config
+            )

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -1,5 +1,6 @@
 """Defines the linter class."""
 
+import time
 from typing import (
     Any,
     Dict,
@@ -32,6 +33,8 @@ class LintingResult:
 
     def __init__(self) -> None:
         self.paths: List[LintedDir] = []
+        self._start_time: float = time.monotonic()
+        self.total_time: float = 0.0
 
     @staticmethod
     def sum_dicts(d1: Dict[str, Any], d2: Dict[str, Any]) -> Dict[str, Any]:
@@ -50,6 +53,10 @@ class LintingResult:
     def add(self, path: LintedDir) -> None:
         """Add a new `LintedDir` to this result."""
         self.paths.append(path)
+
+    def stop_timer(self):
+        """Stop the linting timer."""
+        self.total_time = time.monotonic() - self._start_time
 
     @overload
     def check_tuples(self, by_path: Literal[False]) -> List[CheckTuple]:

--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -216,7 +216,8 @@ def get_runner(
     allow_process_parallelism: bool = True,
 ) -> BaseRunner:
     """Generate a runner instance based on parallel and sytem configuration."""
-    if parallel > 1 and sys.version_info > (3, 7):
+    # Python multiprocessing isn't supported in 3.6 and before.
+    if parallel > 1 and sys.version_info >= (3, 7):
         # Process parallelism isn't really supported during testing
         # so this flag allows us to fall back to a threaded runner
         # in those cases.

--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -217,6 +217,7 @@ def get_runner(
 ) -> BaseRunner:
     """Generate a runner instance based on parallel and sytem configuration."""
     # Python multiprocessing isn't supported in 3.6 and before.
+    # The library exists but we get pickling errors with LintedFile.
     if parallel > 1 and sys.version_info >= (3, 7):
         # Process parallelism isn't really supported during testing
         # so this flag allows us to fall back to a threaded runner

--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -35,18 +35,18 @@ class BaseRunner(ABC):
     def iter_rendered(self, fnames):
         """Iterate through rendered files ready for linting."""
         for fname in fnames:
-            yield self.linter.render_file(fname, self.config)
+            yield fname, self.linter.render_file(fname, self.config)
 
     def iter_partials(self, fnames, fix: bool = False):
         """Iterate through partials for linted files.
 
         Generates filenames and objects which return LintedFiles.
         """
-        for rendered in self.iter_rendered(fnames):
+        for fname, rendered in self.iter_rendered(fnames):
             # Generate a fresh ruleset
             rule_set = self.linter.get_ruleset(config=rendered.config)
             yield (
-                rendered.templated_file.fname,
+                fname,
                 functools.partial(
                     self.linter.lint_rendered,
                     rendered,

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -561,7 +561,7 @@ class RuleSet:
         # Make sure we actually return the original class
         return cls
 
-    def get_rulelist(self, config):
+    def get_rulelist(self, config) -> List[BaseRule]:
         """Use the config to return the appropriate rules.
 
         We use the config both for whitelisting and blacklisting, but also

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -88,8 +88,8 @@ class TemplatedFile:
     def __init__(
         self,
         source_str: str,
+        fname: str,
         templated_str: Optional[str] = None,
-        fname: Optional[str] = None,
         sliced_file: Optional[List[TemplatedFileSlice]] = None,
         raw_sliced: Optional[List[RawFileSlice]] = None,
     ):
@@ -123,7 +123,7 @@ class TemplatedFile:
     @classmethod
     def from_string(cls, raw):
         """Create TemplatedFile from a string."""
-        return cls(source_str=raw)
+        return cls(source_str=raw, fname="<string>")
 
     def __bool__(self):
         """Return true if there's a templated file."""
@@ -383,7 +383,7 @@ class RawTemplater:
         """
 
     def process(
-        self, *, in_str: str, fname: Optional[str] = None, config=None, formatter=None
+        self, *, in_str: str, fname: str, config=None, formatter=None
     ) -> Tuple[Optional[TemplatedFile], list]:
         """Process a string and return a TemplatedFile.
 

--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -131,6 +131,11 @@ class DbtTemplater(JinjaTemplater):
                 DbtMethodName.Path, method_arguments=[]
             )
 
+        if self.formatter:
+            self.formatter.dispatch_compilation_header(
+                "dbt templater", "Project Compiled."
+            )
+
         return self.dbt_selector_method
 
     def _get_profiles_dir(self):

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -174,7 +174,7 @@ class JinjaTemplater(PythonTemplater):
         )
 
     def process(
-        self, *, in_str: str, fname: Optional[str] = None, config=None, formatter=None
+        self, *, in_str: str, fname: str, config=None, formatter=None
     ) -> Tuple[Optional[TemplatedFile], list]:
         """Process a string and return the new string.
 

--- a/src/sqlfluff/core/templaters/python.py
+++ b/src/sqlfluff/core/templaters/python.py
@@ -200,7 +200,7 @@ class PythonTemplater(RawTemplater):
         return live_context
 
     def process(
-        self, *, in_str: str, fname: Optional[str] = None, config=None, formatter=None
+        self, *, in_str: str, fname: str, config=None, formatter=None
     ) -> Tuple[Optional[TemplatedFile], list]:
         """Process a string and return a TemplatedFile.
 

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -370,9 +370,10 @@ def test__cli__command_fix_stdin_logging_to_stderr(monkeypatch):
     perfect_sql = "select col from table"
 
     class MockLinter(sqlfluff.core.Linter):
-        def lint_fix(self, *args, **kwargs):
-            self._warn_unfixable("<FAKE CODE>")
-            return super().lint_fix(*args, **kwargs)
+        @classmethod
+        def lint_fix_parsed(cls, *args, **kwargs):
+            cls._warn_unfixable("<FAKE CODE>")
+            return super().lint_fix_parsed(*args, **kwargs)
 
     monkeypatch.setattr(sqlfluff.cli.commands, "Linter", MockLinter)
     result = invoke_assert_code(

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -570,8 +570,13 @@ def test__linter__skip_dbt_model_disabled(in_dbt_project_dir):  # noqa
     conf = FluffConfig(configs={"core": {"templater": "dbt"}})
     lntr = Linter(config=conf)
     linted_path = lntr.lint_path(path="models/my_new_project/disabled_model.sql")
-    # Check that the file is skipped
-    assert len(linted_path.files) == 0
+    # Check that the file is still there
+    assert len(linted_path.files) == 1
+    linted_file = linted_path.files[0]
+    # Make sure it appears as expected.
+    assert linted_file.path == "models/my_new_project/disabled_model.sql"
+    assert not linted_file.templated_file
+    assert not linted_file.tree
 
 
 def test_delayed_exception():

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -570,9 +570,8 @@ def test__linter__skip_dbt_model_disabled(in_dbt_project_dir):  # noqa
     conf = FluffConfig(configs={"core": {"templater": "dbt"}})
     lntr = Linter(config=conf)
     linted_path = lntr.lint_path(path="models/my_new_project/disabled_model.sql")
-    linted_file = linted_path.files[0]
-    assert linted_file.path == "models/my_new_project/disabled_model.sql"
-    assert not linted_file.templated_file
+    # Check that the file is skipped
+    assert len(linted_path.files) == 0
 
 
 def test_delayed_exception():

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -496,7 +496,7 @@ def test_linted_file_ignore_masked_violations(
         time_dict={},
         tree=None,
         ignore_mask=ignore_mask,
-        templated_file=TemplatedFile(""),
+        templated_file=TemplatedFile.from_string(""),
     )
     result = lf._ignore_masked_violations(violations)
     expected_violations = [v for i, v in enumerate(violations) if i in expected]

--- a/test/core/templaters/base_test.py
+++ b/test/core/templaters/base_test.py
@@ -45,7 +45,7 @@ def test__templater_raw():
     """Test the raw templater."""
     t = RawTemplater()
     instr = "SELECT * FROM {{blah}}"
-    outstr, _ = t.process(in_str=instr)
+    outstr, _ = t.process(in_str=instr, fname="test")
     assert instr == str(outstr)
 
 
@@ -143,7 +143,10 @@ def test__templated_file_get_line_pos_of_char_pos(
 ):
     """Test TemplatedFile.get_line_pos_of_char_pos."""
     file = TemplatedFile(
-        source_str=source_str, templated_str=templated_str, sliced_file=file_slices
+        source_str=source_str,
+        templated_str=templated_str,
+        sliced_file=file_slices,
+        fname="test",
     )
     res_line_no, res_line_pos = file.get_line_pos_of_char_pos(in_charpos)
     assert res_line_no == out_line_no
@@ -167,7 +170,9 @@ def test__templated_file_find_slice_indices_of_templated_pos(
     templated_position, inclusive, file_slices, sliced_idx_start, sliced_idx_stop
 ):
     """Test TemplatedFile._find_slice_indices_of_templated_pos."""
-    file = TemplatedFile(source_str="Dummy String", sliced_file=file_slices)
+    file = TemplatedFile(
+        source_str="Dummy String", sliced_file=file_slices, fname="test"
+    )
     res_start, res_stop = file._find_slice_indices_of_templated_pos(
         templated_position, inclusive=inclusive
     )
@@ -288,7 +293,10 @@ def test__templated_file_templated_slice_to_source_slice(
 ):
     """Test TemplatedFile.templated_slice_to_source_slice."""
     file = TemplatedFile(
-        source_str="Dummy String", sliced_file=file_slices, raw_sliced=raw_slices
+        source_str="Dummy String",
+        sliced_file=file_slices,
+        raw_sliced=raw_slices,
+        fname="test",
     )
     source_slice = file.templated_slice_to_source_slice(in_slice)
     literal_test = file.is_source_slice_literal(source_slice)
@@ -299,6 +307,7 @@ def test__templated_file_source_only_slices():
     """Test TemplatedFile.source_only_slices."""
     file = TemplatedFile(
         source_str=" Dummy String again ",  # NB: has length 20
+        fname="test",
         raw_sliced=[
             RawFileSlice("a" * 10, "literal", 0),
             RawFileSlice("b" * 7, "comment", 10),

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -37,7 +37,7 @@ FROM events
 def test__templater_jinja(instr, expected_outstr):
     """Test jinja templating and the treatment of whitespace."""
     t = JinjaTemplater(override_context=dict(blah="foo", condition="a < 10"))
-    outstr, _ = t.process(in_str=instr, config=FluffConfig())
+    outstr, _ = t.process(in_str=instr, fname="test", config=FluffConfig())
     assert str(outstr) == expected_outstr
 
 
@@ -45,7 +45,7 @@ def test__templater_jinja_error_variable():
     """Test missing variable error handling in the jinja templater."""
     t = JinjaTemplater(override_context=dict(blah="foo"))
     instr = JINJA_STRING
-    outstr, vs = t.process(in_str=instr, config=FluffConfig())
+    outstr, vs = t.process(in_str=instr, fname="test", config=FluffConfig())
     assert str(outstr) == "SELECT * FROM f, o, o WHERE \n\n"
     # Check we have violations.
     assert len(vs) > 0
@@ -57,7 +57,7 @@ def test__templater_jinja_error_syntax():
     """Test syntax problems in the jinja templater."""
     t = JinjaTemplater()
     instr = "SELECT {{foo} FROM jinja_error\n"
-    outstr, vs = t.process(in_str=instr, config=FluffConfig())
+    outstr, vs = t.process(in_str=instr, fname="test", config=FluffConfig())
     # Check we just skip templating.
     assert str(outstr) == instr
     # Check we have violations.
@@ -70,7 +70,7 @@ def test__templater_jinja_error_catatrophic():
     """Test error handling in the jinja templater."""
     t = JinjaTemplater(override_context=dict(blah=7))
     instr = JINJA_STRING
-    outstr, vs = t.process(in_str=instr, config=FluffConfig())
+    outstr, vs = t.process(in_str=instr, fname="test", config=FluffConfig())
     assert not outstr
     assert len(vs) > 0
 

--- a/test/core/templaters/python_test.py
+++ b/test/core/templaters/python_test.py
@@ -17,7 +17,7 @@ def test__templater_python():
     """Test the python templater."""
     t = PythonTemplater(override_context=dict(blah="foo"))
     instr = PYTHON_STRING
-    outstr, _ = t.process(in_str=instr)
+    outstr, _ = t.process(in_str=instr, fname="test")
     assert str(outstr) == "SELECT * FROM foo"
 
 
@@ -26,7 +26,7 @@ def test__templater_python_error():
     t = PythonTemplater(override_context=dict(noblah="foo"))
     instr = PYTHON_STRING
     with pytest.raises(SQLTemplaterError):
-        t.process(in_str=instr)
+        t.process(in_str=instr, fname="test")
 
 
 @pytest.mark.parametrize(

--- a/test/fixtures/linter/autofix/bigquery/004_templating/after.sql
+++ b/test/fixtures/linter/autofix/bigquery/004_templating/after.sql
@@ -10,16 +10,16 @@ raw_effect_sizes AS (
     SELECT
         COUNT(1) AS campaign_count,
         {{corr_states}}
-    {% for action in considered_actions %}
+        {% for action in considered_actions %}
         , SAFE_DIVIDE(SAFE_MULTIPLY(CORR({{metric}}_rate_su, {{action}}), STDDEV_POP({{metric}}_rate_su)), STDDEV_POP({{action}})) AS {{metric}}_{{action}}
-    {% endfor %}
+        {% endfor %}
     FROM
         `{{gcp_project}}.{{dataset}}.global_actions_states`
     GROUP BY
         {{corr_states}}
 ),
 
-  {% for action in considered_actions %}
+{% for action in considered_actions %}
 {{action}}_raw_effect_sizes AS (
     SELECT
         COUNT(1) AS campaign_count_{{action}},
@@ -41,15 +41,15 @@ raw_effect_sizes AS (
 new_raw_effect_sizes AS (
     SELECT
         {{corr_states}}
-    {% for action in considered_actions %}
+        {% for action in considered_actions %}
         , {{metric}}_{{action}}
         , campaign_count_{{action}}
-    {% endfor %}
+        {% endfor %}
     FROM
     {% for action in considered_actions %}
     {% if loop.first %}
     {{action}}_raw_effect_sizes
-    {% else %}
+        {% else %}
     JOIN
         {{action}}_raw_effect_sizes
         USING
@@ -62,11 +62,11 @@ imputed_effect_sizes AS (
     SELECT
         {{corr_states}}
         , o.campaign_count AS campaign_count
-    {% for action in considered_actions %}
+        {% for action in considered_actions %}
         , COALESCE(IF(IS_NAN(o.{{metric}}_{{action}}), 0, o.{{metric}}_{{action}}), 0) AS {{metric}}_{{action}}
         , COALESCE(IF(IS_NAN(n.{{metric}}_{{action}}), 0, n.{{metric}}_{{action}}), 0) AS new_{{metric}}_{{action}}
         , n.campaign_count_{{action}}
-{% endfor %}
+    {% endfor %}
     FROM
         raw_effect_sizes o
     JOIN


### PR DESCRIPTION
This PR has a couple of things to still shake out. Namely that one test is failing for a reason I don't understand, and it looks like the CLI output is treading on toes when running in parallel. Those issues aside, I think it's ready for a review, at least from an architecture standpoint.

This resolves #1088 .

I've tested it on our large dbt project with the dbt templater and it's FAST.

It also builds on #1103 so will be easier to review once that's merged.

In short:
- We render the sql files in the main thread and then pass them to the child threads for parsing and linting.
- The rest of the changes are making enough methods in the linter _static_ or _class_ methods to do that in a way that we don't have to create a new `Linter` object each time.