### PR TITLE
Add SET SCHEMA and DROP SCHEMA support to ANSI dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Respect XDG base dirs on Mac OS ([#889](https://github.com/sqlfluff/sqlfluff/issues/889)).
 - Fix bug [#1082](https://github.com/sqlfluff/sqlfluff/issues/1082), adding
   support for BigQuery `select as struct '1' as bb, 2 as aa` syntax
+- Fix bug [#1080](https://github.com/sqlfluff/sqlfluff/issues/1080), add
+  SET SCHEMA and DROP SCHEMA support to ANSI dialect.
 
 Contributors:
 - [@GitHub-Username](Link to GitHub profile) ([#PR-Number](Link to PR))

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2047,6 +2047,32 @@ class CreateSchemaStatementSegment(BaseSegment):
 
 
 @ansi_dialect.segment()
+class SetSchemaStatementSegment(BaseSegment):
+    """A `SET SCHEMA` statement."""
+
+    type = "set_schema_statement"
+    match_grammar = Sequence(
+        "SET",
+        "SCHEMA",
+        Ref("IfNotExistsGrammar", optional=True),
+        Ref("SchemaReferenceSegment"),
+    )
+
+
+@ansi_dialect.segment()
+class DropSchemaStatementSegment(BaseSegment):
+    """A `DROP SCHEMA` statement."""
+
+    type = "drop_schema_statement"
+    match_grammar = Sequence(
+        "DROP",
+        "SCHEMA",
+        Ref("IfNotExistsGrammar", optional=True),
+        Ref("SchemaReferenceSegment"),
+    )
+
+
+@ansi_dialect.segment()
 class CreateDatabaseStatementSegment(BaseSegment):
     """A `CREATE DATABASE` statement."""
 
@@ -2719,6 +2745,8 @@ class StatementSegment(BaseSegment):
         Ref("CreateRoleStatementSegment"),
         Ref("AlterTableStatementSegment"),
         Ref("CreateSchemaStatementSegment"),
+        Ref("SetSchemaStatementSegment"),
+        Ref("DropSchemaStatementSegment"),
         Ref("CreateDatabaseStatementSegment"),
         Ref("CreateExtensionStatementSegment"),
         Ref("CreateIndexStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -662,7 +662,7 @@ class AlterVirtualSchemaStatementSegment(BaseSegment):
     )
 
 
-@exasol_dialect.segment()
+@exasol_dialect.segment(replace=True)
 class DropSchemaStatementSegment(BaseSegment):
     """A `DROP` statement for EXASOL schema.
 

--- a/test/fixtures/parser/ansi/drop_schema_a.sql
+++ b/test/fixtures/parser/ansi/drop_schema_a.sql
@@ -1,0 +1,1 @@
+drop schema my_schema

--- a/test/fixtures/parser/ansi/drop_schema_a.yml
+++ b/test/fixtures/parser/ansi/drop_schema_a.yml
@@ -1,0 +1,7 @@
+file:
+  statement:
+    drop_schema_statement:
+    - keyword: drop
+    - keyword: schema
+    - schema_reference:
+        identifier: my_schema

--- a/test/fixtures/parser/ansi/set_schema_a.sql
+++ b/test/fixtures/parser/ansi/set_schema_a.sql
@@ -1,0 +1,1 @@
+set schema my_schema

--- a/test/fixtures/parser/ansi/set_schema_a.yml
+++ b/test/fixtures/parser/ansi/set_schema_a.yml
@@ -1,0 +1,7 @@
+file:
+  statement:
+    set_schema_statement:
+    - keyword: set
+    - keyword: schema
+    - schema_reference:
+        identifier: my_schema


### PR DESCRIPTION
I have added SET SCHEMA and DROP SCHEMA support to ANSI dialect. The bug was originally opened for Postgres, but I noticed that it is supported by ANSI (and CREATE SCHEMA was already added there actually).

Closes #1080