### PR TITLE
Add a rule to warn on "= NULL" or "<> NULL" comparisons

### DIFF
--- a/src/sqlfluff/rules/L049.py
+++ b/src/sqlfluff/rules/L049.py
@@ -1,0 +1,73 @@
+"""Implementation of Rule L006."""
+
+
+from sqlfluff.core.rules.base import BaseRule, LintResult
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+
+
+@document_fix_compatible
+class Rule_L049(BaseRule):
+    """Comparisons with NULL should use "IS" or "IS NOT".
+
+    | **Anti-pattern**
+    | In this example, the <> is used to check for NULL values'.
+
+    .. code-block:: sql
+
+        SELECT
+            a
+        FROM foo
+        WHERE a <> NULL
+
+
+    | **Best practice**
+    | Use "IS" or "IS NOT" to check for NULL values.
+
+    .. code-block:: sql
+
+        SELECT
+            a
+        FROM foo
+        WHERE a IS NOT NULL
+    """
+
+    def _eval(self, segment, **kwargs):
+        """Relational operators should not be used to check for NULL values."""
+        # Iterate through children of this segment looking for any of the
+        # target types. We also check for whether any of the children start
+        # or end with the targets.
+
+        # We ignore any targets which start or finish this segment. They'll
+        # be dealt with by the parent segment. That also means that we need
+        # to have at least three children.
+
+        if len(segment.segments) <= 2:
+            return LintResult()
+
+        operator = None
+        for idx, sub_seg in enumerate(segment.segments):
+            # Skip anything which is whitespace
+            if sub_seg.is_whitespace:
+                continue
+            # Skip any non-code elements
+            if not sub_seg.is_code:
+                continue
+
+            # Is it a target in itself?
+            if not operator and sub_seg.name in ("equals", "not_equal_to"):
+                self.logger.debug(
+                    "Found Target [main] @%s: %r", sub_seg.pos_marker, sub_seg.raw
+                )
+                operator = sub_seg
+            elif operator:
+                # Skip anything which is whitespace
+                if sub_seg.is_whitespace:
+                    continue
+                # Skip any non-code elements
+                if not sub_seg.is_code:
+                    continue
+                if sub_seg.name == "null_literal":
+                    return LintResult(anchor=operator)
+
+                else:
+                    operator = None


### PR DESCRIPTION
### Brief summary of the change made

Adds a new rule, L049, that warns on use of `=` or `<>` to compare against `NULL` values. Such code should use `IS` or `IS NOT` instead. Did not add a fix routine -- should we? Are there cases (even if rare) where it's appropriate/necessary to do this?

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
