### PR TITLE
Use posargs to enable pytest_xdist for standard unit tests only

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -159,7 +159,7 @@ jobs:
       # working dir on D drive which causes problems.
       run: |
         mkdir temp_pytest
-        python -m tox -e winpy
+        python -m tox -e winpy -- -n 2 test
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -61,7 +61,7 @@ jobs:
         echo 'EOF' >> $GITHUB_ENV
     - name: Run the tests
       run: |
-        tox -e ${{ env.TOXENV }}
+        tox -e ${{ env.TOXENV }} -- -n 2 test
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1
       with:

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands =
     # Clean up from previous tests
     python util.py clean-tests
     # Run tests
-    pytest -n 2 -vv -rs --cov=sqlfluff --cov-report=xml {posargs: test}
+    pytest -vv -rs --cov=sqlfluff --cov-report=xml {posargs: test}
 
 [testenv:cov-init]
 setenv =


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
This should hopefully resolve the issues in #1957 with pytest_xdist causing unit test failures in dbt tests. moves `-n 2` option to standard unit tests only.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
