### PR TITLE
Handle initial whitespace lines in rule L001

### DIFF
--- a/src/sqlfluff/rules/L001.py
+++ b/src/sqlfluff/rules/L001.py
@@ -41,7 +41,7 @@ class Rule_L001(BaseRule):
             # If we find a newline, which is preceded by whitespace, then bad
             deletions = []
             idx = -1
-            while raw_stack[idx].is_type("whitespace"):
+            while abs(idx) <= len(raw_stack) and raw_stack[idx].is_type("whitespace"):
                 deletions.append(raw_stack[idx])
                 idx -= 1
             return LintResult(

--- a/test/fixtures/rules/std_rule_cases/L001.yml
+++ b/test/fixtures/rules/std_rule_cases/L001.yml
@@ -3,3 +3,8 @@ rule: L001
 test_fail_trailing_whitespace:
   fail_str: "SELECT 1     \n"
   fix_str: "SELECT 1\n"
+
+
+test_fail_trailing_whitespace_on_initial_blank_line:
+  fail_str: " \nSELECT 1     \n"
+  fix_str: "\nSELECT 1\n"


### PR DESCRIPTION
### Brief summary of the change made
Fixes #1371 

Currently we don't handle this:

```sql
printf ' \nSELECT 1' | sqlfluff fix -
```

As it throws this:

```
==== finding fixable violations ====
CRITICAL   [L001] Applying rule L001 threw an Exception: tuple index out of range 
Traceback (most recent call last):
  File "/home/vladimir/work/extern/sqlfluff/venv/lib/python3.9/site-packages/sqlfluff/core/rules/base.py", line 301, in crawl
    res = self._eval(
  File "/home/vladimir/work/extern/sqlfluff/venv/lib/python3.9/site-packages/sqlfluff/rules/L001.py", line 44, in _eval
    while raw_stack[idx].is_type("whitespace"):
IndexError: tuple index out of range
```

This is because we don't do a length check in rule L001 before decrementing the index. We do do this check on similar lookback rules (L016, L018) so similar enough change to add this, and a test case for it.

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
