### PR TITLE
ALTER GROUP fix to accommodate quoted objects

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -486,13 +486,13 @@ class AlterGroupSegment(BaseSegment):
                 OneOf("ADD", "DROP"),
                 "USER",
                 Delimited(
-                    Ref("NakedIdentifierSegment"),
+                    Ref("ObjectReferenceSegment"),
                 ),
             ),
             Sequence(
                 "RENAME",
                 "TO",
-                Ref("NakedIdentifierSegment"),
+                Ref("ObjectReferenceSegment"),
             ),
         ),
     )

--- a/test/fixtures/dialects/redshift/redshift_alter_group.sql
+++ b/test/fixtures/dialects/redshift/redshift_alter_group.sql
@@ -10,3 +10,6 @@ drop user dwuser1, dwuser2;
 
 alter group admin_group
 rename to administrators;
+
+alter group admin_group
+add user "test.user";

--- a/test/fixtures/dialects/redshift/redshift_alter_group.yml
+++ b/test/fixtures/dialects/redshift/redshift_alter_group.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 82b93369d7da8e8e186c76ba669a39cdcdf861fdbd93cba091aaf89c77e0b80d
+_hash: a538acbf3613b80cf16457e14adde74d70dfa28d3dab8192a28ebf75f15488b5
 file:
 - statement:
     alter_group:
@@ -12,7 +12,8 @@ file:
     - identifier: admin_group
     - keyword: add
     - keyword: user
-    - identifier: dwuser
+    - object_reference:
+        identifier: dwuser
 - statement_terminator: ;
 - statement:
     alter_group:
@@ -21,9 +22,11 @@ file:
     - identifier: admin_group
     - keyword: add
     - keyword: user
-    - identifier: dwuser1
+    - object_reference:
+        identifier: dwuser1
     - comma: ','
-    - identifier: dwuser2
+    - object_reference:
+        identifier: dwuser2
 - statement_terminator: ;
 - statement:
     alter_group:
@@ -32,7 +35,8 @@ file:
     - identifier: admin_group
     - keyword: drop
     - keyword: user
-    - identifier: dwuser
+    - object_reference:
+        identifier: dwuser
 - statement_terminator: ;
 - statement:
     alter_group:
@@ -41,9 +45,11 @@ file:
     - identifier: admin_group
     - keyword: drop
     - keyword: user
-    - identifier: dwuser1
+    - object_reference:
+        identifier: dwuser1
     - comma: ','
-    - identifier: dwuser2
+    - object_reference:
+        identifier: dwuser2
 - statement_terminator: ;
 - statement:
     alter_group:
@@ -52,5 +58,16 @@ file:
     - identifier: admin_group
     - keyword: rename
     - keyword: to
-    - identifier: administrators
+    - object_reference:
+        identifier: administrators
+- statement_terminator: ;
+- statement:
+    alter_group:
+    - keyword: alter
+    - keyword: group
+    - identifier: admin_group
+    - keyword: add
+    - keyword: user
+    - object_reference:
+        identifier: '"test.user"'
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
This is a fix for issue #2186. `NakedIdentifierStatement` will be changed to `ObjectReferenceSegment` to accommodate quoting.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
