### PR TITLE
Allow optional alias for BigQuery WITH OFFSET

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -278,7 +278,12 @@ bigquery_dialect.replace(
         Sequence(
             "FOR", "SYSTEM_TIME", "AS", "OF", Ref("ExpressionSegment"), optional=True
         ),
-        Sequence("WITH", "OFFSET", "AS", Ref("SingleIdentifierGrammar"), optional=True),
+        Sequence(
+            "WITH",
+            "OFFSET",
+            Sequence("AS", Ref("SingleIdentifierGrammar"), optional=True),
+            optional=True,
+        ),
     ),
     FunctionNameIdentifierSegment=OneOf(
         # In BigQuery struct() has a special syntax, so we don't treat it as a function

--- a/test/fixtures/parser/bigquery/select_with_offset_3.sql
+++ b/test/fixtures/parser/bigquery/select_with_offset_3.sql
@@ -1,0 +1,2 @@
+SELECT i, offset
+FROM UNNEST([1, 2, 3]) AS i WITH OFFSET

--- a/test/fixtures/parser/bigquery/select_with_offset_3.yml
+++ b/test/fixtures/parser/bigquery/select_with_offset_3.yml
@@ -1,0 +1,46 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 72c2062dc03c248070b79735a710450c8dfc21668e33ab281559d719c1ab51f2
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: i
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: offset
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+          - table_expression:
+              function:
+                function_name:
+                  function_name_identifier: UNNEST
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    array_literal:
+                    - start_square_bracket: '['
+                    - expression:
+                        literal: '1'
+                    - comma: ','
+                    - expression:
+                        literal: '2'
+                    - comma: ','
+                    - expression:
+                        literal: '3'
+                    - end_square_bracket: ']'
+                  end_bracket: )
+          - alias_expression:
+              keyword: AS
+              identifier: i
+          - keyword: WITH
+          - keyword: OFFSET


### PR DESCRIPTION
### Brief summary of the change made

Fixes #1329 

### Are there any other side effects of this change that we should be aware of?

Nope!

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
