### PR TITLE
Tsql partition by multiple columns

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1165,7 +1165,7 @@ class PartitionByClause(BaseSegment):
     match_grammar = Sequence(
         "PARTITION",
         "BY",
-        Ref("ColumnReferenceSegment"),
+        Delimited(Ref("ColumnReferenceSegment"),),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1165,7 +1165,9 @@ class PartitionByClause(BaseSegment):
     match_grammar = Sequence(
         "PARTITION",
         "BY",
-        Delimited(Ref("ColumnReferenceSegment"),),
+        Delimited(
+            Ref("ColumnReferenceSegment"),
+        ),
     )
 
 

--- a/test/fixtures/dialects/tsql/select.sql
+++ b/test/fixtures/dialects/tsql/select.sql
@@ -21,7 +21,7 @@ SELECT
 	'TSQL' AS 's escaping quotes test',
 	'',
 	'''',
-    ROW_NUMBER()OVER(PARTITION BY [EventNM] ORDER BY [DateofEvent] desc) AS [RN],
+    ROW_NUMBER()OVER(PARTITION BY [EventNM], [PersonID] ORDER BY [DateofEvent] desc) AS [RN],
     RANK()OVER(PARTITION BY [EventNM] ORDER BY [DateofEvent] desc) AS [R],
     DENSE_RANK()OVER(PARTITION BY [EventNM] ORDER BY [DateofEvent] desc) AS [DR],
     NTILE(5)OVER(PARTITION BY [EventNM] ORDER BY [DateofEvent] desc) AS [NT],

--- a/test/fixtures/dialects/tsql/select.yml
+++ b/test/fixtures/dialects/tsql/select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8a044d4b6fa44d1be2ffa498135e8405fa5742a7c4745b8fc57dba6bc1d03ce2
+_hash: 8e3c1290dece31e9c4c8eef3aac5358d3d24375f98e14fb431cb8656b9f76044
 file:
   batch:
     statement:
@@ -151,6 +151,9 @@ file:
                 - keyword: BY
                 - column_reference:
                     identifier: '[EventNM]'
+                - comma: ','
+                - column_reference:
+                    identifier: '[PersonID]'
                 orderby_clause:
                 - keyword: ORDER
                 - keyword: BY


### PR DESCRIPTION
Updating TSQL to allow a PARTITION BY clause to include multiple columns.  Also updated a test case to include the scenario.