### PR TITLE
Improve rules L003 and L019 by processing multi-line fixes in one pass.

### DIFF
--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -7,6 +7,7 @@ Implements various runner types for SQLFluff:
   - Multithread (used only by automated tests)
 """
 from abc import ABC
+import bdb
 import functools
 import logging
 import multiprocessing.dummy
@@ -92,7 +93,7 @@ class SequentialRunner(BaseRunner):
         for fname, partial in self.iter_partials(fnames, fix=fix):
             try:
                 yield partial()
-            except KeyboardInterrupt:
+            except (bdb.BdbQuit, KeyboardInterrupt):
                 raise
             except Exception as e:
                 self._handle_lint_path_exception(fname, e)

--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -92,6 +92,8 @@ class SequentialRunner(BaseRunner):
         for fname, partial in self.iter_partials(fnames, fix=fix):
             try:
                 yield partial()
+            except KeyboardInterrupt:
+                raise
             except Exception as e:
                 self._handle_lint_path_exception(fname, e)
 

--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -93,7 +93,7 @@ class SequentialRunner(BaseRunner):
         for fname, partial in self.iter_partials(fnames, fix=fix):
             try:
                 yield partial()
-            except (bdb.BdbQuit, KeyboardInterrupt):
+            except (bdb.BdbQuit, KeyboardInterrupt):  #pragma: no cover
                 raise
             except Exception as e:
                 self._handle_lint_path_exception(fname, e)

--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -93,7 +93,7 @@ class SequentialRunner(BaseRunner):
         for fname, partial in self.iter_partials(fnames, fix=fix):
             try:
                 yield partial()
-            except (bdb.BdbQuit, KeyboardInterrupt):  #pragma: no cover
+            except (bdb.BdbQuit, KeyboardInterrupt):  # pragma: no cover
                 raise
             except Exception as e:
                 self._handle_lint_path_exception(fname, e)

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -14,6 +14,7 @@ should flag on the segment FOLLOWING, the place that the desired element is
 missing.
 """
 
+import bdb
 import copy
 import logging
 import pathlib
@@ -309,7 +310,7 @@ class BaseRule:
                 path=pathlib.Path(fname) if fname else None,
                 templated_file=templated_file,
             )
-        except KeyboardInterrupt:
+        except (bdb.BdbQuit, KeyboardInterrupt):
             raise
         # Any exception at this point would halt the linter and
         # cause the user to get no results

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -310,7 +310,7 @@ class BaseRule:
                 path=pathlib.Path(fname) if fname else None,
                 templated_file=templated_file,
             )
-        except (bdb.BdbQuit, KeyboardInterrupt):  #pragma: no cover
+        except (bdb.BdbQuit, KeyboardInterrupt):  # pragma: no cover
             raise
         # Any exception at this point would halt the linter and
         # cause the user to get no results

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -310,7 +310,7 @@ class BaseRule:
                 path=pathlib.Path(fname) if fname else None,
                 templated_file=templated_file,
             )
-        except (bdb.BdbQuit, KeyboardInterrupt):
+        except (bdb.BdbQuit, KeyboardInterrupt):  #pragma: no cover
             raise
         # Any exception at this point would halt the linter and
         # cause the user to get no results

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -309,6 +309,8 @@ class BaseRule:
                 path=pathlib.Path(fname) if fname else None,
                 templated_file=templated_file,
             )
+        except KeyboardInterrupt:
+            raise
         # Any exception at this point would halt the linter and
         # cause the user to get no results
         except Exception as e:

--- a/src/sqlfluff/rules/L019.py
+++ b/src/sqlfluff/rules/L019.py
@@ -147,6 +147,9 @@ class Rule_L019(BaseRule):
                 else:
                     # We've run out of whitespace to delete, time to fix
                     last_leading_comma_seg = memory["last_leading_comma_seg"]
+                    # Scan backwards to find the last code segment, skipping
+                    # over lines that are either entirely blank or just a
+                    # comment. We want to place the comma immediately after it.
                     last_code_seg = None
                     while last_code_seg is None or last_code_seg.is_type("newline"):
                         last_code_seg = self._last_code_seg(

--- a/src/sqlfluff/rules/L019.py
+++ b/src/sqlfluff/rules/L019.py
@@ -147,6 +147,17 @@ class Rule_L019(BaseRule):
                 else:
                     # We've run out of whitespace to delete, time to fix
                     last_leading_comma_seg = memory["last_leading_comma_seg"]
+                    last_code_seg = None
+                    while last_code_seg is None or last_code_seg.is_type("newline"):
+                        last_code_seg = self._last_code_seg(
+                            raw_stack[
+                                : raw_stack.index(
+                                    last_code_seg
+                                    if last_code_seg
+                                    else memory["last_leading_comma_seg"]
+                                )
+                            ]
+                        )
                     return LintResult(
                         anchor=last_leading_comma_seg,
                         description="Found leading comma. Expected only trailing.",
@@ -157,11 +168,11 @@ class Rule_L019(BaseRule):
                                 for d in memory["whitespace_deletions"]
                             ],
                             LintFix(
-                                "create",
-                                anchor=memory["anchor_for_new_trailing_comma_seg"],
+                                "edit",
+                                last_code_seg,
                                 # Reuse the previous leading comma violation to
                                 # create a new trailing comma
-                                edit=last_leading_comma_seg,
+                                [last_code_seg, last_leading_comma_seg],
                             ),
                         ],
                     )

