### PR TITLE
fix spelling of "preceding"

### DIFF
--- a/src/sqlfluff/core/parser/grammar/greedy.py
+++ b/src/sqlfluff/core/parser/grammar/greedy.py
@@ -18,7 +18,7 @@ class GreedyUntil(BaseGrammar):
     """Matching for GreedyUntil works just how you'd expect.
 
     Args:
-        enforce_whitespace_preceeding (:obj:`bool`): Should the GreedyUntil
+        enforce_whitespace_preceding (:obj:`bool`): Should the GreedyUntil
             match only match the content if it's preceded by whitespace?
             (defaults to False). This is useful for some keywords which may
             have false alarms on some array accessors.
@@ -26,8 +26,8 @@ class GreedyUntil(BaseGrammar):
     """
 
     def __init__(self, *args, **kwargs):
-        self.enforce_whitespace_preceeding_terminator = kwargs.pop(
-            "enforce_whitespace_preceeding_terminator", False
+        self.enforce_whitespace_preceding_terminator = kwargs.pop(
+            "enforce_whitespace_preceding_terminator", False
         )
         super().__init__(*args, **kwargs)
         if not self.allow_gaps:  # pragma: no cover
@@ -43,7 +43,7 @@ class GreedyUntil(BaseGrammar):
             segments,
             parse_context,
             matchers=self._elements,
-            enforce_whitespace_preceeding_terminator=self.enforce_whitespace_preceeding_terminator,
+            enforce_whitespace_preceding_terminator=self.enforce_whitespace_preceding_terminator,
             include_terminator=False,
         )
 
@@ -53,7 +53,7 @@ class GreedyUntil(BaseGrammar):
         segments,
         parse_context,
         matchers,
-        enforce_whitespace_preceeding_terminator,
+        enforce_whitespace_preceding_terminator,
         include_terminator=False,
     ):
         """Matching for GreedyUntil works just how you'd expect."""
@@ -72,7 +72,7 @@ class GreedyUntil(BaseGrammar):
             # Do we have a match?
             if mat:
                 # Do we need to enforce whitespace preceding?
-                if enforce_whitespace_preceeding_terminator:
+                if enforce_whitespace_preceding_terminator:
                     # Does the match include some whitespace already?
                     # Work forward
                     idx = 0
@@ -204,7 +204,7 @@ class StartsWith(GreedyUntil):
             match.unmatched_segments,
             parse_context,
             matchers=[self.terminator],
