### PR TITLE
templater-dbt: Change dbt dependency to dbt-core

### DIFF
--- a/plugins/sqlfluff-templater-dbt/setup.py
+++ b/plugins/sqlfluff-templater-dbt/setup.py
@@ -63,6 +63,6 @@ setup(
         "Topic :: Utilities",
         "Topic :: Software Development :: Quality Assurance",
     ],
-    install_requires=["sqlfluff>=0.7.0", "dbt>=0.17"],
+    install_requires=["sqlfluff>=0.7.0", "dbt-core>=0.17"],
     entry_points={"sqlfluff": ["sqlfluff_templater_dbt = sqlfluff_templater_dbt"]},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ usedevelop = true
 # is often on different drive (C) from working dir (D), which causes problems.
 setenv =
     COVERAGE_FILE = .coverage.{envname}
-    winpy: TMPDIR = temp_pytest 
+    winpy: TMPDIR = temp_pytest
 allowlist_externals =
     make
 deps =
@@ -23,11 +23,17 @@ deps =
     # Install the main project
     -e .
     # Define dbt versions
-    dbt017: dbt==0.17.2
-    dbt018: dbt==0.18.2
-    dbt019: dbt==0.19.2
-    dbt020: dbt==0.20.2
-    dbt021: dbt==0.21.0
+    dbt017: dbt-core==0.17.2
+    dbt018: dbt-core==0.18.2
+    dbt019: dbt-core==0.19.2
+    dbt020: dbt-core==0.20.2
+    dbt021: dbt-core==0.21.0
+    # Define dbt-postgres versions
+    dbt017: dbt-postgres==0.17.2
+    dbt018: dbt-postgres==0.18.2
+    dbt019: dbt-postgres==0.19.2
+    dbt020: dbt-postgres==0.20.2
+    dbt021: dbt-postgres==0.21.0
     # Install the plugins as required
     dbt0{17,18,19,20,21}: plugins/sqlfluff-templater-dbt
 # Include any other steps necessary for testing below.


### PR DESCRIPTION
### Brief summary of the change made

sqlfluff-templater-dbt dependency on dbt ends up pulling
dbt-postgres, dbt-redshift, dbt-snowflake and dbt-bigquery
which are all pretty large. This commit changes the dependency
to dbt-core instead.

Fixes #1769

### Are there any other side effects of this change that we should be aware of?
If a user installs sqlfluff in a different environment than dbt (for eg. using pipx or venv),
he/she would have to install additional dbt database dependencies (eg. dbt-bigquery)
...

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
