### PR TITLE
TSQL - add IDENTITY column constraint

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -832,6 +832,7 @@ class ColumnConstraintSegment(BaseSegment):
                 Ref("BracketedColumnReferenceListGrammar", optional=True),
             ),
             Ref("CommentClauseSegment"),
+            Ref("IdentityGrammar"),
         ),
     )
 
@@ -1332,6 +1333,28 @@ class FilegroupClause(BaseSegment):
     match_grammar = Sequence(
         "ON",
         Ref("SingleIdentifierGrammar"),
+    )
+
+
+@tsql_dialect.segment()
+class IdentityGrammar(BaseSegment):
+    """`IDENTITY (1,1)` in table schemas.
+
+    https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql-identity-property?view=sql-server-ver15
+    """
+
+    type = "identity_grammar"
+    match_grammar = Sequence(
+        "IDENTITY",
+        # optional (seed, increment) e.g. (1, 1)
+        Bracketed(
+            Sequence(
+                Ref("NumericLiteralSegment"),
+                Ref("CommaSegment"),
+                Ref("NumericLiteralSegment"),
+            ),
+            optional=True,
+        ),
     )
 
 

--- a/test/fixtures/dialects/tsql/create_table_constraints.sql
+++ b/test/fixtures/dialects/tsql/create_table_constraints.sql
@@ -1,0 +1,6 @@
+CREATE TABLE [dbo].[example](
+    [Column A] [int] IDENTITY,
+    [Column B] [int] IDENTITY(1, 1) NOT NULL,
+    [ColumnC] varchar(100) DEFAULT 'mydefault',
+    [ColumnDecimal] DATE DEFAULT GETDATE()
+)

--- a/test/fixtures/dialects/tsql/create_table_constraints.yml
+++ b/test/fixtures/dialects/tsql/create_table_constraints.yml
@@ -1,0 +1,69 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 00ac2b2b84ec5ad7b4403e585311d99ac16677e09ca4ece6ea9ebbc3f3e83177
+file:
+  batch:
+    statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - identifier: '[dbo]'
+        - dot: .
+        - identifier: '[example]'
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: '[Column A]'
+            data_type:
+              identifier: '[int]'
+            column_constraint_segment:
+              identity_grammar:
+                keyword: IDENTITY
+        - comma: ','
+        - column_definition:
+          - identifier: '[Column B]'
+          - data_type:
+              identifier: '[int]'
+          - column_constraint_segment:
+              identity_grammar:
+                keyword: IDENTITY
+                bracketed:
+                - start_bracket: (
+                - literal: '1'
+                - comma: ','
+                - literal: '1'
+                - end_bracket: )
+          - column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            identifier: '[ColumnC]'
+            data_type:
+              identifier: varchar
+              bracketed:
+                start_bracket: (
+                expression:
+                  literal: '100'
+                end_bracket: )
+            column_constraint_segment:
+              keyword: DEFAULT
+              literal: "'mydefault'"
+        - comma: ','
+        - column_definition:
+            identifier: '[ColumnDecimal]'
+            data_type:
+              identifier: DATE
+            column_constraint_segment:
+              keyword: DEFAULT
+              function:
+                function_name:
+                  function_name_identifier: GETDATE
+                bracketed:
+                  start_bracket: (
+                  end_bracket: )
+        - end_bracket: )


### PR DESCRIPTION
### Brief summary of the change made

Adds IDENTITY(1,1) as a valid table creation column constraint for TSQL as per https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql-identity-property?view=sql-server-ver15

Partially fixes #1728

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
