### PR TITLE
Bug fix of L054 for Snowflake and Exasol

### DIFF
--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -531,7 +531,7 @@ class ConnectByClauseSegment(BaseSegment):
 class GroupByClauseSegment(BaseSegment):
     """A `GROUP BY` clause like in `SELECT`."""
 
-    type = "group_by_clause"
+    type = "groupby_clause"
     match_grammar = StartsWith(
         Sequence("GROUP", "BY"),
         terminator=OneOf(

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -354,7 +354,7 @@ class GroupByClauseSegment(BaseSegment):
     https://docs.snowflake.com/en/sql-reference/constructs/group-by.html
     """
 
-    type = "group_by_clause"
+    type = "groupby_clause"
     match_grammar = StartsWith(
         Sequence("GROUP", "BY"),
         terminator=OneOf("ORDER", "LIMIT", "HAVING", "QUALIFY", "WINDOW"),

--- a/test/fixtures/dialects/exasol/SelectStatement.yml
+++ b/test/fixtures/dialects/exasol/SelectStatement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c779ff30a065b616a67966cb4168c174892973c083415a6b0168ace96a4dbdc0
+_hash: f1da09d766adcb8b0440010fe51cd8ec89da33e7abba1cef0f78d7d93775309a
 file:
 - statement:
     select_statement:
@@ -130,7 +130,7 @@ file:
             table_expression:
               table_reference:
                 identifier: sales
-      group_by_clause:
+      groupby_clause:
       - keyword: GROUP
       - keyword: BY
       - column_reference:
@@ -181,7 +181,7 @@ file:
               start_bracket: (
               identifier: c_id
               end_bracket: )
-      group_by_clause:
+      groupby_clause:
       - keyword: GROUP
       - keyword: BY
       - column_reference:
@@ -271,7 +271,7 @@ file:
               table_expression:
                 table_reference:
                   identifier: tmp_view
-        group_by_clause:
+        groupby_clause:
         - keyword: GROUP
         - keyword: BY
         - grouping_sets_clause:

--- a/test/fixtures/dialects/snowflake/snowflake_select_grouping_sets.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_select_grouping_sets.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1b58af1b9ec665e495748f09a8c16b331e7d6572b749910bce4fbc6442c4147a
+_hash: 70e95061a6732fdc5d61840f32ff4f24d6a2d2ddf6d444cbd7e483d1c36d5265
 file:
 - statement:
     select_statement:
@@ -23,7 +23,7 @@ file:
             table_expression:
               table_reference:
                 identifier: baz
-      group_by_clause:
+      groupby_clause:
       - keyword: GROUP
       - keyword: BY
       - grouping_sets_clause:
@@ -69,7 +69,7 @@ file:
             table_expression:
               table_reference:
                 identifier: nurses
-      group_by_clause:
+      groupby_clause:
       - keyword: group
       - keyword: by
       - grouping_sets_clause:
@@ -115,7 +115,7 @@ file:
             table_expression:
               table_reference:
                 identifier: nurses
-      group_by_clause:
+      groupby_clause:
       - keyword: group
       - keyword: by
       - grouping_sets_clause:

--- a/test/fixtures/dialects/snowflake/snowflake_within_group.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_within_group.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 48d1d4a41ba2ccbfcaf09a19a7b4de7347309f744d4e537496390b9a43297237
+_hash: e30ac870b37caef9be67bf46f101a591c2c3bef1c0d6ed6822107fc4121c9a96
 file:
 - statement:
     with_compound_statement:
@@ -124,7 +124,7 @@ file:
               table_expression:
                 table_reference:
                   identifier: favourite_fruits
-        group_by_clause:
+        groupby_clause:
         - keyword: group
         - keyword: by
         - column_reference:
@@ -297,7 +297,7 @@ file:
             identifier: o_totalprice
           comparison_operator: '>'
           literal: '450000'
-      group_by_clause:
+      groupby_clause:
       - keyword: group
       - keyword: by
       - column_reference:
@@ -421,7 +421,7 @@ file:
             identifier: o_totalprice
           comparison_operator: '>'
           literal: '450000'
-      group_by_clause:
+      groupby_clause:
       - keyword: group
       - keyword: by
       - column_reference:
@@ -473,7 +473,7 @@ file:
             table_expression:
               table_reference:
                 identifier: collation_demo
-      group_by_clause:
+      groupby_clause:
       - keyword: group
       - keyword: by
       - column_reference:
@@ -525,7 +525,7 @@ file:
             table_expression:
               table_reference:
                 identifier: collation_demo
-      group_by_clause:
+      groupby_clause:
       - keyword: group
       - keyword: by
       - column_reference:

--- a/test/fixtures/rules/std_rule_cases/L054.yml
+++ b/test/fixtures/rules/std_rule_cases/L054.yml
@@ -451,3 +451,19 @@ test_fail_consistent_snowflake:
     rules:
       L054:
         group_by_and_order_by_style: consistent
+
+test_fail_consistent_exasol:
+  fail_str: |
+    select
+      a,
+      b,
+      c
+    from test_table
+    group by 1, b
+    order by 1, 2
+  configs:
+    core:
+      dialect: exasol
+    rules:
+      L054:
+        group_by_and_order_by_style: consistent

--- a/test/fixtures/rules/std_rule_cases/L054.yml
+++ b/test/fixtures/rules/std_rule_cases/L054.yml
@@ -435,3 +435,19 @@ test_fail_implicit_expression_order_by_custom_implicit:
     rules:
       L054:
         group_by_and_order_by_style: implicit
+
+test_fail_consistent_snowflake:
+  fail_str: |
+    select
+      a,
+      b,
+      c
+    from test_table
+    group by 1, b
+    order by 1, 2
+  configs:
+    core:
+      dialect: snowflake
+    rules:
+      L054:
+        group_by_and_order_by_style: consistent


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->

Fixes GROUP BY grammar type for snowflake and Exasol to be consistent with other dialects and to allow L054 to work on these grammars

### Are there any other side effects of this change that we should be aware of?
The clause does change from type `group_by_clause` to `groupby_clause` so if anyone depends on that using API then they will need to update. But it's more consistent so we should make this change IMHO.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
