### PR TITLE
Add missing test case

### DIFF
--- a/test/core/parser/lexer_test.py
+++ b/test/core/parser/lexer_test.py
@@ -161,3 +161,4 @@ def test__parser__lexer_trim_post_subdivide(caplog):
         assert res.elements[0].raw == ";"
         assert res.elements[1].raw == "\n"
         assert res.elements[2].raw == "/"
+        assert len(res.elements) == 3


### PR DESCRIPTION
### Brief summary of the change made
#1696 removed the only `RegexLexer` with a `trim_post_subdivide`. This reduced our test case coverage below the magic 100%.

This PR adds back a test case for that to bring us back up to 100%.

As it's not used we could just remove the code, but could be useful in future.

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
