### PR TITLE
Pytest coverage exceptions for Core code - part 1

### DIFF
--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -68,7 +68,7 @@ def nested_combine(*dicts: dict) -> dict:
             if k in r and isinstance(r[k], dict):
                 if isinstance(d[k], dict):
                     r[k] = nested_combine(r[k], d[k])
-                else:
+                else:  # pragma: no cover
                     raise ValueError(
                         "Key {!r} is a dict in one config but not another! PANIC: {!r}".format(
                             k, d[k]
@@ -203,7 +203,7 @@ class ConfigLoader:
             elif k.startswith("sqlfluff:"):
                 # Return a tuple of nested values
                 key = tuple(k[len("sqlfluff:") :].split(":"))
-            else:
+            else:  # pragma: no cover
                 # if it doesn't start with sqlfluff, then don't go
                 # further on this iteration
                 continue
@@ -240,7 +240,7 @@ class ConfigLoader:
                 if dp in r:
                     if isinstance(r[dp], dict):
                         r = r[dp]
-                    else:
+                    else:  # pragma: no cover
                         raise ValueError(f"Overriding config value with section! [{k}]")
                 else:
                     r[dp] = {}
@@ -374,7 +374,7 @@ class ConfigLoader:
             next_path_to_visit = (
                 path_to_visit / given_path.relative_to(path_to_visit).parts[0]
             )
-            if next_path_to_visit == path_to_visit:
+            if next_path_to_visit == path_to_visit:  # pragma: no cover
                 # we're not making progress...
                 # [prevent infinite loop]
                 break
@@ -465,7 +465,7 @@ class FluffConfig:
         like Linter(), Parser() and Lexer() can be instantiated with a
         FluffConfig or with the convenience kwargs: dialect & rules.
         """
-        if (dialect or rules) and config:
+        if (dialect or rules) and config:  # pragma: no cover
             raise ValueError(
                 "Cannot specify `config` with `dialect` or `rules`. Any config object "
                 "specifies its own dialect and rules."
@@ -543,7 +543,7 @@ class FluffConfig:
         # Coerce the value into something more useful.
         config_val = coerce_value(val)
         # Sort out core if not there
-        if len(config_path) == 1:
+        if len(config_path) == 1:  # pragma: no cover TODO?
             config_path = ["core"] + config_path
         # Current section:
         dict_buff = [self._configs]
@@ -592,7 +592,7 @@ class FluffConfig:
         if config_line.startswith("--"):
             config_line = config_line[2:].strip()
         # Strip preceding sqlfluff line.
-        if not config_line.startswith("sqlfluff:"):
+        if not config_line.startswith("sqlfluff:"):  # pragma: no cover
             config_logger.warning(
                 "Unable to process inline config statement: %r", config_line
             )

--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -44,7 +44,7 @@ class Dialect:
         self.inherits_from = inherits_from
         self.root_segment_name = root_segment_name
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return f"<Dialect: {self.name}>"
 
     def expand(self) -> "Dialect":
@@ -63,7 +63,7 @@ class Dialect:
                 with expanded references.
         """
         # Are we already expanded?
-        if self.expanded:
+        if self.expanded:  # pragma: no cover
             raise ValueError("Attempted to re-expand an already expanded dialect.")
 
         expanded_copy = self.copy_as(name=self.name)
@@ -108,7 +108,7 @@ class Dialect:
         `replace` method can be used to override particular rules.
         """
         # Are we already expanded?
-        if self.expanded:
+        if self.expanded:  # pragma: no cover
             # If we copy an already expanded dialect then any SegmentGenerators
             # won't respond. This is most likely a mistake.
             raise ValueError("Attempted to copy an already expanded dialect.")
@@ -141,10 +141,10 @@ class Dialect:
             """Wrap a segment and register it against the dialect."""
             n = cls.__name__
             if replace:
-                if n not in self._library:
+                if n not in self._library:  # pragma: no cover
                     raise ValueError(f"{n!r} is not already registered in {self!r}")
             else:
-                if n in self._library:
+                if n in self._library:  # pragma: no cover
                     raise ValueError(f"{n!r} is already registered in {self!r}")
             self._library[n] = cls
             # Pass it back after registering it
@@ -166,7 +166,7 @@ class Dialect:
         will iterate through the kwargs
         """
         for n in kwargs:
-            if n in self._library:
+            if n in self._library:  # pragma: no cover
                 raise ValueError(f"{n!r} is already registered in {self!r}")
             self._library[n] = kwargs[n]
 
@@ -176,7 +176,7 @@ class Dialect:
         Usage is very similar to add, but elements specified must already exist.
         """
         for n in kwargs:
-            if n not in self._library:
+            if n not in self._library:  # pragma: no cover
                 raise ValueError(f"{n!r} is not already registered in {self!r}")
             self._library[n] = kwargs[n]
 
@@ -186,9 +186,9 @@ class Dialect:
         This is typically for dialect inheritance. This method
         also validates that the result is a grammar.
         """
-        if name not in self._library:
+        if name not in self._library:  # pragma: no cover
             raise ValueError(f"Element {name} not found in dialect.")
-        if not isinstance(self._library[name], BaseGrammar):
+        if not isinstance(self._library[name], BaseGrammar):  # pragma: no cover
             raise TypeError(
                 f"Attempted to fetch non grammar [{name}] with get_grammar."
             )
@@ -200,9 +200,9 @@ class Dialect:
         This is typically for dialect inheritance. This method
         also validates that the result is a segment.
         """
-        if name not in self._library:
+        if name not in self._library:  # pragma: no cover
             raise ValueError(f"Element {name} not found in dialect.")
-        if not issubclass(self._library[name], BaseSegment):
+        if not issubclass(self._library[name], BaseSegment):  # pragma: no cover
             raise TypeError(
                 f"Attempted to fetch non segment [{name}] with get_segment."
             )
@@ -215,20 +215,20 @@ class Dialect:
         as a result.
 
         """
-        if not self.expanded:
+        if not self.expanded:  # pragma: no cover
             raise RuntimeError("Dialect must be expanded before use.")
 
         if name in self._library:
             res = self._library[name]
             if res:
                 return res
-            else:
+            else:  # pragma: no cover
                 raise ValueError(
                     "Unexpected Null response while fetching {!r} from {}".format(
                         name, self.name
                     )
                 )
-        else:
+        else:  # pragma: no cover
             raise RuntimeError(
                 "Grammar refers to {!r} which was not found in the {} dialect".format(
                     name, self.name
@@ -249,7 +249,7 @@ class Dialect:
         """Fetch the lexer struct for this dialect."""
         if self.lexer_matchers:
             return self.lexer_matchers
-        else:
+        else:  # pragma: no cover
             raise ValueError(f"Lexing struct has not been set for dialect {self}")
 
     def patch_lexer_matchers(self, lexer_patch):
@@ -258,7 +258,7 @@ class Dialect:
         Used to edit the lexer of a sub-dialect.
         """
         buff = []
-        if not self.lexer_matchers:
+        if not self.lexer_matchers:  # pragma: no cover
             raise ValueError("Lexer struct must be defined before it can be patched!")
 
         # Make a new data struct for lookups
@@ -280,7 +280,7 @@ class Dialect:
         """
         buff = []
         found = False
-        if not self.lexer_matchers:
+        if not self.lexer_matchers:  # pragma: no cover
             raise ValueError("Lexer struct must be defined before it can be patched!")
 
         for elem in self.lexer_matchers:
@@ -292,7 +292,7 @@ class Dialect:
             else:
                 buff.append(elem)
 
-        if not found:
+        if not found:  # pragma: no cover
             raise ValueError(
                 "Lexer struct insert before '%s' failed because tag never found."
             )

--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -62,11 +62,11 @@ class SQLBaseError(ValueError):
             return self.rule.description
         else:
             # Return the first element - probably a string message
-            if len(self.args) > 1:
+            if len(self.args) > 1:  # pragma: no cover TODO?
                 return self.args
             elif len(self.args) == 1:
                 return self.args[0]
-            else:
+            else:  # pragma: no cover TODO?
                 return self.__class__.__name__
 
     def get_info_dict(self):
@@ -84,7 +84,7 @@ class SQLBaseError(ValueError):
     def ignore_if_in(self, ignore_iterable):
         """Ignore this violation if it matches the iterable."""
         # Type conversion
-        if isinstance(ignore_iterable, str):
+        if isinstance(ignore_iterable, str):  # pragma: no cover TODO?
             ignore_iterable = []
         # Ignoring
         if self._identifier in ignore_iterable:

--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -39,17 +39,21 @@ class LintedDir:
         self.files.append(file)
 
     @overload
-    def check_tuples(self, by_path: Literal[False]) -> List[CheckTuple]:
+    def check_tuples(
+        self, by_path: Literal[False]
+    ) -> List[CheckTuple]:  # pragma: no cover
         """Return a List of CheckTuples when by_path is False."""
         ...
 
     @overload
-    def check_tuples(self, by_path: Literal[True]) -> Dict[str, List[CheckTuple]]:
+    def check_tuples(
+        self, by_path: Literal[True]
+    ) -> Dict[str, List[CheckTuple]]:  # pragma: no cover
         """Return a Dict of paths and CheckTuples when by_path is True."""
         ...
 
     @overload
-    def check_tuples(self, by_path: bool = False):
+    def check_tuples(self, by_path: bool = False):  # pragma: no cover
         """Default overload method."""
         ...
 
@@ -105,7 +109,7 @@ class LintedDir:
             if file.num_violations(fixable=True, **kwargs) > 0:
                 buffer[file.path] = file.persist_tree(suffix=fixed_file_suffix)
                 result = buffer[file.path]
-            else:
+            else:  # pragma: no cover TODO?
                 buffer[file.path] = True
                 result = "SKIP"
 
@@ -116,7 +120,7 @@ class LintedDir:
     @property
     def tree(self) -> Optional[BaseSegment]:
         """A convenience method for when there is only one file and we want the tree."""
-        if len(self.files) > 1:
+        if len(self.files) > 1:  # pragma: no cover
             raise ValueError(
                 ".tree() cannot be called when a LintedDir contains more than one file."
             )

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -83,7 +83,7 @@ class LintedFile(NamedTuple):
             if isinstance(types, type) and issubclass(types, SQLBaseError):
                 types = (types,)
             else:
-                types = tuple(types)
+                types = tuple(types)  # pragma: no cover TODO?
             violations = [v for v in violations if isinstance(v, types)]
         # Filter rules
         if rules:
@@ -354,13 +354,15 @@ class LintedFile(NamedTuple):
                 )
             # If it's an insertion (i.e. the string in the pre-fix template is '') then we
             # won't be able to place it, so skip.
-            elif not enriched_patch.templated_str:
+            elif not enriched_patch.templated_str:  # pragma: no cover TODO?
                 linter_logger.info(
                     "      - Skipping insertion patch in templated section: %s",
                     enriched_patch,
                 )
             # If the string from the templated version isn't in the source, then we can't fix it.
-            elif enriched_patch.templated_str not in enriched_patch.source_str:
+            elif (
+                enriched_patch.templated_str not in enriched_patch.source_str
+            ):  # pragma: no cover TODO?
                 linter_logger.info(
                     "      - Skipping edit patch on templated content: %s",
                     enriched_patch,

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -135,7 +135,7 @@ class Linter:
             violations.append(err)
             return None, violations, config
 
-        if not tokens:
+        if not tokens:  # pragma: no cover TODO?
             return None, violations, config
 
         # Check that we've got sensible indentation from the lexer.
@@ -230,7 +230,7 @@ class Linter:
                     action: Optional[str]
                     if "=" in comment_remainder:
                         action, rule_part = comment_remainder.split("=", 1)
-                        if action not in {"disable", "enable"}:
+                        if action not in {"disable", "enable"}:  # pragma: no cover
                             return SQLParseError(
                                 "Malformed 'noqa' section. "
                                 "Expected 'noqa: enable=<rule>[,...] | all' "
@@ -395,7 +395,7 @@ class Linter:
                 if fix and fixes:
                     linter_logger.info(f"Applying Fixes [{crawler.code}]: {fixes}")
                     # Do some sanity checks on the fixes before applying.
-                    if fixes == last_fixes:
+                    if fixes == last_fixes:  # pragma: no cover
                         cls._warn_unfixable(crawler.code)
                     else:
                         last_fixes = fixes
@@ -495,7 +495,7 @@ class Linter:
         if parsed.config.get("dialect") == "ansi" and linted_file.get_violations(
             fixable=True if fix else None, types=SQLParseError
         ):
-            if formatter:
+            if formatter:  # pragma: no cover TODO?
                 formatter.dispatch_dialect_warning()
 
         return linted_file
@@ -544,7 +544,7 @@ class Linter:
             templated_file, templater_violations = self.templater.process(
                 in_str=in_str, fname=fname, config=config, formatter=self.formatter
             )
-        except SQLTemplaterSkipFile as s:
+        except SQLTemplaterSkipFile as s:  # pragma: no cover
             linter_logger.warning(str(s))
             templated_file = None
             templater_violations = []
@@ -808,7 +808,7 @@ class Linter:
         for linted_file in runner.run(fnames, fix):
             linted_path.add(linted_file)
             # If any fatal errors, then stop iteration.
-            if any(v.fatal for v in linted_file.violations):
+            if any(v.fatal for v in linted_file.violations):  # pragma: no cover
                 linter_logger.error("Fatal linting error. Halting further linting.")
                 break
         return linted_path
@@ -823,7 +823,7 @@ class Linter:
     ) -> LintingResult:
         """Lint an iterable of paths."""
         # If no paths specified - assume local
-        if len(paths) == 0:
+        if len(paths) == 0:  # pragma: no cover
             paths = (os.getcwd(),)
         # Set up the result to hold what we get back
         result = LintingResult()

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -59,17 +59,21 @@ class LintingResult:
         self.total_time = time.monotonic() - self._start_time
 
     @overload
-    def check_tuples(self, by_path: Literal[False]) -> List[CheckTuple]:
+    def check_tuples(
+        self, by_path: Literal[False]
+    ) -> List[CheckTuple]:  # pragma: no cover
         """Return a List of CheckTuples when by_path is False."""
         ...
 
     @overload
-    def check_tuples(self, by_path: Literal[True]) -> Dict[LintedDir, List[CheckTuple]]:
+    def check_tuples(
+        self, by_path: Literal[True]
+    ) -> Dict[LintedDir, List[CheckTuple]]:  # pragma: no cover
         """Return a Dict of LintedDir and CheckTuples when by_path is True."""
         ...
 
     @overload
-    def check_tuples(self, by_path: bool = False):
+    def check_tuples(self, by_path: bool = False):  # pragma: no cover
         """Default overload method."""
         ...
 
@@ -106,7 +110,9 @@ class LintingResult:
 
     def violation_dict(self, **kwargs):
         """Return a dict of paths and violations."""
-        return self.combine_dicts(path.violation_dict(**kwargs) for path in self.paths)
+        return self.combine_dicts(
+            path.violation_dict(**kwargs) for path in self.paths
+        )  # pragma: no cover TODO?
 
     def stats(self) -> Dict[str, Any]:
         """Return a stats dictionary of this result."""
@@ -167,7 +173,7 @@ class LintingResult:
         )
 
     @property
-    def tree(self) -> Optional[BaseSegment]:
+    def tree(self) -> Optional[BaseSegment]:  # pragma: no cover
         """A convenience method for when there is only one file and we want the tree."""
         if len(self.paths) > 1:
             raise ValueError(

--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -60,7 +60,7 @@ class BaseRunner(ABC):
 
     def run(self, fnames: List[str], fix: bool):
         """Run linting on the specified list of files."""
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     @classmethod
     def _init_global(cls, config):
@@ -75,7 +75,7 @@ class BaseRunner(ABC):
     def _handle_lint_path_exception(fname, e):
         if isinstance(e, IOError):
             # IOErrors are caught in commands.py, so propagate it
-            raise (e)
+            raise (e)  # pragma: no cover
         linter_logger.warning(
             f"""Unable to lint {fname} due to an internal error. \
 Please report this as an issue with your query's contents and stacktrace below!
@@ -138,7 +138,7 @@ class ParallelRunner(BaseRunner):
                                 lint_result.path, lint_result, only_fixable=fix
                             )
                         yield lint_result
-            except KeyboardInterrupt:
+            except KeyboardInterrupt:  # pragma: no cover
                 # On keyboard interrupt (Ctrl-C), terminate the workers.
                 # Notify the user we've received the signal and are cleaning up,
                 # in case it takes awhile.
@@ -174,7 +174,7 @@ class MultiProcessRunner(ParallelRunner):
     MAP_FUNCTION_NAME = "imap_unordered"
 
     @classmethod
-    def _init_global(cls, config):
+    def _init_global(cls, config):  # pragma: no cover
         super()._init_global(config)
 
         # Disable signal handling in the child processes to let the parent

--- a/src/sqlfluff/core/rules/analysis/select_crawler.py
+++ b/src/sqlfluff/core/rules/analysis/select_crawler.py
@@ -54,7 +54,7 @@ class SelectCrawler:
         """
         for o in cls.crawl(segment, queries, dialect, False):
             return o
-        assert False, "Should be unreachable"
+        assert False, "Should be unreachable"  # pragma: no cover
 
     @classmethod
     def crawl(

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -24,7 +24,7 @@ from collections import namedtuple
 from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.errors import SQLLintError
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from sqlfluff.core.templaters import TemplatedFile
 
 # The ghost of a rule (mostly used for testing)
@@ -109,10 +109,10 @@ class LintFix:
     """
 
     def __init__(self, edit_type, anchor: BaseSegment, edit=None):
-        if edit_type not in ["create", "edit", "delete"]:
+        if edit_type not in ["create", "edit", "delete"]:  # pragma: no cover
             raise ValueError(f"Unexpected edit_type: {edit_type}")
         self.edit_type = edit_type
-        if not anchor:
+        if not anchor:  # pragma: no cover
             raise ValueError("Fixes must provide an anchor.")
         self.anchor = anchor
         # Coerce to list
@@ -151,12 +151,12 @@ class LintFix:
         """
         if self.edit_type == "create":
             if isinstance(self.edit, BaseSegment):
-                if len(self.edit.raw) == 0:
+                if len(self.edit.raw) == 0:  # pragma: no cover TODO?
                     return True
             elif all(len(elem.raw) == 0 for elem in self.edit):
                 return True
         elif self.edit_type == "edit" and self.edit == self.anchor:
-            return True
+            return True  # pragma: no cover TODO?
         return False
 
     def __repr__(self):
@@ -164,7 +164,7 @@ class LintFix:
             detail = f"delete:{self.anchor.raw!r}"
         elif self.edit_type in ("edit", "create"):
             if hasattr(self.edit, "raw"):
-                new_detail = self.edit.raw
+                new_detail = self.edit.raw  # pragma: no cover TODO?
             else:
                 new_detail = "".join(s.raw for s in self.edit)
 
@@ -173,7 +173,7 @@ class LintFix:
             else:
                 detail = f"create:{new_detail!r}"
         else:
-            detail = ""
+            detail = ""  # pragma: no cover TODO?
         return "<LintFix: {} @{} {}>".format(
             self.edit_type, self.anchor.pos_marker, detail
         )
@@ -191,7 +191,7 @@ class LintFix:
             return False
         if not self.edit == other.edit:
             return False
-        return True
+        return True  # pragma: no cover TODO?
 
 
 class BaseRule:
@@ -234,7 +234,7 @@ class BaseRule:
         except AttributeError:
             self.logger.info(f"No config_keywords defined for {code}")
 
-    def _eval(self, **kwargs):
+    def _eval(self, **kwargs):  # pragma: no cover
         """Evaluate this rule against the current context.
 
         This should indicate whether a linting violation has occurred and/or
@@ -408,7 +408,7 @@ class BaseRule:
         return tuple(buff)
 
     @classmethod
-    def get_parent_of(cls, segment, root_segment):
+    def get_parent_of(cls, segment, root_segment):  # pragma: no cover TODO?
         """Return the segment immediately containing segment.
 
         NB: This is recursive.
@@ -534,7 +534,7 @@ class RuleSet:
         """
         rule_name_match = self.valid_rule_name_regex.match(cls.__name__)
         # Validate the name
-        if not rule_name_match:
+        if not rule_name_match:  # pragma: no cover
             raise ValueError(
                 (
                     "Tried to register rule on set {!r} with unexpected "
@@ -551,7 +551,7 @@ class RuleSet:
             code = f"{plugin_name}_{code}"
 
         # Keep track of the *class* in the register. Don't instantiate yet.
-        if code in self._register:
+        if code in self._register:  # pragma: no cover
             raise ValueError(
                 "Rule {!r} has already been registered on RuleSet {!r}!".format(
                     code, self.name
@@ -591,7 +591,7 @@ class RuleSet:
         blacklisted_unknown_rule_codes = [
             r for r in blacklist if r not in self._register
         ]
-        if any(blacklisted_unknown_rule_codes):
+        if any(blacklisted_unknown_rule_codes):  # pragma: no cover
             rules_logger.warning(
                 "Tried to blacklist unknown rules: {!r}".format(
                     blacklisted_unknown_rule_codes

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -355,7 +355,7 @@ class BaseRule:
                 if lerr:
                     new_lerrs.append(lerr)
                 new_fixes += elem.fixes
-        else:
+        else:  # pragma: no cover
             raise TypeError(
                 "Got unexpected result [{!r}] back from linting rule: {!r}".format(
                     res, self.code

--- a/src/sqlfluff/core/rules/doc_decorators.py
+++ b/src/sqlfluff/core/rules/doc_decorators.py
@@ -13,7 +13,7 @@ def document_fix_compatible(cls):
     return cls
 
 
-def is_fix_compatible(cls) -> bool:
+def is_fix_compatible(cls) -> bool:  # pragma: no cover TODO?
     """Return whether the rule is documented as fixable."""
     return FIX_COMPATIBLE in cls.__doc__
 
@@ -29,7 +29,7 @@ def document_configuration(cls, ruleset="std"):
     """
     if ruleset == "std":
         config_info = get_config_info()
-    else:
+    else:  # pragma: no cover
         raise (
             NotImplementedError(
                 "Add another config info dict for the new ruleset here!"
@@ -41,7 +41,7 @@ def document_configuration(cls, ruleset="std"):
         for keyword in sorted(cls.config_keywords):
             try:
                 info_dict = config_info[keyword]
-            except KeyError:
+            except KeyError:  # pragma: no cover
                 raise KeyError(
                     "Config value {!r} for rule {} is not configured in `config_info`.".format(
                         keyword, cls.__name__

--- a/src/sqlfluff/core/timing.py
+++ b/src/sqlfluff/core/timing.py
@@ -20,7 +20,7 @@ class TimingSummary:
     def summary(self) -> Dict[str, Dict[str, float]]:
         """Generate a summary for display."""
         vals: Dict[str, List[float]] = defaultdict(list)
-        if not self.steps:
+        if not self.steps:  # pragma: no cover
             return {}
 
         for timing_dict in self._timings:


### PR DESCRIPTION
### Brief summary of the change made

Progress on #1314 this adds coverage exceptions (using `# pragma: no cover`) for the `src/sql/core` files exception for:
- src/sql/core/parser (big one and this PR is big enough)
- src/sql/core/templaters (a lot of changes in #1264 waiting to be merged so best left alone)

**_It often seems to be `src/sqlfluff/core/linter/runner.py` which causes us noise in PR so hopefully the fact it is covered to 100% in this PR will reduce that noise until we can get to 100%._**

The remaining ones will be covered in a future PR.

The rest have been addressed and now show 100% coverage:

```
Name                                                 Stmts   Miss  Cover   Missing
----------------------------------------------------------------------------------
src/sqlfluff/__init__.py                                 9      0   100%
src/sqlfluff/api/__init__.py                             2      0   100%
src/sqlfluff/api/info.py                                 9      0   100%
src/sqlfluff/api/simple.py                              32      0   100%
src/sqlfluff/cli/__init__.py                             0      0   100%
src/sqlfluff/cli/commands.py                           276      0   100%
src/sqlfluff/cli/formatters.py                         134      0   100%
src/sqlfluff/cli/helpers.py                             75      0   100%
src/sqlfluff/core/__init__.py                            8      0   100%
src/sqlfluff/core/config.py                            266      0   100%
src/sqlfluff/core/dialects/__init__.py                  17      0   100%
src/sqlfluff/core/dialects/base.py                      83      0   100%
src/sqlfluff/core/dialects/common.py                     9      0   100%
src/sqlfluff/core/errors.py                             67      0   100%
src/sqlfluff/core/file_helpers.py                        9      0   100%
src/sqlfluff/core/linter/__init__.py                     4      0   100%
src/sqlfluff/core/linter/common.py                      35      0   100%
src/sqlfluff/core/linter/linted_dir.py                  44      0   100%
src/sqlfluff/core/linter/linted_file.py                178      0   100%
src/sqlfluff/core/linter/linter.py                     329      0   100%
src/sqlfluff/core/linter/linting_result.py              72      0   100%
src/sqlfluff/core/linter/runner.py                      86      0   100%
src/sqlfluff/core/parser/__init__.py                     7      0   100%
src/sqlfluff/core/parser/context.py                     82      7    91%   50-51, 120-121, 156, 182, 195
src/sqlfluff/core/parser/grammar/__init__.py             6      0   100%
src/sqlfluff/core/parser/grammar/anyof.py               98      2    98%   84, 188
src/sqlfluff/core/parser/grammar/base.py               273     19    93%   103, 173, 284, 288, 472, 594, 650, 660, 674, 738, 744-745, 759-760, 795, 807, 829, 839-847
src/sqlfluff/core/parser/grammar/conditional.py         34      7    79%   46, 50, 54, 56, 60, 71, 88
src/sqlfluff/core/parser/grammar/delimited.py           76      5    93%   33, 84, 130, 178, 211
src/sqlfluff/core/parser/grammar/greedy.py              86     11    87%   34, 82-83, 85-86, 98-99, 101-102, 142, 180
src/sqlfluff/core/parser/grammar/noncode.py             18      2    89%   24, 30
src/sqlfluff/core/parser/grammar/sequence.py           135      7    95%   54, 111, 224, 252, 290, 311-312
src/sqlfluff/core/parser/helpers.py                     30      2    93%   8, 30
src/sqlfluff/core/parser/lexer.py                      216      4    98%   196, 249, 312, 546
src/sqlfluff/core/parser/markers.py                     77      6    92%   10, 52, 55, 58, 61, 105
src/sqlfluff/core/parser/match_logging.py               35      1    97%   22
src/sqlfluff/core/parser/match_result.py                55     10    82%   12, 75-83, 91-92, 100, 120
src/sqlfluff/core/parser/match_wrapper.py               26      1    96%   55
src/sqlfluff/core/parser/matchable.py                   15      3    80%   9-10, 30
src/sqlfluff/core/parser/parser.py                      16      1    94%   9
src/sqlfluff/core/parser/parsers.py                     59      1    98%   175
src/sqlfluff/core/parser/segments/__init__.py            5      0   100%
src/sqlfluff/core/parser/segments/base.py              434     38    91%   88, 96, 102, 111, 147, 196, 223, 247-252, 254, 305-306, 328, 362, 457, 473, 541-554, 618-621, 737, 758, 780, 786, 797, 898, 907, 975, 1055
src/sqlfluff/core/parser/segments/ephemeral.py          25      0   100%
src/sqlfluff/core/parser/segments/generator.py           5      0   100%
src/sqlfluff/core/parser/segments/meta.py               35      3    91%   28, 83, 103
src/sqlfluff/core/parser/segments/raw.py               110      1    99%   140
src/sqlfluff/core/plugin/__init__.py                     4      0   100%
src/sqlfluff/core/plugin/hookspecs.py                    9      0   100%
src/sqlfluff/core/plugin/host.py                         8      0   100%
src/sqlfluff/core/plugin/lib.py                         14      0   100%
src/sqlfluff/core/rules/__init__.py                     13      0   100%
src/sqlfluff/core/rules/analysis/__init__.py             0      0   100%
src/sqlfluff/core/rules/analysis/select.py              71      0   100%
src/sqlfluff/core/rules/analysis/select_crawler.py      69      0   100%
src/sqlfluff/core/rules/base.py                        191      0   100%
src/sqlfluff/core/rules/config_info.py                   6      0   100%
src/sqlfluff/core/rules/doc_decorators.py               25      0   100%
src/sqlfluff/core/rules/loader.py                       15      0   100%
src/sqlfluff/core/string_helpers.py                     14      0   100%
src/sqlfluff/core/templaters/__init__.py                 5      0   100%
src/sqlfluff/core/templaters/base.py                   167      8    95%   53, 109, 133, 196, 226, 287, 291, 331
src/sqlfluff/core/templaters/dbt.py                    156    109    30%   47, 52-55, 60-65, 70-81, 86-89, 95-132, 137-164, 175-191, 198-211, 215, 221-224, 240-282, 285-369
src/sqlfluff/core/templaters/jinja.py                  148      6    96%   59, 90, 136, 199, 262-264
src/sqlfluff/core/templaters/python.py                 343      6    98%   564, 775-787, 878
src/sqlfluff/core/timing.py                             21      0   100%
src/sqlfluff/dialects/__init__.py                        0      0   100%
src/sqlfluff/dialects/ansi_keywords.py                   2      0   100%
src/sqlfluff/dialects/dialect_ansi.py                  478      0   100%
src/sqlfluff/dialects/dialect_bigquery.py              136      0   100%
src/sqlfluff/dialects/dialect_exasol.py                530      0   100%
src/sqlfluff/dialects/dialect_exasol_fs.py              85      0   100%
src/sqlfluff/dialects/dialect_mysql.py                 154      0   100%
src/sqlfluff/dialects/dialect_postgres.py               43      0   100%
src/sqlfluff/dialects/dialect_snowflake.py             120      0   100%
src/sqlfluff/dialects/dialect_teradata.py              104      0   100%
src/sqlfluff/dialects/exasol_keywords.py                 3      0   100%
src/sqlfluff/diff_quality_plugin.py                     22      0   100%
src/sqlfluff/rules/L001.py                              13      0   100%
src/sqlfluff/rules/L002.py                              11      0   100%
src/sqlfluff/rules/L003.py                             201      0   100%
src/sqlfluff/rules/L004.py                              22      0   100%
src/sqlfluff/rules/L005.py                              11      0   100%
src/sqlfluff/rules/L006.py                              68      0   100%
src/sqlfluff/rules/L007.py                              29      0   100%
src/sqlfluff/rules/L008.py                              24      0   100%
src/sqlfluff/rules/L009.py                              19      0   100%
src/sqlfluff/rules/L010.py                              74      0   100%
src/sqlfluff/rules/L011.py                              22      0   100%
src/sqlfluff/rules/L012.py                               3      0   100%
src/sqlfluff/rules/L013.py                              18      0   100%
src/sqlfluff/rules/L014.py                              23      0   100%
src/sqlfluff/rules/L015.py                              28      0   100%
src/sqlfluff/rules/L016.py                             166      0   100%
src/sqlfluff/rules/L017.py                              18      0   100%
src/sqlfluff/rules/L018.py                              49      0   100%
src/sqlfluff/rules/L019.py                              56      0   100%
src/sqlfluff/rules/L020.py                              21      0   100%
src/sqlfluff/rules/L021.py                              16      0   100%
src/sqlfluff/rules/L022.py                              80      0   100%
src/sqlfluff/rules/L023.py                              29      0   100%
src/sqlfluff/rules/L024.py                               9      0   100%
src/sqlfluff/rules/L025.py                              24      0   100%
src/sqlfluff/rules/L026.py                              20      0   100%
src/sqlfluff/rules/L027.py                              12      0   100%
src/sqlfluff/rules/L028.py                              25      0   100%
src/sqlfluff/rules/L029.py                              10      0   100%
src/sqlfluff/rules/L030.py                              11      0   100%
src/sqlfluff/rules/L031.py                              76      0   100%
src/sqlfluff/rules/L032.py                               8      0   100%
src/sqlfluff/rules/L033.py                               8      0   100%
src/sqlfluff/rules/L034.py                              45      0   100%
src/sqlfluff/rules/L035.py                              18      0   100%
src/sqlfluff/rules/L036.py                              84      0   100%
src/sqlfluff/rules/L037.py                              40      0   100%
src/sqlfluff/rules/L038.py                              21      0   100%
src/sqlfluff/rules/L039.py                              27      0   100%
src/sqlfluff/rules/L040.py                               7      0   100%
src/sqlfluff/rules/L041.py                              22      0   100%
src/sqlfluff/rules/L042.py                              20      0   100%
src/sqlfluff/rules/L043.py                              43      0   100%
src/sqlfluff/rules/L044.py                              41      0   100%
src/sqlfluff/rules/L045.py                              21      0   100%
src/sqlfluff/rules/L046.py                              31      0   100%
src/sqlfluff/rules/L047.py                              21      0   100%
src/sqlfluff/rules/L048.py                              12      0   100%
src/sqlfluff/rules/__init__.py                           0      0   100%
src/sqlfluff/testing/__init__.py                         0      0   100%
src/sqlfluff/testing/rules.py                           72      0   100%
----------------------------------------------------------------------------------
TOTAL                                                 8387    260    97%
```

Most of the missing coverage is for exceptions that do not need test coverage. There are a few that ideally we would have coverage for. They have been marked `TODO` for now, but still skipped from coverage as the aim is to get us to 100% coverage given the tests we have (or the easy ones to add) to more easily spot regressions and avoid the coverage alert changes we frequently see now. I couldn't see any easy tests to add for the `TODO`s that I could add to this PR.

### Are there any other side effects of this change that we should be aware of?
Only side effect is some lines that possible should be covered are now accepted as not having coverage. They have been marked with TODO if anyone wants to add coverage at some point.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

Not applicable for this change.
