### PR TITLE
Add coverage for `TRUNCATE` statement in Spark3 dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -708,6 +708,23 @@ class MsckRepairTableStatementSegment(hive_dialect.get_segment("MsckRepairTableS
     type = "msck_repair_table_statement"
 
 
+@spark3_dialect.segment(replace=True)
+class TruncateStatementSegment(BaseSegment):
+    """A `TRUNCATE TABLE` statement.
+
+    https://spark.apache.org/docs/latest/sql-ref-syntax-ddl-truncate-table.html
+    """
+
+    type = "truncate_table_statement"
+
+    match_grammar = Sequence(
+        "TRUNCATE",
+        "TABLE",
+        Ref("TableReferenceSegment"),
+        Ref("PartitionSpecGrammar", optional=True),
+    )
+
+
 # Auxiliary Statements
 @spark3_dialect.segment()
 class AddExecutablePackage(BaseSegment):

--- a/test/fixtures/dialects/spark3/truncate_table.sql
+++ b/test/fixtures/dialects/spark3/truncate_table.sql
@@ -1,5 +1,5 @@
 -- Removes all rows from the table in the partition specified
-TRUNCATE TABLE Student partition(age=10);
+TRUNCATE TABLE Student PARTITION(Age = 10);
 
 -- Removes all rows from the table from all partitions
 TRUNCATE TABLE Student;

--- a/test/fixtures/dialects/spark3/truncate_table.sql
+++ b/test/fixtures/dialects/spark3/truncate_table.sql
@@ -1,0 +1,5 @@
+-- Removes all rows from the table in the partition specified
+TRUNCATE TABLE Student partition(age=10);
+
+-- Removes all rows from the table from all partitions
+TRUNCATE TABLE Student;

--- a/test/fixtures/dialects/spark3/truncate_table.yml
+++ b/test/fixtures/dialects/spark3/truncate_table.yml
@@ -1,0 +1,29 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 4871e58ad2d1c347f50b5a277837cff162364514a2d85415fc3c8545160d4520
+file:
+- base:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: Student
+    unparsable:
+      raw: partition
+      bracketed:
+      - start_bracket: (
+      - raw: age
+      - raw: '='
+      - raw: '10'
+      - end_bracket: )
+- statement_terminator: ;
+- base:
+    truncate_table:
+    - keyword: TRUNCATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: Student
+- statement_terminator: ;

--- a/test/fixtures/dialects/spark3/truncate_table.yml
+++ b/test/fixtures/dialects/spark3/truncate_table.yml
@@ -3,25 +3,26 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4871e58ad2d1c347f50b5a277837cff162364514a2d85415fc3c8545160d4520
+_hash: d08b60a673b7a607091e271b2376fcef17e158b7f8ca215d319d7f68cc142fa9
 file:
 - base:
-    truncate_table:
+    truncate_table_statement:
     - keyword: TRUNCATE
     - keyword: TABLE
     - table_reference:
         identifier: Student
-    unparsable:
-      raw: partition
-      bracketed:
-      - start_bracket: (
-      - raw: age
-      - raw: '='
-      - raw: '10'
-      - end_bracket: )
+    - keyword: PARTITION
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          identifier: Age
+        comparison_operator:
+          raw_comparison_operator: '='
+        literal: '10'
+        end_bracket: )
 - statement_terminator: ;
 - base:
-    truncate_table:
+    truncate_table_statement:
     - keyword: TRUNCATE
     - keyword: TABLE
     - table_reference:


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Addes class in spark3 dialect to match `TRUNCATE` statements and test cases to verify successful matching.

### Are there any other side effects of this change that we should be aware of?
N/A. This is a straightforward one :) 

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
