### PR TITLE
Update deprecated fishtown-analytics/dbt_utils package

### DIFF
--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/packages.yml
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/packages.yml
@@ -1,3 +1,3 @@
 packages:
-    - package: fishtown-analytics/dbt_utils
-      version: ["0.6.3"]
+    - package: dbt-labs/dbt_utils
+      version: ["0.8.0"]


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
As mentioned [here](https://github.com/sqlfluff/sqlfluff/pull/2052#issuecomment-986918166) we are receiving a warning about using the deprecated fishtown-analytics/dbt_utils package in our dbt unit tests. I noticed this on all dbt tests (not just 1.0.0) so want to see if we can make this straight swap in the existing tests.

If the unit tests fail then I'll close and make part of the the dbt 1.0.0 compatibility work

### Are there any other side effects of this change that we should be aware of?
Not sure, let's see the CI results 😄 

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
