### PR TITLE
Add fixture YAML generation checks

### DIFF
--- a/.github/workflows/check-yaml-files-generation.yml
+++ b/.github/workflows/check-yaml-files-generation.yml
@@ -11,8 +11,7 @@ jobs:
         python-version: '3.8'
     - name: Install dependencies
       run: |
-        pip install -Ur requirements.txt -Ur requirements_dev.txt
-        python setup.py develop
+        pip install -e -Ur requirements.txt -Ur requirements_dev.txt
     - name: Generate the YAML files
       run: |
         python test/generate_parse_fixture_yml.py
@@ -20,7 +19,7 @@ jobs:
       run: |
         if [ -n "$(git status --porcelain)" ]; then
           git diff
-          echo "Generated YAML files do no match branch."
+          echo "Generated YAML files do not match branch."
           echo "Please run the following command to generate these:"
           echo "  python test/generate_parse_fixture_yml.py"
           exit 1

--- a/.github/workflows/check-yaml-files-generation.yml
+++ b/.github/workflows/check-yaml-files-generation.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -Ur requirements.txt -Ur requirements_dev.txt
-        pip install -e
+        python setup.py develop
     - name: Generate the YAML files
       run: |
         python test/generate_parse_fixture_yml.py

--- a/.github/workflows/check-yaml-files-generation.yml
+++ b/.github/workflows/check-yaml-files-generation.yml
@@ -1,0 +1,27 @@
+name: "Check generated YAML files"
+on: pull_request
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        pip install -Ur requirements.txt -Ur requirements_dev.txt
+    - name: Generate the YAML files
+      run: |
+        python test/generate_parse_fixture_yml.py
+    - name: Generate the YAML files
+      run: |
+        if [ -n "$(git status --porcelain)" ]; then
+          git diff
+          echo "Generated YAML files do no match branch."
+          echo "Please run the following command to generate these:"
+          echo "  python test/generate_parse_fixture_yml.py"
+          exit 1
+        fi
+

--- a/.github/workflows/check-yaml-files-generation.yml
+++ b/.github/workflows/check-yaml-files-generation.yml
@@ -11,7 +11,8 @@ jobs:
         python-version: '3.8'
     - name: Install dependencies
       run: |
-        pip install -e -Ur requirements.txt -Ur requirements_dev.txt
+        pip install -Ur requirements.txt -Ur requirements_dev.txt
+        pip install -e
     - name: Generate the YAML files
       run: |
         python test/generate_parse_fixture_yml.py

--- a/.github/workflows/check-yaml-files-generation.yml
+++ b/.github/workflows/check-yaml-files-generation.yml
@@ -12,10 +12,11 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -Ur requirements.txt -Ur requirements_dev.txt
+        python setup.py develop
     - name: Generate the YAML files
       run: |
         python test/generate_parse_fixture_yml.py
