### PR TITLE
Add test to ensure pip install works

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -189,7 +189,7 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         files: ./coverage.xml
-  pip-test-pull=request:
+  pip-test-pull-request:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     name: pip install tests for forks

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -195,9 +195,9 @@ jobs:
       matrix:
         include:
           - name: 'main'
-            location: https://github.com/sqlfluf/sqlfluff@main
+            location: sqlfluff/sqlfluff.git@main
           - name: 'branch'
-            location: https://github.com/${GITHUB_REPOSITORY}@${GITHUB_REF##*/}
+            location: ${GITHUB_REPOSITORY}.git@${GITHUB_REF##*/}
     name: ${{ matrix.name }} pip tests
     steps:
     - name: Set up Python
@@ -206,7 +206,7 @@ jobs:
         python-version: '3.10'
     - name: Install dependencies
       run: |
-        pip install git+${{ matrix.location }}
+        pip install git+ssh://git@github.com/${{ matrix.location }}
     - name: Run the tests
       run: |
         sqlfluff --version

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -190,6 +190,8 @@ jobs:
       with:
         files: ./coverage.xml
   pip-test-pull-request:
+    # Test that using pip install works as we've missed
+    # some dependencies in the past - see #1842
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     name: pip install tests

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -192,7 +192,7 @@ jobs:
   pip-test-pull-request:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    name: pip install tests for forks
+    name: pip install tests
     steps:
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -189,16 +189,8 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         files: ./coverage.xml
-  pip-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - name: 'main'
-            location: sqlfluff/sqlfluff.git@main
-          - name: 'branch'
-            location: ${GITHUB_REPOSITORY}.git@${GITHUB_REF##*/}
-    name: ${{ matrix.name }} pip tests
+  pip-test-main:
+    name: pip install tests
     steps:
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -206,7 +198,7 @@ jobs:
         python-version: '3.10'
     - name: Install dependencies
       run: |
-        pip install git+ssh://git@github.com/${{ matrix.location }}
+        pip install git+https://github.com/{{ github.repository }}@{{ github.head_ref }}
     - name: Run the tests
       run: |
         sqlfluff --version

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -190,6 +190,7 @@ jobs:
       with:
         files: ./coverage.xml
   pip-test-main:
+    runs-on: ubuntu-latest
     name: pip install tests
     steps:
     - name: Set up Python

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -203,8 +203,12 @@ jobs:
     - name: Install dependencies
       run: |
         pip install git+https://github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.head_ref }}
-    - name: Run the tests
+    - name: Run the version test
       run: |
         sqlfluff --version
-
-
+    - name: Run a simple select parse test
+      run: |
+        echo "select 1" | sqlfluff parse -
+    - name: Run a simple select lint test
+      run: |
+        echo "select 1" | sqlfluff lint -

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -199,7 +199,7 @@ jobs:
         python-version: '3.10'
     - name: Install dependencies
       run: |
-        pip install git+https://github.com/{{ github.repository }}@{{ github.head_ref }}
+        pip install git+https://github.com/${{ github.repository }}@${{ github.head_ref }}
     - name: Run the tests
       run: |
         sqlfluff --version

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -189,9 +189,10 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         files: ./coverage.xml
-  pip-test-main:
+  pip-test-pull=request:
     runs-on: ubuntu-latest
-    name: pip install tests
+    if: github.event_name == 'pull_request'
+    name: pip install tests for forks
     steps:
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -199,8 +200,9 @@ jobs:
         python-version: '3.10'
     - name: Install dependencies
       run: |
-        pip install git+https://github.com/${{ github.repository }}@${{ github.head_ref }}
+        pip install git+https://github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.head_ref }}
     - name: Run the tests
       run: |
         sqlfluff --version
+
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -189,4 +189,25 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         files: ./coverage.xml
+  pip-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: 'main'
+            location: https://github.com/sqlfluf/sqlfluff@main
+          - name: 'branch'
+            location: https://github.com/${GITHUB_REPOSITORY}@${GITHUB_REF##*/}
+    name: ${{ matrix.name }} pip tests
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        pip install git+${{ matrix.location }}
+    - name: Run the tests
+      run: |
+        sqlfluff --version
 


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
Fixes the recent issue with 0.8.0 whereby a new dependency was added but not added to setup.py so `pip install sqlfluff` failed.

This adds a test to our CI which does the following:
- `pip install git+https://github.com/@pull_request_author/sqlfluff@branch`
- `sqlfluff --version`

That is, it doesn't set up the full dev environment and instead mimics what users would see with a `pip install` to ensure that works, even if requirements.txt and requirements_dev.txt are not installed.

Proved this failed here when this branch was based on the broken v0.8.0: https://github.com/sqlfluff/sqlfluff/pull/1843/commits/5d3a11a2ce4fb60ae0a68b1c4c7504e923ca5c48
And that it passed when #1843 change was included: https://github.com/sqlfluff/sqlfluff/pull/1843/commits/0d9a2bc1165e26fa7619b5e4bab7d3b7c9ba15f2

### Are there any other side effects of this change that we should be aware of?
An extra CI test, but it's very quick, and runs in parallel.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
