### PR TITLE
Add `skip_install` to static analysis sections of tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -79,9 +79,11 @@ commands =
 commands = python test/generate_parse_fixture_yml.py
 
 [testenv:linting]
+skip_install = true
 commands = flake8
 
 [testenv:doclinting]
+skip_install = true
 commands = doc8 docs/source --file-encoding utf8
 
 [testenv:docbuild]
@@ -91,6 +93,7 @@ deps =
 commands = make -C docs html
 
 [testenv:mypy]
+skip_install = true
 commands = mypy src/sqlfluff
 
 [flake8]


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Very simple PR. We are currently installing the sqlfluff package into our `linting`,`doclinting`, and `mypy` tox environments. These are all static analysis tools and hence don't need the package installed to run. 
We therefore add `skip_install=True` to these sections.
Approach is used in many other projects (e.g. flake8 https://github.com/PyCQA/flake8/blob/main/tox.ini)

### Are there any other side effects of this change that we should be aware of?
No as mentioned above these tox environments aren't actually touching the package.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
