### PR TITLE
Snowflake: Add implementation for CREATE TASK statement (#1597)

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -125,6 +125,8 @@ snowflake_dialect.sets("unreserved_keywords").update(
         "TERSE",
         "TABULAR",
         "UNSET",
+        "USER_TASK_TIMEOUT_MS",
+        "USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE",
         "WAIT_FOR_COMPLETION",
         "WAREHOUSE_SIZE",
     ]
@@ -449,6 +451,7 @@ class StatementSegment(ansi_dialect.get_segment("StatementSegment")):  # type: i
         insert=[
             Ref("UseStatementSegment"),
             Ref("CreateStatementSegment"),
+            Ref("CreateTaskSegment"),
             Ref("CreateCloneStatementSegment"),
             Ref("ShowStatementSegment"),
             Ref("AlterUserSegment"),
@@ -1369,6 +1372,93 @@ class CreateTableStatementSegment(BaseSegment):
 
 
 @snowflake_dialect.segment()
+class CreateTaskSegment(BaseSegment):
+    """A snowflake `CREATE TASK` statement.
+
+    https://docs.snowflake.com/en/sql-reference/sql/create-task.html
+    """
+
+    type = "create_task_statement"
+
+    match_grammar = Sequence(
+        "CREATE",
+        Sequence("OR", "REPLACE", optional=True),
+        "TASK",
+        Sequence("IF", "NOT", "EXISTS", optional=True),
+        Ref("ObjectReferenceSegment"),
+        Indent,
+        Sequence(
+            "WAREHOUSE",
+            Ref("EqualsSegment"),
+            Ref("ObjectReferenceSegment"),
+            optional=True,
+        ),
+        Sequence(
+            "SCHEDULE",
+            Ref("EqualsSegment"),
+            Ref("QuotedLiteralSegment"),
+            optional=True,
+        ),
+        Sequence(
+            "ALLOW_OVERLAPPING_EXECUTION",
+            Ref("EqualsSegment"),
+            Ref("BooleanLiteralGrammar"),
+            optional=True,
+        ),
+        Delimited(
+            Sequence(
+                Ref("ParameterNameSegment"),
+                Ref("EqualsSegment"),
+                OneOf(
+                    Ref("BooleanLiteralGrammar"),
+                    Ref("QuotedLiteralSegment"),
+                    Ref("NumericLiteralSegment"),
+                ),
+            ),
+            delimiter=Ref("CommaSegment"),
+            optional=True,
+        ),
+        Sequence(
+            "USER_TASK_TIMEOUT_MS",
+            Ref("EqualsSegment"),
+            Ref("NumericLiteralSegment"),
+            optional=True,
+        ),
+        Sequence(
+            "USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE",
+            Ref("EqualsSegment"),
+            Ref("QuotedLiteralSegment"),
+            optional=True,
+        ),
+        Sequence(
+            "COPY",
+            "GRANTS",
+            optional=True,
+        ),
+        Ref("CreateStatementCommentSegment", optional=True),
+        Sequence(
+            "AFTER",
+            Ref("ObjectReferenceSegment"),
+            optional=True,
+        ),
+        Dedent,
+        Sequence(
+            "WHEN",
+            Indent,
+            Ref("ExpressionSegment"),
+            Dedent,
+            optional=True,
+        ),
+        Sequence(
+            Ref.keyword("AS"),
+            Indent,
+            Ref("StatementSegment"),
+            Dedent,
+        ),
+    )
+
+
+@snowflake_dialect.segment()
 class CreateStatementSegment(BaseSegment):
     """A snowflake `CREATE` statement.
 
@@ -1405,7 +1495,6 @@ class CreateStatementSegment(BaseSegment):
             Sequence("FILE", "FORMAT"),
             "STAGE",
             "STREAM",
-            "TASK",
         ),
         Sequence("IF", "NOT", "EXISTS", optional=True),
         Ref("ObjectReferenceSegment"),

--- a/test/fixtures/dialects/snowflake/snowflake_create_task.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_create_task.sql
@@ -1,0 +1,86 @@
+-- Examples from the documentation
+
+CREATE TASK t1
+    SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles'
+    TIMESTAMP_INPUT_FORMAT = 'YYYY-MM-DD HH24'
+    USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = 'XSMALL'
+AS
+    INSERT INTO mytable(ts) VALUES(1);
+
+CREATE TASK mytask_hour
+    WAREHOUSE = mywh
+    SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles'
+    TIMESTAMP_INPUT_FORMAT = 'YYYY-MM-DD HH24'
+AS
+    INSERT INTO mytable(ts) VALUES(1, 2, 3);
+
+-- All possible optional clauses
+CREATE OR REPLACE TASK IF NOT EXISTS t1
+    WAREHOUSE = mywh
+    SCHEDULE = 'USING CRON 0 9-17 * * SUN America/Los_Angeles'
+    ALLOW_OVERLAPPING_EXECUTION = TRUE
+    TIMESTAMP_INPUT_FORMAT = 'YYYY-MM-DD HH24'
+    USER_TASK_TIMEOUT_MS = 25
+    USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = 'XSMALL'
+    COPY GRANTS
+    COMMENT = 'Hello world'
+    AFTER dependency_task
+AS
+    INSERT INTO mytable(ts) VALUES(1);
+
+-- Only mandatory clauses
+CREATE TASK t1
+AS
+    INSERT INTO mytable(ts) VALUES(1);
+
+-- Real life examples
+CREATE OR REPLACE TASK insert_session
+    WAREHOUSE = eng_wh
+    SCHEDULE = 'USING CRON 45 6 * * * UTC'
+AS
+    INSERT INTO sch.s_session
+    SELECT
+        *,
+        sum(break) OVER (PARTITION BY serial ORDER BY datetime) AS session_id
+    FROM
+        (
+            SELECT *
+            FROM base_table
+        )
+;
+
+
+CREATE OR REPLACE TASK update_session
+    WAREHOUSE = eng_wh
+    AFTER insert_session
+AS
+    UPDATE sch.s_session
+    SET lag_datetime = v.lag_datetime, row_number = v.row_number
+    FROM
+        (
+            SELECT
+                *,
+                (
+                    sum(break) OVER (PARTITION BY serial ORDER BY datetime)
+                ) AS session_id
+            FROM
+                (
+                    SELECT *
+                    FROM derived_table
+                )
+            ORDER BY serial, datetime
+        ) AS v
+    WHERE sch.s_session.event_id = v.event_id
+;
+
+CREATE OR REPLACE TASK sch.truncate_session
+    WAREHOUSE = eng_wh
+    AFTER sch.update_session
+AS
+    CALL sch.session_agg_insert();
+
+CREATE OR REPLACE TASK insert__agg
+    WAREHOUSE = eng_wh
+    SCHEDULE = 'USING CRON 15 7 2 * * UTC'
+AS
+    CALL auto_device_insert();

--- a/test/fixtures/dialects/snowflake/snowflake_create_task.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_create_task.yml
@@ -1,0 +1,447 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 30f5f73cf11d4e4c4483381ee36a2c8dd448e80932b59d6d468e9286882f755f
+file:
+- statement:
+    create_task_statement:
+    - keyword: CREATE
+    - keyword: TASK
+    - object_reference:
+        identifier: t1
+    - keyword: SCHEDULE
+    - comparison_operator: '='
+    - literal: "'USING CRON 0 9-17 * * SUN America/Los_Angeles'"
+    - parameter: TIMESTAMP_INPUT_FORMAT
+    - comparison_operator: '='
+    - literal: "'YYYY-MM-DD HH24'"
+    - keyword: USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE
+    - comparison_operator: '='
+    - literal: "'XSMALL'"
+    - keyword: AS
+    - statement:
+        insert_statement:
+        - keyword: INSERT
+        - keyword: INTO
+        - table_reference:
+            identifier: mytable
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              identifier: ts
+            end_bracket: )
+        - values_clause:
+            keyword: VALUES
+            bracketed:
+              start_bracket: (
+              literal: '1'
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_task_statement:
+    - keyword: CREATE
+    - keyword: TASK
+    - object_reference:
+        identifier: mytask_hour
+    - keyword: WAREHOUSE
+    - comparison_operator: '='
+    - object_reference:
+        identifier: mywh
+    - keyword: SCHEDULE
+    - comparison_operator: '='
+    - literal: "'USING CRON 0 9-17 * * SUN America/Los_Angeles'"
+    - parameter: TIMESTAMP_INPUT_FORMAT
+    - comparison_operator: '='
+    - literal: "'YYYY-MM-DD HH24'"
+    - keyword: AS
+    - statement:
+        insert_statement:
+        - keyword: INSERT
+        - keyword: INTO
+        - table_reference:
+            identifier: mytable
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              identifier: ts
+            end_bracket: )
+        - values_clause:
+            keyword: VALUES
+            bracketed:
+            - start_bracket: (
+            - literal: '1'
+            - comma: ','
+            - literal: '2'
+            - comma: ','
+            - literal: '3'
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_task_statement:
+    - keyword: CREATE
+    - binary_operator: OR
+    - keyword: REPLACE
+    - keyword: TASK
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - object_reference:
+        identifier: t1
+    - keyword: WAREHOUSE
+    - comparison_operator: '='
+    - object_reference:
+        identifier: mywh
+    - keyword: SCHEDULE
+    - comparison_operator: '='
+    - literal: "'USING CRON 0 9-17 * * SUN America/Los_Angeles'"
+    - keyword: ALLOW_OVERLAPPING_EXECUTION
+    - comparison_operator: '='
+    - literal: 'TRUE'
+    - parameter: TIMESTAMP_INPUT_FORMAT
+    - comparison_operator: '='
+    - literal: "'YYYY-MM-DD HH24'"
+    - keyword: USER_TASK_TIMEOUT_MS
+    - comparison_operator: '='
+    - literal: '25'
+    - keyword: USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE
+    - comparison_operator: '='
+    - literal: "'XSMALL'"
+    - keyword: COPY
+    - keyword: GRANTS
+    - snowflake_comment:
+        keyword: COMMENT
+        comparison_operator: '='
+        literal: "'Hello world'"
+    - keyword: AFTER
+    - object_reference:
+        identifier: dependency_task
+    - keyword: AS
+    - statement:
+        insert_statement:
+        - keyword: INSERT
+        - keyword: INTO
+        - table_reference:
+            identifier: mytable
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              identifier: ts
+            end_bracket: )
+        - values_clause:
+            keyword: VALUES
+            bracketed:
+              start_bracket: (
+              literal: '1'
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_task_statement:
+    - keyword: CREATE
+    - keyword: TASK
+    - object_reference:
+        identifier: t1
+    - keyword: AS
+    - statement:
+        insert_statement:
+        - keyword: INSERT
+        - keyword: INTO
+        - table_reference:
+            identifier: mytable
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              identifier: ts
+            end_bracket: )
+        - values_clause:
+            keyword: VALUES
+            bracketed:
+              start_bracket: (
+              literal: '1'
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_task_statement:
+    - keyword: CREATE
+    - binary_operator: OR
+    - keyword: REPLACE
+    - keyword: TASK
+    - object_reference:
+        identifier: insert_session
+    - keyword: WAREHOUSE
+    - comparison_operator: '='
+    - object_reference:
+        identifier: eng_wh
+    - keyword: SCHEDULE
+    - comparison_operator: '='
+    - literal: "'USING CRON 45 6 * * * UTC'"
+    - keyword: AS
+    - statement:
+        insert_statement:
+        - keyword: INSERT
+        - keyword: INTO
+        - table_reference:
+          - identifier: sch
+          - dot: .
+          - identifier: s_session
+        - select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            - comma: ','
+            - select_clause_element:
+                function:
+                  function_name:
+                    function_name_identifier: sum
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: break
+                    end_bracket: )
+                  over_clause:
+                    keyword: OVER
+                    bracketed:
+                      start_bracket: (
+                      window_specification:
+                        partitionby_clause:
+                        - keyword: PARTITION
+                        - keyword: BY
+                        - expression:
+                            column_reference:
+                              identifier: serial
+                        orderby_clause:
+                        - keyword: ORDER
+                        - keyword: BY
+                        - column_reference:
+                            identifier: datetime
+                      end_bracket: )
+                alias_expression:
+                  keyword: AS
+                  identifier: session_id
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    bracketed:
+                      start_bracket: (
+                      select_statement:
+                        select_clause:
+                          keyword: SELECT
+                          select_clause_element:
+                            wildcard_expression:
+                              wildcard_identifier:
+                                star: '*'
+                        from_clause:
+                          keyword: FROM
+                          from_expression:
+                            from_expression_element:
+                              table_expression:
+                                table_reference:
+                                  identifier: base_table
+                      end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_task_statement:
+    - keyword: CREATE
+    - binary_operator: OR
+    - keyword: REPLACE
+    - keyword: TASK
+    - object_reference:
+        identifier: update_session
+    - keyword: WAREHOUSE
+    - comparison_operator: '='
+    - object_reference:
+        identifier: eng_wh
+    - keyword: AFTER
+    - object_reference:
+        identifier: insert_session
+    - keyword: AS
+    - statement:
+        update_statement:
+          keyword: UPDATE
+          table_reference:
+          - identifier: sch
+          - dot: .
+          - identifier: s_session
+          set_clause_list:
+          - keyword: SET
+          - set_clause:
+            - column_reference:
+                identifier: lag_datetime
+            - comparison_operator: '='
+            - column_reference:
+              - identifier: v
+              - dot: .
+              - identifier: lag_datetime
+          - comma: ','
+          - set_clause:
+            - column_reference:
+                identifier: row_number
+            - comparison_operator: '='
+            - column_reference:
+              - identifier: v
+              - dot: .
+              - identifier: row_number
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  bracketed:
+                    start_bracket: (
+                    select_statement:
+                      select_clause:
+                      - keyword: SELECT
+                      - select_clause_element:
+                          wildcard_expression:
+                            wildcard_identifier:
+                              star: '*'
+                      - comma: ','
+                      - select_clause_element:
+                          expression:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                function:
+                                  function_name:
+                                    function_name_identifier: sum
+                                  bracketed:
+                                    start_bracket: (
+                                    expression:
+                                      column_reference:
+                                        identifier: break
+                                    end_bracket: )
+                                  over_clause:
+                                    keyword: OVER
+                                    bracketed:
+                                      start_bracket: (
+                                      window_specification:
+                                        partitionby_clause:
+                                        - keyword: PARTITION
+                                        - keyword: BY
+                                        - expression:
+                                            column_reference:
+                                              identifier: serial
+                                        orderby_clause:
+                                        - keyword: ORDER
+                                        - keyword: BY
+                                        - column_reference:
+                                            identifier: datetime
+                                      end_bracket: )
+                              end_bracket: )
+                          alias_expression:
+                            keyword: AS
+                            identifier: session_id
+                      from_clause:
+                        keyword: FROM
+                        from_expression:
+                          from_expression_element:
+                            table_expression:
+                              bracketed:
+                                start_bracket: (
+                                select_statement:
+                                  select_clause:
+                                    keyword: SELECT
+                                    select_clause_element:
+                                      wildcard_expression:
+                                        wildcard_identifier:
+                                          star: '*'
+                                  from_clause:
+                                    keyword: FROM
+                                    from_expression:
+                                      from_expression_element:
+                                        table_expression:
+                                          table_reference:
+                                            identifier: derived_table
+                                end_bracket: )
+                      orderby_clause:
+                      - keyword: ORDER
+                      - keyword: BY
+                      - column_reference:
+                          identifier: serial
+                      - comma: ','
+                      - column_reference:
+                          identifier: datetime
+                    end_bracket: )
+                alias_expression:
+                  keyword: AS
+                  identifier: v
+          where_clause:
+            keyword: WHERE
+            expression:
+            - column_reference:
+              - identifier: sch
+              - dot: .
+              - identifier: s_session
+              - dot: .
+              - identifier: event_id
+            - comparison_operator: '='
+            - column_reference:
+              - identifier: v
+              - dot: .
+              - identifier: event_id
+- statement_terminator: ;
+- statement:
+    create_task_statement:
+    - keyword: CREATE
+    - binary_operator: OR
+    - keyword: REPLACE
+    - keyword: TASK
+    - object_reference:
+      - identifier: sch
+      - dot: .
+      - identifier: truncate_session
+    - keyword: WAREHOUSE
+    - comparison_operator: '='
+    - object_reference:
+        identifier: eng_wh
+    - keyword: AFTER
+    - object_reference:
+      - identifier: sch
+      - dot: .
+      - identifier: update_session
+    - keyword: AS
+    - statement:
+        call_segment:
+          keyword: CALL
+          function:
+            function_name:
+              identifier: sch
+              dot: .
+              function_name_identifier: session_agg_insert
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_task_statement:
+    - keyword: CREATE
+    - binary_operator: OR
+    - keyword: REPLACE
+    - keyword: TASK
+    - object_reference:
+        identifier: insert__agg
+    - keyword: WAREHOUSE
+    - comparison_operator: '='
+    - object_reference:
+        identifier: eng_wh
+    - keyword: SCHEDULE
+    - comparison_operator: '='
+    - literal: "'USING CRON 15 7 2 * * UTC'"
+    - keyword: AS
+    - statement:
+        call_segment:
+          keyword: CALL
+          function:
+            function_name:
+              function_name_identifier: auto_device_insert
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Closes #1597 

This PR adds an implementation for the ``CREATE TASK`` expression for the Snowflake dialect as described [in the docs](https://docs.snowflake.com/en/sql-reference/sql/create-task.html)

```
CREATE [ OR REPLACE ] TASK [ IF NOT EXISTS ] <name>
  [ WAREHOUSE = <string> ]
  [ SCHEDULE = '{ <num> MINUTE | USING CRON <expr> <time_zone> }' ]
  [ ALLOW_OVERLAPPING_EXECUTION = TRUE | FALSE ]
  [ <session_parameter> = <value> [ , <session_parameter> = <value> ... ] ]
  [ USER_TASK_TIMEOUT_MS = <num> ]
  [ USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE = <string> ]
  [ COPY GRANTS ]
  [ COMMENT = '<string_literal>' ]
  [ AFTER <string> ]
[ WHEN <boolean_expr> ]
AS
  <sql>
```

Open questions/issues:
- [x] How to implement the ``WHEN`` clause?
- [ ] ``SCHEDULE`` clause is implemented as literal string, not broken down further
- [ ] Is the implementation of using a generic ``StatementSegment`` for the ``AS`` clause correct?