### PR TITLE
Add unittest for rules docstring

### DIFF
--- a/plugins/sqlfluff-plugin-example/src/example/rules.py
+++ b/plugins/sqlfluff-plugin-example/src/example/rules.py
@@ -47,7 +47,7 @@ class Rule_Example_L001(BaseRule):
     | **Anti-pattern**
     | Using ORDER BY one some forbidden columns.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT *
         FROM foo
@@ -58,7 +58,7 @@ class Rule_Example_L001(BaseRule):
     | **Best practice**
     | Do not order by these columns.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT *
         FROM foo

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -205,6 +205,7 @@ class BaseRule:
 
     """
 
+    _check_docstring = True
     _works_on_unparsable = True
     targets_templated = False
 

--- a/src/sqlfluff/rules/L001.py
+++ b/src/sqlfluff/rules/L001.py
@@ -10,7 +10,7 @@ class Rule_L001(BaseRule):
     | **Anti-pattern**
     | The • character represents a space.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
             a
@@ -19,7 +19,7 @@ class Rule_L001(BaseRule):
     | **Best practice**
     | Remove trailing spaces.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
             a

--- a/src/sqlfluff/rules/L002.py
+++ b/src/sqlfluff/rules/L002.py
@@ -19,7 +19,7 @@ class Rule_L002(BaseRule):
     | The • character represents a space and the → character represents a tab.
     | In this example, the second line contains two spaces and one tab.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
         ••→a
@@ -28,7 +28,7 @@ class Rule_L002(BaseRule):
     | **Best practice**
     | Change the line to use spaces only.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
         ••••a

--- a/src/sqlfluff/rules/L003.py
+++ b/src/sqlfluff/rules/L003.py
@@ -22,7 +22,7 @@ class Rule_L003(BaseRule):
     | The • character represents a space.
     | In this example, the third line contains five spaces instead of four.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
         ••••a,
@@ -33,7 +33,7 @@ class Rule_L003(BaseRule):
     | **Best practice**
     | Change the indentation to use a multiple of four spaces.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
         ••••a,

--- a/src/sqlfluff/rules/L004.py
+++ b/src/sqlfluff/rules/L004.py
@@ -22,7 +22,7 @@ class Rule_L004(BaseRule):
     | **Anti-pattern**
     | Using tabs instead of spaces when indent_unit config set to spaces (default).
 
-    .. code-block::
+    .. code-block:: sql
 
         select
         ••••a,
@@ -32,7 +32,7 @@ class Rule_L004(BaseRule):
     | **Best practice**
     | Change the line to use spaces only.
 
-    .. code-block::
+    .. code-block:: sql
 
         select
         ••••a,

--- a/src/sqlfluff/rules/L005.py
+++ b/src/sqlfluff/rules/L005.py
@@ -15,7 +15,7 @@ class Rule_L005(BaseRule):
     | The • character represents a space.
     | There is an extra space in line two before the comma.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
             a•,
@@ -25,7 +25,7 @@ class Rule_L005(BaseRule):
     | **Best practice**
     | Remove the space before the comma.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
             a,

--- a/src/sqlfluff/rules/L008.py
+++ b/src/sqlfluff/rules/L008.py
@@ -14,7 +14,7 @@ class Rule_L008(BaseRule):
     | The • character represents a space.
     | In this example, there is no space between the comma and 'zoo'.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
             *
@@ -24,7 +24,7 @@ class Rule_L008(BaseRule):
     | **Best practice**
     | Keep a single space after the comma.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
             *

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -8,7 +8,7 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 @document_fix_compatible
 class Rule_L009(BaseRule):
-    r"""Files must end with a trailing newline.
+    """Files must end with a trailing newline.
 
     | **Anti-pattern**
     | The content in file without ends without a trailing newline, the $ represents end of file.

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -9,6 +9,7 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible
 @document_fix_compatible
 class Rule_L009(BaseRule):
     """Files must end with a trailing newline."""
+
     _check_docstring = False
 
     def _eval(self, segment, siblings_post, parent_stack, **kwargs):

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -8,7 +8,27 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 @document_fix_compatible
 class Rule_L009(BaseRule):
-    """Files must end with a trailing newline."""
+    """Files must end with a trailing newline.
+
+    | **Anti-pattern**
+    | The content in file without end with a trailing newline.
+
+    .. code-block:: sql
+
+        SELECT
+            a
+        FROM foo
+
+    | **Best practice**
+    | Add trailing newline to the end, the \n character represents a newline symbol.
+
+    .. code-block:: sql
+
+        SELECT
+            a
+        FROM foo\n
+
+    """
 
     _check_docstring = False
 

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -18,7 +18,7 @@ class Rule_L009(BaseRule):
         SELECT
             a
         FROM foo$
-        
+
         -- Ending on an indented line means there is no newline at the end of the file, the • represents space.
 
         SELECT
@@ -43,7 +43,7 @@ class Rule_L009(BaseRule):
             a
         FROM foo
         $
-        
+
         -- Ensuring the last line is not indented so is just a newline.
 
         SELECT

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -46,7 +46,7 @@ class Rule_L009(BaseRule):
         
         -- Ensuring the last line is not indented so is just a newline.
 
-       SELECT
+        SELECT
         ••••a
         FROM
         ••••foo

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -8,7 +8,7 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 @document_fix_compatible
 class Rule_L009(BaseRule):
-    """Files must end with a trailing newline.
+    r"""Files must end with a trailing newline.
 
     | **Anti-pattern**
     | The content in file without end with a trailing newline.
@@ -29,8 +29,6 @@ class Rule_L009(BaseRule):
         FROM foo\n
 
     """
