### PR TITLE
Exasol: Fix typo in `REORGANIZE` statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -3049,7 +3049,7 @@ class FlushStatisticsSegment(BaseSegment):
 class RecompressReorganizeSegment(BaseSegment):
     """`RECOMPRESS` and `REOGRANIZE` statement."""
 
-    type = "recompress_reorganzie_statement"
+    type = "recompress_reorganize_statement"
     match_grammar = Sequence(
         OneOf("RECOMPRESS", "REORGANIZE"),
         OneOf(

--- a/test/fixtures/parser/exasol/RecompressStatement.yml
+++ b/test/fixtures/parser/exasol/RecompressStatement.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f6694bc11f14adcf50e867e4f1656f2e3b3b3eb38a3ec29a1dccb82c13b441c5
+_hash: 12717d423891499caf01b58d7ee219869c78cf89ef38ce5ca72305e1121c2a5f
 file:
 - statement:
-    recompress_reorganzie_statement:
+    recompress_reorganize_statement:
     - keyword: RECOMPRESS
     - keyword: TABLE
     - object_reference:
@@ -18,7 +18,7 @@ file:
         end_bracket: )
 - statement_terminator: ;
 - statement:
-    recompress_reorganzie_statement:
+    recompress_reorganize_statement:
     - keyword: RECOMPRESS
     - keyword: TABLES
     - object_reference:


### PR DESCRIPTION
### Brief summary of the change made
This fixes just a very small typo in the `REORGANIZE` statement.
...

### Are there any other side effects of this change that we should be aware of?
...

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