-            enforce_whitespace_preceeding_terminator=self.enforce_whitespace_preceeding_terminator,
+            enforce_whitespace_preceding_terminator=self.enforce_whitespace_preceding_terminator,
             include_terminator=self.include_terminator,
         )
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -945,7 +945,7 @@ class PartitionClauseSegment(BaseSegment):
     match_grammar = StartsWith(
         "PARTITION",
         terminator=OneOf("ORDER", Ref("FrameClauseUnitGrammar")),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
     parse_grammar = Sequence(
         "PARTITION",
@@ -1132,7 +1132,7 @@ class SelectClauseElementSegment(BaseSegment):
         "LIMIT",
         Ref("CommaSegment"),
         Ref("SetOperatorSegment"),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
 
     parse_grammar = OneOf(
@@ -1171,7 +1171,7 @@ class SelectClauseSegment(BaseSegment):
             "OVERLAPS",
             Ref("SetOperatorSegment"),
         ),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
 
     parse_grammar = Sequence(
@@ -1290,7 +1290,7 @@ class FromClauseSegment(BaseSegment):
     match_grammar = StartsWith(
         "FROM",
         terminator=Ref("FromClauseTerminatorGrammar"),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
     parse_grammar = Sequence(
         "FROM",
@@ -1578,7 +1578,7 @@ class WhereClauseSegment(BaseSegment):
     match_grammar = StartsWith(
         "WHERE",
         terminator=Ref("WhereClauseTerminatorGrammar"),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
     parse_grammar = Sequence(
         "WHERE",
@@ -1638,7 +1638,7 @@ class GroupByClauseSegment(BaseSegment):
     match_grammar = StartsWith(
         Sequence("GROUP", "BY"),
         terminator=OneOf("ORDER", "LIMIT", "HAVING", "QUALIFY", "WINDOW"),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
     parse_grammar = Sequence(
         "GROUP",
@@ -1666,7 +1666,7 @@ class HavingClauseSegment(BaseSegment):
     match_grammar = StartsWith(
         "HAVING",
         terminator=OneOf("ORDER", "LIMIT", "QUALIFY", "WINDOW"),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
     parse_grammar = Sequence(
         "HAVING",
@@ -1794,7 +1794,7 @@ class UnorderedSelectStatementSegment(BaseSegment):
             Ref("LimitClauseSegment"),
             Ref("NamedWindowSegment"),
         ),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
 
     parse_grammar = Sequence(
@@ -1826,7 +1826,7 @@ class SelectStatementSegment(BaseSegment):
         terminator=OneOf(
             Ref("SetOperatorSegment"), Ref("WithNoSchemaBindingClauseSegment")
         ),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
 
     # Inherit most of the parse grammar from the original.

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -195,7 +195,7 @@ class QualifyClauseSegment(BaseSegment):
     match_grammar = StartsWith(
         "QUALIFY",
         terminator=OneOf("WINDOW", "ORDER", "LIMIT"),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
 
     parse_grammar = Sequence(
@@ -759,7 +759,7 @@ class PartitionBySegment(BaseSegment):
     match_grammar = StartsWith(
         "PARTITION",
         terminator=OneOf("CLUSTER", "OPTIONS", "AS", Ref("DelimiterSegment")),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
     parse_grammar = Sequence(
         "PARTITION",
@@ -776,7 +776,7 @@ class ClusterBySegment(BaseSegment):
     match_grammar = StartsWith(
         "CLUSTER",
         terminator=OneOf("OPTIONS", "AS", Ref("DelimiterSegment")),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
     parse_grammar = Sequence(
         "CLUSTER",

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -109,7 +109,7 @@ exasol_dialect.add(
             Ref("TablePartitionByGrammar"),
             Ref("DelimiterSegment"),
         ),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     ),
     TablePartitionByGrammar=StartsWith(
         Sequence(
@@ -127,7 +127,7 @@ exasol_dialect.add(
             Ref("TableDistributeByGrammar"),
             Ref("DelimiterSegment"),
         ),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     ),
     TableConstraintEnableDisableGrammar=OneOf("ENABLE", "DISABLE"),
     EscapedIdentifierSegment=RegexParser(
@@ -215,7 +215,7 @@ class SelectStatementSegment(BaseSegment):
     match_grammar = StartsWith(
         Ref("SelectClauseSegment"),
         terminator=Ref("SetOperatorSegment"),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
 
     parse_grammar = Sequence(
@@ -280,7 +280,7 @@ class ConnectByClauseSegment(BaseSegment):
             "LIMIT",
             Ref("SetOperatorSegment"),
         ),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
     parse_grammar = OneOf(
         Sequence(
@@ -320,7 +320,7 @@ class GroupByClauseSegment(BaseSegment):
             "QUALIFY",
             Ref("SetOperatorSegment"),
         ),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
     parse_grammar = Sequence(
         "GROUP",

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -251,7 +251,7 @@ class GroupByClauseSegment(BaseSegment):
     match_grammar = StartsWith(
         Sequence("GROUP", "BY"),
         terminator=OneOf("ORDER", "LIMIT", "HAVING", "QUALIFY", "WINDOW"),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
     parse_grammar = Sequence(
         "GROUP",
@@ -1638,7 +1638,7 @@ class DeleteUsingClauseSegment(BaseSegment):
     match_grammar = StartsWith(
         "USING",
         terminator=Ref.keyword("WHERE"),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
     parse_grammar = Sequence(
         "USING",
@@ -1656,5 +1656,5 @@ class FromClauseTerminatingUsingWhereSegment(ansi_dialect.get_segment("FromClaus
     match_grammar = StartsWith(
         "FROM",
         terminator=OneOf(Ref.keyword("USING"), Ref.keyword("WHERE")),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -718,7 +718,7 @@ class QualifyClauseSegment(BaseSegment):
     match_grammar = StartsWith(
         "QUALIFY",
         terminator=OneOf("ORDER", "LIMIT", "QUALIFY", "WINDOW"),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
     parse_grammar = Sequence(
         "QUALIFY",

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -327,7 +327,7 @@ class UnorderedSelectStatementSegment(BaseSegment):
             Ref("WithNoSchemaBindingClauseSegment"),
             Ref("OrderByClauseSegment"),
         ),
-        enforce_whitespace_preceeding_terminator=True,
+        enforce_whitespace_preceding_terminator=True,
     )
 
     parse_grammar = ansi_dialect.get_segment(

--- a/src/sqlfluff/rules/L036.py
+++ b/src/sqlfluff/rules/L036.py
@@ -200,11 +200,11 @@ class Rule_L036(BaseRule):
                     ),
                 ]
 
-                # Set the position marker for removing the preceeding
+                # Set the position marker for removing the preceding
                 # whitespace and newline, which we'll use below.
                 start_idx = modifier_idx
             else:
-                # Set the position marker for removing the preceeding
+                # Set the position marker for removing the preceding
                 # whitespace and newline, which we'll use below.
                 start_idx = select_targets_info.first_select_target_idx
 

--- a/src/sqlfluff/rules/L039.py
+++ b/src/sqlfluff/rules/L039.py
@@ -19,7 +19,7 @@ class Rule_L039(BaseRule):
         FROM foo
 
     | **Best practice**
-    | Unless an indent or preceeding a comment, whitespace should
+    | Unless an indent or preceding a comment, whitespace should
     | be a single space.
 
     .. code-block:: sql

--- a/test/cli/formatters_test.py
+++ b/test/cli/formatters_test.py
@@ -41,6 +41,6 @@ def test__cli__formatters__violation():
     # Position is 3, 3 becase foobarbar is on the third
     # line (i.e. it has two newlines preceding it) and
     # it's at the third position in that line (i.e. there
-    # are two characters between it and the preceeding
+    # are two characters between it and the preceding
     # newline).
     assert escape_ansi(f) == "L:   3 | P:   3 |    A | DESC"

--- a/test/core/parser/grammar_test.py
+++ b/test/core/parser/grammar_test.py
@@ -632,7 +632,7 @@ def test__parser__grammar_greedyuntil(
     """Test the GreedyUntil grammar."""
     grammar = GreedyUntil(
         StringParser(keyword, KeywordSegment),
-        enforce_whitespace_preceeding_terminator=enforce_ws,
+        enforce_whitespace_preceding_terminator=enforce_ws,
     )
     with RootParseContext(dialect=fresh_ansi_dialect) as ctx:
         assert (

--- a/test/fixtures/linter/autofix/bigquery/004_templating/after.sql
+++ b/test/fixtures/linter/autofix/bigquery/004_templating/after.sql
@@ -25,7 +25,7 @@ raw_effect_sizes AS (
         COUNT(1) AS campaign_count_{{action}},
         {{corr_states}}
         -- NOTE: The L003 fix routine behaves a little strangely here around the templated
-        -- code, specifically the indentation of STDDEV_POP and preceeding comments. This
+        -- code, specifically the indentation of STDDEV_POP and preceding comments. This
         -- is a bug currently with no obvious solution.
         , SAFE_DIVIDE(SAFE_MULTIPLY(CORR({{metric}}_rate_su, {{action}}), STDDEV_POP({{metric}}_rate_su)),
                         STDDEV_POP({{action}})) AS {{metric}}_{{action}}

--- a/test/fixtures/linter/autofix/bigquery/004_templating/before.sql
+++ b/test/fixtures/linter/autofix/bigquery/004_templating/before.sql
@@ -25,7 +25,7 @@ WITH
     COUNT(1) AS campaign_count_{{action}},
     {{corr_states}}
     -- NOTE: The L003 fix routine behaves a little strangely here around the templated
-    -- code, specifically the indentation of STDDEV_POP and preceeding comments. This
+    -- code, specifically the indentation of STDDEV_POP and preceding comments. This
     -- is a bug currently with no obvious solution.
     ,SAFE_DIVIDE(SAFE_MULTIPLY(CORR({{metric}}_rate_su, {{action}}), STDDEV_POP({{metric}}_rate_su)),
       STDDEV_POP({{action}})) AS {{metric}}_{{action}}


### PR DESCRIPTION
### Brief summary of the change made
Trivial fix to spelling of "preceeding" to "preceding".
