### PR TITLE
Fix a couple of small issues with CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       # Run the windows jobs on a schedule.
       - win-py37

--- a/.github/workflows/check-yaml-files-generation.yml
+++ b/.github/workflows/check-yaml-files-generation.yml
@@ -1,7 +1,7 @@
 name: "Check generated YAML files"
 on: pull_request
 jobs:
-  changelog:
+  ymlchecks:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
### Brief summary of the change made

Makes a couple of small tweaks to the CI jobs:
- Changes CiCircle nightly job to run on `main` instead of `master` - guess we missed this on the rename?
- Corrects name of Check YML job - my fault as copied from the changelog job and didn't update it

### Are there any other side effects of this change that we should be aware of?
Nopo

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
