### PR TITLE
Snowflake - fix parsing of UNPIVOT

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -57,6 +57,7 @@ snowflake_dialect.sets("reserved_keywords").update(
         "SAMPLE",
         "SOME",
         "TABLESAMPLE",
+        "UNPIVOT",
     ]
 )
 
@@ -98,7 +99,6 @@ snowflake_dialect.sets("unreserved_keywords").update(
         "SIZE_LIMIT",
         "SUSPEND",
         "TERSE",
-        "UNPIVOT",
         "UNSET",
         "TABULAR",
     ]

--- a/test/fixtures/parser/snowflake/snowflake_pivot.sql
+++ b/test/fixtures/parser/snowflake/snowflake_pivot.sql
@@ -1,3 +1,6 @@
 -- NB This is a pivot expression With and Alias. The alias should be parsed seperately to the pivot.
 SELECT * FROM my_tbl
-PIVOT (min(f_val) FOR f_id IN (1, 2)) AS f (a, b)
+PIVOT (min(f_val) FOR f_id IN (1, 2)) AS f (a, b);
+
+SELECT * FROM my_tbl
+UNPIVOT (val FOR col_name IN (a, b));

--- a/test/fixtures/parser/snowflake/snowflake_pivot.yml
+++ b/test/fixtures/parser/snowflake/snowflake_pivot.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7f1285dc62a3c63fd8071b6c93607056a2037aa233a01fbb0a71aba9d790e616
+_hash: 17005657ac2d78f41aa5fd59b02ca74bf5dec1670f4dd5d97781bf774384a59a
 file:
-  statement:
+- statement:
     select_statement:
       select_clause:
         keyword: SELECT
@@ -54,3 +54,35 @@ file:
                 - comma: ','
                 - identifier: b
                 end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: my_tbl
+          from_unpivot_expression:
+            keyword: UNPIVOT
+            bracketed:
+            - start_bracket: (
+            - identifier: val
+            - keyword: FOR
+            - identifier: col_name
+            - keyword: IN
+            - bracketed:
+              - start_bracket: (
+              - identifier: a
+              - comma: ','
+              - identifier: b
+              - end_bracket: )
+            - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Fix parsing of UNPIVOT by adding it to the list of reserved keywords.

Fixes #1474.

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
