### PR TITLE
Parse UPDATE/INSERT within WITH clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1919,6 +1919,11 @@ ansi_dialect.add(
         OptionallyBracketed(Ref("SelectStatementSegment")),
         Ref("NonSetSelectableGrammar"),
     ),
+    # Things that do not behave like select statements, which can form part of with expressions.
+    NonWithNonSelectableGrammar=OneOf(
+        Ref("UpdateStatementSegment"),
+        Ref("InsertStatementSegment"),
+    ),
     # Things that behave like select statements, which can form part of set expressions.
     NonSetSelectableGrammar=OneOf(
         Ref("ValuesClauseSegment"),
@@ -1979,7 +1984,10 @@ class WithCompoundStatementSegment(BaseSegment):
             Ref("CTEDefinitionSegment"),
             terminator=Ref.keyword("SELECT"),
         ),
-        Ref("NonWithSelectableGrammar"),
+        OneOf(
+            Ref("NonWithSelectableGrammar"),
+            Ref("NonWithNonSelectableGrammar"),
+        ),
     )
 
 

--- a/test/fixtures/dialects/ansi/insert_with_statement.sql
+++ b/test/fixtures/dialects/ansi/insert_with_statement.sql
@@ -1,0 +1,13 @@
+INSERT INTO table2 (column1, column2, column3)
+WITH mycte AS (
+    SELECT
+        foo,
+        bar
+    FROM mytable1
+)
+
+SELECT
+    foo,
+    bar,
+    baz
+FROM mycte;

--- a/test/fixtures/dialects/ansi/insert_with_statement.yml
+++ b/test/fixtures/dialects/ansi/insert_with_statement.yml
@@ -1,0 +1,71 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 99c45c475a1848dd2bacc4d30513c0aeece9add81e8e8945a5e1cb8a5dfe508d
+file:
+  statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        identifier: table2
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          identifier: column1
+      - comma: ','
+      - column_reference:
+          identifier: column2
+      - comma: ','
+      - column_reference:
+          identifier: column3
+      - end_bracket: )
+    - with_compound_statement:
+        keyword: WITH
+        common_table_expression:
+          identifier: mycte
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    identifier: foo
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    identifier: bar
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: mytable1
+            end_bracket: )
+        select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                identifier: foo
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: bar
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: baz
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: mycte
+  statement_terminator: ;

--- a/test/fixtures/dialects/ansi/with_insert_statement_a.sql
+++ b/test/fixtures/dialects/ansi/with_insert_statement_a.sql
@@ -1,0 +1,10 @@
+WITH mycte AS (
+    SELECT
+        foo,
+        bar,
+        baz
+    FROM mytable1
+)
+
+INSERT INTO table2 (column1, column2, column3)
+VALUES ('value1', 'value2', 'value3');

--- a/test/fixtures/dialects/ansi/with_insert_statement_a.yml
+++ b/test/fixtures/dialects/ansi/with_insert_statement_a.yml
@@ -1,0 +1,64 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 3a2d3406d99d525d25feb25e4e8a14675c5f926173be494dbf0b4172b6cd71eb
+file:
+  statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        identifier: mycte
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  identifier: foo
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  identifier: bar
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  identifier: baz
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      identifier: mytable1
+          end_bracket: )
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          identifier: table2
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            identifier: column1
+        - comma: ','
+        - column_reference:
+            identifier: column2
+        - comma: ','
+        - column_reference:
+            identifier: column3
+        - end_bracket: )
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - literal: "'value1'"
+          - comma: ','
+          - literal: "'value2'"
+          - comma: ','
+          - literal: "'value3'"
+          - end_bracket: )
+  statement_terminator: ;

--- a/test/fixtures/dialects/ansi/with_insert_statement_b.sql
+++ b/test/fixtures/dialects/ansi/with_insert_statement_b.sql
@@ -1,0 +1,11 @@
+WITH mycte AS (
+    SELECT
+        foo,
+        bar,
+        baz
+    FROM mytable1
+)
+
+INSERT INTO table2 (column1, column2, column3)
+SELECT foo, bar, baz
+FROM mycte;

--- a/test/fixtures/dialects/ansi/with_insert_statement_b.yml
+++ b/test/fixtures/dialects/ansi/with_insert_statement_b.yml
@@ -3,15 +3,15 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4e55be927c4b974020c6f1ad74a4788a3944c840e8ac30e8d9a64c342d9c2e5d
+_hash: aa7c6ef91dbe0f6dc7a57830f2e7f44bc3036d32b91244799511fab4cfb4b011
 file:
   statement:
     with_compound_statement:
-      unparsable:
-      - keyword: WITH
-      - raw: mycte
-      - raw: AS
-      - bracketed:
+      keyword: WITH
+      common_table_expression:
+        identifier: mycte
+        keyword: AS
+        bracketed:
           start_bracket: (
           select_statement:
             select_clause:
@@ -35,23 +35,41 @@ file:
                     table_reference:
                       identifier: mytable1
           end_bracket: )
-      - raw: INSERT
-      - raw: INTO
-      - raw: table2
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          identifier: table2
       - bracketed:
         - start_bracket: (
-        - raw: column1
+        - column_reference:
+            identifier: column1
         - comma: ','
-        - raw: column2
+        - column_reference:
+            identifier: column2
         - comma: ','
-        - raw: column3
+        - column_reference:
+            identifier: column3
         - end_bracket: )
