### PR TITLE
Fix Windows Clause for Exasol

### DIFF
--- a/src/sqlfluff/dialects/exasol_keywords.py
+++ b/src/sqlfluff/dialects/exasol_keywords.py
@@ -307,6 +307,7 @@ RESERVED_KEYWORDS = [
     "PARAMETER_SPECIFIC_NAME",
     "PARAMETER_SPECIFIC_SCHEMA",
     "PARTIAL",
+    "PARTITION",  # Should really be an unreserved keyword but need to make Window clauses work
     "PATH",
     "PERMISSION",
     "PLACING",
@@ -679,7 +680,6 @@ UNRESERVED_KEYWORDS = [
     "OVERFLOW",
     "OWNER",
     "PADDING",
-    "PARTITION",
     "PASCAL",
     "PASSWORD",
     "PASSWORD_EXPIRY_POLICY",

--- a/test/fixtures/parser/exasol/AlterTableDistributePartition.yml
+++ b/test/fixtures/parser/exasol/AlterTableDistributePartition.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2a6296c29ad6e9316135428fa8abbe21c4d0039827e8de8089f00091f1ec22e2
+_hash: be9fb04dae55e497359a66308352420f1be32e598756edffeb4c8d17ec224bc5
 file:
 - statement:
     alter_table_statment:
@@ -42,10 +42,10 @@ file:
         - column_reference:
             identifier: shop_id
         - comma: ','
+        - keyword: PARTITION
+        - keyword: BY
         - column_reference:
-            identifier: PARTITION
-        - raw: BY
-        - raw: order_date
+            identifier: order_date
 - statement_terminator: ;
 - statement:
     alter_table_statment:

--- a/test/fixtures/parser/exasol/CreateTableStatement.yml
+++ b/test/fixtures/parser/exasol/CreateTableStatement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 305c28ddb5ed4dc24fbdb15a2f530f63d8f982e59689d684771f25bcf1797a28
+_hash: 06f4d585f863aeae32bcb5a4c5751c146f85ee52194ffb2b65553b57187cfd85
 file:
 - statement:
     create_table_statement:
@@ -291,10 +291,10 @@ file:
         - column_reference:
             identifier: order_id
         - comma: ','
+        - keyword: PARTITION
+        - keyword: BY
         - column_reference:
-            identifier: PARTITION
-        - raw: BY
-        - raw: order_date
+            identifier: order_date
       - end_bracket: )
     - keyword: COMMENT
     - keyword: IS

--- a/test/fixtures/parser/exasol/SelectStatement.sql
+++ b/test/fixtures/parser/exasol/SelectStatement.sql
@@ -28,3 +28,26 @@ WITH mylist AS (
     AS mylist (a,b,c)
 )
 SELECT * from mylist;
+----
+SELECT
+rowid,
+ROW_NUMBER () OVER (
+    PARTITION BY (
+        col1,
+        col2
+    )
+    ORDER BY
+        col1 DESC,
+        col2 DESC
+);
+----
+SELECT
+rowid,
+ROW_NUMBER () OVER (
+    PARTITION BY (
+        col1,
+        col2
+    ))
+ORDER BY
+    col1 DESC,
+    col2 DESC;

--- a/test/fixtures/parser/exasol/SelectStatement.yml
+++ b/test/fixtures/parser/exasol/SelectStatement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 18e3e2c6265d18a4a24b1a03e943b118258f82fa32168def7c2bcb2e3df3003f
+_hash: 26a649a78a700af5b96505cb7e682052a188dbf7f6dd8ff67f6435067cf82c5d
 file:
 - statement:
     select_statement:
@@ -492,4 +492,92 @@ file:
               table_expression:
                 table_reference:
                   identifier: mylist
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          bare_function: rowid
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: ROW_NUMBER
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - bracketed:
+                    - start_bracket: (
+                    - expression:
+                        column_reference:
+                          identifier: col1
+                    - comma: ','
+                    - expression:
+                        column_reference:
+                          identifier: col2
+                    - end_bracket: )
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: col1
+                  - keyword: DESC
+                  - comma: ','
+                  - column_reference:
+                      identifier: col2
+                  - keyword: DESC
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          bare_function: rowid
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: ROW_NUMBER
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - bracketed:
+                    - start_bracket: (
+                    - expression:
+                        column_reference:
+                          identifier: col1
+                    - comma: ','
+                    - expression:
+                        column_reference:
+                          identifier: col2
+                    - end_bracket: )
+                end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          identifier: col1
+      - keyword: DESC
+      - comma: ','
+      - column_reference:
+          identifier: col2
+      - keyword: DESC
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Fixes #1460

### Are there any other side effects of this change that we should be aware of?
This moves `PARTITION` from being a unreserved keyword to a reserved one. Technically this is not correct as it should be unreserved, but without this the `PARTITION BY` is being seen as an identifier and changing that would be a good bit more complicated so think this is the easiest short term solution with little enough downsides. The whole reserved/unreserved thing is not strictly defined in SQLFluff in other dialects and probably could do with a bit of a review to be honest.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
