### PR TITLE
docs: set `dbt_modules` to `dbt_packages`

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -478,7 +478,7 @@ In *.sqlfluffignore*:
 .. code-block::
 
     target/
-    dbt_modules/
+    dbt_packages/
     macros/
 
 You can set the dbt project directory, profiles directory and profile with:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -478,6 +478,9 @@ In *.sqlfluffignore*:
 .. code-block::
 
     target/
+    # dbt <1.0.0
+    dbt_modules/
+    # dbt >=1.0.0
     dbt_packages/
     macros/
 

--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/.sqlfluffignore
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/.sqlfluffignore
@@ -1,3 +1,6 @@
+# dbt <1.0.0
 dbt_modules/
+# dbt >=1.0.0
+dbt_packages/
 macros/
 target/


### PR DESCRIPTION

<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
The default name for the packages folder is `dbt_packages` since dbt v1.0.0 (see https://github.com/dbt-labs/dbt-core/issues/3523)
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `python test/generate_parse_fixture_yml.py` or by running `tox` locally).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
