### PR TITLE
Issue 857: Fix bug that can prevent linting ephemeral models

### DIFF
--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -35,6 +35,7 @@ class BaseRunner(ABC):
 
     def iter_rendered(self, fnames):
         """Iterate through rendered files ready for linting."""
+        fnames = self.linter.templater.sequence_files(fnames, config=self.config)
         for fname in fnames:
             yield fname, self.linter.render_file(fname, self.config)
 

--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -35,7 +35,9 @@ class BaseRunner(ABC):
 
     def iter_rendered(self, fnames):
         """Iterate through rendered files ready for linting."""
-        fnames = self.linter.templater.sequence_files(fnames, config=self.config)
+        fnames = self.linter.templater.sequence_files(
+            fnames, config=self.config, formatter=self.linter.formatter
+        )
         for fname in fnames:
             yield fname, self.linter.render_file(fname, self.config)
 

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -440,6 +440,11 @@ class RawTemplater:
         arguments in here.
         """
 
+    def sequence_files(self, fnames: List[str], config=None):
+        """Given files to be processed, return a valid processing sequence."""
+        # Default is to process in the original order.
+        return fnames
+
     def process(
         self, *, in_str: str, fname: str, config=None, formatter=None
     ) -> Tuple[Optional[TemplatedFile], list]:

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -440,7 +440,7 @@ class RawTemplater:
         arguments in here.
         """
 
-    def sequence_files(self, fnames: List[str], config=None):
+    def sequence_files(self, fnames: List[str], config=None, formatter=None):
         """Given files to be processed, return a valid processing sequence."""
         # Default is to process in the original order.
         return fnames

--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -36,6 +36,8 @@ class DbtTemplater(JinjaTemplater):
     def __init__(self, **kwargs):
         self.sqlfluff_config = None
         self.formatter = None
+        self.project_dir = None
+        self.profiles_dir = None
         self.working_dir = os.getcwd()
         self._sequential_fails = 0
         super().__init__(**kwargs)
@@ -161,8 +163,7 @@ class DbtTemplater(JinjaTemplater):
 
         return self.dbt_selector_method
 
-    @cached_property
-    def profiles_dir(self):
+    def _get_profiles_dir(self):
         """Get the dbt profiles directory from the configuration.
 
         The default is `~/.dbt` in 0.17 but we use the
@@ -189,8 +190,7 @@ class DbtTemplater(JinjaTemplater):
 
         return dbt_profiles_dir
 
-    @cached_property
-    def project_dir(self):
+    def _get_project_dir(self):
         """Get the dbt project directory from the configuration.
 
         Defaults to the working directory.
@@ -244,17 +244,24 @@ class DbtTemplater(JinjaTemplater):
 
     def _walk_dependents(self, fname, config=None):
         self.sqlfluff_config = config
+        if not self.project_dir:
+            self.project_dir = self._get_project_dir()
+        if not self.profiles_dir:
+            self.profiles_dir = self._get_profiles_dir()
         fname_absolute_path = os.path.abspath(fname)
