### PR TITLE
New Rule L055: Use LEFT JOIN instead of RIGHT JOIN.

### DIFF
--- a/src/sqlfluff/rules/L055.py
+++ b/src/sqlfluff/rules/L055.py
@@ -2,10 +2,8 @@
 from typing import Optional
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
-@document_fix_compatible
 class Rule_L055(BaseRule):
     """Use LEFT JOIN instead of RIGHT JOIN.
 

--- a/src/sqlfluff/rules/L055.py
+++ b/src/sqlfluff/rules/L055.py
@@ -1,0 +1,51 @@
+"""Implementation of Rule L055."""
+from typing import Optional
+
+from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+
+
+@document_fix_compatible
+class Rule_L055(BaseRule):
+    """Use LEFT JOIN instead of RIGHT JOIN.
+
+    | **Anti-pattern**
+    | RIGHT JOIN is used.
+
+    .. code-block:: sql
+       :force:
+
+        SELECT
+            foo.col1,
+            bar.col2
+        FROM foo
+        RIGHT JOIN bar
+            ON foo.bar_id = bar.id;
+
+    | **Best practice**
+    | Refactor and use LEFT JOIN instead.
+
+    .. code-block:: sql
+       :force:
+
+        SELECT
+            foo.col1,
+            bar.col2
+        FROM bar
+        LEFT JOIN foo
+            ON foo.bar_id = bar.id;
+    """
+
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        """Use LEFT JOIN instead of RIGHT JOIN."""
+        # We are only interested in JOIN clauses.
+        if context.segment.type != "join_clause":
+            return None
+
+        # We identify non-lone JOIN by looking at first child segment.
+        if {"right", "join"}.issubset(
+            {segment.name for segment in context.segment.segments}
+        ):
+            return LintResult(context.segment.segments[0])
+
+        return None

--- a/test/fixtures/rules/std_rule_cases/L055.yml
+++ b/test/fixtures/rules/std_rule_cases/L055.yml
@@ -1,0 +1,167 @@
+rule: L055
+
+test_fail_right_join:
+  fail_str: |
+    SELECT
+        foo.col1,
+        bar.col2
+    FROM foo
+    RIGHT JOIN bar
+        ON foo.bar_id = bar.id;
+
+test_pass_left_join:
+  pass_str: |
+    SELECT
+        foo.col1,
+        bar.col2
+    FROM bar
+    LEFT JOIN foo
+        ON foo.bar_id = bar.id;
+
+test_pass_inner_join:
+  pass_str: |
+    SELECT
+        foo.col1,
+        bar.col2
+    FROM bar
+    INNER JOIN foo
+        ON foo.bar_id = bar.id;
+
+test_fail_right_and_right_join:
+  fail_str: |
+    SELECT
+        foo.col1,
+        bar.col2,
+        baz.col3
+    FROM foo
+    RIGHT JOIN bar
+        ON foo.bar_id = bar.id
+    RIGHT JOIN baz
+        ON foo.baz_id = baz.id;
+
+test_fail_right_and_left_join:
+  fail_str: |
+    SELECT
+        foo.col1,
+        bar.col2,
+        baz.col3
+    FROM foo
+    RIGHT JOIN bar
+        ON foo.bar_id = bar.id
+    LEFT JOIN baz
+        ON foo.baz_id = baz.id;
+
+test_fail_right_and_inner_join:
+  fail_str: |
+    SELECT
+        foo.col1,
+        bar.col2,
+        baz.col3
+    FROM foo
+    RIGHT JOIN bar
+        ON foo.bar_id = bar.id
+    INNER JOIN baz
+        ON foo.baz_id = baz.id;
+
+test_pass_left_inner_join:
+  pass_str: |
+    SELECT
+        foo.col1,
+        bar.col2,
+        baz.col3
+    FROM bar
+    LEFT JOIN foo
+        ON foo.bar_id = bar.id
+    INNER JOIN baz
+        ON foo.baz_id = baz.id;
+
+test_fail_subquery_right_join:
+  fail_str: |
+    SELECT
+        col1,
+        col2
+    FROM (
+        SELECT
+            foo.col1,
+            bar.col2
+        FROM foo
+        RIGHT JOIN bar
+            ON foo.bar_id = bar.id
+    );
+
+test_pass_subquery_left_join:
+  pass_str: |
+    SELECT
+        col1,
+        col2
+    FROM (
+        SELECT
+            foo.col1,
+            bar.col2
+        FROM bar
+        LEFT JOIN foo
+            ON foo.bar_id = bar.id
+    );
+
+test_pass_subquery_inner_join:
+  pass_str: |
+    SELECT
+        col1,
+        col2
+    FROM (
+        SELECT
+            foo.col1,
+            bar.col2
+        FROM bar
+        INNER JOIN foo
+            ON foo.bar_id = bar.id
+    );
+    
+test_fail_with_right_join:
+  fail_str: |
+    WITH cte AS (
+        SELECT
+            foo.col1,
+            bar.col2
+        FROM foo
+        RIGHT JOIN bar
+            ON foo.bar_id = bar.id
+    )
+
+    SELECT
+        col1,
+        col2
+    FROM cte;
+
+test_pass_with_left_join:
+  pass_str: |
+    WITH cte AS (
+        SELECT
+            foo.col1,
+            bar.col2
+        FROM bar
+        LEFT JOIN foo
+            ON foo.bar_id = bar.id
+    )
+
+    SELECT
+        col1,
+        col2
+    FROM cte;
+
+test_pass_with_inner_join:
+  pass_str: |
+    WITH cte AS (
+        SELECT
+            foo.col1,
+            bar.col2
+        FROM bar
+        INNER JOIN foo
+            ON foo.bar_id = bar.id
+    )
+
+    SELECT
+        col1,
+        col2
+    FROM cte;
+    


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
This PR provides a new rule to raise a linting error when a RIGHT JOIN is detected and suggests that the user refactors to use a LEFT JOIN instead. Fixes #1749.

This is a very common style guide rule, for example in the popular fishtown analytics SQL guide:
![image](https://user-images.githubusercontent.com/80432516/142502738-c44e199e-20bd-46bf-8899-86532dea3984.png)
 
Logic is very simple for this rule and I've included a bunch of unit tests.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
