### PR TITLE
Remove `lint_templated_tokens` as no longer does anything

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -45,9 +45,6 @@ single_table_references = consistent
 unquoted_identifiers_policy = all
 
 # Some rules have their own specific config.
-[sqlfluff:rules:L003]
-lint_templated_tokens = True
-
 [sqlfluff:rules:L007]  # Keywords
 operator_new_lines = after
 

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -159,8 +159,6 @@ class Linter:
                 )
                 # Don't enable the templating blocks.
                 templating_blocks_indent = False
-                # Disable the linting of L003 on templated tokens.
-                config.set_value(["rules", "L003", "lint_templated_tokens"], False)
 
         # The file will have been lexed without config, so check all indents
         # are enabled.

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -64,13 +64,6 @@ STANDARD_CONFIG_INFO_DICT = {
             "applied to keywords."
         ),
     },
-    "lint_templated_tokens": {
-        "validation": [True, False],
-        "definition": (
-            "Should lines starting with a templating placeholder"
-            " such as `{{blah}}` have their indentation linted"
-        ),
-    },
     "select_clause_trailing_comma": {
         "validation": ["forbid", "require"],
         "definition": (

--- a/src/sqlfluff/rules/L003.py
+++ b/src/sqlfluff/rules/L003.py
@@ -45,7 +45,7 @@ class Rule_L003(BaseRule):
     """
 
     _works_on_unparsable = False
-    config_keywords = ["tab_space_size", "indent_unit", "lint_templated_tokens"]
+    config_keywords = ["tab_space_size", "indent_unit"]
 
     @staticmethod
     def _make_indent(num=1, tab_space_size=4, indent_unit="space"):

--- a/test/core/rules/config_test.py
+++ b/test/core/rules/config_test.py
@@ -87,10 +87,9 @@ def test_rules_configs_are_dynamically_documented():
     class RuleWithConfig(BaseRule):
         """A new rule with configuration."""
 
-        config_keywords = ["comma_style", "lint_templated_tokens"]
+        config_keywords = ["comma_style"]
 
     assert "comma_style" in RuleWithConfig.__doc__
-    assert "lint_templated_tokens" in RuleWithConfig.__doc__
 
     @document_configuration
     class RuleWithoutConfig(BaseRule):

--- a/test/fixtures/linter/autofix/bigquery/003_templating/after.sql
+++ b/test/fixtures/linter/autofix/bigquery/003_templating/after.sql
@@ -6,7 +6,6 @@
 
 -- Force indentation linting.
 -- sqlfluff: indentation: template_blocks_indent: force
--- sqlfluff: rules: L003: lint_templated_tokens: True
 
 SELECT
     {{corr_states}}

--- a/test/fixtures/linter/autofix/bigquery/003_templating/before.sql
+++ b/test/fixtures/linter/autofix/bigquery/003_templating/before.sql
@@ -6,7 +6,6 @@
 
 -- Force indentation linting.
 -- sqlfluff: indentation: template_blocks_indent: force
--- sqlfluff: rules: L003: lint_templated_tokens: True
 
 SELECT
     {{corr_states}}


### PR DESCRIPTION
### Brief summary of the change made
Fixes #1533 
Removed unused option

### Are there any other side effects of this change that we should be aware of?
This was removed in #1444 but even before then didn't seem to do anything.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/parser` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
