### PR TITLE
Don't allow fixes to COPY code from templated regions

### DIFF
--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -230,24 +230,33 @@ class LintFix:
 
     @classmethod
     def replace(
-        cls, anchor_segment: BaseSegment, edit_segments: Iterable[BaseSegment]
+        cls,
+        anchor_segment: BaseSegment,
+        edit_segments: Iterable[BaseSegment],
+        source: Optional[Iterable[BaseSegment]] = None,
     ) -> "LintFix":
         """Replace supplied anchor segment with the edit segments."""
-        return cls("replace", anchor_segment, edit_segments)
+        return cls("replace", anchor_segment, edit_segments, source)
 
     @classmethod
     def create_before(
-        cls, anchor_segment: BaseSegment, edit_segments: Iterable[BaseSegment]
+        cls,
+        anchor_segment: BaseSegment,
+        edit_segments: Iterable[BaseSegment],
+        source: Optional[Iterable[BaseSegment]] = None,
     ) -> "LintFix":
         """Create edit segments before the supplied anchor segment."""
-        return cls("create_before", anchor_segment, edit_segments)
+        return cls("create_before", anchor_segment, edit_segments, source)
 
     @classmethod
     def create_after(
-        cls, anchor_segment: BaseSegment, edit_segments: Iterable[BaseSegment]
+        cls,
+        anchor_segment: BaseSegment,
+        edit_segments: Iterable[BaseSegment],
+        source: Optional[Iterable[BaseSegment]] = None,
     ) -> "LintFix":
         """Create edit segments after the supplied anchor segment."""
-        return cls("create_after", anchor_segment, edit_segments)
+        return cls("create_after", anchor_segment, edit_segments, source)
 
     def has_template_conflicts(self, templated_file: TemplatedFile) -> bool:
         """Does this fix conflict with (i.e. touch) templated code?"""

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -117,7 +117,7 @@ class LintFix:
             to be moved *after* the edit), for a `replace` it implies the
             segment to be replaced.
         edit (:obj:`BaseSegment`, optional): For `replace` and `create` fixes,
-            this holsd the iterable of segments to create or replace at the
+            this holds the iterable of segments to create or replace at the
             given `anchor` point.
         source (:obj:`BaseSegment`, optional): For `replace` and `create` fixes,
             this holds iterable of segments that provided code. IMPORTANT: The

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -167,7 +167,7 @@ class LintFix:
             # Once stripped, we shouldn't replace any markers because
             # later code may rely on them being accurate, which we
             # can't guarantee with edits.
-        self.source = list(source) if source else None
+        self.source = [seg for seg in source if seg.pos_marker] if source else []
 
     def is_trivial(self):
         """Return true if the fix is trivial.
@@ -292,7 +292,7 @@ class LintFix:
             templated_file, templated_slices
         )
 
-        # Check the result from checking the fix slices.
+        # We have the fix slices. Now check for conflicts.
         result = check_fn(fs.slice_type == "templated" for fs in fix_slices)
         if result or not self.source:
             return result
@@ -306,10 +306,10 @@ class LintFix:
 
     @staticmethod
     def _raw_slices_from_templated_slices(templated_file, templated_slices):
-        fix_slices: Set[RawFileSlice] = set()
+        raw_slices: Set[RawFileSlice] = set()
         for templated_slice in templated_slices:
             try:
-                fix_slices.update(
+                raw_slices.update(
                     templated_file.raw_slices_spanning_source_slice(
                         templated_file.templated_slice_to_source_slice(templated_slice)
                     )
@@ -320,7 +320,7 @@ class LintFix:
                 # it is the correct action, because the other (anchor) slice
                 # is still valid.
                 pass
-        return fix_slices
+        return raw_slices
 
 
 EvalResultType = Union[LintResult, List[LintResult], None]

--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -199,7 +199,11 @@ class Rule_L031(BaseRule):
                     for d in [alias_info.alias_exp_ref, alias_info.whitespace_ref]
                 ],
                 *[
-                    LintFix.replace(alias, [alias.edit(alias_info.table_ref.raw)])
+                    LintFix.replace(
+                        alias,
+                        [alias.edit(alias_info.table_ref.raw)],
+                        source=[alias_info.table_ref],
+                    )
                     for alias in [alias_info.alias_identifier_ref, *ids_refs]
                 ],
             ]

--- a/src/sqlfluff/rules/L043.py
+++ b/src/sqlfluff/rules/L043.py
@@ -102,6 +102,7 @@ class Rule_L043(BaseRule):
                     coalesce_arg_2,
                     SymbolSegment(")", name="end_bracket", type="end_bracket"),
                 ],
+                source=[coalesce_arg_2],
             ),
         ] + (
             # Segments to delete -- i.e. all child segments at both levels EXCEPT:

--- a/src/sqlfluff/rules/L045.py
+++ b/src/sqlfluff/rules/L045.py
@@ -3,10 +3,8 @@ from typing import Optional
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.analysis.select_crawler import Query, SelectCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 
-@document_fix_compatible
 class Rule_L045(BaseRule):
     """Query defines a CTE (common-table expression) but does not use it.
 

--- a/src/sqlfluff/rules/L058.py
+++ b/src/sqlfluff/rules/L058.py
@@ -76,11 +76,9 @@ class Rule_L058(BaseRule):
             create_after_last_when = nested_clauses.apply(
                 lambda seg: [NewlineSegment(), WhitespaceSegment(indent_str), seg]
             )
