### PR TITLE
TSQL: "LANGUAGE" is not a reserved keyword

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -114,7 +114,6 @@ RESERVED_KEYWORDS = [
     "JOIN",
     "KEY",
     "KILL",
-    "LANGUAGE",
     "LEFT",
     "LIKE",
     "LINENO",
@@ -284,6 +283,7 @@ UNRESERVED_KEYWORDS = [
     "KEEPFIXED",
     "KEEPIDENTITY",
     "LABEL",  # Azure Synapse Analytics specific, reserved keyword but could break TSQL parsing to add there
+    "LANGUAGE",
     "M",
     "MAX_DURATION",
     "MAX_GRANT_PERCENT",

--- a/test/fixtures/dialects/tsql/select.sql
+++ b/test/fixtures/dialects/tsql/select.sql
@@ -25,6 +25,7 @@ SELECT
 	'TSQL' AS 's escaping quotes test',
 	'',
 	'''',
+	all_pop.Language,
     ROW_NUMBER()OVER(PARTITION BY [EventNM], [PersonID] ORDER BY [DateofEvent] desc) AS [RN],
     RANK()OVER(PARTITION BY [EventNM] ORDER BY [DateofEvent] desc) AS [R],
     DENSE_RANK()OVER(PARTITION BY [EventNM] ORDER BY [DateofEvent] desc) AS [DR],

--- a/test/fixtures/dialects/tsql/select.yml
+++ b/test/fixtures/dialects/tsql/select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bb5c55dcb8d413ed253075f0acf9a544c5eae896d6a6eac2ed0fcf3c9feacf40
+_hash: a32062c726bb7835174f0a69607504cf36df31d9350ef8d6c547f61b8d438fdd
 file:
   batch:
     statement:
@@ -165,6 +165,12 @@ file:
         - comma: ','
         - select_clause_element:
             literal: "''''"
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - identifier: all_pop
+            - dot: .
+            - identifier: Language
         - comma: ','
         - select_clause_element:
             function:


### PR DESCRIPTION
In TSQL, "LANGUAGE" is not yet a reserved keyword.  It's a valid name for a column.  This PR moves "LANGUAGE" from TSQL's reserved keyword list to its unreserved keyword list.  It also adds a test case element.