### PR TITLE
L025 should look at subqueries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ appdirs
 backports.cached-property; python_version < '3.8'
 # To get the encoding of files.
 chardet
-click>=7.1
+click>=8.0
 colorama>=0.3
 # Used for diffcover plugin
 diff-cover>=2.5.0

--- a/src/sqlfluff/core/rules/analysis/select_crawler.py
+++ b/src/sqlfluff/core/rules/analysis/select_crawler.py
@@ -155,6 +155,8 @@ class SelectCrawler:
         query_class: Type = Query,
     ):
         self.dialect: Dialect = dialect
+        # "query_class" allows users of the class to customize/extend the
+        # Query class, so they can manage additional, custom info.
         self.query_class = query_class
         self.query_tree: Optional[Query] = None
 

--- a/src/sqlfluff/rules/L025.py
+++ b/src/sqlfluff/rules/L025.py
@@ -96,7 +96,6 @@ class Rule_L025(BaseRule):
                 for r in select_info.reference_buffer:
                     for tr in r.extract_possible_references(level=r.ObjectReferenceLevel.TABLE):  # type: ignore
                         # This function walks up the query's parent stack if necessary.
-                        # Reuses the existing "for r in references:" loop from L025.
                         cls._resolve_and_mark_reference(query, tr.part)
 
         # Visit children.

--- a/src/sqlfluff/rules/L025.py
+++ b/src/sqlfluff/rules/L025.py
@@ -17,8 +17,7 @@ from sqlfluff.core.rules.base import (
     EvalResultType,
 )
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible
-from sqlfluff.core.rules.functional import Segments
-import sqlfluff.core.rules.functional.segment_predicates as sp
+from sqlfluff.core.rules.functional import Segments, sp
 from sqlfluff.core.dialects.common import AliasInfo
 
 

--- a/src/sqlfluff/rules/L025.py
+++ b/src/sqlfluff/rules/L025.py
@@ -102,7 +102,7 @@ class Rule_L025(BaseRule):
     @classmethod
     def _resolve_and_mark_reference(cls, query: L025Query, ref: str):
         # Does this query define the referenced alias?
-        if ref in query.aliases:
+        if any(ref == a.ref_str for a in query.aliases):
             # Yes. Record the reference.
             query.tbl_refs.add(ref)
         elif query.parent:

--- a/src/sqlfluff/rules/L026.py
+++ b/src/sqlfluff/rules/L026.py
@@ -3,7 +3,7 @@
 from sqlfluff.core.rules.analysis.select import get_aliases_from_select
 from sqlfluff.core.rules.base import EvalResultType, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import document_configuration
-from sqlfluff.rules.L025 import Rule_L020
+from sqlfluff.rules.L020 import Rule_L020
 
 
 @document_configuration

--- a/src/sqlfluff/rules/L028.py
+++ b/src/sqlfluff/rules/L028.py
@@ -2,11 +2,11 @@
 
 from sqlfluff.core.rules.base import LintResult, EvalResultType, RuleContext
 from sqlfluff.core.rules.doc_decorators import document_configuration
-from sqlfluff.rules.L025 import Rule_L025
+from sqlfluff.rules.L020 import Rule_L020
 
 
 @document_configuration
-class Rule_L028(Rule_L025):
+class Rule_L028(Rule_L020):
     """References should be consistent in statements with a single table.
 
     NB: This rule is disabled by default for BigQuery due to its use of

--- a/src/sqlfluff/rules/L028.py
+++ b/src/sqlfluff/rules/L028.py
@@ -103,7 +103,7 @@ class Rule_L028(Rule_L020):
         return violation_buff or None
 
     def _eval(self, context: RuleContext) -> EvalResultType:
-        """Override Rule L025 for dialects that use structs, or SELECT aliases."""
+        """Override base class for dialects that use structs, or SELECT aliases."""
         # Config type hints
         self.force_enable: bool
 

--- a/test/fixtures/rules/std_rule_cases/L025.yml
+++ b/test/fixtures/rules/std_rule_cases/L025.yml
@@ -96,3 +96,9 @@ test_pass_subselect_uses_alias_2:
       , COL_B
     from INSERTS INS
     where COL_B != (select max(COL_B) from INSERTS X where INS.COL_A = X.COL_A)
+
+test_pass_subselect_uses_alias_3:
+  pass_str: |
+    SELECT col_1
+    FROM table_a AS a
+    WHERE NOT EXISTS (SELECT TRUE FROM table_b AS b WHERE a.col_4 = b.col_1)

--- a/test/fixtures/rules/std_rule_cases/L025.yml
+++ b/test/fixtures/rules/std_rule_cases/L025.yml
@@ -76,3 +76,23 @@ test_pass_tsql_object_reference_override:
   configs:
     core:
       dialect: tsql
+
+test_pass_subselect_uses_alias_1:
+  pass_str: |
+    SELECT
+        col1,
+        (
+            SELECT count(*)
+            FROM base
+            WHERE a.col2 = base.col2
+        )
+    FROM
+        without_dup AS a
+
+test_pass_subselect_uses_alias_2:
+  pass_str: |
+    select
+      COL_A
+      , COL_B
+    from INSERTS INS
+    where COL_B != (select max(COL_B) from INSERTS X where INS.COL_A = X.COL_A)


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made

Fixes #1462

This is basically a rewrite of `L025`. Previously, it inherited from `L020`. Now, its implementation largely relies on `SelectCrawler`. A couple of other rules needlessly inherited from `L025` that could've simply inherited from `L020` -- I updated those, because after the rewrite, inheriting from `L025` no longer worked.


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
