### PR TITLE
Adds extra check to L054 to avoid weird error messages

### DIFF
--- a/src/sqlfluff/rules/L054.py
+++ b/src/sqlfluff/rules/L054.py
@@ -96,6 +96,10 @@ class Rule_L054(BaseRule):
             if segment.name in column_reference_category_map
         }
 
+        # If there are no column references then just return
+        if not column_reference_category_set:
+            return LintResult(memory=context.memory)
+
         if self.group_by_and_order_by_style == "consistent":
             # If consistent naming then raise lint error if either:
 

--- a/test/fixtures/rules/std_rule_cases/L054.yml
+++ b/test/fixtures/rules/std_rule_cases/L054.yml
@@ -436,9 +436,9 @@ test_fail_implicit_expression_order_by_custom_implicit:
       L054:
         group_by_and_order_by_style: implicit
 
-test_fail_implicit_expression_order_by_custom_implicit:
+test_pass_no_qa:
   pass_str: |
-    SELECT foo.set.barr
+    SELECT foo.set.barr  --noqa: PRS
     FROM foo
     GROUP BY  --noqa: PRS
       foo.set.barr

--- a/test/fixtures/rules/std_rule_cases/L054.yml
+++ b/test/fixtures/rules/std_rule_cases/L054.yml
@@ -104,7 +104,7 @@ test_pass_explicit_expression_order_by_default:
         sum(baz) AS sum_value
     FROM fake_table
     ORDER BY
-        foo, power(bar, 2) 
+        foo, power(bar, 2)
 
 test_fail_implicit_expression_order_by_default:
   fail_str: |
@@ -114,7 +114,7 @@ test_fail_implicit_expression_order_by_default:
         sum(baz) AS sum_value
     FROM fake_table
     ORDER BY
-        1, power(bar, 2) 
+        1, power(bar, 2)
 
 test_pass_explicit_group_by_custom_explicit:
   pass_str: |
@@ -256,7 +256,7 @@ test_pass_explicit_expression_order_by_custom_explicit:
         sum(baz) AS sum_value
     FROM fake_table
     ORDER BY
-        foo, power(bar, 2) 
+        foo, power(bar, 2)
   configs:
     rules:
       L054:
@@ -416,7 +416,7 @@ test_fail_explicit_expression_order_by_custom_implicit:
         sum(baz) AS sum_value
     FROM fake_table
     ORDER BY
-        foo, power(bar, 2) 
+        foo, power(bar, 2)
   configs:
     rules:
       L054:
@@ -435,3 +435,10 @@ test_fail_implicit_expression_order_by_custom_implicit:
     rules:
       L054:
         group_by_and_order_by_style: implicit
+
+test_fail_implicit_expression_order_by_custom_implicit:
+  pass_str: |
+    SELECT foo.set.barr
+    FROM foo
+    GROUP BY  --noqa: PRS
+      foo.set.barr

--- a/test/fixtures/rules/std_rule_cases/L054.yml
+++ b/test/fixtures/rules/std_rule_cases/L054.yml
@@ -435,10 +435,3 @@ test_fail_implicit_expression_order_by_custom_implicit:
     rules:
       L054:
         group_by_and_order_by_style: implicit
-
-test_pass_no_qa:
-  pass_str: |
-    SELECT foo.set.barr  --noqa: PRS
-    FROM foo
-    GROUP BY  --noqa: PRS
-      foo.set.barr

--- a/test/rules/std_L054_test.py
+++ b/test/rules/std_L054_test.py
@@ -63,4 +63,3 @@ def test__rules__std_L054_noqa() -> None:
     results_prs = [r for r in result if r["code"] == "PRS"]
     assert len(results_l054) == 0
     assert len(results_prs) == 0
-

--- a/test/rules/std_L054_test.py
+++ b/test/rules/std_L054_test.py
@@ -31,3 +31,36 @@ def test__rules__std_L054_raised() -> None:
         results_l054[0]["description"]
         == "Inconsistent column references in GROUP BY/ORDER BY clauses."
     )
+
+
+def test__rules__std_L054_unparsable() -> None:
+    """Test unparsable group by doesn't result in bad rule L054 error."""
+    sql = """
+    SELECT foo.set.barr
+    FROM foo
+    GROUP BY
+      foo.set.barr
+    """
+    result = sqlfluff.lint(sql)
+
+    results_l054 = [r for r in result if r["code"] == "L054"]
+    results_prs = [r for r in result if r["code"] == "PRS"]
+    assert len(results_l054) == 0
+    assert len(results_prs) > 0
+
+
+def test__rules__std_L054_noqa() -> None:
+    """Test unparsable group by with no qa doesn't result in bad rule L054 error."""
+    sql = """
+    SELECT foo.set.barr  --noqa: PRS
+    FROM foo
+    GROUP BY  --noqa: PRS
+      foo.set.barr
+    """
+    result = sqlfluff.lint(sql)
+
+    results_l054 = [r for r in result if r["code"] == "L054"]
+    results_prs = [r for r in result if r["code"] == "PRS"]
+    assert len(results_l054) == 0
+    assert len(results_prs) == 0
+


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->

Follow on from #1981 and #1987

Don't try to pop an empty column set in L054 to avoid weird error messages. Shouldn't really happen if there are no parsing errors and no `--noqa` (so took me a while to reproduce a test case!) but good check to have I think.

@jpy-git can you review too please since you added this rule?

### Are there any other side effects of this change that we should be aware of?
Don't think so

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
