### PR TITLE
Support Double Precision in ANSI

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -547,6 +547,7 @@ class DatatypeSegment(BaseSegment):
             Bracketed(Ref("NumericLiteralSegment"), optional=True),
             Sequence(OneOf("WITH", "WITHOUT"), "TIME", "ZONE", optional=True),
         ),
+        Sequence("DOUBLE", Sequence("PRECISION", optional=True),),
         Sequence(
             OneOf(
                 Sequence(

--- a/test/fixtures/parser/ansi/create_table_double_precision.sql
+++ b/test/fixtures/parser/ansi/create_table_double_precision.sql
@@ -1,0 +1,1 @@
+CREATE TABLE test ( angle double precision );

--- a/test/fixtures/parser/ansi/create_table_double_precision.yml
+++ b/test/fixtures/parser/ansi/create_table_double_precision.yml
@@ -1,0 +1,22 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 6d3a0ef214ac96690502bf67cdab220126c5777f65faf4585d91a9868faa7efd
+file:
+  statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: test
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          identifier: angle
+          data_type:
+          - keyword: double
+          - keyword: precision
+        end_bracket: )
+  statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Fixes #1523 

### Are there any other side effects of this change that we should be aware of?
Nope. This was already supported in a similar fashion in Exasol.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
