### PR TITLE
Show all LintResult in Rule_L020

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -132,7 +132,9 @@ class BaseSegment:
         )
 
     def __hash__(self):
-        return hash((self.__class__.__name__, self.raw, self.pos_marker.source_position()))
+        return hash(
+            (self.__class__.__name__, self.raw, self.pos_marker.source_position())
+        )
 
     def __repr__(self):
         return f"<{self.__class__.__name__}: ({self.pos_marker})>"

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -131,6 +131,9 @@ class BaseSegment:
             )
         )
 
+    def __hash__(self):
+        return hash((self.__class__.__name__, self.raw, self.pos_marker.source_position()))
+
     def __repr__(self):
         return f"<{self.__class__.__name__}: ({self.pos_marker})>"
 

--- a/src/sqlfluff/rules/L020.py
+++ b/src/sqlfluff/rules/L020.py
@@ -75,10 +75,10 @@ class Rule_L020(BaseRule):
                     # Reference the element, not the string.
                     anchor=aliases.segment,
                     description=(
-                        "Duplicate table alias {!r}. Table "
-                        "aliases should be unique."
+                        "Duplicate table alias {!r}. Table " "aliases should be unique."
                     ).format(aliases.ref_str),
-                ) for aliases in duplicate
+                )
+                for aliases in duplicate
             ]
         else:
             return None

--- a/src/sqlfluff/rules/L020.py
+++ b/src/sqlfluff/rules/L020.py
@@ -64,22 +64,24 @@ class Rule_L020(BaseRule):
 
         """
         # Are any of the aliases the same?
+        duplicate = set()
         for a1, a2 in itertools.combinations(table_aliases, 2):
             # Compare the strings
             if a1.ref_str == a2.ref_str and a1.ref_str:
-                # If there are any, then the rest of the code
-                # won't make sense so just return here.
-                return [
-                    LintResult(
-                        # Reference the element, not the string.
-                        anchor=a2.segment,
-                        description=(
-                            "Duplicate table alias {!r}. Table "
-                            "aliases should be unique."
-                        ).format(a2.ref_str),
-                    )
-                ]
-        return None
+                duplicate.add(a2)
+        if duplicate:
+            return [
+                LintResult(
+                    # Reference the element, not the string.
+                    anchor=aliases.segment,
+                    description=(
+                        "Duplicate table alias {!r}. Table "
+                        "aliases should be unique."
+                    ).format(aliases.ref_str),
+                ) for aliases in duplicate
+            ]
+        else:
+            return None
 
     def _eval(self, segment, parent_stack, dialect, **kwargs):
         """Get References and Aliases and allow linting.

--- a/test/fixtures/rules/std_rule_cases/L020.yml
+++ b/test/fixtures/rules/std_rule_cases/L020.yml
@@ -1,5 +1,13 @@
 rule: L020
 
-test_fail_duplicated_aliases:
+test_fail_exactly_once_duplicated_aliases:
   # duplicate aliases
   fail_str: select 1 from table_1 as a join table_2 as a using(pk)
+
+test_fail_two_duplicated_aliases:
+  fail_str: |
+    select 1
+    from table_1 as a
+    join table_2 as a on a.pk = b.pk
+    join table_3 as b on a.pk = b.pk
+    join table_4 as b on b.pk = b.pk

--- a/test/rules/std_L020_test.py
+++ b/test/rules/std_L020_test.py
@@ -1,0 +1,86 @@
+"""Tests the python routines within L020."""
+
+import sqlfluff
+
+
+def test__rules__std_L020_one_aliases_one_duplicate():
+    """Verify that L020 returns the correct error message for one duplicate table aliases occur one times."""
+    sql = """
+        SELECT
+            a.pk
+        FROM table_1 AS a
+        JOIN table_2 AS a ON a.pk = a.pk
+    """
+    result = sqlfluff.lint(sql)
+    assert "L020" in [r["code"] for r in result]
+    assert [r["code"] for r in result].count("L020") == 1
+
+
+def test__rules__std_L020_one_aliases_two_duplicate():
+    """Verify that L020 returns the correct error message for one duplicate table aliases occur two times."""
+    sql = """
+        SELECT
+            a.pk
+        FROM table_1 AS a
+        JOIN table_2 AS a ON a.pk = a.pk
+        JOIN table_3 AS a ON a.pk = a.pk
+    """
+    result = sqlfluff.lint(sql)
+    result_filter = [r for r in result if r["code"] == "L020"]
+    # Error message only show two times, not three
+    assert len(result_filter) == 2
+    assert (
+        len(
+            [
+                r
+                for r in result_filter
+                if "Duplicate table alias 'a'" in r["description"]
+            ]
+        )
+        == 2
+    )
+    # Test specific line number
+    assert result_filter[0]["line_no"] == 5
+    assert result_filter[1]["line_no"] == 6
+
+
+def test__rules__std_L020_complex():
+    """Verify that L020 returns the correct error message for complex example."""
+    sql = """
+        SELECT
+            a.pk,
+            b.pk
+        FROM table_1 AS a
+        JOIN table_2 AS a ON a.pk = a.pk
+        JOIN table_3 AS b ON a.pk = b.pk
+        JOIN table_4 AS b ON b.pk = b.pk
+        JOIN table_5 AS a ON b.pk = a.pk
+    """
+    result = sqlfluff.lint(sql)
+    result_filter = [r for r in result if r["code"] == "L020"]
+    # Error message only show two times, not three
+    assert len(result_filter) == 3
+    assert (
+        len(
+            [
+                r
+                for r in result_filter
+                if "Duplicate table alias 'a'" in r["description"]
+            ]
+        )
+        == 2
+    )
+    assert (
+        len(
+            [
+                r
+                for r in result_filter
+                if "Duplicate table alias 'b'" in r["description"]
+            ]
+        )
+        == 1
+    )
+    # Test specific line number
+    assert result_filter[0]["line_no"] == 6
+    assert result_filter[1]["line_no"] == 8
+    assert result_filter[2]["line_no"] == 9


### PR DESCRIPTION
### Brief summary of the change made

Rule_L020 only show first LintResult before,
after this patch merge Rule_L020 would show
all duplicate table aliases, without duplicate
position

### Are there any other side effects of this change that we should be aware of?

I think this PR no need add `std_rule_cases` here, am I wrong?

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - ~`.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.`~  Already exists and no need