### PR TITLE
Add missing chardet install in setup.py

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -208,9 +208,15 @@ jobs:
     - name: Run the version test
       run: |
         sqlfluff --version
-    - name: Run a simple select parse test
+    - name: Run a simple select parse test via stdin
       run: |
         echo "select 1" | sqlfluff parse -
-    - name: Run a simple select lint test
+    - name: Run a simple select lint test via stdin
       run: |
         echo "select 1" | sqlfluff lint -
+    - name: Run a simple select parse test via file
+      run: |
+        sqlfluff parse <(echo "select 1")
+    - name: Run a simple select lint test via file
+      run: |
+        sqlfluff lint <(echo "select 1")

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,8 @@ setup(
         "tblib",
         # For handling progress bars
         "tqdm",
+        # To get the encoding of files.
+        "chardet",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Fixes #1925. chardet was missing from setup.py. 

The reason we likely missed this in unit tests was because in tox.ini we install requirements.txt (which had chardet), followed by a developer install of sqlfluff, rather than installing the package and its requirements via just setup.py. This is something I've already resolved in #1860 so just need that merged in to prevent this in the future.

### Are there any other side effects of this change that we should be aware of?
No, fixes missing requirement

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
