### PR TITLE
Remove config.ini in favor of setup.cfg

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,8 @@ whenever a new release is published to GitHub.
 
 #### Release checklist:
 
-- [ ] Change the version in `src/sqlfluff/config.ini` and `plugins/sqlfluff-templator-dbt/setup.py`
+- [ ] Change the version in `setup.cfg` and `plugins/sqlfluff-templator-dbt/setup.cfg`
+- [ ] Update the stable_version in the `[sqlfluff_docs]` section of `setup.cfg`
 - [ ] Copy the draft releases from https://github.com/sqlfluff/sqlfluff/releases to [CHANGELOG.md](CHANGELOG.md)
 - [ ] Add markdown links to PRs and contributors
 - [ ] Check each issue title is clear, and if not edit issue title (which will automatically update Release notes on next PR merged, as the Draft one is recreated in full each time). Also edit locally in [CHANGELOG.md](CHANGELOG.md)
@@ -191,7 +192,7 @@ whenever a new release is published to GitHub.
 - [ ] Announce the release on Twitter (@tunetheweb can do this or let him know your Twitter handle if you want access to Tweet on SQLFluff’s behalf).
 
 :warning: **Before creating a new release, ensure that
-[src/sqlfluff/config.ini](src/sqlfluff/config.ini) is up-to-date with a new version** :warning:.
+[setup.cfg](setup.cfg) is up-to-date with a new version** :warning:.
 If this is not done, PyPI will reject the package. Also, ensure you have used that
 version as a part of the tag and have described the changes accordingly.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,8 +20,8 @@ import configparser
 # Get the global config info as currently stated
 # (we use the config file to avoid actually loading any python here)
 config = configparser.ConfigParser()
-config.read(["../../src/sqlfluff/config.ini"])
-stable_version = config.get("sqlfluff", "stable_version")
+config.read(["../../setup.cfg"])
+stable_version = config.get("sqlfluff_docs", "stable_version")
 
 # -- Project information -----------------------------------------------------
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -29,3 +29,6 @@ ignore_missing_imports = True
 
 [mypy-tqdm.*]
 ignore_missing_imports = True
+
+[mypy-importlib_metadata.*]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ colorama>=0.3
 dataclasses; python_version < '3.7'
 # Used for diffcover plugin
 diff-cover>=2.5.0
+# importlib_metadata backport for python 3.6 & 3.7
+importlib_metadata; python_version < '3.8'
 Jinja2
 # oyaml is like pyyaml but preserves orderings
 oyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,8 @@ install_requires =
     dataclasses; python_version < '3.7'
     # Used for diffcover plugin
     diff-cover>=2.5.0
+    # importlib_metadata backport for python 3.6 & 3.7
+    importlib_metadata; python_version < '3.8'
     Jinja2
     # oyaml is like pyyaml but preserves orderings
     oyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = sqlfluff
+version = 0.8.2
 description = The SQL Linter for Humans
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -104,3 +105,6 @@ sqlfluff =
 sqlfluff =
     config.ini
     core/default_config.cfg
+
+[sqlfluff_docs]
+stable_version = 0.8.2

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python
 """The script for setting up sqlfluff."""
-import configparser
 from setuptools import setup
 
-# Get the global config info as currently stated
-# (we use the config file to avoid actually loading any python here)
-config = configparser.ConfigParser()
-config.read(["src/sqlfluff/config.ini"])
-version = config.get("sqlfluff", "version")
-
-setup(version=version)
+setup()

--- a/src/sqlfluff/__init__.py
+++ b/src/sqlfluff/__init__.py
@@ -1,14 +1,18 @@
 """Sqlfluff is a SQL linter for humans."""
-import importlib.metadata
 import sys
 import pytest
 
 # Expose the public API.
 from sqlfluff.api import lint, fix, parse, list_rules, list_dialects  # noqa: F401
 
+# Import metadata (using importlib_metadata backport for python versions <3.8)
+if sys.version_info < (3, 8, 0):
+    import importlib_metadata as metadata
+else:
+    from importlib import metadata
 
 # Get the current version
-__version__ = importlib.metadata.version("sqlfluff")
+__version__ = metadata.version("sqlfluff")
 
 # Check major python version
 if sys.version_info[0] < 3:

--- a/src/sqlfluff/__init__.py
+++ b/src/sqlfluff/__init__.py
@@ -1,19 +1,14 @@
 """Sqlfluff is a SQL linter for humans."""
+import importlib.metadata
 import sys
 import pytest
 
 # Expose the public API.
 from sqlfluff.api import lint, fix, parse, list_rules, list_dialects  # noqa: F401
 
-# Set the version attribute of the library
-import pkg_resources
-import configparser
 
 # Get the current version
-config = configparser.ConfigParser()
-config.read([pkg_resources.resource_filename("sqlfluff", "config.ini")])
-
-__version__ = config.get("sqlfluff", "version")
+__version__ = importlib.metadata.version("sqlfluff")
 
 # Check major python version
 if sys.version_info[0] < 3:

--- a/src/sqlfluff/config.ini
+++ b/src/sqlfluff/config.ini
@@ -1,4 +1,0 @@
-# Config file for SQLFluff, mostly for version info for now
-[sqlfluff]
-version=0.8.2
-stable_version=0.8.2

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -350,8 +350,8 @@ def test__cli__command_versioning():
     pkg_version = sqlfluff.__version__
     # Get the version info from the config file
     config = configparser.ConfigParser()
-    config.read_file(open("src/sqlfluff/config.ini"))
-    config_version = config["sqlfluff"]["version"]
+    config.read_file(open("setup.cfg"))
+    config_version = config["metadata"]["version"]
     assert pkg_version == config_version
     # Get the version from the cli
     runner = CliRunner()


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
This is a follow up PR to #1960 in which I discuss moving the package version from the custom `config.ini` setup to a more standard approach in `setup.cfg`. 

I have updated all `config.ini` references to now refer to the version attribute in `setup.cfg`.
I have also included updates to CONTRIBUTING.md with updated release instructions.
The `stable_version` used in doc builds has been moved to a `[sqlfluff_docs]` section in `setup.cfg`.

I have tested building both packages, ran unit tests and test built the docs and all looks good.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
