### PR TITLE
Add cursor syntax to mysql dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for cursor syntax specific to mysql dialect [#1145](https://github.com/sqlfluff/sqlfluff/pull/1145)
 - Support sequential shorthand casts [#1178](https://github.com/sqlfluff/sqlfluff/pull/1178)
 - Support for select statement syntax specific to mysql dialect [#1175](https://github.com/sqlfluff/sqlfluff/issues/1175)
 - Support for the CALL statement for the mysql dialect [#1144](https://github.com/sqlfluff/sqlfluff/issues/1144)

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -287,6 +287,8 @@ class StatementSegment(ansi_dialect.get_segment("StatementSegment")):  # type: i
             Ref("SetAssignmentStatementSegment"),
             Ref("IfExpressionStatement"),
             Ref("CallStoredProcedureSegment"),
+            Ref("CursorOpenCloseSegment"),
+            Ref("CursorFetchSegment"),
         ],
     )
 
@@ -549,40 +551,46 @@ class IntoClauseSegment(BaseSegment):
                     Ref("SessionVariableNameSegment"),
                     Ref("LocalVariableNameSegment"),
                 ),
-            ),
-            Sequence("DUMPFILE", Ref("QuotedLiteralSegment")),
-            Sequence(
-                "OUTFILE",
-                Ref("QuotedLiteralSegment"),
+                Sequence("DUMPFILE", Ref("QuotedLiteralSegment")),
                 Sequence(
-                    "CHARACTER", "SET", Ref("NakedIdentifierSegment"), optional=True
-                ),
-                Sequence(
-                    OneOf("FIELDS", "COLUMNS"),
+                    "OUTFILE",
+                    Ref("QuotedLiteralSegment"),
                     Sequence(
-                        "TERMINATED", "BY", Ref("QuotedLiteralSegment"), optional=True
+                        "CHARACTER", "SET", Ref("NakedIdentifierSegment"), optional=True
                     ),
                     Sequence(
-                        Ref.keyword("OPTIONALLY", optional=True),
-                        "ENCLOSED",
-                        "BY",
-                        Ref("QuotedLiteralSegment"),
+                        OneOf("FIELDS", "COLUMNS"),
+                        Sequence(
+                            "TERMINATED",
+                            "BY",
+                            Ref("QuotedLiteralSegment"),
+                            optional=True,
+                        ),
+                        Sequence(
+                            Ref.keyword("OPTIONALLY", optional=True),
+                            "ENCLOSED",
+                            "BY",
+                            Ref("QuotedLiteralSegment"),
+                            optional=True,
+                        ),
+                        Sequence(
+                            "ESCAPED", "BY", Ref("QuotedLiteralSegment"), optional=True
+                        ),
                         optional=True,
                     ),
                     Sequence(
-                        "ESCAPED", "BY", Ref("QuotedLiteralSegment"), optional=True
+                        "LINES",
+                        Sequence(
+                            "STARTING", "BY", Ref("QuotedLiteralSegment"), optional=True
+                        ),
+                        Sequence(
+                            "TERMINATED",
+                            "BY",
+                            Ref("QuotedLiteralSegment"),
+                            optional=True,
+                        ),
+                        optional=True,
                     ),
-                    optional=True,
-                ),
-                Sequence(
-                    "LINES",
-                    Sequence(
-                        "STARTING", "BY", Ref("QuotedLiteralSegment"), optional=True
-                    ),
-                    Sequence(
-                        "TERMINATED", "BY", Ref("QuotedLiteralSegment"), optional=True
-                    ),
-                    optional=True,
                 ),
             ),
         ),
@@ -760,4 +768,44 @@ class SelectPartitionClauseSegment(BaseSegment):
     match_grammar = Sequence(
         "PARTITION",
         Bracketed(Delimited(Ref("ObjectReferenceSegment"))),
+    )
+
+
+@mysql_dialect.segment()
+class CursorOpenCloseSegment(BaseSegment):
+    """This is a CLOSE or Open statement.
+
+    https://dev.mysql.com/doc/refman/8.0/en/close.html
+    https://dev.mysql.com/doc/refman/8.0/en/open.html
+    """
+
+    type = "cursor_open_close_segment"
+
+    match_grammar = Sequence(
+        OneOf("CLOSE", "OPEN"),
+        OneOf(
+            Ref("SingleIdentifierGrammar"),
+            Ref("QuotedIdentifierSegment"),
+        ),
+    )
+
+
+@mysql_dialect.segment()
+class CursorFetchSegment(BaseSegment):
+    """This is a FETCH statement.
+
+    https://dev.mysql.com/doc/refman/8.0/en/fetch.html
+    """
+
+    type = "cursor_fetch_segment"
+
+    match_grammar = Sequence(
+        "FETCH",
+        Sequence(Ref.keyword("NEXT", optional=True), "FROM", optional=True),
+        Ref("NakedIdentifierSegment"),
+        "INTO",
+        Delimited(
+            Ref("SessionVariableNameSegment"),
+            Ref("LocalVariableNameSegment"),
+        ),
     )

--- a/test/fixtures/parser/mysql/close.sql
+++ b/test/fixtures/parser/mysql/close.sql
@@ -1,0 +1,1 @@
+CLOSE curcursor;

--- a/test/fixtures/parser/mysql/close.yml
+++ b/test/fixtures/parser/mysql/close.yml
@@ -1,0 +1,6 @@
+file:
+  statement:
+    cursor_open_close_segment:
+      keyword: CLOSE
+      identifier: curcursor
+  statement_terminator: ;

