### PR TITLE
Prevent CodeCov commenting on coverage differences too early

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,7 +2,7 @@
 # https://docs.codecov.io/docs/codecovyml-reference
 
 codecov:
-  branch: master
+  branch: main
   bot: "codecov-io"
   ci:
     - "github.com"
@@ -10,7 +10,7 @@ codecov:
   disable_default_path_fixes: no
   require_ci_to_pass: yes
   notify:
-    after_n_builds: 2
+    after_n_builds: 14
     wait_for_ci: yes
 
 coverage:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -11,8 +11,9 @@ codecov:
   require_ci_to_pass: yes
   notify:
     # We have 4 versions of python, 3 dbt and 2 windows checks
-    # So after 7 tests at least one python and one dbt check will
-    # have run, meaning we should have accurate coverage
+    # So after 6 tests at least one python and one dbt check will
+    # have run, meaning we should have accurate coverage. We'll
+    # go with 7 for luck and in case we add any other tests.
     after_n_builds: 7
     wait_for_ci: yes
 

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -10,7 +10,7 @@ codecov:
   disable_default_path_fixes: no
   require_ci_to_pass: yes
   notify:
-    after_n_builds: 14
+    after_n_builds: 6
     wait_for_ci: yes
 
 coverage:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -10,7 +10,10 @@ codecov:
   disable_default_path_fixes: no
   require_ci_to_pass: yes
   notify:
-    after_n_builds: 6
+    # We have 4 versions of python, 3 dbt and 2 windows checks
+    # So after 7 tests at least one python and one dbt check will
+    # have run, meaning we should have accurate coverage
+    after_n_builds: 7
     wait_for_ci: yes
 
 coverage:


### PR DESCRIPTION
### Brief summary of the change made
Currently when you open a PR you often get a false Coverage report when some, but not the main tests have finished. This PR ups the limit to prevent this from happening.

I picked 7 because we have:
- 4 main checks (3.6, 3.7, 3.8, 3.9)
- 3 dbt checks (018, 019, 020)
- 2 windows (py3.8 and dbt)
Or 9 coverage reports.

We want at least one main check and one dbt check to have completed so the minimum number of checks for that to have happened is 6. We'll add one for luck to get to lucky number 7.

### Are there any other side effects of this change that we should be aware of?
Also changed default branch to `main`

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
