### PR TITLE
Optionally allow additional configurable characters in L057

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -101,4 +101,4 @@ group_by_and_order_by_style = consistent
 unquoted_identifiers_policy = all
 quoted_identifiers_policy = all
 allow_space_in_identifier = False
-additional_allowed_identifiers = ""
+additional_allowed_characters = ""

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -101,3 +101,4 @@ group_by_and_order_by_style = consistent
 unquoted_identifiers_policy = all
 quoted_identifiers_policy = all
 allow_space_in_identifier = False
+additional_allowed_identifiers = ""

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -130,7 +130,8 @@ STANDARD_CONFIG_INFO_DICT = {
     },
     "additional_allowed_characters": {
         "definition": (
-            "Optional list of extra allowed characters, in addition to alphanumerics (A-Z, a-z, 0-9) and underscores."
+            "Optional list of extra allowed characters, "
+            "in addition to alphanumerics (A-Z, a-z, 0-9) and underscores."
         ),
     },
 }

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -129,7 +129,9 @@ STANDARD_CONFIG_INFO_DICT = {
         "definition": ("Should spaces in identifiers be allowed?"),
     },
     "additional_allowed_characters": {
-        "definition": ("List of allowed characters."),
+        "definition": (
+            "Optional list of extra allowed characters, in addition to alphanumerics (A-Z,a-z,0-9) and underscores."
+        ),
     },
 }
 

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -130,7 +130,7 @@ STANDARD_CONFIG_INFO_DICT = {
     },
     "additional_allowed_characters": {
         "definition": (
-            "Optional list of extra allowed characters, in addition to alphanumerics (A-Z,a-z,0-9) and underscores."
+            "Optional list of extra allowed characters, in addition to alphanumerics (A-Z, a-z, 0-9) and underscores."
         ),
     },
 }

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -128,7 +128,7 @@ STANDARD_CONFIG_INFO_DICT = {
         "validation": [True, False],
         "definition": ("Should spaces in identifiers be allowed?"),
     },
-    "additional_allowed_identifiers": {
+    "additional_allowed_characters": {
         "definition": ("List of allowed characters."),
     },
 }

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -128,6 +128,9 @@ STANDARD_CONFIG_INFO_DICT = {
         "validation": [True, False],
         "definition": ("Should spaces in identifiers be allowed?"),
     },
+    "additional_allowed_identifiers": {
+        "definition": ("List of allowed characters."),
+    },
 }
 
 

--- a/src/sqlfluff/rules/L057.py
+++ b/src/sqlfluff/rules/L057.py
@@ -45,6 +45,7 @@ class Rule_L057(BaseRule):
         "quoted_identifiers_policy",
         "unquoted_identifiers_policy",
         "allow_space_in_identifier",
+        "additional_allowed_identifiers",
     ]
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
@@ -53,6 +54,7 @@ class Rule_L057(BaseRule):
         self.quoted_identifiers_policy: str
         self.unquoted_identifiers_policy: str
         self.allow_space_in_identifier: bool
+        self.additional_allowed_identifiers: str
 
         # Exit early if not a single identifier.
         if context.segment.name not in ("naked_identifier", "quoted_identifier"):
@@ -88,12 +90,16 @@ class Rule_L057(BaseRule):
             if identifiers_policy_applicable(
                 self.quoted_identifiers_policy, context.parent_stack
             ) and not (
-                identifier.replace("_", "").replace("-", "").isalnum()
+                identifier.replace("_", "")
+                .translate(str.maketrans("", "", self.additional_allowed_identifiers))
+                .isalnum()
                 or (
                     self.allow_space_in_identifier
                     and identifier.replace("_", "")
-                    .replace("-", "")
                     .replace(" ", "")
+                    .translate(
+                        str.maketrans("", "", self.additional_allowed_identifiers)
+                    )
                     .isalnum()
                 )
             ):

--- a/src/sqlfluff/rules/L057.py
+++ b/src/sqlfluff/rules/L057.py
@@ -45,23 +45,23 @@ class Rule_L057(BaseRule):
         "quoted_identifiers_policy",
         "unquoted_identifiers_policy",
         "allow_space_in_identifier",
-        "additional_allowed_identifiers",
+        "additional_allowed_characters",
     ]
 
     @staticmethod
     def _standard_cleanups(
         identifier: str,
         allow_space_in_identifier: bool,
-        additional_allowed_identifiers: str,
+        additional_allowed_characters: str,
     ) -> str:
 
         # We always allow underscores so strip them out
         identifier = identifier.replace("_", "")
 
         # Set the identified minus the allowed characters
-        if additional_allowed_identifiers:
+        if additional_allowed_characters:
             identifier = identifier.translate(
-                str.maketrans("", "", additional_allowed_identifiers)
+                str.maketrans("", "", additional_allowed_characters)
             )
 
         # Strip spaces if allowed (note a separate config as only valid for quoted identifiers)
@@ -76,7 +76,7 @@ class Rule_L057(BaseRule):
         self.quoted_identifiers_policy: str
         self.unquoted_identifiers_policy: str
         self.allow_space_in_identifier: bool
-        self.additional_allowed_identifiers: str
+        self.additional_allowed_characters: str
 
         # Exit early if not a single identifier.
         if context.segment.name not in ("naked_identifier", "quoted_identifier"):
