### PR TITLE
TSQL (ASA): Allow for table identifier in DELETE clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2116,8 +2116,9 @@ class FileSegment(BaseFileSegment):
 class DeleteStatementSegment(BaseSegment):
     """A `DELETE` statement.
 
-    DELETE FROM <table name> [ WHERE <search condition> ]
+    https://docs.microsoft.com/en-us/sql/t-sql/statements/delete-transact-sql?view=sql-server-ver15
     Overriding ANSI to remove StartsWith logic which assumes statements have been delimited
+    and to allow for Azure Synapse Analytics-specific DELETE statements
     """
 
     type = "delete_statement"
@@ -2125,6 +2126,7 @@ class DeleteStatementSegment(BaseSegment):
     # definitely a statement, we just don't know what type yet.
     match_grammar = Sequence(
         "DELETE",
+        Ref("TableReferenceSegment", optional=True),  # Azure Synapse Analytics-specific
         Ref("FromClauseSegment"),
         Ref("WhereClauseSegment", optional=True),
         Ref("DelimiterSegment", optional=True),

--- a/test/fixtures/dialects/tsql/delete_azure_synapse_analytics.sql
+++ b/test/fixtures/dialects/tsql/delete_azure_synapse_analytics.sql
@@ -1,0 +1,5 @@
+DELETE dbo.Table2   
+FROM dbo.Table2   
+    INNER JOIN dbo.Table1   
+    ON (dbo.Table2.ColA = dbo.Table1.ColA)
+    WHERE dboTable2.ColA = 1; 

--- a/test/fixtures/dialects/tsql/delete_azure_synapse_analytics.yml
+++ b/test/fixtures/dialects/tsql/delete_azure_synapse_analytics.yml
@@ -1,0 +1,63 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: d2c61d379d8c39938482d02df983b8690fa6689e21120deb05d50cc4d810664a
+file:
+  batch:
+    statement:
+      delete_statement:
+        keyword: DELETE
+        table_reference:
+        - identifier: dbo
+        - dot: .
+        - identifier: Table2
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - identifier: dbo
+                - dot: .
+                - identifier: Table2
+            join_clause:
+            - keyword: INNER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                  - identifier: dbo
+                  - dot: .
+                  - identifier: Table1
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - column_reference:
+                      - identifier: dbo
+                      - dot: .
+                      - identifier: Table2
+                      - dot: .
+                      - identifier: ColA
+                    - comparison_operator: '='
+                    - column_reference:
+                      - identifier: dbo
+                      - dot: .
+                      - identifier: Table1
+                      - dot: .
+                      - identifier: ColA
+                    end_bracket: )
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+            - identifier: dboTable2
+            - dot: .
+            - identifier: ColA
+            comparison_operator: '='
+            literal: '1'
+        statement_terminator: ;


### PR DESCRIPTION
TSQL (Azure Synapse Analytics) allows for a table to be specified as part of a DELETE clause in order to support JOINs within a DELETE statement's WHERE clause.

+TableReferenceSegment ref at the right place in TSQL's DeleteStatementSegment
+Test case