### PR TITLE
Enhance error message L010 base on configure

### DIFF
--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -90,7 +90,7 @@ You can then run :code:`sqlfluff lint test.sql` to lint this file.
     L:   1 | P:   9 | L006 | Missing whitespace after +
     L:   1 | P:  11 | L039 | Unnecessary whitespace found.
     L:   2 | P:   1 | L003 | Indent expected and not found compared to line #1
-    L:   2 | P:  10 | L010 | Keywords not consistently upper case.
+    L:   2 | P:  10 | L010 | Keywords must be consistently upper case.
     L:   2 | P:  15 | L009 | Files must end with a trailing newline.
 
 You'll see that *SQLFluff* has failed the linting check for this file.

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -90,7 +90,7 @@ You can then run :code:`sqlfluff lint test.sql` to lint this file.
     L:   1 | P:   9 | L006 | Missing whitespace after +
     L:   1 | P:  11 | L039 | Unnecessary whitespace found.
     L:   2 | P:   1 | L003 | Indent expected and not found compared to line #1
-    L:   2 | P:  10 | L010 | Inconsistent capitalisation of keywords.
+    L:   2 | P:  10 | L010 | Keywords not consistently upper case.
     L:   2 | P:  15 | L009 | Files must end with a trailing newline.
 
 You'll see that *SQLFluff* has failed the linting check for this file.
@@ -122,7 +122,7 @@ error (violation of *L006*) no longer shows up.
                            | calculations and aggregates.
     L:   1 | P:  13 | L039 | Unnecessary whitespace found.
     L:   2 | P:   1 | L003 | Indent expected and not found compared to line #1
-    L:   2 | P:  10 | L010 | Inconsistent capitalisation of keywords.
+    L:   2 | P:  10 | L010 | Keywords must be consistently upper case.
     L:   2 | P:  15 | L009 | Files must end with a trailing newline.
 
 To fix the remaining issues, we're going to use one of the more
@@ -141,7 +141,7 @@ For now, we only want to fix the following rules: *L003*, *L009*, *L010*
     ==== finding violations ====
     == [test.sql] FAIL
     L:   2 | P:   1 | L003 | Indent expected and not found compared to line #1
-    L:   2 | P:  10 | L010 | Inconsistent capitalisation of keywords.
+    L:   2 | P:  10 | L010 | Keywords must be consistently upper case.
     L:   2 | P:  15 | L009 | Files must end with a trailing newline.
     ==== fixing violations ====
     3 fixable linting violations found

--- a/docs/source/production.rst
+++ b/docs/source/production.rst
@@ -64,7 +64,7 @@ The output will look something like:
     Diff: origin/master...HEAD, staged and unstaged changes
     -------------
     sql/audience_size_queries/constraints/_postcondition_check_gdpr_compliance.sql (0.0%):
-    sql/audience_size_queries/constraints/_postcondition_check_gdpr_compliance.sql:5: Inconsistent capitalisation of unquoted identifiers.
+    sql/audience_size_queries/constraints/_postcondition_check_gdpr_compliance.sql:5: Unquoted Identifiers must be consistently upper case.
     -------------
     Total:   1 line
     Violations: 1 line

--- a/examples/01_basic_api_usage.py
+++ b/examples/01_basic_api_usage.py
@@ -11,7 +11,7 @@ result = sqlfluff.lint(my_bad_query, dialect="bigquery")
 
 # result =
 # [
-#     {"code": "L010", "line_no": 1, "line_pos": 1, "description": "Inconsistent capitalisation of keywords."}
+#     {"code": "L010", "line_no": 1, "line_pos": 1, "description": "Keywords must be consistently upper case."}
 #     ...
 # ]
 

--- a/src/sqlfluff/rules/L010.py
+++ b/src/sqlfluff/rules/L010.py
@@ -156,23 +156,8 @@ class Rule_L010(BaseRule):
             )
             return LintResult(memory=memory)
         else:
-
             # build description based on the policy in use
-            if cap_policy == "consistent":
-                consistency = "consistently "
-
-            if concrete_policy in ["upper", "lower"]:
-                policy = f"{concrete_policy} case."
-            elif concrete_policy == "capitalise":
-                policy = "capitalised."
-            elif concrete_policy == "pascal":
-                policy = "pascal case."
-
-            # build description based on the policy in use
-            if cap_policy == "consistent":
-                consistency = "consistently "
-            else:
-                consistency = ""
+            consistency = "consistently " if cap_policy == "consistent" else ""
 
             if concrete_policy in ["upper", "lower"]:
                 policy = f"{concrete_policy} case."

