### PR TITLE
BigQuery: Allow keywords in column reference components

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -30,7 +30,9 @@ from sqlfluff.core.parser import (
     OptionallyBracketed,
     Indent,
     Dedent,
+    Matchable,
 )
+from sqlfluff.core.parser.segments.base import BracketedSegment
 
 from sqlfluff.core.dialects import load_raw_dialect
 
@@ -122,6 +124,18 @@ bigquery_dialect.add(
         name="atsign_literal",
         type="literal",
         trim_chars=("@",),
+    ),
+    # Add a Full equivalent which also allow keywords
+    NakedIdentifierSegmentFull=RegexParser(
+        r"[A-Z0-9_]*[A-Z][A-Z0-9_]*",
+        CodeSegment,
+        name="naked_identifier_all",
+        type="identifier",
+    ),
+    SingleIdentifierGrammarFull=OneOf(
+        Ref("NakedIdentifierSegment"),
+        Ref("QuotedIdentifierSegment"),
+        Ref("NakedIdentifierSegmentFull"),
     ),
 )
 
@@ -633,9 +647,42 @@ ObjectReferenceSegment = ansi_dialect.get_segment("ObjectReferenceSegment")
 
 @bigquery_dialect.segment(replace=True)
 class ColumnReferenceSegment(ObjectReferenceSegment):  # type: ignore
-    """A reference to column, field or alias."""
+    """A reference to column, field or alias.
+
+    We override this for BigQuery to allow keyword structures (using Full)
+    and to properly return references for objects
+    """
 
     type = "column_reference"
+    match_grammar: Matchable = Sequence(
+        Ref("SingleIdentifierGrammar"),
+        Sequence(
+            OneOf(Ref("DotSegment"), Sequence(Ref("DotSegment"), Ref("DotSegment"))),
+            Delimited(
+                Ref("SingleIdentifierGrammarFull"),
+                delimiter=OneOf(
+                    Ref("DotSegment"), Sequence(Ref("DotSegment"), Ref("DotSegment"))
+                ),
+                terminator=OneOf(
+                    "ON",
+                    "AS",
+                    "USING",
+                    Ref("CommaSegment"),
+                    Ref("CastOperatorSegment"),
+                    Ref("StartSquareBracketSegment"),
+                    Ref("StartBracketSegment"),
+                    Ref("BinaryOperatorGrammar"),
+                    Ref("ColonSegment"),
+                    Ref("DelimiterSegment"),
+                    BracketedSegment,
+                ),
+                allow_gaps=False,
+            ),
+            allow_gaps=False,
+            optional=True,
+        ),
+        allow_gaps=False,
+    )
 
     def extract_possible_references(self, level):
         """Extract possible references of a given level."""

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -649,8 +649,13 @@ ObjectReferenceSegment = ansi_dialect.get_segment("ObjectReferenceSegment")
 class ColumnReferenceSegment(ObjectReferenceSegment):  # type: ignore
     """A reference to column, field or alias.
 
-    We override this for BigQuery to allow keyword structures (using Full)
-    and to properly return references for objects
+    We override this for BigQuery to allow keywords in structures
+    (using Full segments) and to properly return references for objects.
+
+    Ref: https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical
+    "A reserved keyword must be a quoted identifier if it is a standalone
+    keyword or the first component of a path expression. It may be unquoted
+    as the second or later component of a path expression."
     """
 
     type = "column_reference"

--- a/test/fixtures/dialects/bigquery/select_column_object_with_keyword.sql
+++ b/test/fixtures/dialects/bigquery/select_column_object_with_keyword.sql
@@ -1,0 +1,7 @@
+-- current is a reserved word but is allowed as part of a nested object name
+SELECT
+  table1.current.column,
+  table1.object.current.column,
+  table1.object.nested.current.column,
+FROM
+  table1

--- a/test/fixtures/dialects/bigquery/select_column_object_with_keyword.sql
+++ b/test/fixtures/dialects/bigquery/select_column_object_with_keyword.sql
@@ -1,4 +1,4 @@
--- current is a reserved word but is allowed as part of a nested object name
+-- current is a reserved word but keywords are allowed as part of a nested object name
 SELECT
   table1.current.column,
   table1.object.current.column,

--- a/test/fixtures/dialects/bigquery/select_column_object_with_keyword.yml
+++ b/test/fixtures/dialects/bigquery/select_column_object_with_keyword.yml
@@ -1,0 +1,48 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e9b7b38575826b8cc463734bcc7647038a51e5b8342f3c2dd6624b233bae30d8
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: table1
+          - dot: .
+          - identifier: current
+          - dot: .
+          - identifier: column
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - identifier: table1
+          - dot: .
+          - identifier: object
+          - dot: .
+          - identifier: current
+          - dot: .
+          - identifier: column
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - identifier: table1
+          - dot: .
+          - identifier: object
+          - dot: .
+          - identifier: nested
+          - dot: .
+          - identifier: current
+          - dot: .
+          - identifier: column
+      - comma: ','
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: table1


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
Fixes #1981 


This is valid BigQuery even though `current` is a keyword:

```sql
-- current is a reserved word but keywords are allowed as part of a nested object name
SELECT
  table1.current.column,
  table1.object.current.column,
  table1.object.nested.current.column,
FROM
  table1
```

Docs: https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical

> A reserved keyword must be a quoted identifier if it is a standalone keyword or the first component of a path expression. It may be unquoted as the second or later component of a path expression.

### Are there any other side effects of this change that we should be aware of?
Only handles Column References. There would be more places where this should be implemented but think this is the main one.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
