### PR TITLE
Add additional metadata for the dbt templater plugin

### DIFF
--- a/plugins/sqlfluff-templater-dbt/setup.py
+++ b/plugins/sqlfluff-templater-dbt/setup.py
@@ -1,10 +1,24 @@
 """Setup file for example plugin."""
 from setuptools import find_packages, setup
 
+long_description = """
+# dbt plugin for SQLFluff
+
+This plugin works with [SQLFluff](https://pypi.org/project/sqlfluff/), the
+SQL linter for humans, to correctly parse and compile SQL projects using
+[dbt](https://pypi.org/project/dbt/).
+"""
+
+
 setup(
     name="sqlfluff-templater-dbt",
     version="0.0.1a1",
     include_package_data=True,
+    license="MIT License",
+    description="Lint your dbt project SQL.",
+    long_description=long_description,
+    # Make sure pypi is expecting markdown!
+    long_description_content_type="text/markdown",
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     install_requires=["sqlfluff>=0.7.0a1", "dbt>=0.17"],


### PR DESCRIPTION
The dbt templater plugin is failing to upload to pypi because it's missing appropriate metadata. This adds the missing fields.