-
-    _check_docstring = False
 
     def _eval(self, segment, siblings_post, parent_stack, **kwargs):
         """Files must end with a trailing newline.

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -9,6 +9,7 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible
 @document_fix_compatible
 class Rule_L009(BaseRule):
     """Files must end with a trailing newline."""
+    _check_docstring = False
 
     def _eval(self, segment, siblings_post, parent_stack, **kwargs):
         """Files must end with a trailing newline.

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -11,22 +11,54 @@ class Rule_L009(BaseRule):
     r"""Files must end with a trailing newline.
 
     | **Anti-pattern**
-    | The content in file without end with a trailing newline.
+    | The content in file without ends without a trailing newline, the $ represents end of file.
+
+    .. code-block:: sql
+
+        SELECT
+            a
+        FROM foo$
+        
+        -- Ending on an indented line means there is no newline at the end of the file, the • represents space.
+
+        SELECT
+        ••••a
+        FROM
+        ••••foo
+        ••••$
+
+        -- Ending on a semi-colon means the last line is not a newline.
+
+        SELECT
+            a
+        FROM foo
+        ;$
+
+    | **Best practice**
+    | Add trailing newline to the end, the $ character represents end of file.
 
     .. code-block:: sql
 
         SELECT
             a
         FROM foo
+        $
+        
+        -- Ensuring the last line is not indented so is just a newline.
 
-    | **Best practice**
-    | Add trailing newline to the end, the \n character represents a newline symbol.
+       SELECT
+        ••••a
+        FROM
+        ••••foo
+        $
 
-    .. code-block:: sql
+        -- Even when ending on a semi-colon, ensure there is a newline after
 
         SELECT
             a
-        FROM foo\n
+        FROM foo
+        ;
+        $
 
     """
 

--- a/src/sqlfluff/rules/L012.py
+++ b/src/sqlfluff/rules/L012.py
@@ -10,7 +10,7 @@ class Rule_L012(Rule_L011):
     separate so that they can be enabled and disabled separately.
 
     | **Anti-pattern**
-    | In this example, the alias 'alias_col' is implicit.
+    | In this example, the alias for column 'a' is implicit.
 
     .. code-block:: sql
 

