### PR TITLE
Issue_1490 TSQL: Support for unicode literals

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -47,6 +47,8 @@ tsql_dialect.insert_lexer_matchers(
             r"\[([a-zA-Z0-9][^\[\]]*)*\]",
             CodeSegment,
         ),
+        # T-SQL unicode strings
+        RegexLexer("single_quote_with_n", r"N'([^'\\]|\\.)*'", CodeSegment),
     ],
     before="back_quote",
 )
@@ -54,6 +56,9 @@ tsql_dialect.insert_lexer_matchers(
 tsql_dialect.add(
     BracketedIdentifierSegment=NamedParser(
         "square_quote", CodeSegment, name="quoted_identifier", type="identifier"
+    ),
+    QuotedLiteralSegmentWithN=NamedParser(
+        "single_quote_with_n", CodeSegment, name="quoted_literal", type="literal"
     ),
 )
 
@@ -69,6 +74,17 @@ tsql_dialect.replace(
         Ref("NakedIdentifierSegment"),
         Ref("QuotedIdentifierSegment"),
         Ref("BracketedIdentifierSegment"),
+    ),
+    LiteralGrammar=OneOf(
+        Ref("QuotedLiteralSegment"),
+        Ref("QuotedLiteralSegmentWithN"),
+        Ref("NumericLiteralSegment"),
+        Ref("BooleanLiteralGrammar"),
+        Ref("QualifiedNumericLiteralSegment"),
+        # NB: Null is included in the literals, because it is a keyword which
+        # can otherwise be easily mistaken for an identifier.
+        Ref("NullLiteralSegment"),
+        Ref("DateTimeLiteralGrammar"),
     ),
     ParameterNameSegment=RegexParser(
         r"[@][A-Za-z0-9_]+", CodeSegment, name="parameter", type="parameter"
@@ -289,7 +305,7 @@ class ObjectReferenceSegment(BaseSegment):
     """A reference to an object.
 
     Update ObjectReferenceSegment to only allow dot separated SingleIdentifierGrammar
-    So Square Bracketed identifers can be matched.
+    So Square Bracketed identifiers can be matched.
     """
 
     type = "object_reference"

--- a/test/fixtures/parser/tsql/create_table_with_sequence_bracketed.yml
+++ b/test/fixtures/parser/tsql/create_table_with_sequence_bracketed.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 575bca81502ad4bdf436da56d34fd4f172e607de210a07308c818c84b99ce23e
+_hash: 684d0bd2a385cfe3dc469475f3071353c2377db4297ba683ef689fdeaee28142
 file:
 - statement:
     if_then_statement:
@@ -44,9 +44,7 @@ file:
                         bracketed:
                           start_bracket: (
                           expression:
-                            data_type:
-                              identifier: N
-                            literal: "'[dbo].[SEQ_SCHEMA_NAME_TABLE_NAME]'"
+                            literal: "N'[dbo].[SEQ_SCHEMA_NAME_TABLE_NAME]'"
                           end_bracket: )
                     - binary_operator: AND
                     - column_reference:
@@ -209,9 +207,7 @@ file:
                         bracketed:
                           start_bracket: (
                           expression:
-                            data_type:
-                              identifier: N
-                            literal: "'[dbo].[SEQ_STAGE_CBS_POPULATION_BASE]'"
+                            literal: "N'[dbo].[SEQ_STAGE_CBS_POPULATION_BASE]'"
                           end_bracket: )
                     - binary_operator: AND
                     - column_reference:

--- a/test/fixtures/rules/std_rule_cases/L048.yml
+++ b/test/fixtures/rules/std_rule_cases/L048.yml
@@ -43,3 +43,17 @@ test_pass_bigquery_udf_triple_double_quote:
   configs:
     core:
       dialect: bigquery
+
+test_pass_tsql_unicode_singe_quote:
+  pass_str: "SELECT a + N'b' + N'c' FROM tbl;"
+
+  configs:
+    core:
+      dialect: tsql
+
+test_fails_tsql_unicode_singe_quote:
+  fail_str: "SELECT a + N'b' + N'c' FROM tbl;"
+
+  configs:
+    core:
+      dialect: ansi

--- a/test/rules/std_L048_test.py
+++ b/test/rules/std_L048_test.py
@@ -1,0 +1,66 @@
+"""Tests the python routines within L048."""
+import pytest
+
+import sqlfluff
+
+
+def test__rules__std_L048() -> None:
+    """L0048 is not raised for quoted literals surrounded by a single whitespace."""
+    sql = "SELECT a + 'b' + 'c' FROM tbl;"
+    result = sqlfluff.lint(sql)
+
+    assert len(result) == 1
+
+    results_l048 = [r for r in result if r["code"] == "L048"]
+    assert not len(results_l048)
+
+
+def test__rules__std_L048_raised() -> None:
+    """L0048 is raised for quoted literals not surrounded by a single whitespace."""
+    sql = "SELECT a +'b'+'c' FROM tbl;"
+    result = sqlfluff.lint(sql)
+
+    assert len(result) == 7
+
+    results_l048 = [r for r in result if r["code"] == "L048"]
+    assert len(results_l048) == 3
+    assert results_l048[0]["description"] == "Missing whitespace before 'b'"
+    assert results_l048[1]["description"] == "Missing whitespace after 'b'"
+    assert results_l048[2]["description"] == "Missing whitespace before 'c'"
+
+
+def test__rules__std_L048_unicode_tsql() -> None:
+    """L0048 is not raised for unicode quoted literals when T-SQL."""
+    sql = "SELECT a + N'b' + N'c' FROM tbl;"
+    result = sqlfluff.lint(sql, dialect="tsql")
+
+    assert len(result) == 1
+
+    results_l048 = [r for r in result if r["code"] == "L048"]
+    assert not len(results_l048)
+
+
+@pytest.mark.parametrize("dialect", ["ansi", "mysql", "postgres", "sqlite", "bigquery"])
+def test__rules__std_L048_unicode_other_dialects(dialect: str) -> None:
+    """L0048 is raised for unicode quoted literals when some other dialects."""
+    sql = "SELECT a + N'b' + N'c' FROM tbl;"
+    result = sqlfluff.lint(sql, dialect=dialect)
+
+    assert len(result) == 3
+
+    results_l048 = [r for r in result if r["code"] == "L048"]
+    assert len(results_l048) == 2
+    assert results_l048[0]["description"] == "Missing whitespace before 'b'"
+    assert results_l048[1]["description"] == "Missing whitespace before 'c'"
+
+
+def test__rules__std_L048_unicode_tsql_small_n() -> None:
+    """L0048 when there is `n` instead of `N` in a T-SQL."""
+    sql = "SELECT a + N'b' + n'c' FROM tbl;"
+    result = sqlfluff.lint(sql, dialect="tsql")
+
+    assert len(result) == 2
+    results_l048 = [r for r in result if r["code"] == "L048"]
+
+    assert len(results_l048) == 1
+    assert results_l048[0]["description"] == "Missing whitespace before 'c'"


### PR DESCRIPTION
Fixes #1490 
* It allows to use unicode single-quoted literals in T-SQL

---
### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
