### PR TITLE
Stop exception in L016 for long Jinja comments

### DIFF
--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -448,9 +448,9 @@ class Rule_L016(Rule_L003):
                 else:
                     break
 
-            # Does the line end in an inline comment that we can move back?
-            if this_line[-1].name == "inline_comment":
-                # Is this line JUST COMMENT (with optional preceding whitespace) if
+            # Does the line end in an inline comment or jinja placeholder that we can move back?
+            if this_line[-1].name == "inline_comment" or this_line[-1].type == "placeholder":
+                # Is this line JUST comment/placeholder (with optional preceding whitespace) if
                 # so, user will have to fix themselves.
                 if len(this_line) == 1 or all(
                     elem.name == "whitespace" or elem.is_meta for elem in this_line[:-1]

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -454,6 +454,7 @@ class Rule_L016(Rule_L003):
                 self.logger.info("Unfixable template segment: %s", this_line[-1])
                 return LintResult(anchor=segment)
 
+            # Does the line end in an inline comment that we can move back?
             if this_line[-1].name == "inline_comment":
                 # Is this line JUST COMMENT (with optional preceding whitespace) if
                 # so, user will have to fix themselves.

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -448,7 +448,8 @@ class Rule_L016(Rule_L003):
                 else:
                     break
 
-            # Don't even attempt to handle template placeholders as don't have content
+            # Don't even attempt to handle template placeholders as we don't have the content
+            # to move it (appears as empty space to us). It will remain as unfixable.
             if this_line[-1].type == "placeholder":
                 self.logger.info("Unfixable template segment: %s", this_line[-1])
                 return LintResult(anchor=segment)

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -449,16 +449,12 @@ class Rule_L016(Rule_L003):
                     break
 
             # Don't even attempt to handle template placeholders as don't have content
-            if (this_line[-1].type == "placeholder"):
-                self.logger.info(
-                    "Unfixable template segment: %s", this_line[-1]
-                )
+            if this_line[-1].type == "placeholder":
+                self.logger.info("Unfixable template segment: %s", this_line[-1])
                 return LintResult(anchor=segment)
 
             # Does the line end in an inline comment or jinja placeholder that we can move back?
-            if (
-                this_line[-1].name == "inline_comment"
-            ):
+            if this_line[-1].name == "inline_comment":
                 # Is this line JUST comment/placeholder (with optional preceding whitespace) if
                 # so, user will have to fix themselves.
                 if len(this_line) == 1 or all(

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -448,10 +448,16 @@ class Rule_L016(Rule_L003):
                 else:
                     break
 
+            # Don't even attempt to handle template placeholders as don't have content
+            if (this_line[-1].type == "placeholder"):
+                self.logger.info(
+                    "Unfixable template segment: %s", this_line[-1]
+                )
+                return LintResult(anchor=segment)
+
             # Does the line end in an inline comment or jinja placeholder that we can move back?
             if (
                 this_line[-1].name == "inline_comment"
-                or this_line[-1].type == "placeholder"
             ):
                 # Is this line JUST comment/placeholder (with optional preceding whitespace) if
                 # so, user will have to fix themselves.

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -454,9 +454,8 @@ class Rule_L016(Rule_L003):
                 self.logger.info("Unfixable template segment: %s", this_line[-1])
                 return LintResult(anchor=segment)
 
-            # Does the line end in an inline comment or jinja placeholder that we can move back?
             if this_line[-1].name == "inline_comment":
-                # Is this line JUST comment/placeholder (with optional preceding whitespace) if
+                # Is this line JUST COMMENT (with optional preceding whitespace) if
                 # so, user will have to fix themselves.
                 if len(this_line) == 1 or all(
                     elem.name == "whitespace" or elem.is_meta for elem in this_line[:-1]

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -449,7 +449,10 @@ class Rule_L016(Rule_L003):
                     break
 
             # Does the line end in an inline comment or jinja placeholder that we can move back?
-            if this_line[-1].name == "inline_comment" or this_line[-1].type == "placeholder":
+            if (
+                this_line[-1].name == "inline_comment"
+                or this_line[-1].type == "placeholder"
+            ):
                 # Is this line JUST comment/placeholder (with optional preceding whitespace) if
                 # so, user will have to fix themselves.
                 if len(this_line) == 1 or all(

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -448,8 +448,10 @@ class Rule_L016(Rule_L003):
                 else:
                     break
 
-            # Don't even attempt to handle template placeholders as we don't have the content
-            # to move it (appears as empty space to us). It will remain as unfixable.
+            # Don't even attempt to handle template placeholders as gets
+            # complicated if logic changes (e.g. moving for loops). Most of
+            # these long lines will likely be single line Jinja comments.
+            # They will remain as unfixable.
             if this_line[-1].type == "placeholder":
                 self.logger.info("Unfixable template segment: %s", this_line[-1])
                 return LintResult(anchor=segment)

--- a/test/fixtures/rules/std_rule_cases/L016.yml
+++ b/test/fixtures/rules/std_rule_cases/L016.yml
@@ -129,3 +129,11 @@ test_compute_line_length_before_template_expansion_2:
         context:
           bi_ecommerce_orders_bi_ecommerce_orders: bq-business-intelligence.user.ecommerce_orders
           table_alias_table_alias_table_alias_table_alias_table_alias_table_alias: t
+
+
+test_long_jina_comment:
+  fail_str: |
+    SELECT *
+    {# comment #}
+    {# ........................................................................... #}
+    FROM table

--- a/test/fixtures/rules/std_rule_cases/L016.yml
+++ b/test/fixtures/rules/std_rule_cases/L016.yml
@@ -137,3 +137,22 @@ test_long_jina_comment:
     {# comment #}
     {# ........................................................................... #}
     FROM table
+  configs:
+    rules:
+      max_line_length: 80
+      L016:
+        ignore_comment_lines: False
+
+
+test_long_jina_comment_ignore:
+  # A Jinja comment is not seen as a SQL comment (perhaps it should be?) so should still fail
+  fail_str: |
+    SELECT *
+    {# comment #}
+    {# ........................................................................... #}
+    FROM table
+  configs:
+    rules:
+      max_line_length: 80
+      L016:
+        ignore_comment_lines: True


### PR DESCRIPTION
### Brief summary of the change made
Fixes #1439 

We don't see to have access to `place_holder` content in rules so can't fix this. So for now it just fails the rule if too long without an auto fix.

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
