### PR TITLE
Fix mypy type raise in L003

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910-1
+    rev: v0.920
     hooks:
     -   id: mypy
         args: [--ignore-missing-imports]

--- a/src/sqlfluff/rules/L003.py
+++ b/src/sqlfluff/rules/L003.py
@@ -344,7 +344,7 @@ class Rule_L003(BaseRule):
             return LintResult(memory=memory)
 
         if raw_stack and raw_stack[-1] is not context.segment:
-            raw_stack = raw_stack + (context.segment,)
+            raw_stack = raw_stack + (context.segment,)  # type: ignore
         res = self._process_raw_stack(
             raw_stack,
             memory,


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
With the new 0.920 release of mypy today it is flagging a new type issue in L003.

The issue is actually a valid one to raise: A tuple of BaseSegment is being appended to a tuple of RawSegment to create a complete raw stack similar to the complete stack I use in L050 or L009, however due to the naming convention I used those rules I could easily type the complete stack. In this case since it appends to the already defined raw stack you can't define the type at that assignment.

A full fix would require some variable renaming and slight rework of L003 so given that this issue is blocking all unrelated PRs I've just inline ignored it.

N.B. If using an earlier version of mypy this issue is not raised, but it will now raise for unused type ignore. Please update your mypy to avoid this: `tox -e mypy -r`, `pip install --upgrade mypy`, or `tox -e pre-commit -- install` depending on which you're using.

### Are there any other side effects of this change that we should be aware of?
No, unblocks other PRs.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
