### PR TITLE
Add ability to parse multiple GO/semicolon delimiters

### DIFF
--- a/src/sqlfluff/core/parser/helpers.py
+++ b/src/sqlfluff/core/parser/helpers.py
@@ -28,7 +28,7 @@ def check_still_complete(
     initial_str = join_segments_raw(segments_in)
     current_str = join_segments_raw(matched_segments + unmatched_segments)
 
-    if initial_str != current_str:
+    if initial_str != current_str:  # pragma: nocover
         raise SQLParseError(
             f"Could not parse: {current_str}",
             segment=unmatched_segments[0],

--- a/src/sqlfluff/core/parser/helpers.py
+++ b/src/sqlfluff/core/parser/helpers.py
@@ -28,7 +28,7 @@ def check_still_complete(
     initial_str = join_segments_raw(segments_in)
     current_str = join_segments_raw(matched_segments + unmatched_segments)
 
-    if initial_str != current_str:  # pragma: nocover
+    if initial_str != current_str:  # pragma: no cover
         raise SQLParseError(
             f"Could not parse: {current_str}",
             segment=unmatched_segments[0],

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -509,7 +509,7 @@ class FileSegment(BaseFileSegment):
     # going straight into instantiating it directly usually.
     parse_grammar = Delimited(
         Ref("StatementSegment"),
-        delimiter=Ref("DelimiterSegment"),
+        delimiter=AnyNumberOf(Ref("DelimiterSegment"), min_times=1),
         allow_gaps=True,
         allow_trailing=True,
     )

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2240,7 +2240,7 @@ class FileSegment(BaseFileSegment):
     # NB: We don't need a match_grammar here because we're
     # going straight into instantiating it directly usually.
     parse_grammar = Delimited(
-        Ref("BatchSegment", optional=True),
+        Ref("BatchSegment"),
         delimiter=AnyNumberOf(Ref("BatchDelimiterSegment"), min_times=1),
         allow_gaps=True,
         allow_trailing=True,

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2240,8 +2240,8 @@ class FileSegment(BaseFileSegment):
     # NB: We don't need a match_grammar here because we're
     # going straight into instantiating it directly usually.
     parse_grammar = Delimited(
-        Ref("BatchSegment"),
-        delimiter=Ref("BatchDelimiterSegment"),
+        Ref("BatchSegment", optional=True),
+        delimiter=AnyNumberOf(Ref("BatchDelimiterSegment"), min_times=1),
         allow_gaps=True,
         allow_trailing=True,
     )

--- a/test/core/parser/parse_test.py
+++ b/test/core/parser/parse_test.py
@@ -65,6 +65,7 @@ def test__parser__parse_expand(seg_list):
 
 
 def test__parser__parse_error():
+    """Test that SQLParseError is raised for unparsable section."""
     in_str = "SELECT ;"
     lnt = Linter()
     parsed = lnt.parse_string(in_str)

--- a/test/core/parser/parse_test.py
+++ b/test/core/parser/parse_test.py
@@ -1,6 +1,8 @@
 """The Test file for The New Parser (Grammar Classes)."""
 
 import logging
+from sqlfluff.core.errors import SQLParseError
+from sqlfluff.core.linter.linter import Linter
 
 from sqlfluff.core.parser import BaseSegment, KeywordSegment, Anything, StringParser
 from sqlfluff.core.parser.context import RootParseContext
@@ -60,3 +62,14 @@ def test__parser__parse_expand(seg_list):
         assert isinstance(res[0], BasicSegment)
         # Check that we now have a keyword inside
         assert isinstance(res[0].segments[0], KeywordSegment)
+
+
+def test__parser__parse_error():
+    in_str = "SELECT ;"
+    lnt = Linter()
+    parsed = lnt.parse_string(in_str)
+
+    assert len(parsed.violations) == 1
+    violation = parsed.violations[0]
+    assert isinstance(violation, SQLParseError)
+    assert violation.desc() == "Line 1, Position 1: Found unparsable section: 'SELECT'"

--- a/test/dialects/ansi_test.py
+++ b/test/dialects/ansi_test.py
@@ -3,7 +3,7 @@
 import pytest
 import logging
 
-from sqlfluff.core import FluffConfig, Linter, SQLParseError
+from sqlfluff.core import FluffConfig, Linter
 from sqlfluff.core.parser import Lexer
 
 
@@ -216,29 +216,3 @@ def test__dialect__ansi_parse_indented_joins(sql_string, indented_joins, meta_lo
         if raw_seg.is_meta
     )
     assert res_meta_locs == meta_loc
-
-
-@pytest.mark.parametrize(
-    "raw,expected_message",
-    [
-        (";;", "Line 1, Position 1: Found unparsable section: ';;'"),
-        ("select id from tbl;", ""),
-        ("select id from tbl;;", "Could not parse: ;"),
-        ("select id from tbl;;;;;;", "Could not parse: ;;;;;"),
-        ("select id from tbl;select id2 from tbl2;", ""),
-        (
-            "select id from tbl;;select id2 from tbl2;",
-            "Could not parse: ;select id2 from tbl2;",
-        ),
-    ],
-)
-def test__dialect__ansi_multiple_semicolons(raw: str, expected_message: str) -> None:
-    """Multiple semicolons should be properly handled."""
-    lnt = Linter()
-    parsed = lnt.parse_string(raw)
-
-    assert len(parsed.violations) == (1 if expected_message else 0)
-    if expected_message:
-        violation = parsed.violations[0]
-        assert isinstance(violation, SQLParseError)
-        assert violation.desc() == expected_message

--- a/test/fixtures/dialects/ansi/semicolon_delimiters.sql
+++ b/test/fixtures/dialects/ansi/semicolon_delimiters.sql
@@ -1,0 +1,6 @@
+-- It's possible to have multiple semicolons between statements.
+SELECT foo FROM bar;;
+SELECT foo FROM bar;
+;
+;
+SELECT foo FROM bar;

--- a/test/fixtures/dialects/ansi/semicolon_delimiters.yml
+++ b/test/fixtures/dialects/ansi/semicolon_delimiters.yml
@@ -1,0 +1,55 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 006385a83dc5e5f0f1689a1e010d466e26ea269f304ae2d7dfdbc09a8007919d
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            identifier: foo
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bar
+- statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            identifier: foo
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bar
+- statement_terminator: ;
+- statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            identifier: foo
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bar
+- statement_terminator: ;

--- a/test/fixtures/dialects/tsql/go_delimiters.sql
+++ b/test/fixtures/dialects/tsql/go_delimiters.sql
@@ -1,0 +1,6 @@
+-- It's possible to have multiple GO between batches.
+SELECT foo FROM bar GO GO
+SELECT foo FROM bar GO
+GO
+GO
+SELECT foo FROM bar GO

--- a/test/fixtures/dialects/tsql/go_delimiters.yml
+++ b/test/fixtures/dialects/tsql/go_delimiters.yml
@@ -1,0 +1,64 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 48ee8f3f556e82816f06c2f0155e2eb39630f07d23a9a0a7cf961d58d58df5eb
+file:
+- batch:
+    statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              identifier: foo
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: bar
+- go_statement:
+    keyword: GO
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              identifier: foo
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: bar
+- go_statement:
+    keyword: GO
+- go_statement:
+    keyword: GO
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              identifier: foo
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: bar
+- go_statement:
+    keyword: GO


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Fixes #2009. Consecutive GO segments separating batch segments were not parsing and likewise for consecutive semicolon segments separating statement segments. These are both valid syntactically, consecutive delimiters in this case are just separating empty statemtents:
![image](https://user-images.githubusercontent.com/80432516/146408005-2534d98c-614e-48d4-b450-c72518cc3030.png)

This is fixed by setting the delimiter to one or more of itself. It gives the correct parse tree and works in the tests.

Removed an old test that was checking that consecutive semicolons raise a parse error, as they shouldn't raise a parse error.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
