### PR TITLE
TSQL dialect - provide alternate ASA PR incorporating ASA into TSQL

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -107,7 +107,9 @@ class StatementSegment(ansi_dialect.get_segment("StatementSegment")):  # type: i
             Ref("DeclareStatementSegment"),
             Ref("SetStatementSegment"),
             Ref("AlterTableSwitchStatementSegment"),
-            Ref("CreateTableAsSelectStatementSegment"),  # Azure Synapse Analytics specific
+            Ref(
+                "CreateTableAsSelectStatementSegment"
+            ),  # Azure Synapse Analytics specific
         ],
     )
 
@@ -234,7 +236,7 @@ class PivotUnpivotStatementSegment(BaseSegment):
                         Ref("ColumnReferenceSegment"),
                         "IN",
                         Bracketed(Delimited(Ref("ColumnReferenceSegment"))),
-                    ),
+                    )
                 ),
             ),
             Sequence(
@@ -696,7 +698,9 @@ class CreateTableStatementSegment(BaseSegment):
             # Create like syntax
             Sequence("LIKE", Ref("TableReferenceSegment")),
         ),
-        Ref("TableDistributionIndexClause", optional=True),  # Azure Synapse Analytics specific
+        Ref(
+            "TableDistributionIndexClause", optional=True
+        ),  # Azure Synapse Analytics specific
     )
 
     parse_grammar = match_grammar

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -23,15 +23,16 @@ from sqlfluff.core.parser import (
 )
 
 from sqlfluff.core.dialects import load_raw_dialect
-from sqlfluff.dialects.tsql_keywords import RESERVED_KEYWORDS
+from sqlfluff.dialects.tsql_keywords import RESERVED_KEYWORDS, UNRESERVED_KEYWORDS
 
 ansi_dialect = load_raw_dialect("ansi")
 tsql_dialect = ansi_dialect.copy_as("tsql")
 
-# Update only RESERVED Keywords
 # Should really clear down the old keywords but some are needed by certain segments
 # tsql_dialect.sets("reserved_keywords").clear()
+# tsql_dialect.sets("unreserved_keywords").clear()
 tsql_dialect.sets("reserved_keywords").update(RESERVED_KEYWORDS)
+tsql_dialect.sets("unreserved_keywords").update(UNRESERVED_KEYWORDS)
 
 tsql_dialect.insert_lexer_matchers(
     [
@@ -105,6 +106,8 @@ class StatementSegment(ansi_dialect.get_segment("StatementSegment")):  # type: i
             Ref("IfExpressionStatement"),
             Ref("DeclareStatementSegment"),
             Ref("SetStatementSegment"),
+            Ref("AlterTableSwitchStatementSegment"),
+            Ref("CreateTableAsSelectStatementSegment"), # Azure Synapse Analytics specific
         ],
     )
 
@@ -659,3 +662,153 @@ class OverlapsClauseSegment(BaseSegment):
 
     type = "overlaps_clause"
     match_grammar = Nothing()