--- a/test/fixtures/parser/mysql/close_qualified.sql
+++ b/test/fixtures/parser/mysql/close_qualified.sql
@@ -1,0 +1,1 @@
+CLOSE `curcursor`;

--- a/test/fixtures/parser/mysql/close_qualified.yml
+++ b/test/fixtures/parser/mysql/close_qualified.yml
@@ -1,0 +1,6 @@
+file:
+  statement:
+    cursor_open_close_segment:
+      keyword: CLOSE
+      identifier: '`curcursor`'
+  statement_terminator: ;

--- a/test/fixtures/parser/mysql/fetch.sql
+++ b/test/fixtures/parser/mysql/fetch.sql
@@ -1,0 +1,1 @@
+fetch curcursor into test;

--- a/test/fixtures/parser/mysql/fetch.yml
+++ b/test/fixtures/parser/mysql/fetch.yml
@@ -1,0 +1,8 @@
+file:
+  statement:
+    cursor_fetch_segment:
+    - keyword: fetch
+    - identifier: curcursor
+    - keyword: into
+    - variable: test
+  statement_terminator: ;

--- a/test/fixtures/parser/mysql/fetch_from.sql
+++ b/test/fixtures/parser/mysql/fetch_from.sql
@@ -1,0 +1,1 @@
+fetch from curcursor into test;

--- a/test/fixtures/parser/mysql/fetch_from.yml
+++ b/test/fixtures/parser/mysql/fetch_from.yml
@@ -1,0 +1,9 @@
+file:
+  statement:
+    cursor_fetch_segment:
+    - keyword: fetch
+    - keyword: from
+    - identifier: curcursor
+    - keyword: into
+    - variable: test
+  statement_terminator: ;

--- a/test/fixtures/parser/mysql/fetch_multiple.sql
+++ b/test/fixtures/parser/mysql/fetch_multiple.sql
@@ -1,0 +1,1 @@
+fetch curcursor into test, test2;

--- a/test/fixtures/parser/mysql/fetch_multiple.yml
+++ b/test/fixtures/parser/mysql/fetch_multiple.yml
@@ -1,0 +1,10 @@
+file:
+  statement:
+    cursor_fetch_segment:
+    - keyword: fetch
+    - identifier: curcursor
+    - keyword: into
+    - variable: test
+    - comma: ','
+    - variable: test2
+  statement_terminator: ;

--- a/test/fixtures/parser/mysql/fetch_next_from.sql
+++ b/test/fixtures/parser/mysql/fetch_next_from.sql
@@ -1,0 +1,1 @@
+fetch next from curcursor into test;

--- a/test/fixtures/parser/mysql/fetch_next_from.yml
+++ b/test/fixtures/parser/mysql/fetch_next_from.yml
@@ -1,0 +1,10 @@
+file:
+  statement:
+    cursor_fetch_segment:
+    - keyword: fetch
+    - keyword: next
+    - keyword: from
+    - identifier: curcursor
+    - keyword: into
+    - variable: test
+  statement_terminator: ;

--- a/test/fixtures/parser/mysql/fetch_session.sql
+++ b/test/fixtures/parser/mysql/fetch_session.sql
@@ -1,0 +1,1 @@
+fetch curcursor into @test;

--- a/test/fixtures/parser/mysql/fetch_session.yml
+++ b/test/fixtures/parser/mysql/fetch_session.yml
@@ -1,0 +1,8 @@
+file:
+  statement:
+    cursor_fetch_segment:
+    - keyword: fetch
+    - identifier: curcursor
+    - keyword: into
+    - variable: '@test'
+  statement_terminator: ;

--- a/test/fixtures/parser/mysql/fetch_session_multiple.sql
+++ b/test/fixtures/parser/mysql/fetch_session_multiple.sql
@@ -1,0 +1,1 @@
+fetch curcursor into @test, @test2;

--- a/test/fixtures/parser/mysql/fetch_session_multiple.yml
+++ b/test/fixtures/parser/mysql/fetch_session_multiple.yml
@@ -1,0 +1,10 @@
+file:
+  statement:
+    cursor_fetch_segment:
+    - keyword: fetch
+    - identifier: curcursor
+    - keyword: into
+    - variable: '@test'
+    - comma: ','
+    - variable: '@test2'
+  statement_terminator: ;

--- a/test/fixtures/parser/mysql/open.sql
+++ b/test/fixtures/parser/mysql/open.sql
@@ -1,0 +1,1 @@
+open curcursor;

--- a/test/fixtures/parser/mysql/open.yml
+++ b/test/fixtures/parser/mysql/open.yml
@@ -1,0 +1,6 @@
+file:
+  statement:
+    cursor_open_close_segment:
+      keyword: open
+      identifier: curcursor
+  statement_terminator: ;

--- a/test/fixtures/parser/mysql/open_qualified.sql
+++ b/test/fixtures/parser/mysql/open_qualified.sql
@@ -1,0 +1,1 @@
+open `curcursor`;

--- a/test/fixtures/parser/mysql/open_qualified.yml
+++ b/test/fixtures/parser/mysql/open_qualified.yml
@@ -1,0 +1,6 @@
+file:
+  statement:
+    cursor_open_close_segment:
+      keyword: open
+      identifier: '`curcursor`'
+  statement_terminator: ;


### PR DESCRIPTION
Added syntax for cursors and made a revision to the `IntoClauseSegment` that was discovered when working on the cursor statement syntax that also uses the `INTO` keyword.
Resolves #1145 