### PR TITLE
Lexer: add non-breaking spaces to whitespace

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -58,7 +58,7 @@ ansi_dialect = Dialect("ansi", root_segment_name="FileSegment")
 
 ansi_dialect.set_lexer_matchers(
     [
-        RegexLexer("whitespace", r"[\t ]+", WhitespaceSegment),
+        RegexLexer("whitespace", r"[\t\xc2\xa0 ]+", WhitespaceSegment),
         RegexLexer(
             "inline_comment",
             r"(--|#)[^\n]*",

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -58,7 +58,7 @@ ansi_dialect = Dialect("ansi", root_segment_name="FileSegment")
 
 ansi_dialect.set_lexer_matchers(
     [
-        RegexLexer("whitespace", r"[\t\xc2\xa0 ]+", WhitespaceSegment),
+        RegexLexer("whitespace", r"[^\S\r\n]+", WhitespaceSegment),
         RegexLexer(
             "inline_comment",
             r"(--|#)[^\n]*",

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -58,6 +58,9 @@ ansi_dialect = Dialect("ansi", root_segment_name="FileSegment")
 
 ansi_dialect.set_lexer_matchers(
     [
+        # Match all forms of whitespace except newlines and carriage returns:
+        # https://stackoverflow.com/questions/3469080/match-whitespace-but-not-newlines
+        # This pattern allows us to also match non-breaking spaces (#2189).
         RegexLexer("whitespace", r"[^\S\r\n]+", WhitespaceSegment),
         RegexLexer(
             "inline_comment",
@@ -76,7 +79,7 @@ ansi_dialect.set_lexer_matchers(
             ),
             trim_post_subdivide=RegexLexer(
                 "whitespace",
-                r"[\t ]+",
+                r"[^\S\r\n]+",
                 WhitespaceSegment,
             ),
         ),

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -120,7 +120,7 @@ tsql_dialect.patch_lexer_matchers(
             ),
             trim_post_subdivide=RegexLexer(
                 "whitespace",
-                r"[\t ]+",
+                r"[^\S\r\n]+",
                 WhitespaceSegment,
             ),
         ),

--- a/test/core/parser/lexer_test.py
+++ b/test/core/parser/lexer_test.py
@@ -83,9 +83,9 @@ def test__parser__lexer_string(raw, res):
         ("fsaljk", r"f", "f"),
         ("fsaljk", r"[fas]*", "fsa"),
         # Matching whitespace segments
-        ("   \t   fsaljk", r"[\t ]*", "   \t   "),
+        ("   \t   fsaljk", r"[^\S\r\n]*", "   \t   "),
         # Matching whitespace segments (with a newline)
-        ("   \t \n  fsaljk", r"[\t ]*", "   \t "),
+        ("   \t \n  fsaljk", r"[^\S\r\n]*", "   \t "),
         # Matching quotes containing stuff
         ("'something boring'   \t \n  fsaljk", r"'[^']*'", "'something boring'"),
         (

--- a/test/fixtures/dialects/ansi/non_breaking_space.sql
+++ b/test/fixtures/dialects/ansi/non_breaking_space.sql
@@ -1,0 +1,2 @@
+#space before from is non-breaking space
+SELECT a,b, c  from sch."blah"

--- a/test/fixtures/dialects/ansi/non_breaking_space.yml
+++ b/test/fixtures/dialects/ansi/non_breaking_space.yml
@@ -1,0 +1,31 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: bd4e28c926e3d5460408d9f53857a363b44ddaaba8da61153c9969cd9e37062a
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: sch
+              - dot: .
+              - identifier: '"blah"'


### PR DESCRIPTION
The lexer can't lex non-breaking spaces.  This PR will add non-breaking spaces to the whitespace lexer.