### PR TITLE
Bugfix PR, fixes issue #1333, wherein test___main___help() defaults to your default Python installation

### DIFF
--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -628,7 +628,9 @@ def test__cli__command_lint_serialize_github_annotation():
 def test___main___help():
     """Test that the CLI can be access via __main__."""
     # nonzero exit is good enough
-    subprocess.check_output([sys.executable, "-m", "sqlfluff", "--help"], env=os.environ)
+    subprocess.check_output(
+        [sys.executable, "-m", "sqlfluff", "--help"], env=os.environ
+    )
 
 
 @pytest.mark.parametrize(

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -8,6 +8,7 @@ import json
 import oyaml as yaml
 import subprocess
 import chardet
+import sys
 
 # Testing libraries
 import pytest
@@ -627,7 +628,7 @@ def test__cli__command_lint_serialize_github_annotation():
 def test___main___help():
     """Test that the CLI can be access via __main__."""
     # nonzero exit is good enough
-    subprocess.check_output(["python", "-m", "sqlfluff", "--help"])
+    subprocess.check_output([sys.executable, "-m", "src.sqlfluff", "--help"])
 
 
 @pytest.mark.parametrize(

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -628,7 +628,7 @@ def test__cli__command_lint_serialize_github_annotation():
 def test___main___help():
     """Test that the CLI can be access via __main__."""
     # nonzero exit is good enough
-    subprocess.check_output([sys.executable, "-m", "src.sqlfluff", "--help"])
+    subprocess.check_output([sys.executable, "-m", "sqlfluff", "--help"], env=os.environ)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

### Brief summary of the change made
Fixes #1333. Changes the call to python in test___main___help() to sys.executable, which is the path of the current instance of Python that you are running. This ensures that sys.path is the same in the subshell. Also passes in os.environ into the subshell, in case the path is defined for any developers in the PYTHONPATH.
...

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

As it is not new functionality, just fixing a test case, there are no additional tests added. Tested the change locally, and the test is passing.