### PR TITLE
TSQL: Allow for !>, !< operators

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -24,6 +24,8 @@ from sqlfluff.core.parser import (
     Indent,
     AnyNumberOf,
     CommentSegment,
+    StringParser,
+    SymbolSegment,
 )
 
 from sqlfluff.core.dialects import load_raw_dialect
@@ -74,6 +76,9 @@ tsql_dialect.patch_lexer_matchers(
             CommentSegment,
             segment_kwargs={"trim_start": ("--")},
         ),
+        # Patching to add !<, !>
+        RegexLexer("greater_than_or_equal", ">=|!<", CodeSegment),
+        RegexLexer("less_than_or_equal", "<=|!>", CodeSegment),
     ]
 )
 
@@ -88,9 +93,27 @@ tsql_dialect.add(
     QuotedLiteralSegmentWithN=NamedParser(
         "single_quote_with_n", CodeSegment, name="quoted_literal", type="literal"
     ),
+    NotGreaterThanSegment=StringParser(
+        "!>", SymbolSegment, name="less_than_equal_to", type="comparison_operator"
+    ),
+    NotLessThanSegment=StringParser(
+        "!<", SymbolSegment, name="greater_than_equal_to", type="comparison_operator"
+    ),
 )
 
 tsql_dialect.replace(
+    ComparisonOperatorGrammar=OneOf(
+        Ref("EqualsSegment"),
+        Ref("GreaterThanSegment"),
+        Ref("LessThanSegment"),
+        Ref("GreaterThanOrEqualToSegment"),
+        Ref("LessThanOrEqualToSegment"),
+        Ref("NotEqualToSegment_a"),
+        Ref("NotEqualToSegment_b"),
+        Ref("LikeOperatorSegment"),
+        Ref("NotGreaterThanSegment"),
+        Ref("NotLessThanSegment"),
+    ),
     SingleIdentifierGrammar=OneOf(
         Ref("NakedIdentifierSegment"),
         Ref("QuotedIdentifierSegment"),

--- a/test/fixtures/dialects/tsql/select.sql
+++ b/test/fixtures/dialects/tsql/select.sql
@@ -1,0 +1,13 @@
+--For testing valid select clause elements
+SELECT
+	CASE WHEN 1 = 1 THEN 'True'
+		 WHEN 1 > 1 THEN 'False'
+		 WHEN 1 < 1 THEN 'False'
+		 WHEN 1 >= 1 THEN 'True'
+		 WHEN 1 <= 1 THEN 'True'
+		 WHEN 1 <> 1 THEN 'False'
+		 WHEN 1 !< 1 THEN 'Why is this a thing?'
+		 WHEN 1 != 1 THEN 'False'
+		 WHEN 1 !> 1 THEN 'NULL Handling, Probably'
+		 ELSE 'Silly Tests'
+	END

--- a/test/fixtures/dialects/tsql/select.yml
+++ b/test/fixtures/dialects/tsql/select.yml
@@ -1,0 +1,92 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 7a3d7a550f46510b3607368ba5d59bd5cbbbc183c7e48dcf23d6761ee6e39161
+file:
+  batch:
+    statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - keyword: WHEN
+              - expression:
+                - literal: '1'
+                - comparison_operator: '='
+                - literal: '1'
+              - keyword: THEN
+              - expression:
+                  literal: "'True'"
+              - keyword: WHEN
+              - expression:
+                - literal: '1'
+                - comparison_operator: '>'
+                - literal: '1'
+              - keyword: THEN
+              - expression:
+                  literal: "'False'"
+              - keyword: WHEN
+              - expression:
+                - literal: '1'
+                - comparison_operator: <
+                - literal: '1'
+              - keyword: THEN
+              - expression:
+                  literal: "'False'"
+              - keyword: WHEN
+              - expression:
+                - literal: '1'
+                - comparison_operator: '>='
+                - literal: '1'
+              - keyword: THEN
+              - expression:
+                  literal: "'True'"
+              - keyword: WHEN
+              - expression:
+                - literal: '1'
+                - comparison_operator: <=
+                - literal: '1'
+              - keyword: THEN
+              - expression:
+                  literal: "'True'"
+              - keyword: WHEN
+              - expression:
+                - literal: '1'
+                - comparison_operator: <>
+                - literal: '1'
+              - keyword: THEN
+              - expression:
+                  literal: "'False'"
+              - keyword: WHEN
+              - expression:
+                - literal: '1'
+                - comparison_operator: '!<'
+                - literal: '1'
+              - keyword: THEN
+              - expression:
+                  literal: "'Why is this a thing?'"
+              - keyword: WHEN
+              - expression:
+                - literal: '1'
+                - comparison_operator: '!='
+                - literal: '1'
+              - keyword: THEN
+              - expression:
+                  literal: "'False'"
+              - keyword: WHEN
+              - expression:
+                - literal: '1'
+                - comparison_operator: '!>'
+                - literal: '1'
+              - keyword: THEN
+              - expression:
+                  literal: "'NULL Handling, Probably'"
+              - keyword: ELSE
+              - expression:
+                  literal: "'Silly Tests'"
+              - keyword: END


### PR DESCRIPTION
I had no idea, but my codebase is aware that TSQL supports comparison operators !> and !<.  

TSQL changes:
import StringParser, SymbolSegment
+RegexLexers to override ANSI <= and >= for both
+StringParsers for both
Update ComparisonOperator to include both StringParsers
New test case including all comparison operators