### PR TITLE
Fix "sqlfluff fix compatible" rules indenting to much in documentation

### DIFF
--- a/src/sqlfluff/core/rules/doc_decorators.py
+++ b/src/sqlfluff/core/rules/doc_decorators.py
@@ -4,12 +4,12 @@ from sqlfluff.core.rules.config_info import get_config_info
 from sqlfluff.core.rules.base import rules_logger  # noqa
 
 
-FIX_COMPATIBLE = "``sqlfluff fix`` compatible."
+FIX_COMPATIBLE = "    ``sqlfluff fix`` compatible."
 
 
 def document_fix_compatible(cls):
     """Mark the rule as fixable in the documentation."""
-    cls.__doc__ = cls.__doc__.replace("\n", f"\n\n{FIX_COMPATIBLE}\n", 1)
+    cls.__doc__ = cls.__doc__.replace("\n", f"\n\n{FIX_COMPATIBLE}\n\n", 1)
     return cls
 
 


### PR DESCRIPTION
### Brief summary of the change made

Noticed in our [Rules documentation](https://docs.sqlfluff.com/en/stable/rules.html) that when `sqlfluff fix compatible` is added, it causes the rest of the documentation to indent:

![image](https://user-images.githubusercontent.com/10931297/133331545-e7474f9c-f8fa-47b2-a359-49835f8741fa.png)

This means the `sqlfluff fix compatible` rules are out of alignment with the non-`sqlfluff fix compatible` rules.

Turns out to be because there it is straight inserted with no indents so looks like the start of a new section.

### Are there any other side effects of this change that we should be aware of?
Don't think so.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
