### PR TITLE
Fix handling of `ISNULL` and `NOTNULL` keywords

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -410,8 +410,6 @@ ansi_dialect.add(
     IsClauseGrammar=OneOf(
         "NULL",
         "NAN",
-        "NOTNULL",
-        "ISNULL",
         Ref("BooleanLiteralGrammar"),
     ),
     SelectClauseSegmentGrammar=Sequence(
@@ -434,6 +432,10 @@ ansi_dialect.add(
         Ref("CommaSegment"),
         Ref("SetOperatorSegment"),
     ),
+    # Define these as grammars to allow child dialects to enable them (since they are non-standard
+    # keywords)
+    IsNullGrammar=Nothing(),
+    NotNullGrammar=Nothing(),
     FromClauseTerminatorGrammar=OneOf(
         "WHERE",
         "LIMIT",
@@ -1434,6 +1436,8 @@ ansi_dialect.add(
                     Ref.keyword("NOT", optional=True),
                     Ref("IsClauseGrammar"),
                 ),
+                Ref("IsNullGrammar"),
+                Ref("NotNullGrammar"),
                 Sequence(
                     # e.g. NOT EXISTS, but other expressions could be met as
                     # well by inverting the condition with the NOT operator

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -187,6 +187,10 @@ postgres_dialect.replace(
         ansi_dialect.get_segment("ColumnReferenceSegment"),
         Ref("TimeZoneGrammar", optional=True),
     ),
+    # Postgres supports the non-standard ISNULL and NONNULL comparison operators. See
+    # https://www.postgresql.org/docs/14/functions-comparison.html
+    IsNullGrammar=Ref.keyword("ISNULL"),
+    NotNullGrammar=Ref.keyword("NOTNULL"),
 )
 
 

--- a/test/dialects/ansi_test.py
+++ b/test/dialects/ansi_test.py
@@ -108,9 +108,10 @@ def test__dialect__ansi__file_lex(raw, res, caplog):
             "concat(left(uaid, 2), '|', right(concat('0000000', SPLIT_PART(uaid, '|', 4)), 10), '|', '00000000')",
         ),
         # Notnull and Isnull
-        ("ExpressionSegment", "c notnull"),
         ("ExpressionSegment", "c is null"),
-        ("ExpressionSegment", "c isnull"),
+        ("ExpressionSegment", "c is not null"),
+        ("SelectClauseElementSegment", "c is null as c_isnull"),
+        ("SelectClauseElementSegment", "c is not null as c_notnull"),
         # Shorthand casting
         ("ExpressionSegment", "NULL::INT"),
         ("SelectClauseElementSegment", "NULL::INT AS user_id"),

--- a/test/dialects/postgres_test.py
+++ b/test/dialects/postgres_test.py
@@ -23,16 +23,8 @@ from sqlfluff.dialects.postgres_keywords import get_keywords, priority_keyword_m
         ("ExpressionSegment", "c notnull"),
         ("SelectClauseElementSegment", "c is null as c_isnull"),
         ("SelectClauseElementSegment", "c is not null as c_notnull"),
-        pytest.param(
-            "SelectClauseElementSegment",
-            "c isnull as c_isnull",
-            marks=[pytest.mark.xfail],
-        ),
-        pytest.param(
-            "SelectClauseElementSegment",
-            "c notnull as c_notnull",
-            marks=[pytest.mark.xfail],
-        ),
+        ("SelectClauseElementSegment", "c isnull as c_isnull"),
+        ("SelectClauseElementSegment", "c notnull as c_notnull"),
     ],
 )
 def test_dialect_postgres_specific_segment_parses(

--- a/test/dialects/postgres_test.py
+++ b/test/dialects/postgres_test.py
@@ -16,6 +16,23 @@ from sqlfluff.dialects.postgres_keywords import get_keywords, priority_keyword_m
             "SelectClauseElementSegment",
             "timestamp with time zone '2021-10-01' AT TIME ZONE 'UTC'",
         ),
