### PR TITLE
[Snowflake] Allow naked AUTOINCREMENT

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1136,14 +1136,17 @@ class ColumnConstraintSegment(BaseSegment):
         ),
         Sequence(
             OneOf("AUTOINCREMENT", "IDENTITY"),
-            OneOf(
-                Bracketed(Delimited(Ref("NumericLiteralSegment"))),
-                Sequence(
-                    "START",
-                    Ref("NumericLiteralSegment"),
-                    "INCREMENT",
-                    Ref("NumericLiteralSegment"),
+            Bracketed(
+                OneOf(
+                    Bracketed(Delimited(Ref("NumericLiteralSegment"))),
+                    Sequence(
+                        "START",
+                        Ref("NumericLiteralSegment"),
+                        "INCREMENT",
+                        Ref("NumericLiteralSegment"),
+                    ),
                 ),
+                optional=True,
             ),
         ),
         Sequence(Ref.keyword("NOT", optional=True), "NULL"),  # NOT NULL or NULL

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1136,15 +1136,13 @@ class ColumnConstraintSegment(BaseSegment):
         ),
         Sequence(
             OneOf("AUTOINCREMENT", "IDENTITY"),
-            Bracketed(
-                OneOf(
-                    Bracketed(Delimited(Ref("NumericLiteralSegment"))),
-                    Sequence(
-                        "START",
-                        Ref("NumericLiteralSegment"),
-                        "INCREMENT",
-                        Ref("NumericLiteralSegment"),
-                    ),
+            OneOf(
+                Bracketed(Delimited(Ref("NumericLiteralSegment"))),
+                Sequence(
+                    "START",
+                    Ref("NumericLiteralSegment"),
+                    "INCREMENT",
+                    Ref("NumericLiteralSegment"),
                 ),
                 optional=True,
             ),

--- a/test/fixtures/dialects/snowflake/snowflake_create_table.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_create_table.sql
@@ -75,3 +75,4 @@ CREATE TABLE timestamp_column_default_value_demo (
 create table test_table (test_column NUMBER autoincrement (0, 1));
 create table test_schema.test_table (test_column NUMBER autoincrement (0, 1));
 create or replace table test_schema.test_table (test_column NUMBER autoincrement (0, 1));
+create table test_schema.test_table (test_column INTEGER AUTOINCREMENT);

--- a/test/fixtures/dialects/snowflake/snowflake_create_table.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4f139270581447fef6fbe67b7a9a52c1d3fe726cfed8296232ab5ff68295a389
+_hash: 65fdfe6e2531089ddce839774f9bd4a4b24477f471c7a5c5e385e006dd7d8f90
 file:
 - statement:
     create_table_statement:
@@ -695,5 +695,23 @@ file:
             - comma: ','
             - literal: '1'
             - end_bracket: )
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: create
+    - keyword: table
+    - table_reference:
+      - identifier: test_schema
+      - dot: .
+      - identifier: test_table
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          identifier: test_column
+          data_type:
+            data_type_identifier: INTEGER
+          column_constraint_segment:
+            keyword: AUTOINCREMENT
         end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Naked `AUTOINCREMENT` (i.e. without modifiers) is allowed in Snowflake ([official documentation](https://docs.snowflake.com/en/sql-reference/sql/create-table.html#syntax)):

```
[ { DEFAULT <expr>
    | { AUTOINCREMENT | IDENTITY } [ ( <start_num> , <step_num> ) | START <num> INCREMENT <num> ] } ]
```

To repro the issue, populate `test.sql`:
```sql
CREATE TABLE test (id INTEGER PRIMARY KEY AUTOINCREMENT);
```

Before:
```
$ sqlfluff lint test.sql --dialect snowflake
== [test.sql] FAIL
L:   1 | P:  18 |  PRS | Line 1, Position 18: Found unparsable section: ' (id
                       | INTEGER PRIMARY KEY AUTOINCREMENT)'
All Finished 📜 🎉!
```

After:
```
$ sqlfluff lint test.sql --dialect snowflake
All Finished 📜 🎉!
```

### Are there any other side effects of this change that we should be aware of?

Workflows explicitly forbidding naked `AUTOINCREMENT`s will silently stop failing.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
