### PR TITLE
added type hints to rule files

### DIFF
--- a/src/sqlfluff/core/parser/segments/__init__.py
+++ b/src/sqlfluff/core/parser/segments/__init__.py
@@ -1,6 +1,7 @@
 """Definitions of the segment classes."""
 
 # flake8: noqa: F401
+from typing import Union
 
 from sqlfluff.core.parser.segments.base import (
     BaseSegment,
@@ -26,3 +27,23 @@ from sqlfluff.core.parser.segments.meta import (
     Dedent,
     TemplateSegment,
 )
+
+AnySegmentType = Union[
+    BaseSegment,
+    BaseFileSegment,
+    UnparsableSegment,
+    BracketedSegment,
+    RawSegment,
+    CodeSegment,
+    UnlexableSegment,
+    CommentSegment,
+    WhitespaceSegment,
+    NewlineSegment,
+    KeywordSegment,
+    SymbolSegment,
+    EphemeralSegment,
+    MetaSegment,
+    Indent,
+    Dedent,
+    TemplateSegment,
+]

--- a/src/sqlfluff/rules/L001.py
+++ b/src/sqlfluff/rules/L001.py
@@ -1,6 +1,10 @@
 """Implementation of Rule L001."""
+from typing import Tuple
+
+from sqlfluff.core.parser.segments import AnySegmentType
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.templaters import TemplatedFile
 
 
 @document_fix_compatible
@@ -27,7 +31,13 @@ class Rule_L001(BaseRule):
         FROM foo
     """
 
-    def _eval(self, segment, raw_stack, templated_file, **kwargs):
+    def _eval(
+        self,
+        segment: AnySegmentType,
+        raw_stack: Tuple[AnySegmentType],
+        templated_file: TemplatedFile,
+        **kwargs
+    ) -> LintResult:
         """Unnecessary trailing whitespace.
 
         Look for newline segments, and then evaluate what

--- a/src/sqlfluff/rules/L002.py
+++ b/src/sqlfluff/rules/L002.py
@@ -1,5 +1,7 @@
 """Implementation of Rule L002."""
+from typing import Optional, Tuple
 
+from sqlfluff.core.parser.segments import AnySegmentType
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
@@ -40,7 +42,9 @@ class Rule_L002(BaseRule):
 
     config_keywords = ["tab_space_size"]
 
-    def _eval(self, segment, raw_stack, **kwargs):
+    def _eval(
+        self, segment: AnySegmentType, raw_stack: Tuple[AnySegmentType], **kwargs
+    ) -> Optional[LintResult]:
         """Mixed Tabs and Spaces in single whitespace.
 
         Only trigger from whitespace segments if they contain

--- a/src/sqlfluff/rules/L004.py
+++ b/src/sqlfluff/rules/L004.py
@@ -1,7 +1,8 @@
 """Implementation of Rule L004."""
+from typing import Optional, Tuple
 
 from sqlfluff.core.parser import WhitespaceSegment
-
+from sqlfluff.core.parser.segments import AnySegmentType
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix
 from sqlfluff.core.rules.doc_decorators import (
     document_fix_compatible,
@@ -45,7 +46,9 @@ class Rule_L004(BaseRule):
     config_keywords = ["indent_unit", "tab_space_size"]
 
     # TODO fix indents after text: https://github.com/sqlfluff/sqlfluff/pull/590#issuecomment-739484190
-    def _eval(self, segment, raw_stack, **kwargs):
+    def _eval(
+        self, segment: AnySegmentType, raw_stack: Tuple[AnySegmentType], **kwargs
+    ) -> Optional[LintResult]:
         """Incorrect indentation found in file."""
         tab = "\t"
         space = " "

--- a/src/sqlfluff/rules/L005.py
+++ b/src/sqlfluff/rules/L005.py
@@ -1,5 +1,7 @@
 """Implementation of Rule L005."""
+from typing import Optional, Tuple
 
+from sqlfluff.core.parser.segments import AnySegmentType
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
@@ -34,7 +36,9 @@ class Rule_L005(BaseRule):
         FROM foo
     """
 
-    def _eval(self, segment, raw_stack, **kwargs):
+    def _eval(
+        self, segment: AnySegmentType, raw_stack: Tuple[AnySegmentType], **kwargs
+    ) -> Optional[LintResult]:
         """Commas should not have whitespace directly before them.
 
         We need at least one segment behind us for this to work.

--- a/test/rules/std_L003_test.py
+++ b/test/rules/std_L003_test.py
@@ -152,6 +152,12 @@ def test__rules__std_L003_make_indent(indent_unit, num, tab_space_size, result):
     assert res == result
 
 
+def test__rules__std_L003_make_indent_invalid_param():
+    """Test Rule_L003._make_indent with invalid indent_unit parameter."""
+    with pytest.raises(ValueError):
+        Rule_L003._make_indent(indent_unit="aaa")
+
+
 class ProtoSeg:
     """Proto Seg for testing."""
 


### PR DESCRIPTION
### Brief summary of the change made
makes progress on #1059 

This PR adds type hints to rule files.
It covers only a few files so far but since it will add a type Unioning all Segment types and another person wanted to join the effort I wanted to push this quickly so they can share it.

At first I wanted to use BaseSegment type but since some of the code works on attributes that are available only on some segment types i think the best solution was to create this AnySegmentType that merges all Segment types.

### Are there any other side effects of this change that we should be aware of?
In L003.py in _make_indent method I added else block for unexpected inputs. Function would raise an exception anyway but this way it should have a nicer message.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
