### PR TITLE
L029: Check quoted identifiers in addition to naked identifiers

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -71,6 +71,7 @@ force_enable = False
 
 [sqlfluff:rules:L029]  # Keyword identifiers
 unquoted_identifiers_policy = aliases
+quoted_identifiers_policy = none
 
 [sqlfluff:rules:L030]  # Function names
 capitalisation_policy = consistent

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -52,6 +52,10 @@ STANDARD_CONFIG_INFO_DICT = {
         "validation": ["all", "aliases", "column_aliases"],
         "definition": "Types of unquoted identifiers to flag violations for",
     },
+    "quoted_identifiers_policy": {
+        "validation": ["all", "aliases", "column_aliases", "none"],
+        "definition": "Types of quoted identifiers to flag violations for",
+    },
     "capitalisation_policy": {
         "validation": ["consistent", "upper", "lower", "capitalise"],
         "definition": "The capitalisation policy to enforce",

--- a/src/sqlfluff/rules/L014.py
+++ b/src/sqlfluff/rules/L014.py
@@ -11,10 +11,10 @@ from sqlfluff.core.rules.doc_decorators import (
 from sqlfluff.rules.L010 import Rule_L010
 
 
-def unquoted_ids_policy_applicable(
+def identifiers_policy_applicable(
     policy: str, parent_stack: Tuple[BaseSegment, ...]
 ) -> bool:
-    """Does `unquoted_identifiers_policy` apply to this segment?"""
+    """Does `(un)quoted_identifiers_policy` apply to this segment?"""
     if policy == "all":
         return True
     is_alias = parent_stack and parent_stack[-1].is_type(
@@ -70,7 +70,7 @@ class Rule_L014(Rule_L010):
     _description_elem = "Unquoted identifiers"
 
     def _eval(self, context: RuleContext) -> LintResult:
-        if unquoted_ids_policy_applicable(
+        if identifiers_policy_applicable(
             self.unquoted_identifiers_policy, context.parent_stack  # type: ignore
         ):
             return super()._eval(context=context)

--- a/src/sqlfluff/rules/L014.py
+++ b/src/sqlfluff/rules/L014.py
@@ -17,6 +17,8 @@ def identifiers_policy_applicable(
     """Does `(un)quoted_identifiers_policy` apply to this segment?"""
     if policy == "all":
         return True
+    if policy == "none":
+        return False
     is_alias = parent_stack and parent_stack[-1].is_type(
         "alias_expression", "column_definition", "with_compound_statement"
     )

--- a/src/sqlfluff/rules/L029.py
+++ b/src/sqlfluff/rules/L029.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import document_configuration
-from sqlfluff.rules.L014 import unquoted_ids_policy_applicable
+from sqlfluff.rules.L014 import identifiers_policy_applicable
 
 
 @document_configuration
@@ -30,14 +30,14 @@ class Rule_L029(BaseRule):
 
     """
 
-    config_keywords = ["unquoted_identifiers_policy"]
+    config_keywords = ["unquoted_identifiers_policy", "quoted_identifiers_policy"]
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Keywords should not be used as identifiers."""
         if (
             (
                 context.segment.name == "naked_identifier"
-                and unquoted_ids_policy_applicable(
+                and identifiers_policy_applicable(
                     self.unquoted_identifiers_policy, context.parent_stack  # type: ignore
                 )
                 and (
@@ -48,8 +48,8 @@ class Rule_L029(BaseRule):
         ) or (
             (
                 context.segment.name == "quoted_identifier"
-                and unquoted_ids_policy_applicable(
-                    self.unquoted_identifiers_policy, context.parent_stack  # type: ignore
+                and identifiers_policy_applicable(
+                    self.quoted_identifiers_policy, context.parent_stack  # type: ignore
                 )
                 and (
                     context.segment.raw.upper()[1:-1]

--- a/src/sqlfluff/rules/L029.py
+++ b/src/sqlfluff/rules/L029.py
@@ -35,13 +35,28 @@ class Rule_L029(BaseRule):
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Keywords should not be used as identifiers."""
         if (
-            context.segment.name == "naked_identifier"
-            and unquoted_ids_policy_applicable(
-                self.unquoted_identifiers_policy, context.parent_stack  # type: ignore
+            (
+                context.segment.name == "naked_identifier"
+                and unquoted_ids_policy_applicable(
+                    self.unquoted_identifiers_policy, context.parent_stack  # type: ignore
+                )
+                and (
+                    context.segment.raw.upper()
+                    in context.dialect.sets("unreserved_keywords")
+                )
             )
-            and (
-                context.segment.raw.upper()
-                in context.dialect.sets("unreserved_keywords")
+        ) or (
+            (
+                context.segment.name == "quoted_identifier"
+                and unquoted_ids_policy_applicable(
+                    self.unquoted_identifiers_policy, context.parent_stack  # type: ignore
+                )
+                and (
+                    context.segment.raw.upper()[1:-1]
+                    in context.dialect.sets("unreserved_keywords")
+                    or context.segment.raw.upper()[1:-1]
+                    in context.dialect.sets("reserved_keywords")
+                )
             )
         ):
             return LintResult(anchor=context.segment)

--- a/test/fixtures/rules/std_rule_cases/L029.yml
+++ b/test/fixtures/rules/std_rule_cases/L029.yml
@@ -36,3 +36,10 @@ test_fail_keyword_as_identifier_5:
     rules:
       L029:
         unquoted_identifiers_policy: column_aliases
+
+test_fail_keyword_as_quoted_identifier:
+  fail_str: SELECT x AS 'date' FROM tbl AS parameter
+  configs:
+    rules:
+      L029:
+        unquoted_identifiers_policy: column_aliases

--- a/test/fixtures/rules/std_rule_cases/L029.yml
+++ b/test/fixtures/rules/std_rule_cases/L029.yml
@@ -1,47 +1,111 @@
 rule: L029
 
-test_pass_valid_identifiers_1:
+test_pass_valid_identifier:
   pass_str: CREATE TABLE artist(artist_name TEXT)
 
-test_fail_keyword_as_identifier_1:
+test_fail_keyword_as_identifier_column:
   fail_str: CREATE TABLE artist(create TEXT)
 
-test_fail_keyword_as_identifier_2:
+test_fail_keyword_as_identifier_column_alias:
   fail_str: SELECT 1 as parameter
 
-test_fail_keyword_as_identifier_3:
+test_fail_keyword_as_identifier_table_alias:
   fail_str: SELECT x FROM tbl AS parameter
 
-test_pass_valid_identifiers_2:
+test_pass_valid_identifier_not_alias:
   # should pass on default config as not alias
   pass_str: SELECT parameter
 
-test_fail_keyword_as_identifier_4:
+test_fail_keyword_as_identifier_not_alias_all:
   fail_str: SELECT parameter
   configs:
     rules:
       L029:
         unquoted_identifiers_policy: all
 
-test_pass_valid_identifiers_3:
+test_pass_valid_identifier_table_alias_column_alias_config:
   pass_str: SELECT x FROM tbl AS parameter
   configs:
     rules:
       L029:
         unquoted_identifiers_policy: column_aliases
 
-test_fail_keyword_as_identifier_5:
+test_fail_keyword_as_identifier_column_alias_config:
   fail_str: SELECT x AS date FROM tbl AS parameter
   configs:
     rules:
       L029:
         unquoted_identifiers_policy: column_aliases
 
-test_fail_keyword_as_quoted_identifier:
-  fail_str: SELECT x AS [date] FROM tbl AS parameter
+test_pass_valid_quoted_identifier:
+  pass_str: CREATE TABLE [artist]([artist_name] TEXT)
   configs:
     rules:
       L029:
-        unquoted_identifiers_policy: column_aliases
+        quoted_identifiers_policy: aliases
+    core:
+      dialect: tsql
+
+test_fail_keyword_as_quoted_identifier_column:
+  fail_str: CREATE TABLE [artist]([create] TEXT)
+  configs:
+    rules:
+      L029:
+        quoted_identifiers_policy: aliases
+    core:
+      dialect: tsql
+
+test_fail_keyword_as_quoted_identifier_column_alias:
+  fail_str: SELECT 1 as [parameter]
+  configs:
+    rules:
+      L029:
+        quoted_identifiers_policy: aliases
+    core:
+      dialect: tsql
+
+test_fail_keyword_as_quoted_identifier_table_alias:
+  fail_str: SELECT [x] FROM [tbl] AS [parameter]
+  configs:
+    rules:
+      L029:
+        quoted_identifiers_policy: aliases
+    core:
+      dialect: tsql
+
+test_pass_valid_quoted_identifier_not_alias:
+  # should pass on default config as not alias
+  pass_str: SELECT [parameter]
+  configs:
+    rules:
+      L029:
+        quoted_identifiers_policy: aliases
+    core:
+      dialect: tsql
+
+test_fail_keyword_as_quoted_identifier_not_alias_all:
+  fail_str: SELECT [parameter]
+  configs:
+    rules:
+      L029:
+        quoted_identifiers_policy: all
+    core:
+      dialect: tsql
+
+test_pass_valid_quoted_identifier_table_alias_column_alias_config:
+  pass_str: SELECT [x] FROM [tbl] AS [parameter]
+  configs:
+    rules:
+      L029:
+        quoted_identifiers_policy: column_aliases
+    core:
+      dialect: tsql
+
+test_fail_keyword_as_quoted_identifier_column_alias_config:
+  fail_str: SELECT [x] AS [date] FROM [tbl] AS [parameter]
+  configs:
+    rules:
+      L029:
+        quoted_identifiers_policy: column_aliases
     core:
       dialect: tsql

--- a/test/fixtures/rules/std_rule_cases/L029.yml
+++ b/test/fixtures/rules/std_rule_cases/L029.yml
@@ -38,8 +38,9 @@ test_fail_keyword_as_identifier_5:
         unquoted_identifiers_policy: column_aliases
 
 test_fail_keyword_as_quoted_identifier:
-  fail_str: SELECT x AS 'date' FROM tbl AS parameter
+  fail_str: SELECT x AS [date] FROM tbl AS parameter
   configs:
     rules:
       L029:
         unquoted_identifiers_policy: column_aliases
+      dialect: tsql

--- a/test/fixtures/rules/std_rule_cases/L029.yml
+++ b/test/fixtures/rules/std_rule_cases/L029.yml
@@ -43,4 +43,5 @@ test_fail_keyword_as_quoted_identifier:
     rules:
       L029:
         unquoted_identifiers_policy: column_aliases
+    core:
       dialect: tsql

--- a/test/fixtures/rules/std_rule_cases/L029.yml
+++ b/test/fixtures/rules/std_rule_cases/L029.yml
@@ -54,7 +54,7 @@ test_fail_keyword_as_quoted_identifier_column:
         quoted_identifiers_policy: aliases
 
 test_pass_keyword_as_quoted_identifier_column_none_policy:
-  fail_str: CREATE TABLE "artist"("create" TEXT)
+  pass_str: CREATE TABLE "artist"("create" TEXT)
   configs:
     rules:
       L029:

--- a/test/fixtures/rules/std_rule_cases/L029.yml
+++ b/test/fixtures/rules/std_rule_cases/L029.yml
@@ -47,13 +47,18 @@ test_pass_valid_quoted_identifier:
       dialect: tsql
 
 test_fail_keyword_as_quoted_identifier_column:
-  fail_str: CREATE TABLE [artist]([create] TEXT)
+  fail_str: CREATE TABLE "artist"("create" TEXT)
   configs:
     rules:
       L029:
         quoted_identifiers_policy: aliases
-    core:
-      dialect: tsql
+
+test_pass_keyword_as_quoted_identifier_column_none_policy:
+  fail_str: CREATE TABLE "artist"("create" TEXT)
+  configs:
+    rules:
+      L029:
+        quoted_identifiers_policy: none
 
 test_fail_keyword_as_quoted_identifier_column_alias:
   fail_str: SELECT 1 as [parameter]
@@ -109,3 +114,4 @@ test_fail_keyword_as_quoted_identifier_column_alias_config:
         quoted_identifiers_policy: column_aliases
     core:
       dialect: tsql
+


### PR DESCRIPTION
Fixes #1747

This PR adjusts L029 to optionally check quoted identifiers in addition to naked identifiers.
In order to do this, we are adding a new configuration keyword, quoted_identifiers_policy, which represents the same thing as unquoted_identifiers_policy but for quoted identifiers.
The options for quoted_identifiers_policy are the same as unquoted_identifiers_policy with the addition of none, representing no checks for quoted identifiers.

We check quoted identifiers by stripping off the first and last character.  If we have a case where this shortcut would fail, we'll need to tweak the code before merging.

Changes:
+quoted_identifiers_policy default of none to default_config.cfg
+quoted_identifiers_policy description in config_info.py
L014.py: Rename unquoted_ids_policy_applicable function to identifiers_policy_applicable in order to reflect change in functionality
L029.py: Reflect renaming of unquoted_ids_policy_applicable function; add quoted_identifiers_policy as a configuration keyword; adjust rule to check quoted identifiers based on the config setting.
L029.yml: Rename test cases to be more descriptive.  Add quoted identifier test cases.
