### PR TITLE
Allow ORDER BY and LIMIT after QUALIFY in BigQuery

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -182,7 +182,7 @@ class QualifyClauseSegment(BaseSegment):
     type = "qualify_clause"
     match_grammar = StartsWith(
         "QUALIFY",
-        terminator=OneOf("WINDOW"),
+        terminator=OneOf("WINDOW", "ORDER", "LIMIT"),
         enforce_whitespace_preceeding_terminator=True,
     )
 

--- a/test/fixtures/parser/bigquery/select_with_qualify.sql
+++ b/test/fixtures/parser/bigquery/select_with_qualify.sql
@@ -3,4 +3,52 @@ SELECT
   RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
 FROM Produce
 WHERE Produce.category = 'vegetable'
+QUALIFY rank <= 3;
+
+SELECT
+  item,
+  RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
+FROM Produce
+WHERE Produce.category = 'vegetable'
 QUALIFY rank <= 3
+ORDER BY item;
+
+SELECT
+  item,
+  RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
+FROM Produce
+WHERE Produce.category = 'vegetable'
+QUALIFY rank <= 3
+LIMIT 5;
+
+SELECT
+  item,
+  RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
+FROM Produce
+WHERE Produce.category = 'vegetable'
+QUALIFY rank <= 3
+ORDER BY item
+LIMIT 5;
+
+SELECT
+  item,
+  RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
+FROM Produce
+WHERE Produce.category = 'vegetable'
+QUALIFY rank <= 3
+WINDOW item_window AS (
+  PARTITION BY category
+  ORDER BY purchases
+  ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING);
+
+SELECT
+  item,
+  RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
+FROM Produce
+WHERE Produce.category = 'vegetable'
+QUALIFY rank <= 3
+ORDER BY item
+WINDOW item_window AS (
+  PARTITION BY category
+  ORDER BY purchases
+  ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING);

--- a/test/fixtures/parser/bigquery/select_with_qualify.sql
+++ b/test/fixtures/parser/bigquery/select_with_qualify.sql
@@ -36,6 +36,14 @@ SELECT
 FROM Produce
 WHERE Produce.category = 'vegetable'
 QUALIFY rank <= 3
+LIMIT 5;
+
+SELECT
+  item,
+  RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
+FROM Produce
+WHERE Produce.category = 'vegetable'
+QUALIFY rank <= 3
 WINDOW item_window AS (
   PARTITION BY category
   ORDER BY purchases

--- a/test/fixtures/parser/bigquery/select_with_qualify.yml
+++ b/test/fixtures/parser/bigquery/select_with_qualify.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 901ff3b4b8953f6d7a65ff905aaf089cb8e6e06ef446a5f8e3e30387fd7b8351
+_hash: ed79513b8ddb6fcec652c988ce5cb77acdffa5ced8d5df1ddf7b7df62f82bf83
 file:
-  statement:
+- statement:
     select_statement:
       select_clause:
       - keyword: SELECT
@@ -64,3 +64,381 @@ file:
             identifier: rank
           comparison_operator: <=
           literal: '3'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: item
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: RANK
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: category
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: purchases
+                  - keyword: DESC
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: Produce
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+          - identifier: Produce
+          - dot: .
+          - identifier: category
+          comparison_operator: '='
+          literal: "'vegetable'"
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          column_reference:
+            identifier: rank
+          comparison_operator: <=
+          literal: '3'
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          identifier: item
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: item
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: RANK
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: category
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: purchases
+                  - keyword: DESC
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: Produce
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+          - identifier: Produce
+          - dot: .
+          - identifier: category
+          comparison_operator: '='
+          literal: "'vegetable'"
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          column_reference:
+            identifier: rank
+          comparison_operator: <=
+          literal: '3'
+      limit_clause:
+        keyword: LIMIT
+        literal: '5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: item
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: RANK
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: category
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: purchases
+                  - keyword: DESC
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: Produce
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+          - identifier: Produce
+          - dot: .
+          - identifier: category
+          comparison_operator: '='
+          literal: "'vegetable'"
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          column_reference:
+            identifier: rank
+          comparison_operator: <=
+          literal: '3'
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          identifier: item
+      limit_clause:
+        keyword: LIMIT
+        literal: '5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: item
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: RANK
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: category
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: purchases
+                  - keyword: DESC
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: Produce
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+          - identifier: Produce
+          - dot: .
+          - identifier: category
+          comparison_operator: '='
+          literal: "'vegetable'"
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          column_reference:
+            identifier: rank
+          comparison_operator: <=
+          literal: '3'
+      named_window:
+        keyword: WINDOW
+        named_window_expression:
+          identifier: item_window
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              partitionby_clause:
+              - keyword: PARTITION
+              - keyword: BY
+              - expression:
+                  column_reference:
+                    identifier: category
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  identifier: purchases
+              frame_clause:
+              - keyword: ROWS
+              - raw: BETWEEN
+              - raw: '2'
+              - raw: PRECEDING
+              - raw: AND
+              - raw: '2'
+              - raw: FOLLOWING
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: item
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: RANK
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: category
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: purchases
+                  - keyword: DESC
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: Produce
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+          - identifier: Produce
+          - dot: .
+          - identifier: category
+          comparison_operator: '='
+          literal: "'vegetable'"
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          column_reference:
+            identifier: rank
+          comparison_operator: <=
+          literal: '3'
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          identifier: item
+      named_window:
+        keyword: WINDOW
+        named_window_expression:
+          identifier: item_window
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              partitionby_clause:
+              - keyword: PARTITION
+              - keyword: BY
+              - expression:
+                  column_reference:
+                    identifier: category
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  identifier: purchases
+              frame_clause:
+              - keyword: ROWS
+              - raw: BETWEEN
+              - raw: '2'
+              - raw: PRECEDING
+              - raw: AND
+              - raw: '2'
+              - raw: FOLLOWING
+            end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/parser/bigquery/select_with_qualify.yml
+++ b/test/fixtures/parser/bigquery/select_with_qualify.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ed79513b8ddb6fcec652c988ce5cb77acdffa5ced8d5df1ddf7b7df62f82bf83
+_hash: 2487633f946fb666690669422d9aa8375a82e9a8026161e5151a6dec4103f14b
 file:
 - statement:
     select_statement:
@@ -257,6 +257,69 @@ file:
       - keyword: BY
       - column_reference:
           identifier: item
+      limit_clause:
+        keyword: LIMIT
+        literal: '5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: item
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: RANK
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: category
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: purchases
+                  - keyword: DESC
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: Produce
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+          - identifier: Produce
+          - dot: .
+          - identifier: category
+          comparison_operator: '='
+          literal: "'vegetable'"
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          column_reference:
+            identifier: rank
+          comparison_operator: <=
+          literal: '3'
       limit_clause:
         keyword: LIMIT
         literal: '5'


### PR DESCRIPTION
### Brief summary of the change made

A further enhancement to BigQuery `QUALIFY` support to allow optional `ORDER BY` and `LIMIT` clauses to be specified afterwards.

### Are there any other side effects of this change that we should be aware of?
...

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
