### PR TITLE
Allow optional enforcing of implicit aliasing of tables (L011) and columns (L012)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,14 @@ tox -e generate-fixture-yml,cov-init,py38,cov-report,linting
 > generates the results for tests in that Python version and the `cov-report-nobt`
 > environment reports those results out to you (excluding dbt).
 
+You can also run specific tests only by making use of `pytest -k` to match test.
+For example below will only run the tests for rule L012 which is much faster while
+working on an issue, before running full tests at the end:
+
+```
+pytest -k L012 -v
+```
+
 To run the dbt-related tests you will have to explicitly include these tests:
 
 ```shell

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -54,6 +54,12 @@ operator_new_lines = after
 [sqlfluff:rules:L010]  # Keywords
 capitalisation_policy = consistent
 
+[sqlfluff:rules:L011]  # Aliasing
+aliasing = explicit
+
+[sqlfluff:rules:L012]  # Aliasing
+aliasing = explicit
+
 [sqlfluff:rules:L014]  # Unquoted identifiers
 extended_capitalisation_policy = consistent
 

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -97,7 +97,7 @@ STANDARD_CONFIG_INFO_DICT = {
     "aliasing": {
         "validation": ["implicit", "explicit"],
         "definition": (
-            "Should alias have an explict AS or is implicit aliasing allowed?"
+            "Should alias have an explict AS or is implicit aliasing required?"
         ),
     },
 }

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -94,6 +94,12 @@ STANDARD_CONFIG_INFO_DICT = {
         "validation": ["before", "after"],
         "definition": ("Should operator be placed before or after newlines."),
     },
+    "aliasing": {
+        "validation": ["implicit", "explicit"],
+        "definition": (
+            "Should alias have an explict AS or is implicit aliasing allowed?"
+        ),
+    },
 }
 
 

--- a/src/sqlfluff/rules/L011.py
+++ b/src/sqlfluff/rules/L011.py
@@ -8,7 +8,8 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 @document_fix_compatible
 class Rule_L011(BaseRule):
-    """Implicit aliasing of table not allowed. Use explicit `AS` clause.
+    """Implicit/explicit aliasing of table to follow preference
+    (explicit using an `AS` clause is default).
 
     | **Anti-pattern**
     | In this example, the alias 'voo' is implicit.
@@ -30,6 +31,8 @@ class Rule_L011(BaseRule):
 
     """
 
+    config_keywords = ["aliasing"]
+
     _target_elems = ("from_expression_element",)
 
     def _eval(self, segment, parent_stack, raw_stack, **kwargs):
@@ -41,9 +44,30 @@ class Rule_L011(BaseRule):
         The use of `raw_stack` is just for working out how much whitespace to add.
 
         """
+        fixes = []
+
         if segment.is_type("alias_expression"):
             if parent_stack[-1].is_type(*self._target_elems):
-                if not any(e.name.lower() == "as" for e in segment.segments):
+                if any(e.name.lower() == "as" for e in segment.segments):
+                    if self.aliasing == "implicit":
+                        if segment.segments[0].name.lower() == "as":
+
+                            # Remove the AS as we're using implict aliasing
+                            fixes.append(LintFix("delete", segment.segments[0]))
+                            anchor = raw_stack[-1]
+
+                            # Remove whitespace before (if exists) or after (if not)
+                            if (
+                                len(raw_stack) > 0
+                                and raw_stack[-1].type == "whitespace"
+                            ):
+                                fixes.append(LintFix("delete", raw_stack[-1]))
+                            elif (len(segment.segments) > 0 and segment.segments[1].type == "whitespace"):
+                                fixes.append(LintFix("delete", segment.segments[1]))
+                            # TODO - check if we're left with a blank line and remove it if so.
+                            return LintResult(anchor=anchor, fixes=fixes)
+
+                else:
                     insert_buff = []
 
                     # Add initial whitespace if we need to...

--- a/src/sqlfluff/rules/L011.py
+++ b/src/sqlfluff/rules/L011.py
@@ -8,7 +8,9 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 @document_fix_compatible
 class Rule_L011(BaseRule):
-    """Implicit/explicit aliasing of table to follow preference
+    """Implicit/explicit aliasing of table.
+
+    Aliasing of table to follow preference
     (explicit using an `AS` clause is default).
 
     | **Anti-pattern**
@@ -67,7 +69,7 @@ class Rule_L011(BaseRule):
                                 and segment.segments[1].type == "whitespace"
                             ):
                                 fixes.append(LintFix("delete", segment.segments[1]))
-                            # TODO - check if we're left with a blank line and remove it if so.
+
                             return LintResult(anchor=anchor, fixes=fixes)
 
                 else:

--- a/src/sqlfluff/rules/L011.py
+++ b/src/sqlfluff/rules/L011.py
@@ -62,7 +62,10 @@ class Rule_L011(BaseRule):
                                 and raw_stack[-1].type == "whitespace"
                             ):
                                 fixes.append(LintFix("delete", raw_stack[-1]))
-                            elif (len(segment.segments) > 0 and segment.segments[1].type == "whitespace"):
+                            elif (
+                                len(segment.segments) > 0
+                                and segment.segments[1].type == "whitespace"
+                            ):
                                 fixes.append(LintFix("delete", segment.segments[1]))
                             # TODO - check if we're left with a blank line and remove it if so.
                             return LintResult(anchor=anchor, fixes=fixes)

--- a/src/sqlfluff/rules/L012.py
+++ b/src/sqlfluff/rules/L012.py
@@ -4,7 +4,8 @@ from sqlfluff.rules.L011 import Rule_L011
 
 
 class Rule_L012(Rule_L011):
-    """Implicit aliasing of column not allowed. Use explicit `AS` clause.
+    """Implicit/explicit aliasing of column to follow preference
+    (explicit using an `AS` clause is default).
 
     NB: This rule inherits its functionality from obj:`Rule_L011` but is
     separate so that they can be enabled and disabled separately.
@@ -28,5 +29,7 @@ class Rule_L012(Rule_L011):
         FROM foo
 
     """
+
+    config_keywords = ["aliasing"]
 
     _target_elems = ("select_clause_element",)

--- a/src/sqlfluff/rules/L012.py
+++ b/src/sqlfluff/rules/L012.py
@@ -4,7 +4,9 @@ from sqlfluff.rules.L011 import Rule_L011
 
 
 class Rule_L012(Rule_L011):
-    """Implicit/explicit aliasing of column to follow preference
+    """Implicit/explicit aliasing of columns.
+
+    Aliasing of columns to follow preference
     (explicit using an `AS` clause is default).
 
     NB: This rule inherits its functionality from obj:`Rule_L011` but is

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -643,8 +643,7 @@ def test__cli__command_lint_serialize_github_annotation():
                 "test/fixtures/linter/identifier_capitalisation.sql"
             ),
             "line": 3,
-            "message": "L012: Implicit aliasing of column not allowed. Use explicit `AS` "
-            "clause.",
+            "message": "L012: Implicit/explicit aliasing of columns.",
             "start_column": 5,
             "end_column": 5,
             "title": "SQLFluff",

--- a/test/fixtures/rules/std_rule_cases/L011.yml
+++ b/test/fixtures/rules/std_rule_cases/L011.yml
@@ -49,18 +49,3 @@ test_fail_implicit_alias_implicit_newline:
     rules:
       L011:
         aliasing: implicit
-
-# TODO - add test for blank line
-# test_fail_implicit_alias_implicit_newlines:
-#   # Add whitespace when fixing implicit aliasing
-#   fail_str: |
-#       select foo.bar from (select 1 as bar)
-#       AS
-#       foo
-#   fix_str: |
-#       select foo.bar from (select 1 as bar)
-#       foo
-#   configs:
-#     rules:
-#       L011:
-#         aliasing: implicit

--- a/test/fixtures/rules/std_rule_cases/L011.yml
+++ b/test/fixtures/rules/std_rule_cases/L011.yml
@@ -6,12 +6,12 @@ test_fail_implicit_alias:
   fix_str: select foo.bar from (select 1 as bar) AS foo
 
 test_fail_implicit_alias_space:
-  # Add whitespace when fixing implicit aliasing
+  # No unnecessary whitespace added when fixing implicit aliasing
   fail_str: select foo.bar from (select 1 as bar) foo
   fix_str: select foo.bar from (select 1 as bar) AS foo
 
 test_fail_implicit_alias_explicit:
-  # Add whitespace when fixing implicit aliasing
+  # Test when explicitly setting explict
   fail_str: select foo.bar from (select 1 as bar) foo
   fix_str: select foo.bar from (select 1 as bar) AS foo
   configs:
@@ -20,9 +20,18 @@ test_fail_implicit_alias_explicit:
         aliasing: explicit
 
 test_fail_implicit_alias_implicit:
-  # Add whitespace when fixing implicit aliasing
+  # Test implicit
   fail_str: select foo.bar from (select 1 as bar) AS foo
   fix_str: select foo.bar from (select 1 as bar) foo
+  configs:
+    rules:
+      L011:
+        aliasing: implicit
+
+test_fail_implicit_alias_implicit_multiple:
+  # Test implicit with multiple tables
+  fail_str: select foo.bar from (select 1 as bar) AS bar, (select 1 as foo) AS foo
+  fix_str: select foo.bar from (select 1 as bar) bar, (select 1 as foo) foo
   configs:
     rules:
       L011:

--- a/test/fixtures/rules/std_rule_cases/L011.yml
+++ b/test/fixtures/rules/std_rule_cases/L011.yml
@@ -4,3 +4,54 @@ test_fail_implicit_alias:
   # Add whitespace when fixing implicit aliasing
   fail_str: select foo.bar from (select 1 as bar)foo
   fix_str: select foo.bar from (select 1 as bar) AS foo
+
+test_fail_implicit_alias_space:
+  # Add whitespace when fixing implicit aliasing
+  fail_str: select foo.bar from (select 1 as bar) foo
+  fix_str: select foo.bar from (select 1 as bar) AS foo
+
+test_fail_implicit_alias_explicit:
+  # Add whitespace when fixing implicit aliasing
+  fail_str: select foo.bar from (select 1 as bar) foo
+  fix_str: select foo.bar from (select 1 as bar) AS foo
+  configs:
+    rules:
+      L011:
+        aliasing: explicit
+
+test_fail_implicit_alias_implicit:
+  # Add whitespace when fixing implicit aliasing
+  fail_str: select foo.bar from (select 1 as bar) AS foo
+  fix_str: select foo.bar from (select 1 as bar) foo
+  configs:
+    rules:
+      L011:
+        aliasing: implicit
+
+test_fail_implicit_alias_implicit_newline:
+  # Add whitespace when fixing implicit aliasing
+  fail_str: |
+      select foo.bar from (select 1 as bar)
+      AS foo
+  fix_str: |
+      select foo.bar from (select 1 as bar)
+      foo
+  configs:
+    rules:
+      L011:
+        aliasing: implicit
+
+# TODO - add test for blank line
+# test_fail_implicit_alias_implicit_newlines:
+#   # Add whitespace when fixing implicit aliasing
+#   fail_str: |
+#       select foo.bar from (select 1 as bar)
+#       AS
+#       foo
+#   fix_str: |
+#       select foo.bar from (select 1 as bar)
+#       foo
+#   configs:
+#     rules:
+#       L011:
+#         aliasing: implicit

--- a/test/fixtures/rules/std_rule_cases/L012.yml
+++ b/test/fixtures/rules/std_rule_cases/L012.yml
@@ -12,3 +12,28 @@ issue_561:
   configs:
     core:
       dialect: snowflake
+
+
+
+test_fail_explicit_column_default:
+  # Test explicit column alias
+  fail_str: select 1 bar from table1 b
+  fix_str: select 1 AS bar from table1 b
+
+test_fail_explicit_column_explicit:
+  # Test explicit column alias
+  fail_str: select 1 bar from table1 b
+  fix_str: select 1 AS bar from table1 b
+  configs:
+    rules:
+      L012:
+        aliasing: explicit
+
+test_fail_explicit_column_implicit:
+  # Test explicit column alias
+  fail_str: select 1 AS bar from table1 b
+  fix_str: select 1 bar from table1 b
+  configs:
+    rules:
+      L012:
+        aliasing: implicit

--- a/test/fixtures/rules/std_rule_cases/L012.yml
+++ b/test/fixtures/rules/std_rule_cases/L012.yml
@@ -8,12 +8,9 @@ issue_561:
         (order by product_position asc) over (partition by (event_id, shelf_position))
       as shelf_catalog_items
     from x
-
   configs:
     core:
       dialect: snowflake
-
-
 
 test_fail_explicit_column_default:
   # Test explicit column alias

--- a/test/rules/std_test.py
+++ b/test/rules/std_test.py
@@ -134,6 +134,7 @@ def test__rules__std_file_dbt(rule, path, violations, project_dir):  # noqa
         {"unquoted_identifiers_policy": "blah"},
         {"L010": {"capitalisation_policy": "blah"}},
         {"L011": {"aliasing": "blah"}},
+        {"L012": {"aliasing": "blah"}},
         {"L014": {"extended_capitalisation_policy": "blah"}},
         {"L030": {"capitalisation_policy": "blah"}},
     ],

--- a/test/rules/std_test.py
+++ b/test/rules/std_test.py
@@ -133,6 +133,7 @@ def test__rules__std_file_dbt(rule, path, violations, project_dir):  # noqa
         {"single_table_references": "blah"},
         {"unquoted_identifiers_policy": "blah"},
         {"L010": {"capitalisation_policy": "blah"}},
+        {"L011": {"aliasing": "blah"}},
         {"L014": {"extended_capitalisation_policy": "blah"}},
         {"L030": {"capitalisation_policy": "blah"}},
     ],


### PR DESCRIPTION
### Brief summary of the change made
Fixes #1400 

### Are there any other side effects of this change that we should be aware of?
Affects rules L011 and L012 which inherits from this. Default is left as explicit.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