--- a/src/sqlfluff/rules/L012.py
+++ b/src/sqlfluff/rules/L012.py
@@ -9,6 +9,24 @@ class Rule_L012(Rule_L011):
     NB: This rule inherits its functionality from obj:`Rule_L011` but is
     separate so that they can be enabled and disabled separately.
 
+    | **Anti-pattern**
+    | In this example, the alias 'alias_col' is implicit.
+
+    .. code-block:: sql
+
+        SELECT
+            a as alias_col
+        FROM foo
+
+    | **Best practice**
+    | Add `AS` to make it explicit.
+
+    .. code-block:: sql
+
+        SELECT
+            a AS alias_col
+        FROM foo
+
     """
 
     _target_elems = ("select_clause_element",)

--- a/src/sqlfluff/rules/L012.py
+++ b/src/sqlfluff/rules/L012.py
@@ -15,7 +15,7 @@ class Rule_L012(Rule_L011):
     .. code-block:: sql
 
         SELECT
-            a as alias_col
+            a
         FROM foo
 
     | **Best practice**

--- a/src/sqlfluff/rules/L014.py
+++ b/src/sqlfluff/rules/L014.py
@@ -31,6 +31,35 @@ class Rule_L014(Rule_L010):
     """Inconsistent capitalisation of unquoted identifiers.
 
     The functionality for this rule is inherited from :obj:`Rule_L010`.
+
+    | **Anti-pattern**
+    | In this example, unquoted identifiers 'a' is in lower-case and
+    | 'B' is in upper-case.
+
+    .. code-block:: sql
+
+        select
+            a,
+            B
+        from foo
+
+    | **Best practice**
+    | Make all unquoted identifiers either in upper-case or in lower-case
+
+    .. code-block:: sql
+
+        select
+            a,
+            b
+        from foo
+
+        -- Also good
+
+        select
+            A,
+            B
+        from foo
+
     """
 
     _target_elems: List[Tuple[str, str]] = [("name", "naked_identifier")]

--- a/src/sqlfluff/rules/L014.py
+++ b/src/sqlfluff/rules/L014.py
@@ -33,7 +33,7 @@ class Rule_L014(Rule_L010):
     The functionality for this rule is inherited from :obj:`Rule_L010`.
 
     | **Anti-pattern**
-    | In this example, unquoted identifiers 'a' is in lower-case and
+    | In this example, unquoted identifier 'a' is in lower-case but
     | 'B' is in upper-case.
 
     .. code-block:: sql

--- a/src/sqlfluff/rules/L014.py
+++ b/src/sqlfluff/rules/L014.py
@@ -44,7 +44,7 @@ class Rule_L014(Rule_L010):
         from foo
 
     | **Best practice**
-    | Make all unquoted identifiers either in upper-case or in lower-case
+    | Ensure all unquoted identifiers are either in upper-case or in lower-case
 
     .. code-block:: sql
 

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -17,6 +17,8 @@ from sqlfluff.rules.L003 import Rule_L003
 class Rule_L016(Rule_L003):
     """Line is too long."""
 
+    _check_docstring = False
+
     config_keywords = [
         "max_line_length",
         "tab_space_size",

--- a/src/sqlfluff/rules/L018.py
+++ b/src/sqlfluff/rules/L018.py
@@ -14,7 +14,7 @@ class Rule_L018(BaseRule):
     | The • character represents a space.
     | In this example, the closing bracket is not aligned with WITH keyword.
 
-    .. code-block::
+    .. code-block:: sql
 
         WITH zoo AS (
             SELECT a FROM foo
@@ -25,7 +25,7 @@ class Rule_L018(BaseRule):
     | **Best practice**
     | Remove the spaces to align the WITH keyword with the closing bracket.
 
-    .. code-block::
+    .. code-block:: sql
 
         WITH zoo AS (
             SELECT a FROM foo

--- a/src/sqlfluff/rules/L020.py
+++ b/src/sqlfluff/rules/L020.py
@@ -10,24 +10,42 @@ class Rule_L020(BaseRule):
     """Table aliases should be unique within each clause.
 
     | **Anti-pattern**