+        # Notnull and Isnull
+        ("ExpressionSegment", "c is null"),
+        ("ExpressionSegment", "c is not null"),
+        ("ExpressionSegment", "c isnull"),
+        ("ExpressionSegment", "c notnull"),
+        ("SelectClauseElementSegment", "c is null as c_isnull"),
+        ("SelectClauseElementSegment", "c is not null as c_notnull"),
+        pytest.param(
+            "SelectClauseElementSegment",
+            "c isnull as c_isnull",
+            marks=[pytest.mark.xfail],
+        ),
+        pytest.param(
+            "SelectClauseElementSegment",
+            "c notnull as c_notnull",
+            marks=[pytest.mark.xfail],
+        ),
     ],
 )
 def test_dialect_postgres_specific_segment_parses(

--- a/test/fixtures/parser/postgres/postgres_null_filters.sql
+++ b/test/fixtures/parser/postgres/postgres_null_filters.sql
@@ -1,0 +1,13 @@
+-- Check nullability tests with standard and non-standard syntax
+SELECT
+    nullable_field IS NULL as standard_is_null,
+    nullable_field ISNULL as non_standard_is_null,
+    nullable_field IS NOT NULL as standard_not_null,
+    nullable_field NOTNULL as non_standard_not_null
+FROM
+    t_test
+WHERE
+    nullable_field IS NULL OR
+    nullable_field ISNULL OR
+    nullable_field IS NOT NULL OR
+    nullable_field NOTNULL

--- a/test/fixtures/parser/postgres/postgres_null_filters.yml
+++ b/test/fixtures/parser/postgres/postgres_null_filters.yml
@@ -1,0 +1,77 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: ae09d433bab0b53a47a3f1b9696cc9f5183af4465966e014eac61f04223069fd
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+          - column_reference:
+              identifier: nullable_field
+          - keyword: IS
+          - keyword: 'NULL'
+          alias_expression:
+            keyword: as
+            identifier: standard_is_null
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              identifier: nullable_field
+            keyword: ISNULL
+          alias_expression:
+            keyword: as
+            identifier: non_standard_is_null
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+              identifier: nullable_field
+          - keyword: IS
+          - keyword: NOT
+          - keyword: 'NULL'
+          alias_expression:
+            keyword: as
+            identifier: standard_not_null
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              identifier: nullable_field
+            keyword: NOTNULL
+          alias_expression:
+            keyword: as
+            identifier: non_standard_not_null
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t_test
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            identifier: nullable_field
+        - keyword: IS
+        - keyword: 'NULL'
+        - binary_operator: OR
+        - column_reference:
+            identifier: nullable_field
+        - keyword: ISNULL
+        - binary_operator: OR
+        - column_reference:
+            identifier: nullable_field
+        - keyword: IS
+        - keyword: NOT
+        - keyword: 'NULL'
+        - binary_operator: OR
+        - column_reference:
+            identifier: nullable_field
+        - keyword: NOTNULL


### PR DESCRIPTION
### Brief summary of the change made
Start treating `ISNULL` and `NOTNULL` as keywords in an expression rather than aliases

Prior to this change, if we were parsing an expression that contained the `ISNULL` or `NOTNULL`, we would treat them as
aliases. Since they are listed as keywords for Postgres and ANSI, this would cause some files to become unparsable (particularly if they were used in statements with actual aliases).

We fix this by introducing grammars for `ISNULL` and `NOTNULL`, and allowing them to be items in an expression. Since the `ISNULL` and `NOTNULL` keywords are non-standard (but are commonly supported), we remove them for the mysql, snowflake and exasol dialects which do not support them (based on the comment [here](https://github.com/sqlfluff/sqlfluff/issues/426#issuecomment-683465473)).

Technically we should also add a redshift dialogue which removes `ISNULL` and `NOTNULL`, but that is too big of a change to make now.

This change also removes `ISNULL` and `NOTNULL` from the `IsClauseGrammar`, as this would have allowed invalid `IS ISNULL` and `IS NOTNULL` constructs in expressions.

Fixes #1067

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
