### PR TITLE
Allow column references in IN statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -869,9 +869,17 @@ ansi_dialect.add(
         Sequence(Ref.keyword("SEPARATOR"), Ref("LiteralGrammar")),
         # like a function call: POSITION ( 'QL' IN 'SQL')
         Sequence(
-            OneOf(Ref("QuotedLiteralSegment"), Ref("SingleIdentifierGrammar")),
+            OneOf(
+                Ref("QuotedLiteralSegment"),
+                Ref("SingleIdentifierGrammar"),
+                Ref("ColumnReferenceSegment"),
+            ),
             "IN",
-            OneOf(Ref("QuotedLiteralSegment"), Ref("SingleIdentifierGrammar")),
+            OneOf(
+                Ref("QuotedLiteralSegment"),
+                Ref("SingleIdentifierGrammar"),
+                Ref("ColumnReferenceSegment"),
+            ),
         ),
         Sequence(OneOf("IGNORE", "RESPECT"), "NULLS"),
     ),

--- a/test/fixtures/dialects/postgres/postgres_position.sql
+++ b/test/fixtures/dialects/postgres/postgres_position.sql
@@ -1,0 +1,7 @@
+select
+  u.user_id,
+  u.user_email,
+  p.product_id
+from user_tb as u
+inner join product_tb as p on u.user_id = p.user_id
+  and position('@domain' in u.user_email) = 0

--- a/test/fixtures/dialects/postgres/postgres_position.yml
+++ b/test/fixtures/dialects/postgres/postgres_position.yml
@@ -1,0 +1,75 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 105579163a4b5e539b3bd94986415ea32621933eeef0bee988d9a4583c666900
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: select
+      - select_clause_element:
+          column_reference:
+          - identifier: u
+          - dot: .
+          - identifier: user_id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - identifier: u
+          - dot: .
+          - identifier: user_email
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - identifier: p
+          - dot: .
+          - identifier: product_id
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: user_tb
+            alias_expression:
+              keyword: as
+              identifier: u
+          join_clause:
+          - keyword: inner
+          - keyword: join
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: product_tb
+              alias_expression:
+                keyword: as
+                identifier: p
+          - join_on_condition:
+              keyword: 'on'
+              expression:
+              - column_reference:
+                - identifier: u
+                - dot: .
+                - identifier: user_id
+              - comparison_operator: '='
+              - column_reference:
+                - identifier: p
+                - dot: .
+                - identifier: user_id
+              - binary_operator: and
+              - function:
+                  function_name:
+                    function_name_identifier: position
+                  bracketed:
+                    start_bracket: (
+                    literal: "'@domain'"
+                    keyword: in
+                    column_reference:
+                    - identifier: u
+                    - dot: .
+                    - identifier: user_email
+                    end_bracket: )
+              - comparison_operator: '='
+              - literal: '0'


### PR DESCRIPTION
Fixes #1969 

### Brief summary of the change made

Expand `IN` grammar to allow column references

### Are there any other side effects of this change that we should be aware of?

Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
