### PR TITLE
Add changelog check action

### DIFF
--- a/.github/workflows/check-changelog-edited.yml
+++ b/.github/workflows/check-changelog-edited.yml
@@ -1,0 +1,10 @@
+name: "Check CHANGELOG.md was edited."
+on: pull_request
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dangoslen/changelog-enforcer@v2
+      with:
+        changeLogPath: 'CHANGELOG.md'

--- a/.github/workflows/check-changelog-edited.yml
+++ b/.github/workflows/check-changelog-edited.yml
@@ -1,4 +1,4 @@
-name: "Check CHANGELOG.md was edited."
+name: "Edited CHANGELOG.md"
 on: pull_request
 jobs:
   changelog:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Contributors:
 - Add a little bit of fun on CLI exit 🎉!
 - Disabled models in the dbt templater are now skipped enitrely rather than
   returning an untemplated file.
+- Add a changelog check to SQLFluff continuous integration.
 
 ## [0.6.0a1] - 2021-05-15
 ### Added


### PR DESCRIPTION
Closes #1094 

Adds a GH action to check that the changelog was edited in each PR. We can make this optional in the repo settings (um, at least Alan can): https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule

Testing this out on this branch. I will attempt to first fail the check and then pass it!