### PR TITLE
Update sqlfluff online links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Contributors:
 - Fix bug [#1083](https://github.com/sqlfluff/sqlfluff/issues/1083), adding
   support for BigQuery named function arguments, used with functions such as
   [ST_GEOGFROMGEOJSON()](https://cloud.google.com/bigquery/docs/reference/standard-sql/geography_functions#st_geogfromgeojson)
+- Update documentation links to sqlfluff-online.
 
 ## [0.6.0a1] - 2021-05-15
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ L:   1 | P:  14 | L006 | Operators should be surrounded by a single space unless
 L:   1 | P:  27 | L001 | Unnecessary trailing whitespace
 ```
 
-You can also have a play using [SQLFluff online](https://sqlfluff-online.herokuapp.com/).
+You can also have a play using [SQLFluff online](https://online.sqlfluff.com/).
 
 For full CLI usage and rules reference, see the docs.
 

--- a/docs/source/teamrollout.rst
+++ b/docs/source/teamrollout.rst
@@ -108,7 +108,7 @@ the `SQLFluff VSCode plugin`_ or `SQLFluff online formatter`_.
 
 .. _`SQLFluff pre-commit hook`: https://github.com/sqlfluff/sqlfluff-github-actions
 .. _`SQLFluff VSCode plugin`: https://github.com/sqlfluff/vscode-sqlfluff
-.. _`SQLFluff online formatter`: https://sqlfluff-online.herokuapp.com/
+.. _`SQLFluff online formatter`: https://online.sqlfluff.com/
 
 4. Do, Review & Reassess
 ------------------------


### PR DESCRIPTION
Quick docs update given a pending change to the sqlfluff-online deployment: https://github.com/sqlfluff/sqlfluff-online/pull/24

The app is currently live at https://online.sqlfluff.com/, and when that PR merges it will auto deploy to GCP which points to the right spot.