### PR TITLE
Fixed Delimited() logic, added TSQL grammar

### DIFF
--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -167,7 +167,19 @@ class Delimited(OneOf):
                         )
                     # No match - Not allowed
                     if not match:
-                        return MatchResult.from_unmatched(mutated_segments)
+                        if self.allow_trailing:
+                            # If we reach this point, the lookahead match has hit a delimiter
+                            # beyond the scope of this Delimited section. Trailing delimiters are allowed,
+                            # so return matched up to this section.
+                            return MatchResult(
+                                matched_segments.matched_segments,
+                                pre_non_code
+                                + match.unmatched_segments
+                                + post_non_code
+                                + delimiter_match.all_segments(),
+                            )
+                        else:
+                            return MatchResult.from_unmatched(mutated_segments)
 
                     if not match.is_complete():
                         # If we reach this point, the lookahead match has hit a delimiter

--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -165,9 +165,22 @@ class Delimited(OneOf):
                             # We've already trimmed
                             trim_noncode=False,
                         )
-                    # No match, or an incomplete match: Not allowed
-                    if not match or not match.is_complete():
+                    # No match - Not allowed
+                    if not match:
                         return MatchResult.from_unmatched(mutated_segments)
+
+                    if not match.is_complete():
+                        # If we reach this point, the lookahead match has hit a delimiter
+                        # beyond the scope of this Delimited section. We should return a
+                        # partial match, and the delimiter as unmatched.
+                        return MatchResult(
+                            matched_segments.matched_segments
+                            + pre_non_code
+                            + match.matched_segments,
+                            match.unmatched_segments
+                            + post_non_code
+                            + delimiter_match.all_segments(),
+                        )
 
                     # We have a complete match!
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1006,8 +1006,14 @@ class CreateViewStatementSegment(BaseSegment):
         Sequence("OR", "ALTER", optional=True),
         "VIEW",
         Ref("ObjectReferenceSegment"),
+        Sequence(
+            "WITH",
+            Delimited("ENCRYPTION", "SCHEMABINDING", "VIEW_METADATA"),
+            optional=True,
+        ),
         "AS",
         Ref("SelectableGrammar"),
