### PR TITLE
Move package metadata to setup.cfg

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,1 @@
 include README.md LICENSE.md CHANGELOG.md
-include src/sqlfluff/config.ini
-include src/sqlfluff/core/default_config.cfg

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ cached-property
 chardet
 click>=7.1
 colorama>=0.3
-configparser
 # dataclasses backport for python 3.6
 dataclasses; python_version < '3.7'
 # Used for diffcover plugin

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,107 @@
+[metadata]
+name = sqlfluff
+description = The SQL Linter for Humans
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/sqlfluff/sqlfluff
+author = Alan Cruickshank
+author_email = alan@designingoverload.com
+license = MIT License
+license_files = LICENSE.md
+project_urls =
+    Homepage = https://www.sqlfluff.com
+    Documentation = https://docs.sqlfluff.com
+    Changes = https://github.com/sqlfluff/sqlfluff/blob/main/CHANGELOG.md
+    Source = https://github.com/sqlfluff/sqlfluff
+    Issue Tracker = https://github.com/sqlfluff/sqlfluff/issues
+    Twitter = https://twitter.com/SQLFluff
+    Chat = https://github.com/sqlfluff/sqlfluff#sqlfluff-on-slack
+classifiers =
+    Development Status :: 4 - Beta
+    Environment :: Console
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Operating System :: Unix
+    Operating System :: POSIX
+    Operating System :: MacOS
+    Operating System :: Microsoft :: Windows
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+    Topic :: Utilities
+    Topic :: Software Development :: Quality Assurance
+keywords =
+    sqlfluff
+    sql
+    linter
+    formatter
+    bigquery
+    exasol
+    hive
+    mysql
+    postgres
+    redshift
+    snowflake
+    spark3
+    sqlite
+    teradata
+    tsql
+    dbt
+
+[options]
+package_dir =
+    =src
+packages = find:
+python_requires = >=3.6
+install_requires =
+    # Used for finding os-specific application config dirs
+    appdirs
+    # Cached property for performance gains
+    cached-property
+    # To get the encoding of files.
+    chardet
+    click>=7.1
+    colorama>=0.3
+    configparser
+    # dataclasses backport for python 3.6
+    dataclasses; python_version < '3.7'
+    # Used for diffcover plugin
+    diff-cover>=2.5.0
+    Jinja2
+    # oyaml is like pyyaml but preserves orderings
+    oyaml
+    # Used for .sqlfluffignore
+    pathspec
+    # We provide a testing library for plugins in sqlfluff.testing
+    pytest
+    # For returning exceptions from multiprocessing.Pool.map()
+    tblib
+    # For parsing pyproject.toml
+    toml
+    # For handling progress bars
+    tqdm
+    # better type hints for older python versions
+    typing_extensions
+
+[options.packages.find]
+where =
+    src
+
+[options.entry_points]
+console_scripts =
+    sqlfluff = sqlfluff.cli.commands:cli
+diff_cover =
+    sqlfluff = sqlfluff.diff_quality_plugin
+sqlfluff =
+    sqlfluff = sqlfluff.core.plugin.lib
+
+[options.package_data]
+sqlfluff =
+    config.ini
+    core/default_config.cfg

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,6 @@ install_requires =
     chardet
     click>=7.1
     colorama>=0.3
-    configparser
     # dataclasses backport for python 3.6
     dataclasses; python_version < '3.7'
     # Used for diffcover plugin

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,4 @@ config = configparser.ConfigParser()
 config.read(["src/sqlfluff/config.ini"])
 version = config.get("sqlfluff", "version")
 
-setup(
-    version=version
-)
+setup(version=version)

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,7 @@
 #!/usr/bin/env python
-
 """The script for setting up sqlfluff."""
-
-
-import sys
-
-if sys.version_info[0] < 3:
-    raise Exception("SQLFluff does not support Python 2. Please upgrade to Python 3.")
-
 import configparser
-from os.path import dirname
-from os.path import join
-
-from setuptools import find_packages, setup
-
+from setuptools import setup
 
 # Get the global config info as currently stated
 # (we use the config file to avoid actually loading any python here)