-        os.chdir(self.project_dir)
-        node = self._find_node(fname_absolute_path, config)
-        if node.depends_on.nodes:
-            templater_logger.info("%s depends on %s", fname, node.depends_on.nodes)
-        for dependent in node.depends_on.nodes:
-            yield from self._walk_dependents(
-                fname=self.dbt_manifest.nodes[dependent].original_file_path,
-                config=config,
-            )
-        yield fname
+        try:
+            os.chdir(self.project_dir)
+            node = self._find_node(fname_absolute_path, config)
+            if node.depends_on.nodes:
+                templater_logger.info("%s depends on %s", fname, node.depends_on.nodes)
+            for dependent in node.depends_on.nodes:
+                yield from self._walk_dependents(
+                    fname=self.dbt_manifest.nodes[dependent].original_file_path,
+                    config=config,
+                )
+            yield fname
+        finally:
+            os.chdir(self.working_dir)
 
     def process(self, *, fname, in_str=None, config=None, formatter=None):
         """Compile a dbt model and return the compiled SQL.
@@ -276,6 +283,8 @@ class DbtTemplater(JinjaTemplater):
         )
 
         self.sqlfluff_config = config
+        self.project_dir = self._get_project_dir()
+        self.profiles_dir = self._get_profiles_dir()
         fname_absolute_path = os.path.abspath(fname)
 
         try:

--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -261,11 +261,17 @@ class DbtTemplater(JinjaTemplater):
                         "%s depends on %s", fname, node.depends_on.nodes
                     )
                 for dependent in node.depends_on.nodes:
-                    yield from self._walk_dependents(
-                        fname=self.dbt_manifest.nodes[dependent].original_file_path,
-                        relative_to=self.project_dir,
-                        config=config,
-                    )
+                    if dependent in self.dbt_manifest.nodes[dependent]:
+                        yield from self._walk_dependents(
+                            fname=self.dbt_manifest.nodes[dependent].original_file_path,
+                            relative_to=self.project_dir,
+                            config=config,
+                        )
+                    else:
+                        templater_logger.warning(
+                            "Dependent model %s not found in project. Skipping.",
+                            dependent,
+                        )
             except SQLTemplaterSkipFile:
                 pass
             finally:

--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -248,9 +248,9 @@ class DbtTemplater(JinjaTemplater):
             self.project_dir = self._get_project_dir()
         if not self.profiles_dir:
             self.profiles_dir = self._get_profiles_dir()
-        fname_absolute_path = os.path.abspath(fname)
         try:
             os.chdir(self.project_dir)
+            fname_absolute_path = os.path.abspath(fname)
             node = self._find_node(fname_absolute_path, config)
             if node.depends_on.nodes:
                 templater_logger.info("%s depends on %s", fname, node.depends_on.nodes)

--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -227,11 +227,15 @@ class DbtTemplater(JinjaTemplater):
                 "please install dbt dependencies through `pip install sqlfluff[dbt]`"
             ) from e
 
-    def sequence_files(self, fnames: List[str], config=None):
+    def sequence_files(self, fnames: List[str], config=None, formatter=None):
         """Reorder fnames to process dependent files first.
 
         This avoids errors when an ephemeral model is processed before use.
         """
+        # Stash the formatter if provided to use in cached methods.
+        self.formatter = formatter
+
+        self._check_dbt_installed()
         if not config:  # pragma: no cover
             raise ValueError(
                 "For the dbt templater, the `sequence_files()` method requires a config object."

--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -238,7 +238,9 @@ class DbtTemplater(JinjaTemplater):
             )
         result = []
         for fname in fnames:
-            for dependent in self._walk_dependents(fname, self.working_dir, config=config):
+            for dependent in self._walk_dependents(
+                fname, self.working_dir, config=config
+            ):
                 if dependent not in result:
                     result.append(dependent)
             return result

--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -257,7 +257,9 @@ class DbtTemplater(JinjaTemplater):
             try:
                 node = self._find_node(fname_absolute_path, config)
                 if node.depends_on.nodes:
-                    templater_logger.info("%s depends on %s", fname, node.depends_on.nodes)
+                    templater_logger.info(
+                        "%s depends on %s", fname, node.depends_on.nodes
+                    )
                 for dependent in node.depends_on.nodes:
                     yield from self._walk_dependents(
                         fname=self.dbt_manifest.nodes[dependent].original_file_path,

--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -254,16 +254,20 @@ class DbtTemplater(JinjaTemplater):
         try:
             os.chdir(self.project_dir)
             fname_absolute_path = os.path.join(relative_to, fname)
-            node = self._find_node(fname_absolute_path, config)
-            if node.depends_on.nodes:
-                templater_logger.info("%s depends on %s", fname, node.depends_on.nodes)
-            for dependent in node.depends_on.nodes:
-                yield from self._walk_dependents(
-                    fname=self.dbt_manifest.nodes[dependent].original_file_path,
-                    relative_to=self.project_dir,
-                    config=config,
-                )
-            yield fname
+            try:
+                node = self._find_node(fname_absolute_path, config)
+                if node.depends_on.nodes:
+                    templater_logger.info("%s depends on %s", fname, node.depends_on.nodes)
+                for dependent in node.depends_on.nodes:
+                    yield from self._walk_dependents(
+                        fname=self.dbt_manifest.nodes[dependent].original_file_path,
+                        relative_to=self.project_dir,
+                        config=config,
+                    )
+            except SQLTemplaterSkipFile:
+                pass
+            finally:
+                yield fname
         finally:
             os.chdir(self.working_dir)
 

--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -289,7 +289,7 @@ class DbtTemplater(JinjaTemplater):
                 # at things it's not supposed to (e.g. directories that weren't
                 # passed to the "lint" command, files excluded by
                 # .sqlfluffignore, etc.
-                if fname in fnames:
+                if os.path.relpath(fname, self.working_dir) in fnames:
                     yield fname
         finally:
             os.chdir(self.working_dir)

--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -289,7 +289,11 @@ class DbtTemplater(JinjaTemplater):
                 # at things it's not supposed to (e.g. directories that weren't
                 # passed to the "lint" command, files excluded by
                 # .sqlfluffignore, etc.
-                if os.path.relpath(fname, self.working_dir) in fnames:
+                if os.path.relpath(
+                    fname, self.working_dir
+                ) in fnames or os.path.relpath(
+                    os.path.join(self.working_dir, fname), self.working_dir
+                ):
                     yield fname
         finally:
             os.chdir(self.working_dir)

--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -261,7 +261,7 @@ class DbtTemplater(JinjaTemplater):
                         "%s depends on %s", fname, node.depends_on.nodes
                     )
                 for dependent in node.depends_on.nodes:
-                    if dependent in self.dbt_manifest.nodes[dependent]:
+                    if dependent in self.dbt_manifest.nodes:
                         yield from self._walk_dependents(
                             fname=self.dbt_manifest.nodes[dependent].original_file_path,
                             relative_to=self.project_dir,

--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -272,7 +272,7 @@ class DbtTemplater(JinjaTemplater):
                             config=config,
                         )
                     else:
-                        templater_logger.warning(
+                        templater_logger.warning(  # pragma: no cover
                             "Dependent model %s not found in project. Skipping.",
                             dependent,
                         )

--- a/test/core/templaters/dbt_test.py
+++ b/test/core/templaters/dbt_test.py
@@ -72,7 +72,10 @@ def test__templater_dbt_templating_result(
 
 
 @pytest.mark.dbt
-def test__templater_dbt_sequence_files_ephemeral_dependency(project_dir, dbt_templater):
+def test__templater_dbt_sequence_files_ephemeral_dependency(
+    dbt_templater,  # noqa: F811
+):
+    """Test that dbt templater sequences files based on dependencies."""
     result = dbt_templater.sequence_files(
         [
             "models/depends_on_ephemeral/b.sql",

--- a/test/core/templaters/dbt_test.py
+++ b/test/core/templaters/dbt_test.py
@@ -73,20 +73,21 @@ def test__templater_dbt_templating_result(
 
 @pytest.mark.dbt
 def test__templater_dbt_sequence_files_ephemeral_dependency(
+    project_dir,  # noqa: F811
     dbt_templater,  # noqa: F811
 ):
     """Test that dbt templater sequences files based on dependencies."""
     result = dbt_templater.sequence_files(
         [
-            "models/depends_on_ephemeral/b.sql",
-            "models/depends_on_ephemeral/c.sql",
+            os.path.join(project_dir, "models/depends_on_ephemeral/b.sql"),
+            os.path.join(project_dir, "models/depends_on_ephemeral/c.sql"),
         ],
         config=FluffConfig(configs=DBT_FLUFF_CONFIG),
     )
     # c.sql should come first because b.sql depends on c.sql.
-    assert result == [
-        "models/depends_on_ephemeral/c.sql",
-        "models/depends_on_ephemeral/b.sql",
+    assert [os.path.basename(p) for p in result] == [
+        "c.sql",
+        "b.sql",
     ]
 
 

--- a/test/core/templaters/dbt_test.py
+++ b/test/core/templaters/dbt_test.py
@@ -38,7 +38,7 @@ def test__templater_dbt_profiles_dir_expanded(dbt_templater):  # noqa: F811
     dbt_templater.sqlfluff_config = FluffConfig(
         configs={"templater": {"dbt": {"profiles_dir": "~/.dbt"}}}
     )
-    profiles_dir = dbt_templater._get_profiles_dir()
+    profiles_dir = dbt_templater.profiles_dir
     # Normalise paths to control for OS variance
     assert os.path.normpath(profiles_dir) == os.path.normpath(
         os.path.expanduser("~/.dbt")
@@ -69,6 +69,17 @@ def test__templater_dbt_templating_result(
         config=FluffConfig(configs=DBT_FLUFF_CONFIG),
     )
     assert str(templated_file) == open("test/fixtures/dbt/" + fname).read()
+
+
+
+@pytest.mark.dbt
+def test__templater_dbt_sequence_files_ephemeral_dependency(project_dir, dbt_templater):
+    result = dbt_templater.sequence_files([
+        os.path.join(project_dir, "models/depends_on_ephemeral/b.sql"),
+        os.path.join("models/depends_on_ephemeral/c.sql"),
+    ], config=FluffConfig(configs=DBT_FLUFF_CONFIG))
+    #test/fixtures/dbt/dbt_project/models/depends_on_ephemeral
+    pass
 
 
 @pytest.mark.dbt
@@ -236,7 +247,7 @@ def test__project_dir_does_not_exist_error(dbt_templater, caplog):  # noqa: F811
     try:
         logger.propagate = True
         with caplog.at_level(logging.ERROR, logger="sqlfluff.templater"):
-            dbt_project_dir = dbt_templater._get_project_dir()
+            dbt_project_dir = dbt_templater.project_dir
         assert (
             f"dbt_project_dir: {dbt_project_dir} could not be accessed. Check it exists."
             in caplog.text

--- a/test/fixtures/dbt/dbt_project/models/depends_on_ephemeral/b.sql
+++ b/test/fixtures/dbt/dbt_project/models/depends_on_ephemeral/b.sql
@@ -1,0 +1,4 @@
+select * 
+from {{ ref('c') }}
+where id = 1
+

--- a/test/fixtures/dbt/dbt_project/models/depends_on_ephemeral/c.sql
+++ b/test/fixtures/dbt/dbt_project/models/depends_on_ephemeral/c.sql
@@ -1,0 +1,5 @@
+{{ config(materialized='ephemeral') }}
+
+select 1 as id
+
+


### PR DESCRIPTION
### Brief summary of the change made

Fixes #857

Adds a new public method to the templater interface to let the templater determine the order for linting files. With dbt, this is used to process dependent models (ephemeral models in particular!) before the models that use them.

### Are there any other side effects of this change that we should be aware of?

* Extends the public interface for templaters (`RawTemplater` and its descendants)
* Changes two more properties of `DbtTemplater` to use `@cached_property` (`profiles_dir` and `project_dir`)
### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
