### PR TITLE
Add -p flag for fix command

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -441,6 +441,7 @@ def do_fixes(lnt, result, formatter=None, **kwargs):
     "--fixed-suffix", default=None, help="An optional suffix to add to fixed files."
 )
 @click.option(
+    "-p",
     "--processes",
     type=int,
     default=1,


### PR DESCRIPTION
## Reason
Currently, both `sqlfluff lint` and `sqlfluff fix` have the `--processes` flag but **only** `sqlfluff lint` has the shortened `-p` flag. 

## Solution
I've added the `-p` flag to the `click.option()` for `sqlfluff fix` to add consistency across both calls. 

-----------
I've read through the CONTRIBUTING.md and noted this statement in the **Maintainers** section: 
> That means for smaller changes and improvements they may review changes as individuals and merge them into the project in a very lightweight way.

Because of that line, I have not cloned and ran the `tox` commands. If this change requires me to do that, please let me know and I will run through the test for this enhancement #1229 