### PR TITLE
Handle template and unfixable errors when fixing stdin

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -475,19 +475,23 @@ def fix(force, paths, processes, bench=False, fixed_suffix="", logger=None, **kw
     # handle stdin case. should output formatted sql to stdout and nothing else.
     if fixing_stdin:
         stdin = sys.stdin.read()
-        result = lnt.lint_string_wrapped(stdin, fname="stdin", fix=True)
 
+        result = lnt.lint_string_wrapped(stdin, fname="stdin", fix=True)
         templater_error = result.num_violations(types=SQLTemplaterError) > 0
+        unfixable_error = result.num_violations(types=SQLLintError, fixable=False) > 0
+
         if result.num_violations(types=SQLLintError, fixable=True) > 0:
             stdout = result.paths[0].files[0].fix_string()[0]
         else:
-            if verbose and templater_error:
-                click.echo(
-                    "Fix aborted due to template variables that could not be parsed."
-                )
+            if verbose:
+                if templater_error:
+                    click.echo("Fix aborted due to unparseable template variables.")
+                if unfixable_error:
+                    click.echo("Unfixable violations detected.")
             stdout = stdin
+
         click.echo(stdout, nl=False)
-        sys.exit(1 if templater_error else 0)
+        sys.exit(1 if templater_error or unfixable_error else 0)
 
     # Lint the paths (not with the fix argument at this stage), outputting as we go.
     click.echo("==== finding fixable violations ====")

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -409,12 +409,13 @@ def test__cli__command_fix_stdin_safety():
 @pytest.mark.parametrize(
     "sql,exit_code",
     [
-        ("create TABLE {{ params.dsfsdfds }}.t (a int)", 1),
-        ("create TABLE a.t (a int)", 0),
-        ("create table a.t (a int)", 0),
+        ("create TABLE {{ params.dsfsdfds }}.t (a int)", 1),  # template error
+        ("create TABLE a.t (a int)", 0),  # fixable error
+        ("create table a.t (a int)", 0),  # perfection
+        ("select col from a join b using (c)", 1),  # unfixable error (using)
     ],
 )
-def test__cli__command_fix_stdin_template_error_exit_code(sql, exit_code):
+def test__cli__command_fix_stdin_error_exit_code(sql, exit_code):
     """Check that the CLI fails nicely if fixing a templated stdin."""
     if exit_code == 0:
         invoke_assert_code(args=[fix, ("-",)], cli_input=sql)

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -406,6 +406,16 @@ def test__cli__command_fix_stdin_safety():
     assert result.output.strip() == perfect_sql
 
 
+def test__cli__command_fix_stdin_template_error():
+    """Check that the CLI fails nicely if fixing a templated stdin."""
+    sql = "create table {{ params.something }}.t (a int)"
+
+    with pytest.raises(SystemExit) as exc_info:
+        invoke_assert_code(args=[fix, ("-",)], cli_input=sql)
+
+    assert exc_info.value.args[0] == 1
+
+
 @pytest.mark.parametrize(
     "rule,fname,prompt,exit_code",
     [


### PR DESCRIPTION
### Brief summary of the change made

Handles templater errors and otherwise unfixable errors better when fixing stdin.

fixes #1196 


Instead of excepting like:


```
➜ echo '--Airflow: ml_cxe_service_metrics -
CREATE TABLE IF NOT EXISTS {{ params.ml_schema }}.daily_service_metrics (
    source_type varchar(10) NOT NULL,
    visit_date date NOT NULL,
    event_name text NOT NULL,
    event_count bigint NOT NULL
)
diststyle even
compound sortkey(visit_date, source_type)
;' | sqlfluff fix - --dialect postgres
Traceback (most recent call last):
...
AttributeError: 'NoneType' object has no attribute 'templated_str
```

This PR allows fluff to exit like

```
➜ echo '--Airflow: ml_cxe_service_metrics -
CREATE TABLE IF NOT EXISTS {{ params.ml_schema }}.daily_service_metrics (
    source_type varchar(10) NOT NULL,
    visit_date date NOT NULL,
    event_name text NOT NULL,
    event_count bigint NOT NULL
)
diststyle even
compound sortkey(visit_date, source_type)
;' | sqlfluff fix - --dialect postgres

The stdin input contains template variables that could not be parsed. Aborting fix.
```

I am not feeling 100% good about this approach. It is better than current state but the _best_ outcome would be to return fixed sql if at all possible. I don't know much about the templater so will leave it to others to decide if it is at all possible to fix via stdin with templated variables..

### Are there any other side effects of this change that we should be aware of?
...

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
