### PR TITLE
Fix issue with inline ignores not respecting comment lines

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -226,6 +226,11 @@ class Linter:
     def parse_noqa(comment: str, line_no: int):
         """Extract ignore mask entries from a comment string."""
         # Also trim any whitespace afterward
+
+        # Comment lines can also have noqa e.g.
+        # --dafhsdkfwdiruweksdkjdaffldfsdlfjksd -- noqa: L016
+        # Therefore extract last possible inline ignore.
+        comment = [c.strip() for c in comment.split("--")][-1]
         if comment.startswith("noqa"):
             # This is an ignore identifier
             comment_remainder = comment[4:]

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -231,7 +231,7 @@ class Linter:
         # --dafhsdkfwdiruweksdkjdaffldfsdlfjksd -- noqa: L016
         # Therefore extract last possible inline ignore.
         comment = [c.strip() for c in comment.split("--")][-1]
-        
+
         if comment.startswith("noqa"):
             # This is an ignore identifier
             comment_remainder = comment[4:]

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -231,6 +231,7 @@ class Linter:
         # --dafhsdkfwdiruweksdkjdaffldfsdlfjksd -- noqa: L016
         # Therefore extract last possible inline ignore.
         comment = [c.strip() for c in comment.split("--")][-1]
+        
         if comment.startswith("noqa"):
             # This is an ignore identifier
             comment_remainder = comment[4:]

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -383,6 +383,7 @@ def test__linter__encoding(fname, config_encoding, lexerror):
         ("noqa: disable=L010", NoQaDirective(0, ("L010",), "disable")),
         ("noqa: disable=all", NoQaDirective(0, None, "disable")),
         ("noqa: disable", SQLParseError),
+        ("Inline comment before inline ignore -- noqa:L001,L002", NoQaDirective(0, ("L001", "L002"), None)),
     ],
 )
 def test_parse_noqa(input, expected):
@@ -520,6 +521,22 @@ def test_parse_noqa(input, expected):
             ],
             [2],
         ],
+        [
+            [dict(comment="Inline comment before inline ignore -- noqa: L002", line_no=1)],
+            [DummyLintError(1)],
+            [0],
+        ],
+        [
+            [
+                dict(comment="Inline comment before inline ignore -- noqa: L002", line_no=1),
+                dict(comment="Inline comment before inline ignore -- noqa: L002", line_no=2),
+            ],
+            [
+                DummyLintError(1),
+                DummyLintError(2),
+            ],
+            [0, 1],
+        ],
     ],
     ids=[
         "1_violation_no_ignore",
@@ -538,6 +555,8 @@ def test_parse_noqa(input, expected):
         "1_violation_line_4_ignore_disable_all_2_3",
         "4_violations_two_types_disable_specific_enable_all",
         "4_violations_two_types_disable_all_enable_specific",
+        "1_violations_comment_inline_ignore",
+        "2_violations_comment_inline_ignore",
     ],
 )
 def test_linted_file_ignore_masked_violations(
@@ -586,6 +605,7 @@ def test_linter_noqa():
         col_n n, --noqa: disable=all
         col_o o,
         col_p p --noqa: enable=all
+        col_q a --Inline comment --noqa: L012
     FROM foo
         """
     result = lntr.lint_string(sql)
@@ -607,7 +627,7 @@ def test_linter_noqa_with_templating():
     {%- set a_var = ["1", "2"] -%}
     SELECT
       this_is_just_a_very_long_line_for_demonstration_purposes_of_a_bug_involving_templated_sql_files, --noqa: L016
-      this_is_not_so_big
+      this_is_not_so_big a --Inline comment --noqa: L012
     FROM
       a_table
         """

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -597,6 +597,7 @@ def test_linter_noqa():
     lntr = Linter(
         config=FluffConfig(
             overrides={
+                "dialect": "bigquery",  # Use bigquery to allow hash comments.
                 "rules": "L012",
             }
         )
@@ -618,8 +619,10 @@ def test_linter_noqa():
         col_m m,
         col_n n, --noqa: disable=all
         col_o o,
-        col_p p --noqa: enable=all
-        col_q a --Inline comment --noqa: L012
+        col_p p, --noqa: enable=all
+        col_q q, --Inline comment --noqa: L012
+        col_r r, /* Block comment */ --noqa: L012
+        col_s s # hash comment --noqa: L012
     FROM foo
         """
     result = lntr.lint_string(sql)
@@ -632,6 +635,7 @@ def test_linter_noqa_with_templating():
     lntr = Linter(
         config=FluffConfig(
             overrides={
+                "dialect": "bigquery",  # Use bigquery to allow hash comments.
                 "templater": "jinja",
                 "rules": "L016",
             }
@@ -641,7 +645,9 @@ def test_linter_noqa_with_templating():
     {%- set a_var = ["1", "2"] -%}
     SELECT
       this_is_just_a_very_long_line_for_demonstration_purposes_of_a_bug_involving_templated_sql_files, --noqa: L016
-      this_is_not_so_big a --Inline comment --noqa: L012
+      this_is_not_so_big a, --Inline comment --noqa: L012
+      this_is_not_so_big b, /* Block comment */ --noqa: L012
+      this_is_not_so_big c # hash comment --noqa: L012
     FROM
       a_table
         """

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -383,7 +383,10 @@ def test__linter__encoding(fname, config_encoding, lexerror):
         ("noqa: disable=L010", NoQaDirective(0, ("L010",), "disable")),
         ("noqa: disable=all", NoQaDirective(0, None, "disable")),
         ("noqa: disable", SQLParseError),
-        ("Inline comment before inline ignore -- noqa:L001,L002", NoQaDirective(0, ("L001", "L002"), None)),
+        (
+            "Inline comment before inline ignore -- noqa:L001,L002",
+            NoQaDirective(0, ("L001", "L002"), None),
+        ),
     ],
 )
 def test_parse_noqa(input, expected):
@@ -522,14 +525,25 @@ def test_parse_noqa(input, expected):
             [2],
         ],
         [
-            [dict(comment="Inline comment before inline ignore -- noqa: L002", line_no=1)],
+            [
+                dict(
+                    comment="Inline comment before inline ignore -- noqa: L002",
+                    line_no=1,
+                )
+            ],
             [DummyLintError(1)],
             [0],
         ],
         [
             [
-                dict(comment="Inline comment before inline ignore -- noqa: L002", line_no=1),
-                dict(comment="Inline comment before inline ignore -- noqa: L002", line_no=2),
+                dict(
+                    comment="Inline comment before inline ignore -- noqa: L002",
+                    line_no=1,
+                ),
+                dict(
+                    comment="Inline comment before inline ignore -- noqa: L002",
+                    line_no=2,
+                ),
             ],
             [
                 DummyLintError(1),


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Fixes #1977. Inline ignores weren't being processed on comment lines leading to issues like seen in the issue and the screenshot below. The fix is very simple.

![image](https://user-images.githubusercontent.com/80432516/143618218-4a7a8809-bab2-4eb6-aa1a-991fbab9e496.png)

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