-    - name: Generate the YAML files
+    - name: Test the generated YAML files
       run: |
         if [ -n "$(git status --porcelain)" ]; then
           git diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support ARRAYS of STRUCTs in BigQuery dialect [#1271](https://github.com/sqlfluff/sqlfluff/issues/1271)
 - Support fields of field references in BigQuery dialect [#1276](https://github.com/sqlfluff/sqlfluff/issues/1276)
 - Support OFFSET and ORDINAL clauses of Array Functions in BigQuery dialect [#1171](https://github.com/sqlfluff/sqlfluff/issues/1171)
+- Added check for generated YML files [#1277](https://github.com/sqlfluff/sqlfluff/issues/1277)
 
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,14 +128,14 @@ Once you're in a virtual environment, run:
 
 ```shell
 pip install -Ur requirements.txt -Ur requirements_dev.txt
-pip install -e
+python setup.py develop
 ```
 
 > `pip install -Ur requirements.txt -Ur requirements_dev.txt` installs the project dependencies
 > as well as the dependencies needed to run linting, formatting, and testing commands. This will
 > install the most up-to-date package versions for all dependencies (-U).
 
-> `pip install -e` installs the package using a link to the source code so that any changes
+> `python setup.py develop` installs the package using a link to the source code so that any changes
 > which you make will immediately be available for use.
 
 ## Building Package

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,16 +127,14 @@ source .venv/bin/activate
 Once you're in a virtual environment, run:
 
 ```shell
-pip install -Ur requirements.txt -Ur requirements_dev.txt
-python setup.py develop
+pip install -e -Ur requirements.txt -Ur requirements_dev.txt
 ```
 
-> `setup.py develop` installs the package using a link to the source code so that any changes
-> which you make will immediately be available for use.
->
-> `pip install -Ur requirements.txt -Ur requirements_dev.txt` installs the project dependencies
-> as well as the dependencies needed to run linting, formatting, and testing commands. This will
-> install the most up-to-date package versions for all dependencies.
+> `pip install -e -Ur requirements.txt -Ur requirements_dev.txt` installs the 
+> project dependencies using a link to the source code (-e) so that any changes
+> which you make will immediately be available for use, as well as the 
+> dependencies needed to run linting, formatting, and testing commands. This will
+> install the most up-to-date package versions for all dependencies (-U).
 
 ## Building Package
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,14 +127,16 @@ source .venv/bin/activate
 Once you're in a virtual environment, run:
 
 ```shell
-pip install -e -Ur requirements.txt -Ur requirements_dev.txt
+pip install -Ur requirements.txt -Ur requirements_dev.txt
+pip install -e
 ```
 
-> `pip install -e -Ur requirements.txt -Ur requirements_dev.txt` installs the 
-> project dependencies using a link to the source code (-e) so that any changes
-> which you make will immediately be available for use, as well as the 
-> dependencies needed to run linting, formatting, and testing commands. This will
+> `pip install -Ur requirements.txt -Ur requirements_dev.txt` installs the project dependencies
+> as well as the dependencies needed to run linting, formatting, and testing commands. This will
 > install the most up-to-date package versions for all dependencies (-U).
+
+> `pip install -e` installs the package using a link to the source code so that any changes
+> which you make will immediately be available for use.
 
 ## Building Package
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,13 +89,13 @@ python version, so you can always specify a particular environment. For example
 if you're developing in python 3.6 you might call...
 
 ```shell
-tox -e py36,linting
+tox -e generate-fixture-yml,py36,linting
 ```
 
 ...or if you also want to see the coverage reporting...
 
 ```shell
-tox -e cov-init,py36,cov-report,linting
+tox -e generate-fixture-yml,cov-init,py36,cov-report,linting
 ```
 
 > NB: The `cov-init` task clears the previous test results, the `py36` environment

--- a/test/fixtures/parser/bigquery/select_mixture_of_array_literals.yml
+++ b/test/fixtures/parser/bigquery/select_mixture_of_array_literals.yml
@@ -30,15 +30,15 @@ file:
               end_square_bracket: ']'
       - comma: ','
       - select_clause_element:
-          expression:
-            array_literal:
-              start_square_bracket: '['
-              expression:
-                literal: '"a"'
-              end_square_bracket: ']'
-          alias_expression:
-            keyword: AS
-            identifier: strcol1
+            expression:
+              array_literal:
+                start_square_bracket: '['
+                expression:
+                  literal: "'a'"
+                end_square_bracket: ']'
+            alias_expression:
+              keyword: AS
+              identifier: strcol1
       - comma: ','
       - select_clause_element:
           expression:

--- a/test/fixtures/parser/bigquery/select_mixture_of_array_literals.yml
+++ b/test/fixtures/parser/bigquery/select_mixture_of_array_literals.yml
@@ -34,7 +34,7 @@ file:
             array_literal:
               start_square_bracket: '['
               expression:
-                literal: "'a'"
+                literal: '"a"'
               end_square_bracket: ']'
           alias_expression:
             keyword: AS

--- a/test/fixtures/parser/bigquery/select_mixture_of_array_literals.yml
+++ b/test/fixtures/parser/bigquery/select_mixture_of_array_literals.yml
@@ -30,15 +30,15 @@ file:
               end_square_bracket: ']'
       - comma: ','
       - select_clause_element:
-            expression:
-              array_literal:
-                start_square_bracket: '['
-                expression:
-                  literal: "'a'"
-                end_square_bracket: ']'
-            alias_expression:
-              keyword: AS
-              identifier: strcol1
+          expression:
+            array_literal:
+              start_square_bracket: '['
+              expression:
+                literal: "'a'"
+              end_square_bracket: ']'
+          alias_expression:
+            keyword: AS
+            identifier: strcol1
       - comma: ','
       - select_clause_element:
           expression:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = linting, doclinting, cov-init, py{36,37,38,39}, dbt0{17,18,19,20}-py{37,38}, cov-report, bench, mypy
+envlist = generate-fixture-yml, linting, doclinting, cov-init, py{36,37,38,39}, dbt0{17,18,19,20}-py{37,38}, cov-report, bench, mypy
 
 [testenv]
 passenv = CI CIRCLECI CIRCLE_* HOME
@@ -49,6 +49,9 @@ setenv =
 commands =
     coverage combine
     coverage report
+
+[testenv:generate-fixture-yml]
+commands = python test/generate_parse_fixture_yml.py
 
 [testenv:linting]
 commands = flake8


### PR DESCRIPTION
Fixes #1277 

This PR adds the following:
- Adds the generate command to `tox.ini` config so YAML files will be generated when contributors run `tox` locally
- Adds a new GitHub Action to check that contributors have included any necessary YAML changes by running the script and checking for diffs. The tests already pick up diffs, but ignores whitespace changes for manually edited files - which can then pollute future PRs when the next person runs the generate scripts.
 
YAML files can still be generated via the python script, via the new tox config above, or via manual editing - as long as they match what would auto generate.