### PR TITLE
Fixed encoding error when linting to file

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -637,7 +637,7 @@ def fix(
 
 
 def _completion_message(config: FluffConfig) -> None:
-    click.echo(f"All Finished{'' if config.get('nocolor') else ' 📜 🎉'}!")
+    click.echo(f"All Finished{'' if (config.get('nocolor') or not sys.stdout.isatty()) else ' 📜 🎉'}!")
 
 
 def quoted_presenter(dumper, data):

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -637,7 +637,9 @@ def fix(
 
 
 def _completion_message(config: FluffConfig) -> None:
-    click.echo(f"All Finished{'' if (config.get('nocolor') or not sys.stdout.isatty()) else ' 📜 🎉'}!")
+    click.echo(
+        f"All Finished{'' if (config.get('nocolor') or not sys.stdout.isatty()) else ' 📜 🎉'}!"
+    )
 
 
 def quoted_presenter(dumper, data):


### PR DESCRIPTION
### Brief summary of the change made
Writing to file using `sqlfluff lint` caused an encoding error due to the completion message containing these Unicode characters ' 📜 🎉'. This PR disables those characters when sys.stdout isn't printed to terminal.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
No test cases added - fix is trivial. Tested in my use case
