### PR TITLE
Issue 845: L016 should compute line length prior to template expansion

### DIFF
--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -373,7 +373,9 @@ class Rule_L016(Rule_L003):
     def _compute_segment_length(cls, segment):
         if segment.is_type("newline"):
             return 0
-        slice_length = segment.pos_marker.source_slice.stop - segment.pos_marker.source_slice.start
+        slice_length = (
+            segment.pos_marker.source_slice.stop - segment.pos_marker.source_slice.start
+        )
         if slice_length:
             return slice_length
         else:
@@ -386,7 +388,10 @@ class Rule_L016(Rule_L003):
         # Use a set to avoid counting segments twice.
         seen_slices = set()
         for segment in segments:
-            slice = (segment.pos_marker.source_slice.start, segment.pos_marker.source_slice.stop)
+            slice = (
+                segment.pos_marker.source_slice.start,
+                segment.pos_marker.source_slice.stop,
+            )
             if slice not in seen_slices:
                 seen_slices.add(slice)
                 line_len += cls._compute_segment_length(segment)

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -369,6 +369,20 @@ class Rule_L016(Rule_L003):
                 break  # pragma: no cover
         return working_buff
 
+    @staticmethod
+    def _compute_source_length(segments):
+        line_len = 0
+        for segment in segments:
+            if segment.is_type("newline"):
+                continue
+            slice_length = segment.pos_marker.source_slice.stop - segment.pos_marker.source_slice.start
+            if slice_length:
+                segment_length = slice_length
+            else:
+                segment_length = len(segment.raw)
+            line_len += segment_length
+        return line_len
+
     def _eval(self, segment, raw_stack, **kwargs):
         """Line is too long.
 
@@ -384,7 +398,7 @@ class Rule_L016(Rule_L003):
             return None
 
         # Now we can work out the line length and deal with the content
-        line_len = sum(len(s.raw) for s in this_line)
+        line_len = self._compute_source_length(this_line)
         if line_len > self.max_line_length:
             # Problem, we'll be reporting a violation. The
             # question is, can we fix it?
@@ -429,7 +443,7 @@ class Rule_L016(Rule_L003):
                     else:
                         break  # pragma: no cover
                 create_elements = line_indent + [this_line[-1], segment]
-                if sum(len(s.raw) for s in create_elements) > self.max_line_length:
+                if self._compute_source_length(create_elements) > self.max_line_length:
                     # The inline comment is NOT on a line by itself, but even if
                     # we move it onto a line by itself, it's still too long. In
                     # this case, the rule should do nothing, otherwise it

--- a/test/fixtures/linter/autofix/bigquery/002_templating/after.sql
+++ b/test/fixtures/linter/autofix/bigquery/002_templating/after.sql
@@ -4,7 +4,10 @@ SELECT
     {{corr_states}}
     {% for action in considered_actions %}
         , aaa(
-            bbb(ccc({{metric}}_r, {{action}}), ddd({{metric}}_r)),
+            bbb(
+                ccc({{metric}}_r, {{action}}),
+                ddd({{metric}}_r)
+            ),
             eee({{action}})
         ) AS {{metric}}_{{action}}
     {% endfor %}

--- a/test/fixtures/rules/std_rule_cases/L016.yml
+++ b/test/fixtures/rules/std_rule_cases/L016.yml
@@ -96,3 +96,36 @@ test_pass_line_too_long_ignore_comments_false:
       max_line_length: 10
       L016:
         ignore_comment_lines: False
+
+test_compute_line_length_before_template_expansion_1:
+  # Line 3 is fine before expansion. Too long after expansion is NOT considered
+  # a violation.
+  pass_str: |
+    SELECT user_id
+    FROM
+        `{{bi_ecommerce_orders}}` {{table_at_job_start}}
+  configs:
+    core:
+      dialect: bigquery
+    templater:
+      jinja:
+        context:
+          table_at_job_start: FOR SYSTEM_TIME AS OF CAST('2021-03-02T01:22:59+00:00' AS TIMESTAMP)
+          bi_ecommerce_orders: bq-business-intelligence.user.ecommerce_orders
+
+
+test_compute_line_length_before_template_expansion_2:
+  # Line 3 is too long before expansion. It's fine after expansion, but the rule
+  # does not look at that.
+  fail_str: |
+    SELECT user_id
+    FROM
+        `{{bi_ecommerce_orders_bi_ecommerce_orders}}` AS {{table_alias_table_alias_table_alias_table_alias_table_alias_table_alias}}
+  configs:
+    core:
+      dialect: bigquery
+    templater:
+      jinja:
+        context:
+          bi_ecommerce_orders_bi_ecommerce_orders: bq-business-intelligence.user.ecommerce_orders
+          table_alias_table_alias_table_alias_table_alias_table_alias_table_alias: t


### PR DESCRIPTION
Fixes #845 
...

### Are there any other side effects of this change that we should be aware of?
...

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
