### PR TITLE
Documentation bug: Fix misplaced TableAliasInfo in L031 documentation

### DIFF
--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -8,6 +8,15 @@ from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
+class TableAliasInfo(NamedTuple):
+    """Structure yielded by_filter_table_expressions()."""
+
+    table_ref: BaseSegment
+    whitespace_ref: BaseSegment
+    alias_exp_ref: BaseSegment
+    alias_identifier_ref: BaseSegment
+
+
 @document_fix_compatible
 class Rule_L031(BaseRule):
     """Avoid table aliases in from clauses and join conditions.
@@ -102,14 +111,6 @@ class Rule_L031(BaseRule):
             )
         return None
 
-    class TableAliasInfo(NamedTuple):
-        """Structure yielded by_filter_table_expressions()."""
-
-        table_ref: BaseSegment
-        whitespace_ref: BaseSegment
-        alias_exp_ref: BaseSegment
-        alias_identifier_ref: BaseSegment
-
     @classmethod
     def _filter_table_expressions(
         cls, base_table, from_expression_elements
@@ -142,7 +143,7 @@ class Rule_L031(BaseRule):
                 continue
 
             alias_identifier_ref = alias_exp_ref.get_child("identifier")
-            yield cls.TableAliasInfo(
+            yield TableAliasInfo(
                 table_ref, whitespace_ref, alias_exp_ref, alias_identifier_ref
             )
 


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
In the Rules Reference documentation section for L031 sphinx has been inserting the `TableAliasInfo` class:
![image](https://user-images.githubusercontent.com/80432516/142737204-f3e8b38e-fd3a-4049-859d-582747a33a1e.png)

This is clearly unintentional and seemed to be caused by the `TableAliasInfo` being defined as a sub-class of `Rule_L031`. I separated the classes in a manner consistent with other similar cases in L036 and L037 and this has resolved the issue in the documentation:
![image](https://user-images.githubusercontent.com/80432516/142737311-a37a8278-9b3f-434a-b7dd-de5eb35ff078.png)


### Are there any other side effects of this change that we should be aware of?
No, doc bugfix

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