--- a/test/fixtures/linter/autofix/ansi/008_looping_rules_l003_l016_l019/after.sql
+++ b/test/fixtures/linter/autofix/ansi/008_looping_rules_l003_l016_l019/after.sql
@@ -2,7 +2,7 @@ SELECT
     COUNT(1) AS campaign_count,
     state_user_v_peer_open,
     business_type,
-    
+
     -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
     --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
     --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be

--- a/test/fixtures/linter/autofix/bigquery/004_templating/after.sql
+++ b/test/fixtures/linter/autofix/bigquery/004_templating/after.sql
@@ -24,9 +24,6 @@ raw_effect_sizes AS (
     SELECT
         COUNT(1) AS campaign_count_{{action}},
         {{corr_states}}
-    -- NOTE: The L003 fix routine behaves a little strangely here around the templated
-    -- code, specifically the indentation of STDDEV_POP and preceeding comments. This
-        -- is a bug currently with no obvious solution.
         , SAFE_DIVIDE(SAFE_MULTIPLY(CORR({{metric}}_rate_su, {{action}}), STDDEV_POP({{metric}}_rate_su)),
                         STDDEV_POP({{action}})) AS {{metric}}_{{action}}
     FROM

--- a/test/fixtures/linter/autofix/bigquery/004_templating/after.sql
+++ b/test/fixtures/linter/autofix/bigquery/004_templating/after.sql
@@ -24,6 +24,9 @@ raw_effect_sizes AS (
     SELECT
         COUNT(1) AS campaign_count_{{action}},
         {{corr_states}}
+        -- NOTE: The L003 fix routine behaves a little strangely here around the templated
+        -- code, specifically the indentation of STDDEV_POP and preceeding comments. This
+        -- is a bug currently with no obvious solution.
         , SAFE_DIVIDE(SAFE_MULTIPLY(CORR({{metric}}_rate_su, {{action}}), STDDEV_POP({{metric}}_rate_su)),
                         STDDEV_POP({{action}})) AS {{metric}}_{{action}}
     FROM

--- a/test/fixtures/linter/autofix/bigquery/004_templating/before.sql
+++ b/test/fixtures/linter/autofix/bigquery/004_templating/before.sql
@@ -24,9 +24,6 @@ WITH
   SELECT
     COUNT(1) AS campaign_count_{{action}},
     {{corr_states}}
-    -- NOTE: The L003 fix routine behaves a little strangely here around the templated
-    -- code, specifically the indentation of STDDEV_POP and preceeding comments. This
-    -- is a bug currently with no obvious solution.
     ,SAFE_DIVIDE(SAFE_MULTIPLY(CORR({{metric}}_rate_su, {{action}}), STDDEV_POP({{metric}}_rate_su)),
       STDDEV_POP({{action}})) AS {{metric}}_{{action}}
   FROM

--- a/test/fixtures/linter/autofix/bigquery/004_templating/before.sql
+++ b/test/fixtures/linter/autofix/bigquery/004_templating/before.sql
@@ -24,6 +24,9 @@ WITH
   SELECT
     COUNT(1) AS campaign_count_{{action}},
     {{corr_states}}
+    -- NOTE: The L003 fix routine behaves a little strangely here around the templated
+    -- code, specifically the indentation of STDDEV_POP and preceeding comments. This
+    -- is a bug currently with no obvious solution.
     ,SAFE_DIVIDE(SAFE_MULTIPLY(CORR({{metric}}_rate_su, {{action}}), STDDEV_POP({{metric}}_rate_su)),
       STDDEV_POP({{action}})) AS {{metric}}_{{action}}
   FROM

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -230,6 +230,28 @@ test_fail_indented_from_with_comment_fix:
     -- Comment
     JOIN t2 USING (user_id)
 
+test_fail_indented_multi_line_comment:
+  fail_str: |
+    SELECT
+    business_type,
+
+    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+    -- coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+    customer_type
+
+    FROM
+    global_actions_states
+  fix_str: |
+    SELECT
+        business_type,
+
+        -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+        -- coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+        customer_type
+
+    FROM
+        global_actions_states
+
 test_fail_attempted_hanger_fix:
   # It's almost a hanger and so should be corrected to one.
   fail_str: |

--- a/test/fixtures/rules/std_rule_cases/L019.yml
+++ b/test/fixtures/rules/std_rule_cases/L019.yml
@@ -234,3 +234,43 @@ trailing_comma_move_past_several_comment_lines:
       # earlier version, the comma before "SAFE_DIVIDE()" was being moved one
       # line per pass. Too lazy!
       runaway_limit: 1
+
+
+leading_comma_move_past_several_comment_lines:
+  fail_str: |
+    SELECT
+    COUNT(1) AS campaign_count
+    ,state_user_v_peer_open,
+    business_type,
+
+    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+    --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
+    --  the "y variable" and uses_small_subject_line to be the "x variable" in terms of the regression line.
+    SAFE_DIVIDE(SAFE_MULTIPLY(CORR(open_rate_su, uses_small_subject_line), STDDEV_POP(open_rate_su)), STDDEV_POP(uses_small_subject_line))
+
+    FROM
+    global_actions_states
+  fix_str: |
+    SELECT
+    COUNT(1) AS campaign_count
+    ,state_user_v_peer_open
+    , business_type
+
+    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+    --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
+    --  the "y variable" and uses_small_subject_line to be the "x variable" in terms of the regression line.
+    , SAFE_DIVIDE(SAFE_MULTIPLY(CORR(open_rate_su, uses_small_subject_line), STDDEV_POP(open_rate_su)), STDDEV_POP(uses_small_subject_line))
+
+    FROM
+    global_actions_states
+  configs:
+    core:
+      # Set runaway_limit=1 to verify the fix only requires one pass. In an
+      # earlier version for the trailing comma case, commas were being moved
+      # "through" comment blocks one line per pass. Too lazy!
+      runaway_limit: 1
+    rules:
+      L019:
+        comma_style: leading

--- a/test/fixtures/rules/std_rule_cases/L019.yml
+++ b/test/fixtures/rules/std_rule_cases/L019.yml
@@ -24,7 +24,7 @@ leading_comma_violation_with_inline_comment:
   fix_str: |
     SELECT
         a,
-        b ,-- inline comment
+        b, -- inline comment
         c,
         /* non inline comment */
         d

--- a/test/fixtures/rules/std_rule_cases/L019.yml
+++ b/test/fixtures/rules/std_rule_cases/L019.yml
@@ -198,3 +198,39 @@ leading_comma_fixing_flows_around_comments:
     rules:
       L019:
         comma_style: leading
+
+trailing_comma_move_past_several_comment_lines:
+  fail_str: |
+    SELECT
+    COUNT(1) AS campaign_count,
+    state_user_v_peer_open
+    ,business_type
+
+    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+    --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
+    --  the "y variable" and uses_small_subject_line to be the "x variable" in terms of the regression line.
+    ,SAFE_DIVIDE(SAFE_MULTIPLY(CORR(open_rate_su, uses_small_subject_line), STDDEV_POP(open_rate_su)), STDDEV_POP(uses_small_subject_line))
+
+    FROM
+    global_actions_states
+  fix_str: |
+    SELECT
+    COUNT(1) AS campaign_count,
+    state_user_v_peer_open,
+    business_type,
+
+    -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
+    --  coefficient is symmetric in its arguments, but since STDDEV_POP(open_rate_su) appears in the
+    --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
+    --  the "y variable" and uses_small_subject_line to be the "x variable" in terms of the regression line.
+    SAFE_DIVIDE(SAFE_MULTIPLY(CORR(open_rate_su, uses_small_subject_line), STDDEV_POP(open_rate_su)), STDDEV_POP(uses_small_subject_line))
+
+    FROM
+    global_actions_states
+  configs:
+    core:
+      # Set runaway_limit=1 to verify the fix only requires one pass. In an
+      # earlier version, the comma before "SAFE_DIVIDE()" was being moved one
+      # line per pass. Too lazy!
+      runaway_limit: 1


### PR DESCRIPTION
Fixes #1387 

This PR fixes a couple of issues:
- Primary fix: Previously, when run in "trailing comma" mode, L019 was only moving commas one line at a time, even if there were multiple comment or blank lines between the initial location and the desired final location. This caused the linter to require additional loops (bad) and could result in hitting the linter loop limit while the comma was in mid-journey.
- Secondary fix: I found that when I fixed the above issue, it surfaced a bug in L003 that had previously been hidden in some cases. Amusingly, when a comma would move through a comment block, it would sometimes trigger useful indentation changes along the way. Now that the comma jumps immediately to the final destination, this was no longer occurring. So I updated L003 to explicitly align a comment **block** preceding a code line with the code line, rather than (old behavior) just aligning the **immediately preceding** comment.

These changes "broke" a few existing tests, but in every case, the new behavior seemed correct/better to me.

The update to L003  changes existing formatting behavior. I believe it's an improvement, but if we have concerns, we can revert to the previous behavior. Note that the previous behavior was inconsistent -- the indentation of comments depended on whether a comma had taken a joyride through the comment block. 🤣 So I recommend we take these changes, or at least refine them farther, _not_ go back.
...

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
