### PR TITLE
Issue 1344: L016: "sqlfluff fix" adds too many newlines

### DIFF
--- a/benchmarks/bench_002/bench_002_pearson_fix.sql
+++ b/benchmarks/bench_002/bench_002_pearson_fix.sql
@@ -6,286 +6,160 @@ raw_effect_sizes AS (
     SELECT
         state_user_v_peer_open,
         business_type,
-        COUNT(*) AS campaign_count
+        COUNT(*) AS campaign_count,
 
-    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
-    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+        -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+        --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
-        ,--  the "y variable" and uses_small_subject_line to be the "x variable" in terms of the regression line.
-        
-
-
-
-
-
-
-
-
+        --  the "y variable" and uses_small_subject_line to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
              SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_small_subject_line),
                 STDDEV_POP(open_rate_su)
             ),
              STDDEV_POP(uses_small_subject_line)
-        ) AS open_uses_small_subject_line
+        ) AS open_uses_small_subject_line,
 
-    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
-    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+        -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+        --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
-        ,--  the "y variable" and uses_personal_subject to be the "x variable" in terms of the regression line.
-        
-
-
-
-
-
-
-
-
+        --  the "y variable" and uses_personal_subject to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
              SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_personal_subject),
                 STDDEV_POP(open_rate_su)
             ),
              STDDEV_POP(uses_personal_subject)
-        ) AS open_uses_personal_subject
+        ) AS open_uses_personal_subject,
 
-    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
-    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+        -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+        --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
-        ,--  the "y variable" and uses_timewarp to be the "x variable" in terms of the regression line.
-        
-
-
-
-
-
-
-
-
+        --  the "y variable" and uses_timewarp to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
              SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_timewarp), STDDEV_POP(open_rate_su)
             ),
              STDDEV_POP(uses_timewarp)
-        ) AS open_uses_timewarp
+        ) AS open_uses_timewarp,
 
-    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
-    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+        -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+        --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
-        ,--  the "y variable" and uses_small_preview to be the "x variable" in terms of the regression line.
-        
-
-
-
-
-
-
-
-
+        --  the "y variable" and uses_small_preview to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
              SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_small_preview), STDDEV_POP(open_rate_su)
             ),
              STDDEV_POP(uses_small_preview)
-        ) AS open_uses_small_preview
+        ) AS open_uses_small_preview,
 
-    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
-    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+        -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+        --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
-        ,--  the "y variable" and uses_personal_to to be the "x variable" in terms of the regression line.
-        
-
-
-
-
-
-
-
-
+        --  the "y variable" and uses_personal_to to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
              SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_personal_to), STDDEV_POP(open_rate_su)
             ),
              STDDEV_POP(uses_personal_to)
-        ) AS open_uses_personal_to
+        ) AS open_uses_personal_to,
 
-    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
-    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+        -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+        --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
-        ,--  the "y variable" and uses_ab_test_subject to be the "x variable" in terms of the regression line.
-        
-
-
-
-
-
-
-
-
+        --  the "y variable" and uses_ab_test_subject to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
              SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_ab_test_subject),
                 STDDEV_POP(open_rate_su)
             ),
              STDDEV_POP(uses_ab_test_subject)
-        ) AS open_uses_ab_test_subject
+        ) AS open_uses_ab_test_subject,
 
-    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
-    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+        -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+        --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
-        ,--  the "y variable" and uses_ab_test_content to be the "x variable" in terms of the regression line.
-        
-
-
-
-
-
-
-
-
+        --  the "y variable" and uses_ab_test_content to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
              SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_ab_test_content),
                 STDDEV_POP(open_rate_su)
             ),
              STDDEV_POP(uses_ab_test_content)
-        ) AS open_uses_ab_test_content
+        ) AS open_uses_ab_test_content,
 
-    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
-    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+        -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+        --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
-        ,--  the "y variable" and uses_preview_text to be the "x variable" in terms of the regression line.
-        
-
-
-
-
-
-
-
-
+        --  the "y variable" and uses_preview_text to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
              SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_preview_text), STDDEV_POP(open_rate_su)
             ),
              STDDEV_POP(uses_preview_text)