@@ -87,7 +87,7 @@ class Rule_L057(BaseRule):
         if context.segment.name == "naked_identifier":
 
             identifier = self._standard_cleanups(
-                identifier, False, self.additional_allowed_identifiers
+                identifier, False, self.additional_allowed_characters
             )
 
             # Evaluate unquoted identifiers.
@@ -105,7 +105,7 @@ class Rule_L057(BaseRule):
             identifier = self._standard_cleanups(
                 identifier,
                 self.allow_space_in_identifier,
-                self.additional_allowed_identifiers,
+                self.additional_allowed_characters,
             )
 
             # BigQuery table references are quoted in back ticks so allow dots

--- a/src/sqlfluff/rules/L057.py
+++ b/src/sqlfluff/rules/L057.py
@@ -88,10 +88,13 @@ class Rule_L057(BaseRule):
             if identifiers_policy_applicable(
                 self.quoted_identifiers_policy, context.parent_stack
             ) and not (
-                identifier.replace("_", "").isalnum()
+                identifier.replace("_", "").replace("-", "").isalnum()
                 or (
                     self.allow_space_in_identifier
-                    and identifier.replace("_", "").replace(" ", "").isalnum()
+                    and identifier.replace("_", "")
+                    .replace("-", "")
+                    .replace(" ", "")
+                    .isalnum()
                 )
             ):
                 return LintResult(anchor=context.segment)

--- a/src/sqlfluff/rules/L057.py
+++ b/src/sqlfluff/rules/L057.py
@@ -64,7 +64,11 @@ class Rule_L057(BaseRule):
             # Evaluate unquoted identifiers.
             if identifiers_policy_applicable(
                 self.unquoted_identifiers_policy, context.parent_stack
-            ) and not (context.segment.raw.replace("_", "").isalnum()):
+            ) and not (
+                context.segment.raw.replace("_", "")
+                .translate(str.maketrans("", "", self.additional_allowed_identifiers))
+                .isalnum()
+            ):
                 return LintResult(anchor=context.segment)
         else:
             # Evaluate quoted identifiers.

--- a/test/fixtures/rules/std_rule_cases/L057.yml
+++ b/test/fixtures/rules/std_rule_cases/L057.yml
@@ -220,3 +220,11 @@ test_fail_star_bigquery:
   configs:
     core:
       dialect: bigquery
+
+test_pass_hyphen_bigquery:
+  pass_str:
+    SELECT a
+    FROM `user.schema.table-something`
+  configs:
+    core:
+      dialect: bigquery

--- a/test/fixtures/rules/std_rule_cases/L057.yml
+++ b/test/fixtures/rules/std_rule_cases/L057.yml
@@ -230,7 +230,7 @@ test_pass_hyphen_bigquery:
       dialect: bigquery
     rules:
       L057:
-        additional_allowed_identifiers: '-'
+        additional_allowed_characters: '-'
 
 test_pass_dot_bigquery:
   pass_str:
@@ -242,7 +242,7 @@ test_pass_dot_bigquery:
       dialect: bigquery
     rules:
       L057:
-        additional_allowed_identifiers: '-.'
+        additional_allowed_characters: '-.'
 
 test_fail_single_quote_bigquery:
   fail_str:
@@ -253,7 +253,7 @@ test_fail_single_quote_bigquery:
       dialect: bigquery
     rules:
       L057:
-        additional_allowed_identifiers: '-.'
+        additional_allowed_characters: '-.'
 
 test_pass_single_quote_bigquery:
   pass_str:
@@ -264,7 +264,7 @@ test_pass_single_quote_bigquery:
       dialect: bigquery
     rules:
       L057:
-        additional_allowed_identifiers: '-''.'
+        additional_allowed_characters: '-''.'
 
 test_pass_single_quote2_bigquery:
   pass_str:
@@ -275,4 +275,4 @@ test_pass_single_quote2_bigquery:
       dialect: bigquery
     rules:
       L057:
-        additional_allowed_identifiers: "-'."
+        additional_allowed_characters: "-'."

--- a/test/fixtures/rules/std_rule_cases/L057.yml
+++ b/test/fixtures/rules/std_rule_cases/L057.yml
@@ -228,3 +228,51 @@ test_pass_hyphen_bigquery:
   configs:
     core:
       dialect: bigquery
+    rules:
+      L057:
+        additional_allowed_identifiers: '-'
+
+test_pass_dot_bigquery:
+  pass_str:
+    SELECT a
+    FROM `user.schema.table-something`
+    WHERE `user.schema.table-something`.a = 1
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L057:
+        additional_allowed_identifiers: '-.'
+
+test_fail_single_quote_bigquery:
+  fail_str:
+    SELECT a
+    FROM `user.schema.table'something`
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L057:
+        additional_allowed_identifiers: '-.'
+
+test_pass_single_quote_bigquery:
+  pass_str:
+    SELECT a
+    FROM `user.schema.table'something`
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L057:
+        additional_allowed_identifiers: '-''.'
+
+test_pass_single_quote2_bigquery:
+  pass_str:
+    SELECT a
+    FROM `user.schema.table'something`
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L057:
+        additional_allowed_identifiers: "-'."


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->

Allow hyphens in L057 as quoted identifiers (same as we allow underscores), as a lot of these are flagging for a lot of my table names in BigQuery.

@jpers36 , any issues with this since you created L057? If you would prefer not to allow this, then happy to move to a BigQuery specific bit of L057 since that already exists.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
