### PR TITLE
Add TRUNCATE to ANSI Dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for TRUNCATE statement [#1194](https://github.com/sqlfluff/sqlfluff/pull/1194)
 - Support for GET DIAGNOSTICS statement syntax specific to mysql dialect [#1148](https://github.com/sqlfluff/sqlfluff/issues/1148)
 - Support for cursor syntax specific to mysql dialect [#1145](https://github.com/sqlfluff/sqlfluff/pull/1145)
 - Support sequential shorthand casts [#1178](https://github.com/sqlfluff/sqlfluff/pull/1178)

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2275,7 +2275,7 @@ class DropStatementSegment(BaseSegment):
 
 
 @ansi_dialect.segment()
-class TruncateStatmentSegement(BaseSegment):
+class TruncateStatementSegment(BaseSegment):
     """`TRUNCATE TABLE` statement."""
 
     type = "truncate_table"
@@ -2812,7 +2812,7 @@ class StatementSegment(BaseSegment):
         Ref("InsertStatementSegment"),
         Ref("TransactionStatementSegment"),
         Ref("DropStatementSegment"),
-        Ref("TruncateStatmentSegement"),
+        Ref("TruncateStatementSegment"),
         Ref("AlterDefaultPrivilegesSegment"),
         Ref("AccessStatementSegment"),
         Ref("CreateTableStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2273,6 +2273,7 @@ class DropStatementSegment(BaseSegment):
         OneOf("RESTRICT", Ref.keyword("CASCADE", optional=True), optional=True),
     )
 
+
 @ansi_dialect.segment()
 class TruncateStatmentSegement(BaseSegment):
     """`TRUNCATE TABLE` statement."""
@@ -2284,6 +2285,7 @@ class TruncateStatmentSegement(BaseSegment):
         Ref.keyword("TABLE", optional=True),
         Ref("TableReferenceSegment"),
     )
+
 
 @ansi_dialect.segment()
 class DropIndexStatementSegment(BaseSegment):

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2273,6 +2273,17 @@ class DropStatementSegment(BaseSegment):
         OneOf("RESTRICT", Ref.keyword("CASCADE", optional=True), optional=True),
     )
 
+@ansi_dialect.segment()
+class TruncateStatmentSegement(BaseSegment):
+    """`TRUNCATE TABLE` statement."""
+
+    type = "truncate_table"
+
+    match_grammar = Sequence(
+        "TRUNCATE",
+        Ref.keyword("TABLE", optional=True),
+        Ref("TableReferenceSegment"),
+    )
 
 @ansi_dialect.segment()
 class DropIndexStatementSegment(BaseSegment):
@@ -2799,6 +2810,7 @@ class StatementSegment(BaseSegment):
         Ref("InsertStatementSegment"),
         Ref("TransactionStatementSegment"),
         Ref("DropStatementSegment"),
+        Ref("TruncateStatmentSegement"),
         Ref("AlterDefaultPrivilegesSegment"),
         Ref("AccessStatementSegment"),
         Ref("CreateTableStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -1536,7 +1536,7 @@ class DeleteStatementSegment(BaseSegment):
 # TRUNCATE
 ############################
 @exasol_dialect.segment(replace=True)
-class TruncateStatmentSegement(BaseSegment):
+class TruncateStatementSegment(BaseSegment):
     """`TRUNCATE TABLE` statement.
 
     https://docs.exasol.com/sql/truncate.htm
@@ -2554,7 +2554,7 @@ class StatementSegment(BaseSegment):
         Ref("ImportStatementSegment"),
         Ref("InsertStatementSegment"),
         Ref("MergeStatementSegment"),
-        Ref("TruncateStatmentSegement"),
+        Ref("TruncateStatementSegment"),
         Ref("UpdateStatementSegment"),
         # Data Definition Language (DDL)
         Ref("AlterTableStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -1535,7 +1535,7 @@ class DeleteStatementSegment(BaseSegment):
 ############################
 # TRUNCATE
 ############################
-@exasol_dialect.segment()
+@exasol_dialect.segment(replace=True)
 class TruncateStatmentSegement(BaseSegment):
     """`TRUNCATE TABLE` statement.
 

--- a/test/dialects/ansi_test.py
+++ b/test/dialects/ansi_test.py
@@ -114,6 +114,8 @@ def test__dialect__ansi__file_lex(raw, res, caplog):
         # Shorthand casting
         ("ExpressionSegment", "NULL::INT"),
         ("SelectClauseElementSegment", "NULL::INT AS user_id"),
+        ("TruncateStatmentSegement", "TRUNCATE TABLE test"),
+        ("TruncateStatmentSegement", "TRUNCATE test"),
     ],
 )
 def test__dialect__ansi_specific_segment_parses(

--- a/test/dialects/ansi_test.py
+++ b/test/dialects/ansi_test.py
@@ -114,8 +114,8 @@ def test__dialect__ansi__file_lex(raw, res, caplog):
         # Shorthand casting
         ("ExpressionSegment", "NULL::INT"),
         ("SelectClauseElementSegment", "NULL::INT AS user_id"),
-        ("TruncateStatmentSegement", "TRUNCATE TABLE test"),
-        ("TruncateStatmentSegement", "TRUNCATE test"),
+        ("TruncateStatementSegment", "TRUNCATE TABLE test"),
+        ("TruncateStatementSegment", "TRUNCATE test"),
     ],
 )
 def test__dialect__ansi_specific_segment_parses(

--- a/test/dialects/exasol_test.py
+++ b/test/dialects/exasol_test.py
@@ -260,7 +260,7 @@ def test_dialect_exasol_specific_segment_parses(
             3,
         ),
         (
-            "TruncateStatmentSegement",
+            "TruncateStatementSegment",
             """
             TRUNCATE TABLE test;
             """,

--- a/test/fixtures/parser/ansi/truncate_a.sql
+++ b/test/fixtures/parser/ansi/truncate_a.sql
@@ -1,0 +1,1 @@
+truncate a

--- a/test/fixtures/parser/ansi/truncate_a.yml
+++ b/test/fixtures/parser/ansi/truncate_a.yml
@@ -1,0 +1,6 @@
+file:
+  statement:
+    truncate_table:
+    - keyword: truncate
+    - table_reference:
+        identifier: a

--- a/test/fixtures/parser/ansi/truncate_table_a.sql
+++ b/test/fixtures/parser/ansi/truncate_table_a.sql
@@ -1,0 +1,1 @@
+truncate table a

--- a/test/fixtures/parser/ansi/truncate_table_a.yml
+++ b/test/fixtures/parser/ansi/truncate_table_a.yml
@@ -1,0 +1,7 @@
+file:
+  statement:
+    truncate_table:
+    - keyword: truncate
+    - keyword: table
+    - table_reference:
+        identifier: a


### PR DESCRIPTION
Adding support for the commonly implemented (but not strictly ANSI) `TRUNCATE TABLE` statement.