### PR TITLE
Indent LIMIT values if on separate line

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1738,6 +1738,7 @@ class LimitClauseSegment(BaseSegment):
     type = "limit_clause"
     match_grammar = Sequence(
         "LIMIT",
+        Indent,
         OneOf(
             Ref("NumericLiteralSegment"),
             Sequence(
@@ -1749,6 +1750,7 @@ class LimitClauseSegment(BaseSegment):
                 Ref("NumericLiteralSegment"),
             ),
         ),
+        Dedent,
     )
 
 

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -42,13 +42,11 @@ test_fail_tab_indentation:
     	a,
     b
     FROM my_tbl
-
   fix_str: |
     SELECT
     	a,
     	b
     FROM my_tbl
-
   configs:
     rules:
       indent_unit: tab
@@ -67,7 +65,6 @@ test_pass_indented_joins_false:
     SELECT a, b, c
     FROM my_tbl
     LEFT JOIN another_tbl USING(a)
-
   configs:
     indentation:
       indented_joins: false
@@ -89,12 +86,10 @@ test_fail_indented_joins_true_fix:
     SELECT a, b, c
     FROM my_tbl
     LEFT JOIN another_tbl USING(a)
-
   fix_str: |
     SELECT a, b, c
     FROM my_tbl
         LEFT JOIN another_tbl USING(a)
-
   configs:
     indentation:
       indented_joins: true
@@ -105,12 +100,10 @@ test_fail_indented_joins_false_fix:
     SELECT a, b, c
     FROM my_tbl
         LEFT JOIN another_tbl USING(a)
-
   fix_str: |
     SELECT a, b, c
     FROM my_tbl
     LEFT JOIN another_tbl USING(a)
-
   configs:
     indentation:
       indented_joins: false
@@ -131,7 +124,6 @@ test_pass_indented_using_on_true:
     FROM my_tbl
         LEFT JOIN another_tbl
             USING(a)
-
   configs:
     indentation:
       indented_joins: true
@@ -144,7 +136,6 @@ test_pass_indented_using_on_false:
     FROM my_tbl
         LEFT JOIN another_tbl
         USING(a)
-
   configs:
     indentation:
       indented_joins: true
@@ -157,13 +148,11 @@ test_fail_indented_using_on_false:
     FROM my_tbl
         LEFT JOIN another_tbl
             USING(a)
-
   fix_str: |
     SELECT a, b, c
     FROM my_tbl
         LEFT JOIN another_tbl
         USING(a)
-
   configs:
     indentation:
       indented_joins: true
@@ -176,13 +165,11 @@ test_fail_indented_joins_using_on_false:
     FROM my_tbl
         LEFT JOIN another_tbl
         USING(a)
-
   fix_str: |
     SELECT a, b, c
     FROM my_tbl
         LEFT JOIN another_tbl
             USING(a)
-
   configs:
     indentation:
       indented_joins: true
@@ -195,13 +182,11 @@ test_fail_indented_joins_using_on_false:
     FROM my_tbl
         LEFT JOIN another_tbl
             USING(a)
-
   fix_str: |
     SELECT a, b, c
     FROM my_tbl
     LEFT JOIN another_tbl
     USING(a)
-
   configs:
     indentation:
       indented_joins: false
@@ -222,7 +207,6 @@ test_fail_indented_from_with_comment_fix:
         t1
         -- Comment
     JOIN t2 USING (user_id)
-
   fix_str: |
     SELECT *
     FROM
@@ -258,7 +242,6 @@ test_fail_attempted_hanger_fix:
     SELECT coalesce(foo,
                   bar)
        FROM tbl
-
   fix_str: |
     SELECT coalesce(foo,
                     bar)
@@ -272,7 +255,6 @@ test_fail_possible_hanger_fix:
     SELECT coalesce(foo,
      bar)
        FROM tbl
-
   fix_str: |
     SELECT coalesce(foo,
                     bar)
@@ -288,7 +270,6 @@ test_fail_consecutive_hangers:
       and d like 'd%'
       and e like 'e%'
       and f like 'f%'
-
   fix_str: |
     select *
     from foo
@@ -309,7 +290,6 @@ test_fail_clean_reindent_fix:
     foo,
                     bar)
        FROM tbl
-
   fix_str: |
     SELECT coalesce(
         foo,
@@ -325,7 +305,6 @@ test_pass_indent_snowflake:
 
     select *
     from source_data
-
   configs:
     core:
       dialect: snowflake
@@ -336,10 +315,8 @@ test_pass_indent_indent_bigquery:
     with source_data as (
         select * from {{ source('source_name', 'xxx_yyy_zzz') }}
     )
-
     select *
     from source_data
-
   configs:
     core:
       dialect: bigquery
@@ -402,3 +379,43 @@ test_jinja_indent_templated_table_name_b:
         {{ product }}
     {% if not loop.last -%} UNION ALL {%- endif %}
     {% endfor %}
+
+# LIMIT and QUALIFY both indent
+test_limit_and_qualify_indent:
+  fail_str: |
+    SELECT
+        a,
+        b
+    FROM
+    my_tbl
+    QUALIFY
+    1
+    LIMIT
+    1
+  fix_str: |
+    SELECT
+        a,
+        b
+    FROM
+        my_tbl
+    QUALIFY
+        1
+    LIMIT
+        1
+  configs:
+    core:
+      dialect: bigquery
+
+# LIMIT and QUALIFY both acceptable on single line
+test_limit_and_qualify_single_line:
+  pass_str: |
+    SELECT
+        a,
+        b
+    FROM
+        my_tbl
+    QUALIFY 1
+    LIMIT 1
+  configs:
+    core:
+      dialect: bigquery


### PR DESCRIPTION
### Brief summary of the change made
Fixes #1682 


### Are there any other side effects of this change that we should be aware of?
Removed a lot of newlines from the test file that I feel made it difficult to read the test cases (since a single new line is also the test case separator).

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
