### PR TITLE
BigQuery: Allow Qualify Clause for UnorderedSelectStatements

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -196,7 +196,7 @@ class QualifyClauseSegment(BaseSegment):
 
 @bigquery_dialect.segment(replace=True)
 class SelectStatementSegment(BaseSegment):
-    """Enhance`SELECT` statement to include QUALIFY."""
+    """Enhance `SELECT` statement to include QUALIFY."""
 
     type = "select_statement"
     match_grammar = ansi_dialect.get_segment(
@@ -208,6 +208,23 @@ class SelectStatementSegment(BaseSegment):
     ).parse_grammar.copy(
         insert=[Ref("QualifyClauseSegment", optional=True)],
         before=Ref("OrderByClauseSegment", optional=True),
+    )
+
+
+@bigquery_dialect.segment(replace=True)
+class UnorderedSelectStatementSegment(BaseSegment):
+    """Enhance unordered `SELECT` statement to include QUALIFY."""
+
+    type = "select_statement"
+    match_grammar = ansi_dialect.get_segment(
+        "UnorderedSelectStatementSegment"
+    ).match_grammar.copy()
+
+    parse_grammar = ansi_dialect.get_segment(
+        "UnorderedSelectStatementSegment"
+    ).parse_grammar.copy(
+        insert=[Ref("QualifyClauseSegment", optional=True)],
+        before=Ref("OverlapsClauseSegment", optional=True),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -746,3 +746,23 @@ class SelectStatementSegment(BaseSegment):
         insert=[Ref("QualifyClauseSegment", optional=True)],
         before=Ref("OrderByClauseSegment", optional=True),
     )
+
+
+@teradata_dialect.segment(replace=True)
+class UnorderedSelectStatementSegment(BaseSegment):
+    """An unordered `SELECT` statement.
+
+    https://dev.mysql.com/doc/refman/5.7/en/select.html
+    """
+
+    type = "select_statement"
+    match_grammar = ansi_dialect.get_segment(
+        "UnorderedSelectStatementSegment"
+    ).match_grammar.copy()
+
+    parse_grammar = ansi_dialect.get_segment(
+        "UnorderedSelectStatementSegment"
+    ).parse_grammar.copy(
+        insert=[Ref("QualifyClauseSegment", optional=True)],
+        before=Ref("OverlapsClauseSegment", optional=True),
+    )

--- a/test/fixtures/parser/bigquery/select_with_union_and_qualify.sql
+++ b/test/fixtures/parser/bigquery/select_with_union_and_qualify.sql
@@ -1,0 +1,13 @@
+SELECT
+  item,
+  RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
+FROM Produce
+WHERE Produce.category = 'vegetable'
+QUALIFY rank <= 3
+UNION ALL
+SELECT
+  item,
+  RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
+FROM Produce
+WHERE Produce.category = 'vegetable'
+QUALIFY rank <= 3

--- a/test/fixtures/parser/bigquery/select_with_union_and_qualify.yml
+++ b/test/fixtures/parser/bigquery/select_with_union_and_qualify.yml
@@ -1,0 +1,128 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 0542922c0f23b3994d1068635810a4fefeee5036c5feb00bf0f5ddda08e6fc20
+file:
+  statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              identifier: item
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: RANK
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+              over_clause:
+                keyword: OVER
+                bracketed:
+                  start_bracket: (
+                  window_specification:
+                    partitionby_clause:
+                    - keyword: PARTITION
+                    - keyword: BY
+                    - expression:
+                        column_reference:
+                          identifier: category
+                    orderby_clause:
+                    - keyword: ORDER
+                    - keyword: BY
+                    - column_reference:
+                        identifier: purchases
+                    - keyword: DESC
+                  end_bracket: )
+            alias_expression:
+              keyword: AS
+              identifier: rank
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: Produce
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+            - identifier: Produce
+            - dot: .
+            - identifier: category
+            comparison_operator: '='
+            literal: "'vegetable'"
+        qualify_clause:
+          keyword: QUALIFY
+          expression:
+            column_reference:
+              identifier: rank
+            comparison_operator: <=
+            literal: '3'
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              identifier: item
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: RANK
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+              over_clause:
+                keyword: OVER
+                bracketed:
+                  start_bracket: (
+                  window_specification:
+                    partitionby_clause:
+                    - keyword: PARTITION
+                    - keyword: BY
+                    - expression:
+                        column_reference:
+                          identifier: category
+                    orderby_clause:
+                    - keyword: ORDER
+                    - keyword: BY
+                    - column_reference:
+                        identifier: purchases
+                    - keyword: DESC
+                  end_bracket: )
+            alias_expression:
+              keyword: AS
+              identifier: rank
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: Produce
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+            - identifier: Produce
+            - dot: .
+            - identifier: category
+            comparison_operator: '='
+            literal: "'vegetable'"
+        qualify_clause:
+          keyword: QUALIFY
+          expression:
+            column_reference:
+              identifier: rank
+            comparison_operator: <=
+            literal: '3'

