### PR TITLE
Fix runtime error (IndexError ) when linting file with jinja "if"

### DIFF
--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -285,8 +285,12 @@ class TemplatedFile:
                 ts_start_sf_stop, ts_stop_sf_stop
             )
         ]
-        if ts_start_sf_start == ts_start_sf_stop:  # pragma: no cover TODO?
-            start_slices = [self.sliced_file[ts_start_sf_start]]
+        if ts_start_sf_start == ts_start_sf_stop:
+            if ts_start_sf_start < len(self.sliced_file):
+                start_slices = [self.sliced_file[ts_start_sf_start]]
+            else:
+                assert ts_start_sf_start == len(self.sliced_file)
+                return self.sliced_file[-1].source_slice
         else:
             start_slices = self.sliced_file[ts_start_sf_start:ts_start_sf_stop]
         if ts_stop_sf_start == ts_stop_sf_stop:  # pragma: no cover TODO?

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -286,10 +286,12 @@ class TemplatedFile:
             )
         ]
         if ts_start_sf_start == ts_start_sf_stop:
+            if ts_start_sf_start > len(self.sliced_file):  # pragma: no cover TODO?
+                # We should never get here
+                raise ValueError("Starting position higher than sliced file position")
             if ts_start_sf_start < len(self.sliced_file):
-                start_slices = [self.sliced_file[ts_start_sf_start]]  # pragma: no cover TODO?
+                return self.sliced_file[1].source_slice
             else:
-                assert ts_start_sf_start == len(self.sliced_file)
                 return self.sliced_file[-1].source_slice
         else:
             start_slices = self.sliced_file[ts_start_sf_start:ts_start_sf_stop]

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -286,7 +286,7 @@ class TemplatedFile:
             )
         ]
         if ts_start_sf_start == ts_start_sf_stop:
-            if ts_start_sf_start > len(self.sliced_file):  # pragma: no cover TODO?
+            if ts_start_sf_start > len(self.sliced_file):  # pragma: no cover
                 # We should never get here
                 raise ValueError("Starting position higher than sliced file position")
             if ts_start_sf_start < len(self.sliced_file):

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -287,7 +287,7 @@ class TemplatedFile:
         ]
         if ts_start_sf_start == ts_start_sf_stop:
             if ts_start_sf_start < len(self.sliced_file):
-                start_slices = [self.sliced_file[ts_start_sf_start]]
+                start_slices = [self.sliced_file[ts_start_sf_start]]  # pragma: no cover TODO?
             else:
                 assert ts_start_sf_start == len(self.sliced_file)
                 return self.sliced_file[-1].source_slice

--- a/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if/after.sql
+++ b/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if/after.sql
@@ -1,0 +1,16 @@
+-- This file combines product data from individual brands into a staging table
+{% set products =  [
+  'table1',
+  'table2'] %}
+
+{% for product in products %}
+SELECT
+    brand,
+    country_code,
+    category,
+    name,
+    id
+FROM
+    product
+{% if not loop.last -%} UNION ALL {%- endif %}
+{% endfor %}

--- a/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if/before.sql
+++ b/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if/before.sql
@@ -1,0 +1,16 @@
+-- This file combines product data from individual brands into a staging table
+{% set products =  [
+  'table1',
+  'table2'] %}
+
+{% for product in products %}
+SELECT
+  brand,
+  country_code,
+  category,
+  name,
+  id
+FROM
+  product
+{% if not loop.last -%} UNION ALL {%- endif %}
+{% endfor %}

--- a/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if/before.sql
+++ b/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if/before.sql
@@ -11,6 +11,6 @@ SELECT
   name,
   id
 FROM
-  product
+  {{ product }}
 {% if not loop.last -%} UNION ALL {%- endif %}
 {% endfor %}

--- a/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if/test-config.yml
+++ b/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if/test-config.yml
@@ -1,0 +1,4 @@
+test-config:
+  rules:
+    - L003
+    - L016

--- a/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if2/after.sql
+++ b/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if2/after.sql
@@ -11,6 +11,7 @@ SELECT
     name,
     id
 FROM
-{{ product }}
-{% if not loop.last -%} UNION ALL {%- endif %}
+    {{ product }}
+{% if not loop.last %} UNION ALL {% endif %}
 {% endfor %}
+ORDER BY 1

--- a/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if2/before.sql
+++ b/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if2/before.sql
@@ -5,12 +5,13 @@
 
 {% for product in products %}
 SELECT
-    brand,
-    country_code,
-    category,
-    name,
-    id
+  brand,
+  country_code,
+  category,
+  name,
+  id
 FROM
-{{ product }}
-{% if not loop.last -%} UNION ALL {%- endif %}
+  {{ product }}
+{% if not loop.last %} UNION ALL {% endif %}
 {% endfor %}
+ORDER BY 1

--- a/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if2/test-config.yml
+++ b/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if2/test-config.yml
@@ -1,0 +1,4 @@
+test-config:
+  rules:
+    - L003
+    - L016


### PR DESCRIPTION
### Brief summary of the change made

Fixes #1414

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
