### PR TITLE
Disable rule L033 for dialects that do not support it (e.g. Exasol, Postgres)

### DIFF
--- a/src/sqlfluff/rules/L033.py
+++ b/src/sqlfluff/rules/L033.py
@@ -26,13 +26,19 @@ class Rule_L033(BaseRule):
 
     """
 
-    def _eval(self, segment, raw_stack, **kwargs):
+    def _eval(self, segment, raw_stack, dialect, **kwargs):
         """Look for UNION keyword not immediately followed by DISTINCT or ALL.
 
         Note that UNION DISTINCT is valid, rule only applies to bare UNION.
         The function does this by looking for a segment of type set_operator
         which has a UNION but no DISTINCT or ALL.
+
+        Note some dialects (e.g. Exasol) do not have concept of UNION DISTINCT,
+        so rule is ignored for them.
         """
+        if dialect.name == "exasol":
+            return LintResult()
+
         if segment.is_type("set_operator"):
             if "UNION" in segment.raw.upper() and not (
                 "ALL" in segment.raw.upper() or "DISTINCT" in segment.raw.upper()

--- a/src/sqlfluff/rules/L033.py
+++ b/src/sqlfluff/rules/L033.py
@@ -36,11 +36,28 @@ class Rule_L033(BaseRule):
         Note some dialects (e.g. Exasol) do not have concept of UNION DISTINCT,
         so rule is ignored for them.
         """
-        if dialect.name == "exasol":
+        if dialect.name not in ["ansi", "bigquery", "hive", "mysql"]:
             return LintResult()
 
         if segment.is_type("set_operator"):
-            if "UNION" in segment.raw.upper() and not (
+            if "union" in segment.raw and not (
+                "ALL" in segment.raw.upper() or "DISTINCT" in segment.raw.upper()
+            ):
+                return LintResult(
+                    anchor=segment,
+                    fixes=[
+                        LintFix(
+                            "edit",
+                            segment.segments[0],
+                            [
+                                KeywordSegment("union"),
+                                WhitespaceSegment(),
+                                KeywordSegment("distinct"),
+                            ],
+                        )
+                    ],
+                )
+            elif "UNION" in segment.raw.upper() and not (
                 "ALL" in segment.raw.upper() or "DISTINCT" in segment.raw.upper()
             ):
                 return LintResult(

--- a/src/sqlfluff/rules/L033.py
+++ b/src/sqlfluff/rules/L033.py
@@ -33,8 +33,8 @@ class Rule_L033(BaseRule):
         The function does this by looking for a segment of type set_operator
         which has a UNION but no DISTINCT or ALL.
 
-        Note some dialects (e.g. Exasol) do not have concept of UNION DISTINCT,
-        so rule is ignored for them.
+        Note only some dialects have concept of UNION DISTINCT, so rule is only
+        applied to dialects that are known to support this syntax.
         """
         if dialect.name not in ["ansi", "bigquery", "hive", "mysql"]:
             return LintResult()

--- a/test/fixtures/rules/std_rule_cases/L033.yml
+++ b/test/fixtures/rules/std_rule_cases/L033.yml
@@ -120,7 +120,7 @@ test_fail_triple_join_with_one_bad_lowercase:
       c,
       d
     from tbl1
-    UNION DISTINCT
+    union distinct
     select
       e,
       f
@@ -157,3 +157,71 @@ test_exasol_union_all:
   configs:
     core:
       dialect: exasol
+
+test_postgres:
+  pass_str: |
+    select
+      a,
+      b
+    from tbl1
+    union
+    select
+      c,
+      d
+    from tbl2
+
+  configs:
+    core:
+      dialect: postgres
+
+test_bigquery:
+  fail_str: |
+    SELECT
+      a,
+      b
+    FROM tbl1
+    UNION
+    SELECT
+      c,
+      d
+    FROM tbl2
+  fix_str: |
+    SELECT
+      a,
+      b
+    FROM tbl1
+    UNION DISTINCT
+    SELECT
+      c,
+      d
+    FROM tbl2
+
+  configs:
+    core:
+      dialect: bigquery
+
+test_bigquery_lower:
+  fail_str: |
+    select
+      a,
+      b
+    from tbl1
+    union
+    select
+      c,
+      d
+    from tbl2
+  fix_str: |
+    select
+      a,
+      b
+    from tbl1
+    union distinct
+    select
+      c,
+      d
+    from tbl2
+
+  configs:
+    core:
+      dialect: bigquery

--- a/test/fixtures/rules/std_rule_cases/L033.yml
+++ b/test/fixtures/rules/std_rule_cases/L033.yml
@@ -1,7 +1,6 @@
 rule: L033
 
-test_1:
-  # Bare UNION without a DISTINCT or ALL
+test_pass_union_all:
   pass_str: |
     SELECT
       a,
@@ -13,7 +12,7 @@ test_1:
       d
     FROM tbl1
 
-test_2:
+test_fail_bare_union:
   fail_str: |
     SELECT
       a,
@@ -35,7 +34,7 @@ test_2:
       d
     FROM tbl1
 
-test_3:
+test_pass_union_distinct:
   pass_str: |
     SELECT
       a,
@@ -47,7 +46,7 @@ test_3:
       d
     FROM tbl1
 
-test_4:
+test_pass_union_distinct_with_comment:
   pass_str: |
     SELECT
       a,
@@ -63,7 +62,7 @@ test_4:
       d
     FROM tbl1
 
-test_5:
+test_fail_triple_join_with_one_bad:
   fail_str: |
     SELECT
       a,
@@ -95,7 +94,7 @@ test_5:
       f
     FROM tbl2
 
-test_6:
+test_fail_triple_join_with_one_bad_lowercase:
   fail_str: |
     select
       a,
@@ -126,3 +125,35 @@ test_6:
       e,
       f
     from tbl2
+
+test_exasol:
+  pass_str: |
+    select
+      a,
+      b
+    from tbl1
+    union
+    select
+      c,
+      d
+    from tbl2
+
+  configs:
+    core:
+      dialect: exasol
+
+test_exasol_union_all:
+  pass_str: |
+    select
+      a,
+      b
+    from tbl1
+    union all
+    select
+      c,
+      d
+    from tbl2
+
+  configs:
+    core:
+      dialect: exasol


### PR DESCRIPTION
### Brief summary of the change made
Fixes #1481 

### Are there any other side effects of this change that we should be aware of?
Gave tests proper name and added uppercase/lowercase support while at it (based on case of `UNION` keyword already set.)

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
