### PR TITLE
Stop numeric literal from splitting valid naked identifiers.

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -85,8 +85,12 @@ ansi_dialect.set_lexer_matchers(
         RegexLexer("back_quote", r"`[^`]*`", CodeSegment),
         # See https://www.geeksforgeeks.org/postgresql-dollar-quoted-string-constants/
         RegexLexer("dollar_quote", r"\$(\w*)\$[^\1]*?\$\1\$", CodeSegment),
+        # Numeric literal matches integers, decimals, and exponential formats,
+        # with a negative lookahead assertion to check it is not part of a naked identifier.
         RegexLexer(
-            "numeric_literal", r"(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?", CodeSegment
+            "numeric_literal",
+            r"(?>\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?(?![a-zA-Z_])",
+            CodeSegment,
         ),
         RegexLexer("not_equal", r"!=|<>", CodeSegment),
         RegexLexer("like_operator", r"!?~~?\*?", CodeSegment),

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -86,10 +86,10 @@ ansi_dialect.set_lexer_matchers(
         # See https://www.geeksforgeeks.org/postgresql-dollar-quoted-string-constants/
         RegexLexer("dollar_quote", r"\$(\w*)\$[^\1]*?\$\1\$", CodeSegment),
         # Numeric literal matches integers, decimals, and exponential formats,
-        # with a negative lookahead assertion to check it is not part of a naked identifier.
+        # with a positve lookahead assertion to check it is not part of a naked identifier.
         RegexLexer(
             "numeric_literal",
-            r"(?>\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?(?![a-zA-Z_])",
+            r"(?>\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?(?=\b)",
             CodeSegment,
         ),
         RegexLexer("not_equal", r"!=|<>", CodeSegment),

--- a/test/fixtures/dialects/ansi/naked_identifiers.sql
+++ b/test/fixtures/dialects/ansi/naked_identifiers.sql
@@ -1,4 +1,7 @@
 -- A valid identifier is alphanumeric and contains at least one letter.
 select "a" as 0_is_a_legal_identifier;
-select "a" as _is_a_legal_identifier;
+select "a" as 00_is_a_legal_identifier;
+select 123_is_a_legal_identifier.456_is_a_legal_identifier;
+select "a" as 0is_a_legal_identifier;
+select _s00.45_is_a_legal_identifier from sdf9_._234awdf;
 select "a" as is_a_legal_identifier0;

--- a/test/fixtures/dialects/ansi/naked_identifiers.sql
+++ b/test/fixtures/dialects/ansi/naked_identifiers.sql
@@ -1,0 +1,4 @@
+-- A valid identifier is alphanumeric and contains at least one letter.
+select "a" as 0_is_a_legal_identifier;
+select "a" as _is_a_legal_identifier;
+select "a" as is_a_legal_identifier0;

--- a/test/fixtures/dialects/ansi/naked_identifiers.yml
+++ b/test/fixtures/dialects/ansi/naked_identifiers.yml
@@ -1,0 +1,40 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: d8fb4dfb32690cd87d3fe797807513918a0662a5945ceff9a800404f6be058ca
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          column_reference:
+            identifier: '"a"'
+          alias_expression:
+            keyword: as
+            identifier: 0_is_a_legal_identifier
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          column_reference:
+            identifier: '"a"'
+          alias_expression:
+            keyword: as
+            identifier: _is_a_legal_identifier
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          column_reference:
+            identifier: '"a"'
+          alias_expression:
+            keyword: as
+            identifier: is_a_legal_identifier0
+- statement_terminator: ;

--- a/test/fixtures/dialects/ansi/naked_identifiers.yml
+++ b/test/fixtures/dialects/ansi/naked_identifiers.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d8fb4dfb32690cd87d3fe797807513918a0662a5945ceff9a800404f6be058ca
+_hash: 7c48a811d6b52d8defed7df8b167b1ea1693d8e4765ba6509ae21cdff0a2901a
 file:
 - statement:
     select_statement:
@@ -25,7 +25,47 @@ file:
             identifier: '"a"'
           alias_expression:
             keyword: as
-            identifier: _is_a_legal_identifier
+            identifier: 00_is_a_legal_identifier
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          column_reference:
+          - identifier: 123_is_a_legal_identifier
+          - dot: .
+          - identifier: 456_is_a_legal_identifier
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          column_reference:
+            identifier: '"a"'
+          alias_expression:
+            keyword: as
+            identifier: 0is_a_legal_identifier
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          column_reference:
+          - identifier: _s00
+          - dot: .
+          - identifier: 45_is_a_legal_identifier
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: sdf9_
+              - dot: .
+              - identifier: _234awdf
 - statement_terminator: ;
 - statement:
     select_statement:


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
The current numeric literal regex is matching the start of valid naked identifier segments and causing them to be split which results in parsing errors (Initially highlighted [here](https://github.com/sqlfluff/sqlfluff/pull/2111#discussion_r768046391)):
![image](https://user-images.githubusercontent.com/80432516/145911420-726a33d2-3c45-40d1-9ab0-4c24fc92467c.png)

This PR adds a negative lookahead assertion to the numeric literal regex to check that we aren't at the start of naked identifier:
![image](https://user-images.githubusercontent.com/80432516/145911702-f41ee604-183f-44bf-9f14-96b97d3330c6.png)

N.B. Since the negative lookahead comes after the exponential matching we don't need to worry about this impacting the parsing of those (evidenced by continued parsing of `select_numeric_literal_exponential_format.sql` unit test) 😄 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
