### PR TITLE
SQLFluff can't find dbt models

### DIFF
--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -3,6 +3,7 @@
 import os
 import os.path
 import logging
+from pathlib import Path
 from typing import List, Optional
 
 from dataclasses import dataclass
@@ -311,10 +312,11 @@ class DbtTemplater(JinjaTemplater):
                         # If we have a node object, use it to clean up the
                         # path we return, i.e. return a path relative to the
                         # working directory.
-                        yield tuple(node.fqn), os.path.relpath(
-                            os.path.join(node.root_path, node.original_file_path),
-                            self.working_dir,
-                        )
+                        yield tuple(node.fqn), str(
+                            (
+                                Path(node.root_path) / node.original_file_path
+                            ).relative_to(Path(self.working_dir))
+                        ),
                     else:
                         # If we don't have a node object, just return fname "as is"
                         # and let the caller deal with this the best it can.

--- a/test/core/templaters/dbt_test.py
+++ b/test/core/templaters/dbt_test.py
@@ -3,6 +3,7 @@
 import os
 import pytest
 import logging
+from pathlib import Path
 
 from sqlfluff.core import FluffConfig, Lexer, Linter
 from sqlfluff.core.errors import SQLTemplaterSkipFile
@@ -79,19 +80,19 @@ def test__templater_dbt_sequence_files_ephemeral_dependency(
     """Test that dbt templater sequences files based on dependencies."""
     result = dbt_templater.sequence_files(
         [
-            os.path.join(project_dir, "models", "depends_on_ephemeral", "a.sql"),
-            os.path.join(project_dir, "models", "depends_on_ephemeral", "b.sql"),
-            os.path.join(project_dir, "models", "depends_on_ephemeral", "c.sql"),
-            os.path.join(project_dir, "models", "depends_on_ephemeral", "d.sql"),
+            str(Path(project_dir) / "models" / "depends_on_ephemeral" / "a.sql"),
+            str(Path(project_dir) / "models" / "depends_on_ephemeral" / "b.sql"),
+            str(Path(project_dir) / "models" / "depends_on_ephemeral" / "c.sql"),
+            str(Path(project_dir) / "models" / "depends_on_ephemeral" / "d.sql"),
         ],
         config=FluffConfig(configs=DBT_FLUFF_CONFIG),
     )
     # c.sql should come first because b.sql depends on c.sql.
     assert result == [
-        os.path.join(project_dir, "models", "depends_on_ephemeral", "a.sql"),
-        os.path.join(project_dir, "models", "depends_on_ephemeral", "c.sql"),
-        os.path.join(project_dir, "models", "depends_on_ephemeral", "b.sql"),
-        os.path.join(project_dir, "models", "depends_on_ephemeral", "d.sql"),
+        str(Path(project_dir) / "models" / "depends_on_ephemeral" / "a.sql"),
+        str(Path(project_dir) / "models" / "depends_on_ephemeral" / "c.sql"),
+        str(Path(project_dir) / "models" / "depends_on_ephemeral" / "b.sql"),
+        str(Path(project_dir) / "models" / "depends_on_ephemeral" / "d.sql"),
     ]
 
 

--- a/test/core/templaters/dbt_test.py
+++ b/test/core/templaters/dbt_test.py
@@ -79,15 +79,19 @@ def test__templater_dbt_sequence_files_ephemeral_dependency(
     """Test that dbt templater sequences files based on dependencies."""
     result = dbt_templater.sequence_files(
         [
+            os.path.join(project_dir, "models/depends_on_ephemeral/a.sql"),
             os.path.join(project_dir, "models/depends_on_ephemeral/b.sql"),
             os.path.join(project_dir, "models/depends_on_ephemeral/c.sql"),
+            os.path.join(project_dir, "models/depends_on_ephemeral/d.sql"),
         ],
         config=FluffConfig(configs=DBT_FLUFF_CONFIG),
     )
     # c.sql should come first because b.sql depends on c.sql.
-    assert [os.path.basename(p) for p in result] == [
-        "c.sql",
-        "b.sql",
+    assert result == [
+        os.path.join(project_dir, "models/depends_on_ephemeral/a.sql"),
+        os.path.join(project_dir, "models/depends_on_ephemeral/c.sql"),
+        os.path.join(project_dir, "models/depends_on_ephemeral/b.sql"),
+        os.path.join(project_dir, "models/depends_on_ephemeral/d.sql"),
     ]
 
 

--- a/test/core/templaters/dbt_test.py
+++ b/test/core/templaters/dbt_test.py
@@ -79,19 +79,19 @@ def test__templater_dbt_sequence_files_ephemeral_dependency(
     """Test that dbt templater sequences files based on dependencies."""
     result = dbt_templater.sequence_files(
         [
-            os.path.join(project_dir, "models/depends_on_ephemeral/a.sql"),
-            os.path.join(project_dir, "models/depends_on_ephemeral/b.sql"),
-            os.path.join(project_dir, "models/depends_on_ephemeral/c.sql"),
-            os.path.join(project_dir, "models/depends_on_ephemeral/d.sql"),
+            os.path.join(project_dir, "models", "depends_on_ephemeral", "a.sql"),
+            os.path.join(project_dir, "models", "depends_on_ephemeral", "b.sql"),
+            os.path.join(project_dir, "models", "depends_on_ephemeral", "c.sql"),
+            os.path.join(project_dir, "models", "depends_on_ephemeral", "d.sql"),
         ],
         config=FluffConfig(configs=DBT_FLUFF_CONFIG),
     )
     # c.sql should come first because b.sql depends on c.sql.
     assert result == [
-        os.path.join(project_dir, "models/depends_on_ephemeral/a.sql"),
-        os.path.join(project_dir, "models/depends_on_ephemeral/c.sql"),
-        os.path.join(project_dir, "models/depends_on_ephemeral/b.sql"),
-        os.path.join(project_dir, "models/depends_on_ephemeral/d.sql"),
+        os.path.join(project_dir, "models", "depends_on_ephemeral", "a.sql"),
+        os.path.join(project_dir, "models", "depends_on_ephemeral", "c.sql"),
+        os.path.join(project_dir, "models", "depends_on_ephemeral", "b.sql"),
+        os.path.join(project_dir, "models", "depends_on_ephemeral", "d.sql"),
     ]
 
 

--- a/test/fixtures/dbt/dbt_project/models/depends_on_ephemeral/a.sql
+++ b/test/fixtures/dbt/dbt_project/models/depends_on_ephemeral/a.sql
@@ -1,0 +1,2 @@
+select 1
+from {{ source('jaffle_shop', 'orders') }}

--- a/test/fixtures/dbt/dbt_project/models/depends_on_ephemeral/d.sql
+++ b/test/fixtures/dbt/dbt_project/models/depends_on_ephemeral/d.sql
@@ -1,0 +1,1 @@
+SELECT 1 FROM bar


### PR DESCRIPTION
Fixes #1510

### Brief summary of the change made

Fixes a bug where the dbt templater was only fixing or linting the first file (and its dependents).

### Are there any other side effects of this change that we should be aware of?

This PR also makes some changes to how `sequence_files()` processes directory names, to try and make file paths more canonical and avoid accidentally processing the same file twice.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
