### PR TITLE
Further fix for L036

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note: Changes are now automatically tracked in [GitHub](https://github.com/sqlfl
 
 ## [0.6.6] - 2021-09-20
 
-Fix some of our autofix where running `fix` sometimes make unintended changes. Added config to rules L011 and L012 to allow prefering implicit aliasing. Also further improved our Postgres support and documentation.
+Fix some of our autofix where running `fix` sometimes made unintended changes. Added config to rules L011 and L012 to allow prefering implicit aliasing. Also further improved our Postgres support and documentation.
 
 ### What's Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note: Changes are now automatically tracked in [GitHub](https://github.com/sqlfl
 
 ## [0.6.6] - 2021-09-20
 
-Fix some of our autofix where running `fix` sometimes made unintended changes. Added config to rules L011 and L012 to allow prefering implicit aliasing. Also further improved our Postgres support and documentation.
+Fixed some of our autofix rules where running `fix` sometimes made unintended changes. Added config to rules L011 and L012 to allow preferring implicit aliasing. Also further improved our Postgres support and documentation.
 
 ### What's Changed
 

--- a/src/sqlfluff/rules/L036.py
+++ b/src/sqlfluff/rules/L036.py
@@ -237,13 +237,13 @@ class Rule_L036(BaseRule):
                                     ),
                                 ]
 
-                            # Once we see a newline, then we're done,
+                            # Once we see a newline, then we're done
                             if select_clause.segments[start_idx - idx].is_type(
                                 "newline",
                             ):
                                 break
 
-                            # Once we see anything other than whitespace,
+                            # If we see anything other than whitespace,
                             # then we're done, but in this case we want to
                             # keep the final newline.
                             if not select_clause.segments[start_idx - idx].is_type(
@@ -300,7 +300,20 @@ class Rule_L036(BaseRule):
                                         select_clause.segments[start_idx - idx],
                                     ),
                                 ]
-                            else:
+
+                            # Once we see a newline, then we're done
+                            if select_clause.segments[start_idx - idx].is_type(
+                                "newline"
+                            ):
+                                break
+
+                            # If we see anything other than whitespace,
+                            # then we're done, but in this case we want to
+                            # keep the final newline.
+                            if not select_clause.segments[start_idx - idx].is_type(
+                                "whitespace", "newline"
+                            ):
+                                copy_with_newline = True
                                 break
                             idx += 1
 

--- a/test/fixtures/rules/std_rule_cases/L036.yml
+++ b/test/fixtures/rules/std_rule_cases/L036.yml
@@ -159,6 +159,10 @@ test_single_select_with_no_from:
   fail_str: "SELECT\n   10000000\n"
   fix_str: "SELECT 10000000\n"
 
+test_single_select_with_no_from_previous_comment:
+  fail_str: "SELECT\n /* test */  10000000\n"
+  fix_str: "SELECT 10000000\n /* test */\n"
+
 test_single_select_with_comment_after_column:
   fail_str: |
     SELECT


### PR DESCRIPTION
### Brief summary of the change made
Noticed I wasn't getting 100% pytest coverage, which looks to be due to #1427. Weird though as Coverage didn't flag this this.

Anyway, addressing that flagged another (admittedly obscure!) edge case - comments BEFORE columns (I mean - who does that!?!?). So added the test case and the support for that.

Note I also fixed some typos in the CHANGELOG.

### Are there any other side effects of this change that we should be aware of?
Nope. Pretty obscure edge case, and added a test case for it.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
