### PR TITLE
Add default parameter to dbt "var" macro stub

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -31,7 +31,7 @@ apply_dbt_builtins = True
 dbt_ref = {% macro ref(model_ref) %}{{model_ref}}{% endmacro %}
 dbt_source = {% macro source(source_name, table) %}{{source_name}}_{{table}}{% endmacro %}
 dbt_config = {% macro config() %}{% for k in kwargs %}{% endfor %}{% endmacro %}
-dbt_var = {% macro var(variable) %}item{% endmacro %}
+dbt_var = {% macro var(variable, default='') %}item{% endmacro %}
 dbt_is_incremental = {% macro is_incremental() %}True{% endmacro %}
 
 # Some rules can be configured directly from the config common to other rules.

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -102,6 +102,7 @@ def assert_structure(yaml_loader, path, code_only=True, include_meta=False):
         ("jinja_b/jinja", False, False),
         # dbt builting
         ("jinja_c_dbt/dbt_builtins", True, False),
+        ("jinja_c_dbt/var_default", True, False),
         # do directive
         ("jinja_e/jinja", True, False),
         # case sensitivity and python literals

--- a/test/fixtures/templater/jinja_c_dbt/var_default.sql
+++ b/test/fixtures/templater/jinja_c_dbt/var_default.sql
@@ -1,0 +1,1 @@
+SELECT {{ var('foo', 42) }}

--- a/test/fixtures/templater/jinja_c_dbt/var_default.yml
+++ b/test/fixtures/templater/jinja_c_dbt/var_default.yml
@@ -1,0 +1,8 @@
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: item


### PR DESCRIPTION
### Brief summary of the change made

Add the default parameter for the stub for the dbt `var` macro.

https://docs.getdbt.com/reference/dbt-jinja-functions/var#variable-default-values

### Are there any other side effects of this change that we should be aware of?

Not that I'm aware

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
