### PR TITLE
Add config CLI argument to lint, fix, and parse

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -177,7 +177,6 @@ def core_options(f: Callable) -> Callable:
     f = click.option(
         "--rules",
         default=None,
-        # short_help='Specify a particular rule, or comma separated rules, to check',
         help=(
             "Narrow the search to only specific rules. For example "
             "specifying `--rules L001` will only search for rule `L001` (Unnecessary "
@@ -189,7 +188,6 @@ def core_options(f: Callable) -> Callable:
     f = click.option(
         "--exclude-rules",
         default=None,
-        # short_help='Specify a particular rule, or comma separated rules to exclude',
         help=(
             "Exclude specific rules. For example "
             "specifying `--exclude-rules L001` will remove rule `L001` (Unnecessary "
@@ -198,6 +196,17 @@ def core_options(f: Callable) -> Callable:
             "Multiple rules can be specified with commas e.g. "
             "`--exclude-rules L001,L002` will exclude violations of rule "
             "`L001` and rule `L002`."
+        ),
+    )(f)
+    f = click.option(
+        "--extra-config",
+        "extra_config_path",
+        default=None,
+        help=(
+            "Include additional config file. By default the config is generated "
+            "from the standard configuration files described in the documentation. This "
+            "argument allows you to specify an additional configuration file that overrides "
+            "the standard configuration files. N.B. cfg format is required."
         ),
     )(f)
     f = click.option(
@@ -225,7 +234,7 @@ def core_options(f: Callable) -> Callable:
     return f
 
 
-def get_config(**kwargs) -> FluffConfig:
+def get_config(extra_config_path: Optional[str] = None, **kwargs) -> FluffConfig:
     """Get a config object from kwargs."""
     if "dialect" in kwargs:
         try:
@@ -249,7 +258,10 @@ def get_config(**kwargs) -> FluffConfig:
     # Instantiate a config object (filtering out the nulls)
     overrides = {k: kwargs[k] for k in kwargs if kwargs[k] is not None}
     try:
-        return FluffConfig.from_root(overrides=overrides)
+        return FluffConfig.from_root(
+            extra_config_path=extra_config_path,
+            overrides=overrides,
+        )
     except SQLFluffUserError as err:  # pragma: no cover
         click.echo(
             colorize(
@@ -396,6 +408,7 @@ def lint(
     logger: Optional[logging.Logger] = None,
     bench: bool = False,
     disable_progress_bar: Optional[bool] = False,
+    extra_config_path: Optional[str] = None,
     **kwargs,
 ) -> NoReturn:
     """Lint SQL files via passing a list of files or using stdin.
@@ -416,7 +429,7 @@ def lint(
         echo 'select col from tbl' | sqlfluff lint -
 
     """
-    config = get_config(**kwargs)
+    config = get_config(extra_config_path, **kwargs)
     non_human_output = format != FormatType.human.value
     lnt, formatter = get_linter_and_formatter(config, silent=non_human_output)
 
@@ -548,6 +561,7 @@ def fix(
     fixed_suffix: str = "",
     logger: Optional[logging.Logger] = None,
     disable_progress_bar: Optional[bool] = False,
+    extra_config_path: Optional[str] = None,
     **kwargs,
 ) -> NoReturn:
     """Fix SQL files.
@@ -560,7 +574,7 @@ def fix(
     # some quick checks
     fixing_stdin = ("-",) == paths
 
-    config = get_config(**kwargs)
+    config = get_config(extra_config_path, **kwargs)
     lnt, formatter = get_linter_and_formatter(config, silent=fixing_stdin)
 
     verbose = config.get("verbose")
@@ -767,6 +781,7 @@ def parse(
     bench: bool,
     nofail: bool,
     logger: Optional[logging.Logger] = None,
+    extra_config_path: Optional[str] = None,
     **kwargs,
 ) -> NoReturn:
     """Parse SQL files and just spit out the result.
@@ -776,7 +791,7 @@ def parse(
     character to indicate reading from *stdin* or a dot/blank ('.'/' ') which will
     be interpreted like passing the current working directory as a path argument.
     """
-    c = get_config(**kwargs)
+    c = get_config(extra_config_path, **kwargs)
     # We don't want anything else to be logged if we want json or yaml output
     non_human_output = format in (FormatType.json.value, FormatType.yaml.value)
     lnt, formatter = get_linter_and_formatter(c, silent=non_human_output)

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -199,7 +199,7 @@ def core_options(f: Callable) -> Callable:
         ),
     )(f)
     f = click.option(
-        "--extra-config",
+        "--config",
         "extra_config_path",
         default=None,
         help=(

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -299,7 +299,7 @@ class ConfigLoader:
         return configs
 
     def load_extra_config(self, extra_config_path: str) -> dict:
-        "Load specified extra config."
+        """Load specified extra config."""
         if not os.path.exists(extra_config_path):
             raise SQLFluffUserError(
                 f"Extra config '{extra_config_path}' does not exist."
@@ -588,7 +588,7 @@ class FluffConfig:
             )
 
     def make_child_from_path(self, path: str) -> "FluffConfig":
-        """Make a new child config at a path but pass on overrides."""
+        """Make a new child config at a path but pass on overrides and extra_config_path."""
         return self.from_path(
             path,
             extra_config_path=self._extra_config_path,

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -298,6 +298,25 @@ class ConfigLoader:
         self._config_cache[str(path)] = configs
         return configs
 
+    def load_extra_config(self, extra_config_path: str) -> dict:
+        "Load specified extra config."
+        if not os.path.exists(extra_config_path):
+            raise SQLFluffUserError(
+                f"Extra config '{extra_config_path}' does not exist."
+            )
+
+        # First check the cache
+        if str(extra_config_path) in self._config_cache:
+            return self._config_cache[str(extra_config_path)]
+
+        configs: dict = {}
+        elems = self._get_config_elems_from_file(extra_config_path)
+        configs = self._incorporate_vals(configs, elems)
+
+        # Store in the cache
+        self._config_cache[str(extra_config_path)] = configs
+        return configs
+
     @staticmethod
     def _get_user_config_dir_path() -> str:
         appname = "sqlfluff"
@@ -329,13 +348,20 @@ class ConfigLoader:
         user_home_path = os.path.expanduser("~")
         return self.load_config_at_path(user_home_path)
 
-    def load_config_up_to_path(self, path: str) -> dict:
+    def load_config_up_to_path(
+        self, path: str, extra_config_path: Optional[str] = None
+    ) -> dict:
         """Loads a selection of config files from both the path and its parent paths."""
         user_appdir_config = self.load_user_appdir_config()
         user_config = self.load_user_config()
         config_paths = self.iter_config_locations_up_to_path(path)
         config_stack = [self.load_config_at_path(p) for p in config_paths]
-        return nested_combine(user_appdir_config, user_config, *config_stack)
+        extra_config = (
+            self.load_extra_config(extra_config_path) if extra_config_path else {}
+        )
+        return nested_combine(
+            user_appdir_config, user_config, *config_stack, extra_config
+        )
 
     @classmethod
     def find_ignore_config_files(
@@ -395,9 +421,13 @@ class FluffConfig:
     def __init__(
         self,
         configs: Optional[dict] = None,
+        extra_config_path: Optional[str] = None,
         overrides: Optional[dict] = None,
         plugin_manager: Optional[pluggy.PluginManager] = None,
     ):
+        self._extra_config_path = (
+            extra_config_path  # We only store this for child configs
+        )
         self._overrides = overrides  # We only store this for child configs
 
         # Fetch a fresh plugin manager if we weren't provided with one
@@ -472,23 +502,33 @@ class FluffConfig:
         # in the child processes.
 
     @classmethod
-    def from_root(cls, overrides: Optional[dict] = None) -> "FluffConfig":
+    def from_root(
+        cls, extra_config_path: Optional[str] = None, overrides: Optional[dict] = None
+    ) -> "FluffConfig":
         """Loads a config object just based on the root directory."""
         loader = ConfigLoader.get_global()
-        c = loader.load_config_up_to_path(path=".")
-        return cls(configs=c, overrides=overrides)
+        c = loader.load_config_up_to_path(path=".", extra_config_path=extra_config_path)
+        return cls(configs=c, extra_config_path=extra_config_path, overrides=overrides)
 
     @classmethod
     def from_path(
         cls,
         path: str,
+        extra_config_path: Optional[str] = None,
         overrides: Optional[dict] = None,
         plugin_manager: Optional[pluggy.PluginManager] = None,
     ) -> "FluffConfig":
         """Loads a config object given a particular path."""
         loader = ConfigLoader.get_global()
-        c = loader.load_config_up_to_path(path=path)
-        return cls(configs=c, overrides=overrides, plugin_manager=plugin_manager)
+        c = loader.load_config_up_to_path(
+            path=path, extra_config_path=extra_config_path
+        )
+        return cls(
+            configs=c,
+            extra_config_path=extra_config_path,
+            overrides=overrides,
+            plugin_manager=plugin_manager,
+        )
 
     @classmethod
     def from_kwargs(
@@ -550,7 +590,10 @@ class FluffConfig:
     def make_child_from_path(self, path: str) -> "FluffConfig":
         """Make a new child config at a path but pass on overrides."""
         return self.from_path(
-            path, overrides=self._overrides, plugin_manager=self._plugin_manager
+            path,
+            extra_config_path=self._extra_config_path,
+            overrides=self._overrides,
+            plugin_manager=self._plugin_manager,
         )
 
     def diff_to(self, other: "FluffConfig") -> dict:

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -102,7 +102,9 @@ class Linter:
     # These are the building blocks of the linting process.
 
     @staticmethod
-    def _load_raw_file_and_config(fname, root_config):
+    def _load_raw_file_and_config(
+        fname: str, root_config: FluffConfig
+    ) -> Tuple[str, FluffConfig, str]:
         """Load a raw file and the associated config."""
         file_config = root_config.make_child_from_path(fname)
         encoding = get_encoding(fname=fname, config=file_config)

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -112,6 +112,25 @@ def test__cli__command_dialect_legacy():
     assert "Please use the 'exasol' dialect instead." in result.stdout
 
 
+def test__cli__command_extra_config_fail():
+    """Check the script raises the right exception on a non-existant extra config path."""
+    result = invoke_assert_code(
+        ret_code=66,
+        args=[
+            lint,
+            [
+                "--extra-config",
+                "test/fixtures/cli/extra_configs/.sqlfluffsdfdfdfsfd",
+                "test/fixtures/cli/extra_config_tsql.sql",
+            ],
+        ],
+    )
+    assert (
+        "Extra config 'test/fixtures/cli/extra_configs/.sqlfluffsdfdfdfsfd' does not exist."
+        in result.stdout
+    )
+
+
 @pytest.mark.parametrize(
     "command",
     [
@@ -263,6 +282,15 @@ def test__cli__command_lint_stdin(command):
         ),
         # Check nofail works
         (lint, ["--nofail", "test/fixtures/linter/parse_lex_error.sql"]),
+        # Check extra-config works (sets dialect to tsql)
+        (
+            lint,
+            [
+                "--extra-config",
+                "test/fixtures/cli/extra_configs/.sqlfluff",
+                "test/fixtures/cli/extra_config_tsql.sql",
+            ],
+        ),
     ],
 )
 def test__cli__command_lint_parse(command):

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -119,7 +119,7 @@ def test__cli__command_extra_config_fail():
         args=[
             lint,
             [
-                "--extra-config",
+                "--config",
                 "test/fixtures/cli/extra_configs/.sqlfluffsdfdfdfsfd",
                 "test/fixtures/cli/extra_config_tsql.sql",
             ],
@@ -282,11 +282,11 @@ def test__cli__command_lint_stdin(command):
         ),
         # Check nofail works
         (lint, ["--nofail", "test/fixtures/linter/parse_lex_error.sql"]),
-        # Check extra-config works (sets dialect to tsql)
+        # Check config works (sets dialect to tsql)
         (
             lint,
             [
-                "--extra-config",
+                "--config",
                 "test/fixtures/cli/extra_configs/.sqlfluff",
                 "test/fixtures/cli/extra_config_tsql.sql",
             ],

--- a/test/fixtures/cli/extra_config_tsql.sql
+++ b/test/fixtures/cli/extra_config_tsql.sql
@@ -1,0 +1,4 @@
+-- Some tsql specifc sql to test config cli argument.
+BEGIN
+    SELECT 'Weekend';
+END

--- a/test/fixtures/cli/extra_configs/.sqlfluff
+++ b/test/fixtures/cli/extra_configs/.sqlfluff
@@ -1,0 +1,2 @@
+[sqlfluff]
+dialect = tsql


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Fixes #1244.
This PR adds a command line argument `--config` to the CLI `lint`, `fix`, and `parse` commands. 

The user can specify an additional config file such that the override logic is (later files override earlier ones):
- `default_config.cfg` (package default)
- `<user_appdir_configs>`
- `<user_homedir_configs>`
- `<user_homedir_configs>`
- `<configs_between_cwd_and_sql_path>`
- `<extra_config_file>` (this PR)
- Any command line arguments

This behaviour was voted on in the Slack channel: https://sqlfluff.slack.com/archives/C01GPHR8J0G/p1637859667129900

If no config files are included in the default config search paths then this argument can be used to specify a single off-path config file which will also be useful for several applications.
(Will investigate in a future PR adding `--ignore-local-config` option to allow only `--config` to be considered)

N.B. This PR focuses on the CLI, I will make a subsequent PR to flow the changes through to the Simple API as well.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