-        ) AS open_uses_preview_text
+        ) AS open_uses_preview_text,
 
-    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
-    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+        -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+        --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
-        ,--  the "y variable" and uses_sto to be the "x variable" in terms of the regression line.
-        
-
-
-
-
-
-
-
-
+        --  the "y variable" and uses_sto to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
              SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_sto), STDDEV_POP(open_rate_su)
             ),
              STDDEV_POP(uses_sto)
-        ) AS open_uses_sto
+        ) AS open_uses_sto,
 
-    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
-    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+        -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+        --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
-        ,--  the "y variable" and uses_freemail_from to be the "x variable" in terms of the regression line.
-        
-
-
-
-
-
-
-
-
+        --  the "y variable" and uses_freemail_from to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
              SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_freemail_from), STDDEV_POP(open_rate_su)
             ),
              STDDEV_POP(uses_freemail_from)
-        ) AS open_uses_freemail_from
+        ) AS open_uses_freemail_from,
 
-    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
-    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+        -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+        --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
-        ,--  the "y variable" and uses_resend_non_openers to be the "x variable" in terms of the regression line.
-        
-
-
-
-
-
-
-
-
+        --  the "y variable" and uses_resend_non_openers to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
              SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_resend_non_openers),
                 STDDEV_POP(open_rate_su)
             ),
              STDDEV_POP(uses_resend_non_openers)
-        ) AS open_uses_resend_non_openers
+        ) AS open_uses_resend_non_openers,
 
-    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
-    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+        -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+        --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
-        ,--  the "y variable" and uses_promo_code to be the "x variable" in terms of the regression line.
-        
-
-
-
-
-
-
-
-
+        --  the "y variable" and uses_promo_code to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
              SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_promo_code), STDDEV_POP(open_rate_su)
             ),
              STDDEV_POP(uses_promo_code)
-        ) AS open_uses_promo_code
+        ) AS open_uses_promo_code,
 
-    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
-    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+        -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+        --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
-        ,--  the "y variable" and uses_prex to be the "x variable" in terms of the regression line.
-        
-
-
-
-
-
-
-
-
+        --  the "y variable" and uses_prex to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
              SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_prex), STDDEV_POP(open_rate_su)
             ),
              STDDEV_POP(uses_prex)
-        ) AS open_uses_prex
+        ) AS open_uses_prex,
 
-    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
-    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+        -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+        --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
-        ,--  the "y variable" and uses_ab_test_from to be the "x variable" in terms of the regression line.
-        
-
-
-
-
-
-
-
-
+        --  the "y variable" and uses_ab_test_from to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
              SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_ab_test_from), STDDEV_POP(open_rate_su)
@@ -303,19 +177,11 @@ imputed_effect_sizes AS (
     SELECT
         campaign_count,
         state_user_v_peer_open,
-        business_type
+        business_type,
 
-    -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
+        -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
         --  take into account states where all campaigns either did or did not perform an 
-        ,--  action. In these cases, we assume that campaign outcome is uncorrelated with 
-        
-
-
-
-
-
-
-
+        --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
              IF(
@@ -324,19 +190,11 @@ imputed_effect_sizes AS (
                 open_uses_small_subject_line
             ),
              0
-        ) AS open_uses_small_subject_line
+        ) AS open_uses_small_subject_line,
 
-    -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
+        -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
         --  take into account states where all campaigns either did or did not perform an 
-        ,--  action. In these cases, we assume that campaign outcome is uncorrelated with 
-        
-
-
-
-
-
-
-
+        --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
              IF(
@@ -345,153 +203,81 @@ imputed_effect_sizes AS (
                 open_uses_personal_subject
             ),
             0
-        ) AS open_uses_personal_subject
+        ) AS open_uses_personal_subject,
 
-    -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
+        -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
         --  take into account states where all campaigns either did or did not perform an 
-        ,--  action. In these cases, we assume that campaign outcome is uncorrelated with 
-        
-
-
-
-
-
-
-
+        --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
              IF(IS_NAN(open_uses_timewarp), 0, open_uses_timewarp), 0
