### PR TITLE
Add `exclude_rules` option for the Simple API

### DIFF
--- a/src/sqlfluff/api/simple.py
+++ b/src/sqlfluff/api/simple.py
@@ -24,7 +24,7 @@ def _unify_str_or_file(sql):
     return sql
 
 
-def lint(sql, dialect="ansi", rules=None):
+def lint(sql, dialect="ansi", rules=None, exclude_rules=None):
     """Lint a sql string or file.
 
     Args:
@@ -33,13 +33,15 @@ def lint(sql, dialect="ansi", rules=None):
         dialect (:obj:`str`, optional): A reference to the dialect of the sql
             to be linted. Defaults to `ansi`.
         rules (:obj:`str` or iterable of :obj:`str`, optional): A subset of rule
-            reference to lint for.
+            references to lint for.
+        exclude_rules (:obj:`str` or iterable of :obj:`str`, optional): A subset of rule
+            references to avoid linting for.
 
     Returns:
         :obj:`list` of :obj:`dict` for each violation found.
     """
     sql = _unify_str_or_file(sql)
-    linter = Linter(dialect=dialect, rules=rules)
+    linter = Linter(dialect=dialect, rules=rules, exclude_rules=exclude_rules)
 
     result = linter.lint_string_wrapped(sql)
     result_records = result.as_records()
@@ -47,7 +49,7 @@ def lint(sql, dialect="ansi", rules=None):
     return [] if not result_records else result_records[0]["violations"]
 
 
-def fix(sql, dialect="ansi", rules=None):
+def fix(sql, dialect="ansi", rules=None, exclude_rules=None):
     """Fix a sql string or file.
 
     Args:
@@ -56,13 +58,15 @@ def fix(sql, dialect="ansi", rules=None):
         dialect (:obj:`str`, optional): A reference to the dialect of the sql
             to be linted. Defaults to `ansi`.
         rules (:obj:`str` or iterable of :obj:`str`, optional): A subset of rule
-            reference to lint for.
+            references to lint for.
+        exclude_rules (:obj:`str` or iterable of :obj:`str`, optional): A subset of rule
+            references to avoid linting for.
 
     Returns:
         :obj:`str` for the fixed sql if possible.
     """
     sql = _unify_str_or_file(sql)
-    linter = Linter(dialect=dialect, rules=rules)
+    linter = Linter(dialect=dialect, rules=rules, exclude_rules=exclude_rules)
 
     result = linter.lint_string_wrapped(sql, fix=True)
     fixed_string = result.paths[0].files[0].fix_string()[0]

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -496,6 +496,7 @@ class FluffConfig:
         config: Optional["FluffConfig"] = None,
         dialect: Optional[str] = None,
         rules: Optional[Union[str, List[str]]] = None,
+        exclude_rules: Optional[Union[str, List[str]]] = None,
     ) -> "FluffConfig":
         """Instantiate a config from either an existing config or kwargs.
 
@@ -520,6 +521,12 @@ class FluffConfig:
                 rules = [rules]
             # Make a comma separated string to pass in as override
             overrides["rules"] = ",".join(rules)
+        if exclude_rules:
+            # If it's a string, make it a list
+            if isinstance(exclude_rules, str):
+                exclude_rules = [exclude_rules]
+            # Make a comma separated string to pass in as override
+            overrides["exclude_rules"] = ",".join(exclude_rules)
         return cls(overrides=overrides)
 
     def get_templater(self, templater_name="jinja", **kwargs):

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -68,10 +68,14 @@ class Linter:
         dialect: Optional[str] = None,
         rules: Optional[Union[str, List[str]]] = None,
         user_rules: Optional[Union[str, List[str]]] = None,
+        exclude_rules: Optional[Union[str, List[str]]] = None,
     ) -> None:
         # Store the config object
         self.config = FluffConfig.from_kwargs(
-            config=config, dialect=dialect, rules=rules
+            config=config,
+            dialect=dialect,
+            rules=rules,
+            exclude_rules=exclude_rules,
         )
         # Get the dialect and templater
         self.dialect = self.config.get("dialect_obj")

--- a/test/api/simple_test.py
+++ b/test/api/simple_test.py
@@ -116,6 +116,23 @@ def test__api__lint_string_specific():
     assert all(elem["code"] in rules for elem in result)
 
 
+def test__api__lint_string_specific_exclude():
+    """Basic checking of lint functionality."""
+    exclude_rules = ["L009", "L010", "L013", "L014", "L036", "L039"]
+    result = sqlfluff.lint(my_bad_query, exclude_rules=exclude_rules)
+    # Check only L044 is found
+    assert len(result) == 1
+    assert "L044" in result[0]["code"]
+
+
+def test__api__lint_string_specific_exclude_all_failed_rules():
+    """Basic checking of lint functionality."""
+    exclude_rules = ["L009", "L010", "L013", "L014", "L036", "L039", "L044"]
+    result = sqlfluff.lint(my_bad_query, exclude_rules=exclude_rules)
+    # Check it passes
+    assert result == []
+
+
 def test__api__fix_string():
     """Basic checking of lint functionality."""
     result = sqlfluff.fix(my_bad_query)
@@ -137,6 +154,13 @@ def test__api__fix_string_specific():
     result = sqlfluff.fix(my_bad_query, rules="L010")
     # Check actual result
     assert result == "SELECT  *, 1, blah AS  fOO  FROM myTable"
+
+
+def test__api__fix_string_specific_exclude():
+    """Basic checking of lint functionality with a specific rule excludsion."""
+    result = sqlfluff.fix(my_bad_query, exclude_rules="L036")
+    # Check actual result
+    assert result == "SELECT *, 1, blah AS foo FROM mytable\n"
 
 
 def test__api__parse_string():

--- a/test/api/simple_test.py
+++ b/test/api/simple_test.py
@@ -157,7 +157,7 @@ def test__api__fix_string_specific():
 
 
 def test__api__fix_string_specific_exclude():
-    """Basic checking of lint functionality with a specific rule excludsion."""
+    """Basic checking of lint functionality with a specific rule exclusion."""
     result = sqlfluff.fix(my_bad_query, exclude_rules="L036")
     # Check actual result
     assert result == "SELECT *, 1, blah AS foo FROM mytable\n"


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
Adds the ability to have `exclude_rules` parameters for the simple API as discussed here: https://github.com/sqlfluff/sqlfluff/pull/1840#discussion_r744994114

### Are there any other side effects of this change that we should be aware of?
Shouldn't be.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
