### PR TITLE
Grammar: Remove hash inline comment from Postgres

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -110,6 +110,13 @@ postgres_dialect.insert_lexer_matchers(
 
 postgres_dialect.patch_lexer_matchers(
     [
+        # Patching comments to remove hash comments
+        RegexLexer(
+            "inline_comment",
+            r"(--)[^\n]*",
+            CommentSegment,
+            segment_kwargs={"trim_start": ("--")},
+        ),
         # In Postgres, the only escape character is ' for single quote strings
         RegexLexer(
             "single_quote", r"(?s)('')+?(?!')|('.*?(?<!')(?:'')*'(?!'))", CodeSegment

--- a/test/fixtures/dialects/postgres/postgres_json_operators.sql
+++ b/test/fixtures/dialects/postgres/postgres_json_operators.sql
@@ -1,0 +1,17 @@
+-- SQL from issue #2033
+SELECT COALESCE(doc#>>'{fields}','') AS field
+FROM mytable
+WHERE doc ->> 'some_field' = 'some_value';
+
+-- Get JSON array element (indexed from zero, negative integers count from the end)
+SELECT '[{"a":"foo"},{"b":"bar"},{"c":"baz"}]'::json->2;
+-- Get JSON object field by key
+SELECT '{"a": {"b":"foo"}}'::json->'a';
+-- Get JSON array element as text
+SELECT '[1,2,3]'::json->>2;
+-- Get JSON object field as text
+SELECT '{"a":1,"b":2}'::json->>'b';
+-- Get JSON object at the specified path
+SELECT '{"a": {"b":{"c": "foo"}}}'::json#>'{a,b}';
+-- Get JSON object at the specified path as text
+SELECT '{"a":[1,2,3],"b":[4,5,6]}'::json#>>'{a,2}';

--- a/test/fixtures/dialects/postgres/postgres_json_operators.yml
+++ b/test/fixtures/dialects/postgres/postgres_json_operators.yml
@@ -1,0 +1,130 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: d232c01fa9b2c94cdffc024b479f2bdee2b5e0f3ef027aae1438d53b8f0264b7
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: COALESCE
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  identifier: doc
+                binary_operator: '#>>'
+                literal: "'{fields}'"
+            - comma: ','
+            - expression:
+                literal: "''"
+            - end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: field
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: mytable
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            identifier: doc
+        - binary_operator: ->>
+        - literal: "'some_field'"
+        - comparison_operator: '='
+        - literal: "'some_value'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - literal: "'[{\"a\":\"foo\"},{\"b\":\"bar\"},{\"c\":\"baz\"}]'"
+          - cast_expression:
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: json
+          - binary_operator: ->
+          - literal: '2'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - literal: "'{\"a\": {\"b\":\"foo\"}}'"
+          - cast_expression:
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: json
+          - binary_operator: ->
+          - literal: "'a'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - literal: "'[1,2,3]'"
+          - cast_expression:
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: json
+          - binary_operator: ->>
+          - literal: '2'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - literal: "'{\"a\":1,\"b\":2}'"
+          - cast_expression:
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: json
+          - binary_operator: ->>
+          - literal: "'b'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - literal: "'{\"a\": {\"b\":{\"c\": \"foo\"}}}'"
+          - cast_expression:
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: json
+          - binary_operator: '#>'
+          - literal: "'{a,b}'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - literal: "'{\"a\":[1,2,3],\"b\":[4,5,6]}'"
+          - cast_expression:
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: json
+          - binary_operator: '#>>'
+          - literal: "'{a,2}'"
+- statement_terminator: ;


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Fixes #2033. The ansi dialect contains hash inline comments, however, these are not available in postgres. This was causing valid Postgres dialect (the #>> and #> JSON operators) to not parse. I have also added unit tests for the parsing of these JSON operators as there wasn't any previously. 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
