### PR TITLE
L028 fix - Allow SELECT column alias in WHERE clauses for certain dialects

### DIFF
--- a/src/sqlfluff/rules/L027.py
+++ b/src/sqlfluff/rules/L027.py
@@ -36,7 +36,7 @@ class Rule_L027(Rule_L025):
         references,
         col_aliases,
         using_cols,
-        parent_select,
+        parent_select
     ):
         # Do we have more than one? If so, all references should be qualified.
         if len(table_aliases) <= 1:

--- a/src/sqlfluff/rules/L027.py
+++ b/src/sqlfluff/rules/L027.py
@@ -36,7 +36,7 @@ class Rule_L027(Rule_L025):
         references,
         col_aliases,
         using_cols,
-        parent_select
+        parent_select,
     ):
         # Do we have more than one? If so, all references should be qualified.
         if len(table_aliases) <= 1:

--- a/src/sqlfluff/rules/L028.py
+++ b/src/sqlfluff/rules/L028.py
@@ -43,6 +43,7 @@ class Rule_L028(Rule_L025):
     """
 
     config_keywords = ["single_table_references", "force_enable"]
+    _allow_select_alias = False
 
     def _lint_references_and_aliases(
         self,
@@ -72,6 +73,10 @@ class Rule_L028(Rule_L025):
             # entirely rather than trying to enforce anything.
             if ref.raw in standalone_aliases:
                 continue
+
+            # Certain dialects allow use of SELECT alias in WHERE clauses
+            if self._allow_select_alias and ref.raw in col_aliases:
+                continue
             this_ref_type = ref.qualification()
             if self.single_table_references == "consistent":
                 if seen_ref_types and this_ref_type not in seen_ref_types:
@@ -97,15 +102,17 @@ class Rule_L028(Rule_L025):
         return violation_buff or None
 
     def _eval(self, context: RuleContext) -> EvalResultType:
-        """Override Rule L025 for dialects that use structs.
-
-        Some dialects use structs (e.g. column.field) which look like
-        table references and so incorrectly trigger this rule.
-        """
+        """Override Rule L025 for dialects that use structs."""
         # Config type hints
         self.force_enable: bool
 
+        # Some dialects use structs (e.g. column.field) which look like
+        # table references and so incorrectly trigger this rule.
         if context.dialect.name in ["bigquery"] and not self.force_enable:
             return LintResult()
+
+        # Certain dialects allow use of SELECT alias in WHERE clauses
+        if context.dialect.name in ["snowflake", "redshift"]:
+            self._allow_select_alias = True
 
         return super()._eval(context=context)

--- a/src/sqlfluff/rules/L028.py
+++ b/src/sqlfluff/rules/L028.py
@@ -102,7 +102,7 @@ class Rule_L028(Rule_L025):
         return violation_buff or None
 
     def _eval(self, context: RuleContext) -> EvalResultType:
-        """Override Rule L025 for dialects that use structs."""
+        """Override Rule L025 for dialects that use structs, or SELECT aliases."""
         # Config type hints
         self.force_enable: bool
 

--- a/test/fixtures/rules/std_rule_cases/L028.yml
+++ b/test/fixtures/rules/std_rule_cases/L028.yml
@@ -103,3 +103,39 @@ test_date_functions_are_excluded:
       dialect: tsql
 
 
+test_select_alias_in_where_clause_1:
+  # This should pass for certain dialects
+  pass_str: |
+    select
+        t.col0,
+        t.col1 + 1 as alias_col1
+    from table1 as t
+    where alias_col1 > 5
+  configs:
+    core:
+      dialect: redshift
+
+
+test_select_alias_in_where_clause_2:
+  # This should pass for certain dialects
+  pass_str: |
+    select
+        t.col0,
+        t.col1 + 1 as alias_col1
+    from table1 as t
+    where alias_col1 > 5
+  configs:
+    core:
+      dialect: snowflake
+
+
+test_select_alias_in_where_clause_3:
+  # This should fail for ansi
+  fail_str: |
+    select
+        t.col0,
+        t.col1 + 1 as alias_col1
+    from table1 as t
+    where alias_col1 > 5
+
+


### PR DESCRIPTION
### Brief summary of the change made
Fixes #1710

### Are there any other side effects of this change that we should be aware of?
Sets Snowflake and Redshift as only two dialects that allow this

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
