### PR TITLE
Fix inline comment interactions with L052

### DIFF
--- a/src/sqlfluff/rules/L052.py
+++ b/src/sqlfluff/rules/L052.py
@@ -59,6 +59,7 @@ class Rule_L052(BaseRule):
                 s
                 for s in pre_semicolon_segments
                 if s.is_comment
+                and s.name != "block_comment"
                 and s.pos_marker.working_line_no
                 == anchor_segment.pos_marker.working_line_no
             ),
@@ -87,7 +88,7 @@ class Rule_L052(BaseRule):
                 if (
                     comment_segment.pos_marker.working_line_no
                     == anchor_segment.pos_marker.working_line_no
-                ):
+                ) and (comment_segment.name != "block_comment"):
                     anchor_segment = comment_segment
 
         return anchor_segment

--- a/src/sqlfluff/rules/L052.py
+++ b/src/sqlfluff/rules/L052.py
@@ -121,7 +121,7 @@ class Rule_L052(BaseRule):
             for segment in complete_stack[::-1]:  # type: ignore
                 if segment.name == "semicolon":
                     semi_colon_exist_flag = True
-                elif (segment.name not in whitespace_set) and (not segment.is_meta):
+                elif segment.is_code:
                     break
                 anchor_segment = segment
 

--- a/test/fixtures/rules/std_rule_cases/L052.yml
+++ b/test/fixtures/rules/std_rule_cases/L052.yml
@@ -152,8 +152,8 @@ test_fail_final_semi_colon_newline_inline_comment:
   fail_str: |
     SELECT a FROM foo -- inline comment
   fix_str: |
-    SELECT a FROM foo
-    ; -- inline comment
+    SELECT a FROM foo -- inline comment
+    ;
   configs:
     rules:
       L052:
@@ -178,13 +178,10 @@ test_fail_same_line_multiple_inline_comment:
 
     -- inline comment
 
-test_fail_newline_move_inline_comment:
-  fail_str: |
+test_pass_newline_inline_comment:
+  pass_str: |
     SELECT a FROM foo -- inline comment
     ;
-  fix_str: |
-    SELECT a FROM foo
-    ; -- inline comment
   configs:
     rules:
       L052:
@@ -196,8 +193,8 @@ test_fail_newline_inline_comment:
     
     ;
   fix_str: |
-    SELECT a FROM foo
-    ; -- inline comment
+    SELECT a FROM foo -- inline comment
+    ;
   configs:
     rules:
       L052:
@@ -211,10 +208,21 @@ test_fail_newline_multiple_inline_comments:
 
     ;
   fix_str: |
-    SELECT a FROM foo
-    ; -- inline comment
+    SELECT a FROM foo -- inline comment
+    ;
 
     -- inline comment
+  configs:
+    rules:
+      L052:
+        semicolon_newline: True
+
+test_fail_newline_trailing_inline_comment:
+  fail_str: |
+    SELECT a FROM foo ; -- inline comment
+  fix_str: |
+    SELECT a FROM foo -- inline comment
+    ;
   configs:
     rules:
       L052:

--- a/test/fixtures/rules/std_rule_cases/L052.yml
+++ b/test/fixtures/rules/std_rule_cases/L052.yml
@@ -137,3 +137,25 @@ test_fail_multiple_newlines_semi_colon_custom_require_newline:
       L052:
         require_final_semicolon: True
         semicolon_newline: True
+
+test_fail_final_semi_colon_same_line_inline_comment:
+  fail_str: |
+    SELECT a FROM foo -- inline comment
+  fix_str: |
+    SELECT a FROM foo; -- inline comment
+  configs:
+    rules:
+      L052:
+        require_final_semicolon: True
+
+test_fail_final_semi_colon_newline_inline_comment:
+  fail_str: |
+    SELECT a FROM foo -- inline comment
+  fix_str: |
+    SELECT a FROM foo
+    ; -- inline comment
+  configs:
+    rules:
+      L052:
+        require_final_semicolon: True
+        semicolon_newline: True