+
+
+@tsql_dialect.segment(replace=True)
+class CreateTableStatementSegment(BaseSegment):
+    """A `CREATE TABLE` statement."""
+
+    type = "create_table_statement"
+    # https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql?view=sql-server-ver15
+    # https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-azure-sql-data-warehouse?view=aps-pdw-2016-au7
+    match_grammar = Sequence(
+        "CREATE",
+        "TABLE",
+        Ref("TableReferenceSegment"),
+        OneOf(
+            # Columns and comment syntax:
+            Sequence(
+                Bracketed(
+                    Delimited(
+                        OneOf(
+                            Ref("TableConstraintSegment"),
+                            Ref("ColumnDefinitionSegment"),
+                        ),
+                    )
+                ),
+                Ref("CommentClauseSegment", optional=True),
+            ),
+            # Create AS syntax:
+            Sequence(
+                "AS",
+                OptionallyBracketed(Ref("SelectableGrammar")),
+            ),
+            # Create like syntax
+            Sequence("LIKE", Ref("TableReferenceSegment")),
+        ),
+        Ref("TableDistributionIndexClause", optional=True), # Azure Synapse Analytics specific
+    )
+
+    parse_grammar = match_grammar
+
+
+@tsql_dialect.segment()
+class TableDistributionIndexClause(BaseSegment):
+    """`CREATE TABLE` distribution / index clause.
+    This is specific to Azure Synapse Analytics.
+    """
+
+    type = "table_distribution_index_clause"
+
+    match_grammar = Sequence(
+        "WITH",
+        Bracketed(
+            OneOf(
+                Sequence(
+                    Ref("TableDistributionClause"),
+                    Ref("CommaSegment"),
+                    Ref("TableIndexClause"),
+                ),
+                Sequence(
+                    Ref("TableIndexClause"),
+                    Ref("CommaSegment"),
+                    Ref("TableDistributionClause"),
+                ),
+                Ref("TableDistributionClause"),
+                Ref("TableIndexClause"),
+            )
+        ),
+    )
+
+
+@tsql_dialect.segment()
+class TableDistributionClause(BaseSegment):
+    """`CREATE TABLE` distribution clause.
+    This is specific to Azure Synapse Analytics.
+    """
+
+    type = "table_distribution_clause"
+
+    match_grammar = Sequence(
+        "DISTRIBUTION",
+        Ref("EqualsSegment"),
+        OneOf(
+            "REPLICATE",
+            "ROUND_ROBIN",
+            Sequence(
+                "HASH",
+                Bracketed(Ref("ColumnReferenceSegment")),
+            ),
+        ),
+    )
+
+
+@tsql_dialect.segment()
+class TableIndexClause(BaseSegment):
+    """`CREATE TABLE` table index clause.
+    This is specific to Azure Synapse Analytics.
+    """
+
+    type = "table_index_clause"
+
+    match_grammar = Sequence(
+        OneOf(
+            "HEAP",
+            Sequence(
+                "CLUSTERED",
+                "COLUMNSTORE",
+                "INDEX",
+            ),
+        ),
+    )
+
+
+@tsql_dialect.segment()
+class AlterTableSwitchStatementSegment(BaseSegment):
+    """An `ALTER TABLE SWITCH` statement."""
+
+    type = "alter_table_switch_statement"
+    # https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql?view=sql-server-ver15
+    # T-SQL's ALTER TABLE SWITCH grammar is different enough to core ALTER TABLE grammar to merit its own definition
+    match_grammar = Sequence(
+        "ALTER",
+        "TABLE",
+        Ref("ObjectReferenceSegment"),
+        "SWITCH",
+        Sequence("PARTITION", Ref("NumericLiteralSegment"), optional=True),
+        "TO",
+        Ref("ObjectReferenceSegment"),
+        Sequence( # Azure Synapse Analytics specific
+            "WITH",
+            Bracketed("TRUNCATE_TARGET", Ref("EqualsSegment"), OneOf("ON", "OFF")),
+            optional=True,
+        ),
+    )
+
+
+@tsql_dialect.segment()
+class CreateTableAsSelectStatementSegment(BaseSegment):
+    """A `CREATE TABLE AS SELECT` statement.
+    This is specific to Azure Synapse Analytics.
+    """
+
+    type = "create_table_as_select_statement"
+    # https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-as-select-azure-sql-data-warehouse?toc=/azure/synapse-analytics/sql-data-warehouse/toc.json&bc=/azure/synapse-analytics/sql-data-warehouse/breadcrumb/toc.json&view=azure-sqldw-latest&preserve-view=true
+    match_grammar = Sequence(
+        "CREATE",
+        "TABLE",
+        Ref("TableReferenceSegment"),
+        Ref("TableDistributionIndexClause"),
+        "AS",
+        Ref("SelectableGrammar"),
+    )

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -107,7 +107,7 @@ class StatementSegment(ansi_dialect.get_segment("StatementSegment")):  # type: i
             Ref("DeclareStatementSegment"),
             Ref("SetStatementSegment"),
             Ref("AlterTableSwitchStatementSegment"),
-            Ref("CreateTableAsSelectStatementSegment"), # Azure Synapse Analytics specific
+            Ref("CreateTableAsSelectStatementSegment"),  # Azure Synapse Analytics specific
         ],
     )
 
@@ -234,7 +234,7 @@ class PivotUnpivotStatementSegment(BaseSegment):
                         Ref("ColumnReferenceSegment"),
                         "IN",
                         Bracketed(Delimited(Ref("ColumnReferenceSegment"))),
