### PR TITLE
Support more complex IN (...) expressions

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1467,8 +1467,7 @@ ansi_dialect.add(
                     Bracketed(
                         OneOf(
                             Delimited(
-                                Ref("LiteralGrammar"),
-                                Ref("IntervalExpressionSegment"),
+                                Ref("Expression_A_Grammar"),
                             ),
                             Ref("SelectableGrammar"),
                             ephemeral_name="InExpression",

--- a/test/fixtures/parser/ansi/select_with_where_clause_functions.sql
+++ b/test/fixtures/parser/ansi/select_with_where_clause_functions.sql
@@ -1,0 +1,6 @@
+select
+	t.column1
+from
+	sch.table1 as t
+where
+	t.b_year in (year(getdate()) , year(getdate()) - 1);

--- a/test/fixtures/parser/ansi/select_with_where_clause_functions.yml
+++ b/test/fixtures/parser/ansi/select_with_where_clause_functions.yml
@@ -1,0 +1,69 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: eceb1338124c97da645a1c603a5a361c08a881511cd0411ad4e373044d6ca0ce
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          column_reference:
+          - identifier: t
+          - dot: .
+          - identifier: column1
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: sch
+              - dot: .
+              - identifier: table1
+            alias_expression:
+              keyword: as
+              identifier: t
+      where_clause:
+        keyword: where
+        expression:
+          column_reference:
+          - identifier: t
+          - dot: .
+          - identifier: b_year
+          keyword: in
+          bracketed:
+          - start_bracket: (
+          - function:
+              function_name:
+                function_name_identifier: year
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: getdate
+                    bracketed:
+                      start_bracket: (
+                      end_bracket: )
+                end_bracket: )
+          - comma: ','
+          - function:
+              function_name:
+                function_name_identifier: year
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: getdate
+                    bracketed:
+                      start_bracket: (
+                      end_bracket: )
+                end_bracket: )
+          - binary_operator: '-'
+          - literal: '1'
+          - end_bracket: )
+  statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Fixes #1542

### Are there any other side effects of this change that we should be aware of?
Changes the core `Expression_A_Grammar` but it matches [the reference](https://www.cockroachlabs.com/docs/v20.2/sql-grammar.html#in_expr) so not sure why this wasn't added before.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
