### PR TITLE
Make Snowflake tags DRY

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -828,10 +828,13 @@ class AlterWarehouseStatementSegment(BaseSegment):
             Sequence(
                 Ref("NakedIdentifierSegment"),
                 "SET",
-                AnyNumberOf(
-                    Ref("WarehouseObjectPropertiesSegment"),
-                    Ref("CommentEqualsClauseSegment"),
-                    Ref("WarehouseObjectParamsSegment"),
+                OneOf(
+                    AnyNumberOf(
+                        Ref("WarehouseObjectPropertiesSegment"),
+                        Ref("CommentEqualsClauseSegment"),
+                        Ref("WarehouseObjectParamsSegment"),
+                    ),
+                    Ref("TagEqualsSegment"),
                 ),
             ),
             Sequence(
@@ -873,7 +876,7 @@ class CommentEqualsClauseSegment(BaseSegment):
 class TagBracketedEqualsSegment(BaseSegment):
     """A tag clause.
 
-    e.g. TAG (tag1= 'value1', tag2 = 'value2')
+    e.g. TAG (tag1 = 'value1', tag2 = 'value2')
     """
 
     type = "tag_bracketed_equals"
@@ -896,7 +899,7 @@ class TagBracketedEqualsSegment(BaseSegment):
 class TagEqualsSegment(BaseSegment):
     """A tag clause.
 
-    e.g. TAG tag1= 'value1', tag2 = 'value2'
+    e.g. TAG tag1 = 'value1', tag2 = 'value2'
     """
 
     type = "tag_equals"
@@ -1102,16 +1105,6 @@ class WarehouseObjectParamsSegment(BaseSegment):
             Ref("EqualsSegment"),
             Ref("NumericLiteralSegment"),
         ),
-        Sequence(
-            "TAG",
-            Delimited(
-                Sequence(
-                    Ref("NakedIdentifierSegment"),
-                    Ref("EqualsSegment"),
-                    Ref("QuotedLiteralSegment"),
-                )
-            ),
-        ),
     )
 
 
@@ -1195,17 +1188,7 @@ class ColumnConstraintSegment(BaseSegment):
             "POLICY",
             Ref("QuotedLiteralSegment"),
         ),
-        Sequence(
-            Sequence("WITH", optional=True),
-            "TAG",
-            Bracketed(
-                Delimited(
-                    Ref("NakedIdentifierSegment"),
-                    Ref("EqualsSegment"),
-                    Ref("QuotedIdentifierSegment"),
-                )
-            ),
-        ),
+        Ref("TagBracketedEqualsSegment", optional=True),
         Ref("ConstraintPropertiesSegment"),
         Sequence("DEFAULT", Ref("QuotedLiteralSegment")),
         Sequence("CHECK", Bracketed(Ref("ExpressionSegment"))),
@@ -1471,18 +1454,7 @@ class CreateTableStatementSegment(BaseSegment):
             Bracketed(Delimited(Ref("ColumnReferenceSegment"))),
             optional=True,
         ),
-        Sequence(
-            Sequence("WITH", optional=True),
-            "TAG",
-            Bracketed(
-                Delimited(
-                    Ref("NakedIdentifierSegment"),
-                    Ref("EqualsSegment"),
-                    Ref("QuotedIdentifierSegment"),
-                )
-            ),
-            optional=True,
-        ),
+        Ref("TagBracketedEqualsSegment", optional=True),
         Ref("CommentEqualsClauseSegment", optional=True),
         OneOf(
             # Create AS syntax:
@@ -1654,6 +1626,7 @@ class CreateStatementSegment(BaseSegment):
                 Ref("WarehouseObjectPropertiesSegment"),
                 Ref("WarehouseObjectParamsSegment"),
             ),
+            Ref("TagBracketedEqualsSegment", optional=True),
             optional=True,
         ),
         Ref("CreateStatementCommentSegment", optional=True),
@@ -1829,14 +1802,7 @@ class CreateExternalTableSegment(BaseSegment):
                 Ref("NakedIdentifierSegment"),
                 optional=True,
             ),
-            Sequence(
-                Sequence("WITH", optional=True),
-                "TAG",
-                Ref("NakedIdentifierSegment"),
-                Ref("EqualsSegment"),
-                Ref("QuotedLiteralSegment"),
-                optional=True,
-            ),
+            Ref("TagBracketedEqualsSegment", optional=True),
             Ref("CreateStatementCommentSegment", optional=True),
         ),
     )

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -840,8 +840,9 @@ class AlterWarehouseStatementSegment(BaseSegment):
             Sequence(
                 Ref("NakedIdentifierSegment"),
                 "UNSET",
-                Delimited(
-                    Ref("NakedIdentifierSegment"),
+                OneOf(
+                    Delimited(Ref("NakedIdentifierSegment")),
+                    Sequence("TAG", Delimited(Ref("NakedIdentifierSegment"))),
                 ),
             ),
         ),

--- a/test/fixtures/dialects/snowflake/snowflake_alter_warehouse.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_warehouse.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 85736815171e540531558007cd393090e8b283c4cee36ddf1aa5cf05c9fc3f24
+_hash: 3e2b9618e0f631b6ae5ebee794c1be3ec49ba8ddf6f71d91d87a7f7030c5de3b
 file:
 - statement:
     alter_warehouse_statement:
@@ -165,7 +165,7 @@ file:
     - keyword: warehouse
     - identifier: LOAD_WH
     - keyword: set
-    - warehouse_object_properties:
+    - tag_equals:
         keyword: TAG
         identifier: thetag
         comparison_operator: '='
@@ -177,7 +177,7 @@ file:
     - keyword: warehouse
     - identifier: LOAD_WH
     - keyword: set
-    - warehouse_object_properties:
+    - tag_equals:
       - keyword: TAG
       - identifier: thetag1
       - comparison_operator: '='


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->

Makes the Snowflake dialect a bit more DRY, by replacing repetitive code for object tagging with the tag segments introduced in #1950. In doing so, a few bugs are fixed as well:

- Tags need to go last in a `create warehouse statement`.
- Tags cannot be combined with other options in an `alter warehouse unset` statement, [same as for schemas](https://github.com/sqlfluff/sqlfluff/pull/1950#discussion_r757818390).
- The tag sequence in `CreateExternalTableSegment` was missing `Bracketed`.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
