### PR TITLE
Fix L049 to allow `= NULL` in SET clauses

### DIFF
--- a/src/sqlfluff/rules/L049.py
+++ b/src/sqlfluff/rules/L049.py
@@ -41,6 +41,10 @@ class Rule_L049(Rule_L006):
         if len(context.segment.segments) <= 2:
             return LintResult()
 
+        # Allow assignments in SET clauses
+        if context.parent_stack and context.parent_stack[-1].is_type("set_clause_list"):
+            return LintResult()
+
         # Iterate through children of this segment looking for equals or "not
         # equals". Once found, check if the next code segment is a NULL literal.
         idx_operator = None

--- a/test/fixtures/rules/std_rule_cases/L049.yml
+++ b/test/fixtures/rules/std_rule_cases/L049.yml
@@ -61,3 +61,8 @@ test_complex_case_1:
     SELECT a
     FROM foo
     WHERE a = b or (c > d or e IS NULL)
+
+test_set_clause:
+  pass_str: |
+    UPDATE table1 SET col = NULL
+    WHERE col = ""


### PR DESCRIPTION
### Brief summary of the change made
Fixes #1774 

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
