### PR TITLE
Bigquery procedural statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -26,8 +26,7 @@ from sqlfluff.core.parser import (
     StringParser,
     RegexParser,
     Nothing,
-    StartsWith,
-    GreedyUntil
+    StartsWith
 )
 
 from sqlfluff.core.dialects import load_raw_dialect

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -527,7 +527,7 @@ class BeginStatementSegment(BaseSegment):
     Scripting BEGIN and END statement with embedded error handling https://cloud.google.com/bigquery/docs/reference/standard-sql/scripting#begin
     """
     type = "begin_statement"
-    match_grammar = StartsWith(Ref.keyword("BEGIN"), terminator="END")
-    parse_grammar = Sequence(Ref.keyword("BEGIN"), Delimited(Ref("StatementSegment"), delimiter=Ref("SemicolonSegment")))
+    match_grammar = StartsWith(Ref.keyword("BEGIN"), terminator=Sequence("END", Ref("SemicolonSegment")))
+    parse_grammar = Sequence(Ref.keyword("BEGIN"), Delimited(Ref("StatementSegment")))
 
 


### PR DESCRIPTION
This Pull Request is being created in order to get help with debugging. It is by no means ready to be approved.

The changes to the dialect_bigquery.sql are addressing [this issue](https://github.com/sqlfluff/sqlfluff/issues/1127).

The two changes I have made are for `DECLARE` statements and for `BEGIN` statements. I have so far been happy with how the declare statement is behaving while parsing that sort of statement.

I am very stuck on the parsing for `BEGIN`.

I have been using this simple, valid Bigquery SQL Script for debugging:
```sql
BEGIN
SELECT 1;
SELECT 2;
END;
```

The Begin statement should encapsulate the entirety of the begin and end and include both SQL statements, but due to the semi-colon, the begin statement is terminating after that first SELECT. I have tried a couple of other ways to address this problem in the python, but still run into the semi-colon problem.

sqlfluff parse file --dialect=bigquery output:

```
[L:  1, P:  1]      |file:
[L:  1, P:  1]      |    statement:
[L:  1, P:  1]      |        begin_statement:
[L:  1, P:  1]      |            keyword:                                          'Begin'
[L:  1, P:  6]      |            newline:                                          '\n'
[L:  2, P:  1]      |            statement:
[L:  2, P:  1]      |                select_statement:
[L:  2, P:  1]      |                    select_clause:
[L:  2, P:  1]      |                        keyword:                              'SELECT'
[L:  2, P:  7]      |                        [META] indent:
[L:  2, P:  7]      |                        whitespace:                           ' '
[L:  2, P:  8]      |                        select_clause_element:
[L:  2, P:  8]      |                            literal:                          '2'
[L:  2, P:  9]      |                    [META] dedent:
[L:  2, P:  9]      |    statement_terminator:                                     ';'
[L:  2, P: 10]      |    newline:                                                  '\n'
[L:  3, P:  1]      |    statement:
[L:  3, P:  1]      |        select_statement:
[L:  3, P:  1]      |            select_clause:
[L:  3, P:  1]      |                keyword:                                      'SELECT'
[L:  3, P:  7]      |                [META] indent:
[L:  3, P:  7]      |                whitespace:                                   ' '
[L:  3, P:  8]      |                select_clause_element:
[L:  3, P:  8]      |                    literal:                                  '1'
[L:  3, P:  9]      |            [META] dedent:
[L:  3, P:  9]      |    statement_terminator:                                     ';'
[L:  3, P: 10]      |    newline:                                                  '\n'
[L:  4, P:  1]      |    statement:
[L:  4, P:  1]      |        transaction_statement:
[L:  4, P:  1]      |            keyword:                                          'END'
[L:  4, P:  4]      |    statement_terminator:                                     ';'
[L:  4, P:  5]      |    newline:                                                  '\n'

```
