### PR TITLE
Exasol: Make references more strict

### DIFF
--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -390,9 +390,9 @@ class WithInvalidForeignKeySegment(BaseSegment):
         Ref("BracketedColumnReferenceListGrammar"),
         Dedent,  # dedent for the indent in the select clause
         "FROM",
-        Ref("ObjectReferenceSegment"),
+        Ref("TableReferenceSegment"),
         "REFERENCING",
-        Ref("ObjectReferenceSegment"),
+        Ref("TableReferenceSegment"),
         Ref("BracketedColumnReferenceListGrammar", optional=True),
     )
 
@@ -403,7 +403,7 @@ class IntoTableSegment(BaseSegment):
 
     type = "into_table_clause"
     match_grammar = StartsWith(Sequence("INTO", "TABLE"), terminator="FROM")
-    parse_grammar = Sequence("INTO", "TABLE", Ref("ObjectReferenceSegment"))
+    parse_grammar = Sequence("INTO", "TABLE", Ref("TableReferenceSegment"))
 
 
 @exasol_dialect.segment(replace=True)
@@ -3078,7 +3078,7 @@ class OpenSchemaSegment(BaseSegment):
     """`OPEN SCHEMA` statement."""
 
     type = "open_schema_statement"
-    match_grammar = Sequence("OPEN", "SCHEMA", Ref("ObjectReferenceSegment"))
+    match_grammar = Sequence("OPEN", "SCHEMA", Ref("SchemaReferenceSegment"))
 
 
 @exasol_dialect.segment()
@@ -3107,12 +3107,12 @@ class RecompressReorganizeSegment(BaseSegment):
         OneOf(
             Sequence(
                 "TABLE",
-                Ref("ObjectReferenceSegment"),
+                Ref("TableReferenceSegment"),
                 Ref("BracketedColumnReferenceListGrammar"),
             ),
-            Sequence("TABLES", Delimited(Ref("ObjectReferenceSegment"))),
-            Sequence("SCHEMA", Ref("ObjectReferenceSegment")),
-            Sequence("SCHEMAS", Delimited(Ref("ObjectReferenceSegment"))),
+            Sequence("TABLES", Delimited(Ref("TableReferenceSegment"))),
+            Sequence("SCHEMA", Ref("SchemaReferenceSegment")),
+            Sequence("SCHEMAS", Delimited(Ref("SchemaReferenceSegment"))),
             "DATABASE",
         ),
         Ref.keyword("ENFORCE", optional=True),
@@ -3129,12 +3129,12 @@ class PreloadSegment(BaseSegment):
         OneOf(
             Sequence(
                 "TABLE",
-                Ref("ObjectReferenceSegment"),
+                Ref("TableReferenceSegment"),
                 Ref("BracketedColumnReferenceListGrammar"),
             ),
-            Sequence("TABLES", Delimited(Ref("ObjectReferenceSegment"))),
-            Sequence("SCHEMA", Ref("ObjectReferenceSegment")),
-            Sequence("SCHEMAS", Delimited(Ref("ObjectReferenceSegment"))),
+            Sequence("TABLES", Delimited(Ref("TableReferenceSegment"))),
+            Sequence("SCHEMA", Ref("SchemaReferenceSegment")),
+            Sequence("SCHEMAS", Delimited(Ref("SchemaReferenceSegment"))),
             "DATABASE",
         ),
     )
