### PR TITLE
Fix L012 documentation

### DIFF
--- a/src/sqlfluff/rules/L012.py
+++ b/src/sqlfluff/rules/L012.py
@@ -18,7 +18,7 @@ class Rule_L012(Rule_L011):
     .. code-block:: sql
 
         SELECT
-            a
+            a alias_col
         FROM foo
 
     | **Best practice**


### PR DESCRIPTION
L012's description was missing the alias in the anti-pattern.  There's no implicit aliasing if there's no alias!