### PR TITLE
Add short form help option (-h)

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -305,7 +305,7 @@ def get_linter_and_formatter(
         return Linter(config=cfg), formatter
 
 
-@click.group()
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option()
 def cli():
     """Sqlfluff is a modular sql linter for humans."""


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
This PR adds a short form `-h` option as an alternative to `--help` on the command line. I like to regularly check the help info on the command line and it's a big convenience to be able to just type `-h`.

Before and after below:
![image](https://user-images.githubusercontent.com/80432516/142737999-534ae7eb-cd4d-43d1-9a47-82ee2ca0f99c.png)

### Are there any other side effects of this change that we should be aware of?
No, this has no impact on existing use of `--help`. Just provides a handy alternative for those that prefer `-h`.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
