### PR TITLE
Issue 1310: L003 fix mixes hanging and clean indents

### DIFF
--- a/src/sqlfluff/rules/L003.py
+++ b/src/sqlfluff/rules/L003.py
@@ -94,7 +94,7 @@ class Rule_L003(BaseRule):
                     # Indent balance is the indent at the start of the first content
                     "indent_balance": this_indent_balance,
                     "hanging_indent": hanger_pos if line_indent_stack else None,
-                    # Clean indent is true if the line *ends* win an indent
+                    # Clean indent is true if the line *ends* with an indent
                     # or has an indent in the initial whitespace.
                     "clean_indent": clean_indent,
                 }
@@ -436,8 +436,7 @@ class Rule_L003(BaseRule):
                     )
                     # If we have a clean indent, we can just add steps in line
                     # with the difference in the indent buffers. simples.
-                    # We can also do this if we've skipped a line. I think?
-                    if this_line["clean_indent"] or this_line_no - k > 1:
+                    if this_line["clean_indent"]:
                         self.logger.debug("        Use clean indent.")
                         desired_indent = default_indent
                     # If we have the option of a hanging indent then use it.

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -256,6 +256,28 @@ test_fail_possible_hanger_fix:
                     bar)
     FROM tbl
 
+test_fail_consecutive_hangers:
+  fail_str: |
+    select *
+    from foo
+    where a like 'a%'
+      and b like 'b%'
+      and c like 'c%'
+      and d like 'd%'
+      and e like 'e%'
+      and f like 'f%'
+
+  fix_str: |
+    select *
+    from foo
+    where a like 'a%'
+          and b like 'b%'
+          and c like 'c%'
+          and d like 'd%'
+          and e like 'e%'
+          and f like 'f%'
+
+
 test_fail_clean_reindent_fix:
   # A "clean" indent is where the previous line ends with an
   # indent token (as per this example). We should use the


### PR DESCRIPTION
Fixes #1310

Rule L003 was only allowing hanging indent for a single line. This results in inconsistent indentation. As an experiment, I disabled the single-line limitation. No tests broke, so I guess this is okay?

I added a new test based on the user-reported issue, so if future concerns arise about this rule, we'll have a test case to make sure we can converge towards a better solution and not "flap" back and forth.
...

### Are there any other side effects of this change that we should be aware of?

As mentioned above, hanging indent is now allowed for any number of consecutive lines.  Is this ever a bad thing? Unsure.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