--- a/test/fixtures/rules/std_rule_cases/L052.yml
+++ b/test/fixtures/rules/std_rule_cases/L052.yml
@@ -227,3 +227,38 @@ test_fail_newline_trailing_inline_comment:
     rules:
       L052:
         semicolon_newline: True
+
+test_fail_newline_preceding_block_comment:
+  fail_str: |
+    SELECT foo
+    FROM bar /* multiline
+    comment
+    */
+    ;
+  fix_str: |
+    SELECT foo
+    FROM bar
+    ; /* multiline
+    comment
+    */
+  configs:
+    rules:
+      L052:
+        semicolon_newline: True
+
+test_fail_newline_trailing_block_comment:
+  fail_str: |
+    SELECT foo
+    FROM bar; /* multiline
+    comment
+    */
+  fix_str: |
+    SELECT foo
+    FROM bar
+    ; /* multiline
+    comment
+    */
+  configs:
+    rules:
+      L052:
+        semicolon_newline: True

--- a/test/fixtures/rules/std_rule_cases/L052.yml
+++ b/test/fixtures/rules/std_rule_cases/L052.yml
@@ -262,3 +262,42 @@ test_fail_newline_trailing_block_comment:
     rules:
       L052:
         semicolon_newline: True
+
+test_fail_newline_block_comment_semi_colon_before:
+  fail_str: |
+    SELECT foo
+    FROM bar;
+    /* multiline
+    comment
+    */
+  fix_str: |
+    SELECT foo
+    FROM bar
+    ;
+    /* multiline
+    comment
+    */
+  configs:
+    rules:
+      L052:
+        semicolon_newline: True
+
+test_fail_newline_block_comment_semi_colon_after:
+  fail_str: |
+    SELECT foo
+    FROM bar
+    /* multiline
+    comment
+    */
+    ;
+  fix_str: |
+    SELECT foo
+    FROM bar
+    ;
+    /* multiline
+    comment
+    */
+  configs:
+    rules:
+      L052:
+        semicolon_newline: True

--- a/test/fixtures/rules/std_rule_cases/L052.yml
+++ b/test/fixtures/rules/std_rule_cases/L052.yml
@@ -159,3 +159,63 @@ test_fail_final_semi_colon_newline_inline_comment:
       L052:
         require_final_semicolon: True
         semicolon_newline: True
+
+test_fail_same_line_inline_comment:
+  fail_str: |
+    SELECT a FROM foo -- inline comment
+    ;
+  fix_str: |
+    SELECT a FROM foo; -- inline comment
+
+test_fail_same_line_multiple_inline_comment:
+  fail_str: |
+    SELECT a FROM foo -- inline comment
+
+    -- inline comment
+    ;
+  fix_str: |
+    SELECT a FROM foo; -- inline comment
+
+    -- inline comment
+
+test_fail_newline_move_inline_comment:
+  fail_str: |
+    SELECT a FROM foo -- inline comment
+    ;
+  fix_str: |
+    SELECT a FROM foo
+    ; -- inline comment
+  configs:
+    rules:
+      L052:
+        semicolon_newline: True
+
+test_fail_newline_inline_comment:
+  fail_str: |
+    SELECT a FROM foo -- inline comment
+    
+    ;
+  fix_str: |
+    SELECT a FROM foo
+    ; -- inline comment
+  configs:
+    rules:
+      L052:
+        semicolon_newline: True
+
+test_fail_newline_multiple_inline_comments:
+  fail_str: |
+    SELECT a FROM foo -- inline comment
+    
+    -- inline comment
+
+    ;
+  fix_str: |
+    SELECT a FROM foo
+    ; -- inline comment
+
+    -- inline comment
+  configs:
+    rules:
+      L052:
+        semicolon_newline: True


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Fix #2014 . This PR addresses the linked issue as well as better defining the interaction of L052 with inline comments.

Unit tests show all the various permutations of L052 comment interactions.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
