### PR TITLE
Fix internal error in L016 when template/whitespace-only line too long

### DIFF
--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -1,8 +1,13 @@
 """Implementation of Rule L016."""
 
-from typing import Optional, Tuple
+from typing import cast, List, Optional, Sequence, Tuple
 
-from sqlfluff.core.parser import NewlineSegment, WhitespaceSegment
+from sqlfluff.core.parser import (
+    BaseSegment,
+    NewlineSegment,
+    RawSegment,
+    WhitespaceSegment,
+)
 
 from sqlfluff.core.rules.base import LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
@@ -26,7 +31,7 @@ class Rule_L016(Rule_L003):
         "ignore_comment_lines",
     ]
 
-    def _eval_line_for_breaks(self, segments):
+    def _eval_line_for_breaks(self, segments: List[RawSegment]) -> List[LintFix]:
         """Evaluate the line for break points.
 
         We split the line into a few particular sections:
@@ -46,11 +51,17 @@ class Rule_L016(Rule_L003):
         indent_section = None
 
         class Section:
-            def __init__(self, segments, role, indent_balance, indent_impulse=0):
+            def __init__(
+                self,
+                segments: Sequence[RawSegment],
+                role: str,
+                indent_balance: int,
+                indent_impulse: Optional[int] = None,
+            ):
                 self.segments = segments
                 self.role = role
                 self.indent_balance = indent_balance
-                self.indent_impulse = indent_impulse
+                self.indent_impulse: int = indent_impulse or 0
 
             def __repr__(self):
                 return "<Section @ {pos}: {role} [{indent_balance}:{indent_impulse}]. {segments!r}>".format(
@@ -64,18 +75,23 @@ class Rule_L016(Rule_L003):
                 )
 
             @property
-            def raw(self):
+            def raw(self) -> str:
                 return "".join(seg.raw for seg in self.segments)
 
             @staticmethod
-            def find_segment_at(segments, loc: Tuple[int, int]):
+            def find_segment_at(segments, loc: Tuple[int, int]) -> RawSegment:
                 for seg in segments:
                     if not seg.is_meta and seg.pos_marker.working_loc == loc:
                         return seg
+                raise ValueError("Segment not found")
 
             def generate_fixes_to_coerce(
-                self, segments, indent_section, crawler, indent
-            ):
+                self,
+                segments: List[RawSegment],
+                indent_section: "Section",
+                crawler: Rule_L016,
+                indent: int,
+            ) -> List[LintFix]:
                 """Generate a list of fixes to create a break at this point.
 
                 The `segments` argument is necessary to extract anchors
@@ -161,12 +177,13 @@ class Rule_L016(Rule_L003):
                     f"Unexpected break generated at {self}"
                 )  # pragma: no cover
 
-        segment_buff = ()
-        whitespace_buff = ()
+        segment_buff: Tuple[RawSegment, ...] = ()
+        whitespace_buff: Tuple[RawSegment, ...] = ()
         indent_impulse = 0
         indent_balance = 0
         is_pause = False
 
+        seg: RawSegment
         for seg in segments:
             if indent_section is None:
                 if seg.is_type("whitespace") or seg.is_meta:
@@ -263,8 +280,9 @@ class Rule_L016(Rule_L003):
         elif indent_impulse:  # pragma: no cover
             role = "breakpoint"
         else:
-            raise ValueError("Is this possible?")  # pragma: no cover
-
+            # This can happen, e.g. with a long template line. Treat it as
+            # unfixable.
+            return []
         chunk_buff.append(
             Section(
                 segments=segment_buff + whitespace_buff,
@@ -281,7 +299,6 @@ class Rule_L016(Rule_L003):
         # First, do we ever go through a negative breakpoint?
         lowest_bal = min(sec.indent_balance for sec in chunk_buff)
         split_at = []  # split_at is probably going to be a list.
-        fixes = []
         if lowest_bal < 0:
             for sec in chunk_buff:
                 if sec.indent_balance == 0 and sec.indent_impulse < 0:
@@ -339,6 +356,7 @@ class Rule_L016(Rule_L003):
         fixes = []
         for split, indent in split_at:
             if split.segments:
+                assert indent_section
                 fixes += split.generate_fixes_to_coerce(
                     segments, indent_section, self, indent
                 )
@@ -348,14 +366,14 @@ class Rule_L016(Rule_L003):
         return fixes
 
     @staticmethod
-    def _gen_line_so_far(raw_stack, initial_buff=None):
+    def _gen_line_so_far(raw_stack: Tuple[RawSegment, ...]) -> List[RawSegment]:
         """Work out from the raw stack what the elements on this line are.
 
         Returns:
             :obj:`list` of segments
 
         """
-        working_buff = initial_buff or []
+        working_buff: List[RawSegment] = []
         idx = -1
         while True:
             if len(raw_stack) >= abs(idx):
@@ -370,7 +388,7 @@ class Rule_L016(Rule_L003):
         return working_buff
 
     @classmethod
-    def _compute_segment_length(cls, segment):
+    def _compute_segment_length(cls, segment: BaseSegment) -> int:
         if segment.is_type("newline"):
             # Generally, we won't see newlines, but if we do, simply ignore
             # them. Rationale: The intent of this rule is to enforce maximum
@@ -400,7 +418,7 @@ class Rule_L016(Rule_L003):
             return len(segment.raw)
 
     @classmethod
-    def _compute_source_length(cls, segments):
+    def _compute_source_length(cls, segments: Sequence[BaseSegment]) -> int:
         line_len = 0
         seen_slices = set()
         for segment in segments:
@@ -442,7 +460,7 @@ class Rule_L016(Rule_L003):
 
         if context.segment.name == "newline":
             # iterate to buffer the whole line up to this point
-            this_line = self._gen_line_so_far(context.raw_stack, [])
+            this_line = self._gen_line_so_far(context.raw_stack)
         else:
             # Otherwise we're all good
             return None
@@ -500,7 +518,10 @@ class Rule_L016(Rule_L003):
                         idx -= 1
                     else:
                         break  # pragma: no cover
-                create_elements = line_indent + [this_line[-1], context.segment]
+                create_elements = line_indent + [
+                    this_line[-1],
+                    cast(RawSegment, context.segment),
+                ]
                 if self._compute_source_length(create_elements) > self.max_line_length:
                     # The inline comment is NOT on a line by itself, but even if
                     # we move it onto a line by itself, it's still too long. In

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -83,7 +83,7 @@ class Rule_L016(Rule_L003):
                 for seg in segments:
                     if not seg.is_meta and seg.pos_marker.working_loc == loc:
                         return seg
-                raise ValueError("Segment not found")
+                raise ValueError("Segment not found")  # pragma: no cover
 
             def generate_fixes_to_coerce(
                 self,

--- a/test/fixtures/rules/std_rule_cases/L016.yml
+++ b/test/fixtures/rules/std_rule_cases/L016.yml
@@ -230,3 +230,11 @@ test_set_statement:
   configs:
     rules:
       max_line_length: 80
+
+
+test_issue_1666_line_too_long_unfixable_jinja:
+  # Note the trailing space at the end of line 1. This is a necessary part of
+  # the test, because the space (which is passed through to the output) was
+  # "tricking" L016 into trying to split the line, then encountering an internal
+  # error.
+  fail_str: "{{ config (schema='bronze', materialized='view', sort =['id','number'], dist = 'all', tags =['longlonglonglonglong']) }} \n\nselect 1\n"


### PR DESCRIPTION
### Brief summary of the change made

Fixes #1666

### Are there any other side effects of this change that we should be aware of?
...

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
