### PR TITLE
Grammar: Add complete datetime units to postgres dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -134,8 +134,24 @@ postgres_dialect.sets("unreserved_keywords").difference_update(
     get_keywords(postgres_keywords, "not-keyword")
 )
 
-# Add the EPOCH datetime unit
-postgres_dialect.sets("datetime_units").update(["EPOCH"])
+# Add datetime units
+postgres_dialect.sets("datetime_units").update(
+    [
+        "CENTURY",
+        "DECADE",
+        "DOW",
+        "DOY",
+        "EPOCH",
+        "ISODOW",
+        "ISOYEAR",
+        "MICROSECONDS",
+        "MILLENNIUM",
+        "MILLISECONDS",
+        "TIMEZONE",
+        "TIMEZONE_HOUR",
+        "TIMEZONE_MINUTE",
+    ]
+)
 
 postgres_dialect.add(
     JsonOperatorSegment=NamedParser(

--- a/test/fixtures/dialects/postgres/postgres_datetime_units.sql
+++ b/test/fixtures/dialects/postgres/postgres_datetime_units.sql
@@ -1,0 +1,64 @@
+SELECT
+    t1.field,
+    EXTRACT(CENTURY FROM t1.sometime) AS a
+FROM t1;
+
+SELECT
+    t1.field,
+    EXTRACT(DECADE FROM t1.sometime) AS a
+FROM t1;
+
+SELECT
+    t1.field,
+    EXTRACT(DOW FROM t1.sometime) AS a
+FROM t1;
+
+SELECT
+    t1.field,
+    EXTRACT(DOY FROM t1.sometime) AS a
+FROM t1;
+
+SELECT
+    t1.field,
+    EXTRACT(EPOCH FROM t1.sometime) AS a
+FROM t1;
+
+SELECT
+    t1.field,
+    EXTRACT(ISODOW FROM t1.sometime) AS a
+FROM t1;
+
+SELECT
+    t1.field,
+    EXTRACT(ISOYEAR FROM t1.sometime) AS a
+FROM t1;
+
+SELECT
+    t1.field,
+    EXTRACT(MICROSECONDS FROM t1.sometime) AS a
+FROM t1;
+
+SELECT
+    t1.field,
+    EXTRACT(MILLENNIUM FROM t1.sometime) AS a
+FROM t1;
+
+SELECT
+    t1.field,
+    EXTRACT(MILLISECONDS FROM t1.sometime) AS a
+FROM t1;
+
+SELECT
+    t1.field,
+    EXTRACT(TIMEZONE FROM t1.sometime) AS a
+FROM t1;
+
+SELECT
+    t1.field,
+    EXTRACT(TIMEZONE_HOUR FROM t1.sometime) AS a
+FROM t1;
+
+SELECT
+    t1.field,
+    EXTRACT(TIMEZONE_MINUTE FROM t1.sometime) AS a
+FROM t1;

--- a/test/fixtures/dialects/postgres/postgres_datetime_units.yml
+++ b/test/fixtures/dialects/postgres/postgres_datetime_units.yml
@@ -1,0 +1,462 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: c7b0edcbaf19c54f2eca37ecf1517629e9dfa4f71deddd40b38ec97d1a37dc9d
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: t1
+          - dot: .
+          - identifier: field
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: EXTRACT
+            bracketed:
+              start_bracket: (
+              date_part: CENTURY
+              keyword: FROM
+              expression:
+                column_reference:
+                - identifier: t1
+                - dot: .
+                - identifier: sometime
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: t1
+          - dot: .
+          - identifier: field
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: EXTRACT
+            bracketed:
+              start_bracket: (
+              date_part: DECADE
+              keyword: FROM
+              expression:
+                column_reference:
+                - identifier: t1
+                - dot: .
+                - identifier: sometime
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: t1
+          - dot: .
+          - identifier: field
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: EXTRACT
+            bracketed:
+              start_bracket: (
+              date_part: DOW
+              keyword: FROM
+              expression:
+                column_reference:
+                - identifier: t1
+                - dot: .
+                - identifier: sometime
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: t1
+          - dot: .
+          - identifier: field
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: EXTRACT
+            bracketed:
+              start_bracket: (
+              date_part: DOY
+              keyword: FROM
+              expression:
+                column_reference:
+                - identifier: t1
+                - dot: .
+                - identifier: sometime
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: t1
+          - dot: .
+          - identifier: field
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: EXTRACT
+            bracketed:
+              start_bracket: (
+              date_part: EPOCH
+              keyword: FROM
+              expression:
+                column_reference:
+                - identifier: t1
+                - dot: .
+                - identifier: sometime
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: t1
+          - dot: .
+          - identifier: field
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: EXTRACT
+            bracketed:
+              start_bracket: (
+              date_part: ISODOW
+              keyword: FROM
+              expression:
+                column_reference:
+                - identifier: t1
+                - dot: .
+                - identifier: sometime
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: t1
+          - dot: .
+          - identifier: field
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: EXTRACT
+            bracketed:
+              start_bracket: (
+              date_part: ISOYEAR
+              keyword: FROM
+              expression:
+                column_reference:
+                - identifier: t1
+                - dot: .
+                - identifier: sometime
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: t1
+          - dot: .
+          - identifier: field
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: EXTRACT
+            bracketed:
+              start_bracket: (
+              date_part: MICROSECONDS
+              keyword: FROM
+              expression:
+                column_reference:
+                - identifier: t1
+                - dot: .
+                - identifier: sometime
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: t1
+          - dot: .
+          - identifier: field
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: EXTRACT
+            bracketed:
+              start_bracket: (
+              date_part: MILLENNIUM
+              keyword: FROM
+              expression:
+                column_reference:
+                - identifier: t1
+                - dot: .
+                - identifier: sometime
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: t1
+          - dot: .
+          - identifier: field
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: EXTRACT
+            bracketed:
+              start_bracket: (
+              date_part: MILLISECONDS
+              keyword: FROM
+              expression:
+                column_reference:
+                - identifier: t1
+                - dot: .
+                - identifier: sometime
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: t1
+          - dot: .
+          - identifier: field
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: EXTRACT
+            bracketed:
+              start_bracket: (
+              date_part: TIMEZONE
+              keyword: FROM
+              expression:
+                column_reference:
+                - identifier: t1
+                - dot: .
+                - identifier: sometime
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: t1
+          - dot: .
+          - identifier: field
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: EXTRACT
+            bracketed:
+              start_bracket: (
+              date_part: TIMEZONE_HOUR
+              keyword: FROM
+              expression:
+                column_reference:
+                - identifier: t1
+                - dot: .
+                - identifier: sometime
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: t1
+          - dot: .
+          - identifier: field
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: EXTRACT
+            bracketed:
+              start_bracket: (
+              date_part: TIMEZONE_MINUTE
+              keyword: FROM
+              expression:
+                column_reference:
+                - identifier: t1
+                - dot: .
+                - identifier: sometime
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t1
+- statement_terminator: ;


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
This PR partially addresses #1886 (just the postgres datetime units). The postgres dialect was missing datetime units which was causing them to be interpreted as column references and triggering linting rules. I have implemented the complete list of additional units from https://www.postgresqltutorial.com/postgresql-extract/

Snowflake datetime units to follow in separate PR.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
