### PR TITLE
Fix L044 assertion failure: "SELECT *" with no "FROM" clause

### DIFF
--- a/src/sqlfluff/rules/L044.py
+++ b/src/sqlfluff/rules/L044.py
@@ -120,7 +120,7 @@ class Rule_L044(BaseRule):
                         if isinstance(o, Query):
                             self._analyze_result_columns(o)
                             return
-                    assert False, "Should be unreachable"  # pragma: no cover
+                    raise RuleFailure(query.selectables[0].selectable)
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Outermost query should produce known number of columns."""

--- a/src/sqlfluff/rules/L044.py
+++ b/src/sqlfluff/rules/L044.py
@@ -120,6 +120,9 @@ class Rule_L044(BaseRule):
                         if isinstance(o, Query):
                             self._analyze_result_columns(o)
                             return
+                    self.logger.debug(
+                        f'Query target "{query.selectables[0].selectable.raw}" has no targets. Generating warning.'
+                    )
                     raise RuleFailure(query.selectables[0].selectable)
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:

--- a/test/fixtures/rules/std_rule_cases/L044.yml
+++ b/test/fixtures/rules/std_rule_cases/L044.yml
@@ -490,3 +490,7 @@ test_fail_two_join_subqueries_one_with_unknown_number_of_columns:
         select b
         from bar
     ) t2;
+
+test_fail_no_source_table:
+  fail_str: |
+    SELECT *


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made

This fixes an assertion failure that appeared in a user's failure log in a [Slack chat](https://sqlfluff.slack.com/archives/C01GX4L213J/p1641331471426900?thread_ts=1641329507.421800&cid=C01GX4L213J) yesterday.
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
