### PR TITLE
TSQL: Proper Indentation of ELSE IF

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1136,11 +1136,11 @@ class IfClauseSegment(BaseSegment):
 
     type = "if_clause"
 
-    match_grammar =         OneOf(
-            Sequence(Ref("IfNotExistsGrammar"), Ref("SelectStatementSegment")),
-            Sequence(Ref("IfExistsGrammar"), Ref("SelectStatementSegment")),
-            Sequence("IF", Ref("ExpressionSegment")),
-        )
+    match_grammar = OneOf(
+        Sequence(Ref("IfNotExistsGrammar"), Ref("SelectStatementSegment")),
+        Sequence(Ref("IfExistsGrammar"), Ref("SelectStatementSegment")),
+        Sequence("IF", Ref("ExpressionSegment")),
+    )
 
 
 @tsql_dialect.segment(replace=True)

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1097,17 +1097,26 @@ class IfExpressionStatement(BaseSegment):
     type = "if_then_statement"
 
     match_grammar = Sequence(
-        OneOf(
-            Sequence(Ref("IfNotExistsGrammar"), Ref("SelectStatementSegment")),
-            Sequence(Ref("IfExistsGrammar"), Ref("SelectStatementSegment")),
-            Sequence("IF", Ref("ExpressionSegment")),
-        ),
+        Ref("IfClauseSegment"),
         Indent,
         Sequence(
             Ref("StatementSegment"),
             Ref("DelimiterSegment", optional=True),
         ),
         Dedent,
+        AnyNumberOf(
+            # ELSE IF included explicitly to allow for correct indentation
+            Sequence(
+                "ELSE",
+                Ref("IfClauseSegment"),
+                Indent,
+                Sequence(
+                    Ref("StatementSegment"),
+                    Ref("DelimiterSegment", optional=True),
+                ),
+                Dedent,
+            ),
+        ),
         Sequence(
             "ELSE",
             Indent,
@@ -1119,6 +1128,19 @@ class IfExpressionStatement(BaseSegment):
             optional=True,
         ),
     )
+
+
+@tsql_dialect.segment()
+class IfClauseSegment(BaseSegment):
+    """IF clause."""
+
+    type = "if_clause"
+
+    match_grammar =         OneOf(
+            Sequence(Ref("IfNotExistsGrammar"), Ref("SelectStatementSegment")),
+            Sequence(Ref("IfExistsGrammar"), Ref("SelectStatementSegment")),
+            Sequence("IF", Ref("ExpressionSegment")),
+        )
 
 
 @tsql_dialect.segment(replace=True)

--- a/test/fixtures/dialects/tsql/add_index.yml
+++ b/test/fixtures/dialects/tsql/add_index.yml
@@ -3,42 +3,43 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6b6820d821497e48e4649c0c14f2f42c8882ccb1c79cf03de2d435c1079a84a8
+_hash: 671c929c9568d702b35f763d589e9a33923aa5201df84bcc9dda4698b9e2bf1b
 file:
 - batch:
     statement:
       if_then_statement:
-        keyword: IF
-        expression:
-        - keyword: NOT
-        - keyword: EXISTS
-        - bracketed:
-            start_bracket: (
-            expression:
-              select_statement:
-                select_clause:
-                  keyword: SELECT
-                  select_clause_element:
-                    wildcard_expression:
-                      wildcard_identifier:
-                        star: '*'
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                        - identifier: sys
-                        - dot: .
-                        - identifier: indexes
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                    column_reference:
-                      identifier: NAME
-                    comparison_operator: '='
-                    literal: "'IX_INTER_VIMR_INFECTIOUS_PEOPLE'"
-            end_bracket: )
+        if_clause:
+          keyword: IF
+          expression:
+          - keyword: NOT
+          - keyword: EXISTS
+          - bracketed:
+              start_bracket: (
+              expression:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      wildcard_expression:
+                        wildcard_identifier:
+                          star: '*'
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                          - identifier: sys
+                          - dot: .
+                          - identifier: indexes
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                      column_reference:
+                        identifier: NAME
+                      comparison_operator: '='
+                      literal: "'IX_INTER_VIMR_INFECTIOUS_PEOPLE'"
+              end_bracket: )
         statement:
           create_index_statement:
           - keyword: CREATE
@@ -63,37 +64,38 @@ file:
 - batch:
     statement:
       if_then_statement:
