### PR TITLE
Using github star instead of watch in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,7 +86,7 @@ html_theme_options = {
     "github_repo": "sqlfluff",
     # Github Fork button
     "github_banner": True,
-    # Github link button
+    # Github star button
     "github_type": "star",
     "github_count": "true",
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,9 +87,8 @@ html_theme_options = {
     # Github Fork button
     "github_banner": True,
     # Github link button
-    "github_button": True,
-    # Codecov button
-    "codecov_button": True,
+    "github_type": "star",
+    "github_count": "true",
 }
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -88,6 +88,7 @@ html_theme_options = {
     "github_banner": True,
     # Github star button
     "github_type": "star",
+    # Use `"true"` instead of `True` for counting github star, see https://ghbtns.com for details
     "github_count": "true",
     # Codecov button
     "codecov_button": True,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,6 +89,8 @@ html_theme_options = {
     # Github star button
     "github_type": "star",
     "github_count": "true",
+    # Codecov button
+    "codecov_button": True,
 }
 
 


### PR DESCRIPTION
### Brief summary of the change made

We should using github star instead of github watch in our docs,
and I think we should remove repo code coverage in our docs too.

**Before**
![image](https://user-images.githubusercontent.com/15820530/131464882-b20e2079-0f4d-4fce-ac44-cfd82607dd24.png)


**After**
![image](https://user-images.githubusercontent.com/15820530/131464912-aa79a13c-a6c1-4975-aedf-8444afda550a.png)

