### PR TITLE
Add README on how to generate docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ for new users is really important. If you are a new user, you are in precisely
 the best position to do this. Familiarise yourself with the tool (as per step
 2 above) and familiarise yourself with the current documentation (live version
 at [docs.sqlfluff.com](https://docs.sqlfluff.com) and the source can be found
-in the [docs/source](https://github.com/sqlfluff/sqlfluff/tree/master/docs/source)
+in the [docs/source](https://github.com/sqlfluff/sqlfluff/tree/main/docs/source)
 folder of the repo). Pull requests are always welcome with documentation
 improvements. Keep in mind that there are linting checks in place for good
 formatting so keep an eye on the tests whenever submitting a PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,11 @@ python setup.py develop
 > `python setup.py develop` installs the package using a link to the source code so that any changes
 > which you make will immediately be available for use.
 
+## Documentation
+
+Documentation is built using Sphinx with some pages being built based on the source code.
+See the [docs/README.md](./docs/README.md) file for more information on how to build and test this.
+
 ## Building Package
 
 New versions of SQLFluff will be published to PyPI automatically via 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,35 @@ larger changes or giving the green light to major structural project
 changes.
 
 ## Nerdy Details
+
+### Developing SQLFluff locally
+
+To use your local development branch of SQLFluff, I recommend you use a virtual
+environment. e.g:
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+```
+> `python3 -m venv .venv` creates a new virtual environment (in current working
+> directory) called `.venv`.
+> `source .venv/bin/activate` activates the virtual environment so that packages
+> can be installed/uninstalled into it. [More info on venv](https://docs.python.org/3/library/venv.html).
+
+Once you are in a virtual environment, run:
+
+```shell
+pip install -Ur requirements.txt -Ur requirements_dev.txt
+python setup.py develop
+```
+
+> `pip install -Ur requirements.txt -Ur requirements_dev.txt` installs the project dependencies
+> as well as the dependencies needed to run linting, formatting, and testing commands. This will
+> install the most up-to-date package versions for all dependencies (-U).
+
+> `python setup.py develop` installs the package using a link to the source code so that any changes
+> which you make will immediately be available for use.
+
 ### Testing
 
 To test locally, SQLFluff uses `tox`, which means you can build locally using...
@@ -109,38 +138,10 @@ tox -e cov-init,dbt018-py38,cov-report-dbt -- -m "dbt"
 
 For more information on adding and running test cases see the [Parser Test README](test/fixtures/parser/README.md) and the [Rules Test README](test/fixtures/rules/std_rule_cases/README.md).
 
-### Using your local version
-
-To trial using your local development branch of SQLFluff, I recommend you use a virtual
-environment. e.g:
-
-```shell
-python3 -m venv .venv
-source .venv/bin/activate
-```
-> `python3 -m venv .venv` creates a new virtual environment (in current working
-> directory) called `.venv`.
-> `source .venv/bin/activate` activates the virtual environment so that packages
-> can be installed/uninstalled into it. [More info on venv](https://docs.python.org/3/library/venv.html).
-
-Once you are in a virtual environment, run:
-
-```shell
-pip install -Ur requirements.txt -Ur requirements_dev.txt
-python setup.py develop
-```
-
-> `pip install -Ur requirements.txt -Ur requirements_dev.txt` installs the project dependencies
-> as well as the dependencies needed to run linting, formatting, and testing commands. This will
-> install the most up-to-date package versions for all dependencies (-U).
-
-> `python setup.py develop` installs the package using a link to the source code so that any changes
-> which you make will immediately be available for use.
-
 ## Documentation
 
 Documentation is built using Sphinx with some pages being built based on the source code.
-See the [docs/README.md](./docs/README.md) file for more information on how to build and test this.
+See the [Documentation Website README.md](./docs/README.md) file for more information on how to build and test this.
 
 ## Building Package
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ You may find it useful to familiarise yourself with the
 [architectural principles here](https://docs.sqlfluff.com/en/latest/architecture.html)
 and with the [current documentation here](https://docs.sqlfluff.com).
 
-## How the community works
+## How The Community Works
 
 SQLFluff is maintained by a community of volunteers, which means we have a
 few processes in place to allow everyone to contribute at a level that suits
@@ -74,7 +74,7 @@ changes.
 
 ## Nerdy Details
 
-### Developing SQLFluff locally
+### Developing and Running SQLFluff Locally
 
 To use your local development branch of SQLFluff, I recommend you use a virtual
 environment. e.g:
@@ -138,7 +138,7 @@ tox -e cov-init,dbt018-py38,cov-report-dbt -- -m "dbt"
 
 For more information on adding and running test cases see the [Parser Test README](test/fixtures/parser/README.md) and the [Rules Test README](test/fixtures/rules/std_rule_cases/README.md).
 
-### Documentation
+### Documentation Website
 
 Documentation is built using Sphinx with some pages being built based on the source code.
 See the [Documentation Website README.md](./docs/README.md) file for more information on how to build and test this.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ environment. e.g:
 python3 -m venv .venv
 source .venv/bin/activate
 ```
+
 > `python3 -m venv .venv` creates a new virtual environment (in current working
 > directory) called `.venv`.
 > `source .venv/bin/activate` activates the virtual environment so that packages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,9 @@ for new users is really important. If you are a new user, you are in precisely
 the best position to do this. Familiarise yourself with the tool (as per step
 2 above) and familiarise yourself with the current documentation (live version
 at [docs.sqlfluff.com](https://docs.sqlfluff.com) and the source can be found
-in the [docs/source](https://github.com/sqlfluff/sqlfluff/tree/main/docs/source)
-folder of the repo). Pull requests are always welcome with documentation
-improvements. Keep in mind that there are linting checks in place for good
-formatting so keep an eye on the tests whenever submitting a PR.
+in the [docs](./docs/) folder of the repo). Pull requests are always welcome
+with documentation improvements. Keep in mind that there are linting checks in
+place for good formatting so keep an eye on the tests whenever submitting a PR.
 
 :star2: **Fifth** - if you are so inclined - pull requests on the core codebase
 are always welcome. Bear in mind that all the tests should pass, and test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,12 +138,12 @@ tox -e cov-init,dbt018-py38,cov-report-dbt -- -m "dbt"
 
 For more information on adding and running test cases see the [Parser Test README](test/fixtures/parser/README.md) and the [Rules Test README](test/fixtures/rules/std_rule_cases/README.md).
 
-## Documentation
+### Documentation
 
 Documentation is built using Sphinx with some pages being built based on the source code.
 See the [Documentation Website README.md](./docs/README.md) file for more information on how to build and test this.
 
-## Building Package
+### Building Package
 
 New versions of SQLFluff will be published to PyPI automatically via 
 [GitHub Actions](.github/workflows/publish-release-to-pypi.yaml) 
@@ -161,7 +161,7 @@ Once both changes are done, open a new Pull Request for these changes.
 If this is not done, PyPI will reject the package. Also, ensure you have used that 
 version as a part of the tag and have described the changes accordingly.
 
-### Manually
+#### Manually
 
 If for some reason the package needs to be submitted to PyPI manually, we use `twine`.
 You will need to be an admin to submit this to PyPI, and you will need a properly

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,10 +9,10 @@ tox -e docbuild, doclint
 The `docbuild` job will recognise when source files have changed and only
 generate the changed files. To force a clean build (for example when changing
 config) rather than the source files use the following command from the project
-root directory (drop the `-C doc` if running from within the `docs` directory).
+root directory (drop the `-C docs` if running from within the `docs` directory).
 
 ```
-make -C doc clean
+make -C docs clean
 ```
 
 The built HTML should be placed in `docs/build/html` and can be opened directly
@@ -23,7 +23,7 @@ and then navigate to http://127.0.0.1:8000/ to view the site locally:
 python -m http.server --directory docs/build/html
 ```
 
-Again, this command is run from the root server, not the `doc` subfolder but you
+Again, this command is run from the root server, not the `docs` subfolder but you
 can alter the path as appropriate if needs be.
 
 If you don't want to use `tox`, then you can complete the steps manually with
@@ -46,4 +46,4 @@ python -m http.server --directory docs/build/html
 ```
 
 The docs use Sphinx and are generated from the source code.
-The config is available in `docs/src/conf.py`.
+The config is available in `docs/source/conf.py`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,39 @@
+# SQLFluff - Generating the document website
+
+You can run the following steps to generate the documentation website:
+
+```
+tox -e docbuild, doclint
+```
+
+The built HTML should be placed in `docs/build/html` and can be opened directly
+or you can launch a webserver with the following:
+
+```
+python -m http.server --directory docs/build/html
+```
+
+Note this is run from the root server, not the `doc` subfolder but you can
+alter the path as appropriate if needs be.
+
+If you don't want to use `tox`, then you can complete the steps manually with
+the following commands after setting up your Python environment as detailed
+in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
+
+```
+cd docs
+pip install -r requirements.txt
+make html
+python -m http.server --directory build/html
+```
+
+Or alternatively from the root folder:
+
+```
+pip install -r docs/requirements.txt
+make -C docs html
+python -m http.server --directory docs/build/html
+```
+
+The docs use Sphinx and are generated from the source code.
+The config is available in `docs/src/conf.py`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,15 +6,25 @@ You can run the following steps to generate the documentation website:
 tox -e docbuild, doclint
 ```
 
+The `docbuild` job will recognise when source files have changed and only
+generate the changed files. To force a clean build (for example when changing
+config) rather than the source files use the following command from the project
+root directory (drop the `-C doc` if running from within the `docs` directory).
+
+```
+make -C doc clean
+```
+
 The built HTML should be placed in `docs/build/html` and can be opened directly
-or you can launch a webserver with the following:
+in the browser or you can launch a simple webserver with the below command
+and then navigate to http://127.0.0.1:8000/ to view the site locally:
 
 ```
 python -m http.server --directory docs/build/html
 ```
 
-Note this is run from the root server, not the `doc` subfolder but you can
-alter the path as appropriate if needs be.
+Again, this command is run from the root server, not the `doc` subfolder but you
+can alter the path as appropriate if needs be.
 
 If you don't want to use `tox`, then you can complete the steps manually with
 the following commands after setting up your Python environment as detailed

--- a/docs/source/developingplugins.rst
+++ b/docs/source/developingplugins.rst
@@ -45,7 +45,7 @@ Codes are used to display errors, they are also used as configuration keys.
 We make it easy for plugin developers to test their rules by
 exposing a testing library in *sqlfluff.testing*.
 
-.. _`sqlfluff/plugins/sqlfluff-plugin-example`: https://github.com/sqlfluff/sqlfluff/tree/master/plugins/sqlfluff-plugin-example
+.. _`sqlfluff/plugins/sqlfluff-plugin-example`: https://github.com/sqlfluff/sqlfluff/tree/main/plugins/sqlfluff-plugin-example
 
 Giving feedback
 ---------------


### PR DESCRIPTION
### Brief summary of the change made
Took a bit to figure this out so thought best to document it

Did some clean up of the CONTRIBUTION.md file while at it:
- Move the installing of the virtual env above testing.
- Renamed it from "Using your local version" to "Developing and Running SQLFluff Locally"
- Made titles in Title case consistently.
- Indented all the Nerdy Details under Nerdy Details.

### Are there any other side effects of this change that we should be aware of?
Nope.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
- - Update a couple of references from `master` to `main`.
