### PR TITLE
Align line length in Python code to 88 characters

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,7 +90,8 @@ html_theme_options = {
     "github_banner": True,
     # GitHub star button
     "github_type": "star",
-    # Use `"true"` instead of `True` for counting GitHub star, see https://ghbtns.com for details
+    # Use `"true"` instead of `True` for counting GitHub star, see https://ghbtns.com
+    # for details
     "github_count": "true",
     # Codecov button
     "codecov_button": True,

--- a/examples/01_basic_api_usage.py
+++ b/examples/01_basic_api_usage.py
@@ -11,7 +11,8 @@ my_bad_query = "SeLEct  *, 1, blah as  fOO  from mySchema.myTable"
 lint_result = sqlfluff.lint(my_bad_query, dialect="bigquery")
 # lint_result =
 # [
-#     {"code": "L010", "line_no": 1, "line_pos": 1, "description": "Keywords must be consistently upper case."}
+#     {"code": "L010", "line_no": 1, "line_pos": 1, "description": "Keywords must be "
+#     "consistently upper case."}
 #     ...
 # ]
 
@@ -49,9 +50,14 @@ def get_json_segment(
         segment_type (str): The segment type to search for.
 
     Yields:
-        Iterator[Union[str, Dict[str, Any], List[Dict[str, Any]]]]: Retrieve children of specified segment type
-                                                                    as either a string for a raw segment or as
-                                                                    JSON or an array of JSON for non-raw segments.
+        Iterator[Union[str, Dict[str, Any], List[Dict[str, Any]]]]: Retrieve children of
+                                                                    specified segment
+                                                                    type as either a
+                                                                    string for a raw
+                                                                    segment or as JSON
+                                                                    or an array of JSON
+                                                                    for non-raw
+                                                                    segments.
     """
     for k, v in parse_result.items():
         if k == segment_type:

--- a/examples/03_getting_rules_and_dialects.py
+++ b/examples/03_getting_rules_and_dialects.py
@@ -13,6 +13,7 @@ dialect_names = [dialect.label for dialect in dialects]
 #  -------- RULES ----------
 
 rules = sqlfluff.list_rules()
-# rules = [RuleTuple(code='Example_L001', description='ORDER BY on these columns is forbidden!'), ...]
+# rules = [RuleTuple(code='Example_L001', description='ORDER BY on these columns is '
+# 'forbidden!'), ...]
 rule_codes = [rule.code for rule in rules]
 # rule_codes = ["L001", "L002", ...]

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -209,7 +209,8 @@ class DbtTemplater(JinjaTemplater):
 
         if not os.path.exists(dbt_profiles_dir):
             templater_logger.error(
-                f"dbt_profiles_dir: {dbt_profiles_dir} could not be accessed. Check it exists."
+                f"dbt_profiles_dir: {dbt_profiles_dir} could not be accessed. "
+                "Check it exists."
             )
 
         return dbt_profiles_dir
@@ -229,7 +230,8 @@ class DbtTemplater(JinjaTemplater):
         )
         if not os.path.exists(dbt_project_dir):
             templater_logger.error(
-                f"dbt_project_dir: {dbt_project_dir} could not be accessed. Check it exists."
+                f"dbt_project_dir: {dbt_project_dir} could not be accessed. Check it "
+                "exists."
             )
 
         return dbt_project_dir
@@ -338,7 +340,8 @@ class DbtTemplater(JinjaTemplater):
             if e.node:
                 return None, [
                     SQLTemplaterError(
-                        f"dbt compilation error on file '{e.node.original_file_path}', {e.msg}",
+                        f"dbt compilation error on file '{e.node.original_file_path}', "
+                        f"{e.msg}",
                         # It's fatal if we're over the limit
                         fatal=self._sequential_fails > self.sequential_fail_limit,
                     )
@@ -348,9 +351,9 @@ class DbtTemplater(JinjaTemplater):
         except DbtFailedToConnectException as e:
             return None, [
                 SQLTemplaterError(
-                    "dbt tried to connect to the database and failed: "
-                    "you could use 'execute' https://docs.getdbt.com/reference/dbt-jinja-functions/execute/ "
-                    f"to skip the database calls. Error: {e.msg}",
+                    "dbt tried to connect to the database and failed: you could use "
+                    "'execute' https://docs.getdbt.com/reference/dbt-jinja-functions"
+                    f"/execute/ to skip the database calls. Error: {e.msg}",
                     fatal=True,
                 )
             ]
@@ -363,7 +366,8 @@ class DbtTemplater(JinjaTemplater):
     def _find_node(self, fname, config=None):
         if not config:  # pragma: no cover
             raise ValueError(
-                "For the dbt templater, the `process()` method requires a config object."
+                "For the dbt templater, the `process()` method requires a config "
+                "object."
             )
         if not fname:  # pragma: no cover
             raise ValueError(
@@ -448,7 +452,8 @@ class DbtTemplater(JinjaTemplater):
         node = self._find_node(fname, config)
 
         # We have to register the connection in dbt >= 1.0.0 ourselves
-        # In previous versions, we relied on the functionality removed in https://github.com/dbt-labs/dbt-core/pull/4062
+        # In previous versions, we relied on the functionality removed in
+        # https://github.com/dbt-labs/dbt-core/pull/4062
         if DBT_VERSION_TUPLE >= (1, 0):
             adapter = get_adapter(self.dbt_config)
             with adapter.connection_named("master"):
@@ -548,7 +553,8 @@ class DbtTemplater(JinjaTemplater):
 class SnapshotExtension(StandaloneTag):
     """Dummy "snapshot" tags so raw dbt templates will parse.
 
-    Context: dbt snapshots (https://docs.getdbt.com/docs/building-a-dbt-project/snapshots/#example)
+    Context: dbt snapshots
+    (https://docs.getdbt.com/docs/building-a-dbt-project/snapshots/#example)
     use custom Jinja "snapshot" and "endsnapshot" tags. However, dbt does not
     actually register those tags with Jinja. Instead, it finds and removes these
     tags during a preprocessing step. However, DbtTemplater needs those tags to

--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/templater.py
@@ -11,8 +11,10 @@ DBT_FLUFF_CONFIG = {
     },
     "templater": {
         "dbt": {
-            "profiles_dir": "plugins/sqlfluff-templater-dbt/test/fixtures/dbt/profiles_yml",
-            "project_dir": "plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project",
+            "profiles_dir": "plugins/sqlfluff-templater-dbt/test/fixtures/dbt"
+            "/profiles_yml",
+            "project_dir": "plugins/sqlfluff-templater-dbt/test/fixtures/dbt"
+            "/dbt_project",
         },
     },
 }

--- a/plugins/sqlfluff-templater-dbt/test/generate_packages_yml.py
+++ b/plugins/sqlfluff-templater-dbt/test/generate_packages_yml.py
@@ -13,7 +13,10 @@ except ImportError:
 
 
 def main(project_dir):
-    """Load Jinja template file packages.yml.jinja2, expand it, write to packages.yml."""
+    """Load Jinja template file packages.yml.jinja2, expand it, # noqa: D415
+
+    write to packages.yml.
+    """
     env = SandboxedEnvironment()
     with open(os.path.join(project_dir, "packages.yml.jinja2")) as f:
         template_str = f.read()

--- a/plugins/sqlfluff-templater-dbt/test/rules_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/rules_test.py
@@ -22,7 +22,10 @@ from test.fixtures.dbt.templater import (  # noqa
     ],
 )
 def test__rules__std_file_dbt(rule, path, violations, project_dir):  # noqa
-    """Test the linter finds the given errors in (and only in) the right places (DBT)."""
+    """Test the linter finds the given errors in (and only in) # noqa: D415
+
+    the right places (DBT).
+    """
     assert_rule_raises_violations_in_file(
         rule=rule,
         fpath=os.path.join(project_dir, path),

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -190,7 +190,10 @@ def test__templater_dbt_slice_file_wrapped_test(
 def test__templater_dbt_templating_test_lex(
     project_dir, dbt_templater, fname  # noqa: F811
 ):
-    """A test to demonstrate the lexer works on both dbt models (with any # of trailing newlines) and dbt tests."""
+    """A test to demonstrate the lexer works on both dbt models # noqa: D415
+
+    (with any # of trailing newlines) and dbt tests.
+    """
     source_fpath = os.path.join(project_dir, fname)
     with open(source_fpath, "r") as source_dbt_model:
         source_dbt_sql = source_dbt_model.read()
@@ -288,7 +291,8 @@ def test__templater_dbt_templating_absolute_path(
         (
             "compiler_error.sql",
             "dbt compilation error on file 'models/my_new_project/compiler_error.sql', "
-            "Unexpected end of template. Jinja was looking for the following tags: 'endfor'",
+            "Unexpected end of template. Jinja was looking for the following tags: "
+            "'endfor'",
         ),
     ],
 )
@@ -331,7 +335,8 @@ def test__templater_dbt_handle_database_connection_failure(
 
     set_relations_cache.side_effect = DbtFailedToConnectException("dummy error")
 
-    src_fpath = "plugins/sqlfluff-templater-dbt/test/fixtures/dbt/error_models/exception_connect_database.sql"
+    src_fpath = "plugins/sqlfluff-templater-dbt/test/fixtures/dbt/error_models"
+    "/exception_connect_database.sql"
     target_fpath = os.path.abspath(
         os.path.join(
             project_dir, "models/my_new_project/exception_connect_database.sql"
@@ -364,7 +369,10 @@ def test__templater_dbt_handle_database_connection_failure(
 
 
 def test__project_dir_does_not_exist_error(dbt_templater, caplog):  # noqa: F811
-    """Test that an error is logged if the specified dbt project directory doesn't exist."""
+    """Test that an error is logged if the specified dbt # noqa: D415
+
+    project directory doesn't exist.
+    """
     dbt_templater.sqlfluff_config = FluffConfig(
         configs={"templater": {"dbt": {"project_dir": "./non_existing_directory"}}}
     )
@@ -375,8 +383,8 @@ def test__project_dir_does_not_exist_error(dbt_templater, caplog):  # noqa: F811
         with caplog.at_level(logging.ERROR, logger="sqlfluff.templater"):
             dbt_project_dir = dbt_templater._get_project_dir()
         assert (
-            f"dbt_project_dir: {dbt_project_dir} could not be accessed. Check it exists."
-            in caplog.text
+            f"dbt_project_dir: {dbt_project_dir} could not be accessed. Check it "
+            "exists." in caplog.text
         )
     finally:
         logger.propagate = original_propagate_value

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -151,15 +151,17 @@ def common_options(f: Callable) -> Callable:
         "--verbose",
         count=True,
         help=(
-            "Verbosity, how detailed should the output be. This is *stackable*, so `-vv`"
-            " is more verbose than `-v`. For the most verbose option try `-vvvv` or `-vvvvv`."
+            "Verbosity, how detailed should the output be. This is *stackable*, so "
+            "`-vv` is more verbose than `-v`. For the most verbose option try `-vvvv` "
+            "or `-vvvvv`."
         ),
     )(f)
     f = click.option(
         "-n",
         "--nocolor",
         is_flag=True,
-        help="No color - if this is set then the output will be without ANSI color codes.",
+        help="No color - if this is set then the output will be without ANSI color "
+        "codes.",
     )(f)
 
     return f
@@ -220,9 +222,9 @@ def core_options(f: Callable) -> Callable:
         default=None,
         help=(
             "Include additional config file. By default the config is generated "
-            "from the standard configuration files described in the documentation. This "
-            "argument allows you to specify an additional configuration file that overrides "
-            "the standard configuration files. N.B. cfg format is required."
+            "from the standard configuration files described in the documentation. "
+            "This argument allows you to specify an additional configuration file that "
+            "overrides the standard configuration files. N.B. cfg format is required."
         ),
         type=click.Path(),
     )(f)
@@ -240,7 +242,8 @@ def core_options(f: Callable) -> Callable:
         "--encoding",
         default="autodetect",
         help=(
-            "Specifiy encoding to use when reading and writing files. Defaults to autodetect."
+            "Specifiy encoding to use when reading and writing files. Defaults to "
+            "autodetect."
         ),
     )(f)
     f = click.option(
@@ -250,7 +253,8 @@ def core_options(f: Callable) -> Callable:
             "Ignore particular families of errors so that they don't cause a failed "
             "run. For example `--ignore parsing` would mean that any parsing errors "
             "are ignored and don't influence the success or fail of a run. Multiple "
-            "options are possible if comma separated e.g. `--ignore parsing,templating`."
+            "options are possible if comma separated e.g. "
+            "`--ignore parsing,templating`."
         ),
     )(f)
     f = click.option(
@@ -282,7 +286,8 @@ def get_config(
     """Get a config object from kwargs."""
     if "dialect" in kwargs:
         try:
-            # We're just making sure it exists at this stage - it will be fetched properly in the linter
+            # We're just making sure it exists at this stage - it will be fetched
+            # properly in the linter
             dialect_selector(kwargs["dialect"])
         except SQLFluffUserError as err:
             click.echo(
@@ -341,7 +346,8 @@ def get_linter_and_formatter(
 ) -> Tuple[Linter, CallbackFormatter]:
     """Get a linter object given a config."""
     try:
-        # We're just making sure it exists at this stage - it will be fetched properly in the linter
+        # We're just making sure it exists at this stage - it will be fetched properly
+        # in the linter
         dialect_selector(cfg.get("dialect"))
     except KeyError:  # pragma: no cover
         click.echo(f"Error: Unknown dialect '{cfg.get('dialect')}'")
@@ -415,7 +421,8 @@ def dialects(**kwargs) -> None:
     "--annotation-level",
     default="notice",
     type=click.Choice(["notice", "warning", "failure"], case_sensitive=False),
-    help="When format is set to github-annotation, default annotation level (default=notice).",
+    help="When format is set to github-annotation, default annotation level "
+    "(default=notice).",
 )
 @click.option(
     "--nofail",
@@ -503,7 +510,8 @@ def lint(
         except OSError:
             click.echo(
                 colorize(
-                    f"The path(s) '{paths}' could not be accessed. Check it/they exist(s).",
+                    f"The path(s) '{paths}' could not be accessed. Check it/they "
+                    "exist(s).",
                     Color.red,
                 )
             )
@@ -692,7 +700,8 @@ def fix(
     if result.num_violations(types=SQLLintError, fixable=True) > 0:
         click.echo("==== fixing violations ====")
         click.echo(
-            f"{result.num_violations(types=SQLLintError, fixable=True)} fixable linting violations found"
+            f"{result.num_violations(types=SQLLintError, fixable=True)} fixable "
+            "linting violations found"
         )
         if force:
             click.echo(f"{colorize('FORCE MODE', Color.red)}: Attempting fixes...")
@@ -737,13 +746,15 @@ def fix(
 
     if result.num_violations(types=SQLLintError, fixable=False) > 0:
         click.echo(
-            f"  [{result.num_violations(types=SQLLintError, fixable=False)} unfixable linting violations found]"
+            f"  [{result.num_violations(types=SQLLintError, fixable=False)} unfixable "
+            "linting violations found]"
         )
         exit_code = 1
 
     if result.num_violations(types=SQLTemplaterError) > 0:
         click.echo(
-            f"  [{result.num_violations(types=SQLTemplaterError)} templating errors found]"
+            f"  [{result.num_violations(types=SQLTemplaterError)} templating errors "
+            "found]"
         )
         exit_code = 1
 
@@ -760,7 +771,8 @@ def fix(
 
 def _completion_message(config: FluffConfig) -> None:
     click.echo(
-        f"All Finished{'' if (config.get('nocolor') or not sys.stdout.isatty()) else ' 📜 🎉'}!"
+        "All Finished"
+        f"{'' if (config.get('nocolor') or not sys.stdout.isatty()) else ' 📜 🎉'}!"
     )
 
 
@@ -904,7 +916,8 @@ def parse(
             ]
 
             if format == FormatType.yaml.value:
-                # For yaml dumping always dump double quoted strings if they contain tabs or newlines.
+                # For yaml dumping always dump double quoted strings if they contain
+                # tabs or newlines.
                 yaml.add_representer(str, quoted_presenter)
                 click.echo(yaml.dump(parsed_strings_dict, sort_keys=False))
             elif format == FormatType.json.value:

--- a/src/sqlfluff/cli/helpers.py
+++ b/src/sqlfluff/cli/helpers.py
@@ -41,7 +41,10 @@ def get_package_version() -> str:
 
 
 def wrap_elem(s: str, width: int) -> List[str]:
-    """Take a string, and attempt to wrap into a list of strings all less than <width>."""
+    """Take a string, and attempt to wrap into a list of strings all less # noqa: D415
+
+    than <width>.
+    """
     return textwrap.wrap(s, width=width)
 
 
@@ -157,7 +160,10 @@ def cli_table(
     max_label_width=10,
     val_align="right",
 ) -> str:
-    """Make a crude ascii table, assuming that `fields` is an iterable of (label, value) pairs."""
+    """Make a crude ascii table, assuming that `fields` is an iterable of # noqa: D415
+
+    (label, value) pairs.
+    """
     # First format all the values into strings
     formatted_fields = []
     for label, value in fields:

--- a/src/sqlfluff/core/__init__.py
+++ b/src/sqlfluff/core/__init__.py
@@ -50,5 +50,6 @@ __all__ = (
 # simply need to install it before creating the worker pool. See these links for
 # additional context:
 # * https://pypi.org/project/tblib/
-# * https://stackoverflow.com/questions/6126007/python-getting-a-traceback-from-a-multiprocessing-process
+# * https://stackoverflow.com/questions/6126007
+# /python-getting-a-traceback-from-a-multiprocessing-process
 tblib.pickling_support.install()

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -74,9 +74,8 @@ def nested_combine(*dicts: dict) -> dict:
                     r[k] = nested_combine(r[k], d[k])
                 else:  # pragma: no cover
                     raise ValueError(
-                        "Key {!r} is a dict in one config but not another! PANIC: {!r}".format(
-                            k, d[k]
-                        )
+                        "Key {!r} is a dict in one config but not another! PANIC: "
+                        "{!r}".format(k, d[k])
                     )
             else:
                 r[k] = d[k]
@@ -222,7 +221,8 @@ class ConfigLoader:
                     # Try to resolve the path.
                     # Make the referenced path.
                     ref_path = os.path.join(os.path.dirname(fpath), val)
-                    # Check if it exists, and if it does, replace the value with the path.
+                    # Check if it exists, and if it does, replace the value with the
+                    # path.
                     if os.path.exists(ref_path):
                         v = ref_path
                 # Add the name to the end of the key
@@ -609,17 +609,20 @@ class FluffConfig:
         except KeyError:
             if templater_name == "dbt":  # pragma: no cover
                 config_logger.warning(
-                    "Starting in sqlfluff version 0.7.0 the dbt templater is distributed as a "
-                    "seperate python package. Please pip install sqlfluff-templater-dbt to use it."
+                    "Starting in sqlfluff version 0.7.0 the dbt templater is "
+                    "distributed as a seperate python package. Please pip install "
+                    "sqlfluff-templater-dbt to use it."
                 )
             raise SQLFluffUserError(
-                "Requested templater {!r} which is not currently available. Try one of {}".format(
-                    templater_name, ", ".join(templater_lookup.keys())
-                )
+                "Requested templater {!r} which is not currently available. Try one of "
+                "{}".format(templater_name, ", ".join(templater_lookup.keys()))
             )
 
     def make_child_from_path(self, path: str) -> "FluffConfig":
-        """Make a new child config at a path but pass on overrides and extra_config_path."""
+        """Make a new child config at a path but pass on overrides # noqa: D415
+
+        and extra_config_path.
+        """
         return self.from_path(
             path,
             extra_config_path=self._extra_config_path,

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -293,7 +293,8 @@ class LintedFile(NamedTuple):
                 )
             except ValueError:
                 linter_logger.info(
-                    "      - Skipping. Source space Value Error. i.e. attempted insertion within templated section."
+                    "      - Skipping. Source space Value Error. i.e. attempted "
+                    "insertion within templated section."
                 )
                 # If we try and slice within a templated section, then we may fail
                 # in which case, we should skip this patch.
@@ -359,14 +360,15 @@ class LintedFile(NamedTuple):
                     "      - Skipping patch over more than two raw slices: %s",
                     enriched_patch,
                 )
-            # If it's an insertion (i.e. the string in the pre-fix template is '') then we
-            # won't be able to place it, so skip.
+            # If it's an insertion (i.e. the string in the pre-fix template is '') then
+            # we won't be able to place it, so skip.
             elif not enriched_patch.templated_str:  # pragma: no cover TODO?
                 linter_logger.info(
                     "      - Skipping insertion patch in templated section: %s",
                     enriched_patch,
                 )
-            # If the string from the templated version isn't in the source, then we can't fix it.
+            # If the string from the templated version isn't in the source, then we
+            # can't fix it.
             elif (
                 enriched_patch.templated_str not in enriched_patch.source_str
             ):  # pragma: no cover TODO?
@@ -381,7 +383,8 @@ class LintedFile(NamedTuple):
                 )
                 if len(positions) != 1:
                     linter_logger.debug(
-                        "        - Skipping edit patch on non-unique templated content: %s",
+                        "        - Skipping edit patch on non-unique templated "
+                        "content: %s",
                         enriched_patch,
                     )
                     continue
@@ -402,7 +405,8 @@ class LintedFile(NamedTuple):
                     source_str=enriched_patch.source_str,
                 )
                 linter_logger.debug(  # pragma: no cover
-                    "      * Keeping Tricky Case. Positions: %s, New Slice: %s, Patch: %s",
+                    "      * Keeping Tricky Case. Positions: %s, New Slice: %s, "
+                    "Patch: %s",
                     positions,
                     new_source_slice,
                     enriched_patch,

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -166,7 +166,8 @@ class Linter:
             )
             if indent_balance != 0:
                 linter_logger.debug(
-                    "Indent balance test failed for %r. Template indents will not be linted for this file.",
+                    "Indent balance test failed for %r. Template indents will not be "
+                    "linted for this file.",
                     templated_file.fname,
                 )
                 # Don't enable the templating blocks.
@@ -211,13 +212,15 @@ class Linter:
         if parsed:
             linter_logger.info("\n###\n#\n# {}\n#\n###".format("Parsed Tree:"))
             linter_logger.info("\n" + parsed.stringify())
-            # We may succeed parsing, but still have unparsable segments. Extract them here.
+            # We may succeed parsing, but still have unparsable segments. Extract them
+            # here.
             for unparsable in parsed.iter_unparsables():
                 # No exception has been raised explicitly, but we still create one here
                 # so that we can use the common interface
                 violations.append(
                     SQLParseError(
-                        "Line {0[0]}, Position {0[1]}: Found unparsable section: {1!r}".format(
+                        "Line {0[0]}, Position {0[1]}: Found unparsable section: "
+                        "{1!r}".format(
                             unparsable.pos_marker.working_loc,
                             unparsable.raw
                             if len(unparsable.raw) < 40
@@ -277,7 +280,8 @@ class Linter:
                             )
                     rules: Optional[Tuple[str, ...]]
                     if rule_part != "all":
-                        # Rules can be globs therefore we compare to the rule_set to expand the globs.
+                        # Rules can be globs therefore we compare to the rule_set to
+                        # expand the globs.
                         unexpanded_rules = tuple(
                             r.strip() for r in rule_part.split(",")
                         )
@@ -307,7 +311,10 @@ class Linter:
     def remove_templated_errors(
         linting_errors: List[SQLBaseError],
     ) -> List[SQLBaseError]:
-        """Filter a list of lint errors, removing those which only occur in templated slices."""
+        """Filter a list of lint errors, removing those which only # noqa: D415
+
+        occur in templated slices.
+        """
         # Filter out any linting errors in templated sections if relevant.
         result: List[SQLBaseError] = []
         for e in linting_errors:
@@ -434,7 +441,8 @@ class Linter:
         # Keep a set of previous versions to catch infinite loops.
         previous_versions = {tree.raw}
 
-        # If we are fixing then we want to loop up to the runaway_limit, otherwise just once for linting.
+        # If we are fixing then we want to loop up to the runaway_limit, otherwise just
+        # once for linting.
         loop_limit = config.get("runaway_limit") if fix else 1
 
         # Dispatch the output for the lint header
@@ -504,7 +512,8 @@ class Linter:
                 # We did not change the file. Either the file is clean (no fixes), or
                 # any fixes which are present will take us back to a previous state.
                 linter_logger.info(
-                    f"Fix loop complete. Stability achieved after {loop}/{loop_limit} loops."
+                    f"Fix loop complete. Stability achieved after {loop}/{loop_limit} "
+                    "loops."
                 )
                 break
         if fix and loop + 1 == loop_limit:
@@ -619,10 +628,12 @@ class Linter:
         if not config.get("templater_obj") == self.templater:
             linter_logger.warning(
                 (
-                    f"Attempt to set templater to {config.get('templater_obj').name} failed. Using {self.templater.name} "
-                    "templater. Templater cannot be set in a .sqlfluff file in a subdirectory of the current working "
-                    "directory. It can be set in a .sqlfluff in the current working directory. See Nesting section of the "
-                    "docs for more details."
+                    f"Attempt to set templater to {config.get('templater_obj').name} "
+                    f"failed. Using {self.templater.name} templater. Templater cannot "
+                    "be set in a .sqlfluff file in a subdirectory of the current "
+                    "working directory. It can be set in a .sqlfluff in the current "
+                    "working directory. See Nesting section of the docs for more "
+                    "details."
                 )
             )
         try:
@@ -968,8 +979,8 @@ class Linter:
         for path in paths:
             progress_bar_paths.set_description(f"path {path}")
 
-            # Iterate through files recursively in the specified directory (if it's a directory)
-            # or read the file directly if it's not
+            # Iterate through files recursively in the specified directory (if it's a
+            # directory) or read the file directly if it's not
             result.add(
                 self.lint_path(
                     path,

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -144,9 +144,9 @@ class LintingResult:
     def as_records(self) -> List[dict]:
         """Return the result as a list of dictionaries.
 
-        Each record contains a key specifying the filepath, and a list of violations. This
-        method is useful for serialization as all objects will be builtin python types
-        (ints, strs).
+        Each record contains a key specifying the filepath, and a list of violations.
+        This method is useful for serialization as all objects will be builtin python
+        types (ints, strs).
         """
         return [
             {
@@ -177,6 +177,7 @@ class LintingResult:
         """A convenience method for when there is only one file and we want the tree."""
         if len(self.paths) > 1:
             raise ValueError(
-                ".tree() cannot be called when a LintingResult contains more than one path."
+                ".tree() cannot be called when a LintingResult contains more than one "
+                "path."
             )
         return self.paths[0].tree

--- a/src/sqlfluff/core/parser/context.py
+++ b/src/sqlfluff/core/parser/context.py
@@ -51,9 +51,8 @@ class RootParseContext:
             indentation_config = {k: bool(v) for k, v in indentation_config.items()}
         except TypeError:  # pragma: no cover
             raise TypeError(
-                "One of the configuration keys in the `indentation` section is not True or False: {!r}".format(
-                    indentation_config
-                )
+                "One of the configuration keys in the `indentation` section is not "
+                "True or False: {!r}".format(indentation_config)
             )
         ctx = cls(
             dialect=config.get("dialect_obj"),

--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -50,7 +50,10 @@ class AnyNumberOf(BaseGrammar):
 
     @staticmethod
     def _first_non_whitespace(segments) -> Optional[str]:
-        """Return the raw upper representation of the first valid non-whitespace segment in the iterable."""
+        """Return the raw upper representation of the first valid # noqa: D415
+
+        non-whitespace segment in the iterable.
+        """
         for segment in segments:
             if segment.raw_segments_upper:
                 return segment.raw_segments_upper

--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -101,9 +101,8 @@ class BaseGrammar(Matchable):
             ):
                 return init_func(elem)
         raise TypeError(
-            "Grammar element [{!r}] was found of unexpected type [{}] was found.".format(
-                elem, type(elem)
-            )  # pragma: no cover
+            "Grammar element [{!r}] was found of unexpected type [{}] was "
+            "found.".format(elem, type(elem))  # pragma: no cover
         )
 
     def __init__(
@@ -135,8 +134,8 @@ class BaseGrammar(Matchable):
                 chunk of code that might be parsed separately.
         """
         # We provide a common interface for any grammar that allows positional elements.
-        # If *any* for the elements are a string and not a grammar, then this is a shortcut
-        # to the Ref.keyword grammar by default.
+        # If *any* for the elements are a string and not a grammar, then this is a
+        # shortcut to the Ref.keyword grammar by default.
         if self.allow_keyword_string_refs:
             self._elements = []
             for elem in args:
@@ -230,7 +229,8 @@ class BaseGrammar(Matchable):
                     best_match_length = res_match.matched_length
             # We could stash segments here, but given we might have some successful
             # matches here, we shouldn't, because they'll be mutated in the wrong way.
-            # Eventually there might be a performance gain from doing that sensibly here.
+            # Eventually there might be a performance gain from doing that sensibly
+            # here.
 
         # If we get here, then there wasn't a complete match. If we
         # has a best_match, return that.
@@ -345,8 +345,8 @@ class BaseGrammar(Matchable):
                 # Here we do the actual transform to the new segment.
                 match = queued_matcher.match(segments[queued_buff_pos:], parse_context)
                 if not match:
-                    # We've had something match in simple matching, but then later excluded.
-                    # Log but then move on to the next item on the list.
+                    # We've had something match in simple matching, but then later
+                    # excluded. Log but then move on to the next item on the list.
                     parse_match_logging(
                         cls.__name__,
                         "_look_ahead_match",
@@ -513,17 +513,20 @@ class BaseGrammar(Matchable):
 
                     if match:
                         # NB: We can only consider this as a nested bracket if the start
-                        # and end tokens are not the same. If a matcher is both a start and
-                        # end token we cannot deepen the bracket stack. In general, quoted
-                        # strings are a typical example where the start and end tokens are
-                        # the same. Currently, though, quoted strings are handled elsewhere
-                        # in the parser, and there are no cases where *this* code has to
-                        # handle identical start and end brackets. For now, consider this
-                        # a small, speculative investment in a possible future requirement.
+                        # and end tokens are not the same. If a matcher is both a start
+                        # and end token we cannot deepen the bracket stack. In general,
+                        # quoted strings are a typical example where the start and end
+                        # tokens are the same. Currently, though, quoted strings are
+                        # handled elsewhere in the parser, and there are no cases where
+                        # *this* code has to handle identical start and end brackets.
+                        # For now, consider this a small, speculative investment in a
+                        # possible future requirement.
                         if matcher in start_brackets and matcher not in end_brackets:
-                            # Add any segments leading up to this to the previous bracket.
+                            # Add any segments leading up to this to the previous
+                            # bracket.
                             bracket_stack[-1].segments += pre
-                            # Add a bracket to the stack and add the matches from the segment.
+                            # Add a bracket to the stack and add the matches from the
+                            # segment.
                             bracket_stack.append(
                                 BracketInfo(
                                     bracket=match.matched_segments[0],
@@ -567,8 +570,8 @@ class BaseGrammar(Matchable):
                                     new_segments = bracket_stack[-1].segments
                                 # Remove the bracket set from the stack
                                 bracket_stack.pop()
-                                # If we're still in a bracket, add the new segments to that bracket
-                                # Otherwise add them to the buffer
+                                # If we're still in a bracket, add the new segments to
+                                # that bracket, otherwise add them to the buffer
                                 if bracket_stack:
                                     bracket_stack[-1].segments += new_segments
                                 else:
@@ -643,7 +646,8 @@ class BaseGrammar(Matchable):
                         else:  # pragma: no cover
                             # This shouldn't happen!?
                             raise NotImplementedError(
-                                "This shouldn't happen. Panic in _bracket_sensitive_look_ahead_match."
+                                "This shouldn't happen. Panic in "
+                                "_bracket_sensitive_look_ahead_match."
                             )
                     # Not in a bracket stack, but no match.
                     # From here we'll drop out to the happy unmatched exit.
@@ -653,16 +657,17 @@ class BaseGrammar(Matchable):
                 if bracket_stack:  # pragma: no cover
                     # No we haven't.
                     raise SQLParseError(
-                        f"Couldn't find closing bracket for opened brackets: `{bracket_stack}`.",
+                        "Couldn't find closing bracket for opened brackets: "
+                        f"`{bracket_stack}`.",
                         segment=bracket_stack[-1].bracket,
                     )
 
             # This is the happy unmatched path. This occurs when:
             # - We reached the end with no open brackets.
             # - No match while outside a bracket stack.
-            # - We found an unexpected end bracket before matching something interesting.
-            # We return with the mutated segments so we can
-            # reuse any bracket matching.
+            # - We found an unexpected end bracket before matching something
+            # interesting. We return with the mutated segments so we can reuse any
+            # bracket matching.
             return ((), MatchResult.from_unmatched(pre_seg_buff + seg_buff), None)
 
     def __str__(self):  # pragma: no cover TODO?
@@ -788,9 +793,8 @@ class Ref(BaseGrammar):
             return self._elements[0]
         else:  # pragma: no cover
             raise ValueError(
-                "Ref grammar can only deal with precisely one element for now. Instead found {!r}".format(
-                    self._elements
-                )
+                "Ref grammar can only deal with precisely one element for now. Instead "
+                "found {!r}".format(self._elements)
             )
 
     def _get_elem(self, dialect):

--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -92,10 +92,10 @@ class Delimited(OneOf):
         while True:
             progressbar_matching.update(n=1)
 
-            # Check to see whether we've exhausted the buffer, either by iterating through it,
-            # or by consuming all the non-code segments already.
-            # NB: If we're here then we've already tried matching the remaining segments against
-            # the content, so we must be in a trailing case.
+            # Check to see whether we've exhausted the buffer, either by iterating
+            # through it, or by consuming all the non-code segments already.
+            # NB: If we're here then we've already tried matching the remaining segments
+            # against the content, so we must be in a trailing case.
             if len(seg_buff) == 0:
                 # Append the remaining buffer in case we're in the not is_code case.
                 matched_segments += seg_buff
@@ -114,7 +114,8 @@ class Delimited(OneOf):
             matchers = [self.delimiter]
             if self.terminator:
                 matchers.append(self.terminator)
-            # If gaps aren't allowed, a gap (or non-code segment), acts like a terminator.
+            # If gaps aren't allowed, a gap (or non-code segment), acts like a
+            # terminator.
             if not self.allow_gaps:
                 matchers.append(NonCodeMatcher())
 
@@ -168,9 +169,10 @@ class Delimited(OneOf):
                     # No match - Not allowed
                     if not match:
                         if self.allow_trailing:
-                            # If we reach this point, the lookahead match has hit a delimiter
-                            # beyond the scope of this Delimited section. Trailing delimiters are allowed,
-                            # so return matched up to this section.
+                            # If we reach this point, the lookahead match has hit a
+                            # delimiter beyond the scope of this Delimited section.
+                            # Trailing delimiters are allowed, so return matched up to
+                            # this section.
                             return MatchResult(
                                 matched_segments.matched_segments,
                                 pre_non_code
@@ -182,9 +184,9 @@ class Delimited(OneOf):
                             return MatchResult.from_unmatched(mutated_segments)
 
                     if not match.is_complete():
-                        # If we reach this point, the lookahead match has hit a delimiter
-                        # beyond the scope of this Delimited section. We should return a
-                        # partial match, and the delimiter as unmatched.
+                        # If we reach this point, the lookahead match has hit a
+                        # delimiter beyond the scope of this Delimited section. We
+                        # should return a partial match, and the delimiter as unmatched.
                         return MatchResult(
                             matched_segments.matched_segments
                             + pre_non_code
@@ -205,7 +207,8 @@ class Delimited(OneOf):
                     if delimiter_matcher is self.delimiter:
                         # Then add the delimiter to the matched segments
                         matched_segments += delimiter_match.matched_segments
-                        # Break this for loop and move on, looking for the next delimiter
+                        # Break this for loop and move on, looking for the next
+                        # delimiter
                         seg_buff = delimiter_match.unmatched_segments
                         # Still got some buffer left. Carry on.
                         continue
@@ -213,8 +216,8 @@ class Delimited(OneOf):
                     elif delimiter_matcher is self.terminator or isinstance(
                         delimiter_matcher, NonCodeMatcher
                     ):
-                        # We just return straight away here. We don't add the terminator to
-                        # this match, it should go with the unmatched parts.
+                        # We just return straight away here. We don't add the terminator
+                        # to this match, it should go with the unmatched parts.
 
                         # First check we've had enough delimiters
                         if (
@@ -230,8 +233,8 @@ class Delimited(OneOf):
                     else:  # pragma: no cover
                         raise RuntimeError(
                             (
-                                "I don't know how I got here. Matched instead on {}, which "
-                                "doesn't appear to be delimiter or terminator"
+                                "I don't know how I got here. Matched instead on {}, "
+                                "which doesn't appear to be delimiter or terminator"
                             ).format(delimiter_matcher)
                         )
                 else:
@@ -276,7 +279,8 @@ class Delimited(OneOf):
                 if mat:
                     # We've got something at the end. Return!
                     if mat.unmatched_segments:
-                        # We have something unmatched and so we should let it also have the trailing elements
+                        # We have something unmatched and so we should let it also have
+                        # the trailing elements
                         return MatchResult(
                             matched_segments.matched_segments
                             + pre_non_code
@@ -284,8 +288,8 @@ class Delimited(OneOf):
                             mat.unmatched_segments + post_non_code,
                         )
                     else:
-                        # If there's nothing unmatched in the most recent match, then we can consume the trailing
-                        # non code segments
+                        # If there's nothing unmatched in the most recent match, then we
+                        # can consume the trailing non code segments
                         return MatchResult.from_matched(
                             matched_segments.matched_segments
                             + pre_non_code
@@ -293,8 +297,8 @@ class Delimited(OneOf):
                             + post_non_code,
                         )
                 else:
-                    # No match at the end, are we allowed to trail? If we are then return,
-                    # otherwise we fail because we can't match the last element.
+                    # No match at the end, are we allowed to trail? If we are then
+                    # return, otherwise we fail because we can't match the last element.
                     if self.allow_trailing:
                         return MatchResult(matched_segments.matched_segments, seg_buff)
                     else:

--- a/src/sqlfluff/core/parser/grammar/greedy.py
+++ b/src/sqlfluff/core/parser/grammar/greedy.py
@@ -43,7 +43,9 @@ class GreedyUntil(BaseGrammar):
             segments,
             parse_context,
             matchers=self._elements,
-            enforce_whitespace_preceding_terminator=self.enforce_whitespace_preceding_terminator,
+            enforce_whitespace_preceding_terminator=(
+                self.enforce_whitespace_preceding_terminator
+            ),
             include_terminator=False,
         )
 
@@ -204,7 +206,9 @@ class StartsWith(GreedyUntil):
             match.unmatched_segments,
             parse_context,
             matchers=[self.terminator],
-            enforce_whitespace_preceding_terminator=self.enforce_whitespace_preceding_terminator,
+            enforce_whitespace_preceding_terminator=(
+                self.enforce_whitespace_preceding_terminator
+            ),
             include_terminator=self.include_terminator,
         )
 

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -103,8 +103,8 @@ class Sequence(BaseGrammar):
                         for e in self._elements[idx:]
                     ):
                         # then it's ok, and we can return what we've got so far.
-                        # No need to deal with anything left over because we're at the end,
-                        # unless it's a meta segment.
+                        # No need to deal with anything left over because we're at the
+                        # end, unless it's a meta segment.
 
                         # We'll add those meta segments after any existing ones. So
                         # the go on the meta_post_nc stack.
@@ -128,7 +128,8 @@ class Sequence(BaseGrammar):
                         # required elements.
                         return MatchResult.from_unmatched(segments)
                 else:
-                    # We've already dealt with potential whitespace above, so carry on to matching
+                    # We've already dealt with potential whitespace above, so carry on
+                    # to matching
                     with parse_context.deeper_match() as ctx:
                         elem_match = elem.match(mid_seg, parse_context=ctx)
 
@@ -144,8 +145,8 @@ class Sequence(BaseGrammar):
                         meta_pre_nc = ()
                         meta_post_nc = ()
                         unmatched_segments = elem_match.unmatched_segments + post_nc
-                        # Each time we do this, we do a sense check to make sure we haven't
-                        # dropped anything. (Because it's happened before!).
+                        # Each time we do this, we do a sense check to make sure we
+                        # haven't dropped anything. (Because it's happened before!).
                         if self.test_env:
                             check_still_complete(
                                 segments,
@@ -156,8 +157,8 @@ class Sequence(BaseGrammar):
                         break
                     else:
                         # If we can't match an element, we should ascertain whether it's
-                        # required. If so then fine, move on, but otherwise we should crash
-                        # out without a match. We have not matched the sequence.
+                        # required. If so then fine, move on, but otherwise we should
+                        # crash out without a match. We have not matched the sequence.
                         if elem.is_optional():
                             # This will crash us out of the while loop and move us
                             # onto the next matching element
@@ -180,9 +181,12 @@ class Sequence(BaseGrammar):
 
 
 class Bracketed(Sequence):
-    """Match if this is a bracketed sequence, with content that matches one of the elements.
+    """Match if this is a bracketed sequence, with content that # noqa: D415
 
-    Note that the contents of the Bracketed Expression are treated as an expected sequence.
+    matches one of the elements.
+
+    Note that the contents of the Bracketed Expression are treated as an expected
+    sequence.
 
     Changelog:
     - Post 0.3.2: Bracketed inherits from Sequence and anything within
@@ -192,8 +196,7 @@ class Bracketed(Sequence):
     - Post 0.1.0: Bracketed was separate from sequence, and the content
       of the expression were treated as options (like OneOf).
     - Pre 0.1.0: Bracketed inherited from Sequence and simply added
-      brackets to that sequence,
-
+      brackets to that sequence.
     """
 
     def __init__(self, *args, **kwargs):
@@ -237,16 +240,19 @@ class Bracketed(Sequence):
     def match(
         self, segments: Tuple["BaseSegment", ...], parse_context: ParseContext
     ) -> MatchResult:
-        """Match if this is a bracketed sequence, with content that matches one of the elements.
+        """Match if this is a bracketed sequence, with content that # noqa: D415
+
+        matches one of the elements.
 
         1. work forwards to find the first bracket.
            If we find something other that whitespace, then fail out.
-        2. Once we have the first bracket, we need to bracket count forward to find its partner.
+        2. Once we have the first bracket, we need to bracket count forward to find its
+           partner.
         3. Assuming we find its partner then we try and match what goes between them
            using the match method of Sequence.
            If we match, great. If not, then we return an empty match.
-           If we never find its partner then we return an empty match but should probably
-           log a parsing warning, or error?
+           If we never find its partner then we return an empty match but should
+           probably log a parsing warning, or error?
 
         """
         # Trim ends if allowed.
@@ -330,7 +336,8 @@ class Bracketed(Sequence):
             else:
                 return MatchResult.from_unmatched(segments)
 
-        # Match the content using super. Sequence will interpret the content of the elements.
+        # Match the content using super. Sequence will interpret the content of the
+        # elements.
         with parse_context.deeper_match() as ctx:
             content_match = super().match(content_segs, parse_context=ctx)
 

--- a/src/sqlfluff/core/parser/lexer.py
+++ b/src/sqlfluff/core/parser/lexer.py
@@ -234,7 +234,8 @@ class RegexLexer(StringLexer):
                 return LexedElement(match_str, self)
             else:
                 lexer_logger.warning(
-                    f"Zero length Lex item returned from {self.name!r}. Report this as a bug."
+                    f"Zero length Lex item returned from {self.name!r}. Report this as "
+                    "a bug."
                 )
         return None
 
@@ -247,7 +248,8 @@ class RegexLexer(StringLexer):
                 return match.span()
             else:  # pragma: no cover
                 lexer_logger.warning(
-                    f"Zero length Lex item returned from {self.name!r}. Report this as a bug."
+                    f"Zero length Lex item returned from {self.name!r}. Report this as "
+                    "a bug."
                 )
         return None
 
@@ -437,7 +439,8 @@ class Lexer:
                                 # Generate a string documenting the gap.
                                 if chars_skipped >= 10:
                                     gap_placeholder_parts.append(
-                                        f"... [{chars_skipped} unused template characters] ..."
+                                        f"... [{chars_skipped} unused template "
+                                        "characters] ..."
                                     )
                                 else:
                                     gap_placeholder_parts.append("...")
@@ -464,7 +467,8 @@ class Lexer:
                 trail_indent = so_slices[-1].slice_type in ("block_start", "block_mid")
                 add_indents = self.config.get("template_blocks_indent", "indentation")
                 lexer_logger.debug(
-                    "    Block Slices: %s. Block Balance: %s. Lead: %s, Trail: %s, Add: %s",
+                    "    Block Slices: %s. Block Balance: %s. Lead: %s, Trail: %s, "
+                    "Add: %s",
                     block_slices,
                     block_balance,
                     lead_dedent,
@@ -593,6 +597,7 @@ class Lexer:
             ):  # pragma: no cover
                 raise ValueError(
                     "Template and lexed elements do not match. This should never "
-                    f"happen {element.raw!r} != {template.templated_str[template_slice]!r}"
+                    f"happen {element.raw!r} != "
+                    f"{template.templated_str[template_slice]!r}"
                 )
         return templated_buff

--- a/src/sqlfluff/core/parser/match_logging.py
+++ b/src/sqlfluff/core/parser/match_logging.py
@@ -73,7 +73,8 @@ class ParseMatchLogObject(LateLoggingObject):
 
 def parse_match_logging(grammar, func, msg, parse_context, v_level=3, **kwargs):
     """Log in a particular consistent format for use while matching."""
-    # Make a late bound log object so we only do the string manipulation when we need to.
+    # Make a late bound log object so we only do the string manipulation when we need
+    # to.
     ParseMatchLogObject(
         parse_context, grammar, func, msg, v_level=v_level, **kwargs
     ).log()

--- a/src/sqlfluff/core/parser/match_wrapper.py
+++ b/src/sqlfluff/core/parser/match_wrapper.py
@@ -66,7 +66,8 @@ def match_wrapper(v_level=3):
                 v_level=v_level,
             ).log()
 
-            # Basic Validation, skipped here because it still happens in the parse commands.
+            # Basic Validation, skipped here because it still happens in the parse
+            # commands.
             return m
 
         return wrapped_match_method

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -56,13 +56,13 @@ class BaseSegment:
     subclasses rather than directly here.
 
     For clarity, the `BaseSegment` is mostly centered around a segment which contains
-    other subsegments. For segments which don't have *children*, refer to the `RawSegment`
-    class (which still inherits from this one).
+    other subsegments. For segments which don't have *children*, refer to the
+    `RawSegment` class (which still inherits from this one).
 
     Segments are used both as instances to hold chunks of text, but also as classes
-    themselves where they function a lot like grammars, and return instances of themselves
-    when they match. The many classmethods in this class are usually to serve their
-    purpose as a matcher.
+    themselves where they function a lot like grammars, and return instances of
+    themselves when they match. The many classmethods in this class are usually to serve
+    their purpose as a matcher.
     """
 
     # `type` should be the *category* of this kind of segment
@@ -95,9 +95,8 @@ class BaseSegment:
 
         if len(segments) == 0:  # pragma: no cover
             raise RuntimeError(
-                "Setting {} with a zero length segment set. This shouldn't happen.".format(
-                    self.__class__
-                )
+                "Setting {} with a zero length segment set. This shouldn't "
+                "happen.".format(self.__class__)
             )
 
         if hasattr(segments, "matched_segments"):  # pragma: no cover TODO?
@@ -306,15 +305,15 @@ class BaseSegment:
                     continue
             except Exception as err:  # pragma: no cover
                 parse_context.logger.error(
-                    "%s has no attribute `is_expandable`. This segment appears poorly constructed.",
+                    "%s has no attribute `is_expandable`. This segment appears poorly "
+                    "constructed.",
                     stmt,
                 )
                 raise err
             if not hasattr(stmt, "parse"):  # pragma: no cover
                 raise ValueError(
-                    "{} has no method `parse`. This segment appears poorly constructed.".format(
-                        stmt
-                    )
+                    "{} has no method `parse`. This segment appears poorly "
+                    "constructed.".format(stmt)
                 )
             parse_depth_msg = "Parse Depth {}. Expanding: {}: {!r}".format(
                 parse_context.parse_depth,
@@ -515,7 +514,8 @@ class BaseSegment:
             with parse_context.deeper_match() as ctx:
                 m = cls.match_grammar.match(segments=segments, parse_context=ctx)
 
-            # Calling unify here, allows the MatchResult class to do all the type checking.
+            # Calling unify here, allows the MatchResult class to do all the type
+            # checking.
             if not isinstance(m, MatchResult):  # pragma: no cover
                 raise TypeError(
                     "[PD:{} MD:{}] {}.match. Result is {}, not a MatchResult!".format(
@@ -643,7 +643,8 @@ class BaseSegment:
                     )
         else:
             for seg in self.segments:
-                # If we're in code_only, only show the code segments, otherwise always true
+                # If we're in code_only, only show the code segments, otherwise always
+                # true
                 if not code_only or seg.is_code:
                     buff.write(
                         seg.stringify(
@@ -827,8 +828,8 @@ class BaseSegment:
 
         A large chunk of the logic around this can be found in the `expand` method.
 
-        Use the parse setting in the context for testing, mostly to check how deep to go.
-        True/False for yes or no, an integer allows a certain number of levels.
+        Use the parse setting in the context for testing, mostly to check how deep to
+        go. True/False for yes or no, an integer allows a certain number of levels.
 
         Optionally, this method allows a custom parse grammar to be
         provided which will override any existing parse grammar
@@ -838,7 +839,8 @@ class BaseSegment:
         if parse_context:
             parse_context.denylist.clear()
 
-        # the parse_depth and recurse kwargs control how deep we will recurse for testing.
+        # the parse_depth and recurse kwargs control how deep we will recurse for
+        # testing.
         if not self.segments:  # pragma: no cover TODO?
             # This means we're a root segment, just return an unmutated self
             return self
@@ -899,8 +901,8 @@ class BaseSegment:
                     self.segments = pre_nc + m.matched_segments + post_nc
                 else:
                     # Incomplete match.
-                    # For now this means the parsing has failed. Lets add the unmatched bit at the
-                    # end as something unparsable.
+                    # For now this means the parsing has failed. Lets add the unmatched
+                    # bit at the end as something unparsable.
                     # TODO: Do something more intelligent here.
                     self.segments = (
                         pre_nc
@@ -913,11 +915,13 @@ class BaseSegment:
                         )
                     )
             elif self.allow_empty and not segments:
-                # Very edge case, but some segments are allowed to be empty other than non-code
+                # Very edge case, but some segments are allowed to be empty other than
+                # non-code
                 self.segments = pre_nc + post_nc
             else:
                 # If there's no match at this stage, then it's unparsable. That's
-                # a problem at this stage so wrap it in an unparsable segment and carry on.
+                # a problem at this stage so wrap it in an unparsable segment and carry
+                # on.
                 self.segments = (
                     pre_nc
                     + (
@@ -934,8 +938,11 @@ class BaseSegment:
                 self.__class__.__name__, parse_context.recurse
             )
         )
-        parse_depth_msg = "###\n#\n# Beginning Parse Depth {}: {}\n#\n###\nInitial Structure:\n{}".format(
-            parse_context.parse_depth + 1, self.__class__.__name__, self.stringify()
+        parse_depth_msg = (
+            "###\n#\n# Beginning Parse Depth {}: {}\n#\n###\nInitial Structure:\n"
+            "{}".format(
+                parse_context.parse_depth + 1, self.__class__.__name__, self.stringify()
+            )
         )
         if parse_context.may_recurse():
             parse_context.logger.debug(parse_depth_msg)
@@ -991,10 +998,12 @@ class BaseSegment:
                                 "create_after",
                             ):
                                 if f.edit_type == "create_after":
-                                    # in the case of a creation after, also add this segment before the edit.
+                                    # in the case of a creation after, also add this
+                                    # segment before the edit.
                                     seg_buffer.append(seg)
 
-                                # We're doing a replacement (it could be a single segment or an iterable)
+                                # We're doing a replacement (it could be a single
+                                # segment or an iterable)
                                 if isinstance(f.edit, BaseSegment):
                                     seg_buffer.append(f.edit)  # pragma: no cover TODO?
                                 else:
@@ -1002,7 +1011,8 @@ class BaseSegment:
                                         seg_buffer.append(s)
 
                                 if f.edit_type == "create_before":
-                                    # in the case of a creation before, also add this segment on the end
+                                    # in the case of a creation before, also add this
+                                    # segment on the end
                                     seg_buffer.append(seg)
 
                             else:  # pragma: no cover
@@ -1011,11 +1021,13 @@ class BaseSegment:
                                         f.edit_type, f
                                     )
                                 )
-                            # We've applied a fix here. Move on, this also consumes the fix
+                            # We've applied a fix here. Move on, this also consumes the
+                            # fix
                             # TODO: Maybe deal with overlapping fixes later.
                             break
                         else:
-                            # We've not used the fix so we should keep it in the list for later.
+                            # We've not used the fix so we should keep it in the list
+                            # for later.
                             unused_fixes.append(f)
                     else:
                         seg_buffer.append(seg)
@@ -1091,7 +1103,8 @@ class BaseSegment:
             for seg_idx, segment in enumerate(self.segments):
 
                 # First check for insertions.
-                # We know it's an insertion if it has length but not in the templated file.
+                # We know it's an insertion if it has length but not in the templated
+                # file.
                 if segment.raw and segment.pos_marker.is_point():
                     # Add it to the insertion buffer if it has length:
                     if segment.raw:
@@ -1103,13 +1116,15 @@ class BaseSegment:
                         )
                     continue
 
-                # If we get here, then we know it's an original.
-                # Check for deletions at the point before this segment (vs the TEMPLATED).
+                # If we get here, then we know it's an original. Check for deletions at
+                # the point before this segment (vs the TEMPLATED).
                 start_diff = segment.pos_marker.templated_slice.start - templated_idx
 
-                # Check to see whether there's a discontinuity before the current segment
+                # Check to see whether there's a discontinuity before the current
+                # segment
                 if start_diff > 0 or insert_buff:
-                    # If we have an insert buffer, then it's an edit, otherwise a deletion.
+                    # If we have an insert buffer, then it's an edit, otherwise a
+                    # deletion.
                     yield FixPatch(
                         slice(
                             segment.pos_marker.templated_slice.start

--- a/src/sqlfluff/core/parser/segments/ephemeral.py
+++ b/src/sqlfluff/core/parser/segments/ephemeral.py
@@ -69,8 +69,8 @@ def allow_ephemeral(func):
             # Reset the ephemeral name on the new version of the grammar otherwise
             # we get infinite recursion.
             new_grammar.ephemeral_name = None
-            # We shouldn't allow nested ephemerals. If they're present, don't create another.
-            # This can happen when grammars call super() on their match method.
+            # We shouldn't allow nested ephemerals. If they're present, don't create
+            # another. This can happen when grammars call super() on their match method.
             if len(segments) == 1 and segments[0].is_type("ephemeral"):
                 return MatchResult.from_matched(segments)
             else:

--- a/src/sqlfluff/core/rules/analysis/select.py
+++ b/src/sqlfluff/core/rules/analysis/select.py
@@ -127,7 +127,8 @@ def _has_value_table_function(table_expr, dialect):
         return False
 
     for function_name in table_expr.recursive_crawl("function_name"):
-        # Other rules can increase whitespace in the function name, so use strip to remove
+        # Other rules can increase whitespace in the function name, so use strip to
+        # remove
         # See: https://github.com/sqlfluff/sqlfluff/issues/1304
         if function_name.raw.lower().strip() in dialect.sets("value_table_functions"):
             return True

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -155,13 +155,14 @@ class LintFix:
             self.edit = copy.deepcopy(edit)
             # Check that any edits don't have a position marker set.
             # We should rely on realignment to make position markers.
-            # Strip position markers of anything enriched, otherwise things can get blurry
+            # Strip position markers of anything enriched, otherwise things can get
+            # blurry
             for seg in self.edit:
                 if seg.pos_marker:
                     # Developer warning.
                     rules_logger.debug(
-                        "Developer Note: Edit segment found with preset position marker. "
-                        "These should be unset and calculated later."
+                        "Developer Note: Edit segment found with preset position "
+                        "marker. These should be unset and calculated later."
                     )
                     seg.pos_marker = None  # type: ignore
             # Once stripped, we shouldn't replace any markers because
@@ -414,8 +415,8 @@ class BaseRule:
     def __init__(self, code, description, **kwargs):
         self.description = description
         self.code = code
-        # kwargs represents the config passed to the rule. Add all kwargs as class attributes
-        # so they can be accessed in rules which inherit from this class
+        # kwargs represents the config passed to the rule. Add all kwargs as class
+        # attributes so they can be accessed in rules which inherit from this class
         for key, value in kwargs.items():
             self.__dict__[key] = value
 
@@ -529,11 +530,12 @@ class BaseRule:
                     segment=segment,
                     fixes=[],
                     description=(
-                        f"""Unexpected exception: {str(e)};
-                        Could you open an issue at https://github.com/sqlfluff/sqlfluff/issues ?
-                        You can ignore this exception for now, by adding '--noqa: {self.code}' at the end
-                        of line {exception_line}
-                        """
+                        f"Unexpected exception: {str(e)};\n"
+                        "Could you open an issue at "
+                        "https://github.com/sqlfluff/sqlfluff/issues ?\n"
+                        "You can ignore this exception for now, by adding '--noqa: "
+                        f"{self.code}' at the end\n"
+                        f"of line {exception_line}\n"
                     ),
                 )
             )
@@ -635,9 +637,10 @@ class BaseRule:
             # We can't fail on a meta segment
             return False
         else:
-            # We know we are at a leaf of the tree but not necessarily at the end of the tree.
-            # Therefore we look backwards up the parent stack and ask if any of the parent segments
-            # have another non-meta child segment after the current one.
+            # We know we are at a leaf of the tree but not necessarily at the end of the
+            # tree. Therefore we look backwards up the parent stack and ask if any of
+            # the parent segments have another non-meta child segment after the current
+            # one.
             child_segment = context.segment
             for parent_segment in context.parent_stack[::-1]:
                 possible_children = [

--- a/src/sqlfluff/core/rules/doc_decorators.py
+++ b/src/sqlfluff/core/rules/doc_decorators.py
@@ -43,9 +43,8 @@ def document_configuration(cls, ruleset="std"):
                 info_dict = config_info[keyword]
             except KeyError:  # pragma: no cover
                 raise KeyError(
-                    "Config value {!r} for rule {} is not configured in `config_info`.".format(
-                        keyword, cls.__name__
-                    )
+                    "Config value {!r} for rule {} is not configured in "
+                    "`config_info`.".format(keyword, cls.__name__)
                 )
             config_doc += "\n    |     `{}`: {}".format(
                 keyword, info_dict["definition"]

--- a/src/sqlfluff/core/rules/functional/__init__.py
+++ b/src/sqlfluff/core/rules/functional/__init__.py
@@ -1,7 +1,8 @@
 """Modules in this directory provide a "functional" API for rule writing.
 
-Wikipedia defines functional programming (https://en.wikipedia.org/wiki/Functional_programming)
-as a declarative programming paradigm where code is built by applying and composing functions.
+Wikipedia defines functional programming
+(https://en.wikipedia.org/wiki/Functional_programming) as a declarative programming
+paradigm where code is built by applying and composing functions.
 
 The modules in this API provide classes and predicates for working with segments
 and slices. The API is loosely inspired by packages such as Pandas and Numpy.

--- a/src/sqlfluff/core/rules/loader.py
+++ b/src/sqlfluff/core/rules/loader.py
@@ -13,7 +13,8 @@ def get_rules_from_path(
     base_module="sqlfluff.rules",
 ):
     """Reads all of the Rule classes from a path into a list."""
-    # Create a rules dictionary for importing in sqlfluff/src/sqlfluff/core/rules/__init__.py
+    # Create a rules dictionary for importing in
+    # sqlfluff/src/sqlfluff/core/rules/__init__.py
     rules = []
 
     for module in sorted(glob(rules_path)):
@@ -28,9 +29,11 @@ def get_rules_from_path(
             rule_class = getattr(rule_module, rule_class_name)
         except AttributeError as e:
             raise AttributeError(
-                f"Rule classes must be named in the format of Rule_L*. [{rule_class_name}]"
+                "Rule classes must be named in the format of Rule_L*. "
+                f"[{rule_class_name}]"
             ) from e
-        # Add the rules to the rules dictionary for sqlfluff/src/sqlfluff/core/rules/__init__.py
+        # Add the rules to the rules dictionary for
+        # sqlfluff/src/sqlfluff/core/rules/__init__.py
         rules.append(rule_class)
 
     return rules

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -401,10 +401,10 @@ class RawTemplater:
         """Placeholder init function.
 
         Here we should load any initial config found in the root directory. The init
-        function shouldn't take any arguments at this stage as we assume that it will load
-        its own config. Maybe at this stage we might allow override parameters to be passed
-        to the linter at runtime from the cli - that would be the only time we would pass
-        arguments in here.
+        function shouldn't take any arguments at this stage as we assume that it will
+        load its own config. Maybe at this stage we might allow override parameters to
+        be passed to the linter at runtime from the cli - that would be the only time we
+        would pass arguments in here.
         """
 
     def sequence_files(

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -118,7 +118,8 @@ class JinjaTemplater(PythonTemplater):
 
         libraries = JinjaTemplater.Libraries()
 
-        # If library_path hash __init__.py we parse it as a one module, else we parse it a set of modules
+        # If library_path hash __init__.py we parse it as a one module, else we parse it
+        # a set of modules
         is_library_module = os.path.exists(os.path.join(library_path, "__init__.py"))
         library_module_name = os.path.basename(library_path)
 
@@ -150,7 +151,8 @@ class JinjaTemplater(PythonTemplater):
                 setattr(libraries, module_name, module)
 
         if is_library_module:
-            # when library is module we have one more root module in hierarchy and we remove it
+            # when library is module we have one more root module in hierarchy and we
+            # remove it
             libraries = getattr(libraries, library_module_name)
 
         # remove magic methods from result
@@ -301,7 +303,8 @@ class JinjaTemplater(PythonTemplater):
         """
         if not config:  # pragma: no cover
             raise ValueError(
-                "For the jinja templater, the `process()` method requires a config object."
+                "For the jinja templater, the `process()` method requires a config "
+                "object."
             )
 
         env, live_context, make_template = self.template_builder(
@@ -371,8 +374,9 @@ class JinjaTemplater(PythonTemplater):
             violations.append(
                 SQLTemplaterError(
                     (
-                        "Unrecoverable failure in Jinja templating: {}. Have you configured "
-                        "your variables? https://docs.sqlfluff.com/en/latest/configuration.html"
+                        "Unrecoverable failure in Jinja templating: {}. Have you "
+                        "configured your variables? "
+                        "https://docs.sqlfluff.com/en/latest/configuration.html"
                     ).format(err)
                 )
             )

--- a/src/sqlfluff/core/templaters/placeholder.py
+++ b/src/sqlfluff/core/templaters/placeholder.py
@@ -100,7 +100,8 @@ class PlaceholderTemplater(RawTemplater):
             live_context["__bind_param_regex"] = KNOWN_STYLES[param_style]
         else:
             raise ValueError(
-                "No param_regex nor param_style was provided to the placeholder templater!"
+                "No param_regex nor param_style was provided to the placeholder "
+                "templater!"
             )
 
         return live_context
@@ -149,9 +150,8 @@ class PlaceholderTemplater(RawTemplater):
             except KeyError as err:
                 # TODO: Add a url here so people can get more help.
                 raise SQLTemplaterError(
-                    "Failure in placeholder templating: {}. Have you configured your variables?".format(
-                        err
-                    )
+                    "Failure in placeholder templating: {}. Have you configured your "
+                    "variables?".format(err)
                 )
             # add the literal to the slices
             template_slices.append(

--- a/src/sqlfluff/core/templaters/python.py
+++ b/src/sqlfluff/core/templaters/python.py
@@ -225,9 +225,8 @@ class PythonTemplater(RawTemplater):
         except KeyError as err:
             # TODO: Add a url here so people can get more help.
             raise SQLTemplaterError(
-                "Failure in Python templating: {}. Have you configured your variables?".format(
-                    err
-                )
+                "Failure in Python templating: {}. Have you configured your "
+                "variables?".format(err)
             )
         raw_sliced, sliced_file, new_str = self.slice_file(
             in_str, new_str, config=config
@@ -332,10 +331,10 @@ class PythonTemplater(RawTemplater):
         last_slice = slices[-1]
 
         if unwrap_wrapped:
-            # If we're unwrapping, there is no need to edit the slices, but we do need to trim
-            # the templated string. We should expect that the template will need to be re-sliced
-            # but we should assume that the function calling this one will deal with that
-            # eventuality.
+            # If we're unwrapping, there is no need to edit the slices, but we do need
+            # to trim the templated string. We should expect that the template will need
+            # to be re-sliced but we should assume that the function calling this one
+            # will deal with that eventuality.
             return (
                 slices,
                 templated_str[
@@ -347,9 +346,10 @@ class PythonTemplater(RawTemplater):
             first_slice.source_slice.start == 0
             and first_slice.templated_slice.start != 0
         ):
-            # This means that there is text at the start of the templated file which doesn't exist
-            # in the raw file. Handle this by adding a templated slice (though it's not really templated)
-            # between 0 and 0 in the raw, and 0 and the current first slice start index in the templated.
+            # This means that there is text at the start of the templated file which
+            # doesn't exist in the raw file. Handle this by adding a templated slice
+            # (though it's not really templated) between 0 and 0 in the raw, and 0 and
+            # the current first slice start index in the templated.
             slices.insert(
                 0,
                 TemplatedFileSlice(
@@ -359,9 +359,10 @@ class PythonTemplater(RawTemplater):
                 ),
             )
         if last_slice.templated_slice.stop != len(templated_str):
-            #  This means that there is text at the end of the templated file which doesn't exist
-            #  in the raw file. Handle this by adding a templated slice beginning and ending at the
-            #  end of the raw, and the current last slice stop and file end in the templated.
+            # This means that there is text at the end of the templated file which
+            # doesn't exist in the raw file. Handle this by adding a templated slice
+            # beginning and ending at the end of the raw, and the current last slice
+            # stop and file end in the templated.
             slices.append(
                 TemplatedFileSlice(
                     "templated",
@@ -477,7 +478,8 @@ class PythonTemplater(RawTemplater):
                 if tinv != linv:
                     src_dir = source_pos > raw_occurrences[tinv]
                     tmp_dir = templ_pos > templated_occurrences[tinv]
-                    # If it's not in the same direction in the source and template remove it.
+                    # If it's not in the same direction in the source and template
+                    # remove it.
                     if src_dir != tmp_dir:  # pragma: no cover
                         templater_logger.debug(
                             "          Invariant found out of order: %r", tinv
@@ -673,7 +675,8 @@ class PythonTemplater(RawTemplater):
             two_way_uniques = [
                 key for key in one_way_uniques if len(templ_occs[key]) == 1
             ]
-            # if we don't have anything to anchor on, then just return (coalescing types)
+            # if we don't have anything to anchor on, then just return (coalescing
+            # types)
             if not raw_occs or not templ_occs or not one_way_uniques:
                 templater_logger.debug(
                     "        No Anchors or Uniques. Yielding Whole: %s", coalesced
@@ -745,7 +748,8 @@ class PythonTemplater(RawTemplater):
                                 templated_str,
                             )
 
-                        # Handle any potential partial slice if we're part way through this one.
+                        # Handle any potential partial slice if we're part way through
+                        # this one.
                         if pos > 0:
                             yield TemplatedFileSlice(
                                 raw_slice.slice_type,
@@ -794,7 +798,8 @@ class PythonTemplater(RawTemplater):
                     )
                     templater_logger.warning(
                         "        Python templater safety value unexpectedly triggered. "
-                        "Please report your raw and compiled query on github for debugging."
+                        "Please report your raw and compiled query on github for "
+                        "debugging."
                     )
                     # NOTE: If a bug is reported here, this will incorrectly
                     # classify more of the query as "templated" than it should.
@@ -832,7 +837,8 @@ class PythonTemplater(RawTemplater):
             # We're very unlikely to get here (impossible?) with just python
             # formatting, but this class is also the base for the jinja templater
             # (and others?) so it may be used there.
-            # One way uniques give us landmarks to try and estimate what to do with them.
+            # One way uniques give us landmarks to try and estimate what to do with
+            # them.
             owu_templ_tuples = cls._sorted_occurrence_tuples(  # pragma: no cover
                 {key: templ_occs[key] for key in one_way_uniques}
             )
@@ -872,7 +878,8 @@ class PythonTemplater(RawTemplater):
                     continue
 
                 templater_logger.debug(
-                    "        Handling OWU: %r @%s (raw @%s) [this_owu_idx: %s, last_owu_dx: %s]",
+                    "        Handling OWU: %r @%s (raw @%s) [this_owu_idx: %s, "
+                    "last_owu_dx: %s]",
                     raw,
                     template_idx,
                     raw_idx,
@@ -980,10 +987,12 @@ class PythonTemplater(RawTemplater):
                         # The ending point of this slice, is already decided.
                         end_point = elem_sub_buffer[-1].end_source_idx()
 
-                        # If start_idx is None, we're in luck. We don't need to include the beginning.
+                        # If start_idx is None, we're in luck. We don't need to include
+                        # the beginning.
                         if include_start:
                             start_point = elem_sub_buffer[0].source_idx
-                        # Otherwise we know it's looped round, we need to include the whole slice.
+                        # Otherwise we know it's looped round, we need to include the
+                        # whole slice.
                         else:  # pragma: no cover
                             start_point = elem_sub_buffer[cur_idx].source_idx
 

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -84,7 +84,8 @@ class JinjaTracer:
             m_id = regex.match(r"^([0-9a-f]+)(_(\d+))?", p)
             if not m_id:
                 raise ValueError(  # pragma: no cover
-                    "Internal error. Trace template output does not match expected format."
+                    "Internal error. Trace template output does not match expected "
+                    "format."
                 )
             if m_id.group(3):
                 # E.g. "2e8577c1d045439ba8d3b9bf47561de3_83". The number after
@@ -234,7 +235,8 @@ class JinjaTracer:
             if elem_type.endswith("_begin"):
                 # When a "begin" tag (whether block, comment, or data) uses
                 # whitespace stripping
-                # (https://jinja.palletsprojects.com/en/3.0.x/templates/#whitespace-control),
+                # (https://jinja.palletsprojects.com/en/3.0.x/templates
+                # /#whitespace-control),
                 # the Jinja lex() function handles this by discarding adjacent
                 # whitespace from in_str. For more insight, see the tokeniter()
                 # function in this file:
@@ -309,12 +311,16 @@ class JinjaTracer:
                             prefix = "set" if set_idx is not None else ""
                             open_ = m_open.group(1)
                             close_ = m_close.group(1)
-                            alternate_code = f"\0{prefix}{unique_alternate_id} {open_} {trimmed_content} {close_}"
+                            alternate_code = (
+                                f"\0{prefix}{unique_alternate_id} {open_} "
+                                f"{trimmed_content} {close_}"
+                            )
                 if block_type == "block_start" and trimmed_content.split()[0] == "set":
                     # Jinja supports two forms of {% set %}:
                     # - {% set variable = value %}
                     # - {% set variable %}value{% endset %}
-                    # https://jinja.palletsprojects.com/en/2.10.x/templates/#block-assignments
+                    # https://jinja.palletsprojects.com/en/2.10.x/templates
+                    # /#block-assignments
                     # When the second format is used, set the variable 'is_set'
                     # to a non-None value. This info is used elsewhere, as
                     # literals inside a {% set %} block require special handling

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -88,8 +88,8 @@ ansi_dialect.set_lexer_matchers(
         RegexLexer("back_quote", r"`[^`]*`", CodeSegment),
         # See https://www.geeksforgeeks.org/postgresql-dollar-quoted-string-constants/
         RegexLexer("dollar_quote", r"\$(\w*)\$[^\1]*?\$\1\$", CodeSegment),
-        # Numeric literal matches integers, decimals, and exponential formats,
-        # with a positve lookahead assertion to check it is not part of a naked identifier.
+        # Numeric literal matches integers, decimals, and exponential formats, with a
+        # positve lookahead assertion to check it is not part of a naked identifier.
         RegexLexer(
             "numeric_literal",
             r"(?>\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?(?=\b)",
@@ -267,8 +267,8 @@ ansi_dialect.add(
             type="bare_function",
         )
     ),
-    # The strange regex here it to make sure we don't accidentally match numeric literals. We
-    # also use a regex to explicitly exclude disallowed keywords.
+    # The strange regex here it to make sure we don't accidentally match numeric
+    # literals. We also use a regex to explicitly exclude disallowed keywords.
     NakedIdentifierSegment=SegmentGenerator(
         # Generate the anti template from the set of reserved keywords
         lambda dialect: RegexParser(
@@ -299,7 +299,8 @@ ansi_dialect.add(
             CodeSegment,
             name="data_type_identifier",
             type="data_type_identifier",
-            anti_template=r"^(NOT)$",  # TODO - this is a stopgap until we implement explicit data types
+            anti_template=r"^(NOT)$",
+            # TODO - this is a stopgap until we implement explicit data types
         ),
     ),
     # Ansi Intervals
@@ -320,7 +321,8 @@ ansi_dialect.add(
     NumericLiteralSegment=NamedParser(
         "numeric_literal", CodeSegment, name="numeric_literal", type="literal"
     ),
-    # NullSegment is defined seperately to the keyword so we can give it a different type
+    # NullSegment is defined seperately to the keyword so we can give it a different
+    # type
     NullLiteralSegment=StringParser(
         "null", KeywordSegment, name="null_literal", type="literal"
     ),
@@ -335,8 +337,8 @@ ansi_dialect.add(
         Ref("NakedIdentifierSegment"), Ref("QuotedIdentifierSegment")
     ),
     BooleanLiteralGrammar=OneOf(Ref("TrueSegment"), Ref("FalseSegment")),
-    # We specifically define a group of arithmetic operators to make it easier to override this
-    # if some dialects have different available operators
+    # We specifically define a group of arithmetic operators to make it easier to
+    # override this if some dialects have different available operators
     ArithmeticBinaryOperatorGrammar=OneOf(
         Ref("PlusSegment"),
         Ref("MinusSegment"),
@@ -426,8 +428,8 @@ ansi_dialect.add(
         Ref("CommaSegment"),
         Ref("SetOperatorSegment"),
     ),
-    # Define these as grammars to allow child dialects to enable them (since they are non-standard
-    # keywords)
+    # Define these as grammars to allow child dialects to enable them (since they are
+    # non-standard keywords)
     IsNullGrammar=Nothing(),
     NotNullGrammar=Nothing(),
     FromClauseTerminatorGrammar=OneOf(
@@ -562,7 +564,8 @@ class DatatypeSegment(BaseSegment):
                     OneOf("VARYING", Sequence("LARGE", "OBJECT")),
                 ),
                 Sequence(
-                    # Some dialects allow optional qualification of data types with schemas
+                    # Some dialects allow optional qualification of data types with
+                    # schemas
                     Sequence(
                         Ref("SingleIdentifierGrammar"),
                         Ref("DotSegment"),
@@ -870,7 +873,7 @@ ansi_dialect.add(
         ),
         Ref(
             "OrderByClauseSegment"
-        ),  # used by string_agg (postgres), group_concat (exasol), listagg (snowflake)...
+        ),  # used by string_agg (postgres), group_concat (exasol),listagg (snowflake)..
         Sequence(Ref.keyword("SEPARATOR"), Ref("LiteralGrammar")),
         # like a function call: POSITION ( 'QL' IN 'SQL')
         Sequence(
@@ -1046,7 +1049,8 @@ class PartitionClauseSegment(BaseSegment):
 class FrameClauseSegment(BaseSegment):
     """A frame clause for window functions.
 
-    As specified in https://docs.oracle.com/cd/E17952_01/mysql-8.0-en/window-functions-frames.html
+    As specified in https://docs.oracle.com/cd/E17952_01/mysql-8.0-en
+    /window-functions-frames.html
     """
 
     type = "frame_clause"
@@ -1079,7 +1083,8 @@ class FromExpressionElementSegment(BaseSegment):
     match_grammar = Sequence(
         Ref("PreTableFunctionKeywordsGrammar", optional=True),
         OptionallyBracketed(Ref("TableExpressionSegment")),
-        # https://cloud.google.com/bigquery/docs/reference/standard-sql/arrays#flattening_arrays
+        # https://cloud.google.com/bigquery/docs/reference/standard-sql
+        # /arrays#flattening_arrays
         Sequence("WITH", "OFFSET", optional=True),
         OneOf(
             Sequence(Ref("AliasExpressionSegment"), Ref("SamplingExpressionSegment")),
@@ -1136,7 +1141,8 @@ class FromExpressionSegment(BaseSegment):
     match_grammar = Sequence(
         Indent,
         OneOf(
-            # check first for MLTableExpression, because of possible FunctionSegment in MainTableExpression
+            # check first for MLTableExpression, because of possible FunctionSegment in
+            # MainTableExpression
             Ref("MLTableExpressionSegment"),
             Ref("FromExpressionElementSegment"),
         ),
@@ -1303,7 +1309,8 @@ class JoinClauseSegment(BaseSegment):
     match_grammar = Sequence(
         # NB These qualifiers are optional
         # TODO: Allow nested joins like:
-        # ....FROM S1.T1 t1 LEFT JOIN ( S2.T2 t2 JOIN S3.T3 t3 ON t2.col1=t3.col1) ON tab1.col1 = tab2.col1
+        # ....FROM S1.T1 t1 LEFT JOIN ( S2.T2 t2 JOIN S3.T3 t3 ON t2.col1=t3.col1) ON
+        # tab1.col1 = tab2.col1
         OneOf(
             "CROSS",
             "INNER",
@@ -1486,7 +1493,8 @@ class CaseExpressionSegment(BaseSegment):
 
 
 ansi_dialect.add(
-    # Expression_A_Grammar https://www.cockroachlabs.com/docs/v20.2/sql-grammar.html#a_expr
+    # Expression_A_Grammar https://www.cockroachlabs.com/docs/v20.2
+    # /sql-grammar.html#a_expr
     Expression_A_Grammar=Sequence(
         OneOf(
             Ref("Expression_C_Grammar"),
@@ -1496,7 +1504,8 @@ ansi_dialect.add(
                     Ref("NegativeSegment"),
                     # Ref('TildeSegment'),
                     "NOT",
-                    "PRIOR",  # used in CONNECT BY clauses (EXASOL, Snowflake, Postgres...)
+                    "PRIOR",
+                    # used in CONNECT BY clauses (EXASOL, Snowflake, Postgres...)
                 ),
                 Ref("Expression_C_Grammar"),
             ),
@@ -1557,9 +1566,9 @@ ansi_dialect.add(
                     Ref.keyword("NOT", optional=True),
                     "BETWEEN",
                     # In a between expression, we're restricted to arithmetic operations
-                    # because if we look for all binary operators then we would match AND
-                    # as both an operator and also as the delimiter within the BETWEEN
-                    # expression.
+                    # because if we look for all binary operators then we would match
+                    # AND as both an operator and also as the delimiter within the
+                    # BETWEEN expression.
                     Ref("Expression_C_Grammar"),
                     AnyNumberOf(
                         Sequence(
@@ -1584,11 +1593,11 @@ ansi_dialect.add(
     # currently no need to define Expression_B.
     # https://www.cockroachlabs.com/docs/v20.2/sql-grammar.htm#b_expr
     #
-    # Expression_C_Grammar https://www.cockroachlabs.com/docs/v20.2/sql-grammar.htm#c_expr
+    # Expression_C_Grammar https://www.cockroachlabs.com/docs/v20.2
+    # /sql-grammar.htm#c_expr
     Expression_C_Grammar=OneOf(
-        Sequence(
-            "EXISTS", Bracketed(Ref("SelectStatementSegment"))
-        ),  # should be first priority, otherwise EXISTS() would be matched as a function
+        Sequence("EXISTS", Bracketed(Ref("SelectStatementSegment"))),
+        # should be first priority, otherwise EXISTS() would be matched as a function
         Sequence(
             OneOf(
                 Ref("Expression_D_Grammar"),
@@ -1597,7 +1606,8 @@ ansi_dialect.add(
             AnyNumberOf(Ref("ShorthandCastSegment")),
         ),
     ),
-    # Expression_D_Grammar https://www.cockroachlabs.com/docs/v20.2/sql-grammar.htm#d_expr
+    # Expression_D_Grammar
+    # https://www.cockroachlabs.com/docs/v20.2/sql-grammar.htm#d_expr
     Expression_D_Grammar=Sequence(
         OneOf(
             Ref("BareFunctionSegment"),
@@ -2030,13 +2040,15 @@ ansi_dialect.add(
     SelectableGrammar=OneOf(
         Ref("WithCompoundStatementSegment"), Ref("NonWithSelectableGrammar")
     ),
-    # Things that behave like select statements, which can form part of with expressions.
+    # Things that behave like select statements, which can form part of with
+    # expressions.
     NonWithSelectableGrammar=OneOf(
         Ref("SetExpressionSegment"),
         OptionallyBracketed(Ref("SelectStatementSegment")),
         Ref("NonSetSelectableGrammar"),
     ),
-    # Things that do not behave like select statements, which can form part of with expressions.
+    # Things that do not behave like select statements, which can form part of with
+    # expressions.
     NonWithNonSelectableGrammar=OneOf(
         Ref("UpdateStatementSegment"),
         Ref("InsertStatementSegment"),
@@ -2626,9 +2638,10 @@ class DropIndexStatementSegment(BaseSegment):
 class AccessStatementSegment(BaseSegment):
     """A `GRANT` or `REVOKE` statement.
 
-    In order to help reduce code duplication we decided to implement other dialect specific grants (like Snowflake)
-    here too which will help with maintainability. We also note that this causes the grammar to be less "correct",
-    but the benefits outweigh the con in our opinion.
+    In order to help reduce code duplication we decided to implement other dialect
+    specific grants (like Snowflake) here too which will help with maintainability. We
+    also note that this causes the grammar to be less "correct", but the benefits
+    outweigh the con in our opinion.
 
 
     Grant specific information:
@@ -2681,7 +2694,8 @@ class AccessStatementSegment(BaseSegment):
         Sequence("FILE", "FORMAT"),
     )
 
-    # We reuse the object names above and simply append an `S` to the end of them to get plurals
+    # We reuse the object names above and simply append an `S` to the end of them to get
+    # plurals
     _schema_object_types_plural = OneOf(
         *[f"{object_name}S" for object_name in _schema_object_names]
     )
@@ -2961,7 +2975,8 @@ class CreateFunctionStatementSegment(BaseSegment):
     structure of the code for those dialects.
     postgres: https://www.postgresql.org/docs/9.1/sql-createfunction.html
     snowflake: https://docs.snowflake.com/en/sql-reference/sql/create-function.html
-    bigquery: https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions
+    bigquery: https://cloud.google.com/bigquery/docs/reference/standard-sql
+    /user-defined-functions
     """
 
     type = "create_function_statement"
@@ -3010,7 +3025,8 @@ class CreateModelStatementSegment(BaseSegment):
     """A BigQuery `CREATE MODEL` statement."""
 
     type = "create_model_statement"
-    # https://cloud.google.com/bigquery-ml/docs/reference/standard-sql/bigqueryml-syntax-create
+    # https://cloud.google.com/bigquery-ml/docs/reference/standard-sql
+    # /bigqueryml-syntax-create
     match_grammar = Sequence(
         "CREATE",
         Ref("OrReplaceGrammar", optional=True),
@@ -3089,7 +3105,8 @@ class DropModelStatementSegment(BaseSegment):
 
     type = "drop_MODELstatement"
     # DROP MODEL <Model name> [IF EXISTS}
-    # https://cloud.google.com/bigquery-ml/docs/reference/standard-sql/bigqueryml-syntax-drop-model
+    # https://cloud.google.com/bigquery-ml/docs/reference/standard-sql
+    # /bigqueryml-syntax-drop-model
     match_grammar = Sequence(
         "DROP",
         "MODEL",
@@ -3265,7 +3282,8 @@ class ExplainStatementSegment(BaseSegment):
 class CreateSequenceOptionsSegment(BaseSegment):
     """Options for Create Sequence statement.
 
-    As specified in https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_6015.htm
+    As specified in https://docs.oracle.com/cd/B19306_01/server.102/b14200
+    /statements_6015.htm
     """
 
     type = "create_sequence_options_segment"
@@ -3293,7 +3311,8 @@ class CreateSequenceOptionsSegment(BaseSegment):
 class CreateSequenceStatementSegment(BaseSegment):
     """Create Sequence statement.
 
-    As specified in https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_6015.htm
+    As specified in https://docs.oracle.com/cd/B19306_01/server.102/b14200
+    /statements_6015.htm
     """
 
     type = "create_sequence_statement"
@@ -3310,7 +3329,8 @@ class CreateSequenceStatementSegment(BaseSegment):
 class AlterSequenceOptionsSegment(BaseSegment):
     """Options for Alter Sequence statement.
 
-    As specified in https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_2011.htm
+    As specified in https://docs.oracle.com/cd/B19306_01/server.102/b14200
+    /statements_2011.htm
     """
 
     type = "alter_sequence_options_segment"
@@ -3335,7 +3355,8 @@ class AlterSequenceOptionsSegment(BaseSegment):
 class AlterSequenceStatementSegment(BaseSegment):
     """Alter Sequence Statement.
 
-    As specified in https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_2011.htm
+    As specified in https://docs.oracle.com/cd/B19306_01/server.102/b14200
+    /statements_2011.htm
     """
 
     type = "alter_sequence_statement"
@@ -3352,7 +3373,8 @@ class AlterSequenceStatementSegment(BaseSegment):
 class DropSequenceStatementSegment(BaseSegment):
     """Drop Sequence Statement.
 
-    As specified in https://docs.oracle.com/cd/E11882_01/server.112/e41084/statements_9001.htm
+    As specified in https://docs.oracle.com/cd/E11882_01/server.112/e41084
+    /statements_9001.htm
     """
 
     type = "drop_sequence_statement"
@@ -3376,7 +3398,8 @@ class DatePartFunctionNameSegment(BaseSegment):
 class CreateTriggerStatementSegment(BaseSegment):
     """Create Trigger Statement.
 
-    Taken from specification in https://www.postgresql.org/docs/14/sql-createtrigger.html
+    Taken from specification in https://www.postgresql.org/docs/14
+    /sql-createtrigger.html
     Edited as per notes in above - what doesn't match ANSI
     """
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -55,10 +55,11 @@ bigquery_dialect.insert_lexer_matchers(
 bigquery_dialect.patch_lexer_matchers(
     [
         # Quoted literals can have r or b (case insensitive) prefixes, in any order, to
-        # indicate a raw/regex string or byte sequence, respectively.  Allow escaped quote
-        # characters inside strings by allowing \" with an optional even multiple of
-        # backslashes in front of it.
-        # https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#string_and_bytes_literals
+        # indicate a raw/regex string or byte sequence, respectively.  Allow escaped
+        # quote characters inside strings by allowing \" with an optional even multiple
+        # of backslashes in front of it.
+        # https://cloud.google.com/bigquery/docs/reference/standard-sql
+        # /lexical#string_and_bytes_literals
         # Triple quoted variant first, then single quoted
         RegexLexer(
             "single_quote",
@@ -176,7 +177,8 @@ bigquery_dialect.replace(
         insert=[Ref("TypelessStructSegment")],
         before=Ref("ExpressionSegment"),
     ),
-    # BigQuery allows underscore in parameter names, and also anything if quoted in backticks
+    # BigQuery allows underscore in parameter names, and also anything if quoted in
+    # backticks
     ParameterNameSegment=OneOf(
         RegexParser(
             r"[A-Z_][A-Z0-9_]*", CodeSegment, name="parameter", type="parameter"
@@ -213,7 +215,8 @@ bigquery_dialect.sets("datetime_units").update(
 )
 
 # In BigQuery, UNNEST() returns a "value table".
-# https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#value_tables
+# https://cloud.google.com/bigquery/docs/reference/standard-sql
+# /query-syntax#value_tables
 bigquery_dialect.sets("value_table_functions").update(["unnest"])
 
 # Bracket pairs (a set of tuples). Note that BigQuery inherits the default
@@ -491,7 +494,8 @@ class WildcardExpressionSegment(BaseSegment):
     ).match_grammar.copy(
         insert=[
             # Optional EXCEPT or REPLACE clause
-            # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_replace
+            # https://cloud.google.com/bigquery/docs/reference/standard-sql
+            # /query-syntax#select_replace
             Ref("ExceptClauseSegment", optional=True),
             Ref("ReplaceClauseSegment", optional=True),
         ]
@@ -592,7 +596,8 @@ class FunctionParameterListGrammar(BaseSegment):
 class TypelessStructSegment(BaseSegment):
     """Expression to construct a STRUCT with implicit types.
 
-    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#typeless_struct_syntax
+    https://cloud.google.com/bigquery/docs/reference/standard-sql
+    /data-types#typeless_struct_syntax
     """
 
     type = "typeless_struct"
@@ -613,7 +618,8 @@ class TypelessStructSegment(BaseSegment):
 class TupleSegment(BaseSegment):
     """Expression to construct a TUPLE.
 
-    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#tuple_syntax
+    https://cloud.google.com/bigquery/docs/reference/standard-sql
+    /data-types#tuple_syntax
     """
 
     type = "tuple"
@@ -624,7 +630,8 @@ class TupleSegment(BaseSegment):
 class NamedArgumentSegment(BaseSegment):
     """Named argument to a function.
 
-    https://cloud.google.com/bigquery/docs/reference/standard-sql/geography_functions#st_geogfromgeojson
+    https://cloud.google.com/bigquery/docs/reference/standard-sql
+    /geography_functions#st_geogfromgeojson
     """
 
     type = "named_argument"
@@ -646,7 +653,8 @@ class LiteralCoercionSegment(BaseSegment):
     - TIME
     - TIMESTAMP
 
-    https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_rules#literal_coercion
+    https://cloud.google.com/bigquery/docs/reference/standard-sql
+    /conversion_rules#literal_coercion
 
     """
 
@@ -892,7 +900,8 @@ class CreateTableStatementSegment(BaseSegment):
     """A `CREATE TABLE` statement."""
 
     type = "create_table_statement"
-    # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_table_statement
+    # https://cloud.google.com/bigquery/docs/reference/standard-sql
+    # /data-definition-language#create_table_statement
     match_grammar = Sequence(
         "CREATE",
         Ref("OrReplaceGrammar", optional=True),
@@ -940,7 +949,8 @@ class ParameterizedSegment(BaseSegment):
 class FromPivotExpressionSegment(BaseSegment):
     """A PIVOT expression.
 
-    https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#pivot_operator
+    https://cloud.google.com/bigquery/docs/reference/standard-sql
+    /query-syntax#pivot_operator
     """
 
     type = "from_pivot_expression"
@@ -971,7 +981,8 @@ class FromPivotExpressionSegment(BaseSegment):
 class FromUnpivotExpressionSegment(BaseSegment):
     """An UNPIVOT expression.
 
-    https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#unpivot_operator
+    https://cloud.google.com/bigquery/docs/reference/standard-sql
+    /query-syntax#unpivot_operator
     """
 
     type = "from_unpivot_expression"
@@ -1058,7 +1069,8 @@ class InsertStatementSegment(BaseSegment):
 class SamplingExpressionSegment(BaseSegment):
     """A sampling expression.
 
-    As per https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#tablesample_operator
+    As per https://cloud.google.com/bigquery/docs/reference/standard-sql
+    /query-syntax#tablesample_operator
     """
 
     type = "sample_expression"

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -88,9 +88,11 @@ exasol_dialect.insert_lexer_matchers(
 
 exasol_dialect.patch_lexer_matchers(
     [
-        # In EXASOL, a double single/double quote resolves as a single/double quote in the string.
-        # It's also used for escaping single quotes inside of STATEMENT strings like in the IMPORT function
-        # https://docs.exasol.com/sql_references/basiclanguageelements.htm#Delimited_Identifiers
+        # In EXASOL, a double single/double quote resolves as a single/double quote in
+        # the string. It's also used for escaping single quotes inside of STATEMENT
+        # strings like in the IMPORT function
+        # https://docs.exasol.com/sql_references
+        # /basiclanguageelements.htm#Delimited_Identifiers
         # https://docs.exasol.com/sql_references/literals.htm
         RegexLexer("single_quote", r"'([^']|'')*'", CodeSegment),
         RegexLexer("double_quote", r'"([^"]|"")*"', CodeSegment),
@@ -962,7 +964,9 @@ class DropSchemaStatementSegment(BaseSegment):
 # VIEW
 ############################
 @exasol_dialect.segment()
-class ViewReferenceSegment(ansi_dialect.get_segment("ObjectReferenceSegment")):  # type: ignore
+class ViewReferenceSegment(
+    ansi_dialect.get_segment("ObjectReferenceSegment")  # type: ignore
+):
     """A reference to an schema."""
 
     type = "view_reference"
@@ -1253,8 +1257,8 @@ class TableInlineConstraintSegment(BaseSegment):
                 max_times=1,
                 min_times=0,
                 # exclude UNRESERVED_KEYWORDS which could used as NakedIdentifier
-                # to make e.g. `id NUMBER CONSTRAINT PRIMARY KEY` work (which is equal to just
-                # `id NUMBER PRIMARY KEY`)
+                # to make e.g. `id NUMBER CONSTRAINT PRIMARY KEY` work (which is equal
+                # to just `id NUMBER PRIMARY KEY`)
                 exclude=OneOf("NOT", "NULL", "PRIMARY", "FOREIGN"),
             ),
             optional=True,
@@ -1288,8 +1292,8 @@ class TableOutOfLineConstraintSegment(BaseSegment):
                 max_times=1,
                 min_times=0,
                 # exclude UNRESERVED_KEYWORDS which could used as NakedIdentifier
-                # to make e.g. `id NUMBER, CONSTRAINT PRIMARY KEY(id)` work (which is equal to just
-                # `id NUMBER, PRIMARY KEY(id)`)
+                # to make e.g. `id NUMBER, CONSTRAINT PRIMARY KEY(id)` work (which is
+                # equal to just `id NUMBER, PRIMARY KEY(id)`)
                 exclude=OneOf("NOT", "NULL", "PRIMARY", "FOREIGN"),
             ),
             optional=True,
@@ -3042,7 +3046,10 @@ class PreferringPreferenceTermSegment(BaseSegment):
 
 @exasol_dialect.segment()
 class PreferringPlusPriorTermSegment(BaseSegment):
-    """The `PLUS` / `PRIOR TO` or `INVERSE` term within a preferring preference term expression."""
+    """The `PLUS` / `PRIOR TO` or `INVERSE` term within a preferring # noqa: D415
+
+    preference term expression.
+    """
 
     type = "plus_prior_inverse"
     match_grammar = OneOf(
@@ -3267,7 +3274,9 @@ class ExplainVirtualSegment(BaseSegment):
 
 
 @exasol_dialect.segment()
-class FunctionReferenceSegment(exasol_dialect.get_segment("ObjectReferenceSegment")):  # type: ignore
+class FunctionReferenceSegment(
+    exasol_dialect.get_segment("ObjectReferenceSegment")  # type: ignore
+):
     """A reference to a function."""
 
     type = "function_reference"
@@ -3513,7 +3522,9 @@ class DatePartFunctionNameSegment(BaseSegment):
 # SCRIPT
 ############################
 @exasol_dialect.segment()
-class ScriptReferenceSegment(exasol_dialect.get_segment("ObjectReferenceSegment")):  # type: ignore
+class ScriptReferenceSegment(
+    exasol_dialect.get_segment("ObjectReferenceSegment")  # type: ignore
+):
     """A reference to a script."""
 
     type = "script_reference"

--- a/src/sqlfluff/dialects/dialect_exasol_keywords.py
+++ b/src/sqlfluff/dialects/dialect_exasol_keywords.py
@@ -307,7 +307,8 @@ RESERVED_KEYWORDS = [
     "PARAMETER_SPECIFIC_NAME",
     "PARAMETER_SPECIFIC_SCHEMA",
     "PARTIAL",
-    "PARTITION",  # Should really be an unreserved keyword but need to make Window clauses work
+    "PARTITION",  # Should really be an unreserved keyword but need to make Window
+    # clauses work
     "PATH",
     "PERMISSION",
     "PLACING",

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -211,7 +211,8 @@ class CreateTableStatementSegment(BaseSegment):
                     optional=True,
                 ),
                 Ref("CommentGrammar", optional=True),
-                # `STORED AS` can be called before or after the additional table properties below
+                # `STORED AS` can be called before or after the additional table
+                # properties below
                 Ref("StoredAsGrammar", optional=True),
                 Sequence(
                     "PARTITIONED",
@@ -566,13 +567,16 @@ class IntervalExpressionSegment(BaseSegment):
 class MsckRepairTableStatementSegment(BaseSegment):
     """An `MSCK REPAIR TABLE`statement.
 
-    Updates the Hive metastore to be aware of any changes to partitions on the underlying file store.
+    Updates the Hive metastore to be aware of any changes to partitions on the
+    underlying file store.
 
-    The `MSCK TABLE` command, and corresponding class in Hive dialect MsckTableStatementSegment,
-    is used to determine mismatches between the Hive metastore and file system. Essentially, it is a dry
-    run of the `MSCK REPAIR TABLE` command.
+    The `MSCK TABLE` command, and corresponding class in Hive dialect
+    MsckTableStatementSegment, is used to determine mismatches between the Hive
+    metastore and file system. Essentially, it is a dry run of the `MSCK REPAIR TABLE`
+    command.
 
-    https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-RecoverPartitions(MSCKREPAIRTABLE)
+    https://cwiki.apache.org/confluence/display/Hive
+    /LanguageManual+DDL#LanguageManualDDL-RecoverPartitions(MSCKREPAIRTABLE)
     """
 
     type = "msck_repair_table_statement"
@@ -598,10 +602,12 @@ class MsckRepairTableStatementSegment(BaseSegment):
 class MsckTableStatementSegment(BaseSegment):
     """An `MSCK TABLE`statement.
 
-    Checks for difference between partition metadata in the Hive metastore and underlying file system.
+    Checks for difference between partition metadata in the Hive metastore and
+    underlying file system.
 
-    Commonly used prior to `MSCK REPAIR TABLE` command, corresponding with class `MsckRepairTableStatementSegment`
-    in Hive dialect, to asses size of updates for one-time or irregularly sized file system updates.
+    Commonly used prior to `MSCK REPAIR TABLE` command, corresponding with class
+    `MsckRepairTableStatementSegment` in Hive dialect, to asses size of updates for
+    one-time or irregularly sized file system updates.
 
     https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-RecoverPartitions(MSCKREPAIRTABLE)
     """

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -1333,7 +1333,8 @@ class DropIndexStatementSegment(BaseSegment):
 
     type = "drop_statement"
     # DROP INDEX <Index name> ON <table_name>
-    # [ALGORITHM [=] {DEFAULT | INPLACE | COPY} | LOCK [=] {DEFAULT | NONE | SHARED | EXCLUSIVE}]
+    # [ALGORITHM [=] {DEFAULT | INPLACE | COPY} | LOCK [=] {DEFAULT | NONE | SHARED |
+    # EXCLUSIVE}]
     match_grammar = Sequence(
         "DROP",
         "INDEX",

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -39,32 +39,43 @@ postgres_dialect.insert_lexer_matchers(
         # - (?s) Switch - .* includes newline characters
         # - U& - must start with U&
         # - (('')+?(?!')|('.*?(?<!')(?:'')*'(?!')))
-        #    ('')+?                                 Any non-zero number of pairs of single quotes -
-        #          (?!')                            that are not then followed by a single quote
+        #    ('')+?                                 Any non-zero number of pairs of
+        #                                           single quotes -
+        #          (?!')                            that are not then followed by a
+        #                                           single quote
         #               |                           OR
         #                ('.*?(?<!')(?:'')*'(?!'))
-        #                 '.*?                      A single quote followed by anything (non-greedy)
-        #                     (?<!')(?:'')*         Any even number of single quotes, including zero
-        #                                  '(?!')   Followed by a single quote, which is not followed by a single quote
+        #                 '.*?                      A single quote followed by anything
+        #                                           (non-greedy)
+        #                     (?<!')(?:'')*         Any even number of single quotes,
+        #                                           including zero
+        #                                  '(?!')   Followed by a single quote, which is
+        #                                           not followed by a single quote
         # - (\s*UESCAPE\s*'[^0-9A-Fa-f'+\-\s)]')?
-        #    \s*UESCAPE\s*                          Whitespace, followed by UESCAPE, followed by whitespace
-        #                 '[^0-9A-Fa-f'+\-\s)]'     Any character that isn't A-F, a-f, 0-9, +-, or whitespace, in quotes
+        #    \s*UESCAPE\s*                          Whitespace, followed by UESCAPE,
+        #                                           followed by whitespace
+        #                 '[^0-9A-Fa-f'+\-\s)]'     Any character that isn't A-F, a-f,
+        #                                           0-9, +-, or whitespace, in quotes
         #                                       ?   This last block is optional
         RegexLexer(
             "unicode_single_quote",
-            r"(?s)U&(('')+?(?!')|('.*?(?<!')(?:'')*'(?!')))(\s*UESCAPE\s*'[^0-9A-Fa-f'+\-\s)]')?",
+            r"(?s)U&(('')+?(?!')|('.*?(?<!')(?:'')*'(?!')))(\s*UESCAPE\s*'"
+            r"[^0-9A-Fa-f'+\-\s)]')?",
             CodeSegment,
         ),
         # This is similar to the Unicode regex, the key differences being:
         # - E - must start with E
         # - The final quote character must be preceded by:
-        # (?<!\\)(?:\\\\)*(?<!')(?:'')     An even/zero number of \ followed by an even/zero number of '
+        # (?<!\\)(?:\\\\)*(?<!')(?:'')     An even/zero number of \ followed by an
+        # even/zero number of '
         # OR
-        # (?<!\\)(?:\\\\)*\\(?<!')(?:'')*' An odd number of \ followed by an odd number of '
+        # (?<!\\)(?:\\\\)*\\(?<!')(?:'')*' An odd number of \ followed by an odd number
+        # of '
         # There is no UESCAPE block
         RegexLexer(
             "escaped_single_quote",
-            r"(?s)E(('')+?(?!')|'.*?((?<!\\)(?:\\\\)*(?<!')(?:'')*|(?<!\\)(?:\\\\)*\\(?<!')(?:'')*')'(?!'))",
+            r"(?s)E(('')+?(?!')|'.*?((?<!\\)(?:\\\\)*(?<!')(?:'')*|(?<!\\)(?:\\\\)*\\"
+            r"(?<!')(?:'')*')'(?!'))",
             CodeSegment,
         ),
         # Double quote Unicode string cannot be empty, and have no single quote escapes
@@ -87,19 +98,21 @@ postgres_dialect.insert_lexer_matchers(
         # Explanation for the regex
         # \\([^(\\\r\n)])+((\\\\)|(?=\n)|(?=\r\n))?
         # \\                                        Starts with backslash
-        #   ([^\\\r\n])+                            Anything that is not a newline or a backslash
+        #   ([^\\\r\n])+                            Anything that is not a newline or a
+        #                                           backslash
         #                 (
         #                  (\\\\)                   Double backslash
         #                        |                  OR
         #                         (?=\n)            The next character is a newline
         #                               |           OR
-        #                                (?=\r\n)   The next 2 characters are a carriage return and a newline
+        #                                (?=\r\n)   The next 2 characters are a carriage
+        #                                           return and a newline
         #                                        )
         #                                         ? The previous clause is optional
         RegexLexer(
-            # For now we'll just treat meta syntax like comments and so just ignore them.
-            # In future we may want to enhance this to actually parse them to ensure they are
-            # valid meta commands.
+            # For now we'll just treat meta syntax like comments and so just ignore
+            # them. In future we may want to enhance this to actually parse them to
+            # ensure they are valid meta commands.
             "meta_command",
             r"\\([^\\\r\n])+((\\\\)|(?=\n)|(?=\r\n))?",
             CommentSegment,
@@ -185,7 +198,8 @@ postgres_dialect.replace(
     NakedIdentifierSegment=SegmentGenerator(
         # Generate the anti template from the set of reserved keywords
         lambda dialect: RegexParser(
-            # Can’t begin with $, must only contain digits, letters, underscore it $ but can’t be all digits.
+            # Can’t begin with $, must only contain digits, letters, underscore it $ but
+            # can’t be all digits.
             r"([A-Z_]+|[0-9]+[A-Z_$])[A-Z0-9_$]*",
             CodeSegment,
             name="naked_identifier",
@@ -245,7 +259,8 @@ postgres_dialect.replace(
     ),
     FrameClauseUnitGrammar=OneOf("RANGE", "ROWS", "GROUPS"),
     # In Postgres, column references may be followed by a time zone cast in all cases.
-    # For more information, see https://www.postgresql.org/docs/11/functions-datetime.html
+    # For more information, see https://www.postgresql.org/docs/11
+    # /functions-datetime.html
     ColumnReferenceSegment=Sequence(
         ansi_dialect.get_segment("ColumnReferenceSegment"),
         Ref("ArrayAccessorSegment", optional=True),
@@ -644,7 +659,8 @@ class AlterFunctionStatementSegment(BaseSegment):
 class AlterFunctionActionSegment(BaseSegment):
     """Alter Function Action Segment.
 
-    Matches the definition of action in https://www.postgresql.org/docs/14/sql-alterfunction.html
+    Matches the definition of action in https://www.postgresql.org/docs/14
+    /sql-alterfunction.html
     """
 
     type = "alter_function_action_segment"
@@ -694,7 +710,8 @@ class WellKnownTextGeometrySegment(BaseSegment):
 
     As specified in https://postgis.net/stuff/postgis-3.1.pdf
 
-    This approach is to maximise 'accepted code' for the parser, rather than be overly restrictive.
+    This approach is to maximise 'accepted code' for the parser, rather than be overly
+    restrictive.
     """
 
     type = "wkt_geometry_type"
@@ -732,7 +749,8 @@ class WellKnownTextGeometrySegment(BaseSegment):
 class FunctionDefinitionGrammar(BaseSegment):
     """This is the body of a `CREATE FUNCTION AS` statement.
 
-    Options supported as defined in https://www.postgresql.org/docs/13/sql-createfunction.html
+    Options supported as defined in https://www.postgresql.org/docs/13
+    /sql-createfunction.html
     """
 
     match_grammar = Sequence(
@@ -949,7 +967,9 @@ class CreateRoleStatementSegment(BaseSegment):
 
 
 @postgres_dialect.segment(replace=True)
-class ExplainStatementSegment(ansi_dialect.get_segment("ExplainStatementSegment")):  # type: ignore
+class ExplainStatementSegment(
+    ansi_dialect.get_segment("ExplainStatementSegment")  # type: ignore
+):
     """An `Explain` statement.
 
     EXPLAIN [ ( option [, ...] ) ] statement
@@ -1314,7 +1334,8 @@ class AlterTableStatementSegment(BaseSegment):
 class AlterTableActionSegment(BaseSegment):
     """Alter Table Action Segment.
 
-    Matches the definition of action in https://www.postgresql.org/docs/13/sql-altertable.html
+    Matches the definition of action in https://www.postgresql.org/docs/13
+    /sql-altertable.html
     """
 
     type = "alter_table_action_segment"
@@ -1626,7 +1647,8 @@ class AlterMaterializedViewStatementSegment(BaseSegment):
 class AlterMaterializedViewActionSegment(BaseSegment):
     """Alter Materialized View Action Segment.
 
-    Matches the definition of action in https://www.postgresql.org/docs/14/sql-altermaterializedview.html
+    Matches the definition of action in https://www.postgresql.org/docs/14
+    /sql-altermaterializedview.html
     """
 
     type = "alter_materialized_view_action_segment"
@@ -2000,7 +2022,8 @@ class LikeOptionSegment(BaseSegment):
 class ColumnConstraintSegment(BaseSegment):
     """A column option; each CREATE TABLE column can have 0 or more.
 
-    This matches the definition in https://www.postgresql.org/docs/13/sql-altertable.html
+    This matches the definition in https://www.postgresql.org/docs/13
+    /sql-altertable.html
     """
 
     type = "column_constraint_segment"
@@ -2065,7 +2088,10 @@ class ColumnConstraintSegment(BaseSegment):
 
 @postgres_dialect.segment()
 class PartitionBoundSpecSegment(BaseSegment):
-    """partition_bound_spec as per https://www.postgresql.org/docs/13/sql-altertable.html."""
+    """partition_bound_spec as per https://www.postgresql.org/docs/13 # noqa: D415
+
+    /sql-altertable.html.
+    """
 
     match_grammar = OneOf(
         Sequence(
@@ -2180,7 +2206,10 @@ class TableConstraintSegment(BaseSegment):
 
 @postgres_dialect.segment()
 class TableConstraintUsingIndexSegment(BaseSegment):
-    """table_constraint_using_index as specified in https://www.postgresql.org/docs/13/sql-altertable.html."""
+    """table_constraint_using_index as specified in https://www.postgresql.org # noqa: D415
+
+    /docs/13/sql-altertable.html.
+    """
 
     match_grammar = Sequence(
         Sequence(  # [ CONSTRAINT <Constraint name> ]
@@ -2203,7 +2232,10 @@ class TableConstraintUsingIndexSegment(BaseSegment):
 
 @postgres_dialect.segment()
 class IndexParametersSegment(BaseSegment):
-    """index_parameters as specified in https://www.postgresql.org/docs/13/sql-altertable.html."""
+    """index_parameters as specified in https://www.postgresql.org # noqa: D415
+
+    /docs/13/sql-altertable.html.
+    """
 
     type = "index_parameters"
 
@@ -2233,7 +2265,8 @@ class IndexParametersSegment(BaseSegment):
 class ReferentialActionSegment(BaseSegment):
     """Foreign Key constraints.
 
-    As found in https://www.postgresql.org/docs/13/infoschema-referential-constraints.html
+    As found in https://www.postgresql.org/docs/13
+    /infoschema-referential-constraints.html
     """
 
     type = "referential_action"
@@ -2249,7 +2282,10 @@ class ReferentialActionSegment(BaseSegment):
 
 @postgres_dialect.segment()
 class ExcludeElementSegment(BaseSegment):
-    """exclude_element segment as found in https://www.postgresql.org/docs/13/sql-altertable.html."""
+    """exclude_element segment as found in https://www.postgresql.org # noqa: D415
+
+    /docs/13/sql-altertable.html.
+    """
 
     match_grammar = Sequence(
         OneOf(Ref("ColumnReferenceSegment"), Bracketed(Ref("ExpressionSegment"))),

--- a/src/sqlfluff/dialects/dialect_postgres_keywords.py
+++ b/src/sqlfluff/dialects/dialect_postgres_keywords.py
@@ -1,18 +1,20 @@
 """Keywords in the Postgres Dialect.
 
-Most of the keywords come from https://www.postgresql.org/docs/13/sql-keywords-appendix.html
-Here, "not-keyword" refers to a word not being a keyword, and will be removed from any default keyword definition,
-these keywords are, or have been, an ANSI keyword.
+Most of the keywords come from https://www.postgresql.org/docs/13
+/sql-keywords-appendix.html
+Here, "not-keyword" refers to a word not being a keyword, and will be removed from any
+default keyword definition, these keywords are, or have been, an ANSI keyword.
 
-There are also some keywords that are(n't) supported as types and function, but there isn't support for that
-distinction at present.
+There are also some keywords that are(n't) supported as types and function, but there
+isn't support for that distinction at present.
 """
 
 
 def priority_keyword_merge(*args):
     """Merge keyword lists, giving priority to entries in later lists.
 
-    *args is a list of keyword lists, these lists should be of tuples in the form (keyword, type)
+    *args is a list of keyword lists, these lists should be of tuples in the form
+    (keyword, type)
 
     """
     keyword_lists = [*args]

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -44,8 +44,8 @@ redshift_dialect.sets("bare_functions").clear()
 redshift_dialect.sets("bare_functions").update(["current_date", "sysdate"])
 
 redshift_dialect.replace(WellKnownTextGeometrySegment=Nothing())
-# TODO: for the time use the ANSI definition and not the updated one from Postgres as not all
-#       data types are supported by Redshift
+# TODO: for the time use the ANSI definition and not the updated one from Postgres as
+# not all data types are supported by Redshift
 redshift_dialect.replace(DatatypeSegment=ansi_dialect.get_segment("DatatypeSegment"))
 
 
@@ -77,7 +77,8 @@ class ColumnEncodingSegment(BaseSegment):
 
     Indicates column compression encoding.
 
-    As specified by: https://docs.aws.amazon.com/redshift/latest/dg/c_Compression_encodings.html
+    As specified by:
+    https://docs.aws.amazon.com/redshift/latest/dg/c_Compression_encodings.html
     """
 
     type = "column_encoding_segment"
@@ -103,7 +104,8 @@ class ColumnEncodingSegment(BaseSegment):
 class ColumnAttributeSegment(BaseSegment):
     """Redshift specific column attributes.
 
-    As specified in https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
+    As specified in
+    https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
     """
 
     type = "column_attribute_segment"
@@ -133,7 +135,8 @@ class ColumnAttributeSegment(BaseSegment):
 class ColumnConstraintSegment(BaseSegment):
     """Redshift specific column constraints.
 
-    As specified in https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
+    As specified in
+    https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
     """
 
     type = "column_constraint_segment"
@@ -153,7 +156,8 @@ class ColumnConstraintSegment(BaseSegment):
 class TableAttributeSegment(BaseSegment):
     """Redshift specific table attributes.
 
-    As specified in https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
+    As specified in
+    https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
     """
 
     type = "table_constraint_segment"
@@ -178,7 +182,8 @@ class TableAttributeSegment(BaseSegment):
 class TableConstraintSegment(BaseSegment):
     """Redshift specific table constraints.
 
-    As specified in https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
+    As specified in
+    https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
     """
 
     type = "table_constraint_segment"
@@ -205,7 +210,8 @@ class TableConstraintSegment(BaseSegment):
 class LikeOptionSegment(BaseSegment):
     """Like Option Segment.
 
-    As specified in https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
+    As specified in
+    https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
     """
 
     type = "like_option_segment"
@@ -217,7 +223,8 @@ class LikeOptionSegment(BaseSegment):
 class CreateTableStatementSegment(BaseSegment):
     """A `CREATE TABLE` statement.
 
-    As specified in https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
+    As specified in
+    https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
     """
 
     type = "create_table_statement"
@@ -257,7 +264,8 @@ class CreateTableStatementSegment(BaseSegment):
 class CreateTableAsStatementSegment(BaseSegment):
     """A `CREATE TABLE AS` statement.
 
-    As specified in https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_AS.html
+    As specified in
+    https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_AS.html
     """
 
     type = "create_table_as_statement"
@@ -287,7 +295,8 @@ class CreateTableAsStatementSegment(BaseSegment):
 class CreateExternalTableStatementSegment(BaseSegment):
     """A `CREATE EXTERNAL TABLE` statement.
 
-    As specified in https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_EXTERNAL_TABLE.html
+    As specified in
+    https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_EXTERNAL_TABLE.html
     TODO: support ROW FORMAT SERDE and WITH SERDEPROPERTIES
     TODO: support TABLE PROPERTIES
     """
@@ -334,7 +343,8 @@ class CreateExternalTableStatementSegment(BaseSegment):
 class CreateExternalTableAsStatementSegment(BaseSegment):
     """A `CREATE EXTERNAL TABLE AS` statement.
 
-    As specified in https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_EXTERNAL_TABLE.html
+    As specified in
+    https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_EXTERNAL_TABLE.html
     TODO: support TABLE PROPERTIES
     """
 
@@ -468,7 +478,8 @@ class StatementSegment(BaseSegment):
 class PartitionedBySegment(BaseSegment):
     """Partitioned By Segment.
 
-    As specified in https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_EXTERNAL_TABLE.html
+    As specified in
+    https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_EXTERNAL_TABLE.html
     """
 
     type = "partitioned_by_segment"
@@ -491,7 +502,8 @@ class PartitionedBySegment(BaseSegment):
 class RowFormatDelimitedSegment(BaseSegment):
     """Row Format Delimited Segment.
 
-    As specified in https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_EXTERNAL_TABLE.html
+    As specified in
+    https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_EXTERNAL_TABLE.html
     """
 
     type = "row_format_deimited_segment"

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -109,7 +109,8 @@ snowflake_dialect.add(
         type="variable",
         trim_chars=("$"),
     ),
-    # We use a RegexParser instead of keywords as some (those with dashes) require quotes:
+    # We use a RegexParser instead of keywords as some (those with dashes) require
+    # quotes:
     WarehouseSize=RegexParser(
         r"'?XSMALL'?|'?SMALL'?|'?MEDIUM'?|'?LARGE'?|'?XLARGE'?|'?XXLARGE'?|'?X2LARGE'?|"
         r"'?XXXLARGE'?|'?X3LARGE'?|'?X4LARGE'?|'?X5LARGE|'?X6LARGE'?|"
@@ -165,7 +166,8 @@ snowflake_dialect.add(
         type="stage_path",
     ),
     S3Path=RegexParser(
-        # See https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+        # See https://docs.aws.amazon.com/AmazonS3/latest/userguide
+        # /bucketnamingrules.html
         r"'s3://[a-z0-9][a-z0-9\.-]{1,61}[a-z0-9](?:/.+)?'",
         CodeSegment,
         name="s3_path",
@@ -179,8 +181,10 @@ snowflake_dialect.add(
         type="bucket_path",
     ),
     AzureBlobStoragePath=RegexParser(
-        # See https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage
-        r"'azure://[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\.blob\.core\.windows\.net/[a-z0-9][a-z0-9\.-]{1,61}[a-z0-9](?:/.+)?'",
+        # See https://docs.microsoft.com/en-us/azure/azure-resource-manager/management
+        # /resource-name-rules#microsoftstorage
+        r"'azure://[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\.blob\.core\.windows\.net/[a-z0-9]"
+        r"[a-z0-9\.-]{1,61}[a-z0-9](?:/.+)?'",
         CodeSegment,
         name="azure_blob_storage_path",
         type="bucket_path",
@@ -293,7 +297,8 @@ snowflake_dialect.sets("reserved_keywords").update(
 )
 
 # Add datetime units and their aliases from
-# https://docs.snowflake.com/en/sql-reference/functions-date-time.html#label-supported-date-time-parts
+# https://docs.snowflake.com/en/sql-reference
+# /functions-date-time.html#label-supported-date-time-parts
 snowflake_dialect.sets("datetime_units").clear()
 snowflake_dialect.sets("datetime_units").update(
     [
@@ -850,7 +855,9 @@ class QualifyClauseSegment(BaseSegment):
 
 
 @snowflake_dialect.segment(replace=True)
-class SelectStatementSegment(ansi_dialect.get_segment("SelectStatementSegment")):  # type: ignore
+class SelectStatementSegment(
+    ansi_dialect.get_segment("SelectStatementSegment")  # type: ignore
+):
     """A snowflake `SELECT` statement including optional Qualify.
 
     https://docs.snowflake.com/en/sql-reference/constructs/qualify.html
@@ -885,7 +892,8 @@ class SelectClauseModifierSegment(BaseSegment):
     type = "select_clause_modifier"
     match_grammar = Sequence(
         OneOf("DISTINCT", "ALL", optional=True),
-        # TOP N is unique to Snowflake, and we can optionally add DISTINCT/ALL in front of it.
+        # TOP N is unique to Snowflake, and we can optionally add DISTINCT/ALL in front
+        # of it.
         Sequence("TOP", Ref("NumericLiteralSegment"), optional=True),
     )
 
@@ -1089,7 +1097,9 @@ class TagEqualsSegment(BaseSegment):
 
 
 @snowflake_dialect.segment(replace=True)
-class UnorderedSelectStatementSegment(ansi_dialect.get_segment("SelectStatementSegment")):  # type: ignore
+class UnorderedSelectStatementSegment(
+    ansi_dialect.get_segment("SelectStatementSegment")  # type: ignore
+):
     """A snowflake unordered `SELECT` statement including optional Qualify.
 
     https://docs.snowflake.com/en/sql-reference/constructs/qualify.html
@@ -1345,7 +1355,9 @@ class WarehouseObjectParamsSegment(BaseSegment):
 
 @snowflake_dialect.segment()
 class ConstraintPropertiesSegment(BaseSegment):
-    """Constraint properties are specified in the CONSTRAINT clause for a CREATE TABLE or ALTER TABLE command.
+    """Constraint properties are specified in the CONSTRAINT clause for a # noqa: D415
+
+    CREATE TABLE or ALTER TABLE command.
 
     https://docs.snowflake.com/en/sql-reference/constraints-properties.html
     """
@@ -1392,7 +1404,8 @@ class ColumnConstraintSegment(BaseSegment):
             "DEFAULT",
             OneOf(
                 Ref("QuotedLiteralSegment"),
-                # https://docs.snowflake.com/en/sql-reference/functions/current_timestamp.html
+                # https://docs.snowflake.com/en/sql-reference/functions
+                # /current_timestamp.html
                 Sequence(
                     "CURRENT_TIMESTAMP",
                     Bracketed(
@@ -1791,7 +1804,8 @@ class CreateStatementSegment(BaseSegment):
         ),
         Ref("IfNotExistsGrammar", optional=True),
         Ref("ObjectReferenceSegment"),
-        # Next set are Pipe statements https://docs.snowflake.com/en/sql-reference/sql/create-pipe.html
+        # Next set are Pipe statements https://docs.snowflake.com/en/sql-reference/sql
+        # /create-pipe.html
         Sequence(
             Sequence(
                 "AUTO_INGEST",
@@ -1813,7 +1827,8 @@ class CreateStatementSegment(BaseSegment):
             ),
             optional=True,
         ),
-        # Next are WAREHOUSE options https://docs.snowflake.com/en/sql-reference/sql/create-warehouse.html
+        # Next are WAREHOUSE options https://docs.snowflake.com/en/sql-reference/sql
+        # /create-warehouse.html
         Sequence(
             Sequence("WITH", optional=True),
             AnyNumberOf(
@@ -2720,8 +2735,9 @@ class AlterUserSegment(BaseSegment):
                 "INTEGRATION",
                 Ref("ObjectReferenceSegment"),
             ),
-            # Snowflake supports the SET command with space delimitted parameters, but it also supports
-            # using commas which is better supported by `Delimited`, so we will just use that.
+            # Snowflake supports the SET command with space delimitted parameters, but
+            # it also supports using commas which is better supported by `Delimited`, so
+            # we will just use that.
             Sequence(
                 "SET",
                 Delimited(
@@ -2771,7 +2787,9 @@ class CreateRoleStatementSegment(BaseSegment):
 
 
 @snowflake_dialect.segment(replace=True)
-class ExplainStatementSegment(ansi_dialect.get_segment("ExplainStatementSegment")):  # type: ignore
+class ExplainStatementSegment(
+    ansi_dialect.get_segment("ExplainStatementSegment")  # type: ignore
+):
     """An `Explain` statement.
 
     EXPLAIN [ USING { TABULAR | JSON | TEXT } ] <statement>
@@ -3130,7 +3148,9 @@ class MergeInsertClauseSegment(BaseSegment):
 
 
 @snowflake_dialect.segment(replace=True)
-class DeleteStatementSegment(ansi_dialect.get_segment("DeleteStatementSegment")):  # type: ignore
+class DeleteStatementSegment(
+    ansi_dialect.get_segment("DeleteStatementSegment")  # type: ignore
+):
     """Update `DELETE` statement to support `USING`."""
 
     parse_grammar = Sequence(
@@ -3161,7 +3181,9 @@ class DeleteUsingClauseSegment(BaseSegment):
 
 
 @snowflake_dialect.segment()
-class FromClauseTerminatingUsingWhereSegment(ansi_dialect.get_segment("FromClauseSegment")):  # type: ignore
+class FromClauseTerminatingUsingWhereSegment(
+    ansi_dialect.get_segment("FromClauseSegment")  # type: ignore
+):
     """Copy `FROM` terminator statement to support `USING` in specific circumstances."""
 
     match_grammar = StartsWith(
@@ -3267,7 +3289,8 @@ class DescribeStatementSegment(BaseSegment):
                 "VIEW",
                 Ref("TableReferenceSegment"),
             ),
-            # https://docs.snowflake.com/en/sql-reference/sql/desc-materialized-view.html
+            # https://docs.snowflake.com/en/sql-reference/sql
+            # /desc-materialized-view.html
             Sequence(
                 "MATERIALIZED",
                 "VIEW",
@@ -3284,7 +3307,8 @@ class DescribeStatementSegment(BaseSegment):
                 "POLICY",
                 Ref("ObjectReferenceSegment"),
             ),
-            # https://docs.snowflake.com/en/sql-reference/sql/desc-row-access-policy.html
+            # https://docs.snowflake.com/en/sql-reference/sql
+            # /desc-row-access-policy.html
             Sequence(
                 "ROW",
                 "ACCESS",

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -8,7 +8,8 @@ some syntax with hive.
 Based on:
 - https://spark.apache.org/docs/latest/sql-ref.html
 - https://spark.apache.org/docs/latest/sql-ref-ansi-compliance.html
-- https://github.com/apache/spark/blob/master/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+- https://github.com/apache/spark/blob/master/sql/catalyst/src/main/antlr4/org/apache
+  /spark/sql/catalyst/parser/SqlBase.g4
 """
 
 from sqlfluff.core.parser import (
@@ -56,9 +57,11 @@ spark3_dialect.patch_lexer_matchers(
         # https://spark.apache.org/docs/latest/api/sql/index.html#_10
         RegexLexer("equals", r"=|==|<=>", CodeSegment),
         # identifiers are delimited with `
-        # within a delimited identifier, ` is used to escape special characters, including `
+        # within a delimited identifier, ` is used to escape special characters,
+        # including `
         # Ex: select `delimited `` with escaped` from `just delimited`
-        # https://spark.apache.org/docs/latest/sql-ref-identifier.html#delimited-identifier
+        # https://spark.apache.org/docs/latest
+        # /sql-ref-identifier.html#delimited-identifier
         RegexLexer("back_quote", r"`([^`]|``)*`", CodeSegment),
     ]
 )
@@ -270,14 +273,18 @@ spark3_dialect.add(
 
 # Hive Segments
 @spark3_dialect.segment()
-class RowFormatClauseSegment(hive_dialect.get_segment("RowFormatClauseSegment")):  # type: ignore
+class RowFormatClauseSegment(
+    hive_dialect.get_segment("RowFormatClauseSegment")  # type: ignore
+):
     """`ROW FORMAT` clause in a CREATE HIVEFORMAT TABLE statement."""
 
     type = "row_format_clause"
 
 
 @spark3_dialect.segment()
-class SkewedByClauseSegment(hive_dialect.get_segment("SkewedByClauseSegment")):  # type: ignore
+class SkewedByClauseSegment(
+    hive_dialect.get_segment("SkewedByClauseSegment")  # type: ignore
+):
     """`SKEWED BY` clause in a CREATE HIVEFORMAT TABLE statement."""
 
     type = "skewed_by_clause"
@@ -632,7 +639,9 @@ class CreateTableStatementSegment(BaseSegment):
 
 
 @spark3_dialect.segment()
-class CreateHiveFormatTableStatementSegment(hive_dialect.get_segment("CreateTableStatementSegment")):  # type: ignore
+class CreateHiveFormatTableStatementSegment(
+    hive_dialect.get_segment("CreateTableStatementSegment")  # type: ignore
+):
     """A `CREATE TABLE` statement using Hive format.
 
     https://spark.apache.org/docs/latest/sql-ref-syntax-ddl-create-table-hiveformat.html
@@ -696,7 +705,9 @@ class DropFunctionStatementSegment(BaseSegment):
 
 
 @spark3_dialect.segment()
-class MsckRepairTableStatementSegment(hive_dialect.get_segment("MsckRepairTableStatementSegment")):  # type: ignore
+class MsckRepairTableStatementSegment(
+    hive_dialect.get_segment("MsckRepairTableStatementSegment")  # type: ignore
+):
     """A `REPAIR TABLE` statement using Hive MSCK (Metastore Check) format.
 
     This class inherits from Hive since Spark leverages Hive format for this command and
@@ -767,7 +778,8 @@ class JoinClauseSegment(BaseSegment):
     match_grammar = Sequence(
         # NB These qualifiers are optional
         # TODO: Allow nested joins like:
-        # ....FROM S1.T1 t1 LEFT JOIN ( S2.T2 t2 JOIN S3.T3 t3 ON t2.col1=t3.col1) ON tab1.col1 = tab2.col1
+        # ....FROM S1.T1 t1 LEFT JOIN ( S2.T2 t2 JOIN S3.T3 t3 ON t2.col1=t3.col1) ON
+        # tab1.col1 = tab2.col1
         OneOf(
             "CROSS",
             "INNER",

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -203,7 +203,8 @@ class TdCollectStatisticsStatementSegment(BaseSegment):
     """A `COLLECT STATISTICS (Optimizer Form)` statement.
 
     # TODO: add expression
-    COLLECT [SUMMARY] (STATISTICS|STAT) [[COLUMN| [UNIQUE] INDEX] (expression (, expression ...)] ON TABLENAME
+    COLLECT [SUMMARY] (STATISTICS|STAT) [[COLUMN| [UNIQUE] INDEX]
+    (expression (, expression ...)] ON TABLENAME
     """
 
     type = "collect_statistics_statement"
@@ -221,7 +222,8 @@ class TdCollectStatisticsStatementSegment(BaseSegment):
         ),
         Delimited(
             OneOf(
-                # UNIQUE INDEX index_name ALL (column_name, ...) ORDER BY VALUES|HASH (column_name)
+                # UNIQUE INDEX index_name ALL (column_name, ...) ORDER BY VALUES|HASH
+                # (column_name)
                 Sequence(
                     Ref.keyword("UNIQUE", optional=True),
                     "INDEX",
@@ -274,7 +276,8 @@ class TdCommentStatementSegment(BaseSegment):
     """A `COMMENT` statement.
 
     COMMENT [ON] (object_kind_1|object_kind_2) name [[AS|IS] comment]
-    object_kind_1: (COLUMN|FUNCTION|GLOP SET|MACRO|MAP|METHOD|PROCEDURE|PROFILE|ROLE|TRIGGER|TYPE|VIEW)
+    object_kind_1: (COLUMN|FUNCTION|GLOP SET|MACRO|MAP|METHOD|PROCEDURE|PROFILE|ROLE|
+                    TRIGGER|TYPE|VIEW)
     object_kind_2: (DATABASE|FILE|TABLE|USER)
     """
 
@@ -455,7 +458,8 @@ class TdColumnConstraintSegment(BaseSegment):
 class TdCreateTableOptions(BaseSegment):
     """CreateTableOptions.
 
-    , NO FALLBACK, NO BEFORE JOURNAL, NO AFTER JOURNAL, CHECKSUM = DEFAULT, DEFAULT MERGEBLOCKRATIO
+    , NO FALLBACK, NO BEFORE JOURNAL, NO AFTER JOURNAL, CHECKSUM = DEFAULT
+    , DEFAULT MERGEBLOCKRATIO
     """
 
     type = "create_table_options_statement"
@@ -518,7 +522,8 @@ class TdTablePartitioningLevel(BaseSegment):
 
     column_partition := ([COLUMN|ROW] column_name (, column_name2, ...) NO AUTOCOMPRESS
 
-    partition_expression := CASE_N, RANGE_N, EXTRACT, expression and in case of multi-level in parenthesis
+    partition_expression := CASE_N, RANGE_N, EXTRACT, expression and in case of
+    multi-level in parenthesis
     """
 
     type = "td_partitioning_level"
@@ -784,7 +789,8 @@ class UnorderedSelectStatementSegment(BaseSegment):
 class SelectClauseModifierSegment(BaseSegment):
     """Things that come after SELECT but before the columns.
 
-    Adds NORMALIZE clause: https://docs.teradata.com/r/2_MC9vCtAJRlKle2Rpb0mA/UuxiA0mklFgv~33X5nyKMA
+    Adds NORMALIZE clause:
+    https://docs.teradata.com/r/2_MC9vCtAJRlKle2Rpb0mA/UuxiA0mklFgv~33X5nyKMA
     """
 
     type = "select_clause_modifier"

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -210,7 +210,8 @@ tsql_dialect.replace(
             optional=True,
         ),
     ),
-    # Overriding SelectClauseSegmentGrammar to remove Delimited logic which assumes statements have been delimited
+    # Overriding SelectClauseSegmentGrammar to remove Delimited logic which assumes
+    # statements have been delimited
     SelectClauseSegmentGrammar=Sequence(
         "SELECT",
         Ref("SelectClauseModifierSegment", optional=True),
@@ -265,9 +266,8 @@ tsql_dialect.replace(
                 Delimited(Ref("FunctionContentsExpressionGrammar")),
             ),
         ),
-        Ref(
-            "OrderByClauseSegment"
-        ),  # used by string_agg (postgres), group_concat (exasol), listagg (snowflake)...
+        Ref("OrderByClauseSegment"),
+        # used by string_agg (postgres), group_concat (exasol),listagg (snowflake)...
         # like a function call: POSITION ( 'QL' IN 'SQL')
         Sequence(
             OneOf(
@@ -422,7 +422,8 @@ class NotEqualToSegment(BaseSegment):
 class SelectClauseElementSegment(BaseSegment):
     """An element in the targets of a select statement.
 
-    Overriding ANSI to remove GreedyUntil logic which assumes statements have been delimited
+    Overriding ANSI to remove GreedyUntil logic which assumes statements have been
+    delimited
     """
 
     type = "select_clause_element"
@@ -448,7 +449,8 @@ class SelectClauseModifierSegment(BaseSegment):
         "DISTINCT",
         "ALL",
         Sequence(
-            # https://docs.microsoft.com/en-us/sql/t-sql/queries/top-transact-sql?view=sql-server-ver15
+            # https://docs.microsoft.com/en-us/sql/t-sql/queries
+            # /top-transact-sql?view=sql-server-ver15
             "TOP",
             OptionallyBracketed(Ref("ExpressionSegment")),
             Sequence("PERCENT", optional=True),
@@ -461,7 +463,8 @@ class SelectClauseModifierSegment(BaseSegment):
 class SelectClauseSegment(BaseSegment):
     """A group of elements in a select target statement.
 
-    Overriding ANSI to remove StartsWith logic which assumes statements have been delimited
+    Overriding ANSI to remove StartsWith logic which assumes statements have been
+    delimited
     """
 
     type = "select_clause"
@@ -499,7 +502,8 @@ class UnorderedSelectStatementSegment(BaseSegment):
 class InsertStatementSegment(BaseSegment):
     """An `INSERT` statement.
 
-    Overriding ANSI definition to remove StartsWith logic that doesn't handle optional delimitation well.
+    Overriding ANSI definition to remove StartsWith logic that doesn't handle optional
+    delimitation well.
     """
 
     type = "insert_statement"
@@ -565,7 +569,8 @@ class SelectStatementSegment(BaseSegment):
 class IntoTableSegment(BaseSegment):
     """`INTO` clause within `SELECT`.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/queries/select-into-clause-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/queries
+    /select-into-clause-transact-sql?view=sql-server-ver15
     """
 
     type = "into_table_clause"
@@ -594,8 +599,10 @@ class WhereClauseSegment(BaseSegment):
 class CreateIndexStatementSegment(BaseSegment):
     """A `CREATE INDEX` or `CREATE STATISTICS` statement.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/create-index-transact-sql?view=sql-server-ver15
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/create-statistics-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /create-index-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /create-statistics-transact-sql?view=sql-server-ver15
     """
 
     type = "create_index_statement"
@@ -625,10 +632,14 @@ class CreateIndexStatementSegment(BaseSegment):
 
 @tsql_dialect.segment()
 class OnPartitionOrFilegroupOptionSegment(BaseSegment):
-    """ON partition scheme or filegroup option in `CREATE INDEX` and 'CREATE TABLE' statements.
+    """ON partition scheme or filegroup option in `CREATE INDEX` # noqa: D415
 
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/create-index-transact-sql?view=sql-server-ver15
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql?view=sql-server-ver15
+    and 'CREATE TABLE' statements.
+
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /create-index-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /create-table-transact-sql?view=sql-server-ver15
     """
 
     type = "on_partition_or_filegroup_statement"
@@ -643,8 +654,10 @@ class OnPartitionOrFilegroupOptionSegment(BaseSegment):
 class FilestreamOnOptionSegment(BaseSegment):
     """FILESTREAM_ON index option in `CREATE INDEX` and 'CREATE TABLE' statements.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/create-index-transact-sql?view=sql-server-ver15
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /create-index-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /create-table-transact-sql?view=sql-server-ver15
     """
 
     type = "filestream_on_option_statement"
@@ -665,7 +678,8 @@ class FilestreamOnOptionSegment(BaseSegment):
 class TextimageOnOptionSegment(BaseSegment):
     """TEXTIMAGE ON option in `CREATE TABLE` statement.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /create-table-transact-sql?view=sql-server-ver15
     """
 
     type = "textimage_on_option_statement"
@@ -682,7 +696,8 @@ class TextimageOnOptionSegment(BaseSegment):
 class ReferencesConstraintGrammar(BaseSegment):
     """REFERENCES constraint option in `CREATE TABLE` statement.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /create-table-transact-sql?view=sql-server-ver15
     """
 
     type = "references_constraint_grammar"
@@ -722,7 +737,8 @@ class ReferencesConstraintGrammar(BaseSegment):
 class CheckConstraintGrammar(BaseSegment):
     """CHECK constraint option in `CREATE TABLE` statement.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /create-table-transact-sql?view=sql-server-ver15
     """
 
     type = "check_constraint_grammar"
@@ -739,7 +755,8 @@ class CheckConstraintGrammar(BaseSegment):
 class RelationalIndexOptionsSegment(BaseSegment):
     """A relational index options in `CREATE INDEX` statement.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/create-index-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /create-index-transact-sql?view=sql-server-ver15
     """
 
     type = "relational_index_options"
@@ -836,7 +853,8 @@ class RelationalIndexOptionsSegment(BaseSegment):
 class MaxDurationSegment(BaseSegment):
     """A `MAX DURATION` clause.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/create-index-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /create-index-transact-sql?view=sql-server-ver15
     """
 
     type = "max_duration"
@@ -888,7 +906,8 @@ class DropStatisticsStatementSegment(BaseSegment):
 class UpdateStatisticsStatementSegment(BaseSegment):
     """An `UPDATE STATISTICS` statement.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/update-statistics-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /update-statistics-transact-sql?view=sql-server-ver15
     """
 
     type = "update_statistics_statement"
@@ -1032,7 +1051,10 @@ class SequenceReferenceSegment(ObjectReferenceSegment):
 
 @tsql_dialect.segment()
 class PivotColumnReferenceSegment(ObjectReferenceSegment):
-    """A reference to a PIVOT column to differentiate it from a regular column reference."""
+    """A reference to a PIVOT column to differentiate it from a # noqa: D415
+
+    regular column reference.
+    """
 
     type = "pivot_column_reference"
 
@@ -1041,7 +1063,8 @@ class PivotColumnReferenceSegment(ObjectReferenceSegment):
 class PivotUnpivotStatementSegment(BaseSegment):
     """Declaration of a variable.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/queries/from-using-pivot-and-unpivot?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/queries
+    /from-using-pivot-and-unpivot?view=sql-server-ver15
     """
 
     type = "from_pivot_expression"
@@ -1081,7 +1104,8 @@ class PivotUnpivotStatementSegment(BaseSegment):
 class DeclareStatementSegment(BaseSegment):
     """Declaration of a variable.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/language-elements/declare-local-variable-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/language-elements
+    /declare-local-variable-transact-sql?view=sql-server-ver15
     """
 
     type = "declare_segment"
@@ -1111,10 +1135,12 @@ class DeclareStatementSegment(BaseSegment):
 
 @tsql_dialect.segment()
 class GoStatementSegment(BaseSegment):
-    """GO signals the end of a batch of Transact-SQL statements to the SQL Server utilities.
+    """GO signals the end of a batch of Transact-SQL statements # noqa: D415
 
-    GO statements are not part of the TSQL language. They are used to signal batch statements
-    so that clients know in how batches of statements can be executed.
+    to the SQL Server utilities.
+
+    GO statements are not part of the TSQL language. They are used to signal batch
+    statements so that clients know in how batches of statements can be executed.
     """
 
     type = "go_statement"
@@ -1322,21 +1348,24 @@ class ColumnConstraintSegment(BaseSegment):
                 "INDEX",
                 Ref("ObjectReferenceSegment"),  # index name
                 OneOf("CLUSTERED", "NONCLUSTERED", optional=True),
-                # other optional blocks (RelationalIndexOptionsSegment, OnIndexOptionSegment,
-                # FilestreamOnOptionSegment) are mentioned above
+                # other optional blocks (RelationalIndexOptionsSegment,
+                # OnIndexOptionSegment,FilestreamOnOptionSegment) are mentioned above
             ),
             # computed_column_definition
             Sequence("AS", Ref("ExpressionSegment")),
             Sequence("PERSISTED", Sequence("NOT", "NULL", optional=True))
-            # other optional blocks (RelationalIndexOptionsSegment, OnIndexOptionSegment,
-            # ReferencesConstraintGrammar, CheckConstraintGrammar) are mentioned above
+            # other optional blocks (RelationalIndexOptionsSegment,
+            # OnIndexOptionSegment, ReferencesConstraintGrammar, CheckConstraintGrammar)
+            # are mentioned above
         ),
     )
 
 
 @tsql_dialect.segment(replace=True)
 class FunctionParameterListGrammar(BaseSegment):
-    """The parameters for a function ie. `(@city_name NVARCHAR(30), @postal_code NVARCHAR(15))`.
+    """The parameters for a function ie.
+
+    `(@city_name NVARCHAR(30), @postal_code NVARCHAR(15))`.
 
     Overriding ANSI (1) to optionally bracket and (2) remove Delimited
     """
@@ -1359,12 +1388,15 @@ class CreateFunctionStatementSegment(BaseSegment):
     This version in the TSQL dialect should be a "common subset" of the
     structure of the code for those dialects.
 
-    Updated to include AS after declaration of RETURNS. Might be integrated in ANSI though.
+    Updated to include AS after declaration of RETURNS. Might be integrated in ANSI
+    though.
 
     postgres: https://www.postgresql.org/docs/9.1/sql-createfunction.html
     snowflake: https://docs.snowflake.com/en/sql-reference/sql/create-function.html
-    bigquery: https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions
-    tsql/mssql : https://docs.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-ver15
+    bigquery: https://cloud.google.com/bigquery/docs/reference/standard-sql
+    /user-defined-functions
+    tsql/mssql : https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /create-function-transact-sql?view=sql-server-ver15
     """
 
     type = "create_function_statement"
@@ -1426,7 +1458,8 @@ class FunctionOptionSegment(BaseSegment):
 class DropFunctionStatementSegment(BaseSegment):
     """A `DROP FUNCTION` statement.
 
-    As per specification https://docs.microsoft.com/en-us/sql/t-sql/statements/drop-function-transact-sql?view=sql-server-ver15
+    As per specification https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /drop-function-transact-sql?view=sql-server-ver15
     """
 
     type = "drop_function_statement"
@@ -2223,8 +2256,10 @@ class AlterTableSwitchStatementSegment(BaseSegment):
     """An `ALTER TABLE SWITCH` statement."""
 
     type = "alter_table_switch_statement"
-    # https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql?view=sql-server-ver15
-    # T-SQL's ALTER TABLE SWITCH grammar is different enough to core ALTER TABLE grammar to merit its own definition
+    # https://docs.microsoft.com/en-us/sql/t-sql/statements
+    # /alter-table-transact-sql?view=sql-server-ver15
+    # T-SQL's ALTER TABLE SWITCH grammar is different enough to core ALTER TABLE grammar
+    # to merit its own definition
     match_grammar = Sequence(
         "ALTER",
         "TABLE",
@@ -2250,7 +2285,10 @@ class CreateTableAsSelectStatementSegment(BaseSegment):
     """
 
     type = "create_table_as_select_statement"
-    # https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-as-select-azure-sql-data-warehouse?toc=/azure/synapse-analytics/sql-data-warehouse/toc.json&bc=/azure/synapse-analytics/sql-data-warehouse/breadcrumb/toc.json&view=azure-sqldw-latest&preserve-view=true
+    # https://docs.microsoft.com/en-us/sql/t-sql/statements
+    # /create-table-as-select-azure-sql-data-warehouse?toc=/azure/synapse-analytics
+    # /sql-data-warehouse/toc.json&bc=/azure/synapse-analytics/sql-data-warehouse
+    # /breadcrumb/toc.json&view=azure-sqldw-latest&preserve-view=true
     match_grammar = Sequence(
         "CREATE",
         "TABLE",
@@ -2317,7 +2355,8 @@ class TransactionStatementSegment(BaseSegment):
         # BEGIN | SAVE TRANSACTION
         # COMMIT [ TRANSACTION | WORK ]
         # ROLLBACK [ TRANSACTION | WORK ]
-        # https://docs.microsoft.com/en-us/sql/t-sql/language-elements/begin-transaction-transact-sql?view=sql-server-ver15
+        # https://docs.microsoft.com/en-us/sql/t-sql/language-elements
+        # /begin-transaction-transact-sql?view=sql-server-ver15
         Sequence(
             "BEGIN",
             Sequence("DISTRIBUTED", optional=True),
@@ -2340,7 +2379,8 @@ class BeginEndSegment(BaseSegment):
     """A `BEGIN/END` block.
 
     Encloses multiple statements into a single statement object.
-    https://docs.microsoft.com/en-us/sql/t-sql/language-elements/begin-end-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/language-elements
+    /begin-end-transact-sql?view=sql-server-ver15
     """
 
     type = "begin_end_block"
@@ -2362,7 +2402,8 @@ class BeginEndSegment(BaseSegment):
 class TryCatchSegment(BaseSegment):
     """A `TRY/CATCH` block pair.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/language-elements/try-catch-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/language-elements
+    /try-catch-transact-sql?view=sql-server-ver15
     """
 
     type = "try_catch"
@@ -2444,9 +2485,10 @@ class FileSegment(BaseFileSegment):
 class DeleteStatementSegment(BaseSegment):
     """A `DELETE` statement.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/delete-transact-sql?view=sql-server-ver15
-    Overriding ANSI to remove StartsWith logic which assumes statements have been delimited
-    and to allow for Azure Synapse Analytics-specific DELETE statements
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /delete-transact-sql?view=sql-server-ver15
+    Overriding ANSI to remove StartsWith logic which assumes statements have been
+    delimited and to allow for Azure Synapse Analytics-specific DELETE statements
     """
 
     type = "delete_statement"
@@ -2475,7 +2517,8 @@ class FromClauseSegment(BaseSegment):
     FROM a JOIN b, c JOIN d
     ```
 
-    Overriding ANSI to remove Delimited logic which assumes statements have been delimited
+    Overriding ANSI to remove Delimited logic which assumes statements have been
+    delimited
     """
 
     type = "from_clause"
@@ -2500,7 +2543,8 @@ class FromClauseSegment(BaseSegment):
 class GroupByClauseSegment(BaseSegment):
     """A `GROUP BY` clause like in `SELECT`.
 
-    Overriding ANSI to remove Delimited logic which assumes statements have been delimited
+    Overriding ANSI to remove Delimited logic which assumes statements have been
+    delimited
     """
 
     type = "groupby_clause"
@@ -2549,7 +2593,8 @@ class HavingClauseSegment(BaseSegment):
 class OrderByClauseSegment(BaseSegment):
     """A `ORDER BY` clause like in `SELECT`.
 
-    Overriding ANSI to remove StartsWith logic which assumes statements have been delimited
+    Overriding ANSI to remove StartsWith logic which assumes statements have been
+    delimited
     """
 
     type = "orderby_clause"
@@ -2590,7 +2635,8 @@ class OrderByClauseSegment(BaseSegment):
 class RenameStatementSegment(BaseSegment):
     """`RENAME` statement.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/rename-transact-sql?view=aps-pdw-2016-au7
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /rename-transact-sql?view=aps-pdw-2016-au7
     Azure Synapse Analytics-specific.
     """
 
@@ -2739,7 +2785,8 @@ class PrintStatementSegment(BaseSegment):
 class OptionClauseSegment(BaseSegment):
     """Query Hint clause.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-query?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/queries
+    /hints-transact-sql-query?view=sql-server-ver15
     """
 
     type = "option_clause"
@@ -2759,7 +2806,8 @@ class OptionClauseSegment(BaseSegment):
 class QueryHintSegment(BaseSegment):
     """Query Hint segment.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-query?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/queries
+    /hints-transact-sql-query?view=sql-server-ver15
     """
 
     type = "query_hint_segment"
@@ -2860,7 +2908,8 @@ class QueryHintSegment(BaseSegment):
 class PostTableExpressionGrammar(BaseSegment):
     """Table Hint clause.  Overloading the PostTableExpressionGrammar to implement.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-table?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/queries
+    /hints-transact-sql-table?view=sql-server-ver15
     """
 
     match_grammar = Sequence(
@@ -2879,7 +2928,8 @@ class PostTableExpressionGrammar(BaseSegment):
 class TableHintSegment(BaseSegment):
     """Table Hint segment.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-table?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/queries
+    /hints-transact-sql-table?view=sql-server-ver15
     """
 
     type = "query_hint_segment"
@@ -2989,7 +3039,8 @@ class ExecuteScriptSegment(BaseSegment):
     """`EXECUTE` statement.
 
     Matching segment name and type from exasol.
-    https://docs.microsoft.com/en-us/sql/t-sql/language-elements/execute-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/language-elements
+    /execute-transact-sql?view=sql-server-ver15
     """
 
     type = "execute_script_statement"
@@ -3029,10 +3080,12 @@ class CreateSchemaStatementSegment(BaseSegment):
     """A `CREATE SCHEMA` statement.
 
     Overriding ANSI to allow for AUTHORIZATION clause
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/create-schema-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /create-schema-transact-sql?view=sql-server-ver15
 
     Not yet implemented: proper schema_element parsing.
-    Once we have an AccessStatementSegment that works for TSQL, this definition should be tweaked to include schema elements.
+    Once we have an AccessStatementSegment that works for TSQL, this definition should
+    be tweaked to include schema elements.
     """
 
     type = "create_schema_statement"
@@ -3056,7 +3109,8 @@ class CreateSchemaStatementSegment(BaseSegment):
 class MergeStatementSegment(BaseSegment):
     """`MERGE` statement.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/statements/merge-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/statements
+    /merge-transact-sql?view=sql-server-ver15
     """
 
     type = "merge_statement"
@@ -3223,7 +3277,8 @@ class MergeInsertClauseSegment(BaseSegment):
 class OutputClauseSegment(BaseSegment):
     """OUTPUT Clause used within DELETE, INSERT, UPDATE, MERGE.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/queries/output-clause-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/queries
+    /output-clause-transact-sql?view=sql-server-ver15
     """
 
     type = "output_clause"
@@ -3263,7 +3318,8 @@ class OutputClauseSegment(BaseSegment):
 class ThrowStatementSegment(BaseSegment):
     """A THROW statement.
 
-    https://docs.microsoft.com/en-us/sql/t-sql/language-elements/throw-transact-sql?view=sql-server-ver15
+    https://docs.microsoft.com/en-us/sql/t-sql/language-elements
+    /throw-transact-sql?view=sql-server-ver15
     """
 
     type = "throw_statement"

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -278,7 +278,9 @@ UNRESERVED_KEYWORDS = [
     "KEEPDEFAULTS",
     "KEEPFIXED",
     "KEEPIDENTITY",
-    "LABEL",  # Azure Synapse Analytics specific, reserved keyword but could break TSQL parsing to add there
+    "LABEL",
+    # Azure Synapse Analytics specific, reserved keyword but could break TSQL parsing to
+    # add there
     "LANGUAGE",
     "LEVEL",
     "LOAD",  # listed as reserved but functionally unreserved

--- a/src/sqlfluff/rules/L003.py
+++ b/src/sqlfluff/rules/L003.py
@@ -60,7 +60,8 @@ class Rule_L003(BaseRule):
             base_unit = " " * tab_space_size
         else:
             raise ValueError(
-                f"Parameter indent_unit has unexpected value: `{indent_unit}`. Expected `tab` or `space`."
+                f"Parameter indent_unit has unexpected value: `{indent_unit}`. Expected"
+                " `tab` or `space`."
             )
         return base_unit * num
 
@@ -126,7 +127,9 @@ class Rule_L003(BaseRule):
                 # ended with an indent then we might be ok.
                 clean_indent = False
                 # Was there an indent after the last code element of the previous line?
-                for search_elem in reversed(result_buffer[line_no - 1]["line_buffer"]):  # type: ignore
+                for search_elem in reversed(
+                    result_buffer[line_no - 1]["line_buffer"]
+                ):  # type: ignore
                     if not search_elem.is_code and not search_elem.is_meta:
                         continue
                     elif search_elem.is_meta and search_elem.indent_val > 0:
@@ -323,7 +326,10 @@ class Rule_L003(BaseRule):
             if context.segment.is_type("whitespace"):
                 # it's whitespace, carry on
                 pass
-            elif context.segment.segments or (context.segment.is_meta and context.segment.indent_val != 0):  # type: ignore
+            elif context.segment.segments or (
+                context.segment.is_meta
+                and context.segment.indent_val != 0  # type: ignore
+            ):
                 # it's not a raw segment or placeholder. Carry on.
                 pass
             else:
@@ -422,7 +428,8 @@ class Rule_L003(BaseRule):
                     and last_code_line in memory["hanging_lines"]
                 )
             ) and (
-                # There MUST also be a non-zero indent. Otherwise we're just on the baseline.
+                # There MUST also be a non-zero indent. Otherwise we're just on the
+                # baseline.
                 this_line["indent_size"]
                 > 0
             ):
@@ -542,7 +549,8 @@ class Rule_L003(BaseRule):
 
             # Work out the difference in indent
             indent_diff = this_line["indent_balance"] - res[k]["indent_balance"]
-            # If we're comparing to a previous, more deeply indented line, then skip and keep looking.
+            # If we're comparing to a previous, more deeply indented line, then skip and
+            # keep looking.
             if indent_diff < 0:
                 continue
 
@@ -663,7 +671,8 @@ class Rule_L003(BaseRule):
                     # to where we need to be? NB: This should only be applied if this is
                     # a CLOSING bracket.
 
-                    # First work out if we have some closing brackets, and if so, how many.
+                    # First work out if we have some closing brackets, and if so, how
+                    # many.
                     b_idx = 0
                     b_num = 0
                     while True:
@@ -685,15 +694,14 @@ class Rule_L003(BaseRule):
                         # It does. This line is fine.
                         pass
                     else:
-                        # It doesn't. That means we *should* have an indent when compared to
-                        # this line and we DON'T.
+                        # It doesn't. That means we *should* have an indent when
+                        # compared to this line and we DON'T.
                         memory["problem_lines"].append(this_line_no)
                         return LintResult(
                             anchor=trigger_segment,
                             memory=memory,
-                            description="Indent expected and not found compared to line #{}".format(
-                                k
-                            ),
+                            description="Indent expected and not found compared to line"
+                            " #{}".format(k),
                             # Add in an extra bit of whitespace for the indent
                             fixes=[
                                 LintFix.create_before(

--- a/src/sqlfluff/rules/L004.py
+++ b/src/sqlfluff/rules/L004.py
@@ -42,7 +42,8 @@ class Rule_L004(BaseRule):
 
     config_keywords = ["indent_unit", "tab_space_size"]
 
-    # TODO fix indents after text: https://github.com/sqlfluff/sqlfluff/pull/590#issuecomment-739484190
+    # TODO fix indents after text:
+    # https://github.com/sqlfluff/sqlfluff/pull/590#issuecomment-739484190
     def _eval(self, context: RuleContext) -> LintResult:
         """Incorrect indentation found in file."""
         # Config type hints
@@ -87,13 +88,16 @@ class Rule_L004(BaseRule):
             elif not (
                 len(context.raw_stack) == 0 or context.raw_stack[-1].is_type("newline")
             ):
-                # give a helpful message if the wrong indent has been found and is not at the start of a newline
+                # give a helpful message if the wrong indent has been found and is not
+                # at the start of a newline
                 description += (
                     " The indent occurs after other text, so a manual fix is needed."
                 )
             else:
-                # If we get here, the indent_unit is tabs, and the number of spaces is not a multiple of tab_space_size
-                description += " The number of spaces is not a multiple of tab_space_size, so a manual fix is needed."
+                # If we get here, the indent_unit is tabs, and the number of spaces is
+                # not a multiple of tab_space_size
+                description += " The number of spaces is not a multiple of "
+                "tab_space_size, so a manual fix is needed."
             return LintResult(
                 anchor=context.segment, fixes=fixes, description=description
             )

--- a/src/sqlfluff/rules/L006.py
+++ b/src/sqlfluff/rules/L006.py
@@ -164,7 +164,8 @@ class Rule_L006(BaseRule):
                             ),
                             fixes=[
                                 LintFix.create_before(
-                                    # NB the anchor here is always in the parent and not anchor
+                                    # NB the anchor here is always in the parent and not
+                                    # anchor
                                     anchor_segment=sub_seg,
                                     edit_segments=[WhitespaceSegment(raw=" ")],
                                 )
@@ -190,7 +191,8 @@ class Rule_L006(BaseRule):
                             ),
                             fixes=[
                                 LintFix.create_before(
-                                    # NB the anchor here is always in the parent and not anchor
+                                    # NB the anchor here is always in the parent and not
+                                    # anchor
                                     anchor_segment=next_seg,
                                     edit_segments=[WhitespaceSegment(raw=" ")],
                                 )

--- a/src/sqlfluff/rules/L007.py
+++ b/src/sqlfluff/rules/L007.py
@@ -69,7 +69,8 @@ class Rule_L007(BaseRule):
                 if context.segment.is_type("binary_operator", "comparison_operator"):
                     # If it's an operator, then check if in "before" mode
                     if self.operator_new_lines == "before":  # type: ignore
-                        # If we're in "before" mode, then check if newline since last code
+                        # If we're in "before" mode, then check if newline since last
+                        # code
                         for s in memory["since_code"]:
                             if s.name == "newline":
                                 # Had a newline - so mark this operator as a fail

--- a/src/sqlfluff/rules/L008.py
+++ b/src/sqlfluff/rules/L008.py
@@ -73,7 +73,10 @@ class Rule_L008(BaseRule):
             return subsequent_whitespace, None
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
-        """Commas should be followed by a single whitespace unless followed by a comment."""
+        """Commas should be followed by a single whitespace unless followed by a # noqa: D415
+
+        comment.
+        """
         # We only care about commas.
         if context.segment.name != "comma":
             return None

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -14,7 +14,8 @@ class Rule_L009(BaseRule):
     """Files must end with a single trailing newline.
 
     | **Anti-pattern**
-    | The content in file does not end with a single trailing newline, the $ represents end of file.
+    | The content in file does not end with a single trailing newline, the $ represents
+    | end of file.
 
     .. code-block:: sql
        :force:
@@ -23,7 +24,8 @@ class Rule_L009(BaseRule):
             a
         FROM foo$
 
-        -- Ending on an indented line means there is no newline at the end of the file, the • represents space.
+        -- Ending on an indented line means there is no newline at the end of the file,
+        -- the • represents space.
 
         SELECT
         ••••a

--- a/src/sqlfluff/rules/L010.py
+++ b/src/sqlfluff/rules/L010.py
@@ -101,7 +101,8 @@ class Rule_L010(BaseRule):
         if cap_policy == "consistent":
             possible_cases = [c for c in cap_policy_opts if c not in refuted_cases]
             self.logger.debug(
-                f"Possible cases after segment '{context.segment.raw}': {possible_cases}"
+                f"Possible cases after segment '{context.segment.raw}': "
+                "{possible_cases}"
             )
             if possible_cases:
                 # Save the latest possible case and skip
@@ -154,8 +155,8 @@ class Rule_L010(BaseRule):
         if fixed_raw == context.segment.raw:
             # No need to fix
             self.logger.debug(
-                f"Capitalisation of segment '{context.segment.raw}' already OK with policy "
-                f"'{concrete_policy}', returning with memory {memory}"
+                f"Capitalisation of segment '{context.segment.raw}' already OK with "
+                f"policy '{concrete_policy}', returning with memory {memory}"
             )
             return LintResult(memory=memory)
         else:
@@ -171,8 +172,8 @@ class Rule_L010(BaseRule):
 
             # Return the fixed segment
             self.logger.debug(
-                f"INCONSISTENT Capitalisation of segment '{context.segment.raw}', fixing to "
-                f"'{fixed_raw}' and returning with memory {memory}"
+                f"INCONSISTENT Capitalisation of segment '{context.segment.raw}', "
+                f"fixing to '{fixed_raw}' and returning with memory {memory}"
             )
 
             return LintResult(

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -64,14 +64,17 @@ class Rule_L016(Rule_L003):
                 self.indent_impulse: int = indent_impulse or 0
 
             def __repr__(self):
-                return "<Section @ {pos}: {role} [{indent_balance}:{indent_impulse}]. {segments!r}>".format(
-                    role=self.role,
-                    indent_balance=self.indent_balance,
-                    indent_impulse=self.indent_impulse,
-                    segments="".join(elem.raw for elem in self.segments),
-                    pos=self.segments[0].get_start_point_marker()
-                    if self.segments
-                    else "",
+                return (
+                    "<Section @ {pos}: {role} [{indent_balance}:{indent_impulse}]. "
+                    "{segments!r}>".format(
+                        role=self.role,
+                        indent_balance=self.indent_balance,
+                        indent_impulse=self.indent_impulse,
+                        segments="".join(elem.raw for elem in self.segments),
+                        pos=self.segments[0].get_start_point_marker()
+                        if self.segments
+                        else "",
+                    )
                 )
 
             @property
@@ -527,7 +530,8 @@ class Rule_L016(Rule_L003):
                     # triggers an endless cycle of "fixes" that simply keeps
                     # adding blank lines.
                     self.logger.info(
-                        "Unfixable inline comment, too long even on a line by itself: %s",
+                        "Unfixable inline comment, too long even on a line by itself: "
+                        "%s",
                         this_line[-1],
                     )
                     if self.ignore_comment_lines:

--- a/src/sqlfluff/rules/L019.py
+++ b/src/sqlfluff/rules/L019.py
@@ -58,7 +58,8 @@ class Rule_L019(BaseRule):
     def _last_comment_seg(raw_stack):
         """Trace the raw stack back to the most recent comment segment.
 
-        A return value of `None` indicates no code segments preceding the current position.
+        A return value of `None` indicates no code segments preceding the current
+        position.
         """
         for segment in raw_stack[::-1]:
             if segment.is_comment:
@@ -69,7 +70,8 @@ class Rule_L019(BaseRule):
     def _last_code_seg(raw_stack: Tuple[RawSegment, ...]) -> Optional[RawSegment]:
         """Trace the raw stack back to the most recent code segment.
 
-        A return value of `None` indicates no code segments preceding the current position.
+        A return value of `None` indicates no code segments preceding the current
+        position.
         """
         for segment in raw_stack[::-1]:
             if segment.is_code or segment.is_type("newline"):

--- a/src/sqlfluff/rules/L020.py
+++ b/src/sqlfluff/rules/L020.py
@@ -22,7 +22,8 @@ class Rule_L020(BaseRule):
             t.b
         FROM foo AS t, bar AS t
 
-        -- this can also happen when using schemas where the implicit alias is the table name:
+        -- this can also happen when using schemas where the implicit alias is the table
+        -- name:
 
         SELECT
             a,
@@ -41,7 +42,8 @@ class Rule_L020(BaseRule):
             b.b
         FROM foo AS f, bar AS b
 
-        -- Also use explicit alias's when referencing two tables with same name from two different schemas
+        -- Also use explicit alias's when referencing two tables with same name from two
+        -- different schemas
 
         SELECT
             f1.a,

--- a/src/sqlfluff/rules/L022.py
+++ b/src/sqlfluff/rules/L022.py
@@ -54,7 +54,8 @@ class Rule_L022(BaseRule):
             )
             for idx, seg in enumerate(expanded_segments):
                 if seg.is_type("bracketed"):
-                    # Check if the preceding keyword is AS, otherwise it's a column name definition in the CTE.
+                    # Check if the preceding keyword is AS, otherwise it's a column name
+                    # definition in the CTE.
                     preceding_keyword = next(
                         (
                             s
@@ -126,7 +127,8 @@ class Rule_L022(BaseRule):
 
                 # Readout of findings
                 self.logger.info(
-                    "blank_lines: %s, comma_line_idx: %s. final_line_idx: %s, final_seg_idx: %s",
+                    "blank_lines: %s, comma_line_idx: %s. final_line_idx: %s, "
+                    "final_seg_idx: %s",
                     blank_lines,
                     comma_line_idx,
                     line_idx,
@@ -147,7 +149,8 @@ class Rule_L022(BaseRule):
                     # to correct the issue.
                     fix_type = "create_before"  # In most cases we just insert newlines.
                     if comma_style == "oneline":
-                        # Here we respect the target comma style to insert at the relevant point.
+                        # Here we respect the target comma style to insert at the
+                        # relevant point.
                         if self.comma_style == "trailing":
                             # Add a blank line after the comma
                             fix_point = forward_slice[comma_seg_idx + 1]
@@ -167,14 +170,15 @@ class Rule_L022(BaseRule):
                         if not comment_lines or line_idx - 1 not in comment_lines:
                             self.logger.info("Comment routines not applicable")
                             if comma_style in ("trailing", "final", "floating"):
-                                # Detected an existing trailing comma or it's a final CTE,
-                                # OR the comma isn't leading or trailing.
+                                # Detected an existing trailing comma or it's a final
+                                # CTE, OR the comma isn't leading or trailing.
                                 # If the preceding segment is whitespace, replace it
                                 if forward_slice[seg_idx - 1].is_type("whitespace"):
                                     fix_point = forward_slice[seg_idx - 1]
                                     fix_type = "replace"
                                 else:
-                                    # Otherwise add a single newline before the end content.
+                                    # Otherwise add a single newline before the end
+                                    # content.
                                     fix_point = forward_slice[seg_idx]
                             elif comma_style == "leading":
                                 # Detected an existing leading comma.

--- a/src/sqlfluff/rules/L023.py
+++ b/src/sqlfluff/rules/L023.py
@@ -45,7 +45,10 @@ class Rule_L023(BaseRule):
     expand_children: Optional[List[str]] = ["common_table_expression"]
 
     def _eval(self, context: RuleContext) -> Optional[List[LintResult]]:
-        """Single whitespace expected in mother segment between pre and post segments."""
+        """Single whitespace expected in mother segment between pre and post # noqa: D415
+
+        segments.
+        """
         error_buffer: List[LintResult] = []
         if context.segment.is_type(self.expected_mother_segment_type):
             last_code = None

--- a/src/sqlfluff/rules/L025.py
+++ b/src/sqlfluff/rules/L025.py
@@ -50,7 +50,8 @@ class Rule_L025(Rule_L020):
         """Check all aliased references against tables referenced in the query."""
         # A buffer to keep any violations.
         violation_buff = []
-        # Check all the references that we have, keep track of which aliases we refer to.
+        # Check all the references that we have, keep track of which aliases we refer
+        # to.
         tbl_refs = set()
         for r in references:
             tbl_refs.update(
@@ -78,9 +79,8 @@ class Rule_L025(Rule_L020):
                 violation_buff.append(
                     LintResult(
                         anchor=alias.segment,
-                        description="Alias {!r} is never used in SELECT statement.".format(
-                            alias.ref_str
-                        ),
+                        description="Alias {!r} is never used in SELECT "
+                        "statement.".format(alias.ref_str),
                         fixes=fixes,
                     )
                 )

--- a/src/sqlfluff/rules/L028.py
+++ b/src/sqlfluff/rules/L028.py
@@ -63,7 +63,8 @@ class Rule_L028(Rule_L025):
         # Check all the references that we have.
         seen_ref_types = set()
         for ref in references:
-            # We skip any unqualified wildcard references (i.e. *). They shouldn't count.
+            # We skip any unqualified wildcard references (i.e. *). They shouldn't
+            # count.
             if not ref.is_qualified() and ref.is_type("wildcard_identifier"):
                 continue
             # Oddball case: Column aliases provided via function calls in by
@@ -93,9 +94,8 @@ class Rule_L028(Rule_L025):
                 violation_buff.append(
                     LintResult(
                         anchor=ref,
-                        description="{} reference {!r} found in single table select.".format(
-                            this_ref_type.capitalize(), ref.raw
-                        ),
+                        description="{} reference {!r} found in single table "
+                        "select.".format(this_ref_type.capitalize(), ref.raw),
                     )
                 )
             seen_ref_types.add(this_ref_type)

--- a/src/sqlfluff/rules/L029.py
+++ b/src/sqlfluff/rules/L029.py
@@ -38,7 +38,8 @@ class Rule_L029(BaseRule):
             (
                 context.segment.name == "naked_identifier"
                 and identifiers_policy_applicable(
-                    self.unquoted_identifiers_policy, context.parent_stack  # type: ignore
+                    self.unquoted_identifiers_policy,  # type: ignore
+                    context.parent_stack,
                 )
                 and (
                     context.segment.raw.upper()

--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -23,7 +23,8 @@ class Rule_L031(BaseRule):
     """Avoid table aliases in from clauses and join conditions.
 
     | **Anti-pattern**
-    | In this example, alias ``o`` is used for the orders table, and ``c`` is used for 'customers' table.
+    | In this example, alias ``o`` is used for the orders table, and ``c`` is used for
+    | 'customers' table.
 
     .. code-block:: sql
 
@@ -52,15 +53,16 @@ class Rule_L031(BaseRule):
             table_alias.b,
         FROM
             table
-            LEFT JOIN table AS table_alias ON table.foreign_key = table_alias.foreign_key
+            LEFT JOIN table AS table_alias ON
+                table.foreign_key = table_alias.foreign_key
 
     """
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Identify aliases in from clause and join conditions.
 
-        Find base table, table expressions in join, and other expressions in select clause
-        and decide if it's needed to report them.
+        Find base table, table expressions in join, and other expressions in select
+        clause and decide if it's needed to report them.
         """
         if context.segment.is_type("select_statement"):
             children = context.functional.segment.children()
@@ -184,7 +186,8 @@ class Rule_L031(BaseRule):
             # Find all references to alias in column references
             for exp_ref in column_reference_segments:
                 used_alias_ref = exp_ref.get_child("identifier")
-                # exp_ref.get_child('dot') ensures that the column reference includes a table reference
+                # exp_ref.get_child('dot') ensures that the column reference includes a
+                # table reference
                 if (
                     used_alias_ref
                     and used_alias_ref.raw == alias_name

--- a/src/sqlfluff/rules/L033.py
+++ b/src/sqlfluff/rules/L033.py
@@ -22,8 +22,8 @@ class Rule_L033(BaseRule):
         SELECT a, b FROM table_1 UNION SELECT a, b FROM table_2
 
     | **Best practice**
-    | Specify ``DISTINCT`` or ``ALL`` after ``UNION``. (Note that ``DISTINCT`` is the default
-    | behavior.
+    | Specify ``DISTINCT`` or ``ALL`` after ``UNION``. (Note that ``DISTINCT`` is the
+    | default behavior.
 
     .. code-block:: sql
 

--- a/src/sqlfluff/rules/L034.py
+++ b/src/sqlfluff/rules/L034.py
@@ -8,7 +8,9 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 @document_fix_compatible
 class Rule_L034(BaseRule):
-    """Use wildcards then simple targets before calculations and aggregates in select statements.
+    """Use wildcards then simple targets before calculations and aggregates in # noqa: D415
+
+    select statements.
 
     | **Anti-pattern**
 
@@ -62,9 +64,14 @@ class Rule_L034(BaseRule):
             ),
         )
 
-        # Track which bands have been seen, with additional empty list for the non-matching elements
-        # If we find a matching target element, we append the element to the corresponding index
-        self.seen_band_elements: List[List[BaseSegment]] = [[] for _ in select_element_order_preference] + [[]]  # type: ignore
+        # Track which bands have been seen, with additional empty list for the
+        # non-matching elements. If we find a matching target element, we append the
+        # element to the corresponding index.
+        self.seen_band_elements: List[List[BaseSegment]] = [
+            [] for _ in select_element_order_preference
+        ] + [
+            []
+        ]  # type: ignore
 
         if context.segment.is_type("select_clause"):
             # Ignore select clauses which belong to:
@@ -92,7 +99,8 @@ class Rule_L034(BaseRule):
 
             # Iterate through all the select targets to find any order violations
             for segment in select_target_elements:
-                # The band index of the current segment in select_element_order_preference
+                # The band index of the current segment in
+                # select_element_order_preference
                 self.current_element_band = None
 
                 # Compare the segment to the bands in select_element_order_preference
@@ -136,14 +144,16 @@ class Rule_L034(BaseRule):
                                 # If the segment doesn't match
                                 pass
 
-                # If the target doesn't exist in select_element_order_preference then it is 'complex' and must go last
+                # If the target doesn't exist in select_element_order_preference then it
+                # is 'complex' and must go last
                 if self.current_element_band is None:
                     self.seen_band_elements[-1].append(segment)
 
             if self.violation_exists:
                 # Create a list of all the edit fixes
-                # We have to do this at the end of iterating through all the select_target_elements to get the order correct
-                # This means we can't add a lint fix to each individual LintResult as we go
+                # We have to do this at the end of iterating through all the
+                # select_target_elements to get the order correct. This means we can't
+                # add a lint fix to each individual LintResult as we go
                 ordered_select_target_elements = [
                     segment for band in self.seen_band_elements for segment in band
                 ]
@@ -159,7 +169,7 @@ class Rule_L034(BaseRule):
                         initial_select_target_element,
                         [replace_select_target_element],
                     )
-                    for initial_select_target_element, replace_select_target_element in zip(
+                    for initial_select_target_element, replace_select_target_element in zip(  # noqa: E501
                         select_target_elements, ordered_select_target_elements
                     )
                     if initial_select_target_element

--- a/src/sqlfluff/rules/L036.py
+++ b/src/sqlfluff/rules/L036.py
@@ -327,8 +327,8 @@ class Rule_L036(BaseRule):
                 fixes=fixes,
             )
 
-        # If we have a wildcard on the same line as the FROM keyword, but not the same line
-        # as the SELECT keyword, we need to move the FROM keyword to its own line.
+        # If we have a wildcard on the same line as the FROM keyword, but not the same
+        # line as the SELECT keyword, we need to move the FROM keyword to its own line.
         # i.e.
         # SELECT
         #   * FROM foo

--- a/src/sqlfluff/rules/L037.py
+++ b/src/sqlfluff/rules/L037.py
@@ -112,8 +112,8 @@ class Rule_L037(BaseRule):
                     anchor=context.segment,
                     fixes=lint_fixes,
                     description=(
-                        "Ambiguous order by clause. Order by "
-                        "clauses should specify order direction for ALL columns or NO columns."
+                        "Ambiguous order by clause. Order by clauses should specify "
+                        "order direction for ALL columns or NO columns."
                     ),
                 )
             ]

--- a/src/sqlfluff/rules/L039.py
+++ b/src/sqlfluff/rules/L039.py
@@ -68,9 +68,11 @@ class Rule_L039(BaseRule):
                 prev_whitespace = None
 
             if seg.is_type("object_reference"):
-                # This variable is a workaround to avoid removing new indents added at the beginning of a segment by L003.
-                # See Github issue #1304: https://github.com/sqlfluff/sqlfluff/issues/1304
-                # It represents the question: are we parsing through leading whitespace in this loop?
+                # This variable is a workaround to avoid removing new indents added at
+                # the beginning of a segment by L003. See Github issue #1304:
+                # https://github.com/sqlfluff/sqlfluff/issues/1304
+                # It represents the question: are we parsing through leading whitespace
+                # in this loop?
                 leading_whitespace = True
                 for child_seg in seg.get_raw_segments():
                     if child_seg.is_whitespace:

--- a/src/sqlfluff/rules/L040.py
+++ b/src/sqlfluff/rules/L040.py
@@ -17,7 +17,8 @@ class Rule_L040(Rule_L010):
     The functionality for this rule is inherited from :obj:`Rule_L010`.
 
     | **Anti-pattern**
-    | In this example, 'null' and 'false' are in lower-case whereas 'TRUE' is in upper-case.
+    | In this example, 'null' and 'false' are in lower-case whereas 'TRUE' is in
+    | upper-case.
 
     .. code-block:: sql
 

--- a/src/sqlfluff/rules/L041.py
+++ b/src/sqlfluff/rules/L041.py
@@ -9,7 +9,9 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible
 
 @document_fix_compatible
 class Rule_L041(BaseRule):
-    """``SELECT`` clause modifiers such as ``DISTINCT`` must be on the same line as ``SELECT``.
+    """``SELECT`` clause modifiers such as ``DISTINCT`` must be on the same # noqa: D415
+
+    line as ``SELECT``.
 
     | **Anti-pattern**
 

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -84,6 +84,7 @@ class Rule_L042(BaseRule):
                 if seg:
                     return LintResult(
                         anchor=seg[0],
-                        description=f"{parent_type} clauses should not contain subqueries. Use CTEs instead",
+                        description=f"{parent_type} clauses should not contain "
+                        "subqueries. Use CTEs instead",
                     )
         return None

--- a/src/sqlfluff/rules/L043.py
+++ b/src/sqlfluff/rules/L043.py
@@ -162,7 +162,8 @@ class Rule_L043(BaseRule):
 
             coalesce_arg_2: BaseSegment
 
-            # Method 1: Check if THEN/ELSE expressions are both Boolean and can therefore be reduced.
+            # Method 1: Check if THEN/ELSE expressions are both Boolean and can
+            # therefore be reduced.
             upper_bools = ["TRUE", "FALSE"]
             if (
                 (then_expression.expression.raw_upper in upper_bools)
@@ -188,9 +189,10 @@ class Rule_L043(BaseRule):
                     fixes=fixes,
                 )
 
-            # Method 2: Check if the condition expression is comparing a column reference to NULL
-            # and whether that column reference is also in either the THEN/ELSE expression.
-            # We can only apply this method when there is only one condition in the condition expression.
+            # Method 2: Check if the condition expression is comparing a column
+            # reference to NULL and whether that column reference is also in either the
+            # THEN/ELSE expression. We can only apply this method when there is only one
+            # condition in the condition expression.
             condition_expression_segments_raw = {
                 segment.raw_upper
                 for segment in condition_expression.expression.segments
@@ -208,11 +210,12 @@ class Rule_L043(BaseRule):
                     .get()
                 )
 
-                # Return None if none found (this condition does not apply to functions).
+                # Return None if none found (this condition does not apply to functions)
                 if not column_reference_segment:
                     return None
 
-                # Check if we can reduce the CASE expression to a single coalesce function.
+                # Check if we can reduce the CASE expression to a single coalesce
+                # function.
                 if (
                     not is_not_prefix
                     and column_reference_segment.raw_upper

--- a/src/sqlfluff/rules/L044.py
+++ b/src/sqlfluff/rules/L044.py
@@ -89,7 +89,8 @@ class Rule_L044(BaseRule):
                 if wildcard.tables:
                     for wildcard_table in wildcard.tables:
                         self.logger.debug(
-                            f"Wildcard: {wildcard.segment.raw} has target {wildcard_table}"
+                            f"Wildcard: {wildcard.segment.raw} has target "
+                            "{wildcard_table}"
                         )
                         # Is it an alias?
                         alias_info = selectable.find_alias(wildcard_table)
@@ -107,7 +108,8 @@ class Rule_L044(BaseRule):
                                 # Not CTE, not table alias. Presumably an
                                 # external table. Warn.
                                 self.logger.debug(
-                                    f"Query target {wildcard_table} is external. Generating warning."
+                                    f"Query target {wildcard_table} is external. "
+                                    "Generating warning."
                                 )
                                 raise RuleFailure(selectable.selectable)
                 else:
@@ -121,7 +123,8 @@ class Rule_L044(BaseRule):
                             self._analyze_result_columns(o)
                             return
                     self.logger.debug(
-                        f'Query target "{query.selectables[0].selectable.raw}" has no targets. Generating warning.'
+                        f'Query target "{query.selectables[0].selectable.raw}" has no '
+                        "targets. Generating warning."
                     )
                     raise RuleFailure(query.selectables[0].selectable)
 

--- a/src/sqlfluff/rules/L050.py
+++ b/src/sqlfluff/rules/L050.py
@@ -89,11 +89,11 @@ class Rule_L050(BaseRule):
             and not raw_stack.all(sp.is_meta())
             # Found leaf of parse tree.
             and not segment.all(sp.is_expandable())
-            # It is possible that a template segment (e.g. {{ config(materialized='view') }})
-            # renders to an empty string and as such is omitted from the parsed tree.
-            # We therefore should flag if a templated raw slice intersects with the
-            # source slices in the raw stack and skip this rule to avoid risking
-            # collisions with template objects.
+            # It is possible that a template segment (e.g.
+            # {{ config(materialized='view') }}) renders to an empty string and as such
+            # is omitted from the parsed tree. We therefore should flag if a templated
+            # raw slice intersects with the source slices in the raw stack and skip this
+            # rule to avoid risking collisions with template objects.
             and not raw_stack.raw_slices.any(rsp.is_slice_type("templated"))
         ):
             return LintResult(

--- a/src/sqlfluff/rules/L052.py
+++ b/src/sqlfluff/rules/L052.py
@@ -19,7 +19,8 @@ class Rule_L052(BaseRule):
     """Statements must end with a semi-colon.
 
     | **Anti-pattern**
-    | A statement is not immediately terminated with a semi-colon, the • represents space.
+    | A statement is not immediately terminated with a semi-colon, the • represents
+    | space.
 
     .. code-block:: sql
        :force:
@@ -49,12 +50,15 @@ class Rule_L052(BaseRule):
 
     @staticmethod
     def _handle_preceding_inline_comments(pre_semicolon_segments, anchor_segment):
-        """Adjust pre_semicolon_segments and anchor_segment to not move preceding inline comments.
+        """Adjust pre_semicolon_segments and anchor_segment to not move # noqa: D415
+
+        preceding inline comments.
 
         We don't want to move inline comments that are on the same line
         as the preceding code segment as they could contain noqa instructions.
         """
-        # See if we have a preceding inline comment on the same line as the preceding segment.
+        # See if we have a preceding inline comment on the same line as the preceding
+        # segment.
         same_line_comment = next(
             (
                 s
@@ -83,7 +87,8 @@ class Rule_L052(BaseRule):
         We don't want to move inline comments that are on the same line
         as the preceding code segment as they could contain noqa instructions.
         """
-        # See if we have a trailing inline comment on the same line as the preceding segment.
+        # See if we have a trailing inline comment on the same line as the preceding
+        # segment.
         for parent_segment in context.parent_stack[::-1]:
             for comment_segment in parent_segment.recursive_crawl("comment"):
                 if (
@@ -107,11 +112,13 @@ class Rule_L052(BaseRule):
             None,
         )
         if statement_segment is None:  # pragma: no cover
-            # If we can't find a parent statement segment then don't try anything special.
+            # If we can't find a parent statement segment then don't try anything
+            # special.
             return False
 
         if not any(statement_segment.recursive_crawl("newline")):
-            # Statement segment has no newlines therefore starts and ends on the same line.
+            # Statement segment has no newlines therefore starts and ends on the same
+            # line.
             return True
 
         return False
@@ -172,8 +179,9 @@ class Rule_L052(BaseRule):
                     )
             # Semi-colon on new line.
             else:
-                # Adjust pre_semicolon_segments and anchor_segment for preceding inline comments.
-                # Inline comments can contain noqa logic so we need to add the newline after the inline comment.
+                # Adjust pre_semicolon_segments and anchor_segment for preceding inline
+                # comments. Inline comments can contain noqa logic so we need to add the
+                # newline after the inline comment.
                 (
                     pre_semicolon_segments,
                     anchor_segment,
@@ -189,7 +197,8 @@ class Rule_L052(BaseRule):
                     # semi-colon/preceding whitespace and then insert the
                     # semi-colon in the correct location.
 
-                    # This handles an edge case in which an inline comment comes after the semi-colon.
+                    # This handles an edge case in which an inline comment comes after
+                    # the semi-colon.
                     anchor_segment = self._handle_trailing_inline_comments(
                         context, anchor_segment
                     )
@@ -258,7 +267,8 @@ class Rule_L052(BaseRule):
                     ]
                 # Semi-colon on new line.
                 else:
-                    # Adjust pre_semicolon_segments and anchor_segment for inline comments.
+                    # Adjust pre_semicolon_segments and anchor_segment for inline
+                    # comments.
                     (
                         pre_semicolon_segments,
                         anchor_segment,

--- a/src/sqlfluff/rules/L054.py
+++ b/src/sqlfluff/rules/L054.py
@@ -8,7 +8,8 @@ class Rule_L054(BaseRule):
     """Inconsistent column references in ``GROUP BY/ORDER BY`` clauses.
 
     | **Anti-pattern**
-    | A mix of implicit and explicit column references are used in a ``GROUP BY`` clause.
+    | A mix of implicit and explicit column references are used in a ``GROUP BY``
+    | clause.
 
     .. code-block:: sql
        :force:
@@ -83,8 +84,10 @@ class Rule_L054(BaseRule):
         if not context.segment.is_type("groupby_clause", "orderby_clause"):
             return None
 
-        # Look at child segments and map column references to either the implict or explicit category.
-        # N.B. segment names are used as the numeric literal type is 'raw', so best to be specific with the name.
+        # Look at child segments and map column references to either the implict or
+        # explicit category.
+        # N.B. segment names are used as the numeric literal type is 'raw', so best to
+        # be specific with the name.
         column_reference_category_map = {
             "ColumnReferenceSegment": "explicit",
             "ExpressionSegment": "explicit",
@@ -104,7 +107,8 @@ class Rule_L054(BaseRule):
             # If consistent naming then raise lint error if either:
 
             if len(column_reference_category_set) > 1:
-                # 1. Both implicit and explicit column references are found in the same clause.
+                # 1. Both implicit and explicit column references are found in the same
+                # clause.
                 return LintResult(
                     anchor=context.segment,
                     memory=context.memory,

--- a/src/sqlfluff/rules/L056.py
+++ b/src/sqlfluff/rules/L056.py
@@ -72,7 +72,8 @@ class Rule_L056(BaseRule):
             "s".lstrip
             return LintResult(
                 procedure_segment,
-                description="'SP_' prefix should not be used for user-defined stored procedures.",
+                description="'SP_' prefix should not be used for user-defined stored "
+                "procedures.",
             )
 
         return None

--- a/test/api/simple_test.py
+++ b/test/api/simple_test.py
@@ -18,7 +18,8 @@ lint_result = [
     },
     {
         "code": "L036",
-        "description": "Select targets should be on a new line unless there is only one select target.",
+        "description": "Select targets should be on a new line unless there is only "
+        "one select target.",
         "line_no": 1,
         "line_pos": 1,
     },

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -73,8 +73,8 @@ def test__cli__command_directed():
     check_b = "Indentation"
     assert check_a in result.output
     assert check_b in result.output
-    # Finally check the WHOLE output to make sure that unexpected newlines are not added.
-    # The replace command just accounts for cross platform testing.
+    # Finally check the WHOLE output to make sure that unexpected newlines are not
+    # added. The replace command just accounts for cross platform testing.
     assert result.output.replace("\\", "/").startswith(expected_output)
 
 
@@ -113,7 +113,10 @@ def test__cli__command_dialect_legacy():
 
 
 def test__cli__command_extra_config_fail():
-    """Check the script raises the right exception on a non-existant extra config path."""
+    """Check the script raises the right exception on a # noqa: D415
+
+    non-existant extra config path.
+    """
     result = invoke_assert_code(
         ret_code=66,
         args=[
@@ -126,8 +129,8 @@ def test__cli__command_extra_config_fail():
         ],
     )
     assert (
-        "Extra config 'test/fixtures/cli/extra_configs/.sqlfluffsdfdfdfsfd' does not exist."
-        in result.stdout
+        "Extra config 'test/fixtures/cli/extra_configs/.sqlfluffsdfdfdfsfd' does not "
+        "exist." in result.stdout
     )
 
 
@@ -301,7 +304,8 @@ def test__cli__command_lint_parse(command):
 @pytest.mark.parametrize(
     "command, ret_code",
     [
-        # Check the script doesn't raise an unexpected exception with badly formed files.
+        # Check the script doesn't raise an unexpected exception with badly formed
+        # files.
         (
             (
                 fix,
@@ -346,7 +350,10 @@ def test__cli__command_lint_parse_with_retcode(command, ret_code):
 
 
 def test__cli__command_lint_warning_explicit_file_ignored():
-    """Check ignoring file works when passed explicitly and ignore file is in the same directory."""
+    """Check ignoring file works when passed explicitly and ignore # noqa: D415
+
+    file is in the same directory.
+    """
     runner = CliRunner()
     result = runner.invoke(
         lint, ["test/fixtures/linter/sqlfluffignore/path_b/query_c.sql"]
@@ -521,10 +528,13 @@ def test__cli__command__fix(rule, fname):
         # L031 fix aliases in joins
         (
             "SELECT u.id, c.first_name, c.last_name, COUNT(o.user_id) "
-            "FROM users as u JOIN customers as c on u.id = c.user_id JOIN orders as o on u.id = o.user_id;",
+            "FROM users as u JOIN customers as c on u.id = c.user_id JOIN orders as o "
+            "on u.id = o.user_id;",
             "L031",
-            "SELECT users.id, customers.first_name, customers.last_name, COUNT(orders.user_id) "
-            "FROM users JOIN customers on users.id = customers.user_id JOIN orders on users.id = orders.user_id;",
+            "SELECT users.id, customers.first_name, customers.last_name, "
+            "COUNT(orders.user_id) "
+            "FROM users JOIN customers on users.id = customers.user_id JOIN orders on "
+            "users.id = orders.user_id;",
         ),
     ],
 )
@@ -770,8 +780,8 @@ def test__cli__command_lint_serialize_github_annotation():
                 "test/fixtures/linter/identifier_capitalisation.sql"
             ),
             "line": 2,
-            "message": "L027: Unqualified reference 'foo' found in select with more than "
-            "one referenced table/view.",
+            "message": "L027: Unqualified reference 'foo' found in select with more "
+            "than one referenced table/view.",
             "start_column": 5,
             "end_column": 5,
             "title": "SQLFluff",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -55,7 +55,8 @@ def get_parse_fixtures(fail_on_missing_yml=False):
                 if not has_yml and fail_on_missing_yml:
                     raise (
                         Exception(
-                            f"Missing .yml file for {os.path.join(d, f)}. Run the test/generate_parse_fixture_yml.py script!"
+                            f"Missing .yml file for {os.path.join(d, f)}. Run the "
+                            "test/generate_parse_fixture_yml.py script!"
                         )
                     )
     return parse_success_examples, parse_structure_examples

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -76,7 +76,10 @@ def test__config__load_file_f():
 
 
 def test__config__load_nested():
-    """Test nested overwrite and order of precedence of config files in the same directory."""
+    """Test nested overwrite and order of precedence of config files # noqa: D415
+
+    in the same directory.
+    """
     c = ConfigLoader()
     cfg = c.load_config_up_to_path(
         os.path.join(

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -261,7 +261,10 @@ def test_lint_path_parallel_wrapper_exception(patched_lint):
 def test__linter__linting_unexpected_error_handled_gracefully(
     patched_lint, patched_logger
 ):
-    """Test that an unexpected internal error is handled gracefully and returns the issue-surfacing file."""
+    """Test that an unexpected internal error is handled gracefully and # noqa: D415
+
+    returns the issue-surfacing file.
+    """
     patched_lint.side_effect = Exception("Something unexpected happened")
     lntr = Linter()
     lntr.lint_paths(("test/fixtures/linter/passing.sql",))
@@ -423,7 +426,10 @@ def test_parse_noqa(input, expected):
 
 
 def test_parse_noqa_no_dups():
-    """Test overlapping glob expansions don't return duplicate rules in NoQaDirective."""
+    """Test overlapping glob expansions don't return duplicate rules # noqa: D415
+
+    in NoQaDirective.
+    """
     result = Linter.parse_noqa(
         comment="noqa:L0*5,L01*", line_no=0, rule_codes=dummy_rule_codes
     )
@@ -691,17 +697,19 @@ def test_linter_noqa_with_templating():
             }
         )
     )
-    sql = """
-    {%- set a_var = ["1", "2"] -%}
-    SELECT
-      this_is_just_a_very_long_line_for_demonstration_purposes_of_a_bug_involving_templated_sql_files, --noqa: L016
-      this_is_not_so_big a, --Inline comment --noqa: L012
-      this_is_not_so_big b, /* Block comment */ --noqa: L012
-      this_is_not_so_big c, # hash comment --noqa: L012
-      this_is_just_a_very_long_line_for_demonstration_purposes_of_a_bug_involving_templated_sql_files, --noqa: L01*
-    FROM
-      a_table
-        """
+    sql = "\n"
+    '"{%- set a_var = ["1", "2"] -%}\n'
+    "SELECT\n"
+    "  this_is_just_a_very_long_line_for_demonstration_purposes_of_a_bug_involving_"
+    "templated_sql_files, --noqa: L016\n"
+    "  this_is_not_so_big a, --Inline comment --noqa: L012\n"
+    "  this_is_not_so_big b, /* Block comment */ --noqa: L012\n"
+    "  this_is_not_so_big c, # hash comment --noqa: L012\n"
+    "  this_is_just_a_very_long_line_for_demonstration_purposes_of_a_bug_involving_"
+    "templated_sql_files, --noqa: L01*\n"
+    "FROM\n"
+    "  a_table\n"
+    "    "
     result = lntr.lint_string(sql)
     assert not result.get_violations()
 
@@ -788,7 +796,10 @@ def test_delayed_exception():
 
 
 def test__attempt_to_change_templater_warning(caplog):
-    """Test warning if user tries to change templater in .sqlfluff file in subdirectory."""
+    """Test warning if user tries to change templater in .sqlfluff # noqa: D415
+
+    file in subdirectory.
+    """
     initial_config = FluffConfig(configs={"core": {"templater": "jinja"}})
     lntr = Linter(config=initial_config)
     updated_config = FluffConfig(configs={"core": {"templater": "python"}})

--- a/test/core/parser/parse_test.py
+++ b/test/core/parser/parse_test.py
@@ -56,7 +56,8 @@ def test__parser__parse_expand(seg_list):
         # Remind ourselves that this should be tuple containing a BasicSegment
         assert isinstance(segments[0], BasicSegment)
 
-        # Now expand those segments, using the base class version (not that it should matter)
+        # Now expand those segments, using the base class version (not that it should
+        # matter)
         res = BasicSegment.expand(segments, parse_context=ctx)
         # Check we get an iterable containing a BasicSegment
         assert isinstance(res[0], BasicSegment)

--- a/test/core/parser/segments_base_test.py
+++ b/test/core/parser/segments_base_test.py
@@ -65,7 +65,8 @@ def test__parser__base_segments_raw(raw_seg):
     assert str(raw_seg) == repr(raw_seg) == "<CodeSegment: ([L:  1, P:  1]) 'foobar'>"
     assert (
         raw_seg.stringify(ident=1, tabsize=2)
-        == "[L:  1, P:  1]      |  raw:                                                        'foobar'\n"
+        == "[L:  1, P:  1]      |  raw:                                                "
+        "        'foobar'\n"
     )
     # Check tuple
     assert raw_seg.to_tuple() == ("raw", ())
@@ -99,8 +100,10 @@ def test__parser__base_segments_base(raw_seg_list, fresh_ansi_dialect):
     assert str(base_seg) == repr(base_seg) == "<DummySegment: ([L:  1, P:  1])>"
     assert base_seg.stringify(ident=1, tabsize=2) == (
         "[L:  1, P:  1]      |  dummy:\n"
-        "[L:  1, P:  1]      |    raw:                                                      'foobar'\n"
-        "[L:  1, P:  7]      |    raw:                                                      '.barfoo'\n"
+        "[L:  1, P:  1]      |    raw:                                                 "
+        "     'foobar'\n"
+        "[L:  1, P:  7]      |    raw:                                                 "
+        "     '.barfoo'\n"
     )
 
 

--- a/test/core/rules/config_test.py
+++ b/test/core/rules/config_test.py
@@ -96,7 +96,10 @@ def test_rules_configs_are_dynamically_documented():
 
 
 def test_rule_exception_is_caught_to_validation():
-    """Assert that a rule that throws an exception on _eval returns it as a validation."""
+    """Assert that a rule that throws an exception on _eval # noqa: D415
+
+    returns it as a validation.
+    """
     std_rule_set = get_ruleset()
 
     @std_rule_set.register
@@ -134,7 +137,10 @@ def test_std_rule_import_fail_bad_naming():
 
 
 def test_rule_set_return_informative_error_when_rule_not_registered():
-    """Assert that a rule that throws an exception on _eval returns it as a validation."""
+    """Assert that a rule that throws an exception on _eval # noqa: D415
+
+    returns it as a validation.
+    """
     cfg = FluffConfig()
     with pytest.raises(ValueError) as e:
         get_rule_from_set("L000", config=cfg)

--- a/test/core/rules/docstring_test.py
+++ b/test/core/rules/docstring_test.py
@@ -23,7 +23,8 @@ def test_content_count(content, min_count):
             if rule._check_docstring is True:
                 assert (
                     rule.__doc__.count(content) >= min_count
-                ), f"{rule.__name__} content {content} does not occur at less {min_count} times"
+                ), f"{rule.__name__} content {content} does not occur at less "
+                f"{min_count} times"
 
 
 def test_keyword_anti_before_best():
@@ -33,4 +34,5 @@ def test_keyword_anti_before_best():
             if rule._check_docstring is True:
                 assert rule.__doc__.index(KEYWORD_ANTI) < rule.__doc__.index(
                     KEYWORD_BEST
-                ), f"{rule.__name__} keyword {KEYWORD_BEST} appears before {KEYWORD_ANTI}"
+                ), f"{rule.__name__} keyword {KEYWORD_BEST} appears before "
+                f"{KEYWORD_ANTI}"

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -10,7 +10,10 @@ from sqlfluff.core.templaters.jinja import JinjaTracer
 from sqlfluff.core import Linter, FluffConfig
 
 
-JINJA_STRING = "SELECT * FROM {% for c in blah %}{{c}}{% if not loop.last %}, {% endif %}{% endfor %} WHERE {{condition}}\n\n"
+JINJA_STRING = (
+    "SELECT * FROM {% for c in blah %}{{c}}{% if not loop.last %}, "
+    "{% endif %}{% endfor %} WHERE {{condition}}\n\n"
+)
 
 
 @pytest.mark.parametrize(
@@ -32,7 +35,10 @@ SELECT
     {% endfor %}
 FROM events
             """,
-            "\n\n\nSELECT\n    event_id\n    \n    , campaign\n    \n    , click_item\n    \nFROM events\n            ",
+            (
+                "\n\n\nSELECT\n    event_id\n    \n    , campaign\n    \n    , "
+                "click_item\n    \nFROM events\n            "
+            ),
         ),
     ],
     ids=["simple", "unboundlocal_bugfix"],
@@ -259,7 +265,10 @@ FROM
 {% if not loop.last -%} UNION ALL {%- endif %}
 {% endfor %}
 """,
-            templated_str="\n\n\nSELECT\n  brand\nFROM\n  table1\nUNION ALL\n\nSELECT\n  brand\nFROM\n  table2\n\n\n",
+            templated_str=(
+                "\n\n\nSELECT\n  brand\nFROM\n  table1\nUNION ALL\n\nSELECT\n  "
+                "brand\nFROM\n  table2\n\n\n"
+            ),
             expected_templated_sliced__source_list=[
                 "{% set products = [\n  'table1',\n  'table2',\n  ] %}",
                 "\n\n",
@@ -483,7 +492,10 @@ def test__templater_full(subpath, code_only, include_meta, yaml_loader, caplog):
             ],
         ),
         (
-            "SELECT {# A comment #} {{field}} {% for i in [1, 3]%}, fld_{{i}}{% endfor %} FROM my_schema.{{my_table}} ",
+            (
+                "SELECT {# A comment #} {{field}} {% for i in [1, 3]%}, "
+                "fld_{{i}}{% endfor %} FROM my_schema.{{my_table}} "
+            ),
             [
                 ("SELECT ", "literal", 0),
                 ("{# A comment #}", "comment", 7),
@@ -570,7 +582,10 @@ def test__templater_jinja_slice_template(test, result):
         ),
         # Example with loops
         (
-            "SELECT {# A comment #} {{field}} {% for i in [1, 3, 7]%}, fld_{{i}}_x{% endfor %} FROM my_schema.{{my_table}} ",
+            (
+                "SELECT {# A comment #} {{field}} {% for i in [1, 3, 7]%}, "
+                "fld_{{i}}_x{% endfor %} FROM my_schema.{{my_table}} "
+            ),
             "SELECT  foobar , fld_1_x, fld_3_x, fld_7_x FROM my_schema.barfoo ",
             dict(field="foobar", my_table="barfoo"),
             [
@@ -599,7 +614,10 @@ def test__templater_jinja_slice_template(test, result):
         ),
         # Example with loops (and utilising the end slice code)
         (
-            "SELECT {# A comment #} {{field}} {% for i in [1, 3, 7]%}, fld_{{i}}{% endfor %} FROM my_schema.{{my_table}} ",
+            (
+                "SELECT {# A comment #} {{field}} {% for i in [1, 3, 7]%}, "
+                "fld_{{i}}{% endfor %} FROM my_schema.{{my_table}} "
+            ),
             "SELECT  foobar , fld_1, fld_3, fld_7 FROM my_schema.barfoo ",
             dict(field="foobar", my_table="barfoo"),
             [
@@ -625,7 +643,8 @@ def test__templater_jinja_slice_template(test, result):
         ),
         # Test a trailing split, and some variables which don't refer anything.
         (
-            "{{ config(materialized='view') }}\n\nSELECT 1 FROM {{ source('finance', 'reconciled_cash_facts') }}\n\n",
+            "{{ config(materialized='view') }}\n\nSELECT 1 FROM {{ source('finance', "
+            "'reconciled_cash_facts') }}\n\n",
             "\n\nSELECT 1 FROM finance_reconciled_cash_facts\n\n",
             dict(
                 config=lambda *args, **kwargs: "",

--- a/test/core/templaters/placeholder_test.py
+++ b/test/core/templaters/placeholder_test.py
@@ -265,7 +265,9 @@ def test__templater_setup():
     t = PlaceholderTemplater(override_context=dict(name="'john'"))
     with pytest.raises(
         ValueError,
-        match=r"No param_regex nor param_style was provided to the placeholder templater",
+        match=(
+            "No param_regex nor param_style was provided to the placeholder templater"
+        ),
     ):
         t.process(in_str="SELECT 2+2", fname="test")
 

--- a/test/core/templaters/python_test.py
+++ b/test/core/templaters/python_test.py
@@ -410,7 +410,8 @@ def test__templater_python_split_uniques_coalesce_rest(
             [("literal", slice(0, 3, None), slice(0, 3, None))],
         ),
         (
-            "SELECT {blah}, {foo:.2f} as foo, {bar}, '{{}}' as convertable from something",
+            "SELECT {blah}, {foo:.2f} as foo, {bar}, '{{}}' as convertable from "
+            "something",
             "SELECT nothing, 435.24 as foo, spam, '{}' as convertable from something",
             True,
             [

--- a/test/dialects/ansi_test.py
+++ b/test/dialects/ansi_test.py
@@ -105,7 +105,8 @@ def test__dialect__ansi__file_lex(raw, res, caplog):
         # Complex Functions
         (
             "ExpressionSegment",
-            "concat(left(uaid, 2), '|', right(concat('0000000', SPLIT_PART(uaid, '|', 4)), 10), '|', '00000000')",
+            "concat(left(uaid, 2), '|', right(concat('0000000', "
+            "SPLIT_PART(uaid, '|', 4)), 10), '|', '00000000')",
         ),
         # Notnull and Isnull
         ("ExpressionSegment", "c is null"),

--- a/test/dialects/conftest.py
+++ b/test/dialects/conftest.py
@@ -108,7 +108,8 @@ def _dialect_specific_segment_not_match(dialect, segmentref, raw, caplog):
 def _validate_dialect_specific_statements(dialect, segment_cls, raw, stmt_count):
     """This validates one or multiple statements against specified segment class.
 
-    It even validates the number of parsed statements with the number of expected statements.
+    It even validates the number of parsed statements with the number of expected
+    statements.
     """
     lnt = Linter(dialect=dialect)
     parsed = lnt.parse_string(raw)
@@ -135,7 +136,10 @@ def dialect_specific_segment_parses():
 
 @pytest.fixture()
 def dialect_specific_segment_not_match():
-    """Fixture to check specific segments of a dialect which will not match to a segment."""
+    """Fixture to check specific segments of a dialect which will # noqa: D415
+
+    not match to a segment.
+    """
     return _dialect_specific_segment_not_match
 
 
@@ -143,6 +147,7 @@ def dialect_specific_segment_not_match():
 def validate_dialect_specific_statements():
     """This validates one or multiple statements against specified segment class.
 
-    It even validates the number of parsed statements with the number of expected statements.
+    It even validates the number of parsed statements with the number of expected
+    statements.
     """
     return _validate_dialect_specific_statements

--- a/test/dialects/postgres_test.py
+++ b/test/dialects/postgres_test.py
@@ -52,7 +52,8 @@ def test_dialect_postgres_specific_segment_parses(
     "raw",
     [
         "SELECT t1.field, EXTRACT(EPOCH FROM t1.sometime) AS myepoch FROM t1",
-        "SELECT t1.field, EXTRACT(EPOCH FROM t1.sometime - t1.othertime) AS myepoch FROM t1",
+        "SELECT t1.field, EXTRACT(EPOCH FROM t1.sometime - t1.othertime) AS myepoch "
+        "FROM t1",
     ],
 )
 def test_epoch_datetime_unit(raw: str) -> None:

--- a/test/dialects/snowflake_test.py
+++ b/test/dialects/snowflake_test.py
@@ -6,15 +6,16 @@ from sqlfluff.core import Linter
 from sqlfluff.core.dialects import dialect_selector
 
 
-# Deprecated: All new tests should be added as .sql and .yml files under `test/fixtures/dialects/snowflake`.
+# Deprecated: All new tests should be added as .sql and .yml files under
+# `test/fixtures/dialects/snowflake`.
 # See test/fixtures/dialects/README.md for more details.
 @pytest.mark.parametrize(
     "segment_cls,raw",
     [
         (
             "CreateCloneStatementSegment",
-            "create table orders_clone_restore clone orders at (timestamp => to_timestamp_tz('04/05/2013 01:02:03', "
-            "'mm/dd/yyyy hh24:mi:ss'));",
+            "create table orders_clone_restore clone orders at (timestamp => "
+            "to_timestamp_tz('04/05/2013 01:02:03', 'mm/dd/yyyy hh24:mi:ss'));",
         ),
         ("ShowStatementSegment", "SHOW GRANTS ON ACCOUNT;"),
         ("ShowStatementSegment", "show tables history in tpch.public;"),
@@ -25,7 +26,8 @@ from sqlfluff.core.dialects import dialect_selector
         ),
         (
             "ShowStatementSegment",
-            "SHOW TERSE SCHEMAS HISTORY LIKE '%META%' IN DATABASE MYDB STARTS WITH 'INT' LIMIT 10 FROM 'LAST_SCHEMA';",
+            "SHOW TERSE SCHEMAS HISTORY LIKE '%META%' IN DATABASE MYDB STARTS WITH "
+            "'INT' LIMIT 10 FROM 'LAST_SCHEMA';",
         ),
         ("ShowStatementSegment", "SHOW GRANTS TO ROLE SECURITYADMIN;"),
         ("ShowStatementSegment", "SHOW GRANTS OF SHARE MY_SHARE;"),

--- a/test/generate_parse_fixture_yml.py
+++ b/test/generate_parse_fixture_yml.py
@@ -23,10 +23,13 @@ def generate_parse_fixture(example):
                 + list(tree.as_record(code_only=True, show_raw=True).items())
             )
             print(
-                "# YML test files are auto-generated from SQL files and should not be edited by",
-                '# hand. To help enforce this, the "hash" field in the file must match a hash',
+                "# YML test files are auto-generated from SQL files and should not be "
+                "edited by",
+                '# hand. To help enforce this, the "hash" field in the file must match '
+                "a hash",
                 "# computed by SQLFluff when running the tests. Please run",
-                "# `python test/generate_parse_fixture_yml.py`  to generate them after adding or",
+                "# `python test/generate_parse_fixture_yml.py`  to generate them after "
+                "adding or",
                 "# altering SQL files.",
                 file=f,
                 sep="\n",

--- a/test/rules/std_L003_test.py
+++ b/test/rules/std_L003_test.py
@@ -160,7 +160,10 @@ def test__rules__std_L003_make_indent_invalid_param():
 
 
 def test__rules__std_L003__get_element_template_info():
-    """Test Rule_L003._get_element_template_info with invalid templated_file parameter."""
+    """Test Rule_L003._get_element_template_info with invalid # noqa: D415
+
+    templated_file parameter.
+    """
     mock_segment = Mock()
     mock_segment.return_value.is_type = True
     with pytest.raises(ValueError):

--- a/test/rules/std_L007_test.py
+++ b/test/rules/std_L007_test.py
@@ -24,7 +24,10 @@ def test__rules__std_L007_default():
 
 
 def test__rules__std_L007_after():
-    """Verify that L007 returns the correct error message when after is explicitly used."""
+    """Verify that L007 returns the correct error message when after # noqa: D415
+
+    is explicitly used.
+    """
     sql = """
         SELECT
             a,

--- a/test/rules/std_L008_test.py
+++ b/test/rules/std_L008_test.py
@@ -4,7 +4,8 @@ import sqlfluff
 
 def test__rules__std_L008_single_raise() -> None:
     """Test case for multiple L008 errors raised when no post comma whitespace."""
-    # This query used to triple count L008. Added memory to log previously fixed commas (issue #2001).
+    # This query used to triple count L008. Added memory to log previously fixed commas
+    # (issue #2001).
     sql = """
     SELECT
         col_a AS a

--- a/test/rules/std_L016_L36_combo_test.py
+++ b/test/rules/std_L016_L36_combo_test.py
@@ -1,31 +1,52 @@
-"""Tests the combination of L016 (no long lines) and L036 (single selects should eb on SELECT line)."""
+"""Tests the combination of L016 (no long lines) and L036 # noqa: D415
+
+(single selects should eb on SELECT line).
+"""
 
 import sqlfluff
 
 
 def test__rules__std_L016_L036_long_line_lint():
-    """Verify that a long line that causes a clash between L016 and L036 is not changed."""
-    sql = "SELECT\n1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\n"
+    """Verify that a long line that causes a clash between L016 and L036  # noqa: D415
+
+    is not changed.
+    """
+    sql = (
+        "SELECT\n1000000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000\n"
+    )
     result = sqlfluff.lint(sql)
     assert "L016" in [r["code"] for r in result]
     assert "L036" in [r["code"] for r in result]
 
 
 def test__rules__std_L016_L036_long_line_fix():
-    """Verify that a long line that causes a clash between L016 and L036 does not add multiple newlines (see #1424)."""
-    sql = "SELECT 1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\n"
+    """Verify that a long line that causes a clash between L016 and L036 does # noqa: D415
+
+    not add multiple newlines (see #1424).
+    """
+    sql = (
+        "SELECT 10000000000000000000000000000000000000000000000000000000000000000000000"
+        "00000000000000000000000000000\n"
+    )
     result = sqlfluff.fix(sql)
-    assert (
-        result
-        == "SELECT\n    1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\n"
+    assert result == (
+        "SELECT\n    100000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000\n"
     )
 
 
 def test__rules__std_L016_L036_long_line_fix2():
-    """Verify that a long line that causes a clash between L016 and L036 does not add multiple newlines (see #1424)."""
-    sql = "SELECT\n    1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\n"
+    """Verify that a long line that causes a clash between L016 and L036 does # noqa: D415
+
+    not add multiple newlines (see #1424).
+    """
+    sql = (
+        "SELECT\n    100000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000\n"
+    )
     result = sqlfluff.fix(sql)
-    assert (
-        result
-        == "SELECT 1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\n"
+    assert result == (
+        "SELECT 10000000000000000000000000000000000000000000000000000000000000000000000"
+        "00000000000000000000000000000\n"
     )

--- a/test/rules/std_L019_test.py
+++ b/test/rules/std_L019_test.py
@@ -21,11 +21,13 @@ def test__rules__std_L019_unparseable():
           SPLIT(intents, ",") AS intent_list,
           {% for feature in readability_features_numeric %}
             CAST(JSON_EXTRACT(readability_scores,
-            '$.data.{{feature}}') AS float64) AS {{feature}} {% if not loop.last %} , {% endif %}
+            '$.data.{{feature}}') AS float64) AS {{feature}} {% if not loop.last %} ,
+            {% endif %}
           {% endfor %},
           {% for feature in readability_features_count_list %}
             CAST(JSON_EXTRACT(asset_structure,
-            '$.{{feature}}') AS float64) AS {{feature}}_count {% if not loop.last %} , {% endif %}
+            '$.{{feature}}') AS float64) AS {{feature}}_count {% if not loop.last %} ,
+            {% endif %}
           {% endfor %},
             track_clicks_text,
             track_clicks_html

--- a/test/rules/std_L020_test.py
+++ b/test/rules/std_L020_test.py
@@ -4,7 +4,10 @@ import sqlfluff
 
 
 def test__rules__std_L020_one_aliases_one_duplicate():
-    """Verify that L020 returns the correct error message for one duplicate table aliases occur one times."""
+    """Verify that L020 returns the correct error message for one # noqa: D415
+
+    duplicate table aliases occur one times.
+    """
     sql = """
         SELECT
             a.pk
@@ -17,7 +20,10 @@ def test__rules__std_L020_one_aliases_one_duplicate():
 
 
 def test__rules__std_L020_one_aliases_two_duplicate():
-    """Verify that L020 returns the correct error message for one duplicate table aliases occur two times."""
+    """Verify that L020 returns the correct error message for one # noqa: D415
+
+    duplicate table aliases occur two times.
+    """
     sql = """
         SELECT
             a.pk

--- a/test/rules/std_test.py
+++ b/test/rules/std_test.py
@@ -22,7 +22,8 @@ from sqlfluff.testing.rules import assert_rule_raises_violations_in_file
             [(3, 1), (4, 1), (5, 1)],
         ),
         # Check we get comma (with leading space/newline) whitespace errors
-        # NB The newline before the comma, should report on the comma, not the newline for clarity.
+        # NB The newline before the comma, should report on the comma, not the newline
+        # for clarity.
         ("L005", "whitespace_errors.sql", [(2, 9)]),
         ("L019", "whitespace_errors.sql", [(4, 1)]),
         # Check we get comma (with incorrect trailing space) whitespace errors,

--- a/test/rules/yaml_test_cases_test.py
+++ b/test/rules/yaml_test_cases_test.py
@@ -25,7 +25,8 @@ def test__rule_test_case(test_case, caplog):
             rule = get_rule_from_set(test_case.rule, config=cfg)
             assert is_fix_compatible(
                 rule
-            ), f'Rule {test_case.rule} returned fixes but does not specify "@document_fix_compatible".'
+            ), f"Rule {test_case.rule} returned fixes but does not specify "
+            '"@document_fix_compatible".'
 
 
 def test__rule_test_global_config():

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -18,7 +18,10 @@ def test_assert_rule_fail_in_sql_handle_parse_error():
 
 
 def test_assert_rule_fail_in_sql_should_fail_queries_that_unexpectedly_pass():
-    """Util assert_rule_fail_in_sql should fail tests when a query passes rules that it violates."""
+    """Util assert_rule_fail_in_sql should fail tests when a query passes # noqa: D415
+
+    rules that it violates.
+    """
     with pytest.raises(Failed) as failed_test:
         assert_rule_fail_in_sql(code="L001", sql="select 1")
     failed_test.match("No L001 failures found in query which should fail")

--- a/tox.ini
+++ b/tox.ini
@@ -134,7 +134,7 @@ commands =
 # D105: Don't require docstrings on magic methods
 ignore = W503, D107, D105, D418
 exclude = .git,__pycache__,env,.tox,build,.venv,venv
-max-line-length = 127
+max-line-length = 88
 extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
     E203,

--- a/util.py
+++ b/util.py
@@ -36,7 +36,8 @@ def clean_tests(path):
         shutil.rmtree(path)
         click.echo(f"Removed {path!r}...")
     # OSError is for python 27
-    # in py36 its FileNotFoundError (but that inherits from IOError, which exists in py27)
+    # in py36 its FileNotFoundError (but that inherits from IOError, which exists in
+    # py27)
     except OSError:
         click.echo(f"Directory {path!r} does not exist. Skipping...")
 
@@ -66,7 +67,8 @@ def benchmark(cmd, runs, from_file):
     # Try and detect a CI environment
     if "CI" in os.environ:
         click.echo("CI detected!")
-        # available_vars = [var for var in os.environ.keys()]  # if var.startswith('CIRCLE')
+        # available_vars = [var for var in os.environ.keys()]
+        # if var.startswith('CIRCLE')
         # click.echo("Available keys: {0!r}".format(available_vars))
         commit_hash = os.environ.get("GITHUB_SHA", None)
         post_results = True
@@ -102,8 +104,10 @@ def benchmark(cmd, runs, from_file):
             click.echo(f"Posting results: {results}")
             api_key = os.environ["SQLFLUFF_BENCHMARK_API_KEY"]
             resp = requests.post(
-                "https://f32cvv8yh3.execute-api.eu-west-1.amazonaws.com/result/gh/{repo}/{commit}".format(
-                    # TODO: update the stats collector eventually to allow the new repo path
+                "https://f32cvv8yh3.execute-api.eu-west-1.amazonaws.com/result/gh"
+                "/{repo}/{commit}".format(
+                    # TODO: update the stats collector eventually to allow the new repo
+                    # path
                     repo="alanmcruickshank/sqlfluff",
                     commit=commit_hash,
                 ),


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
Sets line length to 88 characters in the flake8 section of tox.ini, so that it aligns with the black default, which is used in pre-commit. This necessitates a lot of manual changes, which black cannot automate.
For line 172 in `src/sqlfluff/rules/L034.py` I had to apply `# noqa: E501`, since I could not find a way to break the line in a way that agrees with black.
There are a number of doc strings where I applied `# noqa: D415` (the first line of a doc string must end in a period, question mark or exclamation mark). To properly fix these, editorial changes to the doc string text are required, which should be done by those who know the code that is being documented.


### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