@@ -3214,7 +3214,7 @@ class ExecuteScriptSegment(BaseSegment):
     match_grammar = Sequence(
         "EXECUTE",
         "SCRIPT",
-        Ref("ObjectReferenceSegment"),
+        Ref("ScriptReferenceSegment"),
         Bracketed(
             Delimited(Ref.keyword("ARRAY", optional=True), Ref("ExpressionSegment")),
             optional=True,

--- a/test/fixtures/dialects/exasol/ExecuteScript.yml
+++ b/test/fixtures/dialects/exasol/ExecuteScript.yml
@@ -3,20 +3,20 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6681b20a2a0f43830205d4e154910b53cfb41982f4e1a437cdce9ef6ad8c9f09
+_hash: 996e085117024ed5ade66d3fb0c8e56e06a45e98e894f5bf8f38a64eeaa971bf
 file:
 - statement:
     execute_script_statement:
     - keyword: EXECUTE
     - keyword: SCRIPT
-    - object_reference:
+    - script_reference:
         identifier: script_1
 - statement_terminator: ;
 - statement:
     execute_script_statement:
     - keyword: EXECUTE
     - keyword: SCRIPT
-    - object_reference:
+    - script_reference:
         identifier: script_1
     - keyword: WITH
     - keyword: OUTPUT
@@ -25,7 +25,7 @@ file:
     execute_script_statement:
     - keyword: EXECUTE
     - keyword: SCRIPT
-    - object_reference:
+    - script_reference:
         identifier: script_2
     - bracketed:
       - start_bracket: (
@@ -45,7 +45,7 @@ file:
     execute_script_statement:
     - keyword: EXECUTE
     - keyword: SCRIPT
-    - object_reference:
+    - script_reference:
         identifier: script_3
     - bracketed:
         start_bracket: (

--- a/test/fixtures/dialects/exasol/OpenCloseSchema.yml
+++ b/test/fixtures/dialects/exasol/OpenCloseSchema.yml
@@ -3,20 +3,20 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0a2e62784075b09001ce7e5f5664ff92edf451c5681f2238d7a40ce254d997ea
+_hash: 451857e48ad7d4bea308e653fcb46058a99cec1bc416eeab1da865ef5ba1d6a6
 file:
 - statement:
     open_schema_statement:
     - keyword: OPEN
     - keyword: SCHEMA
-    - object_reference:
+    - schema_reference:
         identifier: test
 - statement_terminator: ;
 - statement:
     open_schema_statement:
     - keyword: OPEN
     - keyword: SCHEMA
-    - object_reference:
+    - schema_reference:
         identifier: '"test"'
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/exasol/PreloadStatement.yml
+++ b/test/fixtures/dialects/exasol/PreloadStatement.yml
@@ -3,13 +3,13 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fc832df27cdfa5ec9952229ae0d8730944f1a63d0b6f92f57cd1649af6cd98f3
+_hash: 8ccdfc4bd57a103aa969a16ee2fe5629a5aafc35c388b9dd597eb941e28a7066
 file:
 - statement:
     preload_statement:
     - keyword: PRELOAD
     - keyword: TABLE
-    - object_reference:
+    - table_reference:
         identifier: t
     - bracketed:
         start_bracket: (
@@ -26,27 +26,27 @@ file:
     preload_statement:
     - keyword: PRELOAD
     - keyword: TABLES
-    - object_reference:
+    - table_reference:
         identifier: t1
     - comma: ','
-    - object_reference:
+    - table_reference:
         identifier: t2
 - statement_terminator: ;
 - statement:
     preload_statement:
     - keyword: PRELOAD
     - keyword: SCHEMAS
-    - object_reference:
+    - schema_reference:
         identifier: s1
     - comma: ','
-    - object_reference:
+    - schema_reference:
         identifier: s2
 - statement_terminator: ;
 - statement:
     preload_statement:
     - keyword: PRELOAD
     - keyword: SCHEMA
-    - object_reference:
+    - schema_reference:
         identifier: s1
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/exasol/RecompressStatement.yml
+++ b/test/fixtures/dialects/exasol/RecompressStatement.yml
@@ -3,13 +3,13 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 12717d423891499caf01b58d7ee219869c78cf89ef38ce5ca72305e1121c2a5f
+_hash: 53a6f747c711b3806acd9c82f64dfd18084a610b473ce52227459a2817d741ce
 file:
 - statement:
     recompress_reorganize_statement:
     - keyword: RECOMPRESS
     - keyword: TABLE
-    - object_reference:
+    - table_reference:
         identifier: t1
     - bracketed:
         start_bracket: (
@@ -21,10 +21,10 @@ file:
     recompress_reorganize_statement:
     - keyword: RECOMPRESS
     - keyword: TABLES
-    - object_reference:
+    - table_reference:
         identifier: t2
     - comma: ','
-    - object_reference:
+    - table_reference:
         identifier: t3
     - keyword: ENFORCE
 - statement_terminator: ;

--- a/test/fixtures/dialects/exasol/SelectStatement.yml
+++ b/test/fixtures/dialects/exasol/SelectStatement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c18d191e0be145ed6b398d233eaca31d5890e8a3bce7a725c72cdca21126215b
+_hash: c779ff30a065b616a67966cb4168c174892973c083415a6b0168ace96a4dbdc0
 file:
 - statement:
     select_statement:
@@ -807,10 +807,10 @@ file:
             identifier: nr
           end_bracket: )
       - keyword: from
-      - object_reference:
+      - table_reference:
           identifier: T1
       - keyword: REFERENCING
-      - object_reference:
+      - table_reference:
           identifier: T2
       - bracketed:
           start_bracket: (
@@ -839,10 +839,10 @@ file:
             identifier: name
         - end_bracket: )
       - keyword: from
-      - object_reference:
+      - table_reference:
           identifier: T1
       - keyword: REFERENCING
-      - object_reference:
+      - table_reference:
           identifier: T2
 - statement_terminator: ;
 - statement:
@@ -864,10 +864,10 @@ file:
             identifier: name
         - end_bracket: )
       - keyword: from
-      - object_reference:
+      - table_reference:
           identifier: T1
       - keyword: REFERENCING
-      - object_reference:
+      - table_reference:
           identifier: T2
       - bracketed:
         - start_bracket: (
@@ -892,7 +892,7 @@ file:
         into_table_clause:
         - keyword: INTO
         - keyword: TABLE
-        - object_reference:
+        - table_reference:
             identifier: t2
       from_clause:
         keyword: FROM


### PR DESCRIPTION
### Brief summary of the change made
This makes the reference in some statements more strict.
It turns some `ObjectReferenceSegment`s into `SchemaReferenceSegment`s, `ScriptReferenceSegment` or `TableReferenceSegment`s in some statements.

### Are there any other side effects of this change that we should be aware of?
This could lead in some broken implementation if one uses the statement types already.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
