### PR TITLE
Normalise path tests for windows

### DIFF
--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -3,6 +3,7 @@
 import pytest
 import logging
 import os
+import os.path
 from typing import List
 from unittest.mock import patch
 
@@ -628,7 +629,8 @@ def test__linter__skip_dbt_model_disabled(project_dir):  # noqa
     # Check that the file is still there
     assert len(linted_path.files) == 1
     linted_file = linted_path.files[0]
-    assert linted_file.path == model_file_path
+    # Normalise paths to control for OS variance
+    assert os.path.normpath(linted_file.path) == os.path.normpath(model_file_path)
     assert not linted_file.templated_file
     assert not linted_file.tree
 

--- a/test/core/templaters/dbt_test.py
+++ b/test/core/templaters/dbt_test.py
@@ -40,7 +40,9 @@ def test__templater_dbt_profiles_dir_expanded(dbt_templater):  # noqa: F811
     )
     profiles_dir = dbt_templater._get_profiles_dir()
     # Normalise paths to control for OS variance
-    assert os.path.normpath(profiles_dir) == os.path.normpath(os.path.expanduser("~/.dbt"))
+    assert os.path.normpath(profiles_dir) == os.path.normpath(
+        os.path.expanduser("~/.dbt")
+    )
 
 
 @pytest.mark.parametrize(

--- a/test/core/templaters/dbt_test.py
+++ b/test/core/templaters/dbt_test.py
@@ -39,7 +39,8 @@ def test__templater_dbt_profiles_dir_expanded(dbt_templater):  # noqa: F811
         configs={"templater": {"dbt": {"profiles_dir": "~/.dbt"}}}
     )
     profiles_dir = dbt_templater._get_profiles_dir()
-    assert profiles_dir == os.path.expanduser("~/.dbt")
+    # Normalise paths to control for OS variance
+    assert os.path.normpath(profiles_dir) == os.path.normpath(os.path.expanduser("~/.dbt"))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Two of the dbt tests are failing on windows because of path normalisation. This addresses that and fixes both.