### PR TITLE
Adding a new BaseFileSegment class for FileSegments to inherit from

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -181,7 +181,7 @@ class Linter:
         tokens: Sequence[BaseSegment],
         config: FluffConfig,
         recurse: bool = True,
-        fname: str = None,
+        fname: Optional[str] = None,
     ) -> Tuple[Optional[BaseSegment], List[SQLParseError]]:
         parser = Parser(config=config)
         violations = []

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -178,13 +178,18 @@ class Linter:
 
     @staticmethod
     def _parse_tokens(
-        tokens: Sequence[BaseSegment], config: FluffConfig, recurse: bool = True
+        tokens: Sequence[BaseSegment],
+        config: FluffConfig,
+        recurse: bool = True,
+        fname: str = None,
     ) -> Tuple[Optional[BaseSegment], List[SQLParseError]]:
         parser = Parser(config=config)
         violations = []
         # Parse the file and log any problems
         try:
-            parsed: Optional[BaseSegment] = parser.parse(tokens, recurse=recurse)
+            parsed: Optional[BaseSegment] = parser.parse(
+                tokens, recurse=recurse, fname=fname
+            )
         except SQLParseError as err:
             linter_logger.info("PARSING FAILED! : %s", err)
             violations.append(err)
@@ -302,7 +307,9 @@ class Linter:
         linter_logger.info("PARSING (%s)", rendered.fname)
 
         if tokens:
-            parsed, pvs = cls._parse_tokens(tokens, rendered.config, recurse=recurse)
+            parsed, pvs = cls._parse_tokens(
+                tokens, rendered.config, recurse=recurse, fname=rendered.fname
+            )
             violations += pvs
         else:
             parsed = None

--- a/src/sqlfluff/core/parser/__init__.py
+++ b/src/sqlfluff/core/parser/__init__.py
@@ -4,6 +4,7 @@
 
 from sqlfluff.core.parser.segments import (
     BaseSegment,
+    BaseFileSegment,
     RawSegment,
     CodeSegment,
     UnlexableSegment,

--- a/src/sqlfluff/core/parser/parser.py
+++ b/src/sqlfluff/core/parser/parser.py
@@ -20,13 +20,13 @@ class Parser:
         self.RootSegment = self.config.get("dialect_obj").get_root_segment()
 
     def parse(
-        self, segments: Sequence["BaseSegment"], recurse=True
+        self, segments: Sequence["BaseSegment"], recurse=True, fname: str = None
     ) -> Optional["BaseSegment"]:
         """Parse a series of lexed tokens using the current dialect."""
         if not segments:
             return None
         # Instantiate the root segment
-        root_segment = self.RootSegment(segments=segments)
+        root_segment = self.RootSegment(segments=segments, fname=fname)
         # Call .parse() on that segment
         with RootParseContext.from_config(config=self.config, recurse=recurse) as ctx:
             parsed = root_segment.parse(parse_context=ctx)

--- a/src/sqlfluff/core/parser/segments/__init__.py
+++ b/src/sqlfluff/core/parser/segments/__init__.py
@@ -4,6 +4,7 @@
 
 from sqlfluff.core.parser.segments.base import (
     BaseSegment,
+    BaseFileSegment,
     UnparsableSegment,
     BracketedSegment,
 )

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -84,14 +84,11 @@ class BaseSegment:
         segments,
         pos_marker=None,
         name: Optional[str] = None,
-        fname: str = None,
     ):
         # A cache variable for expandable
         self._is_expandable = None
         # Surrogate name option.
         self._surrogate_name = name