-        keyword: IF
-        expression:
-        - keyword: NOT
-        - keyword: EXISTS
-        - bracketed:
-            start_bracket: (
-            expression:
-              select_statement:
-                select_clause:
-                  keyword: SELECT
-                  select_clause_element:
-                    wildcard_expression:
-                      wildcard_identifier:
-                        star: '*'
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                        - identifier: sys
-                        - dot: .
-                        - identifier: indexes
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                    column_reference:
-                      identifier: NAME
-                    comparison_operator: '='
-                    literal: "'IX_INTER_FOUNDATION_NICE_IC_INTAKE_COUNT'"
-            end_bracket: )
+        if_clause:
+          keyword: IF
+          expression:
+          - keyword: NOT
+          - keyword: EXISTS
+          - bracketed:
+              start_bracket: (
+              expression:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      wildcard_expression:
+                        wildcard_identifier:
+                          star: '*'
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                          - identifier: sys
+                          - dot: .
+                          - identifier: indexes
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                      column_reference:
+                        identifier: NAME
+                      comparison_operator: '='
+                      literal: "'IX_INTER_FOUNDATION_NICE_IC_INTAKE_COUNT'"
+              end_bracket: )
         statement:
           create_index_statement:
           - keyword: CREATE
@@ -118,36 +120,37 @@ file:
 - batch:
     statement:
       if_then_statement:
-        keyword: IF
-        expression:
-          keyword: EXISTS
-          bracketed:
-            start_bracket: (
-            expression:
-              select_statement:
-                select_clause:
-                  keyword: SELECT
-                  select_clause_element:
-                    wildcard_expression:
-                      wildcard_identifier:
-                        star: '*'
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                        - identifier: sys
-                        - dot: .
-                        - identifier: indexes
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                    column_reference:
-                      identifier: NAME
-                    comparison_operator: '='
-                    literal: "'IX_INTER_VIMR_REPRODUCTION_NUMBER'"
-            end_bracket: )
+        if_clause:
+          keyword: IF
+          expression:
+            keyword: EXISTS
+            bracketed:
+              start_bracket: (
+              expression:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      wildcard_expression:
+                        wildcard_identifier:
+                          star: '*'
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                          - identifier: sys
+                          - dot: .
+                          - identifier: indexes
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                      column_reference:
+                        identifier: NAME
+                      comparison_operator: '='
+                      literal: "'IX_INTER_VIMR_REPRODUCTION_NUMBER'"
+              end_bracket: )
         statement:
           create_index_statement:
           - keyword: CREATE

--- a/test/fixtures/dialects/tsql/create_table_with_sequence_bracketed.yml
+++ b/test/fixtures/dialects/tsql/create_table_with_sequence_bracketed.yml
@@ -3,54 +3,55 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2f509b3ffe1777e61f26cf971ecfd2368a6a6a99034a0a790b75279352bceb87
+_hash: 59202d90193c4d265c1e253a4d4a911b2f3464346590c15d70eef16c9d93e443
 file:
 - batch:
     statement:
       if_then_statement:
-        keyword: IF
-        expression:
-        - keyword: NOT
-        - keyword: EXISTS
-        - bracketed:
-            start_bracket: (
-            expression:
-              select_statement:
-                select_clause:
-                  keyword: SELECT
-                  select_clause_element:
-                    wildcard_expression:
-                      wildcard_identifier:
-                        star: '*'
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                        - identifier: sys
-                        - dot: .
-                        - identifier: sequences
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                  - column_reference:
-                      identifier: object_id
-                  - comparison_operator: '='
-                  - function:
-                      function_name:
-                        function_name_identifier: OBJECT_ID
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          literal: "N'[dbo].[SEQ_SCHEMA_NAME_TABLE_NAME]'"
-                        end_bracket: )
-                  - binary_operator: AND
-                  - column_reference:
-                      identifier: type
-                  - comparison_operator: '='
-                  - literal: "'SO'"
-            end_bracket: )
+        if_clause:
+          keyword: IF
+          expression:
+          - keyword: NOT
+          - keyword: EXISTS
+          - bracketed:
+              start_bracket: (
+              expression:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      wildcard_expression:
+                        wildcard_identifier:
+                          star: '*'
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                          - identifier: sys
+                          - dot: .
+                          - identifier: sequences
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                    - column_reference:
+                        identifier: object_id
+                    - comparison_operator: '='
+                    - function:
+                        function_name:
+                          function_name_identifier: OBJECT_ID
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            literal: "N'[dbo].[SEQ_SCHEMA_NAME_TABLE_NAME]'"
+                          end_bracket: )
+                    - binary_operator: AND
+                    - column_reference:
+                        identifier: type
+                    - comparison_operator: '='
+                    - literal: "'SO'"
+              end_bracket: )
         statement:
           create_sequence_statement:
           - keyword: CREATE
