### PR TITLE
Move typing_extensions from requirements_dev.txt to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,28 @@
+# Core
 click>=7.1
 colorama>=0.3
 configparser
-cached-property
-# oyaml is like pyyaml but preserves orderings
 oyaml
 Jinja2
+# Used for diffcover plugin
 diff-cover>=2.5.0
-# pathspec handles the .sqlfluffignore file
+# Used for .sqlfluffignore
 pathspec
-pytest
-tblib
+# Used for finding os-specific application config dirs
 appdirs
+# Cached property for performance gains
+cached-property
 # dataclasses backport for python 3.6
 dataclasses; python_version < '3.7'
-chardet
+# better type hints for older python versions
+typing_extensions
+# We provide a testing library for plugins in sqlfluff.testing
+pytest
+# For parsing pyproject.toml
 toml
+# For returning exceptions from multiprocessing.Pool.map()
+tblib
+# For handling progress bars
 tqdm
+# To get the encoding of files.
+chardet

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 click>=7.1
 colorama>=0.3
 configparser
+# oyaml is like pyyaml but preserves orderings
 oyaml
 Jinja2
 # Used for diffcover plugin

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,29 +1,28 @@
-# Core
-click>=7.1
-colorama>=0.3
-configparser
-# oyaml is like pyyaml but preserves orderings
-oyaml
-Jinja2
-# Used for diffcover plugin
-diff-cover>=2.5.0
-# Used for .sqlfluffignore
-pathspec
 # Used for finding os-specific application config dirs
 appdirs
 # Cached property for performance gains
 cached-property
-# dataclasses backport for python 3.6
-dataclasses; python_version < '3.7'
-# better type hints for older python versions
-typing_extensions
-# We provide a testing library for plugins in sqlfluff.testing
-pytest
-# For parsing pyproject.toml
-toml
-# For returning exceptions from multiprocessing.Pool.map()
-tblib
-# For handling progress bars
-tqdm
 # To get the encoding of files.
 chardet
+click>=7.1
+colorama>=0.3
+configparser
+# dataclasses backport for python 3.6
+dataclasses; python_version < '3.7'
+# Used for diffcover plugin
+diff-cover>=2.5.0
+Jinja2
+# oyaml is like pyyaml but preserves orderings
+oyaml
+# Used for .sqlfluffignore
+pathspec
+# We provide a testing library for plugins in sqlfluff.testing
+pytest
+# For returning exceptions from multiprocessing.Pool.map()
+tblib
+# For parsing pyproject.toml
+toml
+# For handling progress bars
+tqdm
+# better type hints for older python versions
+typing_extensions

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,7 +14,6 @@ pytest-cov
 pytest-sugar
 # MyPy
 mypy
-typing_extensions
 types-toml
 types-pkg_resources
 types-chardet

--- a/setup.py
+++ b/setup.py
@@ -95,34 +95,34 @@ setup(
         "Topic :: Software Development :: Quality Assurance",
     ],
     install_requires=[
-        # Core
-        "click>=7.1",
-        "colorama>=0.3",
-        "configparser",
-        "oyaml",
-        "Jinja2",
-        # Used for diffcover plugin
-        "diff-cover>=2.5.0",
-        # Used for .sqlfluffignore
-        "pathspec",
         # Used for finding os-specific application config dirs
         "appdirs",
         # Cached property for performance gains
         "cached-property",
-        # dataclasses backport for python 3.6
-        "dataclasses; python_version < '3.7'",
-        # better type hints for older python versions
-        "typing_extensions",
-        # We provide a testing library for plugins in sqlfluff.testing
-        "pytest",
-        # For parsing pyproject.toml
-        "toml",
-        # For returning exceptions from multiprocessing.Pool.map()
-        "tblib",
-        # For handling progress bars
-        "tqdm",
         # To get the encoding of files.
         "chardet",
+        "click>=7.1",
+        "colorama>=0.3",
+        "configparser",
+        # dataclasses backport for python 3.6
+        "dataclasses; python_version < '3.7'",
+        # Used for diffcover plugin
+        "diff-cover>=2.5.0",
+        "Jinja2",
+        # oyaml is like pyyaml but preserves orderings
+        "oyaml",
+        # Used for .sqlfluffignore
+        "pathspec",
+        # We provide a testing library for plugins in sqlfluff.testing
+        "pytest",
+        # For returning exceptions from multiprocessing.Pool.map()
+        "tblib",
+        # For parsing pyproject.toml
+        "toml",
+        # For handling progress bars
+        "tqdm",
+        # better type hints for older python versions
+        "typing_extensions",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
This addresses an issue discovered as part of developing the SQLFluff docker image. `typing_extensions` should be in `requirements.txt` not `requirements_dev.txt`. Makes sense to address this in its own PR rather than the docker image one.
![image](https://user-images.githubusercontent.com/80432516/142855392-346c0c67-99f6-4df8-a38f-d09202b5b477.png)

Also added the comments on dependencies from `setup.py`

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
