### PR TITLE
Fix spacing issue for BigQuery UNNEST statement for rules L003 and L025

### DIFF
--- a/src/sqlfluff/core/rules/analysis/select.py
+++ b/src/sqlfluff/core/rules/analysis/select.py
@@ -132,6 +132,7 @@ def _has_value_table_function(table_expr, dialect):
         return False
 
     for function_name in table_expr.recursive_crawl("function_name"):
-        if function_name.raw.lower() in dialect.sets("value_table_functions"):
+        # Other rules can increase whitespace in the function name so use strip
+        if function_name.raw.lower().strip() in dialect.sets("value_table_functions"):
             return True
     return False

--- a/src/sqlfluff/core/rules/analysis/select.py
+++ b/src/sqlfluff/core/rules/analysis/select.py
@@ -132,7 +132,8 @@ def _has_value_table_function(table_expr, dialect):
         return False
 
     for function_name in table_expr.recursive_crawl("function_name"):
-        # Other rules can increase whitespace in the function name so use strip
+        # Other rules can increase whitespace in the function name, so use strip to remove
+        # See: https://github.com/sqlfluff/sqlfluff/issues/1304
         if function_name.raw.lower().strip() in dialect.sets("value_table_functions"):
             return True
     return False

--- a/test/fixtures/linter/autofix/bigquery/005_unnest_spacing/after.sql
+++ b/test/fixtures/linter/autofix/bigquery/005_unnest_spacing/after.sql
@@ -1,0 +1,6 @@
+SELECT
+    category,
+    value
+FROM
+    table1,
+    UNNEST(1, 2, 3) AS category

--- a/test/fixtures/linter/autofix/bigquery/005_unnest_spacing/before.sql
+++ b/test/fixtures/linter/autofix/bigquery/005_unnest_spacing/before.sql
@@ -1,0 +1,6 @@
+SELECT
+    category,
+    value
+FROM
+    table1,
+UNNEST(1, 2, 3) AS category

--- a/test/fixtures/linter/autofix/bigquery/005_unnest_spacing/test-config.yml
+++ b/test/fixtures/linter/autofix/bigquery/005_unnest_spacing/test-config.yml
@@ -1,0 +1,4 @@
+test-config:
+  rules:
+    - L003
+    - L025


### PR DESCRIPTION
### Brief summary of the change made

Fixes #1302 so when SQL fails L003 (and adds indentation spacing) it doesn't break rule L025 (which has a special case for BigQuery that doesn't work when spacing is added).

### Are there any other side effects of this change that we should be aware of?

Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

I don't know how to add a test case for this to be honest as it only happens for a combination of rules. If someone can suggest how to add test cases for multiple rules then let me know as would be good to prevent this regressing in future.

I tried adding a rules fixture test case with the following:

```
  configs:
    core:
      dialect: bigquery
      rules: L003,L025
```

But still only rule L025 is run.

However it's a simple change, and coverage won't change since the line is already covered so if this is not possible then think it's still good to merge.