-    | In this example, same table 'foo' have two aliases 'f1' and 'f2'.
+    | In this example, the alias 't' is reused for two different ables:
 
     .. code-block:: sql
 
         SELECT
-            f1.a,
-            f2.a
-        FROM foo f1, foo f2
+            t.a,
+            t.b
+        FROM foo AS t, bar AS t
+        
+        -- this can also happen when using schemas where the implicit alias is the table name:
+
+        SELECT
+            a,
+            b
+        FROM
+            2020.foo,
+            2021.foo
 
     | **Best practice**
-    | Make all table with the some aliases.
+    | Make all tables have a unique alias
 
     .. code-block:: sql
 
         SELECT
             f.a,
-            f.a
-        FROM foo f, foo f
+            b.b
+        FROM foo AS f, bar AS b
+        
+        -- Also use explicit alias's when referencing two tables with same name from two different schemas
+
+        SELECT
+            f1.a,
+            f2.b
+        FROM
+            2020.foo AS f1,
+            2021.foo AS f2
 
     """
 

--- a/src/sqlfluff/rules/L020.py
+++ b/src/sqlfluff/rules/L020.py
@@ -7,7 +7,29 @@ from sqlfluff.core.rules.analysis.select import get_select_statement_info
 
 
 class Rule_L020(BaseRule):
-    """Table aliases should be unique within each clause."""
+    """Table aliases should be unique within each clause.
+
+    | **Anti-pattern**
+    | In this example, same table 'foo' have two aliases 'f1' and 'f2'.
+
+    .. code-block:: sql
+
+        SELECT
+            f1.a,
+            f2.a
+        FROM foo f1, foo f2
+
+    | **Best practice**
+    | Make all table with the some aliases.
+
+    .. code-block:: sql
+
+        SELECT
+            f.a,
+            f.a
+        FROM foo f, foo f
+
+    """
 
     def _lint_references_and_aliases(
         self,

--- a/src/sqlfluff/rules/L020.py
+++ b/src/sqlfluff/rules/L020.py
@@ -18,7 +18,7 @@ class Rule_L020(BaseRule):
             t.a,
             t.b
         FROM foo AS t, bar AS t
-        
+
         -- this can also happen when using schemas where the implicit alias is the table name:
 
         SELECT
@@ -37,7 +37,7 @@ class Rule_L020(BaseRule):
             f.a,
             b.b
         FROM foo AS f, bar AS b
-        
+
         -- Also use explicit alias's when referencing two tables with same name from two different schemas
 
         SELECT

--- a/src/sqlfluff/rules/L023.py
+++ b/src/sqlfluff/rules/L023.py
@@ -14,7 +14,7 @@ class Rule_L023(BaseRule):
 
     | **Anti-pattern**
 
-    .. code-block::
+    .. code-block:: sql
 
         WITH plop AS(
             SELECT * FROM foo
@@ -28,7 +28,7 @@ class Rule_L023(BaseRule):
     | Add a space after AS, to avoid confusing
     | it for a function.
 
-    .. code-block::
+    .. code-block:: sql
 
         WITH plop AS•(
             SELECT * FROM foo

--- a/src/sqlfluff/rules/L024.py
+++ b/src/sqlfluff/rules/L024.py
@@ -11,7 +11,7 @@ class Rule_L024(Rule_L023):
 
     | **Anti-pattern**
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT b
         FROM foo
@@ -22,7 +22,7 @@ class Rule_L024(Rule_L023):
     | Add a space after USING, to avoid confusing it
     | for a function.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT b
         FROM foo

--- a/src/sqlfluff/rules/L037.py
+++ b/src/sqlfluff/rules/L037.py
@@ -22,7 +22,7 @@ class Rule_L037(BaseRule):
 
     | **Anti-pattern**
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
             a, b
@@ -33,7 +33,7 @@ class Rule_L037(BaseRule):
     | If any columns in the ORDER BY clause specify ASC or DESC, they should all
       do so.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
             a, b

--- a/src/sqlfluff/rules/L038.py
+++ b/src/sqlfluff/rules/L038.py
@@ -22,7 +22,7 @@ class Rule_L038(BaseRule):
 
     | **Anti-pattern**
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
             a, b,
@@ -30,7 +30,7 @@ class Rule_L038(BaseRule):
 
     | **Best practice**
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
             a, b

--- a/src/sqlfluff/rules/L039.py
+++ b/src/sqlfluff/rules/L039.py
@@ -12,7 +12,7 @@ class Rule_L039(BaseRule):
 
     | **Anti-pattern**
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
             a,        b
@@ -22,7 +22,7 @@ class Rule_L039(BaseRule):
     | Unless an indent or preceeding a comment, whitespace should
     | be a single space.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT
             a, b

--- a/src/sqlfluff/rules/L040.py
+++ b/src/sqlfluff/rules/L040.py
@@ -17,7 +17,7 @@ class Rule_L040(Rule_L010):
     The functionality for this rule is inherited from :obj:`Rule_L010`.
 
     | **Anti-pattern**
-    | In this example, 'null' and 'false' is in lower-case whereas 'TRUE' is in upper-case.
+    | In this example, 'null' and 'false' are in lower-case whereas 'TRUE' is in upper-case.
 
     .. code-block:: sql
 

--- a/src/sqlfluff/rules/L040.py
+++ b/src/sqlfluff/rules/L040.py
@@ -15,6 +15,40 @@ class Rule_L040(Rule_L010):
     """Inconsistent capitalisation of boolean/null literal.
 
     The functionality for this rule is inherited from :obj:`Rule_L010`.