@@ -21,114 +9,6 @@ config = configparser.ConfigParser()
 config.read(["src/sqlfluff/config.ini"])
 version = config.get("sqlfluff", "version")
 
-
-def read(*names, **kwargs):
-    """Read a file and return the contents as a string."""
-    return open(
-        join(dirname(__file__), *names), encoding=kwargs.get("encoding", "utf8")
-    ).read()
-
-
 setup(
-    name="sqlfluff",
-    version=version,
-    license="MIT License",
-    description="The SQL Linter for Humans",
-    long_description=read("README.md"),
-    # Make sure pypi is expecting markdown!
-    long_description_content_type="text/markdown",
-    author="Alan Cruickshank",
-    author_email="alan@designingoverload.com",
-    url="https://github.com/sqlfluff/sqlfluff",
-    python_requires=">=3.6",
-    keywords=[
-        "sqlfluff",
-        "sql",
-        "linter",
-        "formatter",
-        "bigquery",
-        "exasol",
-        "hive",
-        "mysql",
-        "postgres",
-        "redshift",
-        "snowflake",
-        "spark3",
-        "sqlite",
-        "teradata",
-        "tsql",
-        "dbt",
-    ],
-    project_urls={
-        "Homepage": "https://www.sqlfluff.com",
-        "Documentation": "https://docs.sqlfluff.com",
-        "Changes": "https://github.com/sqlfluff/sqlfluff/blob/main/CHANGELOG.md",
-        "Source": "https://github.com/sqlfluff/sqlfluff",
-        "Issue Tracker": "https://github.com/sqlfluff/sqlfluff/issues",
-        "Twitter": "https://twitter.com/SQLFluff",
-        "Chat": "https://github.com/sqlfluff/sqlfluff#sqlfluff-on-slack",
-    },
-    packages=find_packages(where="src"),
-    package_dir={"": "src"},
-    include_package_data=True,
-    classifiers=[
-        # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers
-        "Development Status :: 4 - Beta",
-        # 'Development Status :: 5 - Production/Stable',
-        "Environment :: Console",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: Unix",
-        "Operating System :: POSIX",
-        "Operating System :: MacOS",
-        "Operating System :: Microsoft :: Windows",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "Topic :: Utilities",
-        "Topic :: Software Development :: Quality Assurance",
-    ],
-    install_requires=[
-        # Used for finding os-specific application config dirs
-        "appdirs",
-        # Cached property for performance gains
-        "cached-property",
-        # To get the encoding of files.
-        "chardet",
-        "click>=7.1",
-        "colorama>=0.3",
-        "configparser",
-        # dataclasses backport for python 3.6
-        "dataclasses; python_version < '3.7'",
-        # Used for diffcover plugin
-        "diff-cover>=2.5.0",
-        "Jinja2",
-        # oyaml is like pyyaml but preserves orderings
-        "oyaml",
-        # Used for .sqlfluffignore
-        "pathspec",
-        # We provide a testing library for plugins in sqlfluff.testing
-        "pytest",
-        # For returning exceptions from multiprocessing.Pool.map()
-        "tblib",
-        # For parsing pyproject.toml
-        "toml",
-        # For handling progress bars
-        "tqdm",
-        # better type hints for older python versions
-        "typing_extensions",
-    ],
-    entry_points={
-        "console_scripts": [
-            "sqlfluff = sqlfluff.cli.commands:cli",
-        ],
-        "diff_cover": ["sqlfluff = sqlfluff.diff_quality_plugin"],
-        "sqlfluff": ["sqlfluff = sqlfluff.core.plugin.lib"],
-    },
+    version=version
 )


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
This PR is a straight swap from `setup.py` to declarative metadata  in `setup.cfg`. Simplifies the setup file and makes it easier for tools to extract the package metadata (e.g. extracting requirements for use in the docker build #1945).

### Are there any other side effects of this change that we should be aware of?
No, exactly the same but uses declarative metadata.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
