### PR TITLE
Fully remove python3.6 references

### DIFF
--- a/src/sqlfluff/__init__.py
+++ b/src/sqlfluff/__init__.py
@@ -26,9 +26,9 @@ __version__ = metadata.version("sqlfluff")
 if sys.version_info[0] < 3:
     raise Exception("Sqlfluff does not support Python 2. Please upgrade to Python 3.")
 # Check minor python version
-elif sys.version_info[1] < 6:
+elif sys.version_info[1] < 7:
     raise Exception(
-        "Sqlfluff %s only supports Python 3.6 and beyond. "
+        "Sqlfluff %s only supports Python 3.7 and beyond. "
         "Use an earlier version of sqlfluff or a later version of Python" % __version__
     )
 

--- a/src/sqlfluff/core/dialects/__init__.py
+++ b/src/sqlfluff/core/dialects/__init__.py
@@ -1,7 +1,7 @@
 """Contains SQL Dialects.
 
 Note that individual dialects are only imported as needed at runtime.
-This avoids circular references in python 3.6.
+This avoids circular references.
 
 To enable this, any modules outside of .dialects cannot import dialects
 directly. They should import `dialect_selector` and use that to fetch

--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -229,9 +229,7 @@ def get_runner(
     allow_process_parallelism: bool = True,
 ) -> BaseRunner:
     """Generate a runner instance based on parallel and system configuration."""
-    # Python multiprocessing isn't supported in 3.6 and before.
-    # The library exists but we get pickling errors with LintedFile.
-    if processes > 1 and sys.version_info >= (3, 7):
+    if processes > 1:
         # Process parallelism isn't really supported during testing
         # so this flag allows us to fall back to a threaded runner
         # in those cases.
@@ -240,10 +238,4 @@ def get_runner(
         else:
             return MultiThreadRunner(linter, config, processes=processes)
     else:
-        if processes > 1:
-            linter_logger.warning(
-                "Parallel linting is not supported in Python %s.%s.",
-                sys.version_info.major,
-                sys.version_info.minor,
-            )
         return SequentialRunner(linter, config)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = generate-fixture-yml, linting, doclinting, docbuild, cov-init, py{36,37,38,39,310}, dbt{017,018,019,020,021,100}-py{37,38,39,310}, cov-report, bench, mypy, winpy, dbt{017,018,019,020,021,100}-winpy
+envlist = generate-fixture-yml, linting, doclinting, docbuild, cov-init, py{37,38,39,310}, dbt{017,018,019,020,021,100}-py{37,38,39,310}, cov-report, bench, mypy, winpy, dbt{017,018,019,020,021,100}-winpy
 
 [testenv]
 passenv = CI CIRCLECI CIRCLE_* HOME SQLFLUFF_BENCHMARK_API_KEY


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Python3.6 support was recently removed in #2141, however, I can still see several references to python 3.6. Seeing if removing these is fine.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
