### PR TITLE
Fix bug where L041 was confused by L016's placement of newlines in the parse tree

### DIFF
--- a/test/fixtures/linter/autofix/ansi/023_l016_confuses_l041/after.sql
+++ b/test/fixtures/linter/autofix/ansi/023_l016_confuses_l041/after.sql
@@ -1,0 +1,10 @@
+SELECT
+        *
+    FROM
+        superverylongtablenamereallyreally1
+    WHERE
+        long_varname_to_trigger_Rule_L016_id in (
+            SELECT distinct
+                id
+            FROM superverylongtablenamereallyreally2 WHERE deletedat IS NULL
+        )

--- a/test/fixtures/linter/autofix/ansi/023_l016_confuses_l041/before.sql
+++ b/test/fixtures/linter/autofix/ansi/023_l016_confuses_l041/before.sql
@@ -1,0 +1,6 @@
+SELECT
+        *
+    FROM
+        superverylongtablenamereallyreally1
+    WHERE
+        long_varname_to_trigger_Rule_L016_id in (SELECT distinct id FROM superverylongtablenamereallyreally2 WHERE deletedat IS NULL)

--- a/test/fixtures/linter/autofix/ansi/023_l016_confuses_l041/test-config.yml
+++ b/test/fixtures/linter/autofix/ansi/023_l016_confuses_l041/test-config.yml
@@ -1,0 +1,4 @@
+test-config:
+  rules:
+    - L016
+    - L041


### PR DESCRIPTION
### Brief summary of the change made

Fixes #1881 

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
