### PR TITLE
Postgres allows for lateral joins

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1235,13 +1235,14 @@ class SelectClauseSegment(BaseSegment):
 
 @ansi_dialect.segment()
 class JoinClauseSegment(BaseSegment):
-    """Any number of join clauses, including the `JOIN` keyword."""
+    """Any number of join clauses, including the `JOIN` keyword.
+
+    The list of elements is moved to separate attribute, because in that way it can
+    be used in postgres' version, where the `LATERAL` is inserted in between.
+    """
 
     type = "join_clause"
-    match_grammar = Sequence(
-        # NB These qualifiers are optional
-        # TODO: Allow nested joins like:
-        # ....FROM S1.T1 t1 LEFT JOIN ( S2.T2 t2 JOIN S3.T3 t3 ON t2.col1=t3.col1) ON tab1.col1 = tab2.col1
+    sequence_list = (
         OneOf(
             "CROSS",
             "INNER",
@@ -1290,6 +1291,12 @@ class JoinClauseSegment(BaseSegment):
         ),
         Dedent,
     )
+    match_grammar = Sequence(
+        # NB These qualifiers are optional
+        # TODO: Allow nested joins like:
+        # ....FROM S1.T1 t1 LEFT JOIN ( S2.T2 t2 JOIN S3.T3 t3 ON t2.col1=t3.col1) ON tab1.col1 = tab2.col1
+        *sequence_list,
+    )
 
     def get_eventual_alias(self) -> AliasInfo:
         """Return the eventual table name referred to by this join clause."""
@@ -1322,7 +1329,7 @@ class FromClauseSegment(BaseSegment):
 
     NOTE: this is a delimited set of table expressions, with a variable
     number of optional join clauses with those table expressions. The
-    delmited aspect is the higher of the two such that the following is
+    delimited aspect is the higher of the two such that the following is
     valid (albeit unusual):
 
     ```

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1,5 +1,4 @@
 """The PostgreSQL dialect."""
-
 from sqlfluff.core.parser import (
     OneOf,
     AnyNumberOf,
@@ -19,6 +18,7 @@ from sqlfluff.core.parser import (
 )
 
 from sqlfluff.core.dialects import load_raw_dialect
+from sqlfluff.dialects.dialect_ansi import JoinClauseSegment as JoinClauseSegmentAnsi
 from sqlfluff.dialects.postgres_keywords import postgres_keywords, get_keywords
 
 ansi_dialect = load_raw_dialect("ansi")
@@ -1814,3 +1814,19 @@ class FunctionSegment(BaseSegment):
         ),
         Ref("PostFunctionGrammar", optional=True),
     )
+
+
+@postgres_dialect.segment(replace=True)
+class JoinClauseSegment(JoinClauseSegmentAnsi):
+    """Any number of join clauses, including the `JOIN` keyword.
+
+    The postgres version allows for lateral joins.
+    """
+
+    sequence_list_with_lateral = (
+        *JoinClauseSegmentAnsi.sequence_list[:2],
+        Sequence("LATERAL", optional=True),
+        *JoinClauseSegmentAnsi.sequence_list[2:],
+    )
+
+    match_grammar = Sequence(*sequence_list_with_lateral)

--- a/test/dialects/postgres_test.py
+++ b/test/dialects/postgres_test.py
@@ -9,7 +9,7 @@ from sqlfluff.dialects.postgres_keywords import get_keywords, priority_keyword_m
 @pytest.mark.parametrize(
     "segment_reference,raw",
     [
-        # AT TIME ZONE constucts
+        # AT TIME ZONE constructs
         ("SelectClauseElementSegment", "c_column AT TIME ZONE 'UTC'"),
         ("SelectClauseElementSegment", "(c_column AT TIME ZONE 'UTC')::time"),
         (
@@ -139,3 +139,26 @@ def test_get_keywords():
     expected_result_2 = ["C", "E"]
 
     assert sorted(get_keywords(kw_list, "non-reserved")) == sorted(expected_result_2)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "select tbl1.id from tbl1 join tbl2 on tbl1.id = tbl2.id;",
+        "select tbl1.id from tbl1 join lateral tbl2 on tbl1.id = tbl2.id;",
+        (
+            "select tbl1.id from tbl1 "
+            "full outer join lateral tbl2 on tbl1.id = tbl2.id "
+            "cross join tbl3 on tbl1.id = tbl3.id "
+            "left join lateral tbl4 on tbl1.id = tbl4.id;"
+        ),
+    ],
+)
+def test_join_can_be_lateral(raw: str) -> None:
+    """Postgres can have a lateral joins."""
+    cfg = FluffConfig(
+        configs={"core": {"exclude_rules": "L009", "dialect": "postgres"}}
+    )
+    lnt = Linter(config=cfg)
+    result = lnt.lint_string(raw)
+    assert result.num_violations() == 0


### PR DESCRIPTION
Fixes #1040 

Provides `LATERAL` joins into Postgres dialect.

---
### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
