### PR TITLE
Support OFFSET and ORDINAL clauses of Array Functions in BigQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support wildcard member field references in BigQuery dialect [#1269](https://github.com/sqlfluff/sqlfluff/issues/1269)
 - Support ARRAYS of STRUCTs in BigQuery dialect [#1271](https://github.com/sqlfluff/sqlfluff/issues/1271)
 - Support fields of field references in BigQuery dialect [#1276](https://github.com/sqlfluff/sqlfluff/issues/1276)
+- Support OFFSET and ORDINAL clauses of Array Functions in BigQuery dialect [#1171](https://github.com/sqlfluff/sqlfluff/issues/1171)
+
 
 ### Changed
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -139,6 +139,7 @@ bigquery_dialect.sets("datetime_units").update(
 bigquery_dialect.sets("unreserved_keywords").add("SYSTEM_TIME")
 bigquery_dialect.sets("unreserved_keywords").remove("FOR")
 bigquery_dialect.sets("unreserved_keywords").add("STRUCT")
+bigquery_dialect.sets("unreserved_keywords").add("ORDINAL")
 # Reserved Keywords
 bigquery_dialect.sets("reserved_keywords").add("FOR")
 
@@ -259,6 +260,21 @@ class FunctionSegment(BaseSegment):
                     optional=True,
                     ephemeral_name="FunctionContentsGrammar",
                 )
+            ),
+            # Functions returning ARRYS in BigQuery can have optional
+            # OFFSET or ORDINAL clauses
+            Sequence(
+                Bracketed(
+                    OneOf(
+                        "OFFSET",
+                        "ORDINAL",
+                    ),
+                    Bracketed(
+                        Ref("NumericLiteralSegment"),
+                    ),
+                    bracket_type="square",
+                ),
+                optional=True,
             ),
             # Functions returning STRUCTs in BigQuery can have the fields
             # elements referenced (e.g. ".a"), including wildcards (e.g. ".*")

--- a/test/fixtures/parser/bigquery/select_function_object_fields.sql
+++ b/test/fixtures/parser/bigquery/select_function_object_fields.sql
@@ -2,5 +2,6 @@ SELECT
   testFunction(a).b AS field,
   testFunction(a).* AS wildcard,
   testFunction(a).b.c AS field_with_field,
-  testFunction(a).b.* AS field_with_wildcard
+  testFunction(a).b.* AS field_with_wildcard,
+  testFunction(a)[OFFSET(0)].* AS field_with_offset_wildcard
 FROM table1

--- a/test/fixtures/parser/bigquery/select_function_object_fields.sql
+++ b/test/fixtures/parser/bigquery/select_function_object_fields.sql
@@ -3,5 +3,6 @@ SELECT
   testFunction(a).* AS wildcard,
   testFunction(a).b.c AS field_with_field,
   testFunction(a).b.* AS field_with_wildcard,
-  testFunction(a)[OFFSET(0)].* AS field_with_offset_wildcard
+  testFunction(a)[OFFSET(0)].* AS field_with_offset_wildcard,
+  testFunction(a)[ORDINAL(1)].* AS field_with_ordinal_wildcard
 FROM table1

--- a/test/fixtures/parser/bigquery/select_function_object_fields.yml
+++ b/test/fixtures/parser/bigquery/select_function_object_fields.yml
@@ -93,6 +93,29 @@ file:
           alias_expression:
             keyword: AS
             identifier: field_with_offset_wildcard
+      - comma: ','
+      - select_clause_element:
+          function:
+          - function_name:
+              function_name_identifier: testFunction
+          - bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: a
+              end_bracket: )
+          - start_square_bracket: '['
+          - keyword: ORDINAL
+          - bracketed:
+              start_bracket: (
+              literal: '1'
+              end_bracket: )
+          - end_square_bracket: ']'
+          - dot: .
+          - star: '*'
+          alias_expression:
+            keyword: AS
+            identifier: field_with_ordinal_wildcard
       from_clause:
         keyword: FROM
         from_expression:

--- a/test/fixtures/parser/bigquery/select_function_object_fields.yml
+++ b/test/fixtures/parser/bigquery/select_function_object_fields.yml
@@ -70,6 +70,29 @@ file:
           alias_expression:
             keyword: AS
             identifier: field_with_wildcard
+      - comma: ','
+      - select_clause_element:
+          function:
+          - function_name:
+              function_name_identifier: testFunction
+          - bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: a
+              end_bracket: )
+          - start_square_bracket: '['
+          - keyword: OFFSET
+          - bracketed:
+              start_bracket: (
+              literal: '0'
+              end_bracket: )
+          - end_square_bracket: ']'
+          - dot: .
+          - star: '*'
+          alias_expression:
+            keyword: AS
+            identifier: field_with_offset_wildcard
       from_clause:
         keyword: FROM
         from_expression:


### PR DESCRIPTION
Fixes #1171 

Adds explicit support of [OFFSET and ORDINAL clauses](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#offset_and_ordinal) of Array Functions, which can then be further referenced by fields:

```sql
SELECT
  testFunction(a)[OFFSET(0)].* AS field_with_offset_wildcard
FROM table1
```
