### PR TITLE
Better error messages on error

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -487,10 +487,18 @@ def fix(force, paths, processes, bench=False, fixed_suffix="", logger=None, **kw
             stdout = stdin
 
         if templater_error:
-            click.echo(colorize("Fix aborted due to unparseable template variables.", "red"))
-            click.echo(colorize("Use '--ignore templating' to ignore templating errors.", "red"))
+            retmessage=colorize("Fix aborted due to unparseable template variables.", "red")
+            click.echo(
+                retmessage,
+            )
+            click.echo(
+                colorize(
+                    "Use '--ignore templating' to ignore templating errors.", "red"
+                ),
+                err=True,
+            )
         if unfixable_error:
-            click.echo(colorize("Unfixable violations detected.", "red"))
+            click.echo(colorize("Unfixable violations detected.", "red"), err=True)
 
         click.echo(stdout, nl=False)
         sys.exit(1 if templater_error or unfixable_error else 0)

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -486,11 +486,11 @@ def fix(force, paths, processes, bench=False, fixed_suffix="", logger=None, **kw
         else:
             stdout = stdin
 
-        if verbose:
-            if templater_error:
-                click.echo("Fix aborted due to unparseable template variables.")
-            if unfixable_error:
-                click.echo("Unfixable violations detected.")
+        if templater_error:
+            click.echo(colorize("Fix aborted due to unparseable template variables.", "red"))
+            click.echo(colorize("Use '--ignore templating' to ignore templating errors.", "red"))
+        if unfixable_error:
+            click.echo(colorize("Unfixable violations detected.", "red"))
 
         click.echo(stdout, nl=False)
         sys.exit(1 if templater_error or unfixable_error else 0)

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -487,14 +487,12 @@ def fix(force, paths, processes, bench=False, fixed_suffix="", logger=None, **kw
             stdout = stdin
 
         if templater_error:
-            retmessage=colorize("Fix aborted due to unparseable template variables.", "red")
             click.echo(
-                retmessage,
+                colorize("Fix aborted due to unparseable template variables.", "red"),
+                err=True,
             )
             click.echo(
-                colorize(
-                    "Use '--ignore templating' to ignore templating errors.", "red"
-                ),
+                colorize("Use '--ignore templating' to attempt to fix anyway.", "red"),
                 err=True,
             )
         if unfixable_error:
@@ -516,7 +514,8 @@ def fix(force, paths, processes, bench=False, fixed_suffix="", logger=None, **kw
                     paths
                 ),
                 "red",
-            )
+            ),
+            err=True,
         )
         sys.exit(1)
 
@@ -763,7 +762,8 @@ def parse(
             colorize(
                 f"The path {path!r} could not be accessed. Check it exists.",
                 "red",
-            )
+            ),
+            err=True,
         )
         sys.exit(1)
 


### PR DESCRIPTION
### Brief summary of the change made
Follow on from #1385 

Following changes:
- The current error is not highlighted in red so is a bit lost.
- Also we only show the error when in `verbose` mode which I think in hindsight is not great.
- Should use stderr so anyone using output from stdout can continue to
- Explain how to override

### Are there any other side effects of this change that we should be aware of?
Nope.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
