### PR TITLE
Add struct support for `hive` and `redshift` (L026, L028)

### DIFF
--- a/src/sqlfluff/rules/L026.py
+++ b/src/sqlfluff/rules/L026.py
@@ -94,7 +94,10 @@ class Rule_L026(Rule_L020):
         # Config type hints
         self.force_enable: bool
 
-        if context.dialect.name in ["bigquery", "hive", "redshift"] and not self.force_enable:
+        if (
+            context.dialect.name in ["bigquery", "hive", "redshift"]
+            and not self.force_enable
+        ):
             return LintResult()
 
         return super()._eval(context=context)

--- a/src/sqlfluff/rules/L026.py
+++ b/src/sqlfluff/rules/L026.py
@@ -94,7 +94,7 @@ class Rule_L026(Rule_L020):
         # Config type hints
         self.force_enable: bool
 
-        if context.dialect.name in ["bigquery"] and not self.force_enable:
+        if context.dialect.name in ["bigquery", "hive", "redshift"] and not self.force_enable:
             return LintResult()
 
         return super()._eval(context=context)

--- a/src/sqlfluff/rules/L028.py
+++ b/src/sqlfluff/rules/L028.py
@@ -108,7 +108,7 @@ class Rule_L028(Rule_L025):
 
         # Some dialects use structs (e.g. column.field) which look like
         # table references and so incorrectly trigger this rule.
-        if context.dialect.name in ["bigquery"] and not self.force_enable:
+        if context.dialect.name in ["bigquery", "hive", "redshift"] and not self.force_enable:
             return LintResult()
 
         # Certain dialects allow use of SELECT alias in WHERE clauses

--- a/src/sqlfluff/rules/L028.py
+++ b/src/sqlfluff/rules/L028.py
@@ -108,7 +108,10 @@ class Rule_L028(Rule_L025):
 
         # Some dialects use structs (e.g. column.field) which look like
         # table references and so incorrectly trigger this rule.
-        if context.dialect.name in ["bigquery", "hive", "redshift"] and not self.force_enable:
+        if (
+            context.dialect.name in ["bigquery", "hive", "redshift"]
+            and not self.force_enable
+        ):
             return LintResult()
 
         # Certain dialects allow use of SELECT alias in WHERE clauses

--- a/test/fixtures/rules/std_rule_cases/L026.yml
+++ b/test/fixtures/rules/std_rule_cases/L026.yml
@@ -1,4 +1,3 @@
----
 rule: L026
 
 test_pass_object_referenced_1:

--- a/test/fixtures/rules/std_rule_cases/L026.yml
+++ b/test/fixtures/rules/std_rule_cases/L026.yml
@@ -9,7 +9,7 @@ test_pass_object_referenced_1:
       dialect: bigquery
     rules:
       L026:
-        force_enable: True
+        force_enable: true
 
 test_fail_object_not_referenced_1:
   desc: Name foo is not referenced in FROM clause. It would need to be at the end of identifier in ticks or an alias.
@@ -20,7 +20,7 @@ test_fail_object_not_referenced_1:
       dialect: bigquery
     rules:
       L026:
-        force_enable: True
+        force_enable: true
 
 test_fail_object_not_referenced_2:
   # References in WHERE clause
@@ -48,7 +48,7 @@ test_pass_object_referenced_4:
       dialect: bigquery
     rules:
       L026:
-        force_enable: True
+        force_enable: true
 
 test_pass_object_referenced_5a:
   # Test ambiguous column reference caused by use of BigQuery structure fields.
@@ -79,7 +79,7 @@ test_pass_object_referenced_5c:
       dialect: bigquery
     rules:
       L026:
-        force_enable: True
+        force_enable: true
 
 test_pass_object_referenced_5d:
   # Test for extra dialect (hive) compatibility

--- a/test/fixtures/rules/std_rule_cases/L026.yml
+++ b/test/fixtures/rules/std_rule_cases/L026.yml
@@ -57,7 +57,7 @@ test_pass_object_referenced_5a:
   # disabled for bigquery
   # https://github.com/sqlfluff/sqlfluff/issues/1503
   pass_str: |
-    SELECT column.field, col
+    SELECT col1.field, col
     FROM `example_dataset2.example_table2`
   configs:
     core:
@@ -66,14 +66,14 @@ test_pass_object_referenced_5a:
 test_pass_object_referenced_5b:
   # Same test as above but default (ANSI) should trigger
   fail_str: |
