### PR TITLE
Added support for psql meta commands

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -93,7 +93,9 @@ postgres_dialect.insert_lexer_matchers(
             # For now we'll just treat meta syntax like comments and so just ignore them.
             # In future we may want to enhance this to actually parse them to ensure they are
             # valid meta commands.
-            "meta_command", r"\\([^(\\\r\n)])+((\\\\)|(?=\n)|(?=\r\n))?", CommentSegment
+            "meta_command",
+            r"\\([^(\\\r\n)])+((\\\\)|(?=\n)|(?=\r\n))?",
+            CommentSegment,
         )
     ],
     before="code",  # Final thing to search for - as psql specific

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1804,9 +1804,4 @@ class FileSegment(BaseSegment):
         Ref("StatementSegment", optional=True),
     )
 
-    def get_table_references(self):
-        """Use parsed tree to extract table references."""
-        references = set()
-        for stmt in self.get_children("statement"):
-            references |= stmt.get_table_references()
-        return references
+    get_table_references = ansi_dialect.get_segment("FileSegment").get_table_references

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -15,7 +15,7 @@ from sqlfluff.core.parser import (
     NamedParser,
     SymbolSegment,
     StartsWith,
-    GreedyUntil
+    GreedyUntil,
 )
 
 from sqlfluff.core.dialects import load_raw_dialect
@@ -90,9 +90,7 @@ postgres_dialect.insert_lexer_matchers(
         #                                        )
         #                                         ? The previous clause is optional
         RegexLexer(
-            "meta_command",
-            r"\\([^(\\\r\n)])+((\\\\)|(?=\n)|(?=\r\n))?",
-            CodeSegment
+            "meta_command", r"\\([^(\\\r\n)])+((\\\\)|(?=\n)|(?=\r\n))?", CodeSegment
         )
     ],
     before="code",  # Final thing to search for - as psql specific
@@ -135,7 +133,7 @@ postgres_dialect.add(
     ),
     PsqlMetaCommandSegment=NamedParser(
         "meta_command", CodeSegment, name="psql_meta_command", type="psql_meta_command"
-    )
+    ),
 )
 
 postgres_dialect.replace(
@@ -1772,11 +1770,13 @@ class StatementSegment(BaseSegment):
         insert=[
             Ref("AlterDefaultPrivilegesStatementSegment"),
             Ref("CommentOnStatementSegment"),
-            Ref("AnalyzeStatementSegment")
+            Ref("AnalyzeStatementSegment"),
         ],
     )
 
-    match_grammar = GreedyUntil(OneOf(Ref("DelimiterSegment"), Ref("PsqlMetaCommandSegment")))
+    match_grammar = GreedyUntil(
+        OneOf(Ref("DelimiterSegment"), Ref("PsqlMetaCommandSegment"))
+    )
 
 
 @postgres_dialect.segment(replace=True)
@@ -1799,12 +1799,9 @@ class FileSegment(BaseSegment):
     parse_grammar = Sequence(
         AnyNumberOf(
             Ref("PsqlMetaCommandSegment"),
-            Sequence(
-                Ref("StatementSegment"),
-                Ref("DelimiterSegment")
-            ),
+            Sequence(Ref("StatementSegment"), Ref("DelimiterSegment")),
         ),
-        Ref("StatementSegment", optional=True)
+        Ref("StatementSegment", optional=True),
     )
 
     def get_table_references(self):

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -90,6 +90,9 @@ postgres_dialect.insert_lexer_matchers(
         #                                        )
         #                                         ? The previous clause is optional
         RegexLexer(
+            # For now we'll just treat meta syntax like comments and so just ignore them.
+            # In future we may want to enhance this to actually parse them to ensure they are
+            # valid meta commands.
             "meta_command", r"\\([^(\\\r\n)])+((\\\\)|(?=\n)|(?=\r\n))?", CommentSegment
         )
     ],

--- a/test/fixtures/parser/postgres/postgres_psql_meta_command.sql
+++ b/test/fixtures/parser/postgres/postgres_psql_meta_command.sql
@@ -1,0 +1,17 @@
+\echo "thing"
+
+\echo "thing"
+
+\x \\
+
+\echo "thing"
+
+SELECT 1; SELECT 2;
+
+SELECT 1 + 3;
+
+SELECT 1;
+
+\echo "thing" \\ SELECT 1;
+
+\echo "thing" \echo "thing2"

--- a/test/fixtures/parser/postgres/postgres_psql_meta_command.yml
+++ b/test/fixtures/parser/postgres/postgres_psql_meta_command.yml
@@ -1,0 +1,52 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 8f1bd3ca1179138a67183b136e2ed3682656071cd1337bc31c61335eddda2f5b
+file:
+- psql_meta_command: \echo "thing"
+- psql_meta_command: \echo "thing"
+- psql_meta_command: \x \\
+- psql_meta_command: \echo "thing"
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          literal: '2'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - literal: '1'
+          - binary_operator: +
+          - literal: '3'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          literal: '1'
+- statement_terminator: ;
+- psql_meta_command: \echo "thing" \\
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          literal: '1'
+- statement_terminator: ;
+- psql_meta_command: '\echo "thing" '
+- psql_meta_command: \echo "thing2"

--- a/test/fixtures/parser/postgres/postgres_psql_meta_command.yml
+++ b/test/fixtures/parser/postgres/postgres_psql_meta_command.yml
@@ -3,12 +3,8 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8f1bd3ca1179138a67183b136e2ed3682656071cd1337bc31c61335eddda2f5b
+_hash: 205d8103278f15d40c051424c403f94a089d75fe0b5cd77742140e2fb6cb28c5
 file:
-- psql_meta_command: \echo "thing"
-- psql_meta_command: \echo "thing"
-- psql_meta_command: \x \\
-- psql_meta_command: \echo "thing"
 - statement:
     select_statement:
       select_clause:
@@ -40,7 +36,6 @@ file:
         select_clause_element:
           literal: '1'
 - statement_terminator: ;
-- psql_meta_command: \echo "thing" \\
 - statement:
     select_statement:
       select_clause:
@@ -48,5 +43,3 @@ file:
         select_clause_element:
           literal: '1'
 - statement_terminator: ;
-- psql_meta_command: '\echo "thing" '
-- psql_meta_command: \echo "thing2"


### PR DESCRIPTION
### Brief summary of the change made
This PR adds support for psql meta commands. Psql commands here start with \, followed by at least one alphabet character, and are then terminated by newline or \\. The File and Statement Segments had to be edited to accommodate for this new functionality.
 
Fixes #1327 

### Are there any other side effects of this change that we should be aware of?
No, Postgres-specific, and all dialect tests are passing

### Pull Request checklist
Test cases added for psql meta commands, and sql commands in the same file (or same line for \\)
Documented regex in file
