### PR TITLE
Docs: fix docker hub link to public URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ L:   1 | P:  14 | L006 | Operators should be surrounded by a single space unless
 L:   1 | P:  27 | L001 | Unnecessary trailing whitespace
 ```
 
-Alternatively, you can use the [**Official SQLFluff Docker Image**](https://hub.docker.com/repository/docker/sqlfluff/sqlfluff/general) or have a play using [**SQLFluff online**](https://online.sqlfluff.com/).
+Alternatively, you can use the [**Official SQLFluff Docker Image**](https://hub.docker.com/r/sqlfluff/sqlfluff) or have a play using [**SQLFluff online**](https://online.sqlfluff.com/).
 
 For full [CLI usage](https://docs.sqlfluff.com/en/stable/cli.html) and [rules reference](https://docs.sqlfluff.com/en/stable/rules.html), see [the SQLFluff docs](https://docs.sqlfluff.com/en/stable/).
 


### PR DESCRIPTION

<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made

[Previous URL](https://hub.docker.com/repository/docker/sqlfluff/sqlfluff/general) from #1945 prompted you to login before redirecting you to the [new public URL](https://hub.docker.com/r/sqlfluff/sqlfluff)


### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
