### PR TITLE
Fix: add tqdm to setup.py installation requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@
 sphinx>=2.4.1
 sphinx-click
 doc8
-tqdm==4.62.3
+tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ dataclasses; python_version < '3.7'
 chardet
 types-chardet
 toml
-tqdm==4.62.3
+tqdm

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
         # For returning exceptions from multiprocessing.Pool.map()
         "tblib",
         # For handling progress bars
-        "tqdm==4.62.3",
+        "tqdm",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,8 @@ setup(
         "toml",
         # For returning exceptions from multiprocessing.Pool.map()
         "tblib",
+        # For handling progress bars
+        "tqdm==4.62.3",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
At v0.8.0, running `pip install sqlfluff` and then invoking `sqlfluff --help` (or any other command) results in the following error: `ModuleNotFoundError: No module named 'tqdm'`.

This PR adds `tqdm` to the installation requirements in  `setup.py` to fix the bug.
