### PR TITLE
Add wildcard support for function fields access in BigQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support alternative indentation for USING and ON clauses [#1250](https://github.com/sqlfluff/sqlfluff/issues/1250)
 - Support COUNT(0) preference over COUNT(*) or COUNT(1) [#1260](https://github.com/sqlfluff/sqlfluff/issues/1260)
 - Support for BigQuery "CREATE table OPTIONS ( description = 'desc' )" [#1205](https://github.com/sqlfluff/sqlfluff/issues/1205)
+- Support wildcard member field references in BigQuery dialect [#](https://github.com/sqlfluff/sqlfluff/issues/)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support alternative indentation for USING and ON clauses [#1250](https://github.com/sqlfluff/sqlfluff/issues/1250)
 - Support COUNT(0) preference over COUNT(*) or COUNT(1) [#1260](https://github.com/sqlfluff/sqlfluff/issues/1260)
 - Support for BigQuery "CREATE table OPTIONS ( description = 'desc' )" [#1205](https://github.com/sqlfluff/sqlfluff/issues/1205)
-- Support wildcard member field references in BigQuery dialect [#](https://github.com/sqlfluff/sqlfluff/issues/)
+- Support wildcard member field references in BigQuery dialect [#1269](https://github.com/sqlfluff/sqlfluff/issues/1269)
 
 ### Changed
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -243,9 +243,16 @@ class FunctionSegment(BaseSegment):
                     ephemeral_name="FunctionContentsGrammar",
                 )
             ),
+            # Functions returning STRUCTs in BigQuery can have the fields
+            # elements referenced (e.g. ".a"), including wildcards (e.g. ".*")
+            # Note: we currently don't support field of fields (e.g. ".a.b", or ".a.b.c")
+            # But bad practice to use them directly, as can't guarantee they exist.
             Sequence(
                 Ref("DotSegment"),
-                Ref("ParameterNameSegment"),
+                OneOf(
+                    Ref("ParameterNameSegment"),
+                    Ref("StarSegment"),
+                ),
                 optional=True,
             ),
         ),

--- a/test/fixtures/parser/bigquery/select_function_object_field_wildcard.sql
+++ b/test/fixtures/parser/bigquery/select_function_object_field_wildcard.sql
@@ -1,0 +1,2 @@
+SELECT testFunction(a).*
+FROM table1

--- a/test/fixtures/parser/bigquery/select_function_object_field_wildcard.yml
+++ b/test/fixtures/parser/bigquery/select_function_object_field_wildcard.yml
@@ -1,0 +1,24 @@
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: testFunction
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: a
+              end_bracket: )
+            dot: .
+            star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: table1


### PR DESCRIPTION
A further enhancement to #1255 to allow wildcard support as well:

```sql
SELECT testFunction(a).*
FROM table1
```
