### PR TITLE
Issue 1268: L034 should not fix inside "INSERT" or "CREATE TABLE AS SELECT"

### DIFF
--- a/src/sqlfluff/rules/L034.py
+++ b/src/sqlfluff/rules/L034.py
@@ -65,9 +65,11 @@ class Rule_L034(BaseRule):
         self.seen_band_elements = [[] for i in select_element_order_preference] + [[]]
 
         # Ignore select clauses which belong to a set expression, which are most commonly a union.
-        if segment.is_type("select_clause") and not parent_stack[-2].is_type(
-            "insert_statement", "set_expression"
-        ) and not parent_stack[-3].is_type('create_table_statement'):
+        if (
+            segment.is_type("select_clause")
+            and not parent_stack[-2].is_type("insert_statement", "set_expression")
+            and not parent_stack[-3].is_type("create_table_statement")
+        ):
             select_clause_segment = segment
             select_target_elements = segment.get_children("select_clause_element")
             if not select_target_elements:

--- a/src/sqlfluff/rules/L034.py
+++ b/src/sqlfluff/rules/L034.py
@@ -64,12 +64,23 @@ class Rule_L034(BaseRule):
         # If we find a matching target element, we append the element to the corresponding index
         self.seen_band_elements = [[] for i in select_element_order_preference] + [[]]
 
-        # Ignore select clauses which belong to a set expression, which are most commonly a union.
-        if (
-            segment.is_type("select_clause")
-            and not parent_stack[-2].is_type("insert_statement", "set_expression")
-            and not parent_stack[-3].is_type("create_table_statement")
-        ):
+        if segment.is_type("select_clause"):
+            # Ignore select clauses which belong to:
+            # - set expression, which is most commonly a union
+            # - insert_statement
+            # - create table statement
+            #
+            # In each of these contexts, the order of columns in a select should
+            # be preserved.
+            if len(parent_stack) >= 2 and parent_stack[-2].is_type(
+                "insert_statement", "set_expression"
+            ):
+                return None
+            if len(parent_stack) >= 3 and parent_stack[-3].is_type(
+                "create_table_statement"
+            ):
+                return None
+
             select_clause_segment = segment
             select_target_elements = segment.get_children("select_clause_element")
             if not select_target_elements:

--- a/src/sqlfluff/rules/L034.py
+++ b/src/sqlfluff/rules/L034.py
@@ -66,8 +66,8 @@ class Rule_L034(BaseRule):
 
         # Ignore select clauses which belong to a set expression, which are most commonly a union.
         if segment.is_type("select_clause") and not parent_stack[-2].is_type(
-            "set_expression"
-        ):
+            "insert_statement", "set_expression"
+        ) and not parent_stack[-3].is_type('create_table_statement'):
             select_clause_segment = segment
             select_target_elements = segment.get_children("select_clause_element")
             if not select_target_elements:

--- a/test/fixtures/rules/std_rule_cases/L034.yml
+++ b/test/fixtures/rules/std_rule_cases/L034.yml
@@ -101,3 +101,38 @@ test_union_statements_ignored:
       c,
       d
     from table_b
+
+test_insert_statements_ignored:
+  pass_str: |
+    INSERT INTO example_schema.example_table
+    (id,
+        example_column,
+        rank_asc,
+        rank_desc)
+    SELECT
+        id,
+        CASE
+            WHEN col_a IN('a',
+                                  'b',
+                    'c') THEN col_a
+        END AS example_column,
+        rank_asc,
+        rank_desc
+    FROM
+      another_schema.another_table
+
+test_create_table_as_select_statements_ignored:
+  pass_str: |
+    CREATE TABLE new_table AS (
+      SELECT
+          id,
+          CASE
+              WHEN col_a IN('a',
+                                    'b',
+                      'c') THEN col_a
+          END AS example_column,
+          rank_asc,
+          rank_desc
+      FROM
+        another_schema.another_table
+    )


### PR DESCRIPTION
Fixes #1268

Prevents L034 from making changes inside "INSERT" or "CREATE TABLE AS SELECT" statements, where the order of columns in a "SELECT" should be preserved.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
