### PR TITLE
Allow Postgres column references to use `AT TIME ZONE`

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -181,6 +181,12 @@ postgres_dialect.replace(
         ),
     ),
     FrameClauseUnitGrammar=OneOf("RANGE", "ROWS", "GROUPS"),
+    # In Postgres, column references may be followed by a time zone cast in all cases.
+    # For more information, see https://www.postgresql.org/docs/11/functions-datetime.html
+    ColumnReferenceSegment=Sequence(
+        ansi_dialect.get_segment("ColumnReferenceSegment"),
+        Ref("TimeZoneGrammar", optional=True),
+    ),
 )
 
 

--- a/test/dialects/postgres_test.py
+++ b/test/dialects/postgres_test.py
@@ -7,6 +7,31 @@ from sqlfluff.dialects.postgres_keywords import get_keywords, priority_keyword_m
 
 
 @pytest.mark.parametrize(
+    "segment_reference,raw",
+    [
+        # AT TIME ZONE constucts
+        ("SelectClauseElementSegment", "c_column AT TIME ZONE 'UTC'"),
+        ("SelectClauseElementSegment", "(c_column AT TIME ZONE 'UTC')::time"),
+        (
+            "SelectClauseElementSegment",
+            "timestamp with time zone '2021-10-01' AT TIME ZONE 'UTC'",
+        ),
+    ],
+)
+def test_dialect_postgres_specific_segment_parses(
+    segment_reference, raw, caplog, dialect_specific_segment_parses
+):
+    """Test that specific segments parse as expected.
+
+    NB: We're testing the PARSE function not the MATCH function
+    although this will be a recursive parse and so the match
+    function of SUBSECTIONS will be tested if present. The match
+    function of the parent will not be tested.
+    """
+    dialect_specific_segment_parses("postgres", segment_reference, raw, caplog)
+
+
+@pytest.mark.parametrize(
     "raw",
     [
         "SELECT t1.field, EXTRACT(EPOCH FROM t1.sometime) AS myepoch FROM t1",

--- a/test/fixtures/parser/postgres/postgres_select.sql
+++ b/test/fixtures/parser/postgres/postgres_select.sql
@@ -35,3 +35,7 @@ SELECT timestamp without time zone '2025-11-20 00:00:00+12';
 SELECT time with time zone '00:00:00+00' AT TIME ZONE 'Africa/Cairo';
 
 SELECT time without time zone '00:00:00' AT TIME ZONE 'Africa/Cairo';
+
+SELECT c_timestamp AT TIME ZONE 'Africa/Cairo' FROM t_table;
+
+SELECT (c_timestamp AT TIME ZONE 'Africa/Cairo')::time FROM t_table;

--- a/test/fixtures/parser/postgres/postgres_select.yml
+++ b/test/fixtures/parser/postgres/postgres_select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: dd3f78fb96f8e11914b856f9705ecba0a61b62487a6918c980a4643d95d9246a
+_hash: 93680ec80e0f28c6e0993ed544b3001e33cbad8887f594d9908b6e1f81cef440
 file:
 - statement:
     select_statement:
@@ -305,4 +305,54 @@ file:
             - keyword: TIME
             - keyword: ZONE
             - literal: "'Africa/Cairo'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            identifier: c_timestamp
+          time_zone_grammar:
+          - keyword: AT
+          - keyword: TIME
+          - keyword: ZONE
+          - literal: "'Africa/Cairo'"
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: c_timestamp
+                time_zone_grammar:
+                - keyword: AT
+                - keyword: TIME
+                - keyword: ZONE
+                - literal: "'Africa/Cairo'"
+              end_bracket: )
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                  keyword: time
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t_table
 - statement_terminator: ;


### PR DESCRIPTION
Prior to this change, it was possible to parse `AT TIME ZONE` declarations with the postgres dialect, but only when used with datetime literals.


### Brief summary of the change made
This PR builds on https://github.com/sqlfluff/sqlfluff/pull/1378 to allow `AT TIME ZONE` to be used with column references in PostgreSQL.

Examples of statements that this allows us to parse:

```
SELECT c_column AT TIME ZONE 'UTC' FROM t_table;

SELECT c_column FROM t_table WHERE (c_column AT TIME ZONE 'UTC')::time < '05:00';
```

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
