### PR TITLE
Remove support for Python 3.6 (it's "end of life" December 23, 2021)

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
     name: Python ${{ matrix.python-version }} tests
     steps:
     - uses: actions/checkout@v2

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -28,7 +28,7 @@ which should give you a sensible read out and not an error.
 .. code-block:: bash
 
     $ python --version
-    Python 3.6.7
+    Python 3.9.1
 
 For most people, their installation of python will come with
 :code:`pip` (the python package manager) preinstalled. To confirm
@@ -37,7 +37,7 @@ this you can type :code:`pip --version` similar to python above.
 .. code-block:: bash
 
     $ pip --version
-    pip 10.0.1 from ...
+    pip 21.3.1 from ...
 
 If however, you do have python installed but not :code:`pip`, then
 the best instructions for what to do next are `on the python website`_.

--- a/plugins/sqlfluff-templater-dbt/setup.cfg
+++ b/plugins/sqlfluff-templater-dbt/setup.cfg
@@ -28,7 +28,6 @@ classifiers =
     Operating System :: Microsoft :: Windows
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -56,7 +55,7 @@ keywords =
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     sqlfluff>=0.7.0
     dbt-core>=0.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,9 @@ cached-property
 chardet
 click>=7.1
 colorama>=0.3
-# dataclasses backport for python 3.6
-dataclasses; python_version < '3.7'
 # Used for diffcover plugin
 diff-cover>=2.5.0
-# importlib_metadata backport for python 3.6 & 3.7
+# importlib_metadata backport for python 3.7
 importlib_metadata; python_version < '3.8'
 Jinja2
 # oyaml is like pyyaml but preserves orderings

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ classifiers =
     Operating System :: Microsoft :: Windows
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -58,7 +57,7 @@ keywords =
 package_dir =
     =src
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     # Used for finding os-specific application config dirs
     appdirs
@@ -68,11 +67,9 @@ install_requires =
     chardet
     click>=7.1
     colorama>=0.3
-    # dataclasses backport for python 3.6
-    dataclasses; python_version < '3.7'
     # Used for diffcover plugin
     diff-cover>=2.5.0
-    # importlib_metadata backport for python 3.6 & 3.7
+    # importlib_metadata backport for python 3.7
     importlib_metadata; python_version < '3.8'
     Jinja2
     # oyaml is like pyyaml but preserves orderings


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made

Removes support for Python 3.6.

<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
