### PR TITLE
Improved test cases names

### DIFF
--- a/test/fixtures/rules/std_rule_cases/L022.yml
+++ b/test/fixtures/rules/std_rule_cases/L022.yml
@@ -1,6 +1,6 @@
 rule: L022
 
-test_1:
+test_pass_blank_line_after_cte_trailing_comma:
   # Test cases for L022, both leading and trailing commas.
   pass_str: |
     with my_cte as (
@@ -13,7 +13,7 @@ test_1:
 
     select * from my_cte cross join other_cte
 
-test_2:
+test_pass_blank_line_after_cte_leading_comma:
   pass_str: |
     with my_cte as (
         select 1
@@ -25,7 +25,7 @@ test_2:
 
     select * from my_cte cross join other_cte
 
-test_3:
+test_fail_no_blank_line_after_each_cte:
   fail_str: |
     with my_cte as (
         select 1
@@ -47,7 +47,7 @@ test_3:
 
     select * from my_cte cross join other_cte
 
-test_4:
+test_fail_no_blank_line_after_cte_before_comment:
   fail_str: |
     with my_cte as (
         select 1
@@ -71,7 +71,7 @@ test_4:
 
     select * from my_cte cross join other_cte
 
-test_5:
+test_fail_no_blank_line_after_last_cte_trailing_comma:
   fail_str: |
     with my_cte as (
         select 1
@@ -93,7 +93,7 @@ test_5:
 
     select * from my_cte cross join other_cte
 
-test_6:
+test_fail_no_blank_line_after_last_cte_leading_comma:
   fail_str: |
     with my_cte as (
         select 1
@@ -115,7 +115,7 @@ test_6:
 
     select * from my_cte cross join other_cte
 
-test_7:
+test_fail_oneline_cte_leading_comma:
   # Fixes oneline cte with leading comma style
   fail_str: |
     with my_cte as (select 1), other_cte as (select 1) select * from my_cte
@@ -133,7 +133,7 @@ test_7:
     rules:
       comma_style: leading
 
-test_8:
+test_fail_cte_floating_comma:
   # Fixes cte with a floating comma
   fail_str: |
     with my_cte as (select 1)

--- a/test/fixtures/rules/std_rule_cases/L023.yml
+++ b/test/fixtures/rules/std_rule_cases/L023.yml
@@ -1,6 +1,6 @@
 rule: L023
 
-test_1:
+test_fail_cte_no_space_after_as:
   # Check fixing of single space rules
   fail_str: WITH a AS(select 1) select * from a
   fix_str: WITH a AS (select 1) select * from a

--- a/test/fixtures/rules/std_rule_cases/L024.yml
+++ b/test/fixtures/rules/std_rule_cases/L024.yml
@@ -1,10 +1,10 @@
 rule: L024
 
-test_1:
+test_fail_no_space_after_using_clause:
   fail_str: select * from a JOIN b USING(x)
   fix_str: select * from a JOIN b USING (x)
 
-test_2:
+test_pass_newline_after_using_clause:
   # Check L024 passes if there's a newline between
   pass_str: |
     select * from a JOIN b USING

--- a/test/fixtures/rules/std_rule_cases/L025.yml
+++ b/test/fixtures/rules/std_rule_cases/L025.yml
@@ -1,14 +1,14 @@
 rule: L025
 
-test_1:
+test_fail_table_alias_not_referenced_1:
   # Aliases not referenced.
   fail_str: SELECT * FROM my_tbl AS foo
   fix_str: SELECT * FROM my_tbl
 
-test_2:
+test_pass_table_alias_referenced:
   pass_str: SELECT * FROM my_tbl AS foo JOIN other_tbl on other_tbl.x = foo.x
 
-test_3:
+test_pass_unaliased_table_referenced:
   # L025 fix with https://github.com/sqlfluff/sqlfluff/issues/449
   pass_str: select ps.*, pandgs.blah from ps join pandgs using(moo)
 
@@ -22,16 +22,16 @@ test_ignore_value_table_functions:
     core:
       dialect: bigquery
 
-test_4:
+test_fail_table_alias_not_referenced_2:
   # Similar to test_1, but with implicit alias.
   fail_str: SELECT * FROM my_tbl foo
   fix_str: SELECT * FROM my_tbl
 
-test_5:
+test_fail_subquery_alias_not_referenced:
   fail_str: select * from (select 1 as a) subquery
   fix_str: select * from (select 1 as a)
 
-test_6:
+test_pass_bigquery_unaliased_table_with_hyphens:
   # Test non-quoted table name containing hyphens: https://github.com/sqlfluff/sqlfluff/issues/895
   # This is more of a smoke test to exercise the
   # ObjectReferenceSegment.extract_reference() function, which is used by L025
@@ -43,7 +43,7 @@ test_6:
     core:
       dialect: bigquery
 
-test_7:
+test_pass_bigquery_aliased_table_with_ticks_referenced:
   # Test ambiguous column reference caused by use of BigQuery structure fields.
   # Here, 'et2' could either be a schema name or a table name.
   # https://github.com/sqlfluff/sqlfluff/issues/1079

--- a/test/fixtures/rules/std_rule_cases/L026.yml
+++ b/test/fixtures/rules/std_rule_cases/L026.yml
@@ -1,6 +1,6 @@
 rule: L026
 
-test_1:
+test_pass_object_referenced_1:
   # References in quotes in bigquery
   pass_str: SELECT bar.user_id FROM `foo.far.bar`
 
@@ -8,28 +8,29 @@ test_1:
     core:
       dialect: bigquery
 
-test_2:
+test_fail_object_not_referenced_1:
+  desc: Name foo is not referenced in FROM clause. It would need to be at the end of identifier in ticks or an alias.
   fail_str: SELECT foo.user_id FROM `foo.far.bar`
 
   configs:
     core:
       dialect: bigquery
 
-test_3:
+test_fail_object_not_referenced_2:
   # References in WHERE clause
   fail_str: SELECT * FROM my_tbl WHERE foo.bar > 0
 
-test_4:
+test_pass_object_referenced_2:
   pass_str: |
     SELECT * FROM db.sc.tbl2
     WHERE a NOT IN (SELECT a FROM db.sc.tbl1)
 
-test_5:
+test_pass_object_referenced_3:
   pass_str: |
     SELECT * FROM db.sc.tbl2
     WHERE a NOT IN (SELECT tbl2.a FROM db.sc.tbl1)
 
-test_6:
+test_pass_object_referenced_4:
   # Test ambiguous column reference caused by use of BigQuery structure fields.
   # Here, 'et2' could either be a schema name or a table name.
   # https://github.com/sqlfluff/sqlfluff/issues/1079

--- a/test/fixtures/rules/std_rule_cases/L028.yml
+++ b/test/fixtures/rules/std_rule_cases/L028.yml
@@ -1,16 +1,16 @@
 rule: L028
 
 # Mixed qualification of references.
-test_1:
+test_fail_single_table_mixed_qualification_of_references:
   fail_str: SELECT my_tbl.bar, baz FROM my_tbl
 
-test_2:
+test_pass_single_table_consistent_references_1:
   pass_str: SELECT bar FROM my_tbl
 
-test_3:
+test_pass_single_table_consistent_references_2:
   pass_str: SELECT my_tbl.bar FROM my_tbl
 
-test_4:
+test_fail_single_table_reference_when_unqualified_config:
   fail_str: SELECT my_tbl.bar FROM my_tbl
 
   configs:
@@ -18,7 +18,7 @@ test_4:
       L028:
         single_table_references: unqualified
 
-test_5:
+test_fail_single_table_reference_when_qualified_config:
   fail_str: SELECT bar FROM my_tbl
 
   configs:
@@ -26,7 +26,7 @@ test_5:
       L028:
         single_table_references: qualified
 
-test_6:
+test_pass_single_table_reference_in_subquery:
   # Catch issues with subqueries properly
   pass_str: |
     SELECT * FROM db.sc.tbl2

--- a/test/fixtures/rules/std_rule_cases/L029.yml
+++ b/test/fixtures/rules/std_rule_cases/L029.yml
@@ -1,36 +1,36 @@
 rule: L029
 
-test_1:
+test_pass_valid_identifiers_1:
   pass_str: CREATE TABLE artist(artist_name TEXT)
 
-test_2:
+test_fail_keyword_as_identifier_1:
   fail_str: CREATE TABLE artist(create TEXT)
 
-test_3:
+test_fail_keyword_as_identifier_2:
   fail_str: SELECT 1 as parameter
 
-test_4:
+test_fail_keyword_as_identifier_3:
   fail_str: SELECT x FROM tbl AS parameter
 
-test_5:
+test_pass_valid_identifiers_2:
   # should pass on default config as not alias
   pass_str: SELECT parameter
 
-test_6:
+test_fail_keyword_as_identifier_4:
   fail_str: SELECT parameter
   configs:
     rules:
       L029:
         unquoted_identifiers_policy: all
 
-test_7:
+test_pass_valid_identifiers_3:
   pass_str: SELECT x FROM tbl AS parameter
   configs:
     rules:
       L029:
         unquoted_identifiers_policy: column_aliases
 
-test_8:
+test_fail_keyword_as_identifier_5:
   fail_str: SELECT x AS date FROM tbl AS parameter
   configs:
     rules:

--- a/test/fixtures/rules/std_rule_cases/L030.yml
+++ b/test/fixtures/rules/std_rule_cases/L030.yml
@@ -1,12 +1,12 @@
 rule: L030
 
 # Inconsistent capitalisation of functions
-test_1:
+test_fail_inconsistent_function_capitalisation_1:
   fail_str: SELECT MAX(id), min(id) from table
 
   fix_str: SELECT MAX(id), MIN(id) from table
 
-test_2:
+test_fail_inconsistent_function_capitalisation_2:
   fail_str: SELECT MAX(id), min(id) from table
 
   fix_str: SELECT max(id), min(id) from table

--- a/test/fixtures/rules/std_rule_cases/L031.yml
+++ b/test/fixtures/rules/std_rule_cases/L031.yml
@@ -1,6 +1,6 @@
 rule: L031
 
-test_1:
+test_pass_allow_self_join_alias:
   # L031 Allow self-joins
   pass_str: |
     select
@@ -9,7 +9,7 @@ test_1:
     from x
     left join x as x_2 on x.foreign_key = x.foreign_key
 
-test_2:
+test_fail_avoid_aliases_1:
   fail_str: |
     SELECT
       u.id,
@@ -30,7 +30,7 @@ test_2:
     JOIN customers on users.id = customers.user_id
     JOIN orders on users.id = orders.user_id;
 
-test_3:
+test_fail_avoid_aliases_2:
   # L031 order by
   fail_str: |
     SELECT
@@ -54,7 +54,7 @@ test_3:
     JOIN orders on users.id = orders.user_id
     order by orders.user_id desc
 
-test_4:
+test_fail_avoid_aliases_3:
   # L031 order by identifier which is the same raw as an alias but refers to a column
   fail_str: |
     SELECT

--- a/test/fixtures/rules/std_rule_cases/L031.yml
+++ b/test/fixtures/rules/std_rule_cases/L031.yml
@@ -79,8 +79,8 @@ test_fail_avoid_aliases_3:
     order by o desc
 
 alias_single_char_identifiers:
-  pass_str: "select b from tbl as a"
-  pass_str: "select b from tbl"
+  fail_str: "select b from tbl as a"
+  fix_str: "select b from tbl"
 
 alias_with_wildcard_identifier:
   fail_str: "select * from tbl as a"

--- a/test/fixtures/rules/std_rule_cases/L032.yml
+++ b/test/fixtures/rules/std_rule_cases/L032.yml
@@ -1,10 +1,11 @@
 rule: L032
 
-test_1:
+test_pass_specify_join_keys:
   pass_str: select x.a from x inner join y on x.id = y.id
 
-test_2:
+test_fail_specify_join_keys_1:
   fail_str: select x.a from x inner join y using (id)
 
-test_3:
+test_fail_specify_join_keys_2:
+  desc: Keys were specified for first join but not the second one.
   fail_str: select x.a from x inner join y on x.id = y.id inner join z using (id)

--- a/test/fixtures/rules/std_rule_cases/L034.yml
+++ b/test/fixtures/rules/std_rule_cases/L034.yml
@@ -1,6 +1,6 @@
 rule: L034
 
-test_1:
+test_pass_select_statement_order:
   pass_str: |
     select
       a,
@@ -8,7 +8,7 @@ test_1:
       c
     from x
 
-test_2:
+test_fail_select_statement_order_1:
   fail_str: |
     select
       a,
@@ -24,7 +24,7 @@ test_2:
       row_number() over (partition by id order by date) as y
     from x
 
-test_3:
+test_fail_select_statement_order_2:
   fail_str: |
     select
       row_number() over (partition by id order by date) as y,
@@ -40,7 +40,7 @@ test_3:
       row_number() over (partition by id order by date) as y
     from x
 
-test_4:
+test_fail_select_statement_order_3:
   fail_str: |
     select
       row_number() over (partition by id order by date) as y,
@@ -56,7 +56,7 @@ test_4:
       row_number() over (partition by id order by date) as y
     from x
 
-test_5:
+test_fail_select_statement_order_4:
   fail_str: |
     select
       row_number() over (partition by id order by date) as y,
@@ -72,7 +72,7 @@ test_5:
       row_number() over (partition by id order by date) as y
     from x
 
-test_6:
+test_fail_select_statement_order_5:
   fail_str: |
     select
       row_number() over (partition by id order by date) as y,

--- a/test/fixtures/rules/std_rule_cases/L040.yml
+++ b/test/fixtures/rules/std_rule_cases/L040.yml
@@ -1,5 +1,5 @@
 rule: L040
 
-test_1:
+test_fail_inconsistent_boolean_capitalisation:
   fail_str: SeLeCt true, FALSE, NULL
   fix_str: SeLeCt true, false, null

--- a/test/fixtures/rules/std_rule_cases/L041.yml
+++ b/test/fixtures/rules/std_rule_cases/L041.yml
@@ -1,6 +1,6 @@
 rule: L041
 
-test_1:
+test_fail_distinct_on_next_line_1:
   fail_str: |
     SELECT
         DISTINCT user_id,
@@ -14,7 +14,7 @@ test_1:
     FROM
         safe_user
 
-test_2:
+test_fail_distinct_on_next_line_2:
   fail_str: |
     SELECT
         -- The table contains duplicates, so we use DISTINCT.
@@ -28,5 +28,5 @@ test_2:
     FROM
         safe_user
 
-test_3:
+test_pass_distinct_on_same_line_with_select:
   pass_str: SELECT DISTINCT user_id FROM safe_user

--- a/test/fixtures/rules/std_rule_cases/L043.yml
+++ b/test/fixtures/rules/std_rule_cases/L043.yml
@@ -1,31 +1,31 @@
 rule: L043
 
-test_1:
+test_pass_case_cannot_be_reduced_1:
   pass_str: |
     select
         fab > 0 as is_fab
     from fancy_table
-test_2:
+test_pass_case_cannot_be_reduced_2:
   pass_str: |
     select
         case when fab > 0 then true end as is_fab
     from fancy_table
-test_3:
+test_pass_case_cannot_be_reduced_3:
   pass_str: |
     select
         case when fab is not null then false end as is_fab
     from fancy_table
-test_4:
+test_pass_case_cannot_be_reduced_4:
   pass_str: |
     select
         case when fab > 0 then true else true end as is_fab
     from fancy_table
-test_5:
+test_pass_case_cannot_be_reduced_5:
   pass_str: |
     select
         case when fab <> 0 then 'just a string' end as fab_category
     from fancy_table
-test_6:
+test_pass_case_cannot_be_reduced_6:
   pass_str: |
     select
         case
@@ -33,7 +33,7 @@ test_6:
           when fab < 0 then 'not a bool'
         end as fab_category
     from fancy_table
-test_7:
+test_fail_unnecessary_case_1:
   fail_str: |
     select
         case
@@ -43,7 +43,7 @@ test_7:
     select
         coalesce(fab > 0, false) as is_fab
     from fancy_table
-test_8:
+test_fail_unnecessary_case_2:
   fail_str: |
     select
         case
@@ -53,7 +53,7 @@ test_8:
     select
         not coalesce(fab > 0, false) as is_fab
     from fancy_table
-test_9:
+test_fail_unnecessary_case_3:
   fail_str: |
     select
         case
@@ -63,7 +63,7 @@ test_9:
     select
         coalesce(fab > 0 and tot > 0, false) as is_fab
     from fancy_table
-test_10:
+test_fail_unnecessary_case_4:
   fail_str: |
     select
         case
@@ -73,7 +73,7 @@ test_10:
     select
         not coalesce(fab > 0 and tot > 0, false) as is_fab
     from fancy_table
-test_11:
+test_fail_unnecessary_case_5:
   fail_str: |
     select
         case
@@ -83,7 +83,7 @@ test_11:
     select
         not coalesce(not fab > 0 or tot > 0, false) as is_fab
     from fancy_table
-test_12:
+test_fail_unnecessary_case_6:
   fail_str: |
     select
         subscriptions_xf.metadata_migrated,

--- a/test/fixtures/rules/std_rule_cases/L044.yml
+++ b/test/fixtures/rules/std_rule_cases/L044.yml
@@ -1,12 +1,13 @@
 rule: L044
 
-test_1:
+test_pass_known_number_of_result_columns_1:
   pass_str: select a, b from t
 
-test_2:
+test_fail_unknown_number_of_result_columns_1:
   fail_str: select * from t
 
-test_3:
+test_pass_known_number_of_result_columns_2:
+  desc: Columns are specified in CTE so * in final query will return only columns specified earlier.
   pass_str: |
     with cte as (
         select
@@ -16,7 +17,7 @@ test_3:
     )
     select * from cte
 
-test_4:
+test_fail_unknown_number_of_result_columns_2:
   fail_str: |
     with cte as (
         select
@@ -27,7 +28,7 @@ test_4:
     select * from cte
 
 
-test_5:
+test_pass_known_number_of_result_columns_3:
   pass_str: |
     with cte as (
         select
@@ -37,7 +38,10 @@ test_5:
     )
     select a, b from cte
 
-test_6:
+test_pass_known_number_of_result_columns_4:
+  desc: |
+    CTE1 has * but columns are specified in final select.
+    CTE2 has columns specified so cte2.* in final select will return only columns specified in CTE2's body.
   pass_str: |
     with cte1 as (
         select
@@ -58,7 +62,7 @@ test_6:
     join cte2
     using (a)
 
-test_7:
+test_fail_unknown_number_of_result_columns_3:
   fail_str: |
     with cte1 as (
         select
@@ -79,7 +83,8 @@ test_7:
     join cte2
     using (a)
 
-test_8:
+test_pass_known_number_of_result_columns_5:
+  desc: Columns specified in subquery so * in final select will return only those columns.
   pass_str: |
     select * from (
         select
@@ -88,7 +93,8 @@ test_8:
             t
     )
 
-test_9:
+test_fail_unknown_number_of_result_columns_4:
+  desc: Select t.* will return unknown number of columns.
   fail_str: |
     with cte as (
         select
@@ -103,7 +109,8 @@ test_9:
     join t
     using (a)
 
-test_10:
+test_fail_unknown_number_of_result_columns_5:
+  desc: Select t_alias.* will return unknown number of columns since the * is used in subquery.
   fail_str: |
     with cte as (
         select
@@ -118,7 +125,8 @@ test_10:
     join (select * from t) as t_alias
     using (a)
 
-test_11:
+test_pass_known_number_of_result_columns_6:
+  desc: Select t_alias.* will return known number of columns since they are defined in subquery.
   pass_str: |
     select
         t_alias.*
@@ -126,7 +134,7 @@ test_11:
     join (select a from t) as t_alias
     using (a)
 
-test_12:
+test_fail_unknown_number_of_result_columns_6:
   fail_str: |
     select
         t_alias.*
@@ -134,7 +142,7 @@ test_12:
     join (select * from t) as t_alias
     using (a)
 
-test_13:
+test_pass_known_number_of_result_columns_7:
   pass_str: |
     with cte as (
         select
@@ -149,28 +157,28 @@ test_13:
     join (select * from t) as t_alias
     using (a)
 
-test_14:
+test_fail_unknown_number_of_result_columns_7:
   fail_str: select *, t.*, t.a, b from t
 
-test_15:
+test_pass_known_number_of_result_columns_8:
   pass_str: |
     select a from t1
     union all
     select b from t2
 
-test_16:
+test_fail_unknown_number_of_result_columns_8:
   fail_str: |
     select a from t1
     union all
     select * from t2
 
-test_17:
+test_fail_unknown_number_of_result_columns_9:
   fail_str: |
     select * from t1
     union all
     select b from t2
 
-test_18:
+test_fail_unknown_number_of_result_columns_10:
   fail_str: |
     with cte as (
       select * from t1
@@ -182,7 +190,7 @@ test_18:
     union all
     select b from t3
 
-test_19:
+test_pass_known_number_of_result_columns_9:
   pass_str: |
     with cte as (
       select a from t1
@@ -194,7 +202,8 @@ test_19:
     union all
     select b from t3
 
-test_20:
+test_pass_known_number_of_result_columns_10:
+  desc: Columns are specified in cte_orders's body so cte_orders.* will return only these columns.
   pass_str: |
     WITH cte_orders AS (
       SELECT customer_id, total
@@ -208,7 +217,8 @@ test_20:
     WHERE
       clients.id = orders.clientId
 
-test_21:
+test_pass_known_number_of_result_columns_11:
+  desc: Columns are specified in cte_orders's body so cte_orders.* will return only these columns.
   pass_str: |
     WITH cte_orders AS (
       SELECT customer_id, total
@@ -219,7 +229,7 @@ test_21:
     FROM
       cte_orders AS orders
 
-test_22:
+test_fail_unknown_number_of_result_columns_11:
   fail_str: |
     WITH cte_orders AS (
       SELECT *
@@ -230,7 +240,8 @@ test_22:
     FROM
       cte_orders AS orders
 
-test_23:
+test_fail_unknown_number_of_result_columns_12:
+  desc: CTE is unused. We select * from orders table which means it's unknown what columns will be returned.
   fail_str: |
     WITH cte_orders AS (
       SELECT customer_id, total
@@ -241,16 +252,17 @@ test_23:
     FROM
       orders AS cte_orders
 
-test_24:
+test_fail_unknown_number_of_result_columns_13:
   fail_str: SELECT p.* FROM races, UNNEST(participants) AS p
 
-test_25:
+test_pass_known_number_of_result_columns_12:
   pass_str: SELECT p FROM races, UNNEST(participants) AS p
 
-test_26:
+test_fail_unknown_number_of_result_columns_14:
   fail_str: SELECT * FROM a JOIN b
 
-test_27:
+test_fail_unknown_number_of_result_columns_15:
+  desc: We know what columns will cte return but we don't know what columns will be returned from joined table b.
   fail_str: |
     WITH cte AS (
       SELECT a
@@ -260,7 +272,8 @@ test_27:
     FROM cte
     JOIN b
 
-test_28:
+test_pass_known_number_of_result_columns_13:
+  desc: Both CTEs define returned columns so * in final select will return known number of columns.
   pass_str: |
     WITH cte1 AS (
       SELECT a
@@ -274,23 +287,23 @@ test_28:
     FROM cte1
     JOIN cte2
 
-test_29:
+test_pass_known_number_of_result_columns_14:
   pass_str: select a, b from `d.t`
   configs:
     core:
       dialect: bigquery
 
-test_30:
+test_fail_unknown_number_of_result_columns_16:
   fail_str: select * from `d.t`
   configs:
     core:
       dialect: bigquery
 
-test_31:
+test_pass_known_number_of_result_columns_15:
   # Issue 915: Crash on statements that don't have a SELECT
   pass_str: CREATE TABLE my_table (id INTEGER)
 
-test_32:
+test_fail_unknown_number_of_result_columns_17:
   # Issue 930: Infinite recursion if CTE queries itself.
   fail_str: |
     with
@@ -300,7 +313,7 @@ test_32:
 
       select * from hubspot__engagement_calls
 
-test_33:
+test_fail_unknown_number_of_result_columns_18:
   # Another test for issue #930
   fail_str: |
     with

--- a/test/fixtures/rules/std_rule_cases/L045.yml
+++ b/test/fixtures/rules/std_rule_cases/L045.yml
@@ -1,9 +1,9 @@
 rule: L045
 
-test_1:
+test_pass_no_cte_defined_1:
   pass_str: select * from t
 
-test_2:
+test_pass_cte_defined_and_used_1:
   pass_str: |
     with cte as (
         select
@@ -13,7 +13,7 @@ test_2:
     )
     select * from cte
 
-test_3:
+test_pass_cte_defined_and_used_2:
   pass_str: |
     WITH cte1 AS (
       SELECT a
@@ -27,7 +27,8 @@ test_3:
     FROM cte1
     JOIN cte2
 
-test_4:
+test_fail_cte_defined_but_unused_1:
+  desc: Two CTEs defined but only one used in final query.
   fail_str: |
     WITH cte1 AS (
       SELECT a
@@ -40,7 +41,8 @@ test_4:
     SELECT *
     FROM cte1
 
-test_5:
+test_fail_cte_defined_but_unused_2:
+  desc: CTE defined but unused in final query even though table alias mimics CTE's name.
   fail_str: |
     WITH cte_orders AS (
       SELECT customer_id, total
@@ -51,7 +53,7 @@ test_5:
     FROM
       orders AS cte_orders
 
-test_6:
+test_pass_cte_defined_and_used_3:
   pass_str: |
     WITH cte1 AS (
       SELECT a
@@ -64,7 +66,8 @@ test_6:
     SELECT *
     FROM cte2
 
-test_7:
+test_fail_cte_defined_but_unused_3:
+  desc: Two CTEs are defined. CTE2 references CTE1 but in final query only CTE1 is used.
   fail_str: |
     WITH cte1 AS (
       SELECT a
@@ -77,11 +80,11 @@ test_7:
     SELECT *
     FROM cte1
 
-test_8:
+test_pass_no_cte_defined_2:
   # Issue 915: Crash on statements that don't have a SELECT
   pass_str: CREATE TABLE my_table (id INTEGER)
 
-test_9:
+test_pass_cte_defined_and_used_4:
   # Issue 944: Detecting use of CTE in nested SELECT
   pass_str: |
     WITH max_date_cte AS (
@@ -93,7 +96,7 @@ test_9:
     FROM warehouse.updated_weekly
     WHERE row_updated_date <= (SELECT max_date FROM max_date_cte)
 
-test_10:
+test_pass_cte_defined_and_used_5:
   # Variant on test_9, the WHERE with a nested SELECT is in a CTE
   pass_str: |
     WITH max_date_cte AS (
@@ -109,7 +112,7 @@ test_10:
     SELECT stuff
     FROM uses_max_date_cte
 
-test_11:
+test_pass_cte_defined_and_used_6:
   # Issue 963: Infinite recursion when a CTE references itself
   pass_str: |
     with pages_xf as (
@@ -124,7 +127,7 @@ test_11:
 
     select * from final
 
-test_12:
+test_fail_cte_defined_but_unused_4:
   # Variant on test_11 where there *is* an unused CTE
   fail_str: |
     with pages_xf as (
@@ -142,7 +145,7 @@ test_12:
 
     select * from final
 
-test_13:
+test_pass_cte_defined_and_used_7:
   # Variant on test_11 where the CTE references itself indirectly
   pass_str: |
     with pages_xf as (

--- a/test/fixtures/rules/std_rule_cases/L046.yml
+++ b/test/fixtures/rules/std_rule_cases/L046.yml
@@ -7,13 +7,13 @@ test_simple_modified:
   # Test that the plus/minus notation works fine.
   pass_str: SELECT 1 from {%+ if true -%} foo {%- endif %}
 
-test_fail_1:
+test_fail_jinja_tags_no_space:
   fail_str: SELECT 1 from {{ref('foo')}}
 
-test_fail_2:
+test_fail_jinja_tags_multiple_spaces:
   fail_str: SELECT 1 from {{      ref('foo')       }}
 
-test_fail_3:
+test_fail_jinja_tags_no_space_2:
   fail_str: SELECT 1 from {{+ref('foo')-}}
 
 test_pass_newlines:


### PR DESCRIPTION
### Brief summary of the change made
This pull request improves remaining test cases' names from issue #574 . It changes names for all test cases with name following pattern: `test_\d+` so the issue can be closed. There are still some test cases that were named like "simple_pass" but since they were not auto-generated I left almost all of those as they were considering them out of scope for this change. 

I added description to a few of the cases using `desc:` yaml key as was recommended in the issue.

Please let me know if the names or descriptions I chose need further changes 🙂

closes #574

### Are there any other side effects of this change that we should be aware of?
I changed test case alias_single_char_identifiers in L031.yml since it seemed to be using wrong keys and was passing only due to second pass_str overwriting first one. Please verify if this is correct.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
