### PR TITLE
Support SETOF in Postgres

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -323,6 +323,7 @@ class CreateFunctionStatementSegment(BaseSegment):
                     ),
                     optional=True,
                 ),
+                Sequence("SETOF", Ref("DatatypeSegment"),),
                 Ref("DatatypeSegment"),
             ),
             optional=True,

--- a/test/fixtures/parser/postgres/postgres_create_function.sql
+++ b/test/fixtures/parser/postgres/postgres_create_function.sql
@@ -92,3 +92,12 @@ $$  LANGUAGE plpgsql
 REVOKE ALL ON FUNCTION check_password(uname TEXT, pass TEXT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION check_password(uname TEXT, pass TEXT) TO admins;
 COMMIT;
+
+CREATE OR REPLACE FUNCTION public.setof_test()
+RETURNS SETOF text
+LANGUAGE sql
+STABLE STRICT
+AS $function$
+select unnest(array['hi', 'test'])
+$function$
+;

--- a/test/fixtures/parser/postgres/postgres_create_function.yml
+++ b/test/fixtures/parser/postgres/postgres_create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5d503776245af71e84cb00d1487c4f06f0b6ab9d6307478e0a84d9207a693262
+_hash: eac5ff2a6ac7137c4ecd4296a967e807932fb33ec25b347b8676442e7e7ceec1
 file:
 - statement:
     create_function_statement:
@@ -511,4 +511,30 @@ file:
 - statement:
     transaction_statement:
       keyword: COMMIT
+- statement_terminator: ;
+- statement:
+    create_function_statement:
+    - keyword: CREATE
+    - binary_operator: OR
+    - keyword: REPLACE
+    - keyword: FUNCTION
+    - function_name:
+        identifier: public
+        dot: .
+        function_name_identifier: setof_test
+    - base:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+    - keyword: RETURNS
+    - keyword: SETOF
+    - data_type:
+        data_type_identifier: text
+    - base:
+      - keyword: LANGUAGE
+      - parameter: sql
+      - keyword: STABLE
+      - keyword: STRICT
+      - keyword: AS
+      - literal: "$function$\nselect unnest(array['hi', 'test'])\n$function$"
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Fixes 1520

### Are there any other side effects of this change that we should be aware of?
Nope. Standard Grammar addition

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
