### PR TITLE
Add DROP TYPE statement to ANSI dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2269,6 +2269,20 @@ class DropSchemaStatementSegment(BaseSegment):
 
 
 @ansi_dialect.segment()
+class DropTypeStatementSegment(BaseSegment):
+    """A `DROP TYPE` statement."""
+
+    type = "drop_type_statement"
+    match_grammar = Sequence(
+        "DROP",
+        "TYPE",
+        Ref("IfExistsGrammar", optional=True),
+        Ref("ObjectReferenceSegment"),
+        OneOf("RESTRICT", "CASCADE", optional=True),
+    )
+
+
+@ansi_dialect.segment()
 class CreateDatabaseStatementSegment(BaseSegment):
     """A `CREATE DATABASE` statement."""
 
@@ -2960,6 +2974,7 @@ class StatementSegment(BaseSegment):
         Ref("CreateSchemaStatementSegment"),
         Ref("SetSchemaStatementSegment"),
         Ref("DropSchemaStatementSegment"),
+        Ref("DropTypeStatementSegment"),
         Ref("CreateDatabaseStatementSegment"),
         Ref("CreateExtensionStatementSegment"),
         Ref("CreateIndexStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -2140,7 +2140,6 @@ class StatementSegment(BaseSegment):
             Ref("AnalyzeStatementSegment"),
             Ref("CreateTableAsStatementSegment"),
             Ref("AlterTriggerStatementSegment"),
-            Ref("DropTypeStatementSegment"),
             Ref("SetStatementSegment"),
         ],
     )

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -2331,7 +2331,7 @@ class InsertStatementSegment(BaseSegment):
     )
 
 
-@postgres_dialect.segment()
+@postgres_dialect.segment(replace=True)
 class DropTypeStatementSegment(BaseSegment):
     """Drop Type Statement.
 

--- a/test/fixtures/dialects/ansi/drop_type.sql
+++ b/test/fixtures/dialects/ansi/drop_type.sql
@@ -1,0 +1,7 @@
+DROP TYPE typename;
+
+DROP TYPE IF EXISTS typename;
+
+DROP TYPE typename CASCADE;
+
+DROP TYPE typename RESTRICT;

--- a/test/fixtures/dialects/ansi/drop_type.yml
+++ b/test/fixtures/dialects/ansi/drop_type.yml
@@ -1,0 +1,39 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 72bf03f3af3cfac791a5bf91d0ca7751c6612592f5c2c8564d37dd77b5b28a1a
+file:
+- statement:
+    drop_type_statement:
+    - keyword: DROP
+    - keyword: TYPE
+    - object_reference:
+        identifier: typename
+- statement_terminator: ;
+- statement:
+    drop_type_statement:
+    - keyword: DROP
+    - keyword: TYPE
+    - keyword: IF
+    - keyword: EXISTS
+    - object_reference:
+        identifier: typename
+- statement_terminator: ;
+- statement:
+    drop_type_statement:
+    - keyword: DROP
+    - keyword: TYPE
+    - object_reference:
+        identifier: typename
+    - keyword: CASCADE
+- statement_terminator: ;
+- statement:
+    drop_type_statement:
+    - keyword: DROP
+    - keyword: TYPE
+    - object_reference:
+        identifier: typename
+    - keyword: RESTRICT
+- statement_terminator: ;


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
This PR adds the DROP TYPE statement to the ANSI dialect. Fixes #1911.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
