### PR TITLE
Choose dbt_utils version based on the dbt version, change how we check if a model is disabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ test-reports
 environment.yml
 .envrc
 **/*FIXED.sql
+
+# Ignore temp packages.yml generated during testing.
+plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/packages.yml

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -381,7 +381,18 @@ class DbtTemplater(JinjaTemplater):
 
         if not results:
             model_name = os.path.splitext(os.path.basename(fname))[0]
-            disabled_model = self.dbt_manifest.find_disabled_by_name(name=model_name)
+            if DBT_VERSION_TUPLE >= (1, 0):
+                disabled_model = None
+                for key, disabled_model_nodes in self.dbt_manifest.disabled.items():
+                    for disabled_model_node in disabled_model_nodes:
+                        if os.path.abspath(
+                            disabled_model_node.original_file_path
+                        ) == os.path.abspath(fname):
+                            disabled_model = disabled_model_node
+            else:
+                disabled_model = self.dbt_manifest.find_disabled_by_name(
+                    name=model_name
+                )
             if disabled_model and os.path.abspath(
                 disabled_model.original_file_path
             ) == os.path.abspath(fname):

--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/packages.yml
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/packages.yml
@@ -1,3 +1,0 @@
-packages:
-    - package: dbt-labs/dbt_utils
-      version: ["0.6.3"]

--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/packages.yml.jinja2
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/packages.yml.jinja2
@@ -1,0 +1,9 @@
+packages:
+    # Reference: dbt_utils compatibility matrix:
+    # https://docs.google.com/spreadsheets/d/1RoDdC69auAtrwiqmkRsgcFdZ3MdNpeKcJrWkmEpXVIs/edit#gid=0
+    - package: dbt-labs/dbt_utils
+{% if DBT_VERSION_TUPLE < (1,0) %}
+      version: ["0.6.3"]
+{% else %}
+      version: ["0.8.0"]
+{% endif %}

--- a/plugins/sqlfluff-templater-dbt/test/generate_packages_yml.py
+++ b/plugins/sqlfluff-templater-dbt/test/generate_packages_yml.py
@@ -1,0 +1,23 @@
+"""Script used for dbt templater tests."""
+import os
+import sys
+
+from jinja2.sandbox import SandboxedEnvironment
+from sqlfluff_templater_dbt.templater import DBT_VERSION_TUPLE
+
+
+def main(project_dir):
+    """Load Jinja template file packages.yml.jinja2, expand it, write to packages.yml."""
+    env = SandboxedEnvironment()
+    with open(os.path.join(project_dir, "packages.yml.jinja2")) as f:
+        template_str = f.read()
+    template = env.from_string(
+        template_str, globals=dict(DBT_VERSION_TUPLE=DBT_VERSION_TUPLE)
+    )
+    expanded = template.render()
+    with open(os.path.join(project_dir, "packages.yml"), "w") as f:
+        f.write(expanded)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/plugins/sqlfluff-templater-dbt/test/generate_packages_yml.py
+++ b/plugins/sqlfluff-templater-dbt/test/generate_packages_yml.py
@@ -1,9 +1,15 @@
 """Script used for dbt templater tests."""
 import os
 import sys
+from typing import Optional, Tuple
 
 from jinja2.sandbox import SandboxedEnvironment
-from sqlfluff_templater_dbt.templater import DBT_VERSION_TUPLE
+
+DBT_VERSION_TUPLE: Optional[Tuple[int, int]] = None
+try:
+    from sqlfluff_templater_dbt.templater import DBT_VERSION_TUPLE
+except ImportError:
+    pass
 
 
 def main(project_dir):
@@ -20,4 +26,5 @@ def main(project_dir):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1])
+    if DBT_VERSION_TUPLE is not None:
+        main(sys.argv[1])

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ deps =
 # tox -e py35 -- project/tests/test_file.py::TestClassName::test_method
 commands =
     # For the dbt test cases install dependencies.
+    python plugins/sqlfluff-templater-dbt/test/generate_packages_yml.py plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project
     dbt{017,018,019,020,021,100}: dbt deps --project-dir plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project --profiles-dir plugins/sqlfluff-templater-dbt/test/fixtures/dbt
     # Clean up from previous tests
     python util.py clean-tests


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made

Makes progress on #2048:
* Converts `packages.yml` to a Jinja template which chooses the `dbt_utils` version based on the version of dbt installed. I considered whether this may be "overengineering", but the existence of this dbt_utils compatibility matrix convinced me this is a reasonable thing to do (a bit of futureproofing).
* Changes how we determine if a dbt model is disabled.

Without these changes, almost all the dbt templater tests are failing in the "parent" PR:
```
=================== 24 failed, 3 passed, 1 skipped in 14.45s ===================
```

With these changes, only two tests are failing:
```
============= 2 failed, 25 passed, 1 skipped, 2 warnings in 20.36s =============
```

<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
