### PR TITLE
TSQL: Table valued functions

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1377,7 +1377,7 @@ class CreateFunctionStatementSegment(BaseSegment):
         Ref("FunctionParameterListGrammar"),
         Sequence(  # Optional function return type
             "RETURNS",
-            Ref("DatatypeSegment"),
+            OneOf(Ref("DatatypeSegment"), "TABLE"),
             optional=True,
         ),
         Ref("FunctionOptionSegment", optional=True),

--- a/test/fixtures/dialects/tsql/functions_a.sql
+++ b/test/fixtures/dialects/tsql/functions_a.sql
@@ -5,3 +5,17 @@ SELECT
     DATEADD(month, -1, column1) AS column1_lastmonth,
     convert(varchar, tbl_b.column1, 23) AS column1_varchar
 FROM tbl_b
+GO
+
+CREATE FUNCTION dbo.RandDate
+(
+@admit       DATE
+)
+RETURNS TABLE
+AS
+     RETURN
+(
+    SELECT @admit 
+    FROM   dbo.[RandomDate]
+);
+GO

--- a/test/fixtures/dialects/tsql/functions_a.yml
+++ b/test/fixtures/dialects/tsql/functions_a.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 252a3ff7798b62db9d272e79c7651940dc7c78d01d9b12d4a373791856ce0b7f
+_hash: 7850580cd7d2591084073d32501f05bb668e2bdb333250f21a3bce62db9b9124
 file:
-  batch:
+- batch:
     statement:
       select_statement:
         select_clause:
@@ -127,3 +127,51 @@ file:
               table_expression:
                 table_reference:
                   identifier: tbl_b
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      create_function_statement:
+      - keyword: CREATE
+      - keyword: FUNCTION
+      - object_reference:
+        - identifier: dbo
+        - dot: .
+        - identifier: RandDate
+      - function_parameter_list:
+          bracketed:
+            start_bracket: (
+            parameter: '@admit'
+            data_type:
+              identifier: DATE
+            end_bracket: )
+      - keyword: RETURNS
+      - keyword: TABLE
+      - keyword: AS
+      - procedure_statement:
+          statement:
+            return_segment:
+              keyword: RETURN
+              expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    select_statement:
+                      select_clause:
+                        keyword: SELECT
+                        select_clause_element:
+                          column_reference:
+                            parameter: '@admit'
+                      from_clause:
+                        keyword: FROM
+                        from_expression:
+                          from_expression_element:
+                            table_expression:
+                              table_reference:
+                              - identifier: dbo
+                              - dot: .
+                              - identifier: '[RandomDate]'
+                  end_bracket: )
+              statement_terminator: ;
+- go_statement:
+    keyword: GO


### PR DESCRIPTION
### Brief summary of the change made
Fixes #1909

This PR adds support for table-valued functions to the TSQL dialect.  TSQL defines TVFs by replacing the standard RETURNS [datatype] with RETURNS TABLE.  This PR adds TABLE as an option in the RETURNS clause.

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