+
+    | **Anti-pattern**
+    | In this example, 'null' and 'false' is in lower-case whereas 'TURE' is in upper-case.
+
+    .. code-block:: sql
+
+        select
+            a,
+            null,
+            TURE,
+            false
+        from foo
+
+    | **Best practice**
+    | Make all literal null/true/false either in upper-case or in lower-case
+
+    .. code-block:: sql
+
+        select
+            a,
+            null,
+            true,
+            false
+        from foo
+
+        -- Also good
+
+        select
+            a,
+            NULL,
+            TRUE,
+            FALSE
+        from foo
+
     """
 
     _target_elems: List[Tuple[str, str]] = [

--- a/src/sqlfluff/rules/L040.py
+++ b/src/sqlfluff/rules/L040.py
@@ -17,7 +17,7 @@ class Rule_L040(Rule_L010):
     The functionality for this rule is inherited from :obj:`Rule_L010`.
 
     | **Anti-pattern**
-    | In this example, 'null' and 'false' is in lower-case whereas 'TURE' is in upper-case.
+    | In this example, 'null' and 'false' is in lower-case whereas 'TRUE' is in upper-case.
 
     .. code-block:: sql
 

--- a/src/sqlfluff/rules/L040.py
+++ b/src/sqlfluff/rules/L040.py
@@ -29,7 +29,7 @@ class Rule_L040(Rule_L010):
         from foo
 
     | **Best practice**
-    | Make all literal null/true/false either in upper-case or in lower-case
+    | Ensure all literal null/true/false literals cases are used consistently
 
     .. code-block:: sql
 

--- a/src/sqlfluff/rules/L040.py
+++ b/src/sqlfluff/rules/L040.py
@@ -35,18 +35,18 @@ class Rule_L040(Rule_L010):
 
         select
             a,
-            null,
-            true,
-            false
+            NULL,
+            TRUE,
+            FALSE
         from foo
 
         -- Also good
 
         select
             a,
-            NULL,
-            TRUE,
-            FALSE
+            null,
+            true,
+            false
         from foo
 
     """

--- a/src/sqlfluff/rules/L040.py
+++ b/src/sqlfluff/rules/L040.py
@@ -24,7 +24,7 @@ class Rule_L040(Rule_L010):
         select
             a,
             null,
-            TURE,
+            TRUE,
             false
         from foo
 