--- a/src/sqlfluff/rules/L010.py
+++ b/src/sqlfluff/rules/L010.py
@@ -46,6 +46,8 @@ class Rule_L010(BaseRule):
         ("type", "binary_operator"),
     ]
     config_keywords = ["capitalisation_policy"]
+    # Human readable target elem for description
+    _description_elem = "Keywords"
 
     def _eval(self, segment, memory, parent_stack, **kwargs):
         """Inconsistent capitalisation of keywords.
@@ -154,15 +156,42 @@ class Rule_L010(BaseRule):
             )
             return LintResult(memory=memory)
         else:
+
+            # build description based on the policy in use
+            if cap_policy == "consistent":
+                consistency = "consistently "
+
+            if concrete_policy in ["upper", "lower"]:
+                policy = f"{concrete_policy} case."
+            elif concrete_policy == "capitalise":
+                policy = "capitalised."
+            elif concrete_policy == "pascal":
+                policy = "pascal case."
+
+            # build description based on the policy in use
+            if cap_policy == "consistent":
+                consistency = "consistently "
+            else:
+                consistency = ""
+
+            if concrete_policy in ["upper", "lower"]:
+                policy = f"{concrete_policy} case."
+            elif concrete_policy == "capitalise":
+                policy = "capitalised."
+            elif concrete_policy == "pascal":
+                policy = "pascal case."
+
             # Return the fixed segment
             self.logger.debug(
                 f"INCONSISTENT Capitalisation of segment '{segment.raw}', fixing to "
                 f"'{fixed_raw}' and returning with memory {memory}"
             )
+
             return LintResult(
                 anchor=segment,
                 fixes=[self._get_fix(segment, fixed_raw)],
                 memory=memory,
+                description=f"{self._description_elem} must be {consistency}{policy}",
             )
 
     def _get_fix(self, segment, fixed_raw):
@@ -171,11 +200,7 @@ class Rule_L010(BaseRule):
         May be overridden by subclasses, which is useful when the parse tree
         structure varies from this simple base case.
         """
-        return LintFix(
-            "edit",
-            segment,
-            segment.edit(fixed_raw),
-        )
+        return LintFix("edit", segment, segment.edit(fixed_raw))
 
     def _init_capitalisation_policy(self):
         """Called first time rule is evaluated to fetch & cache the policy."""

--- a/src/sqlfluff/rules/L014.py
+++ b/src/sqlfluff/rules/L014.py
@@ -64,6 +64,7 @@ class Rule_L014(Rule_L010):
 
     _target_elems: List[Tuple[str, str]] = [("name", "naked_identifier")]
     config_keywords = ["extended_capitalisation_policy", "unquoted_identifiers_policy"]
+    _description_elem = "Unquoted identifiers"
 
     def _eval(self, segment, memory, parent_stack, **kwargs):
         if unquoted_ids_policy_applicable(

--- a/src/sqlfluff/rules/L030.py
+++ b/src/sqlfluff/rules/L030.py
@@ -40,6 +40,7 @@ class Rule_L030(Rule_L010):
     """
 
     _target_elems: List[Tuple[str, str]] = [("type", "function_name")]
+    _description_elem = "Function names"
 
     def _get_fix(self, segment, fixed_raw):
         """Overrides the base class.

--- a/src/sqlfluff/rules/L040.py
+++ b/src/sqlfluff/rules/L040.py
@@ -55,3 +55,4 @@ class Rule_L040(Rule_L010):
         ("name", "null_literal"),
         ("name", "boolean_literal"),
     ]
+    _description_elem = "Boolean/null literals"