+        Sequence("WITH", "CHECK", "OPTION", optional=True),
         Ref("DelimiterSegment", optional=True),
     )
 

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -247,6 +247,7 @@ UNRESERVED_KEYWORDS = [
     "DISTRIBUTION",  # Azure Synapse Analytics specific
     "DW",
     "DY",
+    "ENCRYPTION",
     "EXPAND",
     "FAST",
     "FORCESCAN",
@@ -301,6 +302,7 @@ UNRESERVED_KEYWORDS = [
     "ROUND_ROBIN",  # Azure Synapse Analytics specific
     "ROWLOCK",
     "S",
+    "SCHEMABINDING",
     "SECOND",
     "SNAPSHOT",
     "SPATIAL_WINDOW_MAX_CELLS",
@@ -313,6 +315,7 @@ UNRESERVED_KEYWORDS = [
     "TRUNCATE_TARGET",  # Azure Synapse Analytics specific
     "UPDLOCK",
     "USER_DB",  # Azure Synapse Analytics specific, deprecated
+    "VIEW_METADATA",
     "W",
     "WEEK",
     "WEEKDAY",

--- a/test/fixtures/dialects/tsql/create_view.sql
+++ b/test/fixtures/dialects/tsql/create_view.sql
@@ -3,4 +3,55 @@ AS
 SELECT TOP (100) SalesPersonID, SUM(TotalDue) AS TotalSales  
 FROM Sales.SalesOrderHeader  
 WHERE OrderDate > CONVERT(DATETIME, '20001231', 101)  
-GROUP BY SalesPersonID
+GROUP BY SalesPersonID;
+
+CREATE OR ALTER VIEW Sales.SalesPersonPerform
+AS
+SELECT TOP (100) SalesPersonID, SUM(TotalDue) AS TotalSales
+FROM Sales.SalesOrderHeader
+WHERE OrderDate > CONVERT(DATETIME, '20001231', 101)
+GROUP BY SalesPersonID;
+
+
+CREATE VIEW Purchasing.PurchaseOrderReject
+WITH SCHEMABINDING
+AS
+SELECT PurchaseOrderID, ReceivedQty, RejectedQty,
+    RejectedQty / ReceivedQty AS RejectRatio, DueDate
+FROM Purchasing.PurchaseOrderDetail
+WHERE RejectedQty / ReceivedQty > 0
+AND DueDate > CONVERT(DATETIME,'20010630',101) ;
+
+
+CREATE VIEW dbo.SeattleOnly
+AS
+SELECT p.LastName, p.FirstName, e.JobTitle, a.City, sp.StateProvinceCode
+FROM HumanResources.Employee e
+INNER JOIN Person.Person p
+ON p.BusinessEntityID = e.BusinessEntityID
+    INNER JOIN Person.BusinessEntityAddress bea
+    ON bea.BusinessEntityID = e.BusinessEntityID
+    INNER JOIN Person.Address a
+    ON a.AddressID = bea.AddressID
+    INNER JOIN Person.StateProvince sp
+    ON sp.StateProvinceID = a.StateProvinceID
+WHERE a.City = 'Seattle'
+WITH CHECK OPTION ;
+
+
+CREATE VIEW dbo.all_supplier_view
+WITH SCHEMABINDING
+AS
+SELECT supplyID, supplier
+  FROM dbo.SUPPLY1
+UNION ALL
+SELECT supplyID, supplier
+  FROM dbo.SUPPLY2
+UNION ALL
+SELECT supplyID, supplier
+  FROM dbo.SUPPLY3
+UNION ALL
+SELECT supplyID, supplier
+  FROM dbo.SUPPLY4;
+
+create view vw_view with schemabinding, view_metadata as select A.ID from A

--- a/test/fixtures/dialects/tsql/create_view.yml
+++ b/test/fixtures/dialects/tsql/create_view.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5241097a37393d8a516cd76083d0cb81c933d61c463d44aefd938bb31ece2dd9
+_hash: 9847203dfe62aa77d02827bd8d172a378991a31f879aaecdd7ea2f81fd78a125
 file:
   batch:
-    statement:
+  - statement:
       create_view_statement:
       - keyword: CREATE
       - binary_operator: OR
@@ -79,3 +79,437 @@ file:
           - keyword: BY
           - column_reference:
               identifier: SalesPersonID
+          statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - binary_operator: OR
+      - keyword: ALTER
+      - keyword: VIEW
+      - object_reference:
+        - identifier: Sales
+        - dot: .
+        - identifier: SalesPersonPerform
+      - keyword: AS
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_modifier:
+              keyword: TOP
+              expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    literal: '100'
+                  end_bracket: )
+          - select_clause_element:
+              column_reference:
+                identifier: SalesPersonID
+          - comma: ','
+          - select_clause_element:
+              function:
+                function_name:
+                  function_name_identifier: SUM
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      identifier: TotalDue
+                  end_bracket: )
+              alias_expression:
+                keyword: AS
+                identifier: TotalSales
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                  - identifier: Sales
+                  - dot: .
+                  - identifier: SalesOrderHeader
+          where_clause:
+            keyword: WHERE
+            expression:
+              column_reference:
+                identifier: OrderDate
+              comparison_operator: '>'
+              function:
+                function_name:
+                  keyword: CONVERT
+                bracketed:
+                - start_bracket: (
+                - data_type:
+                    identifier: DATETIME
+                - comma: ','
+                - expression:
+                    literal: "'20001231'"
+                - comma: ','
+                - expression:
+                    literal: '101'
+                - end_bracket: )
+          groupby_clause:
+          - keyword: GROUP
+          - keyword: BY
+          - column_reference:
+              identifier: SalesPersonID
+          statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: VIEW
+      - object_reference:
+        - identifier: Purchasing
+        - dot: .
+        - identifier: PurchaseOrderReject
+      - keyword: WITH
+      - keyword: SCHEMABINDING
+      - keyword: AS
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                identifier: PurchaseOrderID
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: ReceivedQty
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: RejectedQty
+          - comma: ','
+          - select_clause_element:
+              expression:
+              - column_reference:
+                  identifier: RejectedQty
+              - binary_operator: /
+              - column_reference:
+                  identifier: ReceivedQty
+              alias_expression:
+                keyword: AS
+                identifier: RejectRatio
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: DueDate
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                  - identifier: Purchasing
+                  - dot: .
+                  - identifier: PurchaseOrderDetail
+          where_clause:
+            keyword: WHERE
+            expression:
+            - column_reference:
+                identifier: RejectedQty
+            - binary_operator: /
+            - column_reference:
+                identifier: ReceivedQty
+            - comparison_operator: '>'
+            - literal: '0'
+            - binary_operator: AND
+            - column_reference:
+                identifier: DueDate
+            - comparison_operator: '>'
+            - function:
+                function_name:
+                  keyword: CONVERT
+                bracketed:
+                - start_bracket: (
+                - data_type:
+                    identifier: DATETIME
+                - comma: ','
+                - expression:
+                    literal: "'20010630'"
+                - comma: ','
+                - expression:
+                    literal: '101'
+                - end_bracket: )
+          statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: VIEW
+      - object_reference:
+        - identifier: dbo
+        - dot: .
+        - identifier: SeattleOnly
+      - keyword: AS
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+              - identifier: p
+              - dot: .
+              - identifier: LastName
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+              - identifier: p
+              - dot: .
+              - identifier: FirstName
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+              - identifier: e
+              - dot: .
+              - identifier: JobTitle
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+              - identifier: a
+              - dot: .
+              - identifier: City
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+              - identifier: sp
+              - dot: .
+              - identifier: StateProvinceCode
+          from_clause:
+            keyword: FROM
+            from_expression:
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                  - identifier: HumanResources
+                  - dot: .
+                  - identifier: Employee
+                alias_expression:
+                  identifier: e
+            - join_clause:
+              - keyword: INNER
+              - keyword: JOIN
+              - from_expression_element:
+                  table_expression:
+                    table_reference:
+                    - identifier: Person
+                    - dot: .
+                    - identifier: Person
+                  alias_expression:
+                    identifier: p
+              - join_on_condition:
+                  keyword: 'ON'
+                  expression:
+                  - column_reference:
+                    - identifier: p
+                    - dot: .
+                    - identifier: BusinessEntityID
+                  - comparison_operator: '='
+                  - column_reference:
+                    - identifier: e
+                    - dot: .
+                    - identifier: BusinessEntityID
+            - join_clause:
+              - keyword: INNER
+              - keyword: JOIN
+              - from_expression_element:
+                  table_expression:
+                    table_reference:
+                    - identifier: Person
+                    - dot: .
+                    - identifier: BusinessEntityAddress
+                  alias_expression:
+                    identifier: bea
+              - join_on_condition:
+                  keyword: 'ON'
+                  expression:
+                  - column_reference:
+                    - identifier: bea
+                    - dot: .
+                    - identifier: BusinessEntityID
+                  - comparison_operator: '='
+                  - column_reference:
+                    - identifier: e
+                    - dot: .
+                    - identifier: BusinessEntityID
+            - join_clause:
+              - keyword: INNER
+              - keyword: JOIN
+              - from_expression_element:
+                  table_expression:
+                    table_reference:
+                    - identifier: Person
+                    - dot: .
+                    - identifier: Address
+                  alias_expression:
+                    identifier: a
+              - join_on_condition:
+                  keyword: 'ON'
+                  expression:
+                  - column_reference:
+                    - identifier: a
+                    - dot: .
+                    - identifier: AddressID
+                  - comparison_operator: '='
+                  - column_reference:
+                    - identifier: bea
+                    - dot: .
+                    - identifier: AddressID
+            - join_clause:
+              - keyword: INNER
+              - keyword: JOIN
+              - from_expression_element:
+                  table_expression:
+                    table_reference:
+                    - identifier: Person
+                    - dot: .
+                    - identifier: StateProvince
+                  alias_expression:
+                    identifier: sp
+              - join_on_condition:
+                  keyword: 'ON'
+                  expression:
+                  - column_reference:
+                    - identifier: sp
+                    - dot: .
+                    - identifier: StateProvinceID
+                  - comparison_operator: '='
+                  - column_reference:
+                    - identifier: a
+                    - dot: .
+                    - identifier: StateProvinceID
+          where_clause:
+            keyword: WHERE
+            expression:
+              column_reference:
+              - identifier: a
+              - dot: .
+              - identifier: City
+              comparison_operator: '='
+              literal: "'Seattle'"
+      - keyword: WITH
+      - keyword: CHECK
+      - keyword: OPTION
+      - statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: VIEW
+      - object_reference:
+        - identifier: dbo
+        - dot: .
+        - identifier: all_supplier_view
+      - keyword: WITH
+      - keyword: SCHEMABINDING
+      - keyword: AS
+      - set_expression:
+        - select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  identifier: supplyID
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  identifier: supplier
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                    - identifier: dbo
+                    - dot: .
+                    - identifier: SUPPLY1
+        - set_operator:
+          - keyword: UNION
+          - keyword: ALL
+        - select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  identifier: supplyID
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  identifier: supplier
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                    - identifier: dbo
+                    - dot: .
+                    - identifier: SUPPLY2
+        - set_operator:
+          - keyword: UNION
+          - keyword: ALL
+        - select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  identifier: supplyID
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  identifier: supplier
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                    - identifier: dbo
+                    - dot: .
+                    - identifier: SUPPLY3
+        - set_operator:
+          - keyword: UNION
+          - keyword: ALL
+        - select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  identifier: supplyID
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  identifier: supplier
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                    - identifier: dbo
+                    - dot: .
+                    - identifier: SUPPLY4
+              statement_terminator: ;
+  - statement:
+      create_view_statement:
+      - keyword: create
+      - keyword: view
+      - object_reference:
+          identifier: vw_view
+      - keyword: with
+      - keyword: schemabinding
+      - comma: ','
+      - keyword: view_metadata
+      - keyword: as
+      - select_statement:
+          select_clause:
+            keyword: select
+            select_clause_element:
+              column_reference:
+              - identifier: A
+              - dot: .
+              - identifier: ID
+          from_clause:
+            keyword: from
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: A


### PR DESCRIPTION
### Brief summary of the change made
This PR does two largely unrelated things. Firstly, it adds options to the tsql CREATE VIEW syntax.
Secondly, it fixes a bug in the Delimited(), which causes rogue behaviour when there is another Delimited within the same statement block.

Fixes #1892 
Fixes #1366

### Are there any other side effects of this change that we should be aware of?
No. Though there are probably some code clean-ups wee can do where people have avoided using Delimited() because of errors they couldn't explain

### Pull Request checklist
Tests added for the TSQL stuff - which served as useful test cases for the Delimited() stuff. I haven't made any explicit unit tests for the delimited change