-                    )
+                    ),
                 ),
             ),
             Sequence(
@@ -696,7 +696,7 @@ class CreateTableStatementSegment(BaseSegment):
             # Create like syntax
             Sequence("LIKE", Ref("TableReferenceSegment")),
         ),
-        Ref("TableDistributionIndexClause", optional=True), # Azure Synapse Analytics specific
+        Ref("TableDistributionIndexClause", optional=True),  # Azure Synapse Analytics specific
     )
 
     parse_grammar = match_grammar
@@ -705,6 +705,7 @@ class CreateTableStatementSegment(BaseSegment):
 @tsql_dialect.segment()
 class TableDistributionIndexClause(BaseSegment):
     """`CREATE TABLE` distribution / index clause.
+
     This is specific to Azure Synapse Analytics.
     """
 
@@ -734,6 +735,7 @@ class TableDistributionIndexClause(BaseSegment):
 @tsql_dialect.segment()
 class TableDistributionClause(BaseSegment):
     """`CREATE TABLE` distribution clause.
+
     This is specific to Azure Synapse Analytics.
     """
 
@@ -756,6 +758,7 @@ class TableDistributionClause(BaseSegment):
 @tsql_dialect.segment()
 class TableIndexClause(BaseSegment):
     """`CREATE TABLE` table index clause.
+
     This is specific to Azure Synapse Analytics.
     """
 
@@ -788,7 +791,7 @@ class AlterTableSwitchStatementSegment(BaseSegment):
         Sequence("PARTITION", Ref("NumericLiteralSegment"), optional=True),
         "TO",
         Ref("ObjectReferenceSegment"),
