### PR TITLE
Add Parameterless Functions and more function names support to BigQuery

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -266,13 +266,21 @@ bigquery_dialect.replace(
         ),
         Sequence("WITH", "OFFSET", "AS", Ref("SingleIdentifierGrammar"), optional=True),
     ),
-    FunctionNameIdentifierSegment=RegexParser(
+    FunctionNameIdentifierSegment=OneOf(
         # In BigQuery struct() has a special syntax, so we don't treat it as a function
-        r"[A-Z][A-Z0-9_]*",
-        CodeSegment,
-        name="function_name_identifier",
-        type="function_name_identifier",
-        anti_template=r"STRUCT",
+        RegexParser(
+            r"[A-Z_][A-Z0-9_]*",
+            CodeSegment,
+            name="function_name_identifier",
+            type="function_name_identifier",
+            anti_template=r"STRUCT",
+        ),
+        RegexParser(
+            r"`[^`]*`",
+            CodeSegment,
+            name="function_name_identifier",
+            type="function_name_identifier",
+        ),
     ),
 )
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -490,6 +490,7 @@ class FunctionParameterListGrammar(BaseSegment):
             Ref("FunctionParameterGrammar"),
             delimiter=Ref("CommaSegment"),
             bracket_pairs_set="angle_bracket_pairs",
+            optional=True,
         )
     )
 

--- a/test/fixtures/parser/ansi/create_function_no_args.sql
+++ b/test/fixtures/parser/ansi/create_function_no_args.sql
@@ -1,0 +1,3 @@
+CREATE FUNCTION add() RETURNS integer
+    AS 'select $1 + $2;'
+    LANGUAGE SQL;

--- a/test/fixtures/parser/ansi/create_function_no_args.yml
+++ b/test/fixtures/parser/ansi/create_function_no_args.yml
@@ -1,0 +1,20 @@
+file:
+  statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: add
+    - base:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+    - keyword: RETURNS
+    - data_type:
+        data_type_identifier: integer
+    - base:
+      - keyword: AS
+      - literal: "'select $1 + $2;'"
+      - keyword: LANGUAGE
+      - parameter: SQL
+  statement_terminator: ;

--- a/test/fixtures/parser/bigquery/create_function_no_args.sql
+++ b/test/fixtures/parser/bigquery/create_function_no_args.sql
@@ -1,0 +1,3 @@
+CREATE FUNCTION add() RETURNS integer
+    AS 'select $1 + $2;'
+    LANGUAGE SQL;

--- a/test/fixtures/parser/bigquery/create_function_no_args.yml
+++ b/test/fixtures/parser/bigquery/create_function_no_args.yml
@@ -1,0 +1,20 @@
+file:
+  statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: add
+    - base:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+    - keyword: RETURNS
+    - data_type:
+        data_type_identifier: integer
+    - base:
+      - keyword: AS
+      - literal: "'select $1 + $2;'"
+      - keyword: LANGUAGE
+      - parameter: SQL
+  statement_terminator: ;

--- a/test/fixtures/parser/bigquery/create_js_function_underscore_name.sql
+++ b/test/fixtures/parser/bigquery/create_js_function_underscore_name.sql
@@ -1,5 +1,5 @@
 CREATE TEMP FUNCTION
-qs(
+_qs(
     y STRING
 )
 RETURNS STRUCT<_product_id ARRAY<INT64>>

--- a/test/fixtures/parser/bigquery/create_js_function_underscore_name.yml
+++ b/test/fixtures/parser/bigquery/create_js_function_underscore_name.yml
@@ -5,7 +5,7 @@ file:
     - keyword: TEMP
     - keyword: FUNCTION
     - function_name:
-        function_name_identifier: qs
+        function_name_identifier: _qs
     - base:
         bracketed:
           start_bracket: (

--- a/test/fixtures/parser/bigquery/select_udf_quote_everything.yml
+++ b/test/fixtures/parser/bigquery/select_udf_quote_everything.yml
@@ -6,7 +6,7 @@ file:
         select_clause_element:
           function:
             function_name:
-              identifier: '`another-gcp-project.functions.timestamp_parsing`'
+              function_name_identifier: '`another-gcp-project.functions.timestamp_parsing`'
             bracketed:
               start_bracket: (
               expression:

--- a/test/fixtures/parser/bigquery/select_udf_quote_project_and_datasetfunctionname.yml
+++ b/test/fixtures/parser/bigquery/select_udf_quote_project_and_datasetfunctionname.yml
@@ -6,9 +6,9 @@ file:
         select_clause_element:
           function:
             function_name:
-            - identifier: '`another-gcp-project`'
-            - dot: .
-            - identifier: '`functions.timestamp_parsing`'
+              identifier: '`another-gcp-project`'
+              dot: .
+              function_name_identifier: '`functions.timestamp_parsing`'
             bracketed:
               start_bracket: (
               expression:


### PR DESCRIPTION
Fixes #1298

Basically same fix as #1254 but for Function Names - BigQuery doesn't define a more restrictive set of requirements for Function identifiers so we shouldn't either.

Also adds support for Parameterless functions in `CREATE FUNCTION` (e.g. `CREATE FUNCTION a() AS...`) which I discovered was [already available in ANSI SQL](https://github.com/sqlfluff/sqlfluff/blob/b6175995b1f92ebdb1fdd8ccf02d1d8465aa5770/src/sqlfluff/dialects/dialect_ansi.py#L2682) but not in the [override for BigQuery](https://github.com/sqlfluff/sqlfluff/blob/b6175995b1f92ebdb1fdd8ccf02d1d8465aa5770/src/sqlfluff/dialects/dialect_bigquery.py#L475). Also added a test case for this for both ANSI and BigQuery.