### PR TITLE
TSQL: INSERT INTO

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2036,7 +2036,7 @@ class SetExpressionSegment(BaseSegment):
 
 @ansi_dialect.segment()
 class InsertStatementSegment(BaseSegment):
-    """A `INSERT` statement."""
+    """An `INSERT` statement."""
 
     type = "insert_statement"
     match_grammar = StartsWith("INSERT")

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -387,6 +387,26 @@ class UnorderedSelectStatementSegment(BaseSegment):
 
 
 @tsql_dialect.segment(replace=True)
+class InsertStatementSegment(BaseSegment):
+    """An `INSERT` statement.
+
+    Overriding ANSI definition to remove StartsWith logic that doesn't handle optional delimitation well.
+    """
+
+    type = "insert_statement"
+    match_grammar = Sequence(
+        "INSERT",
+        # Maybe OVERWRITE is just snowflake?
+        # (It's also Hive but that has full insert grammar implementation)
+        Ref.keyword("OVERWRITE", optional=True),
+        "INTO",
+        Ref("TableReferenceSegment"),
+        Ref("BracketedColumnReferenceListGrammar", optional=True),
+        Ref("SelectableGrammar"),
+    )
+
+
+@tsql_dialect.segment(replace=True)
 class WithCompoundStatementSegment(BaseSegment):
     """A `SELECT` statement preceded by a selection of `WITH` clauses.
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -396,9 +396,6 @@ class InsertStatementSegment(BaseSegment):
     type = "insert_statement"
     match_grammar = Sequence(
         "INSERT",
-        # Maybe OVERWRITE is just snowflake?
-        # (It's also Hive but that has full insert grammar implementation)
-        Ref.keyword("OVERWRITE", optional=True),
         "INTO",
         Ref("TableReferenceSegment"),
         Ref("BracketedColumnReferenceListGrammar", optional=True),

--- a/test/fixtures/dialects/tsql/insert_statement.sql
+++ b/test/fixtures/dialects/tsql/insert_statement.sql
@@ -28,3 +28,11 @@ SELECT
 	[SOURCE]
 FROM 
    STAGE.ECDC_CASES
+GO
+
+BEGIN
+  INSERT INTO HumanResources.NewEmployee   
+      SELECT EmpID, LastName, FirstName, Phone,   
+             Address, City, StateProvince, PostalCode, CurrentFlag  
+      FROM EmployeeTemp;  
+END

--- a/test/fixtures/dialects/tsql/insert_statement.sql
+++ b/test/fixtures/dialects/tsql/insert_statement.sql
@@ -36,3 +36,11 @@ BEGIN
              Address, City, StateProvince, PostalCode, CurrentFlag  
       FROM EmployeeTemp;  
 END
+
+GO
+
+INSERT INTO HumanResources.NewEmployee   
+    SELECT EmpID, LastName, FirstName, Phone,   
+            Address, City, StateProvince, PostalCode, CurrentFlag  
+    FROM EmployeeTemp;  
+GO

--- a/test/fixtures/dialects/tsql/insert_statement.yml
+++ b/test/fixtures/dialects/tsql/insert_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3e17d7edc5e82b94d0669718b7fac5a3e78e27d015cf7f20c3a12b28b747c09b
+_hash: fcc2c419a37911d07ab039b188f6e412314e583c409af33781667403759fc7c4
 file:
 - batch:
     statement:
@@ -325,3 +325,62 @@ file:
                         identifier: EmployeeTemp
                 statement_terminator: ;
       - keyword: END
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+        - identifier: HumanResources
+        - dot: .
+        - identifier: NewEmployee
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                identifier: EmpID
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: LastName
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: FirstName
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: Phone
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: Address
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: City
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: StateProvince
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: PostalCode
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: CurrentFlag
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: EmployeeTemp
+            statement_terminator: ;
+- go_statement:
+    keyword: GO

--- a/test/fixtures/dialects/tsql/insert_statement.yml
+++ b/test/fixtures/dialects/tsql/insert_statement.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 29d352ee96d634cd54d1cd65cf5b64eb1d733096f8625acb03b246022db3279f
+_hash: 3e17d7edc5e82b94d0669718b7fac5a3e78e27d015cf7f20c3a12b28b747c09b
 file:
-  batch:
+- batch:
     statement:
       insert_statement:
       - keyword: INSERT
@@ -264,3 +264,64 @@ file:
                   - identifier: STAGE
                   - dot: .
                   - identifier: ECDC_CASES
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          insert_statement:
+          - keyword: INSERT
+          - keyword: INTO
+          - table_reference:
+            - identifier: HumanResources
+            - dot: .
+            - identifier: NewEmployee
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    identifier: EmpID
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    identifier: LastName
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    identifier: FirstName
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    identifier: Phone
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    identifier: Address
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    identifier: City
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    identifier: StateProvince
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    identifier: PostalCode
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    identifier: CurrentFlag
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: EmployeeTemp
+                statement_terminator: ;
+      - keyword: END


### PR DESCRIPTION
Fixes #2045

The ANSI InsertStatementSegment definition uses StartsWith(), which is generally incompatible with the way that we handle TSQL's optional delimitation.  This PR overrides with a TSQL-specific implementation of InsertStatementSegment not using StartsWith(). 

Added a test case proving that this fixes 2045.

Also fixed a trivial typo in ANSI documentation.