### PR TITLE
Linter Test Name Duplication

### DIFF
--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -158,7 +158,7 @@ test_fail_indented_using_on_false:
       indented_joins: true
       indented_using_on: false
 
-test_fail_indented_joins_using_on_false:
+test_fail_indented_joins_using_on_true:
   # 2.e) specific True, and failing
   fail_str: |
     SELECT a, b, c

--- a/test/fixtures/rules/std_rule_cases/L014.yml
+++ b/test/fixtures/rules/std_rule_cases/L014.yml
@@ -26,7 +26,7 @@ test_pass_consistent_capitalisation_with_multiple_words_with_numbers:
   # Numbers count as part of words so following letter can be upper or lower
   pass_str: SELECT AppleFritter, Apple123fritter, Apple123Fritter
 
-test_fail_inconsistent_capitalisation_1:
+test_fail_inconsistent_capitalisation_lower_case:
   # Test that fixes are consistent
   fail_str: SELECT a,   B
   fix_str: SELECT a,   b
@@ -126,7 +126,7 @@ test_fail_consistent_capitalisation_policy_pascal_5:
       L014:
         extended_capitalisation_policy: upper
 
-test_fail_inconsistent_capitalisation_1:
+test_fail_inconsistent_capitalisation_pascal_v_capitalise:
   # Pascal vs Capitalise
   fail_str: SELECT AppleFritter, Banana_split
   fix_str: SELECT AppleFritter, Banana_Split

--- a/test/fixtures/rules/std_rule_cases/L043.yml
+++ b/test/fixtures/rules/std_rule_cases/L043.yml
@@ -75,16 +75,6 @@ test_pass_case_cannot_be_reduced_10:
             else bar
         end as test
     from baz;
-test_pass_case_cannot_be_reduced_10:
-  pass_str: |
-    select
-        foo,
-        case
-            when
-                bar is not null or abs(foo) > 0 then '123'
-            else bar
-        end as test
-    from baz;
 test_pass_case_cannot_be_reduced_11:
   pass_str: |
     SELECT


### PR DESCRIPTION
Two of the L003 linter tests have duplicate names.  I've adjusted one to properly match the test case.

Two of the L014 linter tests have duplicate names.  I've adjusted one to properly match the test case.

Two of the L043 linter tests are exactly the same.  I've removed one.