+            segments = [item for sublist in create_after_last_when for item in sublist]
             fixes.append(
-                LintFix.create_after(
-                    case1_last_when.get(),
-                    [item for sublist in create_after_last_when for item in sublist],
-                )
+                LintFix.create_after(case1_last_when.get(), segments, source=segments)
             )
 
             # Delete the outer "else" clause.

--- a/src/sqlfluff/testing/rules.py
+++ b/src/sqlfluff/testing/rules.py
@@ -85,12 +85,8 @@ def assert_rule_fail_in_sql(code, sql, configs=None, line_numbers=None):
                     line_numbers, actual_line_numbers
                 )
             )
-    # The query should already have been fixed if possible so just return the raw.
-    if linted.num_violations(fixable=True) > 0:
-        fixed, _ = linted.fix_string()
-        return fixed
-    else:
-        return linted.tree.raw
+    fixed, _ = linted.fix_string()
+    return fixed
 
 
 def assert_rule_pass_in_sql(code, sql, configs=None):

--- a/test/fixtures/rules/std_rule_cases/L031.yml
+++ b/test/fixtures/rules/std_rule_cases/L031.yml
@@ -193,3 +193,16 @@ issue_1639:
   configs:
     core:
       dialect: tsql
+
+test_no_copy_code_out_of_template:
+  fail_str: |
+    SELECT t.repo_id
+    FROM {{ source_table }} AS t
+  fix_str: |
+    SELECT t.repo_id
+    FROM {{ source_table }} AS t
+  configs:
+    templater:
+      jinja:
+        context:
+          source_table: foobar

--- a/test/fixtures/rules/std_rule_cases/L031.yml
+++ b/test/fixtures/rules/std_rule_cases/L031.yml
@@ -194,7 +194,7 @@ issue_1639:
     core:
       dialect: tsql
 
-test_no_copy_code_out_of_template:
+test_fail_no_copy_code_out_of_template:
   # The rule wants to replace "t" with "foobar", but
   # LintFix.has_template_conflicts() correctly prevents it copying code out
   # of the templated region. Hence, fix_str and fail_str are the same.

--- a/test/fixtures/rules/std_rule_cases/L031.yml
+++ b/test/fixtures/rules/std_rule_cases/L031.yml
@@ -195,6 +195,9 @@ issue_1639:
       dialect: tsql
 
 test_no_copy_code_out_of_template:
+  # The rule wants to replace "t" with "foobar", but
+  # LintFix.has_template_conflicts() correctly prevents it copying code out
+  # of the templated region. Hence, fix_str and fail_str are the same.
   fail_str: |
     SELECT t.repo_id
     FROM {{ source_table }} AS t

--- a/test/fixtures/rules/std_rule_cases/L043.yml
+++ b/test/fixtures/rules/std_rule_cases/L043.yml
@@ -199,3 +199,33 @@ test_fail_unnecessary_case_8:
         foo,
         coalesce(bar, '123') as test
     from baz;
+
+test_fail_no_copy_code_out_of_template:
+  # The rule wants to replace the case statement with coalesce(), but
+  # LintFix.has_template_conflicts() correctly prevents it copying code out
+  # of the templated region. Hence, fix_str and fail_str are the same.
+  fail_str: |
+    select
+        foo,
+        case
+            when
+                bar is null then {{ result }}
+            else bar
+        end as test
+    from baz;
+  fix_str: |
+    select
+        foo,
+        case
+            when
+                bar is null then {{ result }}
+            else bar
+        end as test
+    from baz;
+  configs:
+    core:
+      ignore_templated_areas: False
+    templater:
+      jinja:
+        context:
+          result: "'123'"

--- a/test/fixtures/rules/std_rule_cases/L058.yml
+++ b/test/fixtures/rules/std_rule_cases/L058.yml
@@ -188,3 +188,37 @@ test_double_nesting_2:
             WHEN species = 'Hyena' THEN 'Cackle'
         END AS sound
     FROM mytable
+
+test_fail_no_copy_code_out_of_template:
+  # The rule wants to replace the case statement with coalesce(), but
+  # LintFix.has_template_conflicts() correctly prevents it copying code out
+  # of the templated region. Hence, fix_str and fail_str are the same.
+  fail_str: |
+    SELECT
+        c1,
+        CASE
+            WHEN species = 'Rat' THEN 'Squeak'
+            ELSE
+                CASE
+                    {{ inner_when }}
+                END
+        END AS sound
+    FROM mytable
+  fix_str: |
+    SELECT
+        c1,
+        CASE
+            WHEN species = 'Rat' THEN 'Squeak'
+            ELSE
+                CASE
+                    {{ inner_when }}
+                END
+        END AS sound
+    FROM mytable
+  configs:
+    core:
+      ignore_templated_areas: False
+    templater:
+      jinja:
+        context:
+          inner_when: "WHEN species = 'Dog' THEN 'Woof'"


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made

Fixes #2051 

This PR builds on yesterday's PR #2220:
* Yesterday's PR discards all fixes from a `LintResult` if any of the fixes **modify** templated code.
* This PR discards all fixes from a `LintResult` if any of the fixes **read from** templated code. This required a slight change to any rules which do this. (Fortunately, there are only a handful of such rules.)

<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