@@ -170,49 +171,50 @@ file:
       - statement_terminator: ;
   - statement:
       if_then_statement:
-        keyword: IF
-        expression:
-        - keyword: NOT
-        - keyword: EXISTS
-        - bracketed:
-            start_bracket: (
-            expression:
-              select_statement:
-                select_clause:
-                  keyword: SELECT
-                  select_clause_element:
-                    wildcard_expression:
-                      wildcard_identifier:
-                        star: '*'
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                        - identifier: sys
-                        - dot: .
-                        - identifier: sequences
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                  - column_reference:
-                      identifier: object_id
-                  - comparison_operator: '='
-                  - function:
-                      function_name:
-                        function_name_identifier: OBJECT_ID
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          literal: "N'[dbo].[SEQ_STAGE_CBS_POPULATION_BASE]'"
-                        end_bracket: )
-                  - binary_operator: AND
-                  - column_reference:
-                      identifier: type
-                  - comparison_operator: '='
-                  - literal: "'SO'"
-            end_bracket: )
+        if_clause:
+          keyword: IF
+          expression:
+          - keyword: NOT
+          - keyword: EXISTS
+          - bracketed:
+              start_bracket: (
+              expression:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      wildcard_expression:
+                        wildcard_identifier:
+                          star: '*'
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                          - identifier: sys
+                          - dot: .
+                          - identifier: sequences
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                    - column_reference:
+                        identifier: object_id
+                    - comparison_operator: '='
+                    - function:
+                        function_name:
+                          function_name_identifier: OBJECT_ID
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            literal: "N'[dbo].[SEQ_STAGE_CBS_POPULATION_BASE]'"
+                          end_bracket: )
+                    - binary_operator: AND
+                    - column_reference:
+                        identifier: type
+                    - comparison_operator: '='
+                    - literal: "'SO'"
+              end_bracket: )
         statement:
           create_sequence_statement:
           - keyword: CREATE

--- a/test/fixtures/dialects/tsql/declare_with_following_statements.yml
+++ b/test/fixtures/dialects/tsql/declare_with_following_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 79b6581e027a1d34417ebe0f432fbf5a2256b48f36ae9a72aca984387e664c19
+_hash: 657a4667a500793a6d76035e65cc1137fb2bda10033e03ec20d44213faa114b1
 file:
   batch:
     create_procedure_statement:
@@ -105,19 +105,20 @@ file:
                 statement_terminator: ;
           - statement:
               if_then_statement:
-                keyword: IF
-                expression:
-                - function:
-                    function_name:
-                      function_name_identifier: OBJECT_ID
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        literal: "'tempdb..#UP'"
-                      end_bracket: )
-                - keyword: IS
-                - keyword: NOT
-                - keyword: 'NULL'
+                if_clause:
+                  keyword: IF
+                  expression:
+                  - function:
+                      function_name:
+                        function_name_identifier: OBJECT_ID
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          literal: "'tempdb..#UP'"
+                        end_bracket: )
+                  - keyword: IS
+                  - keyword: NOT
+                  - keyword: 'NULL'
                 statement:
                   drop_statement:
                   - keyword: DROP

--- a/test/fixtures/dialects/tsql/if_else.yml
+++ b/test/fixtures/dialects/tsql/if_else.yml
@@ -3,39 +3,40 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 39cb26283b2b0a6c616e448985191047bdbe96083d2ae4c209013f4acb77d9f6
+_hash: 499066367fdfc5eddede58a953e4501a95bce8f002ba298c2ef3fb82212fe719
 file:
   batch:
     statement:
       if_then_statement:
-      - keyword: IF
-      - expression:
-          literal: '1'
-          comparison_operator: <=
-          bracketed:
-            start_bracket: (
-            expression:
-              select_statement:
-                select_clause:
-                  keyword: SELECT
-                  select_clause_element:
-                    column_reference:
-                      identifier: Weight
-                from_clause:
-                  keyword: from
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          identifier: DimProduct
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                    column_reference:
-                      identifier: ProductKey
-                    comparison_operator: '='
-                    literal: '1'
-            end_bracket: )
+      - if_clause:
+          keyword: IF
+          expression:
+            literal: '1'
+            comparison_operator: <=
+            bracketed:
+              start_bracket: (
+              expression:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      column_reference:
+                        identifier: Weight
+                  from_clause:
+                    keyword: from
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            identifier: DimProduct
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                      column_reference:
+                        identifier: ProductKey
+                      comparison_operator: '='
+                      literal: '1'
+              end_bracket: )
       - statement:
           select_statement:
             select_clause:

--- a/test/fixtures/dialects/tsql/if_else_begin_end.yml
+++ b/test/fixtures/dialects/tsql/if_else_begin_end.yml
@@ -3,39 +3,40 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fc5dcc464685b03f6db7bba3764faac8d0cd1321e7d649849f9a8dfd4a0be728
+_hash: 50bffae428c6fb4b0214894dc0fbc101e2e808ce0f0139cb6926bcf71a1aad05
 file:
   batch:
     statement:
       if_then_statement:
-      - keyword: IF
-      - expression:
-          literal: '1'
-          comparison_operator: <=
-          bracketed:
-            start_bracket: (
-            expression:
-              select_statement:
-                select_clause:
-                  keyword: SELECT
-                  select_clause_element:
-                    column_reference:
-                      identifier: Weight
-                from_clause:
-                  keyword: from
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          identifier: DimProduct
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                    column_reference:
-                      identifier: ProductKey
-                    comparison_operator: '='
-                    literal: '1'
-            end_bracket: )
+      - if_clause:
+          keyword: IF
+          expression:
+            literal: '1'
+            comparison_operator: <=
+            bracketed:
+              start_bracket: (
+              expression:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      column_reference:
+                        identifier: Weight
+                  from_clause:
+                    keyword: from
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            identifier: DimProduct
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                      column_reference:
+                        identifier: ProductKey
+                      comparison_operator: '='
+                      literal: '1'
+              end_bracket: )
       - statement:
           begin_end_block:
           - keyword: BEGIN

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -460,8 +460,54 @@ test_exasol_script:
     core:
       dialect: exasol
 
-test_tsql_else_if:
+test_pass_tsql_else_if:
   pass_str: |
+    IF (1 > 1)
+        PRINT 'A';
+    ELSE IF (2 > 2)
+        PRINT 'B';
+    ELSE IF (3 > 3)
+        PRINT 'C';
+    ELSE
+        PRINT 'D';
+  configs:
+    core:
+      dialect: tsql
+
+test_fail_tsql_else_if:
+  fail_str: |
+    IF (1 > 1)
+      PRINT 'A';
+     ELSE IF (2 > 2)
+         PRINT 'B';
+    ELSE IF (3 > 3)
+     PRINT 'C';
+    ELSE
+            PRINT 'D';
+  fix_str: |
+    IF (1 > 1)
+        PRINT 'A';
+    ELSE IF (2 > 2)
+        PRINT 'B';
+    ELSE IF (3 > 3)
+        PRINT 'C';
+    ELSE
+        PRINT 'D';
+  configs:
+    core:
+      dialect: tsql
+
+test_fail_tsql_else_if_successive:
+  fail_str: |
+    IF (1 > 1)
+        PRINT 'A';
+        ELSE IF (2 > 2)
+            PRINT 'B';
+            ELSE IF (3 > 3)
+                PRINT 'C';
+                ELSE
+                    PRINT 'D';
+  fix_str: |
     IF (1 > 1)
         PRINT 'A';
     ELSE IF (2 > 2)

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -459,3 +459,17 @@ test_exasol_script:
   configs:
     core:
       dialect: exasol
+
+test_tsql_else_if:
+  pass_str: |
+    IF (1 > 1)
+        PRINT 'A';
+    ELSE IF (2 > 2)
+        PRINT 'B';
+    ELSE IF (3 > 3)
+        PRINT 'C';
+    ELSE
+        PRINT 'D';
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
L003 currently lints TSQL ELSE IF statements with successive indentation:
```
IF (1 > 1)
    PRINT 'A';
ELSE IF (2 > 2)
    PRINT 'B';
    ELSE IF (3 > 3)
        PRINT 'C';
        ELSE IF (4 > 4)
            PRINT 'D';
            ELSE IF (5 > 5)
                PRINT 'E';
                ELSE
                    PRINT 'Z';
```

This fix will adjust the indentation:
```
IF (1 > 1)
    PRINT 'A';
ELSE IF (2 > 2)
    PRINT 'B';
ELSE IF (3 > 3)
    PRINT 'C';
ELSE IF (4 > 4)
    PRINT 'D';
ELSE IF (5 > 5)
    PRINT 'E';
ELSE
    PRINT 'Z';
```

Dialect Changes:
-Added an ELSE IF section to IfExpressionSegment
-Created an IfClauseSegment to reduce repetition in the definition

Test Case Changes:
-Added L003 test to confirm new indentation
-Parse test cases including IF have changed slightly to represent new IfClauseSegment