### PR TITLE
Upgrade `click` version to 8.0+ to support `click.shell_completion`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ appdirs
 backports.cached-property; python_version < '3.8'
 # To get the encoding of files.
 chardet
-click>=7.1
+click>=8.0
 colorama>=0.3
 # Used for diffcover plugin
 diff-cover>=2.5.0


### PR DESCRIPTION
### Brief summary of the change made

* Upgrade `click` to 8.0+ to pick up the `click.shell_completion` module.

#### Context
* In `v0.9.1`, it uses `click.shell_completion` module (Per https://github.com/sqlfluff/sqlfluff/pull/2218/files#diff-7a86f6d03eb73c44995f1e9419b42ed5bac7b033a873623f77c00f9f0ac99a62R3).
* `shell_completion` module does not exist till `click` v8.0
* If a project has imported only v7.* of `click` and it installed `sqlfluff` v0.9.1, calling `sqlfluff` from command line will throw a `ModuleNotFoundError` exception due to `click.shell_completion` not found.

### Are there any other side effects of this change that we should be aware of?

* This forces users of `sqlfluff` to upgrade to `click` v.8+.

### Pull Request checklist
- [x] Added appropriate documentation for the change.
   * Change that pulled in `click.shell_completion` module: https://github.com/sqlfluff/sqlfluff/pull/2218/files#diff-7a86f6d03eb73c44995f1e9419b42ed5bac7b033a873623f77c00f9f0ac99a62R3
   * `click.shell_completion` does not exist till v8.9+
      * PR: https://github.com/pallets/click/pull/1622, file that was added: https://github.com/pallets/click/pull/1622/files#diff-076151bca96783a6553f19f519de6b1a4bd8f9675a41353728ef70a4255eec40R1
