### PR TITLE
DbtTemplater.sequence_files() should not add new files to the list

### DIFF
--- a/src/sqlfluff/core/templaters/dbt.py
+++ b/src/sqlfluff/core/templaters/dbt.py
@@ -253,6 +253,12 @@ class DbtTemplater(JinjaTemplater):
             for fqn, dependent in self._walk_dependents(
                 fname, fnames, self.working_dir, config=config
             ):
+                # Skip filenames we didn't have already. sequence_files() is
+                # not allowed to add new files, only resequence the existing
+                # ones.
+                if dependent not in fnames:
+                    continue
+
                 add = False
                 if fqn:
                     # We have a fully-qualified name. Use it to avoid

--- a/test/core/templaters/dbt_test.py
+++ b/test/core/templaters/dbt_test.py
@@ -72,28 +72,53 @@ def test__templater_dbt_templating_result(
     assert str(templated_file) == open("test/fixtures/dbt/" + fname).read()
 
 
+examples = [
+    [
+        (
+            Path("models") / "depends_on_ephemeral" / "a.sql",
+            Path("models") / "depends_on_ephemeral" / "b.sql",
+            Path("models") / "depends_on_ephemeral" / "d.sql",
+        ),
+        # c.sql is not present in the original list and should not appear here, even
+        # though b.sql depends on it.
+        (
+            Path("models") / "depends_on_ephemeral" / "a.sql",
+            Path("models") / "depends_on_ephemeral" / "b.sql",
+            Path("models") / "depends_on_ephemeral" / "d.sql",
+        ),
+    ],
+    [
+        (
+            Path("models") / "depends_on_ephemeral" / "a.sql",
+            Path("models") / "depends_on_ephemeral" / "b.sql",
+            Path("models") / "depends_on_ephemeral" / "c.sql",
+            Path("models") / "depends_on_ephemeral" / "d.sql",
+        ),
+        # c.sql should come first because b.sql depends on c.sql.
+        (
+            Path("models") / "depends_on_ephemeral" / "a.sql",
+            Path("models") / "depends_on_ephemeral" / "c.sql",
+            Path("models") / "depends_on_ephemeral" / "b.sql",
+            Path("models") / "depends_on_ephemeral" / "d.sql",
+        ),
+    ],
+]
+
+
+@pytest.mark.parametrize("fnames", examples)
 @pytest.mark.dbt
 def test__templater_dbt_sequence_files_ephemeral_dependency(
-    project_dir,  # noqa: F811
-    dbt_templater,  # noqa: F811
+    project_dir, dbt_templater, fnames  # noqa: F811  # noqa: F811
 ):
     """Test that dbt templater sequences files based on dependencies."""
+    fnames_input, fnames_expected_sequence = fnames
     result = dbt_templater.sequence_files(
-        [
-            str(Path(project_dir) / "models" / "depends_on_ephemeral" / "a.sql"),
-            str(Path(project_dir) / "models" / "depends_on_ephemeral" / "b.sql"),
-            str(Path(project_dir) / "models" / "depends_on_ephemeral" / "c.sql"),
-            str(Path(project_dir) / "models" / "depends_on_ephemeral" / "d.sql"),
-        ],
+        [str(Path(project_dir) / fn) for fn in fnames_input],
         config=FluffConfig(configs=DBT_FLUFF_CONFIG),
     )
-    # c.sql should come first because b.sql depends on c.sql.
-    assert result == [
-        str(Path(project_dir) / "models" / "depends_on_ephemeral" / "a.sql"),
-        str(Path(project_dir) / "models" / "depends_on_ephemeral" / "c.sql"),
-        str(Path(project_dir) / "models" / "depends_on_ephemeral" / "b.sql"),
-        str(Path(project_dir) / "models" / "depends_on_ephemeral" / "d.sql"),
-    ]
+    pd = Path(project_dir)
+    expected = [str(pd / fn) for fn in fnames_expected_sequence]
+    assert result == expected
 
 
 @pytest.mark.dbt


### PR DESCRIPTION
### Brief summary of the change made

Follow-up to #1510, #857

When following model dependencies, `sequence_files()` should not introduce any new files to the list, only reorder existing ones.
...

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
