### PR TITLE
Ignore select statements with macros in L034

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,13 +133,6 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: mypy
-  dbt017-py38:
-    <<: *common
-    docker:
-      - image: circleci/python:3.8
-        environment:
-          TOXENV: dbt017-py38
-          TOX_ARGS: -m dbt
   dbt018-py38:
     <<: *common
     docker:
@@ -181,7 +174,6 @@ workflows:
       - py37
       - py38
       - py39
-      - dbt017-py38
       - dbt018-py38
       - dbt019-py38
       - bench

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- L034 now ignores select statements which contain macros.
+
 Contributors:
 - [@GitHub-Username](Link to GitHub profile) ([#PR-Number](Link to PR))
 - [@bolajiwahab](https://github.com/bolajiwahab) ([#1063])(https://github.com/sqlfluff/sqlfluff/pull/1063)
@@ -16,7 +19,7 @@ Contributors:
 - Better exception handling for the simple parsing API (`sqlfluff.parse`)
   which now raises an exception which holds all potential parsing issues
   and prints nicely with more than one issue.
-- Fix bug [#1037](https://github.com/sqlfluff/sqlfluff/issues/1037), in which fix 
+- Fix bug [#1037](https://github.com/sqlfluff/sqlfluff/issues/1037), in which fix
   logging had been sent to stdout when reading data from stdin.
 - Add a little bit of fun on CLI exit 🎉!
 - Disabled models in the dbt templater are now skipped enitrely rather than
@@ -31,7 +34,7 @@ Contributors:
 - Lint and fix parallelism using `--parallel` CLI argument
 - Fix [1051](https://github.com/sqlfluff/sqlfluff/issues/1051), adding support
   for bitwise operators `&`, `|`, `^`, `<<`, `>>`
-  
+
 ## [0.5.6] - 2021-05-14
 - Bugfix release for an issue in `L016` introduced in `0.5.4`.
 - Fix for `L016` issue where `DISTINCT` keywords were mangled during

--- a/src/sqlfluff/rules/L034.py
+++ b/src/sqlfluff/rules/L034.py
@@ -8,7 +8,7 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 @document_fix_compatible
 class Rule_L034(BaseRule):
-    """Use wildcards then simple select targets before calculations and aggregates.
+    """Use wildcards then simple targets before calculations and aggregates in select statements.
 
     | **Anti-pattern**
 
@@ -42,21 +42,14 @@ class Rule_L034(BaseRule):
             self.seen_band_elements[i + 1 : :]
         ):
             # Found a violation (i.e. a simpler element that *follows* a more
-            # complex element. Find the more complex element occurring JUST
-            # PRIOR TO "segment" by sorting on line number and position, then
-            # report that as the location of the issue.
-            more_complex_segments = sorted(
-                itertools.chain(*self.seen_band_elements[i + 1 : :]),
-                key=lambda s: (s.pos_marker.line_no, s.pos_marker.line_pos),
-            )
-            misplaced_segment = more_complex_segments[-1]
-            if misplaced_segment not in [v.anchor for v in self.violation_buff]:
-                self.violation_buff.append(LintResult(anchor=misplaced_segment))
+            # complex element.
+            self.violation_exists = True
         self.current_element_band = i
         self.seen_band_elements[i].append(segment)
 
     def _eval(self, segment, **kwargs):
         self.violation_buff = []
+        self.violation_exists = False
         # Bands of select targets in order to be enforced
         select_element_order_preference = (
             ("wildcard_expression",),
@@ -74,6 +67,7 @@ class Rule_L034(BaseRule):
         self.seen_band_elements = [[] for i in select_element_order_preference] + [[]]
 
         if segment.is_type("select_clause"):
+            select_clause_segment = segment
             select_target_elements = segment.get_children("select_clause_element")
             if not select_target_elements:
                 return None
@@ -128,7 +122,7 @@ class Rule_L034(BaseRule):
                 if self.current_element_band is None:
                     self.seen_band_elements[-1].append(segment)
 
-            if self.violation_buff:
+            if self.violation_exists:
                 # Create a list of all the edit fixes
                 # We have to do this at the end of iterating through all the select_target_elements to get the order correct
                 # This means we can't add a lint fix to each individual LintResult as we go
@@ -145,8 +139,10 @@ class Rule_L034(BaseRule):
                         select_target_elements, ordered_select_target_elements
                     )
                 ]
-
-                # Add the set of fixes to the last lint result in the violation buffer
-                self.violation_buff[-1].fixes = fixes
+                # Anchoring on the select statement segment ensures that
+                # select statements which include macro targets are ignored
+                # when ignore_templated_areas is set
+                lint_result = LintResult(anchor=select_clause_segment, fixes=fixes)
+                self.violation_buff = [lint_result]
 
         return self.violation_buff or None

--- a/src/sqlfluff/rules/L034.py
+++ b/src/sqlfluff/rules/L034.py
@@ -1,7 +1,5 @@
 """Implementation of Rule L034."""
 
-import itertools
-
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible
 

--- a/src/sqlfluff/testing/rules.py
+++ b/src/sqlfluff/testing/rules.py
@@ -15,6 +15,8 @@ class RuleTestCase(NamedTuple):
 
     rule: Optional[str] = None
     desc: Optional[str] = None
+    templater: Optional[str] = None
+    dbt_model_name: Optional[str] = None
     pass_str: Optional[str] = None
     fail_str: Optional[str] = None
     fix_str: Optional[str] = None

--- a/src/sqlfluff/testing/rules.py
+++ b/src/sqlfluff/testing/rules.py
@@ -15,8 +15,6 @@ class RuleTestCase(NamedTuple):
 
     rule: Optional[str] = None
     desc: Optional[str] = None
-    templater: Optional[str] = None
-    dbt_model_name: Optional[str] = None
     pass_str: Optional[str] = None
     fail_str: Optional[str] = None
     fix_str: Optional[str] = None

--- a/test/core/templaters/dbt_test.py
+++ b/test/core/templaters/dbt_test.py
@@ -148,6 +148,7 @@ def test__templater_dbt_skips_disabled_model(in_dbt_project_dir, dbt_templater):
         "incremental.sql",
         "single_trailing_newline.sql",
         "multiple_trailing_newline.sql",
+        "L034_test.sql",
     ],
 )
 @pytest.mark.dbt
@@ -158,7 +159,6 @@ def test__dbt_templated_models_do_not_raise_lint_error(
     lntr = Linter(config=FluffConfig(configs=DBT_FLUFF_CONFIG))
     lnt = lntr.lint_path(path="models/my_new_project/" + fname)
     violations = lnt.check_tuples()
-    print(violations)
     assert len(violations) == 0
 
 

--- a/test/fixtures/dbt_project/models/my_new_project/L034_test.sql
+++ b/test/fixtures/dbt_project/models/my_new_project/L034_test.sql
@@ -1,0 +1,7 @@
+-- L034 should ignore this as one of the select targets uses a macro
+
+select
+    {{ dbt_utils.surrogate_key(['spots', 'moos']) }} as spot_moo_id,
+    date(birth_date) as birth_date,
+    name
+from cows

--- a/test/fixtures/rules/std_rule_cases/L034.yml
+++ b/test/fixtures/rules/std_rule_cases/L034.yml
@@ -15,7 +15,7 @@ test_2:
       row_number() over (partition by id order by date) as y,
       b
     from x
-  line_numbers: [3]
+  line_numbers: [1]
 
   fix_str: |
     select
@@ -31,7 +31,7 @@ test_3:
       *,
       cast(b as int) as b_int
     from x
-  line_numbers: [2]
+  line_numbers: [1]
 
   fix_str: |
     select
@@ -47,7 +47,7 @@ test_4:
       cast(b as int) as b_int,
       *
     from x
-  line_numbers: [2, 3]
+  line_numbers: [1]
 
   fix_str: |
     select
@@ -63,7 +63,7 @@ test_5:
       b::int,
       *
     from x
-  line_numbers: [2, 3]
+  line_numbers: [1]
 
   fix_str: |
     select
@@ -80,7 +80,7 @@ test_6:
       2::int + 4 as sum,
       cast(b) as c
     from x
-  line_numbers: [2, 4]
+  line_numbers: [1]
 
   fix_str: |
     select


### PR DESCRIPTION
Several users have now reported that L034 will apply broken fixes to select statements which contain macros (https://getdbt.slack.com/archives/CV2KM39KR/p1622420620013500), most commonly dbt's `{{ dbt_utils.surrogate_key() }}`. This change anchors L034 on the select statement segment so that statements using macros are completed ignored by the rule.

@barrywhart I realise this changes the behaviour that you added in https://github.com/sqlfluff/sqlfluff/pull/918, so I'm interested for your thoughts. For us to keep the behaviour you added and be able to ignore the statement if it contains a templated section we'll need to add additional functionality to the ignore_templated_areas logic.

I've had to remove the dbt017-py38 tests due to an incompability with dbt utils 0.6.3 which was throwing the following error as a result of https://getdbt.slack.com/archives/C2JRRQDTL/p1610568190132200: 
```
sqlfluff.core.errors.SQLTemplaterError: dbt compilation error on file 'models/my_new_project/L034_test.sql', 'dbt.context.providers.ParseDatabaseWrapper object' has no attribute 'dispatch'
```