### PR TITLE
New Rule L053: Remove outer brackets from top-level statements.

### DIFF
--- a/src/sqlfluff/rules/L053.py
+++ b/src/sqlfluff/rules/L053.py
@@ -67,7 +67,7 @@ class Rule_L053(BaseRule):
                 [
                     segment
                     for segment in context.segment.segments
-                    if segment.name not in bracket_set
+                    if segment.name not in bracket_set and not segment.is_meta
                 ],
             )
         ]

--- a/src/sqlfluff/rules/L053.py
+++ b/src/sqlfluff/rules/L053.py
@@ -46,10 +46,14 @@ class Rule_L053(BaseRule):
         """Top-level statements should not be wrapped in brackets."""
         # We only care about bracketed segements that are direct
         # descendants of a top-level statement segment.
+        if context.dialect.name == "tsql":
+            top_level_parent_stack_types = ["file", "batch", "statement"]
+        else:
+            top_level_parent_stack_types = ["file", "statement"]
         if not (
             context.segment.is_type("bracketed")
             and [segment.type for segment in context.parent_stack]
-            == ["file", "statement"]
+            == top_level_parent_stack_types
         ):
             return None
 

--- a/src/sqlfluff/rules/L053.py
+++ b/src/sqlfluff/rules/L053.py
@@ -46,14 +46,14 @@ class Rule_L053(BaseRule):
         """Top-level statements should not be wrapped in brackets."""
         # We only care about bracketed segements that are direct
         # descendants of a top-level statement segment.
-        if context.dialect.name == "tsql":
-            top_level_parent_stack_types = ["file", "batch", "statement"]
-        else:
-            top_level_parent_stack_types = ["file", "statement"]
         if not (
             context.segment.is_type("bracketed")
-            and [segment.type for segment in context.parent_stack]
-            == top_level_parent_stack_types
+            and [
+                segment.type
+                for segment in context.parent_stack
+                if segment.type != "batch"
+            ]
+            == ["file", "statement"]
         ):
             return None
 

--- a/src/sqlfluff/rules/L053.py
+++ b/src/sqlfluff/rules/L053.py
@@ -58,7 +58,7 @@ class Rule_L053(BaseRule):
             return None
 
         # Replace the bracketed segment with it's
-        # children, exluding the bracket symbols.
+        # children, excluding the bracket symbols.
         bracket_set = {"start_bracket", "end_bracket"}
         fixes = [
             LintFix(

--- a/test/fixtures/rules/std_rule_cases/L053.yml
+++ b/test/fixtures/rules/std_rule_cases/L053.yml
@@ -21,6 +21,12 @@ test_fail_outer_brackets_inner_subquery:
     SELECT foo
     FROM (select * from bar)
 
+test_pass_set_statement_brackets:
+  pass_str: |
+    (SELECT 1)
+    UNION
+    (SELECT 1)
+
 test_pass_no_outer_brackets_tsql:
   pass_str: |
     SELECT foo
@@ -47,6 +53,15 @@ test_fail_outer_brackets_inner_subquery_tsql:
   fix_str: |
     SELECT foo
     FROM (select * from bar)
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_begin_end_statement_brackets_tsql:
+  pass_str: |
+    BEGIN
+      (SELECT 1)
+    END
   configs:
     core:
       dialect: tsql

--- a/test/fixtures/rules/std_rule_cases/L053.yml
+++ b/test/fixtures/rules/std_rule_cases/L053.yml
@@ -1,0 +1,22 @@
+rule: L053
+
+test_pass_no_outer_brackets:
+  pass_str: |
+    SELECT foo
+    FROM bar
+
+test_fail_outer_brackets:
+  fail_str: |
+    (SELECT foo
+    FROM bar)
+  fix_str: |
+    SELECT foo
+    FROM bar
+
+test_fail_outer_brackets_inner_subquery:
+  fail_str: |
+    (SELECT foo
+    FROM (select * from bar))
+  fix_str: |
+    SELECT foo
+    FROM (select * from bar)

--- a/test/fixtures/rules/std_rule_cases/L053.yml
+++ b/test/fixtures/rules/std_rule_cases/L053.yml
@@ -20,3 +20,33 @@ test_fail_outer_brackets_inner_subquery:
   fix_str: |
     SELECT foo
     FROM (select * from bar)
+
+test_pass_no_outer_brackets_tsql:
+  pass_str: |
+    SELECT foo
+    FROM bar
+  configs:
+    core:
+      dialect: tsql
+
+test_fail_outer_brackets_tsql:
+  fail_str: |
+    (SELECT foo
+    FROM bar)
+  fix_str: |
+    SELECT foo
+    FROM bar
+  configs:
+    core:
+      dialect: tsql
+
+test_fail_outer_brackets_inner_subquery_tsql:
+  fail_str: |
+    (SELECT foo
+    FROM (select * from bar))
+  fix_str: |
+    SELECT foo
+    FROM (select * from bar)
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Fixes #1899. This PR adds a rule to remove outer brackets on top-level SQL queries. Refer to corresponding issue for discussion.
![image](https://user-images.githubusercontent.com/80432516/142018644-c1eac197-b2f1-4914-a6d2-03b366fdd848.png)


### Are there any other side effects of this change that we should be aware of?
No. Small tweak to L050 to fix issue but has no downstream impact.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
