### PR TITLE
MySQL: Change and drop column in alter table

### DIFF
--- a/test/fixtures/dialects/mysql/alter_table.sql
+++ b/test/fixtures/dialects/mysql/alter_table.sql
@@ -2,3 +2,24 @@ ALTER TABLE `users`
     MODIFY COLUMN
     `name` varchar(255) NOT NULL,
     COMMENT "name of user";
+
+ALTER TABLE `users` RENAME TO `user`;
+
+ALTER TABLE `user` RENAME AS `users`;
+
+ALTER TABLE `users` RENAME `user`;
+
+ALTER TABLE `users`
+CHANGE COLUMN `birthday` `date_of_birth` INT(11) NULL DEFAULT NULL;
+
+ALTER TABLE `users`
+CHANGE COLUMN `birthday` `date_of_birth` INT(11) NOT NULL;
+
+ALTER TABLE `users`
+CHANGE COLUMN `birthday` `date_of_birth` INT(11) FIRST;
+
+ALTER TABLE `users`
+CHANGE COLUMN `birthday` `date_of_birth` INT(11) AFTER `name`;
+
+ALTER TABLE `users`
+DROP COLUMN `age`;

--- a/test/fixtures/dialects/mysql/alter_table.yml
+++ b/test/fixtures/dialects/mysql/alter_table.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 58d5de301d45cbee14a06aed404dc92d347eca4acb9b1104cd2cb64956b2ff0f
+_hash: 334ab689c5b966ac68643b7eaea3e499a10b695e5428c3a92753ea7a4f7705e5
 file:
-  statement:
+- statement:
     alter_table_statement:
     - keyword: ALTER
     - keyword: TABLE
@@ -28,4 +28,139 @@ file:
     - comma: ','
     - parameter: COMMENT
     - literal: '"name of user"'
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: '`users`'
+    - keyword: RENAME
+    - keyword: TO
+    - table_reference:
+        identifier: '`user`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: '`user`'
+    - keyword: RENAME
+    - keyword: AS
+    - table_reference:
+        identifier: '`users`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: '`users`'
+    - keyword: RENAME
+    - table_reference:
+        identifier: '`user`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: '`users`'
+    - keyword: CHANGE
+    - keyword: COLUMN
+    - column_reference:
+        identifier: '`birthday`'
+    - column_definition:
+      - identifier: '`date_of_birth`'
+      - data_type:
+          data_type_identifier: INT
+          bracketed:
+            start_bracket: (
+            expression:
+              literal: '11'
+            end_bracket: )
+      - column_constraint_segment:
+          keyword: 'NULL'
+      - column_constraint_segment:
+          keyword: DEFAULT
+          literal: 'NULL'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: '`users`'
+    - keyword: CHANGE
+    - keyword: COLUMN
+    - column_reference:
+        identifier: '`birthday`'
+    - column_definition:
+        identifier: '`date_of_birth`'
+        data_type:
+          data_type_identifier: INT
+          bracketed:
+            start_bracket: (
+            expression:
+              literal: '11'
+            end_bracket: )
+        column_constraint_segment:
+        - keyword: NOT
+        - keyword: 'NULL'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: '`users`'
+    - keyword: CHANGE
+    - keyword: COLUMN
+    - column_reference:
+        identifier: '`birthday`'
+    - column_definition:
+        identifier: '`date_of_birth`'
+        data_type:
+          data_type_identifier: INT
+          bracketed:
+            start_bracket: (
+            expression:
+              literal: '11'
+            end_bracket: )
+    - keyword: FIRST
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: '`users`'
+    - keyword: CHANGE
+    - keyword: COLUMN
+    - column_reference:
+        identifier: '`birthday`'
+    - column_definition:
+        identifier: '`date_of_birth`'
+        data_type:
+          data_type_identifier: INT
+          bracketed:
+            start_bracket: (
+            expression:
+              literal: '11'
+            end_bracket: )
+    - keyword: AFTER
+    - column_reference:
+        identifier: '`name`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: '`users`'
+    - keyword: DROP
+    - keyword: COLUMN
+    - column_reference:
+        identifier: '`age`'
+- statement_terminator: ;


### PR DESCRIPTION
- [x] Add support for change column and drop column in an alter table statement

Fixes #1628

I added a new alter table definition instead of adding my changes to the ANSI one as suggested by @tunetheweb here: https://github.com/sqlfluff/sqlfluff/issues/1628#issuecomment-942475593 because I'm really new to Python and it seemed safer to only change and test the MySQL dialect.

I also limited my change to the couple of use cases in the original issue. 

I could try to work on a couple more use cases from the [MySQL docs](https://dev.mysql.com/doc/refman/8.0/en/alter-table.html) shared by @WittierDinosaur with a little of guidance.


### Are there any other side effects of this change that we should be aware of?

Not that I know.

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

