### PR TITLE
Correct codecov badge for Docs website

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,6 +79,8 @@ html_static_path = ["_static"]
 # -- Options for Alabaster Theme ---------------------------------------------
 
 html_theme_options = {
+    # Set branch to main (used by Codecov button)
+    "badge_branch": "main",
     "logo": "images/sqlfluff-lrg.png",
     # Icon for iOS shortcuts
     "touch_icon": "images/sqlfluff-sm2-sq.png",


### PR DESCRIPTION
### Brief summary of the change made
Corrects the codecov badge on https://docs.sqlfluff.com/ to use the `main` branch (as we use) rather than the default `master` branch, which has a pitiful 96% code coverage 😁

Docs: https://alabaster.readthedocs.io/en/latest/customization.html#theme-options

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
