### PR TITLE
Fix L022 to not flag CTE column definitions

### DIFF
--- a/src/sqlfluff/rules/L022.py
+++ b/src/sqlfluff/rules/L022.py
@@ -54,7 +54,20 @@ class Rule_L022(BaseRule):
             )
             for idx, seg in enumerate(expanded_segments):
                 if seg.is_type("bracketed"):
-                    bracket_indices.append(idx)
+                    # Check if the preceding keyword is AS, otherwise it's a column name definition in the CTE.
+                    preceding_keyword = next(
+                        (
+                            s
+                            for s in expanded_segments[:idx][::-1]
+                            if s.is_type("keyword")
+                        ),
+                        None,
+                    )
+                    if (
+                        preceding_keyword is not None
+                        and preceding_keyword.raw.upper() == "AS"
+                    ):
+                        bracket_indices.append(idx)
 
             # Work through each point and deal with it individually
             for bracket_idx in bracket_indices:

--- a/test/fixtures/rules/std_rule_cases/L022.yml
+++ b/test/fixtures/rules/std_rule_cases/L022.yml
@@ -151,3 +151,14 @@ test_fail_cte_floating_comma:
     other_cte as (select 1)
 
     select * from my_cte cross join other_cte
+
+test_pass_column_name_definition:
+  # Issue #2136
+  pass_str: |
+    with recursive t(n) as (
+        select 1
+        union all
+        select n + 1 from t
+    )
+
+    select n from t limit 100;


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Fixes #2136. L022 currently uses closing bracket to find the end of a CTE. This is fine for most cases but unintentionally flags CTE column definitions as described in the linked issue. Fix is simple: Check that the preceding keyword to the bracketed segment is AS 👌

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
