### PR TITLE
Correct path in github action

### DIFF
--- a/.github/workflows/publish-dbt-templater-release-to-pypi.yaml
+++ b/.github/workflows/publish-dbt-templater-release-to-pypi.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Build Distribution (dbt plugin)
         # Run this in the right directory so that we get the right Manifest
         working-directory: plugins/sqlfluff-templater-dbt
-        run: python plugins/sqlfluff-templater-dbt/setup.py sdist bdist_wheel
+        run: python setup.py sdist bdist_wheel
       
       - name: Copy builds to main dist folder
         # We move them here so that the github action can still access them


### PR DESCRIPTION
In the github action for the plugin, I'd updated the working path but not corrected the path to the script accordingly. This means the action fails.