### PR TITLE
Remove unnecessary context section, from code and the docs

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -181,7 +181,7 @@ these can be configured by setting param_style to the names above
 
 .. code-block:: cfg
 
-    [sqlfluff:templater:placeholder:context]
+    [sqlfluff:templater:placeholder]
     param_style=colon
     my_name='john'
 

--- a/src/sqlfluff/core/templaters/placeholder.py
+++ b/src/sqlfluff/core/templaters/placeholder.py
@@ -65,8 +65,7 @@ class PlaceholderTemplater(RawTemplater):
         if config:
             # This is now a nested section
             loaded_context = (
-                config.get_section((self.templater_selector, self.name, "context"))
-                or {}
+                config.get_section((self.templater_selector, self.name)) or {}
             )
         else:
             loaded_context = {}


### PR DESCRIPTION
A small improvement after #1871 

I used the python templater as an example, but in this case the "context" subsection is not needed. So I removed it from the templater and the relative docs to make it simpler.