--- a/src/sqlfluff/rules/L044.py
+++ b/src/sqlfluff/rules/L044.py
@@ -32,7 +32,7 @@ class Rule_L044(BaseRule):
     | * `CREATE TABLE (<<column schema>>) AS SELECT *`
 
 
-    .. code-block::
+    .. code-block:: sql
 
         WITH cte AS (
             SELECT * FROM foo
@@ -45,7 +45,7 @@ class Rule_L044(BaseRule):
     | **Best practice**
     | Somewhere along the "path" to the source data, specify columns explicitly.
 
-    .. code-block::
+    .. code-block:: sql
 
         WITH cte AS (
             SELECT * FROM foo

--- a/src/sqlfluff/rules/L045.py
+++ b/src/sqlfluff/rules/L045.py
@@ -15,7 +15,7 @@ class Rule_L045(BaseRule):
     | Defining a CTE that is not used by the query is harmless, but it means
     | the code is unnecesary and could be removed.
 
-    .. code-block::
+    .. code-block:: sql
 
         WITH cte1 AS (
           SELECT a
@@ -32,7 +32,7 @@ class Rule_L045(BaseRule):
     | **Best practice**
     | Remove unused CTEs.
 
-    .. code-block::
+    .. code-block:: sql
 
         WITH cte1 AS (
           SELECT a

--- a/src/sqlfluff/rules/L046.py
+++ b/src/sqlfluff/rules/L046.py
@@ -10,7 +10,7 @@ class Rule_L046(BaseRule):
     | Jinja tags with either no whitespace or very long whitespace
     | are hard to read.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT {{    a     }} from {{ref('foo')}}
 
@@ -18,7 +18,7 @@ class Rule_L046(BaseRule):
     | A single whitespace surrounding Jinja tags, alternatively
     | longer gaps containing newlines are acceptable.
 
-    .. code-block::
+    .. code-block:: sql
 
         SELECT {{ a }} from {{ ref('foo') }};
         SELECT {{ a }} from {{

--- a/test/core/rules/docstring_test.py
+++ b/test/core/rules/docstring_test.py
@@ -1,4 +1,4 @@
-"""Test rules docstring"""
+"""Test rules docstring."""
 import pytest
 
 from sqlfluff.core.plugin.host import get_plugin_manager
@@ -14,24 +14,23 @@ KEYWORD_CODE_BLOCK = "\n    .. code-block:: sql\n"
         (KEYWORD_ANTI, 1),
         (KEYWORD_BEST, 1),
         (KEYWORD_CODE_BLOCK, 2),
-    ]
+    ],
 )
 def test_content_count(content, min_count):
-    """Test docstring have specific content"""
+    """Test docstring have specific content."""
     for plugin_rules in get_plugin_manager().hook.get_rules():
         for rule in plugin_rules:
             if rule._check_docstring is True:
-                assert rule.__doc__.count(content) >= min_count, \
-                    f"{rule.__name__} content {content} do not occurrences at less {min_count} times"
+                assert (
+                    rule.__doc__.count(content) >= min_count
+                ), f"{rule.__name__} content {content} do not occurrences at less {min_count} times"
 
 
 def test_keyword_anti_before_best():
-    """Test docstring anti pattern before best pattern"""
+    """Test docstring anti pattern before best pattern."""
     for plugin_rules in get_plugin_manager().hook.get_rules():
         for rule in plugin_rules:
             if rule._check_docstring is True:
-                assert rule.__doc__.index(KEYWORD_ANTI) < rule.__doc__.index(KEYWORD_BEST), \
-                    f"{rule.__name__} keyword {KEYWORD_BEST} appear before {KEYWORD_ANTI}"
-
-
-
+                assert rule.__doc__.index(KEYWORD_ANTI) < rule.__doc__.index(
+                    KEYWORD_BEST
+                ), f"{rule.__name__} keyword {KEYWORD_BEST} appear before {KEYWORD_ANTI}"

--- a/test/core/rules/docstring_test.py
+++ b/test/core/rules/docstring_test.py
@@ -23,7 +23,7 @@ def test_content_count(content, min_count):
             if rule._check_docstring is True:
                 assert (
                     rule.__doc__.count(content) >= min_count
-                ), f"{rule.__name__} content {content} do not occurrences at less {min_count} times"
+                ), f"{rule.__name__} content {content} does not occur at less {min_count} times"
 
 
 def test_keyword_anti_before_best():
@@ -33,4 +33,4 @@ def test_keyword_anti_before_best():
             if rule._check_docstring is True:
                 assert rule.__doc__.index(KEYWORD_ANTI) < rule.__doc__.index(
                     KEYWORD_BEST
-                ), f"{rule.__name__} keyword {KEYWORD_BEST} appear before {KEYWORD_ANTI}"
+                ), f"{rule.__name__} keyword {KEYWORD_BEST} appears before {KEYWORD_ANTI}"

--- a/test/core/rules/docstring_test.py
+++ b/test/core/rules/docstring_test.py
@@ -1,0 +1,37 @@
+"""Test rules docstring"""
+import pytest
+
+from sqlfluff.core.plugin.host import get_plugin_manager
+
+KEYWORD_ANTI = "\n    | **Anti-pattern**"
+KEYWORD_BEST = "\n    | **Best practice**"
+KEYWORD_CODE_BLOCK = "\n    .. code-block:: sql\n"
+
+
+@pytest.mark.parametrize(
+    "content,count",
+    [
+        (KEYWORD_ANTI, 1),
+        (KEYWORD_BEST, 1),
+        (KEYWORD_CODE_BLOCK, 2),
+    ]
+)
+def test_content_count(content, count):
+    """Test docstring have specific content"""
+    for plugin_rules in get_plugin_manager().hook.get_rules():
+        for rule in plugin_rules:
+            if rule._check_docstring is True:
+                assert rule.__doc__.count(content) == count, \
+                    f"{rule.__name__} do not occurrences content {content} with {count} times"
+
+
+def test_keyword_anti_before_best():
+    """Test docstring anti pattern before best pattern"""
+    for plugin_rules in get_plugin_manager().hook.get_rules():
+        for rule in plugin_rules:
+            if rule._check_docstring is True:
+                assert rule.__doc__.index(KEYWORD_ANTI) < rule.__doc__.index(KEYWORD_BEST), \
+                    f"{rule.__name__} keyword {KEYWORD_BEST} appear before {KEYWORD_ANTI}"
+
+
+

--- a/test/core/rules/docstring_test.py
+++ b/test/core/rules/docstring_test.py
@@ -9,20 +9,20 @@ KEYWORD_CODE_BLOCK = "\n    .. code-block:: sql\n"
 
 
 @pytest.mark.parametrize(
-    "content,count",
+    "content,min_count",
     [
         (KEYWORD_ANTI, 1),
         (KEYWORD_BEST, 1),
         (KEYWORD_CODE_BLOCK, 2),
     ]
 )
-def test_content_count(content, count):
+def test_content_count(content, min_count):
     """Test docstring have specific content"""
     for plugin_rules in get_plugin_manager().hook.get_rules():
         for rule in plugin_rules:
             if rule._check_docstring is True:
-                assert rule.__doc__.count(content) == count, \
-                    f"{rule.__name__} do not occurrences content {content} with {count} times"
+                assert rule.__doc__.count(content) >= min_count, \
+                    f"{rule.__name__} content {content} do not occurrences at less {min_count} times"
 
 
 def test_keyword_anti_before_best():


### PR DESCRIPTION
### Brief summary of the change made

Add unittest for sqlfluff rules docstring for more readable doc and avoid regression.
before this patch, our rules ref have wrong syntax of code
![image](https://user-images.githubusercontent.com/15820530/131327462-dd067237-d3a3-4d49-b14b-50e298730423.png)

Some of the rule without example
![image](https://user-images.githubusercontent.com/15820530/131327598-b0c60756-8c73-43d9-8f65-50807101cb92.png)

And this path should fix this. 