### PR TITLE
L027: Remove unnessary crawl in get_select_statement_info

### DIFF
--- a/src/sqlfluff/core/rules/analysis/select.py
+++ b/src/sqlfluff/core/rules/analysis/select.py
@@ -31,8 +31,6 @@ def get_select_statement_info(
     # potential others.
     sc = segment.get_child("select_clause")
     reference_buffer = list(sc.recursive_crawl("object_reference"))
-    # Add any wildcard references
-    reference_buffer += list(sc.recursive_crawl("wildcard_identifier"))
     for potential_clause in (
         "where_clause",
         "groupby_clause",

--- a/src/sqlfluff/rules/L027.py
+++ b/src/sqlfluff/rules/L027.py
@@ -1,10 +1,10 @@
 """Implementation of Rule L027."""
 
 from sqlfluff.core.rules.base import LintResult
-from sqlfluff.rules.L025 import Rule_L025
+from sqlfluff.rules.L020 import Rule_L020
 
 
-class Rule_L027(Rule_L025):
+class Rule_L027(Rule_L020):
     """References should be qualified if select has more than one referenced table/view.
 
     NB: Except if they're present in a USING clause.

--- a/test/rules/std_L027_test.py
+++ b/test/rules/std_L027_test.py
@@ -1,0 +1,15 @@
+"""Tests the python routines within L027."""
+
+import sqlfluff
+
+
+def test__rules__std_L027_wildcard_single_count():
+    """Verify that L027 is only raised once for wildcard (see issue #1973)."""
+    sql = """
+        SELECT *
+        FROM foo
+        INNER JOIN bar;
+    """
+    result = sqlfluff.lint(sql)
+    assert "L027" in [r["code"] for r in result]
+    assert [r["code"] for r in result].count("L027") == 1


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Resolves #1973. Please, refer to the issue for description of fix.

N.B. some reason L027 was inheriting from L025 (which in turn inherits from L020) even though L025 provides no extra logic, I have corrected this to inherit from L020.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
