### PR TITLE
Fix typo on the In the Wild page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+- Fix typo in the in the wild page [#](https://github.com/sqlfluff/sqlfluff/issues/)
 
 ## [0.6.3] - 2021-08-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
-- Fix typo in the in the wild page [#](https://github.com/sqlfluff/sqlfluff/issues/)
+- Fix typo in the in the wild page [#1285](https://github.com/sqlfluff/sqlfluff/pull/1285)
 
 ## [0.6.3] - 2021-08-16
 ### Added

--- a/docs/source/inthewild.rst
+++ b/docs/source/inthewild.rst
@@ -40,10 +40,10 @@ Just add a section below by raising a PR on Github by
   - Reduced burden on Analytics Engineers to remember every single style rule.
   - New Analytics Engineers can quickly see and learn what "good SQL" looks
     like at Surfline and start writing it from day 1.
-- The `HTTP Archive <https://httparchive.org>` uses SQLFluff to automatically
+- The `HTTP Archive <https://httparchive.org>`_ uses SQLFluff to automatically
   check for quality and consistency of code submitted by the many contributors
-  to this project. In particular our annual `Web Almanac <https://almanac.httparchive.org>`
+  to this project. In particular our annual `Web Almanac <https://almanac.httparchive.org>`_
   attracts hundreds of volunteers to help analyse our BigQuery dataset and
   being able automatically lint Pull Requests through GitHub Actions is a
   fantastic way to help us maintain our growing repositary of
-  `over a thousand queries <https://github.com/HTTPArchive/almanac.httparchive.org/tree/main/sql>`.
+  `over a thousand queries <https://github.com/HTTPArchive/almanac.httparchive.org/tree/main/sql>`_.


### PR DESCRIPTION
Noticed in the last release that the links add #1267 don't work on this page: https://docs.sqlfluff.com/en/stable/inthewild.html

Looks like I missed an underscore :-(