-        # Add the file path to FileSegment
-        self._file_path = fname
 
         if len(segments) == 0:  # pragma: no cover
             raise RuntimeError(
@@ -1136,3 +1133,33 @@ class UnparsableSegment(BaseSegment):
         As this is an unparsable, it should yield itself.
         """
         yield self
+
+
+class BaseFileSegment(BaseSegment):
+    """A segment representing a whole file or script.
+
+    This is also the default "root" segment of the dialect,
+    and so is usually instantiated directly. It therefore
+    has no match_grammar.
+    """
+
+    type = "file"
+    # The file segment is the only one which can start or end with non-code
+    can_start_end_non_code = True
+    # A file can be empty!
+    allow_empty = True
+
+    def __init__(
+        self,
+        segments,
+        pos_marker=None,
+        name: Optional[str] = None,
+        fname: Optional[str] = None,
+    ):
+        self._file_path = fname
+        super().__init__(segments, pos_marker=pos_marker, name=name)
+
+    @property
+    def file_path(self):
+        """File path of a parsed SQL file."""
+        return self._file_path

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -79,11 +79,20 @@ class BaseSegment:
     # What other kwargs need to be copied when applying fixes.
     additional_kwargs: List[str] = []
 
-    def __init__(self, segments, pos_marker=None, name: Optional[str] = None):
+    def __init__(
+        self,
+        segments,
+        pos_marker=None,
+        name: Optional[str] = None,
+        fname: str = None,
+    ):
         # A cache variable for expandable
         self._is_expandable = None
         # Surrogate name option.
         self._surrogate_name = name
+        # Add the file path to FileSegment
+        self._file_path = fname
+
         if len(segments) == 0:  # pragma: no cover
             raise RuntimeError(
                 "Setting {} with a zero length segment set. This shouldn't happen.".format(
@@ -152,6 +161,14 @@ class BaseSegment:
         return [seg for seg in self.segments if not seg.is_type("comment")]
 
     # ################ PUBLIC PROPERTIES
+
+    @property
+    def file_path(self):
+        """File path of a parsed SQL file.
+
+        This returns None if the RootSegment is not a file
+        or if the segment is not the RootSegment (e.g. StatementSegment)."""
+        return self._file_path
 
     @property
     def name(self):

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -163,14 +163,6 @@ class BaseSegment:
     # ################ PUBLIC PROPERTIES
 
     @property
-    def file_path(self):
-        """File path of a parsed SQL file.
-
-        This returns None if the RootSegment is not a file
-        or if the segment is not the RootSegment (e.g. StatementSegment)."""
-        return self._file_path
-
-    @property
     def name(self):
         """The name of this segment.
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -484,6 +484,11 @@ class FileSegment(BaseSegment):
             references |= stmt.get_table_references()
         return references
 
+    @property
+    def file_path(self):
+        """File path of a parsed SQL file."""
+        return self._file_path
+
 
 @ansi_dialect.segment()
 class IntervalExpressionSegment(BaseSegment):

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -18,6 +18,7 @@ from typing import Generator, List, Tuple, NamedTuple, Optional, Union
 from sqlfluff.core.parser import (
     Matchable,
     BaseSegment,
+    BaseFileSegment,
     KeywordSegment,
     SymbolSegment,
     Sequence,
@@ -454,19 +455,13 @@ ansi_dialect.add(
 
 
 @ansi_dialect.segment()
-class FileSegment(BaseSegment):
+class FileSegment(BaseFileSegment):
     """A segment representing a whole file or script.
 
     This is also the default "root" segment of the dialect,
     and so is usually instantiated directly. It therefore
     has no match_grammar.
     """
-
-    type = "file"
-    # The file segment is the only one which can start or end with non-code
-    can_start_end_non_code = True
-    # A file can be empty!
-    allow_empty = True
 
     # NB: We don't need a match_grammar here because we're
     # going straight into instantiating it directly usually.
@@ -483,11 +478,6 @@ class FileSegment(BaseSegment):
         for stmt in self.get_children("statement"):
             references |= stmt.get_table_references()
         return references
-
-    @property
-    def file_path(self):
-        """File path of a parsed SQL file."""
-        return self._file_path
 
 
 @ansi_dialect.segment()

--- a/src/sqlfluff/dialects/dialect_exasol_fs.py
+++ b/src/sqlfluff/dialects/dialect_exasol_fs.py
@@ -122,6 +122,11 @@ class FileSegment(BaseSegment):
         allow_trailing=True,
     )
 
+    @property
+    def file_path(self):
+        """File path of a parsed SQL file."""
+        return self._file_path
+
 
 ############################
 # FUNCTION

--- a/src/sqlfluff/dialects/dialect_exasol_fs.py
+++ b/src/sqlfluff/dialects/dialect_exasol_fs.py
@@ -18,6 +18,7 @@ from sqlfluff.core.parser import (
     BaseSegment,
     Bracketed,
     Delimited,
+    BaseFileSegment,
     GreedyUntil,
     OneOf,
     Ref,
@@ -104,7 +105,7 @@ class StatementSegment(BaseSegment):
 
 
 @exasol_fs_dialect.segment(replace=True)
-class FileSegment(BaseSegment):
+class FileSegment(BaseFileSegment):
     """This ovewrites the FileSegment from ANSI.
 
     The reason is because SCRIPT and FUNCTION statements
@@ -112,20 +113,12 @@ class FileSegment(BaseSegment):
     A semicolon is the terminator of the statement within the function / script
     """
 
-    type = "file"
-    can_start_end_non_code = True
-    allow_empty = True
     parse_grammar = Delimited(
         Ref("StatementSegment"),
         delimiter=Ref("FunctionScriptTerminatorSegment"),
         allow_gaps=True,
         allow_trailing=True,
     )
-
-    @property
-    def file_path(self):
-        """File path of a parsed SQL file."""
-        return self._file_path
 
 
 ############################

--- a/test/core/parser/segments_base_test.py
+++ b/test/core/parser/segments_base_test.py
@@ -6,6 +6,7 @@ from sqlfluff.core.parser import (
     PositionMarker,
     RawSegment,
     BaseSegment,
+    BaseFileSegment,
 )
 from sqlfluff.core.templaters import TemplatedFile
 from sqlfluff.core.parser.context import RootParseContext
@@ -115,3 +116,12 @@ def test__parser__base_segments_base_compare():
     assert ds1 == ds2
     # Check a different match on the same details are not the same
     assert ds1 != dsa2
+
+
+def test__parser__base_segments_file(raw_seg_list):
+    """Test BaseFileSegment to behave as expected."""
+    base_seg = BaseFileSegment(raw_seg_list, fname="/some/dir/file.sql")
+    assert base_seg.type == "file"
+    assert base_seg.file_path == "/some/dir/file.sql"
+    assert base_seg.can_start_end_non_code
+    assert base_seg.allow_empty


### PR DESCRIPTION
### Brief summary of the change made
This adds a new property `file_path` to the BaseSegment which is filled in the RootSegment e.g. FileSegment. This solves the request in  #1472.

This PR is made to discuss the implementation, maybe someone with more knowledge about the architecture has a suggestion to improve this. Tests will be added.
...

### Are there any other side effects of this change that we should be aware of?
...

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
