### PR TITLE
Set _works_on_unparsable to False by default

### DIFF
--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -265,7 +265,7 @@ class BaseRule:
     """
 
     _check_docstring = True
-    _works_on_unparsable = True
+    _works_on_unparsable = False
     targets_templated = False
 
     def __init__(self, code, description, **kwargs):

--- a/src/sqlfluff/rules/L003.py
+++ b/src/sqlfluff/rules/L003.py
@@ -46,7 +46,6 @@ class Rule_L003(BaseRule):
 
     """
 
-    _works_on_unparsable = False
     _ignore_types: List[str] = ["script_content"]
     config_keywords = ["tab_space_size", "indent_unit"]
 

--- a/src/sqlfluff/rules/L018.py
+++ b/src/sqlfluff/rules/L018.py
@@ -36,7 +36,6 @@ class Rule_L018(BaseRule):
 
     """
 
-    _works_on_unparsable = False
     config_keywords = ["tab_space_size"]
 
     def _eval(self, context: RuleContext) -> LintResult:

--- a/src/sqlfluff/rules/L019.py
+++ b/src/sqlfluff/rules/L019.py
@@ -51,7 +51,6 @@ class Rule_L019(BaseRule):
 
     """
 
-    _works_on_unparsable = False
     config_keywords = ["comma_style"]
 
     @staticmethod

--- a/src/sqlfluff/rules/L044.py
+++ b/src/sqlfluff/rules/L044.py
@@ -58,8 +58,6 @@ class Rule_L044(BaseRule):
 
     """
 
-    _works_on_unparsable = False
-
     def _handle_alias(self, selectable, alias_info, query):
         select_info_target = SelectCrawler.get(
             query, alias_info.from_expression_element


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Partially addresses unparseable related issues in #2134. Previously we tried to apply fixes to unparseable segments unless specifically specified otherwise. However, you cannot expect reasonable application of rules to a parse tree that contains an unparseable segment as it won't obey logical structure. 

### Are there any other side effects of this change that we should be aware of?
Fixes will be a bit more picky as to what they apply to.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
