### PR TITLE
EXASOL_FS: Fix adapter script type

### DIFF
--- a/src/sqlfluff/dialects/dialect_exasol_fs.py
+++ b/src/sqlfluff/dialects/dialect_exasol_fs.py
@@ -7,11 +7,12 @@ A semicolon is the terminator of the statement within the function / script
 https://docs.exasol.com
 """
 
-# TODO: How to turn off Jinja templating? In LUA language its possible to use {{}}. this is parsed as Jinja
 # TODO: How to prevent bracket check in script body?
 #       e.g. LUA: local _stmt = [[SOME ASSIGNMENT WITH OPEN BRACKET ( ]]
 #                 ...do some stuff ...
 #                 local _stmt = _stmt .. [[ ) ]]
+# https://github.com/sqlfluff/sqlfluff/issues/1479
+
 from sqlfluff.core.parser import (
     AnyNumberOf,
     Anything,
@@ -440,7 +441,7 @@ class CreateAdapterScriptStatementSegment(BaseSegment):
     https://docs.exasol.com/sql/create_script.htm
     """
 
-    type = "create_udf_script"
+    type = "create_adapter_script"
 
     is_ddl = True
     is_dml = False

--- a/test/fixtures/parser/exasol_fs/CreateAdapterScriptStatement.yml
+++ b/test/fixtures/parser/exasol_fs/CreateAdapterScriptStatement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5bf591f52324f5203ac1eec5603e624ae1135c8e2fbabf3e38b53ccdc3b40fff
+_hash: 04a170aaadc13bb37ac1f61cdc5d168533ac9c818fb7a2f940a4ad54e824e349
 file:
   statement:
     create_adapter_script:

--- a/test/fixtures/parser/exasol_fs/CreateAdapterScriptStatement.yml
+++ b/test/fixtures/parser/exasol_fs/CreateAdapterScriptStatement.yml
@@ -6,7 +6,7 @@
 _hash: 5bf591f52324f5203ac1eec5603e624ae1135c8e2fbabf3e38b53ccdc3b40fff
 file:
   statement:
-    create_udf_script:
+    create_adapter_script:
     - keyword: CREATE
     - keyword: JAVA
     - keyword: ADAPTER


### PR DESCRIPTION


### Brief summary of the change made
This fixes the adapter script type for dialect `exasol_fs` and removes a TODO which was resolved in #690.
...

### Are there any other side effects of this change that we should be aware of?
no

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
