### PR TITLE
Correct typo in SQLFluff name

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ L:   1 | P:  27 | L001 | Unnecessary trailing whitespace
 
 You can also have a play using [**SQLFluff online**](https://online.sqlfluff.com/).
 
-For full [CLI usage](https://docs.sqlfluff.com/en/stable/cli.html) and [rules reference](https://docs.sqlfluff.com/en/stable/rules.html), see [the SQLFLuff docs](https://docs.sqlfluff.com/en/stable/).
+For full [CLI usage](https://docs.sqlfluff.com/en/stable/cli.html) and [rules reference](https://docs.sqlfluff.com/en/stable/rules.html), see [the SQLFluff docs](https://docs.sqlfluff.com/en/stable/).
 
 # Documentation
 
@@ -79,7 +79,7 @@ We have a fast-growing community [on Slack](https://join.slack.com/t/sqlfluff/sh
 
 # SQLFluff on Twitter
 
-Follow us [on Twitter @SQLFLuff](https://twitter.com/SQLFluff) for announcements and other related posts.
+Follow us [on Twitter @SQLFluff](https://twitter.com/SQLFluff) for announcements and other related posts.
 
 # Contributing
 

--- a/docs/source/jointhecommunity.rst
+++ b/docs/source/jointhecommunity.rst
@@ -9,4 +9,4 @@ We have a fast-growing `community on Slack <https://join.slack.com/t/sqlfluff/sh
 SQLFluff on Twitter
 ====================
 
-Follow us On Twitter `@SQLFLuff <https://twitter.com/SQLFluff>`_ for annoncements and other related posts.
+Follow us On Twitter `@SQLFluff <https://twitter.com/SQLFluff>`_ for annoncements and other related posts.

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         "Changes": "https://github.com/sqlfluff/sqlfluff/blob/main/CHANGELOG.md",
         "Source": "https://github.com/sqlfluff/sqlfluff",
         "Issue Tracker": "https://github.com/sqlfluff/sqlfluff/issues",
-        "Twitter": "https://twitter.com/SQLFLuff",
+        "Twitter": "https://twitter.com/SQLFluff",
         "Chat": "https://github.com/sqlfluff/sqlfluff#sqlfluff-on-slack",
     },
     packages=find_packages(where="src"),


### PR DESCRIPTION
### Brief summary of the change made
Correct `SQLFLuff` (with a capital `L`) to `SQLFluff` in a few places.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
