### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Although SQL is reasonable consistent in it's implementations, there are a number of different dialects available with variations of syntax and grammar. **SQLFluff** currently supports the following SQL dialects (though perhaps not in full):
 
-- ANSI SQL - this is the base version and on occasion may not strictly follow the ANSI/ISO SQL definition 
+- ANSI SQL - this is the base version and on occasion may not strictly follow the ANSI/ISO SQL definition
 - [BigQuery](https://cloud.google.com/bigquery/)
 - [Exasol](https://www.exasol.com/)
 - [MySQL](https://www.mysql.com/)
@@ -34,7 +34,7 @@ Pull requests from those that know the missing syntax or dialects are especially
 
 ## Templates Supported
 
-SQL itself doesn't lend itself well to [modularity](https://docs.getdbt.com/docs/viewpoint#section-modularity), so to introduce some flexibility and reusability it is often [templated](https://en.wikipedia.org/wiki/Template_processor as discussed more in [our modularity documentation](https://docs.sqlfluff.com/en/stable/realworld.html#modularity).
+SQL itself doesn't lend itself well to [modularity](https://docs.getdbt.com/docs/viewpoint#section-modularity), so to introduce some flexibility and reusability it is often [templated](https://en.wikipedia.org/wiki/Template_processor) as discussed more in [our modularity documentation](https://docs.sqlfluff.com/en/stable/realworld.html#modularity).
 
 **SQLFluff** supports the following templates:
 - [Jinja](https://jinja.palletsprojects.com/) (aka Jinja2)


### PR DESCRIPTION
### Brief summary of the change made

Add missing closing paren on link and trailing whitespace

### Are there any other side effects of this change that we should be aware of?

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
