### PR TITLE
Hive: Fix bug in CREATE TABLE WITH syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -237,7 +237,7 @@ class CreateTableStatementSegment(BaseSegment):
                 Ref("CommentGrammar", optional=True),
                 Sequence(
                     "AS",
-                    OptionallyBracketed(Ref("SelectStatementSegment")),
+                    OptionallyBracketed(Ref("SelectableGrammar")),
                     optional=True,
                 ),
             ),

--- a/test/fixtures/dialects/hive/create_table_with.sql
+++ b/test/fixtures/dialects/hive/create_table_with.sql
@@ -1,0 +1,10 @@
+CREATE TABLE masonboro_sandbox.test
+AS
+WITH us_sales
+AS (
+    SELECT rev
+    FROM masonboro_sales.us_2021
+)
+
+SELECT rev
+FROM us_sales;

--- a/test/fixtures/dialects/hive/create_table_with.yml
+++ b/test/fixtures/dialects/hive/create_table_with.yml
@@ -1,0 +1,53 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 58b971db8b8f1d1b70f382ec872b8746f9916600e7cab8f137029eeae2139694
+file:
+  statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - identifier: masonboro_sandbox
+      - dot: .
+      - identifier: test
+    - keyword: AS
+    - with_compound_statement:
+        keyword: WITH
+        common_table_expression:
+          identifier: us_sales
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  column_reference:
+                    identifier: rev
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                      - identifier: masonboro_sales
+                      - dot: .
+                      - identifier: us_2021
+            end_bracket: )
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              column_reference:
+                identifier: rev
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: us_sales
+  statement_terminator: ;


### PR DESCRIPTION
_Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge._

_Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log._

### Brief summary of the change made
_If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it._
Fixes #1772
Makes it possible to parse CREATE TABLE statements with WITH clauses.
...

### Are there any other side effects of this change that we should be aware of?
...
No
### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