-        ) AS open_uses_timewarp
+        ) AS open_uses_timewarp,
 
-    -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
+        -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
         --  take into account states where all campaigns either did or did not perform an 
-        ,--  action. In these cases, we assume that campaign outcome is uncorrelated with 
-        
-
-
-
-
-
-
-
+        --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
              IF(IS_NAN(open_uses_small_preview), 0, open_uses_small_preview), 0
-        ) AS open_uses_small_preview
+        ) AS open_uses_small_preview,
 
-    -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
+        -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
         --  take into account states where all campaigns either did or did not perform an 
-        ,--  action. In these cases, we assume that campaign outcome is uncorrelated with 
-        
-
-
-
-
-
-
-
+        --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
              IF(IS_NAN(open_uses_personal_to), 0, open_uses_personal_to), 0
-        ) AS open_uses_personal_to
+        ) AS open_uses_personal_to,
 
-    -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
+        -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
         --  take into account states where all campaigns either did or did not perform an 
-        ,--  action. In these cases, we assume that campaign outcome is uncorrelated with 
-        
-
-
-
-
-
-
-
+        --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
              IF(
                 IS_NAN(open_uses_ab_test_subject), 0, open_uses_ab_test_subject
             ),
             0
-        ) AS open_uses_ab_test_subject
+        ) AS open_uses_ab_test_subject,
 
-    -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
+        -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
         --  take into account states where all campaigns either did or did not perform an 
-        ,--  action. In these cases, we assume that campaign outcome is uncorrelated with 
-        
-
-
-
-
-
-
-
+        --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
              IF(
                 IS_NAN(open_uses_ab_test_content), 0, open_uses_ab_test_content
             ),
             0
-        ) AS open_uses_ab_test_content
+        ) AS open_uses_ab_test_content,
 
-    -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
+        -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
         --  take into account states where all campaigns either did or did not perform an 
-        ,--  action. In these cases, we assume that campaign outcome is uncorrelated with 
-        
-
-
-
-
-
-
-
+        --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
              IF(IS_NAN(open_uses_preview_text), 0, open_uses_preview_text), 0
-        ) AS open_uses_preview_text
+        ) AS open_uses_preview_text,
 
-    -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
+        -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
         --  take into account states where all campaigns either did or did not perform an 
-        ,--  action. In these cases, we assume that campaign outcome is uncorrelated with 
-        
-
-
-
-
-
-
-
+        --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
             IF(IS_NAN(open_uses_sto), 0, open_uses_sto), 0
-        ) AS open_uses_sto
+        ) AS open_uses_sto,
 
-    -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
+        -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
         --  take into account states where all campaigns either did or did not perform an 
-        ,--  action. In these cases, we assume that campaign outcome is uncorrelated with 
-        
-
-
-
-
-
-
-
+        --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
              IF(IS_NAN(open_uses_freemail_from), 0, open_uses_freemail_from), 0
-        ) AS open_uses_freemail_from
+        ) AS open_uses_freemail_from,
 
-    -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
+        -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
         --  take into account states where all campaigns either did or did not perform an 
-        ,--  action. In these cases, we assume that campaign outcome is uncorrelated with 
-        
-
-
-
-
-
-
-
+        --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
              IF(
@@ -500,51 +286,27 @@ imputed_effect_sizes AS (
                 open_uses_resend_non_openers
             ),
              0
-        ) AS open_uses_resend_non_openers
+        ) AS open_uses_resend_non_openers,
 
-    -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
+        -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
         --  take into account states where all campaigns either did or did not perform an 
-        ,--  action. In these cases, we assume that campaign outcome is uncorrelated with 
-        
-
-
-
-
-
-
-
+        --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
              IF(IS_NAN(open_uses_promo_code), 0, open_uses_promo_code), 0
-        ) AS open_uses_promo_code
+        ) AS open_uses_promo_code,
 
-    -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
+        -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
         --  take into account states where all campaigns either did or did not perform an 