-    SELECT column.field
+    SELECT col1.field
     FROM table1
 
 test_pass_object_referenced_5c:
   # Same test as above but for BigQuery but force is
   # enabled so should fail
   fail_str: |
-    SELECT column.field
+    SELECT col1.field
     FROM `example_dataset2.example_table2`
   configs:
     core:
@@ -84,14 +84,14 @@ test_pass_object_referenced_5c:
 
 test_pass_object_referenced_5d:
   # Test for extra dialect (hive) compatibility
-  pass_str: SELECT column.field, col FROM example_table
+  pass_str: SELECT col1.field, col2 FROM example_table
   configs:
     core:
       dialect: hive
 
 test_pass_object_referenced_5e:
   # Test for extra dialect (redshift) compatibility
-  pass_str: SELECT column.field, col FROM example_table
+  pass_str: SELECT col1.field, col2 FROM example_table
   configs:
     core:
       dialect: redshift

--- a/test/fixtures/rules/std_rule_cases/L026.yml
+++ b/test/fixtures/rules/std_rule_cases/L026.yml
@@ -1,3 +1,4 @@
+---
 rule: L026
 
 test_pass_object_referenced_1:
@@ -9,7 +10,7 @@ test_pass_object_referenced_1:
       dialect: bigquery
     rules:
       L026:
-        force_enable: True
+        force_enable: true
 
 test_fail_object_not_referenced_1:
   desc: Name foo is not referenced in FROM clause. It would need to be at the end of identifier in ticks or an alias.
@@ -20,7 +21,7 @@ test_fail_object_not_referenced_1:
       dialect: bigquery
     rules:
       L026:
-        force_enable: True
+        force_enable: true
 
 test_fail_object_not_referenced_2:
   # References in WHERE clause
@@ -48,7 +49,7 @@ test_pass_object_referenced_4:
       dialect: bigquery
     rules:
       L026:
-        force_enable: True
+        force_enable: true
 
 test_pass_object_referenced_5a:
   # Test ambiguous column reference caused by use of BigQuery structure fields.
@@ -56,7 +57,7 @@ test_pass_object_referenced_5a:
   # disabled for bigquery
   # https://github.com/sqlfluff/sqlfluff/issues/1503
   pass_str: |
-    SELECT column.field
+    SELECT column.field, col
     FROM `example_dataset2.example_table2`
   configs:
     core:
@@ -79,7 +80,21 @@ test_pass_object_referenced_5c:
       dialect: bigquery
     rules:
       L026:
-        force_enable: True
+        force_enable: true
+
+test_pass_object_referenced_5d:
+  # Test for extra dialect (hive) compatibility
+  pass_str: SELECT column.field, col FROM example_table
+  configs:
+    core:
+      dialect: hive
+
+test_pass_object_referenced_5e:
+  # Test for extra dialect (redshift) compatibility
+  pass_str: SELECT column.field, col FROM example_table
+  configs:
+    core:
+      dialect: redshift
 
 test_pass_object_referenced_6:
   # Test references in subqueries (see issue #1939)

--- a/test/fixtures/rules/std_rule_cases/L026.yml
+++ b/test/fixtures/rules/std_rule_cases/L026.yml
@@ -10,7 +10,7 @@ test_pass_object_referenced_1:
       dialect: bigquery
     rules:
       L026:
-        force_enable: "True"
+        force_enable: True
 
 test_fail_object_not_referenced_1:
   desc: Name foo is not referenced in FROM clause. It would need to be at the end of identifier in ticks or an alias.
@@ -21,7 +21,7 @@ test_fail_object_not_referenced_1:
       dialect: bigquery
     rules:
       L026:
-        force_enable: "True"
+        force_enable: True
 
 test_fail_object_not_referenced_2:
   # References in WHERE clause
@@ -49,7 +49,7 @@ test_pass_object_referenced_4:
       dialect: bigquery
     rules:
       L026:
-        force_enable: "True"
+        force_enable: True
 
 test_pass_object_referenced_5a:
   # Test ambiguous column reference caused by use of BigQuery structure fields.
@@ -80,7 +80,7 @@ test_pass_object_referenced_5c:
       dialect: bigquery
     rules:
       L026:
-        force_enable: "True"
+        force_enable: True
 
 test_pass_object_referenced_5d:
   # Test for extra dialect (hive) compatibility

--- a/test/fixtures/rules/std_rule_cases/L026.yml
+++ b/test/fixtures/rules/std_rule_cases/L026.yml
@@ -10,7 +10,7 @@ test_pass_object_referenced_1:
       dialect: bigquery
     rules:
       L026:
-        force_enable: true
+        force_enable: "True"
 
 test_fail_object_not_referenced_1:
   desc: Name foo is not referenced in FROM clause. It would need to be at the end of identifier in ticks or an alias.
@@ -21,7 +21,7 @@ test_fail_object_not_referenced_1:
       dialect: bigquery
     rules:
       L026:
-        force_enable: true
+        force_enable: "True"
 
 test_fail_object_not_referenced_2:
   # References in WHERE clause
@@ -49,7 +49,7 @@ test_pass_object_referenced_4:
       dialect: bigquery
     rules:
       L026:
-        force_enable: true
+        force_enable: "True"
 
 test_pass_object_referenced_5a:
   # Test ambiguous column reference caused by use of BigQuery structure fields.
@@ -80,7 +80,7 @@ test_pass_object_referenced_5c:
       dialect: bigquery
     rules:
       L026:
-        force_enable: true
+        force_enable: "True"
 
 test_pass_object_referenced_5d:
   # Test for extra dialect (hive) compatibility

--- a/test/fixtures/rules/std_rule_cases/L028.yml
+++ b/test/fixtures/rules/std_rule_cases/L028.yml
@@ -55,7 +55,7 @@ test_value_table_functions_do_not_require_qualification:
       dialect: bigquery
     rules:
       L028:
-        force_enable:true
+        force_enable: true
 
 test_object_references_1a:
   # This should fail as "a" is an unreference object

--- a/test/fixtures/rules/std_rule_cases/L028.yml
+++ b/test/fixtures/rules/std_rule_cases/L028.yml
@@ -1,4 +1,3 @@
----
 rule: L028
 
 # Mixed qualification of references.

--- a/test/fixtures/rules/std_rule_cases/L028.yml
+++ b/test/fixtures/rules/std_rule_cases/L028.yml
@@ -78,7 +78,7 @@ test_object_references_1c:
       dialect: bigquery
     rules:
       L028:
-        force_enable: "True"
+        force_enable: True
 
 test_object_references_1d:
   # This should not-fail as "a" is potentially a STRUCT

--- a/test/fixtures/rules/std_rule_cases/L028.yml
+++ b/test/fixtures/rules/std_rule_cases/L028.yml
@@ -77,7 +77,7 @@ test_object_references_1c:
       dialect: bigquery
     rules:
       L028:
-        force_enable: True
+        force_enable: true
 
 test_object_references_1d:
   # This should not-fail as "a" is potentially a STRUCT

--- a/test/fixtures/rules/std_rule_cases/L028.yml
+++ b/test/fixtures/rules/std_rule_cases/L028.yml
@@ -1,3 +1,4 @@
+---
 rule: L028
 
 # Mixed qualification of references.
@@ -55,7 +56,7 @@ test_value_table_functions_do_not_require_qualification:
       dialect: bigquery
     rules:
       L028:
-        force_enable: True
+        force_enable:true
 
 test_object_references_1a:
   # This should fail as "a" is an unreference object
@@ -77,8 +78,21 @@ test_object_references_1c:
       dialect: bigquery
     rules:
       L028:
-        force_enable: True
+        force_enable: true
 
+test_object_references_1d:
+  # This should not-fail as "a" is potentially a STRUCT
+  pass_str: SELECT a.bar, b FROM my_tbl
+  configs:
+    core:
+      dialect: hive
+
+test_object_references_1e:
+  # This should not-fail as "a" is potentially a STRUCT
+  pass_str: SELECT a.bar, b FROM my_tbl
+  configs:
+    core:
+      dialect: redshift
 
 test_tsql_pivot_are_excluded:
   # This should pass as tsql PIVOT columns do not need to be

--- a/test/fixtures/rules/std_rule_cases/L028.yml
+++ b/test/fixtures/rules/std_rule_cases/L028.yml
@@ -78,7 +78,7 @@ test_object_references_1c:
       dialect: bigquery
     rules:
       L028:
-        force_enable: true
+        force_enable: "True"
 
 test_object_references_1d:
   # This should not-fail as "a" is potentially a STRUCT


### PR DESCRIPTION
### Brief summary of the change made
There is a `struct` complex datatype in `hive` and `redshift` dialects
You can easily access values using following syntax
```sql
select col.field1, col2
from db.tbl
```
There are `L026` violations raised while linting
This PR allows such syntax for hive+redshift same as for bigquery 

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
