### PR TITLE
Add DETERMINISTIC support for BigQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 
+- Support for DETERMINISTIC user defined functions [#1251](https://github.com/sqlfluff/sqlfluff/issues/1251)
+
 ## [0.6.2] - 2021-07-22
 ### Added
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -220,6 +220,10 @@ class FunctionDefinitionGrammar(BaseSegment):
     match_grammar = Sequence(
         AnyNumberOf(
             Sequence(
+                OneOf("DETERMINISTIC", Sequence("NOT", "DETERMINISTIC")),
+                optional=True,
+            ),
+            Sequence(
                 "LANGUAGE",
                 # Not really a parameter, but best fit for now.
                 Ref("ParameterNameSegment"),

--- a/test/fixtures/parser/bigquery/create_js_function_deterministic.sql
+++ b/test/fixtures/parser/bigquery/create_js_function_deterministic.sql
@@ -1,0 +1,7 @@
+CREATE FUNCTION
+qs(
+    y STRING
+)
+DETERMINISTIC
+LANGUAGE js
+AS " return y; "

--- a/test/fixtures/parser/bigquery/create_js_function_deterministic.yml
+++ b/test/fixtures/parser/bigquery/create_js_function_deterministic.yml
@@ -1,0 +1,20 @@
+file:
+  statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: qs
+    - base:
+        bracketed:
+          start_bracket: (
+          parameter: y
+          data_type:
+            data_type_identifier: STRING
+          end_bracket: )
+    - base:
+      - keyword: DETERMINISTIC
+      - keyword: LANGUAGE
+      - parameter: js
+      - keyword: AS
+      - literal: '" return y; "'


### PR DESCRIPTION
Fixes #1251 

Note technically this is only supported for `LANGUAGE js` but so is `OPTIONS` and it wasn't restricted when it was implemented, so I kept this simple and did the same for this.