-        ,--  action. In these cases, we assume that campaign outcome is uncorrelated with 
-        
-
-
-
-
-
-
-
+        --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
              IF(IS_NAN(open_uses_prex), 0, open_uses_prex), 0
-        ) AS open_uses_prex
+        ) AS open_uses_prex,
 
-    -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
+        -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
         --  take into account states where all campaigns either did or did not perform an 
-        ,--  action. In these cases, we assume that campaign outcome is uncorrelated with 
-        
-
-
-
-
-
-
-
+        --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
              IF(IS_NAN(open_uses_ab_test_from), 0, open_uses_ab_test_from), 0

--- a/test/fixtures/linter/autofix/ansi/008_looping_rules_l003_l016_l019/after.sql
+++ b/test/fixtures/linter/autofix/ansi/008_looping_rules_l003_l016_l019/after.sql
@@ -1,0 +1,19 @@
+SELECT
+    COUNT(1) AS campaign_count,
+    state_user_v_peer_open,
+    business_type,
+    
+    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+    --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
+    --  the "y variable" and uses_small_subject_line to be the "x variable" in terms of the regression line.
+    SAFE_DIVIDE(
+        SAFE_MULTIPLY(
+            CORR(open_rate_su, uses_small_subject_line),
+            STDDEV_POP(open_rate_su)
+        ),
+        STDDEV_POP(uses_small_subject_line)
+    )
+
+FROM
+    global_actions_states

--- a/test/fixtures/linter/autofix/ansi/008_looping_rules_l003_l016_l019/before.sql
+++ b/test/fixtures/linter/autofix/ansi/008_looping_rules_l003_l016_l019/before.sql
@@ -1,0 +1,13 @@
+SELECT
+COUNT(1) AS campaign_count,
+state_user_v_peer_open
+,business_type
+
+-- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+--  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+--  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
+--  the "y variable" and uses_small_subject_line to be the "x variable" in terms of the regression line.
+,SAFE_DIVIDE(SAFE_MULTIPLY(CORR(open_rate_su, uses_small_subject_line), STDDEV_POP(open_rate_su)), STDDEV_POP(uses_small_subject_line))
+
+FROM
+global_actions_states

--- a/test/fixtures/linter/autofix/ansi/008_looping_rules_l003_l016_l019/test-config.yml
+++ b/test/fixtures/linter/autofix/ansi/008_looping_rules_l003_l016_l019/test-config.yml
@@ -1,0 +1,5 @@
+test-config:
+  rules:
+    - L003
+    - L016
+    - L019

--- a/test/fixtures/rules/std_rule_cases/L016.yml
+++ b/test/fixtures/rules/std_rule_cases/L016.yml
@@ -32,6 +32,25 @@ test_fail_line_too_long_with_comments_3:
     rules:
       max_line_length: 18
 
+test_fail_line_too_long_with_comments_4:
+  # In this case, the inline comment is NOT on a line by itself (note the
+  # leading comma), but even if we move it onto a line by itself, it's still
+  # too long. In this case, the rule should do nothing, otherwise it triggers
+  # an endless cycle of "fixes" that simply keeps adding blank lines.
+  fail_str: |
+    SELECT
+    c1
+    ,--  the "y variable" and uses_small_subject_line to be the "x variable" in terms of the regression line.
+    c2
+  fix_str: |
+    SELECT
+    c1
+    ,--  the "y variable" and uses_small_subject_line to be the "x variable" in terms of the regression line.
+    c2
+  configs:
+    rules:
+      max_line_length: 80
+
 test_fail_line_too_long_only_comments:
   # Check long lines that are only comments are linted correctly
   fail_str: "-- Some really long comments on their own line\n\nSELECT 1"


### PR DESCRIPTION
Fixes #1344 

L016 "Line is too long" has a bug that causes it to behave pathologically if it finds a line with an inline comment that is:
* Is on a line with other code
* Exceeds the maximum line length even after moving it to a line by itself

E.g.
```
    ,--  the "y variable" and uses_small_subject_line to be the "x variable" in terms of the regression line.
```

In this case, L016 keeps adding blank lines endlessly until it hits the `sqlfluff fix` iteration limit (typically 10).
### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