-        Sequence( # Azure Synapse Analytics specific
+        Sequence(  # Azure Synapse Analytics specific
             "WITH",
             Bracketed("TRUNCATE_TARGET", Ref("EqualsSegment"), OneOf("ON", "OFF")),
             optional=True,
@@ -799,6 +802,7 @@ class AlterTableSwitchStatementSegment(BaseSegment):
 @tsql_dialect.segment()
 class CreateTableAsSelectStatementSegment(BaseSegment):
     """A `CREATE TABLE AS SELECT` statement.
+
     This is specific to Azure Synapse Analytics.
     """
 

--- a/src/sqlfluff/dialects/tsql_keywords.py
+++ b/src/sqlfluff/dialects/tsql_keywords.py
@@ -234,10 +234,10 @@ RESERVED_KEYWORDS = [
 
 UNRESERVED_KEYWORDS = [
     "COLUMNSTORE",
-    "DISTRIBUTION",     # Azure Synapse Analytics specific
-    "HASH",             # Azure Synapse Analytics specific
-    "REPLICATE",        # Azure Synapse Analytics specific
-    "ROUND_ROBIN",      # Azure Synapse Analytics specific
+    "DISTRIBUTION",  # Azure Synapse Analytics specific
+    "HASH",  # Azure Synapse Analytics specific
+    "REPLICATE",  # Azure Synapse Analytics specific
+    "ROUND_ROBIN",  # Azure Synapse Analytics specific
     "SWITCH",
     "TRUNCATE_TARGET",  # Azure Synapse Analytics specific
 ]

--- a/src/sqlfluff/dialects/tsql_keywords.py
+++ b/src/sqlfluff/dialects/tsql_keywords.py
@@ -230,3 +230,14 @@ RESERVED_KEYWORDS = [
     "WRITETEXT",
     "XACT_ABORT",
 ]
+
+
+UNRESERVED_KEYWORDS = [
+    "COLUMNSTORE",
+    "DISTRIBUTION",     # Azure Synapse Analytics specific
+    "HASH",             # Azure Synapse Analytics specific
+    "REPLICATE",        # Azure Synapse Analytics specific
+    "ROUND_ROBIN",      # Azure Synapse Analytics specific
+    "SWITCH",
+    "TRUNCATE_TARGET",  # Azure Synapse Analytics specific
+]

--- a/test/fixtures/parser/tsql/alter_table_switch.sql
+++ b/test/fixtures/parser/tsql/alter_table_switch.sql
@@ -1,0 +1,2 @@
+--TRUNCATE_TARGET is Azure Synapse Analytics specific
+ALTER TABLE [Facility].[PL_stage] SWITCH TO [Facility].[PL_BASE] WITH (TRUNCATE_TARGET = ON);

--- a/test/fixtures/parser/tsql/alter_table_switch.yml
+++ b/test/fixtures/parser/tsql/alter_table_switch.yml
@@ -1,0 +1,29 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e4dcf89409d1fb59f15905e9180b162da7dbe35646c5071f0244d723d2c9bba1
+file:
+  statement:
+    alter_table_switch_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - object_reference:
+      - identifier: '[Facility]'
+      - dot: .
+      - identifier: '[PL_stage]'
+    - keyword: SWITCH
+    - keyword: TO
+    - object_reference:
+      - identifier: '[Facility]'
+      - dot: .
+      - identifier: '[PL_BASE]'
+    - keyword: WITH
+    - bracketed:
+      - start_bracket: (
+      - keyword: TRUNCATE_TARGET
+      - comparison_operator: '='
+      - keyword: 'ON'
+      - end_bracket: )
+  statement_terminator: ;

--- a/test/fixtures/parser/tsql/create_table_as_select.sql
+++ b/test/fixtures/parser/tsql/create_table_as_select.sql
@@ -1,0 +1,14 @@
+--Azure Synapse Analytics specific
+CREATE TABLE [dbo].[PL_stage]
+WITH (DISTRIBUTION = HASH([ID]), HEAP)
+AS
+SELECT 	 e.[ID]
+		,e.[ArriveDate]
+		,e.[Contribution]
+		,e.[DischargeDate]
+		,e.[Encounter]
+		,e.[Facility]
+		,e.[Region]
+		,e.[LOS]
+FROM dbo.Encounter e
+JOIN dbo.Finance f ON e.[ID] = f.[ID]

--- a/test/fixtures/parser/tsql/create_table_as_select.yml
+++ b/test/fixtures/parser/tsql/create_table_as_select.yml
@@ -1,0 +1,116 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: ccf2139792b0b001dbf8c281b026f2c7c8afa5a781ed1a9802d16aa0f27c804a
+file:
+  statement:
+    create_table_as_select_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - identifier: '[dbo]'
+      - dot: .
+      - identifier: '[PL_stage]'
+    - table_distribution_index_clause:
+        keyword: WITH
+        bracketed:
+          start_bracket: (
+          table_distribution_clause:
+          - keyword: DISTRIBUTION
+          - comparison_operator: '='
+          - keyword: HASH
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: '[ID]'
+              end_bracket: )
+          comma: ','
+          table_index_clause:
+            keyword: HEAP
+          end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - identifier: e
+            - dot: .
+            - identifier: '[ID]'
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - identifier: e
+            - dot: .
+            - identifier: '[ArriveDate]'
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - identifier: e
+            - dot: .
+            - identifier: '[Contribution]'
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - identifier: e
+            - dot: .
+            - identifier: '[DischargeDate]'
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - identifier: e
+            - dot: .
+            - identifier: '[Encounter]'
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - identifier: e
+            - dot: .
+            - identifier: '[Facility]'
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - identifier: e
+            - dot: .
+            - identifier: '[Region]'
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - identifier: e
+            - dot: .
+            - identifier: '[LOS]'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - identifier: dbo
+                - dot: .
+                - identifier: Encounter
+              alias_expression:
+                identifier: e
+            join_clause:
+              keyword: JOIN
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                  - identifier: dbo
+                  - dot: .
+                  - identifier: Finance
+                alias_expression:
+                  identifier: f
+              join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - identifier: e
+                  - dot: .
+                  - identifier: '[ID]'
+                - comparison_operator: '='
+                - column_reference:
+                  - identifier: f
+                  - dot: .
+                  - identifier: '[ID]'

--- a/test/fixtures/parser/tsql/create_table_with_distribution.sql
+++ b/test/fixtures/parser/tsql/create_table_with_distribution.sql
@@ -1,0 +1,7 @@
+--Azure Synapse Analytics specific
+CREATE TABLE [dbo].[EC DC] (
+    [Column B] [varchar](100),
+    [ColumnC] varchar(100),
+    [ColumnDecimal] decimal(10,3)
+)
+WITH (CLUSTERED COLUMNSTORE INDEX, DISTRIBUTION = ROUND_ROBIN);

--- a/test/fixtures/parser/tsql/create_table_with_distribution.yml
+++ b/test/fixtures/parser/tsql/create_table_with_distribution.yml
@@ -1,0 +1,65 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: eaeb8b2cef95c274fb4931668ab729c4966484c1bccf1ba0ba98a91044808dc1
+file:
+  statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - identifier: '[dbo]'
+      - dot: .
+      - identifier: '[EC DC]'
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          identifier: '[Column B]'
+          data_type:
+            identifier: '[varchar]'
+            bracketed:
+              start_bracket: (
+              expression:
+                literal: '100'
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          identifier: '[ColumnC]'
+          data_type:
+            identifier: varchar
+            bracketed:
+              start_bracket: (
+              expression:
+                literal: '100'
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          identifier: '[ColumnDecimal]'
+          data_type:
+            identifier: decimal
+            bracketed:
+            - start_bracket: (
+            - expression:
+                literal: '10'
+            - comma: ','
+            - expression:
+                literal: '3'
+            - end_bracket: )
+      - end_bracket: )
+    - table_distribution_index_clause:
+        keyword: WITH
+        bracketed:
+          start_bracket: (
+          table_index_clause:
+          - keyword: CLUSTERED
+          - keyword: COLUMNSTORE
+          - keyword: INDEX
+          comma: ','
+          table_distribution_clause:
+          - keyword: DISTRIBUTION
+          - comparison_operator: '='
+          - keyword: ROUND_ROBIN
+          end_bracket: )
+  statement_terminator: ;

--- a/test/fixtures/parser/tsql/minimal_function_no_alter.sql
+++ b/test/fixtures/parser/tsql/minimal_function_no_alter.sql
@@ -1,0 +1,7 @@
+-- including just in case; Azure Synapse Analytics does not support OR ALTER
+-- https://docs.microsoft.com/en-us/sql/t-sql/statements/create-function-sql-data-warehouse?view=aps-pdw-2016-au7
+CREATE FUNCTION [dbo].[add] (@add_1 int, @add_2 int) RETURNS integer
+AS 
+BEGIN
+	RETURN @add_1 + @add_2
+END

--- a/test/fixtures/parser/tsql/minimal_function_no_alter.yml
+++ b/test/fixtures/parser/tsql/minimal_function_no_alter.yml
@@ -1,0 +1,37 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 1b9f505b6b997a86fb0ac7923fb49eff037ffa49362772f5ea22ba2b40548260
+file:
+  statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: FUNCTION
+    - object_reference:
+      - identifier: '[dbo]'
+      - dot: .
+      - identifier: '[add]'
+    - base:
+        bracketed:
+        - start_bracket: (
+        - parameter: '@add_1'
+        - data_type:
+            identifier: int
+        - comma: ','
+        - parameter: '@add_2'
+        - data_type:
+            identifier: int
+        - end_bracket: )
+    - keyword: RETURNS
+    - data_type:
+        identifier: integer
+    - function_statement:
+      - keyword: AS
+      - raw: BEGIN
+      - raw: RETURN
+      - raw: '@add_1'
+      - raw: +
+      - raw: '@add_2'
+      - raw: END


### PR DESCRIPTION
### Brief summary of the change made
This is an alternate PR to #1442.  

Adding support for Azure Synapse Analytics within the TSQL dialect.

TSQL dialect changes:
+Unreserved keywords list
+ALTER TABLE SWITCH segment
+CTAS segment
+CREATE TABLE segment replacing ANSI standard
+table distribution and index clause
+table distribution clause
+table index clause

New TSQL unreserved keywords:
"COLUMNSTORE",
"DISTRIBUTION",     # Azure Synapse Analytics specific
"HASH",             # Azure Synapse Analytics specific
"REPLICATE",        # Azure Synapse Analytics specific
"ROUND_ROBIN",      # Azure Synapse Analytics specific
"SWITCH",
"TRUNCATE_TARGET",  # Azure Synapse Analytics specific

New TSQL test cases:
ALTER TABLE SWITCH
CTAS
CREATE TABLE with a distribution and index clause
CREATE FUNCTION with no ALTER