### PR TITLE
Grammar: Add DROP POLICY statement to postgres dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -2166,6 +2166,7 @@ class StatementSegment(BaseSegment):
             Ref("SetStatementSegment"),
             Ref("DropFunctionStatementSegment"),
             Ref("CreatePolicyStatementSegment"),
+            Ref("DropPolicyStatementSegment"),
         ],
     )
 
@@ -2435,4 +2436,24 @@ class CreatePolicyStatementSegment(BaseSegment):
         ),
         Sequence("USING", Bracketed(Ref("ExpressionSegment")), optional=True),
         Sequence("WITH", "CHECK", Bracketed(Ref("ExpressionSegment")), optional=True),
+    )
+
+
+@postgres_dialect.segment()
+class DropPolicyStatementSegment(BaseSegment):
+    """A `DROP POLICY` statement.
+
+    As Specified in https://www.postgresql.org/docs/14/sql-droppolicy.html
+    """
+
+    type = "drop_policy_statement"
+    match_grammar = StartsWith(Sequence("DROP", "POLICY"))
+    parse_grammar = Sequence(
+        "DROP",
+        "POLICY",
+        Ref("IfExistsGrammar", optional=True),
+        Ref("ObjectReferenceSegment"),
+        "ON",
+        Ref("TableReferenceSegment"),
+        OneOf("CASCADE", "RESTRICT", optional=True),
     )

--- a/test/fixtures/dialects/postgres/postgres_drop_policy.sql
+++ b/test/fixtures/dialects/postgres/postgres_drop_policy.sql
@@ -1,0 +1,5 @@
+DROP POLICY account_managers ON accounts;
+DROP POLICY IF EXISTS account_managers ON accounts;
+DROP POLICY account_managers ON accounts CASCADE;
+DROP POLICY account_managers ON accounts RESTRICT;
+DROP POLICY IF EXISTS account_managers ON accounts RESTRICT;

--- a/test/fixtures/dialects/postgres/postgres_drop_policy.yml
+++ b/test/fixtures/dialects/postgres/postgres_drop_policy.yml
@@ -1,0 +1,64 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 5e9709e8abf96cd4c55171f63ddb5b2dbc1c2b9298c8d6ff94ac36e11a7675ef
+file:
+- statement:
+    drop_policy_statement:
+    - keyword: DROP
+    - keyword: POLICY
+    - object_reference:
+        identifier: account_managers
+    - keyword: 'ON'
+    - table_reference:
+        identifier: accounts
+- statement_terminator: ;
+- statement:
+    drop_policy_statement:
+    - keyword: DROP
+    - keyword: POLICY
+    - keyword: IF
+    - keyword: EXISTS
+    - object_reference:
+        identifier: account_managers
+    - keyword: 'ON'
+    - table_reference:
+        identifier: accounts
+- statement_terminator: ;
+- statement:
+    drop_policy_statement:
+    - keyword: DROP
+    - keyword: POLICY
+    - object_reference:
+        identifier: account_managers
+    - keyword: 'ON'
+    - table_reference:
+        identifier: accounts
+    - keyword: CASCADE
+- statement_terminator: ;
+- statement:
+    drop_policy_statement:
+    - keyword: DROP
+    - keyword: POLICY
+    - object_reference:
+        identifier: account_managers
+    - keyword: 'ON'
+    - table_reference:
+        identifier: accounts
+    - keyword: RESTRICT
+- statement_terminator: ;
+- statement:
+    drop_policy_statement:
+    - keyword: DROP
+    - keyword: POLICY
+    - keyword: IF
+    - keyword: EXISTS
+    - object_reference:
+        identifier: account_managers
+    - keyword: 'ON'
+    - table_reference:
+        identifier: accounts
+    - keyword: RESTRICT
+- statement_terminator: ;


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Fixes #2015. Adds DROP POLICY statement to the postgres dialect. (CREATE POLICY was added in #2021)

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
