### PR TITLE
Support COUNT(0) preference over COUNT(*) or COUNT(1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support more identifiers in BigQuery dialect [#1253](https://github.com/sqlfluff/sqlfluff/issues/1253)
 - Support function member field references in BigQuery dialect [#1255](https://github.com/sqlfluff/sqlfluff/issues/1255)
 - Support alternative indentation for USING and ON clauses [#1250](https://github.com/sqlfluff/sqlfluff/issues/1250)
+- Support COUNT(0) preference over COUNT(*) or COUNT(1) [#1260](https://github.com/sqlfluff/sqlfluff/issues/1260)
 
 ## [0.6.2] - 2021-07-22
 ### Added

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -74,3 +74,4 @@ forbid_subquery_in = join
 
 [sqlfluff:rules:L047]  # Consistent syntax to count all rows
 prefer_count_1 = False
+prefer_count_0 = False

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -84,7 +84,11 @@ STANDARD_CONFIG_INFO_DICT = {
     },
     "prefer_count_1": {
         "validation": [True, False],
-        "definition": ("Should count(1) be preferred over count(*)?"),
+        "definition": ("Should count(1) be preferred over count(*) and count(0)?"),
+    },
+    "prefer_count_0": {
+        "validation": [True, False],
+        "definition": ("Should count(0) be preferred over count(*) and count(1)?"),
     },
 }
 

--- a/src/sqlfluff/rules/L047.py
+++ b/src/sqlfluff/rules/L047.py
@@ -82,82 +82,36 @@ class Rule_L047(BaseRule):
             if len(f_content) != 1:
                 return None
 
-            if self.prefer_count_1 and f_content[0].is_type("star"):
-                return LintResult(
-                    anchor=segment,
-                    fixes=[
-                        LintFix(
-                            "edit",
-                            f_content[0],
-                            f_content[0].edit(f_content[0].raw.replace("*", "1")),
-                        ),
-                    ],
-                )
-            elif self.prefer_count_1 and f_content[0].is_type("expression"):
-                expression_content = [
-                    seg for seg in f_content[0].segments if not seg.is_meta
-                ]
-                if (
-                    len(expression_content) == 1
-                    and expression_content[0].is_type("literal")
-                    and expression_content[0].raw == "0"
-                ):
-                    return LintResult(
-                        anchor=segment,
-                        fixes=[
-                            LintFix(
-                                "edit",
-                                expression_content[0],
-                                expression_content[0].edit(
-                                    expression_content[0].raw.replace("0", "1")
-                                ),
-                            ),
-                        ],
-                    )
-            elif self.prefer_count_0 and f_content[0].is_type("star"):
-                return LintResult(
-                    anchor=segment,
-                    fixes=[
-                        LintFix(
-                            "edit",
-                            f_content[0],
-                            f_content[0].edit(f_content[0].raw.replace("*", "0")),
-                        ),
-                    ],
-                )
-            elif self.prefer_count_0 and f_content[0].is_type("expression"):
-                expression_content = [
-                    seg for seg in f_content[0].segments if not seg.is_meta
-                ]
-                if (
-                    len(expression_content) == 1
-                    and expression_content[0].is_type("literal")
-                    and expression_content[0].raw == "1"
-                ):
-                    return LintResult(
-                        anchor=segment,
-                        fixes=[
-                            LintFix(
-                                "edit",
-                                expression_content[0],
-                                expression_content[0].edit(
-                                    expression_content[0].raw.replace("1", "0")
-                                ),
-                            ),
-                        ],
-                    )
-            elif (
-                not self.prefer_count_1
-                and not self.prefer_count_0
-                and f_content[0].is_type("expression")
+            preferred = "*"
+            if self.prefer_count_1:
+                preferred = "1"
+            elif self.prefer_count_0:
+                preferred = "0"
+
+            if f_content[0].is_type("star") and (
+                self.prefer_count_1 or self.prefer_count_0
             ):
+                return LintResult(
+                    anchor=segment,
+                    fixes=[
+                        LintFix(
+                            "edit",
+                            f_content[0],
+                            f_content[0].edit(f_content[0].raw.replace("*", preferred)),
+                        ),
+                    ],
+                )
+
+            if f_content[0].is_type("expression"):
                 expression_content = [
                     seg for seg in f_content[0].segments if not seg.is_meta
                 ]
+
                 if (
                     len(expression_content) == 1
                     and expression_content[0].is_type("literal")
-                    and expression_content[0].raw == "1"
+                    and expression_content[0].raw in ["0", "1"]
+                    and expression_content[0].raw != preferred
                 ):
                     return LintResult(
                         anchor=segment,
@@ -166,24 +120,9 @@ class Rule_L047(BaseRule):
                                 "edit",
                                 expression_content[0],
                                 expression_content[0].edit(
-                                    expression_content[0].raw.replace("1", "*")
-                                ),
-                            ),
-                        ],
-                    )
-                elif (
-                    len(expression_content) == 1
-                    and expression_content[0].is_type("literal")
-                    and expression_content[0].raw == "0"
-                ):
-                    return LintResult(
-                        anchor=segment,
-                        fixes=[
-                            LintFix(
-                                "edit",
-                                expression_content[0],
-                                expression_content[0].edit(
-                                    expression_content[0].raw.replace("0", "*")
+                                    expression_content[0].raw.replace(
+                                        expression_content[0].raw, preferred
+                                    )
                                 ),
                             ),
                         ],

--- a/src/sqlfluff/rules/L047.py
+++ b/src/sqlfluff/rules/L047.py
@@ -14,7 +14,7 @@ class Rule_L047(BaseRule):
 
     Note:
         If both `prefer_count_1` and `prefer_count_0` are set to true
-        then `prefer_count_1` has preference.
+        then `prefer_count_1` has precedence.
 
     COUNT(*), COUNT(1), and even COUNT(0) are equivalent syntaxes in many SQL
     engines due to optimizers interpreting these instructions as

--- a/test/fixtures/rules/std_rule_cases/L047.yml
+++ b/test/fixtures/rules/std_rule_cases/L047.yml
@@ -23,6 +23,71 @@ passes_on_count_1:
       L047:
         prefer_count_1: True
 
+changes_count_0_to_count_star:
+  fail_str: |
+    select
+        foo,
+        count(0)
+    from my_table
+    group by
+      foo
+
+  fix_str: |
+    select
+        foo,
+        count(*)
+    from my_table
+    group by
+      foo
+
+passes_on_count_0:
+  pass_str: |
+    select
+        foo,
+        count(0)
+    from my_table
+    group by
+      foo
+
+  configs: &prefer_count_0
+    rules:
+      L047:
+        prefer_count_0: True
+
+passes_on_count_1_if_both_present:
+  pass_str: |
+    select
+        foo,
+        count(1)
+    from my_table
+    group by
+      foo
+
+  configs: &prefer_both
+    rules:
+      L047:
+        prefer_count_0: True
+        prefer_count_1: True
+
+changes_to_count_1_if_both_present:
+  fail_str: |
+    select
+        foo,
+        count(*)
+    from my_table
+    group by
+      foo
+
+  fix_str: |
+    select
+        foo,
+        count(1)
+    from my_table
+    group by
+      foo
+
+  configs: *prefer_both
+
 changes_count_1_to_count_star:
   fail_str: |
     select
@@ -57,6 +122,25 @@ handles_whitespaces:
     group by
       foo
 
+changes_count_star_to_count_0:
+  fail_str: |
+    select
+        foo,
+        count(*)
+    from my_table
+    group by
+      foo
+
+  fix_str: |
+    select
+        foo,
+        count(0)
+    from my_table
+    group by
+      foo
+
+  configs: *prefer_count_0
+
 changes_count_star_to_count_1:
   fail_str: |
     select
@@ -74,7 +158,7 @@ changes_count_star_to_count_1:
     group by
       foo
 
-  configs: *prefer_count_1
+  configs:  *prefer_count_1
 
 changes_count_star_to_count_1_handle_new_line:
   fail_str: |

--- a/test/fixtures/rules/std_rule_cases/L047.yml
+++ b/test/fixtures/rules/std_rule_cases/L047.yml
@@ -160,6 +160,44 @@ changes_count_star_to_count_1:
 
   configs: *prefer_count_1
 
+changes_count_1_to_count_0:
+  fail_str: |
+    select
+        foo,
+        count(1)
+    from my_table
+    group by
+      foo
+
+  fix_str: |
+    select
+        foo,
+        count(0)
+    from my_table
+    group by
+      foo
+
+  configs: *prefer_count_0
+
+changes_count_0_to_count_1:
+  fail_str: |
+    select
+        foo,
+        count(0)
+    from my_table
+    group by
+      foo
+
+  fix_str: |
+    select
+        foo,
+        count(1)
+    from my_table
+    group by
+      foo
+
+  configs: *prefer_count_1
+
 changes_count_star_to_count_1_handle_new_line:
   fail_str: |
     select

--- a/test/fixtures/rules/std_rule_cases/L047.yml
+++ b/test/fixtures/rules/std_rule_cases/L047.yml
@@ -158,7 +158,7 @@ changes_count_star_to_count_1:
     group by
       foo
 
-  configs:  *prefer_count_1
+  configs: *prefer_count_1
 
 changes_count_star_to_count_1_handle_new_line:
   fail_str: |


### PR DESCRIPTION
Fixes #1260 

I've gone with the simpler option of two separate configs to avoid breaking backwards compatibility. So you can have:

```yml
prefer_count_1: True
```

or:

```yml
prefer_count_0: True
```

And if both are specified:
```yml
prefer_count_1: True
prefer_count_0: True
```

Then `prefer_count_1` takes precedence (no matter what order they are specified in).

As I say, ideally you'd not be able to have contradictory params like this, so let me know if you think we should introduce a breaking change here instead.

Barry

P.S. I swear I'm not trying to annoy you @barrywhart - I just seem to get each next PR finished just at the exact same time as you merge the last one! 😁