### PR TITLE
TSQL: Remove match possibilities for segments with no TSQL equivalent

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -299,17 +299,6 @@ class DropModelStatementSegment(BaseSegment):
 
 
 @tsql_dialect.segment(replace=True)
-class LimitClauseSegment(BaseSegment):
-    """A `LIMIT` clause like in `SELECT`.
-
-    Not present in T-SQL.
-    """
-
-    type = "limit_clause"
-    match_grammar = Nothing()
-
-
-@tsql_dialect.segment(replace=True)
 class OverlapsClauseSegment(BaseSegment):
     """An `OVERLAPS` clause like in `SELECT.
 
@@ -317,15 +306,4 @@ class OverlapsClauseSegment(BaseSegment):
     """
 
     type = "overlaps_clause"
-    match_grammar = Nothing()
-
-
-@tsql_dialect.segment(replace=True)
-class NamedWindowSegment(BaseSegment):
-    """A WINDOW clause.
-
-    Not present in T-SQL.
-    """
-
-    type = "named_window"
     match_grammar = Nothing()

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -287,7 +287,7 @@ class CreateModelStatementSegment(BaseSegment):
     match_grammar = Nothing()
 
 
-@ansi_dialect.segment(replace=True)
+@tsql_dialect.segment(replace=True)
 class DropModelStatementSegment(BaseSegment):
     """A `DROP MODEL` statement.
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -258,7 +258,8 @@ class CreateViewStatementSegment(BaseSegment):
 class IntervalExpressionSegment(BaseSegment):
     """An interval expression segment.
 
-    Not present in T-SQL. """
+    Not present in T-SQL.
+    """
 
     type = "interval_expression"
     match_grammar = Nothing()
@@ -268,7 +269,8 @@ class IntervalExpressionSegment(BaseSegment):
 class CreateExtensionStatementSegment(BaseSegment):
     """A `CREATE EXTENSION` statement.
 
-    Not present in T-SQL. """
+    Not present in T-SQL.
+    """
 
     type = "create_extension_statement"
     match_grammar = Nothing()
@@ -278,7 +280,8 @@ class CreateExtensionStatementSegment(BaseSegment):
 class CreateModelStatementSegment(BaseSegment):
     """A BigQuery `CREATE MODEL` statement.
 
-    Not present in T-SQL. """
+    Not present in T-SQL.
+    """
 
     type = "create_model_statement"
     match_grammar = Nothing()
@@ -288,7 +291,8 @@ class CreateModelStatementSegment(BaseSegment):
 class DropModelStatementSegment(BaseSegment):
     """A `DROP MODEL` statement.
 
-    Not present in T-SQL. """
+    Not present in T-SQL.
+    """
 
     type = "drop_MODELstatement"
     match_grammar = Nothing()
@@ -298,7 +302,8 @@ class DropModelStatementSegment(BaseSegment):
 class LimitClauseSegment(BaseSegment):
     """A `LIMIT` clause like in `SELECT`.
 
-    Not present in T-SQL. """
+    Not present in T-SQL.
+    """
 
     type = "limit_clause"
     match_grammar = Nothing()
@@ -308,7 +313,8 @@ class LimitClauseSegment(BaseSegment):
 class OverlapsClauseSegment(BaseSegment):
     """An `OVERLAPS` clause like in `SELECT.
 
-    Not present in T-SQL. """
+    Not present in T-SQL.
+    """
 
     type = "overlaps_clause"
     match_grammar = Nothing()
@@ -318,8 +324,8 @@ class OverlapsClauseSegment(BaseSegment):
 class NamedWindowSegment(BaseSegment):
     """A WINDOW clause.
 
-    Not present in T-SQL. """
+    Not present in T-SQL.
+    """
 
     type = "named_window"
     match_grammar = Nothing()
-

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -10,6 +10,7 @@ from sqlfluff.core.parser import (
     Bracketed,
     Ref,
     Anything,
+    Nothing,
     RegexLexer,
     CodeSegment,
     RegexParser,

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -251,3 +251,74 @@ class CreateViewStatementSegment(BaseSegment):
         "AS",
         Ref("SelectableGrammar"),
     )
+
+
+@tsql_dialect.segment(replace=True)
+class IntervalExpressionSegment(BaseSegment):
+    """An interval expression segment.
+
+    Not present in T-SQL. """
+
+    type = "interval_expression"
+    match_grammar = Nothing()
+
+
+@tsql_dialect.segment(replace=True)
+class CreateExtensionStatementSegment(BaseSegment):
+    """A `CREATE EXTENSION` statement.
+
+    Not present in T-SQL. """
+
+    type = "create_extension_statement"
+    match_grammar = Nothing()
+
+
+@tsql_dialect.segment(replace=True)
+class CreateModelStatementSegment(BaseSegment):
+    """A BigQuery `CREATE MODEL` statement.
+
+    Not present in T-SQL. """
+
+    type = "create_model_statement"
+    match_grammar = Nothing()
+
+
+@ansi_dialect.segment(replace=True)
+class DropModelStatementSegment(BaseSegment):
+    """A `DROP MODEL` statement.
+
+    Not present in T-SQL. """
+
+    type = "drop_MODELstatement"
+    match_grammar = Nothing()
+
+
+@tsql_dialect.segment(replace=True)
+class LimitClauseSegment(BaseSegment):
+    """A `LIMIT` clause like in `SELECT`.
+
+    Not present in T-SQL. """
+
+    type = "limit_clause"
+    match_grammar = Nothing()
+
+
+@tsql_dialect.segment(replace=True)
+class OverlapsClauseSegment(BaseSegment):
+    """An `OVERLAPS` clause like in `SELECT.
+
+    Not present in T-SQL. """
+
+    type = "overlaps_clause"
+    match_grammar = Nothing()
+
+
+@tsql_dialect.segment(replace=True)
+class NamedWindowSegment(BaseSegment):
+    """A WINDOW clause.
+
+    Not present in T-SQL. """
+
+    type = "named_window"
+    match_grammar = Nothing()
+


### PR DESCRIPTION
### Brief summary of the change made
Remapping segments to Nothing() that have no TSQL equivalent.  This will keep the linter from pursing paths that include TSQL non-keywords and failing with the runtime error "Grammar refers to '<Keyword>KeywordSegment' which was not found in the tsql dialect".

