### PR TITLE
Re-enable dbt tests that connect to Postgres on Windows runner.

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -21,166 +21,166 @@ on:
       - main
 
 jobs:
-  # linting:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       jobs: [ 'linting', 'doclinting', 'docbuild', 'yamllint' ]
-  #   name: ${{ matrix.jobs }} tests
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v2
-  #     with:
-  #       python-version: '3.10'
-  #   - name: Install dependencies
-  #     run: |
-  #       pip install tox
-  #   - name: Run the tests
-  #     run: |
-  #       tox -e ${{ matrix.jobs }}
-  # python-version-tests:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       python-version: [ '3.7', '3.8', '3.9', '3.10' ]
-  #   name: Python ${{ matrix.python-version }} tests
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v2
-  #     with:
-  #       python-version: ${{ matrix.python-version }}
-  #   - name: Install dependencies
-  #     run: |
-  #       pip install tox
-  #   - name: Set Tox Python Param
-  #     run: |
-  #       echo 'TOXENV<<EOF' >> $GITHUB_ENV
-  #       echo "${{ matrix.python-version }}" | sed "s/\.//" | sed "s/^/py/" >> $GITHUB_ENV
-  #       echo 'EOF' >> $GITHUB_ENV
-  #   - name: Run the tests
-  #     run: |
-  #       tox -e ${{ env.TOXENV }} -- -n 2 test
-  #   - name: Upload Coverage Report
-  #     uses: codecov/codecov-action@v1
-  #     with:
-  #       files: ./coverage.xml
-  # other-tests:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       jobs: [ 'bench', 'mypy' ]
-  #   name: ${{ matrix.jobs }} tests
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v2
-  #     with:
-  #       python-version: '3.10'
-  #   - name: Install dependencies
-  #     run: |
-  #       pip install tox
-  #   - name: Set Tox Params
-  #     run: |
-  #       echo "TOXENV=${{ matrix.jobs }}" >> $GITHUB_ENV
-  #   - name: Run the tests
-  #     env:
-  #       SQLFLUFF_BENCHMARK_API_KEY: ${{ secrets.SQLFLUFF_BENCHMARK_API_KEY }}
-  #     run: |
-  #       tox -e ${{ env.TOXENV }}
-  # examples:
-  #   runs-on: ubuntu-latest
-  #   name: example tests
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v2
-  #     with:
-  #       python-version: '3.10'
-  #   - name: Install dependencies
-  #     run: |
-  #       pip install -e .
-  #       pip install tqdm
-  #   - name: Test the example files
-  #     run: |
-  #       for file in examples/*
-  #       do
-  #         echo "Running $file"
-  #         python "$file"
-  #       done
-  # dbt-tests:
-  #   runs-on: ubuntu-latest
-  #   services:
-  #     # Label used to access the service container
-  #     postgres:
-  #       # Docker Hub image
-  #       image: postgres
-  #       # Provide the password for postgres
-  #       env:
-  #         POSTGRES_PASSWORD: password
-  #       # Set health checks to wait until postgres has started
-  #       options: >-
-  #         --health-cmd pg_isready
-  #         --health-interval 10s
-  #         --health-timeout 5s
-  #         --health-retries 5
-  #       ports:
-  #         # Maps tcp port 5432 on service container to the host
-  #         - 5432:5432
-  #   strategy:
-  #     matrix:
-  #       dbt-version: [ 'dbt018', 'dbt019', 'dbt020', 'dbt021', 'dbt100' ]
-  #   name: DBT Plugin ${{ matrix.dbt-version }} tests
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v2
-  #     with:
-  #       python-version: '3.8'
-  #   - name: Install dependencies
-  #     run: |
-  #       pip install tox
-  #   - name: Run the tests
-  #     run: |
-  #       tox -e ${{ matrix.dbt-version }} -- plugins/sqlfluff-templater-dbt
-  #   - name: Upload Coverage Report
-  #     uses: codecov/codecov-action@v1
-  #     with:
-  #       files: ./coverage.xml
-  # python-windows-tests:
-  #   runs-on: windows-latest
-  #   name: Python 3.8 Windows tests
-  #   steps:
-  #   - name: Set git to use LF
-  #     run: |
-  #       git config --global core.autocrlf false
-  #       git config --global core.eol lf
-  #   - uses: actions/checkout@v2
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v2
-  #     with:
-  #       python-version: '3.8'
-  #   - name: List Env
-  #     shell: bash
-  #     run: |
-  #       env | sort
-  #   - name: Install dependencies
-  #     shell: bash
-  #     run: |
-  #       pip install tox
-  #   - name: Run the tests
-  #     shell: bash
-  #     # Set python temp dir in working dir as on GitHub Actions Windows
-  #     # machine often has system temp dir (which tox uses) on C drive and
-  #     # working dir on D drive which causes problems.
-  #     run: |
-  #       mkdir temp_pytest
-  #       python -m tox -e winpy -- -n 2 test
-  #   - name: Upload Coverage Report
-  #     uses: codecov/codecov-action@v1
-  #     with:
-  #       files: ./coverage.xml
+  linting:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jobs: [ 'linting', 'doclinting', 'docbuild', 'yamllint' ]
+    name: ${{ matrix.jobs }} tests
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        pip install tox
+    - name: Run the tests
+      run: |
+        tox -e ${{ matrix.jobs }}
+  python-version-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+    name: Python ${{ matrix.python-version }} tests
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install tox
+    - name: Set Tox Python Param
+      run: |
+        echo 'TOXENV<<EOF' >> $GITHUB_ENV
+        echo "${{ matrix.python-version }}" | sed "s/\.//" | sed "s/^/py/" >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+    - name: Run the tests
+      run: |
+        tox -e ${{ env.TOXENV }} -- -n 2 test
+    - name: Upload Coverage Report
+      uses: codecov/codecov-action@v1
+      with:
+        files: ./coverage.xml
+  other-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jobs: [ 'bench', 'mypy' ]
+    name: ${{ matrix.jobs }} tests
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        pip install tox
+    - name: Set Tox Params
+      run: |
+        echo "TOXENV=${{ matrix.jobs }}" >> $GITHUB_ENV
+    - name: Run the tests
+      env:
+        SQLFLUFF_BENCHMARK_API_KEY: ${{ secrets.SQLFLUFF_BENCHMARK_API_KEY }}
+      run: |
+        tox -e ${{ env.TOXENV }}
+  examples:
+    runs-on: ubuntu-latest
+    name: example tests
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        pip install -e .
+        pip install tqdm
+    - name: Test the example files
+      run: |
+        for file in examples/*
+        do
+          echo "Running $file"
+          python "$file"
+        done
+  dbt-tests:
+    runs-on: ubuntu-latest
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: password
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+    strategy:
+      matrix:
+        dbt-version: [ 'dbt018', 'dbt019', 'dbt020', 'dbt021', 'dbt100' ]
+    name: DBT Plugin ${{ matrix.dbt-version }} tests
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        pip install tox
+    - name: Run the tests
+      run: |
+        tox -e ${{ matrix.dbt-version }} -- plugins/sqlfluff-templater-dbt
+    - name: Upload Coverage Report
+      uses: codecov/codecov-action@v1
+      with:
+        files: ./coverage.xml
+  python-windows-tests:
+    runs-on: windows-latest
+    name: Python 3.8 Windows tests
+    steps:
+    - name: Set git to use LF
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: List Env
+      shell: bash
+      run: |
+        env | sort
+    - name: Install dependencies
+      shell: bash
+      run: |
+        pip install tox
+    - name: Run the tests
+      shell: bash
+      # Set python temp dir in working dir as on GitHub Actions Windows
+      # machine often has system temp dir (which tox uses) on C drive and
+      # working dir on D drive which causes problems.
+      run: |
+        mkdir temp_pytest
+        python -m tox -e winpy -- -n 2 test
+    - name: Upload Coverage Report
+      uses: codecov/codecov-action@v1
+      with:
+        files: ./coverage.xml
   python-windows-dbt-tests:
     runs-on: windows-latest
     name: DBT Plugin Python 3.8 Windows tests
@@ -212,37 +212,36 @@ jobs:
       # None of these test need temp dir set
       run: |
         python -m tox -e dbt018-winpy -- plugins/sqlfluff-templater-dbt
-      #  -m "not dbt_connection_failure and not needs_dbt_connection"
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1
       with:
         files: ./coverage.xml
-  # pip-test-pull-request:
-  #   # Test that using pip install works as we've missed
-  #   # some dependencies in the past - see #1842
-  #   runs-on: ubuntu-latest
-  #   if: github.event_name == 'pull_request'
-  #   name: pip install tests
-  #   steps:
-  #   - name: Set up Python
-  #     uses: actions/setup-python@v2
-  #     with:
-  #       python-version: '3.10'
-  #   - name: Install dependencies
-  #     run: |
-  #       pip install git+https://github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.head_ref }}
-  #   - name: Run the version test
-  #     run: |
-  #       sqlfluff --version
-  #   - name: Run a simple select parse test via stdin
-  #     run: |
-  #       echo "select 1" | sqlfluff parse -
-  #   - name: Run a simple select lint test via stdin
-  #     run: |
-  #       echo "select 1" | sqlfluff lint -
-  #   - name: Run a simple select parse test via file
-  #     run: |
-  #       sqlfluff parse <(echo "select 1")
-  #   - name: Run a simple select lint test via file
-  #     run: |
-  #       sqlfluff lint <(echo "select 1")
+  pip-test-pull-request:
+    # Test that using pip install works as we've missed
+    # some dependencies in the past - see #1842
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    name: pip install tests
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        pip install git+https://github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.head_ref }}
+    - name: Run the version test
+      run: |
+        sqlfluff --version
+    - name: Run a simple select parse test via stdin
+      run: |
+        echo "select 1" | sqlfluff parse -
+    - name: Run a simple select lint test via stdin
+      run: |
+        echo "select 1" | sqlfluff lint -
+    - name: Run a simple select parse test via file
+      run: |
+        sqlfluff parse <(echo "select 1")
+    - name: Run a simple select lint test via file
+      run: |
+        sqlfluff lint <(echo "select 1")

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -190,7 +190,7 @@ jobs:
         $pgService = Get-Service -Name postgresql*
         Set-Service -InputObject $pgService -Status running -StartupType automatic
         Start-Process -FilePath "$env:PGBIN\pg_isready" -Wait -PassThru
-    - name: Create postgres user on Windows
+    - name: Set postgres user password
       run: |
         & $env:PGBIN\psql --command="ALTER USER postgres PASSWORD 'password';" --command="\du"
     - name: Set git to use LF

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -185,6 +185,19 @@ jobs:
     runs-on: windows-latest
     name: DBT Plugin Python 3.8 Windows tests
     steps:
+    - name: Start PostgreSQL on Windows
+      run: |
+        $pgService = Get-Service -Name postgresql*
+        Set-Service -InputObject $pgService -Status running -StartupType automatic
+        Start-Process -FilePath "$env:PGBIN\pg_isready" -Wait -PassThru
+    - name: Create postgres user on Windows
+      run: |
+        & $env:PGBIN\psql --command="CREATE USER postgres PASSWORD 'password'" --command="\du"
+    - name: Create postgres database
+      run: |
+        & $env:PGBIN\createdb --owner=postgres postgres
+        $env:PGPASSWORD = 'password'
+        & $env:PGBIN\psql --username=postgres --host=localhost --list postgres
     - name: Set git to use LF
       run: |
         git config --global core.autocrlf false

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -195,8 +195,8 @@ jobs:
         & $env:PGBIN\psql --command="ALTER USER postgres PASSWORD 'password';" --command="\du"
     - name: Create postgres database
       run: |
-        & $env:PGBIN\createdb --owner=postgres postgres
         $env:PGPASSWORD = 'password'
+        & $env:PGBIN\createdb --owner=postgres postgres
         & $env:PGBIN\psql --username=postgres --host=localhost --list postgres
     - name: Set git to use LF
       run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -192,7 +192,7 @@ jobs:
         Start-Process -FilePath "$env:PGBIN\pg_isready" -Wait -PassThru
     - name: Create postgres user on Windows
       run: |
-        & $env:PGBIN\psql --command="CREATE USER postgres PASSWORD 'password'" --command="\du"
+        & $env:PGBIN\psql --command="ALTER USER postgres PASSWORD 'password';" --command="\du"
     - name: Create postgres database
       run: |
         & $env:PGBIN\createdb --owner=postgres postgres

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -21,166 +21,166 @@ on:
       - main
 
 jobs:
-  linting:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        jobs: [ 'linting', 'doclinting', 'docbuild', 'yamllint' ]
-    name: ${{ matrix.jobs }} tests
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        pip install tox
-    - name: Run the tests
-      run: |
-        tox -e ${{ matrix.jobs }}
-  python-version-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
-    name: Python ${{ matrix.python-version }} tests
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        pip install tox
-    - name: Set Tox Python Param
-      run: |
-        echo 'TOXENV<<EOF' >> $GITHUB_ENV
-        echo "${{ matrix.python-version }}" | sed "s/\.//" | sed "s/^/py/" >> $GITHUB_ENV
-        echo 'EOF' >> $GITHUB_ENV
-    - name: Run the tests
-      run: |
-        tox -e ${{ env.TOXENV }} -- -n 2 test
-    - name: Upload Coverage Report
-      uses: codecov/codecov-action@v1
-      with:
-        files: ./coverage.xml
-  other-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        jobs: [ 'bench', 'mypy' ]
-    name: ${{ matrix.jobs }} tests
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        pip install tox
-    - name: Set Tox Params
-      run: |
-        echo "TOXENV=${{ matrix.jobs }}" >> $GITHUB_ENV
-    - name: Run the tests
-      env:
-        SQLFLUFF_BENCHMARK_API_KEY: ${{ secrets.SQLFLUFF_BENCHMARK_API_KEY }}
-      run: |
-        tox -e ${{ env.TOXENV }}
-  examples:
-    runs-on: ubuntu-latest
-    name: example tests
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        pip install -e .
-        pip install tqdm
-    - name: Test the example files
-      run: |
-        for file in examples/*
-        do
-          echo "Running $file"
-          python "$file"
-        done
-  dbt-tests:
-    runs-on: ubuntu-latest
-    services:
-      # Label used to access the service container
-      postgres:
-        # Docker Hub image
-        image: postgres
-        # Provide the password for postgres
-        env:
-          POSTGRES_PASSWORD: password
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 5432:5432
-    strategy:
-      matrix:
-        dbt-version: [ 'dbt018', 'dbt019', 'dbt020', 'dbt021', 'dbt100' ]
-    name: DBT Plugin ${{ matrix.dbt-version }} tests
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-    - name: Install dependencies
-      run: |
-        pip install tox
-    - name: Run the tests
-      run: |
-        tox -e ${{ matrix.dbt-version }} -- plugins/sqlfluff-templater-dbt
-    - name: Upload Coverage Report
-      uses: codecov/codecov-action@v1
-      with:
-        files: ./coverage.xml
-  python-windows-tests:
-    runs-on: windows-latest
-    name: Python 3.8 Windows tests
-    steps:
-    - name: Set git to use LF
-      run: |
-        git config --global core.autocrlf false
-        git config --global core.eol lf
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-    - name: List Env
-      shell: bash
-      run: |
-        env | sort
-    - name: Install dependencies
-      shell: bash
-      run: |
-        pip install tox
-    - name: Run the tests
-      shell: bash
-      # Set python temp dir in working dir as on GitHub Actions Windows
-      # machine often has system temp dir (which tox uses) on C drive and
-      # working dir on D drive which causes problems.
-      run: |
-        mkdir temp_pytest
-        python -m tox -e winpy -- -n 2 test
-    - name: Upload Coverage Report
-      uses: codecov/codecov-action@v1
-      with:
-        files: ./coverage.xml
+  # linting:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       jobs: [ 'linting', 'doclinting', 'docbuild', 'yamllint' ]
+  #   name: ${{ matrix.jobs }} tests
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v2
+  #     with:
+  #       python-version: '3.10'
+  #   - name: Install dependencies
+  #     run: |
+  #       pip install tox
+  #   - name: Run the tests
+  #     run: |
+  #       tox -e ${{ matrix.jobs }}
+  # python-version-tests:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+  #   name: Python ${{ matrix.python-version }} tests
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v2
+  #     with:
+  #       python-version: ${{ matrix.python-version }}
+  #   - name: Install dependencies
+  #     run: |
+  #       pip install tox
+  #   - name: Set Tox Python Param
+  #     run: |
+  #       echo 'TOXENV<<EOF' >> $GITHUB_ENV
+  #       echo "${{ matrix.python-version }}" | sed "s/\.//" | sed "s/^/py/" >> $GITHUB_ENV
+  #       echo 'EOF' >> $GITHUB_ENV
+  #   - name: Run the tests
+  #     run: |
+  #       tox -e ${{ env.TOXENV }} -- -n 2 test
+  #   - name: Upload Coverage Report
+  #     uses: codecov/codecov-action@v1
+  #     with:
+  #       files: ./coverage.xml
+  # other-tests:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       jobs: [ 'bench', 'mypy' ]
+  #   name: ${{ matrix.jobs }} tests
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v2
+  #     with:
+  #       python-version: '3.10'
+  #   - name: Install dependencies
+  #     run: |
+  #       pip install tox
+  #   - name: Set Tox Params
+  #     run: |
+  #       echo "TOXENV=${{ matrix.jobs }}" >> $GITHUB_ENV
+  #   - name: Run the tests
+  #     env:
+  #       SQLFLUFF_BENCHMARK_API_KEY: ${{ secrets.SQLFLUFF_BENCHMARK_API_KEY }}
+  #     run: |
+  #       tox -e ${{ env.TOXENV }}
+  # examples:
+  #   runs-on: ubuntu-latest
+  #   name: example tests
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v2
+  #     with:
+  #       python-version: '3.10'
+  #   - name: Install dependencies
+  #     run: |
+  #       pip install -e .
+  #       pip install tqdm
+  #   - name: Test the example files
+  #     run: |
+  #       for file in examples/*
+  #       do
+  #         echo "Running $file"
+  #         python "$file"
+  #       done
+  # dbt-tests:
+  #   runs-on: ubuntu-latest
+  #   services:
+  #     # Label used to access the service container
+  #     postgres:
+  #       # Docker Hub image
+  #       image: postgres
+  #       # Provide the password for postgres
+  #       env:
+  #         POSTGRES_PASSWORD: password
+  #       # Set health checks to wait until postgres has started
+  #       options: >-
+  #         --health-cmd pg_isready
+  #         --health-interval 10s
+  #         --health-timeout 5s
+  #         --health-retries 5
+  #       ports:
+  #         # Maps tcp port 5432 on service container to the host
+  #         - 5432:5432
+  #   strategy:
+  #     matrix:
+  #       dbt-version: [ 'dbt018', 'dbt019', 'dbt020', 'dbt021', 'dbt100' ]
+  #   name: DBT Plugin ${{ matrix.dbt-version }} tests
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v2
+  #     with:
+  #       python-version: '3.8'
+  #   - name: Install dependencies
+  #     run: |
+  #       pip install tox
+  #   - name: Run the tests
+  #     run: |
+  #       tox -e ${{ matrix.dbt-version }} -- plugins/sqlfluff-templater-dbt
+  #   - name: Upload Coverage Report
+  #     uses: codecov/codecov-action@v1
+  #     with:
+  #       files: ./coverage.xml
+  # python-windows-tests:
+  #   runs-on: windows-latest
+  #   name: Python 3.8 Windows tests
+  #   steps:
+  #   - name: Set git to use LF
+  #     run: |
+  #       git config --global core.autocrlf false
+  #       git config --global core.eol lf
+  #   - uses: actions/checkout@v2
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v2
+  #     with:
+  #       python-version: '3.8'
+  #   - name: List Env
+  #     shell: bash
+  #     run: |
+  #       env | sort
+  #   - name: Install dependencies
+  #     shell: bash
+  #     run: |
+  #       pip install tox
+  #   - name: Run the tests
+  #     shell: bash
+  #     # Set python temp dir in working dir as on GitHub Actions Windows
+  #     # machine often has system temp dir (which tox uses) on C drive and
+  #     # working dir on D drive which causes problems.
+  #     run: |
+  #       mkdir temp_pytest
+  #       python -m tox -e winpy -- -n 2 test
+  #   - name: Upload Coverage Report
+  #     uses: codecov/codecov-action@v1
+  #     with:
+  #       files: ./coverage.xml
   python-windows-dbt-tests:
     runs-on: windows-latest
     name: DBT Plugin Python 3.8 Windows tests
@@ -193,11 +193,6 @@ jobs:
     - name: Create postgres user on Windows
       run: |
         & $env:PGBIN\psql --command="ALTER USER postgres PASSWORD 'password';" --command="\du"
-    - name: Create postgres database
-      run: |
-        $env:PGPASSWORD = 'password'
-        & $env:PGBIN\createdb --owner=postgres postgres
-        & $env:PGBIN\psql --username=postgres --host=localhost --list postgres
     - name: Set git to use LF
       run: |
         git config --global core.autocrlf false
@@ -216,37 +211,38 @@ jobs:
       # Do not set explicitly temp dir for dbt as causes problems
       # None of these test need temp dir set
       run: |
-        python -m tox -e dbt018-winpy -- plugins/sqlfluff-templater-dbt -m "not dbt_connection_failure and not needs_dbt_connection"
+        python -m tox -e dbt018-winpy -- plugins/sqlfluff-templater-dbt
+      #  -m "not dbt_connection_failure and not needs_dbt_connection"
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1
       with:
         files: ./coverage.xml
-  pip-test-pull-request:
-    # Test that using pip install works as we've missed
-    # some dependencies in the past - see #1842
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    name: pip install tests
-    steps:
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        pip install git+https://github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.head_ref }}
-    - name: Run the version test
-      run: |
-        sqlfluff --version
-    - name: Run a simple select parse test via stdin
-      run: |
-        echo "select 1" | sqlfluff parse -
-    - name: Run a simple select lint test via stdin
-      run: |
-        echo "select 1" | sqlfluff lint -
-    - name: Run a simple select parse test via file
-      run: |
-        sqlfluff parse <(echo "select 1")
-    - name: Run a simple select lint test via file
-      run: |
-        sqlfluff lint <(echo "select 1")
+  # pip-test-pull-request:
+  #   # Test that using pip install works as we've missed
+  #   # some dependencies in the past - see #1842
+  #   runs-on: ubuntu-latest
+  #   if: github.event_name == 'pull_request'
+  #   name: pip install tests
+  #   steps:
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v2
+  #     with:
+  #       python-version: '3.10'
+  #   - name: Install dependencies
+  #     run: |
+  #       pip install git+https://github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.head_ref }}
+  #   - name: Run the version test
+  #     run: |
+  #       sqlfluff --version
+  #   - name: Run a simple select parse test via stdin
+  #     run: |
+  #       echo "select 1" | sqlfluff parse -
+  #   - name: Run a simple select lint test via stdin
+  #     run: |
+  #       echo "select 1" | sqlfluff lint -
+  #   - name: Run a simple select parse test via file
+  #     run: |
+  #       sqlfluff parse <(echo "select 1")
+  #   - name: Run a simple select lint test via file
+  #     run: |
+  #       sqlfluff lint <(echo "select 1")

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -226,10 +226,8 @@ def test__templater_dbt_skips_disabled_model(dbt_templater, project_dir):  # noq
     "fname",
     [
         "use_var.sql",
-        pytest.param("incremental.sql", marks=pytest.mark.needs_dbt_connection),
-        pytest.param(
-            "single_trailing_newline.sql", marks=pytest.mark.needs_dbt_connection
-        ),
+        "incremental.sql",
+        "single_trailing_newline.sql",
         "L034_test.sql",
     ],
 )
@@ -325,7 +323,6 @@ def test__templater_dbt_handle_exceptions(
     DBT_VERSION_TUPLE < (1, 0), reason="mocks a function that's only used in dbt >= 1.0"
 )
 @mock.patch("dbt.adapters.postgres.impl.PostgresAdapter.set_relations_cache")
-@pytest.mark.dbt_connection_failure
 def test__templater_dbt_handle_database_connection_failure(
     set_relations_cache, project_dir, dbt_templater  # noqa: F811
 ):


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
During the work on #2230  it was decided to disable the Windows dbt tests that require a Postgres connection in order to get that important fix through. This PR makes a Postgres database available on the Windows runner so that we can re-enable those tests 😄 

Simplified version of this article: https://www.cybertec-postgresql.com/en/postgresql-github-actions-continuous-integration/

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
