### PR TITLE
Postgres: add `CONCURRENTLY` and `FINALIZE` keywords to `DETACH PARTITION`

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -730,7 +730,13 @@ class AlterTableStatementSegment(BaseSegment):
                             "DEFAULT",
                         ),
                     ),
-                    Sequence("DETACH", "PARTITION", Ref("ParameterNameSegment")),
+                    Sequence(
+                        "DETACH",
+                        "PARTITION",
+                        Ref("ParameterNameSegment"),
+                        Ref.keyword("CONCURRENTLY", optional=True),
+                        Ref.keyword("FINALIZE", optional=True),
+                    ),
                 ),
             ),
             Sequence(

--- a/src/sqlfluff/dialects/postgres_keywords.py
+++ b/src/sqlfluff/dialects/postgres_keywords.py
@@ -306,6 +306,7 @@ postgres_docs_keywords = [
     ("FILE", "not-keyword"),
     ("FILTER", "non-reserved"),
     ("FINAL", "not-keyword"),
+    ("FINALIZE", "non-reserved"),
     ("FINISH", "not-keyword"),
     ("FIRST", "non-reserved"),
     ("FIRST_VALUE", "not-keyword"),

--- a/test/fixtures/parser/postgres/postgres_alter_table.sql
+++ b/test/fixtures/parser/postgres/postgres_alter_table.sql
@@ -75,6 +75,9 @@ ALTER TABLE cities
 ALTER TABLE measurement
     DETACH PARTITION measurement_y2015m12;
 
+ALTER TABLE measurement
+    DETACH PARTITION measurement_y2021m10 CONCURRENTLY FINALIZE;
+
 ALTER TABLE landing.workorderhistory
 ADD CONSTRAINT workorder_id_foreign_key
 FOREIGN KEY(workorderid) REFERENCES landing.workorder(id);

--- a/test/fixtures/parser/postgres/postgres_alter_table.yml
+++ b/test/fixtures/parser/postgres/postgres_alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: dcfa7d689c0b44df6919c9da2f574211959f343f126a1b38763f815f75543abc
+_hash: 264cddb2818c93bf82d95c4cd2a9ad35998aea040cba3ce7ec840dd50c3ad71b
 file:
 - statement:
     alter_table_statement:
@@ -617,6 +617,18 @@ file:
     - keyword: DETACH
     - keyword: PARTITION
     - parameter: measurement_y2015m12
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: measurement
+    - keyword: DETACH
+    - keyword: PARTITION
+    - parameter: measurement_y2021m10
+    - keyword: CONCURRENTLY
+    - keyword: FINALIZE
 - statement_terminator: ;
 - statement:
     alter_table_statement:


### PR DESCRIPTION

### Brief summary of the change made

These were added in Postgres 14

- https://www.postgresql.org/docs/14/sql-altertable.html#SQL-ALTERTABLE-DETACH-PARTITION
- https://www.postgresql.org/docs/14/sql-keywords-appendix.html


### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