--- a/test/api/simple_test.py
+++ b/test/api/simple_test.py
@@ -13,7 +13,7 @@ lint_result = [
         "code": "L010",
         "line_no": 1,
         "line_pos": 1,
-        "description": "Inconsistent capitalisation of keywords.",
+        "description": "Keywords must be consistently upper case.",
     },
     {
         "code": "L036",
@@ -43,7 +43,7 @@ lint_result = [
         "code": "L010",
         "line_no": 1,
         "line_pos": 20,
-        "description": "Inconsistent capitalisation of keywords.",
+        "description": "Keywords must be consistently upper case.",
     },
     {
         "code": "L039",
@@ -55,7 +55,7 @@ lint_result = [
         "code": "L014",
         "line_no": 1,
         "line_pos": 24,
-        "description": "Inconsistent capitalisation of unquoted identifiers.",
+        "description": "Unquoted identifiers must be consistently lower case.",
     },
     {
         "code": "L039",
@@ -67,7 +67,7 @@ lint_result = [
         "code": "L010",
         "line_no": 1,
         "line_pos": 29,
-        "description": "Inconsistent capitalisation of keywords.",
+        "description": "Keywords must be consistently upper case.",
     },
     {
         "code": "L009",
@@ -79,7 +79,7 @@ lint_result = [
         "code": "L014",
         "line_no": 1,
         "line_pos": 34,
-        "description": "Inconsistent capitalisation of unquoted identifiers.",
+        "description": "Unquoted identifiers must be consistently lower case.",
     },
 ]
 

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -583,7 +583,7 @@ def test__cli__command_lint_serialize_github_annotation():
                 "test/fixtures/linter/identifier_capitalisation.sql"
             ),
             "line": 3,
-            "message": "L014: Inconsistent capitalisation of unquoted identifiers.",
+            "message": "L014: Unquoted identifiers must be consistently lower case.",
             "start_column": 5,
             "end_column": 5,
             "title": "SQLFluff",
@@ -595,7 +595,7 @@ def test__cli__command_lint_serialize_github_annotation():
                 "test/fixtures/linter/identifier_capitalisation.sql"
             ),
             "line": 4,
-            "message": "L010: Inconsistent capitalisation of keywords.",
+            "message": "L010: Keywords must be consistently lower case.",
             "start_column": 1,
             "end_column": 1,
             "title": "SQLFluff",
@@ -607,7 +607,7 @@ def test__cli__command_lint_serialize_github_annotation():
                 "test/fixtures/linter/identifier_capitalisation.sql"
             ),
             "line": 4,
-            "message": "L014: Inconsistent capitalisation of unquoted identifiers.",
+            "message": "L014: Unquoted identifiers must be consistently lower case.",
             "start_column": 12,
             "end_column": 12,
             "title": "SQLFluff",
@@ -619,7 +619,7 @@ def test__cli__command_lint_serialize_github_annotation():
                 "test/fixtures/linter/identifier_capitalisation.sql"
             ),
             "line": 4,
-            "message": "L014: Inconsistent capitalisation of unquoted identifiers.",
+            "message": "L014: Unquoted identifiers must be consistently lower case.",
             "start_column": 18,
             "end_column": 18,
             "title": "SQLFluff",

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -41,7 +41,7 @@ def invoke_assert_code(
 
 expected_output = """== [test/fixtures/linter/indentation_error_simple.sql] FAIL
 L:   2 | P:   4 | L003 | Indentation not hanging or a multiple of 4 spaces
-L:   5 | P:  10 | L010 | Inconsistent capitalisation of keywords.
+L:   5 | P:  10 | L010 | Keywords must be consistently upper case.
 L:   5 | P:  13 | L031 | Avoid using aliases in join condition
 """
 
@@ -456,13 +456,13 @@ def test__cli__command_parse_serialize_from_stdin(serialize):
                             "code": "L010",
                             "line_no": 1,
                             "line_pos": 1,
-                            "description": "Inconsistent capitalisation of keywords.",
+                            "description": "Keywords must be consistently upper case.",
                         },
                         {
                             "code": "L010",
                             "line_no": 1,
                             "line_pos": 10,
-                            "description": "Inconsistent capitalisation of keywords.",
+                            "description": "Keywords must be consistently upper case.",
                         },
                     ],
                 }

--- a/test/fixtures/rules/std_rule_cases/L010.yml
+++ b/test/fixtures/rules/std_rule_cases/L010.yml
@@ -18,6 +18,15 @@ test_fail_capitalisation_policy_lower:
       L010:
         capitalisation_policy: lower
 
+test_fail_capitalisation_policy_upper:
+  # Fix for https://github.com/sqlfluff/sqlfluff/issues/476
+  fail_str: select * from MOO order by dt desc
+  fix_str: SELECT * FROM MOO ORDER BY dt DESC
+  configs:
+    rules:
+      L010:
+        capitalisation_policy: upper
+
 test_fail_capitalisation_policy_capitalise:
   # Test for capitalised casing
   fail_str: SELECT * FROM MOO ORDER BY dt DESC


### PR DESCRIPTION
### Brief summary of the change made

closes https://github.com/sqlfluff/sqlfluff/issues/1128 and base on pr https://github.com/sqlfluff/sqlfluff/pull/1173.
Cause @scrambldchannel  seem not work on https://github.com/sqlfluff/sqlfluff/pull/1173 anymore, so I start PR base on it
and set @scrambldchannel as the co-author

Currently Rule L010 error message too generic, we should show configure what we set in the error message

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
