### PR TITLE
Exasol: Fix UDF script syntax

### DIFF
--- a/test/fixtures/dialects/exasol/CreateUDFScriptDotSyntax.sql
+++ b/test/fixtures/dialects/exasol/CreateUDFScriptDotSyntax.sql
@@ -1,0 +1,4 @@
+CREATE PYTHON SCALAR SCRIPT sample_simple (...) EMITS (...) AS
+def run(ctx):
+ ctx.emit(True, False)
+/

--- a/test/fixtures/dialects/exasol/CreateUDFScriptDotSyntax.yml
+++ b/test/fixtures/dialects/exasol/CreateUDFScriptDotSyntax.yml
@@ -1,0 +1,43 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: ceb461cff4af3a0c4752bcddad80552df62c258111b4112f46248e19eb01cc31
+file:
+  statement:
+    create_udf_script:
+    - keyword: CREATE
+    - keyword: PYTHON
+    - keyword: SCALAR
+    - keyword: SCRIPT
+    - script_reference:
+        identifier: sample_simple
+    - bracketed:
+        start_bracket: (
+        identifier: '...'
+        end_bracket: )
+    - keyword: EMITS
+    - bracketed:
+        start_bracket: (
+        identifier: '...'
+        end_bracket: )
+    - keyword: AS
+    - script_content:
+      - raw: def
+      - raw: run
+      - bracketed:
+          start_bracket: (
+          raw: ctx
+          end_bracket: )
+      - raw: ':'
+      - raw: ctx
+      - raw: .
+      - raw: emit
+      - bracketed:
+        - start_bracket: (
+        - raw: 'True'
+        - comma: ','
+        - raw: 'False'
+        - end_bracket: )
+  function_script_terminator: /


### PR DESCRIPTION
### Brief summary of the change made
This fixes the syntax for Exasol udf scripts and allows (...) parameter syntax.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