--- a/test/fixtures/parser/snowflake/snowflake_qualify_union.sql
+++ b/test/fixtures/parser/snowflake/snowflake_qualify_union.sql
@@ -1,0 +1,11 @@
+select
+    col1,
+    col2
+from some_table
+qualify row_number() over (partition by col1 order by col1) = 1
+union all
+select
+    col1,
+    col2
+from some_table
+qualify row_number() over (partition by col1 order by col1) = 1

--- a/test/fixtures/parser/snowflake/snowflake_qualify_union.yml
+++ b/test/fixtures/parser/snowflake/snowflake_qualify_union.yml
@@ -1,0 +1,102 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 371c117719284838c3ed35657264ef371c8c0e2fc685de5aaa84f39173629ba2
+file:
+  statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            column_reference:
+              identifier: col1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              identifier: col2
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: some_table
+        having_clause:
+          keyword: qualify
+          expression:
+            function:
+              function_name:
+                function_name_identifier: row_number
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+              over_clause:
+                keyword: over
+                bracketed:
+                  start_bracket: (
+                  window_specification:
+                    partitionby_clause:
+                    - keyword: partition
+                    - keyword: by
+                    - expression:
+                        column_reference:
+                          identifier: col1
+                    orderby_clause:
+                    - keyword: order
+                    - keyword: by
+                    - column_reference:
+                        identifier: col1
+                  end_bracket: )
+            comparison_operator: '='
+            literal: '1'
+    - set_operator:
+      - keyword: union
+      - keyword: all
+    - select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            column_reference:
+              identifier: col1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              identifier: col2
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: some_table
+        having_clause:
+          keyword: qualify
+          expression:
+            function:
+              function_name:
+                function_name_identifier: row_number
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+              over_clause:
+                keyword: over
+                bracketed:
+                  start_bracket: (
+                  window_specification:
+                    partitionby_clause:
+                    - keyword: partition
+                    - keyword: by
+                    - expression:
+                        column_reference:
+                          identifier: col1
+                    orderby_clause:
+                    - keyword: order
+                    - keyword: by
+                    - column_reference:
+                        identifier: col1
+                  end_bracket: )
+            comparison_operator: '='
+            literal: '1'

--- a/test/fixtures/parser/teradata/qualify_expression_union.sql
+++ b/test/fixtures/parser/teradata/qualify_expression_union.sql
@@ -1,0 +1,3 @@
+SELECT id FROM mytable qualify x = 1
+UNION ALL
+SELECT id FROM mytable qualify x = 1;

--- a/test/fixtures/parser/teradata/qualify_expression_union.yml
+++ b/test/fixtures/parser/teradata/qualify_expression_union.yml
@@ -1,0 +1,53 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 2f6d9afa2747242b3c11b93c40d5ea425b36b0a71e5a7165f693d9e0d05eac54
+file:
+  statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              identifier: id
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: mytable
+        qualify_clause:
+          keyword: qualify
+          expression:
+            column_reference:
+              identifier: x
+            comparison_operator: '='
+            literal: '1'
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              identifier: id
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: mytable
+        qualify_clause:
+          keyword: qualify
+          expression:
+            column_reference:
+              identifier: x
+            comparison_operator: '='
+            literal: '1'
+  statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

The `QUALIFY` clause was added by myself to BigQuery in #1281 but currently it is not set up to be used in UnorderedSelectStatements as used by the `UNION` statements:

```sql
SELECT a
FROM b
QUALIFY a > 122
UNION ALL
SELECT a
FROM b
QUALIFY a > 122
```

This PR adds that support.

I also added it to snowflake and teradata while at it as see they use this too

### Are there any other side effects of this change that we should be aware of?

Shouldn't be

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
