### PR TITLE
Allow BigQuery UDF with triple quoted bodies to pass rule L048

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -77,6 +77,20 @@ bigquery_dialect.add(
         type="literal",
         trim_chars=('"',),
     ),
+    DoubleQuotedUDFBody=NamedParser(
+        "double_quote",
+        CodeSegment,
+        name="udf_body",
+        type="udf_body",
+        trim_chars=('"',),
+    ),
+    SingleQuotedUDFBody=NamedParser(
+        "single_quote",
+        CodeSegment,
+        name="udf_body",
+        type="udf_body",
+        trim_chars=("'",),
+    ),
     StructKeywordSegment=StringParser("struct", KeywordSegment, name="struct"),
     StartAngleBracketSegment=StringParser(
         "<", SymbolSegment, name="start_angle_bracket", type="start_angle_bracket"
@@ -377,8 +391,8 @@ class FunctionDefinitionGrammar(BaseSegment):
             Sequence(
                 "AS",
                 OneOf(
-                    Ref("DoubleQuotedLiteralSegment"),
-                    Ref("QuotedLiteralSegment"),
+                    Ref("DoubleQuotedUDFBody"),
+                    Ref("SingleQuotedUDFBody"),
                     Bracketed(
                         OneOf(Ref("ExpressionSegment"), Ref("SelectStatementSegment"))
                     ),

--- a/test/fixtures/parser/bigquery/create_function_no_args.yml
+++ b/test/fixtures/parser/bigquery/create_function_no_args.yml
@@ -14,7 +14,7 @@ file:
         data_type_identifier: integer
     - base:
       - keyword: AS
-      - literal: "'select $1 + $2;'"
+      - udf_body: "'select $1 + $2;'"
       - keyword: LANGUAGE
       - parameter: SQL
   statement_terminator: ;

--- a/test/fixtures/parser/bigquery/create_js_function_complex_types.yml
+++ b/test/fixtures/parser/bigquery/create_js_function_complex_types.yml
@@ -85,4 +85,4 @@ file:
       - keyword: LANGUAGE
       - parameter: js
       - keyword: AS
-      - literal: "\"\"\"\n    CODE GOES HERE\n\"\"\""
+      - udf_body: "\"\"\"\n    CODE GOES HERE\n\"\"\""

--- a/test/fixtures/parser/bigquery/create_js_function_deterministic.yml
+++ b/test/fixtures/parser/bigquery/create_js_function_deterministic.yml
@@ -17,4 +17,4 @@ file:
       - keyword: LANGUAGE
       - parameter: js
       - keyword: AS
-      - literal: '" return y; "'
+      - udf_body: '" return y; "'

--- a/test/fixtures/parser/bigquery/create_js_function_options_library_array.yml
+++ b/test/fixtures/parser/bigquery/create_js_function_options_library_array.yml
@@ -44,4 +44,4 @@ file:
         - end_square_bracket: ']'
         - end_bracket: )
       - keyword: AS
-      - literal: "\"\"\"\n    CODE GOES HERE\n\"\"\""
+      - udf_body: "\"\"\"\n    CODE GOES HERE\n\"\"\""

--- a/test/fixtures/parser/bigquery/create_js_function_quoted_name.yml
+++ b/test/fixtures/parser/bigquery/create_js_function_quoted_name.yml
@@ -29,4 +29,4 @@ file:
       - keyword: LANGUAGE
       - parameter: js
       - keyword: AS
-      - literal: "\"\"\"\n    CODE GOES HERE\n\"\"\""
+      - udf_body: "\"\"\"\n    CODE GOES HERE\n\"\"\""

--- a/test/fixtures/parser/bigquery/create_js_function_simple.yml
+++ b/test/fixtures/parser/bigquery/create_js_function_simple.yml
@@ -16,4 +16,4 @@ file:
       - keyword: LANGUAGE
       - parameter: js
       - keyword: AS
-      - literal: '" return y; "'
+      - udf_body: '" return y; "'

--- a/test/fixtures/parser/bigquery/create_js_function_underscore_name.yml
+++ b/test/fixtures/parser/bigquery/create_js_function_underscore_name.yml
@@ -29,4 +29,4 @@ file:
       - keyword: LANGUAGE
       - parameter: js
       - keyword: AS
-      - literal: "\"\"\"\n    CODE GOES HERE\n\"\"\""
+      - udf_body: "\"\"\"\n    CODE GOES HERE\n\"\"\""

--- a/test/fixtures/rules/std_rule_cases/L048.yml
+++ b/test/fixtures/rules/std_rule_cases/L048.yml
@@ -19,3 +19,27 @@ test_pass_comma:
         CASE WHEN col2 IN ('a', 'b') THEN 'Y' ELSE 'N' END AS new_column_case
     FROM some_table
     WHERE col2 IN ('a', 'b', 'c', 'd');
+
+test_pass_bigquery_udf_triple_single_quote:
+  pass_str: |
+   CREATE TEMPORARY FUNCTION a()
+   LANGUAGE js
+   AS '''
+   CODE GOES HERE
+   ''';
+
+  configs:
+    core:
+      dialect: bigquery
+
+test_pass_bigquery_udf_triple_double_quote:
+  pass_str: |
+   CREATE TEMPORARY FUNCTION a()
+   LANGUAGE js
+   AS """
+   CODE GOES HERE
+   """;
+
+  configs:
+    core:
+      dialect: bigquery


### PR DESCRIPTION
Rule L048 is the following:

> Quoted literals should be surrounded by a single whitespace.
> 
> _sqlfluff fix compatible._
> 
> **Anti-pattern**
> In this example, there is a space missing space between the string ‘foo’
> and the keyword AS.
> ```sql
> SELECT
>     'foo'AS bar
> FROM foo
> ```
> **Best practice**
> Keep a single space.
> ```sql
> SELECT
>     'foo' AS bar
> FROM foo
> ```
> 

That currently doesn't work with BigQuery User Defined Functions using the triple quote syntax:

```sql
CREATE TEMPORARY FUNCTION a()
LANGUAGE js
AS '''
CODE GOES HERE
''';
```

As it fails with ` Missing whitespace after []; } '''` because currently the UDF body is defined as a literal.

This PR moves it to it's own type (exactly the same as quoted literals except for the type) so rule L048 can be run on the rest of the code past and ignore these triple quoted bodies.
