### PR TITLE
Fix bug where "sqlfluff fix" deletes dbt "{% snapshot %}" line

### DIFF
--- a/plugins/sqlfluff-templater-dbt/setup.py
+++ b/plugins/sqlfluff-templater-dbt/setup.py
@@ -63,6 +63,6 @@ setup(
         "Topic :: Utilities",
         "Topic :: Software Development :: Quality Assurance",
     ],
-    install_requires=["sqlfluff>=0.7.0", "dbt-core>=0.17"],
+    install_requires=["sqlfluff>=0.7.0", "dbt-core>=0.17", "jinja2-simple-tags>=0.3.1"],
     entry_points={"sqlfluff": ["sqlfluff_templater_dbt = sqlfluff_templater_dbt"]},
 )

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -411,7 +411,6 @@ class DbtTemplater(JinjaTemplater):
 
                             def make_template(in_str):
                                 env.add_extension(SnapshotExtension)
-                                env.add_extension(EndSnapshotExtension)
                                 return env.from_string(in_str, globals=globals)
 
                 return old_from_string(*args, **kwargs)
@@ -514,18 +513,10 @@ class DbtTemplater(JinjaTemplater):
 
 
 class SnapshotExtension(StandaloneTag):
-    """Dummy "snapshot" tag so raw dbt templates will parse."""
+    """Dummy "snapshot" tags so raw dbt templates will parse."""
 
-    tags = {"snapshot"}
-
-    def render(self, format_string=None):
-        return ""
-
-
-class EndSnapshotExtension(StandaloneTag):
-    """Dummy "endsnapshot" tag so raw dbt templates will parse."""
-
-    tags = {"endsnapshot"}
+    tags = {"snapshot", "endsnapshot"}
 
     def render(self, format_string=None):
+        """Dummy method that renders the tag."""
         return ""

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -513,7 +513,15 @@ class DbtTemplater(JinjaTemplater):
 
 
 class SnapshotExtension(StandaloneTag):
-    """Dummy "snapshot" tags so raw dbt templates will parse."""
+    """Dummy "snapshot" tags so raw dbt templates will parse.
+
+    Context: dbt snapshots (https://docs.getdbt.com/docs/building-a-dbt-project/snapshots/#example)
+    use custom Jinja "snapshot" and "endsnapshot" tags. However, dbt does not
+    actually register those tags with Jinja. Instead, it finds and removes these
+    tags during a preprocessing step. However, DbtTemplater needs those tags to
+    actually parse, because JinjaTracer creates and uses Jinja to process
+    another template similar to the original one.
+    """
 
     tags = {"snapshot", "endsnapshot"}
 

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -20,6 +20,7 @@ from dbt.exceptions import (
     FailedToConnectException as DbtFailedToConnectException,
 )
 from jinja2 import Environment
+from jinja2_simple_tags import StandaloneTag
 
 from sqlfluff.core.errors import SQLTemplaterError, SQLTemplaterSkipFile
 
@@ -409,6 +410,8 @@ class DbtTemplater(JinjaTemplater):
                             globals = args[2] if len(args) >= 3 else kwargs["globals"]
 
                             def make_template(in_str):
+                                env.add_extension(SnapshotExtension)
+                                env.add_extension(EndSnapshotExtension)
                                 return env.from_string(in_str, globals=globals)
 
                 return old_from_string(*args, **kwargs)
@@ -470,7 +473,7 @@ class DbtTemplater(JinjaTemplater):
         compiled_sql = compiled_sql + "\n" * n_trailing_newlines
 
         raw_sliced, sliced_file, templated_sql = self.slice_file(
-            node.raw_sql,
+            source_dbt_sql,
             compiled_sql,
             config=config,
             make_template=make_template,
@@ -484,7 +487,7 @@ class DbtTemplater(JinjaTemplater):
                 TemplatedFileSlice(
                     slice_type="literal",
                     source_slice=slice(
-                        len(node.raw_sql) - n_trailing_newlines, len(node.raw_sql)
+                        len(source_dbt_sql) - n_trailing_newlines, len(source_dbt_sql)
                     ),
                     templated_slice=slice(
                         len(templated_sql) - n_trailing_newlines, len(templated_sql)
@@ -493,7 +496,7 @@ class DbtTemplater(JinjaTemplater):
             )
         return (
             TemplatedFile(
-                source_str=node.raw_sql,
+                source_str=source_dbt_sql,
                 templated_str=templated_sql,
                 fname=fname,
                 sliced_file=sliced_file,
@@ -508,3 +511,21 @@ class DbtTemplater(JinjaTemplater):
         # DbtTemplater uses the original heuristic-based template slicer.
         # TODO: Can it be updated to use TemplateTracer?
         return slice_template(in_str, cls._get_jinja_env())
+
+
+class SnapshotExtension(StandaloneTag):
+    """Dummy "snapshot" tag so raw dbt templates will parse."""
+
+    tags = {"snapshot"}
+
+    def render(self, format_string=None):
+        return ""
+
+
+class EndSnapshotExtension(StandaloneTag):
+    """Dummy "endsnapshot" tag so raw dbt templates will parse."""
+
+    tags = {"endsnapshot"}
+
+    def render(self, format_string=None):
+        return ""

--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/snapshots/issue_1771.sql
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/snapshots/issue_1771.sql
@@ -1,0 +1,17 @@
+{% snapshot dim_aggregated_brand_hierarchy_snapshot %}
+
+{{
+    config(
+      strategy='check',
+      unique_key='c1',
+      target_schema='snapshots',
+      check_cols='all'
+    )
+}}
+
+select
+    c1
+from
+    foo
+
+{% endsnapshot %}

--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/snapshots/issue_1771.sql.after
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/snapshots/issue_1771.sql.after
@@ -1,0 +1,16 @@
+{% snapshot dim_aggregated_brand_hierarchy_snapshot %}
+
+{{
+    config(
+      strategy='check',
+      unique_key='c1',
+      target_schema='snapshots',
+      check_cols='all'
+    )
+}}
+
+    select c1
+    from
+        foo
+
+{% endsnapshot %}

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -230,12 +230,16 @@ def test__dbt_templated_models_fix_does_not_corrupt_file(
         os.remove(fsp)
     lntr = Linter(config=FluffConfig(configs=DBT_FLUFF_CONFIG))
     lnt = lntr.lint_path(os.path.join(project_dir, path), fix=True)
-    lnt.persist_changes(fixed_file_suffix="FIXED")
-    with open(os.path.join(project_dir, path + ".after")) as f:
-        comp_buff = f.read()
-    with open(os.path.join(project_dir, path.replace(".sql", "FIXED.sql"))) as f:
-        fixed_buff = f.read()
-    assert fixed_buff == comp_buff
+    try:
+        lnt.persist_changes(fixed_file_suffix="FIXED")
+        with open(os.path.join(project_dir, path + ".after")) as f:
+            comp_buff = f.read()
+        with open(os.path.join(project_dir, path.replace(".sql", "FIXED.sql"))) as f:
+            fixed_buff = f.read()
+        assert fixed_buff == comp_buff
+    finally:
+        for fsp in glob.glob(os.path.join(project_dir, "snapshots", "*FIXED.sql")):
+            os.remove(fsp)
 
 
 def test__templater_dbt_templating_absolute_path(


### PR DESCRIPTION
### Brief summary of the change made

Fixes #1771 

### Are there any other side effects of this change that we should be aware of?

During templater processing, registers two Jinja extensions on the environment that we "intercept" from dbt, one for the `snapshot` tag and one for the `endsnapshot` tag

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