-      - raw: SELECT
-      - raw: foo
-      - comma: ','
-      - raw: bar
-      - comma: ','
-      - raw: baz
-      - raw: FROM
-      - raw: mycte
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                identifier: foo
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: bar
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: baz
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: mycte
   statement_terminator: ;

--- a/test/fixtures/dialects/ansi/with_insert_statement_b.yml
+++ b/test/fixtures/dialects/ansi/with_insert_statement_b.yml
@@ -1,0 +1,57 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 4e55be927c4b974020c6f1ad74a4788a3944c840e8ac30e8d9a64c342d9c2e5d
+file:
+  statement:
+    with_compound_statement:
+      unparsable:
+      - keyword: WITH
+      - raw: mycte
+      - raw: AS
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  identifier: foo
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  identifier: bar
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  identifier: baz
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      identifier: mytable1
+          end_bracket: )
+      - raw: INSERT
+      - raw: INTO
+      - raw: table2
+      - bracketed:
+        - start_bracket: (
+        - raw: column1
+        - comma: ','
+        - raw: column2
+        - comma: ','
+        - raw: column3
+        - end_bracket: )
+      - raw: SELECT
+      - raw: foo
+      - comma: ','
+      - raw: bar
+      - comma: ','
+      - raw: baz
+      - raw: FROM
+      - raw: mycte
+  statement_terminator: ;

--- a/test/fixtures/dialects/ansi/with_insert_with_statement.sql
+++ b/test/fixtures/dialects/ansi/with_insert_with_statement.sql
@@ -1,14 +1,22 @@
-WITH mycte AS (
+WITH mycte1 AS (
     SELECT
         foo,
         bar,
         baz
-    FROM mytable1
+    FROM mytable
 )
 
 INSERT INTO table2 (column1, column2, column3)
+WITH mycte2 AS (
+    SELECT
+        foo,
+        bar,
+        baz
+    FROM mycte1
+)
+
 SELECT
     foo,
     bar,
     baz
-FROM mycte;
+FROM mycte2;

--- a/test/fixtures/dialects/ansi/with_insert_with_statement.yml
+++ b/test/fixtures/dialects/ansi/with_insert_with_statement.yml
@@ -1,0 +1,104 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 26c4cfcd873e4af02a5f95df27034c6ae6c4722857dc7713b740d2c599250953
+file:
+  statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        identifier: mycte1
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  identifier: foo
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  identifier: bar
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  identifier: baz
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      identifier: mytable
+          end_bracket: )
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          identifier: table2
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            identifier: column1
+        - comma: ','
+        - column_reference:
+            identifier: column2
+        - comma: ','
+        - column_reference:
+            identifier: column3
+        - end_bracket: )
+      - with_compound_statement:
+          keyword: WITH
+          common_table_expression:
+            identifier: mycte2
+            keyword: AS
+            bracketed:
+              start_bracket: (
+              select_statement:
+                select_clause:
+                - keyword: SELECT
+                - select_clause_element:
+                    column_reference:
+                      identifier: foo
+                - comma: ','
+                - select_clause_element:
+                    column_reference:
+                      identifier: bar
+                - comma: ','
+                - select_clause_element:
+                    column_reference:
+                      identifier: baz
+                from_clause:
+                  keyword: FROM
+                  from_expression:
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                          identifier: mycte1
+              end_bracket: )
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  identifier: foo
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  identifier: bar
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  identifier: baz
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      identifier: mycte2
+  statement_terminator: ;

--- a/test/fixtures/dialects/ansi/with_update_statement.sql
+++ b/test/fixtures/dialects/ansi/with_update_statement.sql
@@ -1,0 +1,12 @@
+WITH mycte AS (
+    SELECT
+        foo,
+        bar
+    FROM mytable1
+)
+
+UPDATE sometable
+SET
+    sometable.baz = mycte.bar
+FROM
+    mycte;

--- a/test/fixtures/dialects/ansi/with_update_statement.yml
+++ b/test/fixtures/dialects/ansi/with_update_statement.yml
@@ -1,0 +1,57 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 5ef45c03d07899104fc767163f3a9edc375940bf3450304ab9e257ebc21396de
+file:
+  statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        identifier: mycte
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  identifier: foo
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  identifier: bar
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      identifier: mytable1
+          end_bracket: )
+      update_statement:
+        keyword: UPDATE
+        table_reference:
+          identifier: sometable
+        set_clause_list:
+          keyword: SET
+          set_clause:
+          - column_reference:
+            - identifier: sometable
+            - dot: .
+            - identifier: baz
+          - comparison_operator: '='
+          - column_reference:
+            - identifier: mycte
+            - dot: .
+            - identifier: bar
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: mycte
+  statement_terminator: ;


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
PR fixes #1888. This PR adds the ability to parse INSERT/UPDATE within a WITH clause as described in the linked issue.

I have this working for the cases described in the linked issue, however, I am struggling to get the following valid query to parse:
```SQL
WITH mycte AS (
    SELECT
        foo,
        bar,
        baz
    FROM mytable1
)

INSERT INTO table2 (column1, column2, column3)
SELECT foo, bar, baz
FROM mycte;
```

I believe the dialect changes I made were sensible and should cover the above case, but still the parsing error, so any help/advice would be greatly appreciated! Thanks 😄 

### Are there any other side effects of this change that we should be aware of?
No, but need help resolving one case of not parsing before we can merge.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
