### PR TITLE
L025 with 'bigquery' dialect: Correctly interpret calling functions with a table as a parameter

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -708,17 +708,33 @@ class ColumnReferenceSegment(ObjectReferenceSegment):  # type: ignore
     )
 
     def extract_possible_references(self, level):
-        """Extract possible references of a given level."""
+        """Extract possible references of a given level.
+
+        Overrides the parent-class function. BigQuery's support for things like
+        the following
+        - Functions that take a table as a parameter (e.g. TO_JSON_STRING)
+          https://cloud.google.com/bigquery/docs/reference/standard-sql/
+          json_functions#to_json_string
+        - STRUCT
+
+        mean that, without schema information (which SQLFluff does not have),
+        references to data are often ambiguous.
+        """
         level = self._level_to_int(level)
         refs = list(self.iter_raw_references())
         if level == self.ObjectReferenceLevel.SCHEMA.value and len(refs) >= 3:
             return [refs[0]]  # pragma: no cover
         if level == self.ObjectReferenceLevel.TABLE.value:
+            # One part: Could be a table, e.g. TO_JSON_STRING(t)
+            # Two parts: Could be schema+table or table+column.
+            # Three parts: Could be table+column+struct or schema+table+column.
             return refs[:2]
-        if level == self.ObjectReferenceLevel.OBJECT.value and len(refs) >= 3:
+        if (
+            level == self.ObjectReferenceLevel.OBJECT.value and len(refs) >= 3
+        ):  # pragma: no cover
             # Ambiguous case: The object (i.e. column) could be the first or
             # second part, so return both.
-            return [refs[1], refs[2]]  # pragma: no cover
+            return [refs[1], refs[2]]
         return super().extract_possible_references(level)
 
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -738,7 +738,7 @@ class ColumnReferenceSegment(ObjectReferenceSegment):  # type: ignore
             # Ambiguous case: The object (i.e. column) could be the first or
             # second part, so return both.
             return [refs[1], refs[2]]
-        return super().extract_possible_references(level)
+        return super().extract_possible_references(level)  # pragma: no cover
 
 
 @bigquery_dialect.segment()

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -717,7 +717,7 @@ class ColumnReferenceSegment(ObjectReferenceSegment):  # type: ignore
           json_functions#to_json_string
         - STRUCT
 
-        mean that, without schema information (which SQLFluff does not have),
+        means that, without schema information (which SQLFluff does not have),
         references to data are often ambiguous.
         """
         level = self._level_to_int(level)

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -726,8 +726,8 @@ class ColumnReferenceSegment(ObjectReferenceSegment):  # type: ignore
             return [refs[0]]  # pragma: no cover
         if level == self.ObjectReferenceLevel.TABLE.value:
             # One part: Could be a table, e.g. TO_JSON_STRING(t)
-            # Two parts: Could be schema+table or table+column.
-            # Three parts: Could be table+column+struct or schema+table+column.
+            # Two parts: Could be dataset+table or table+column.
+            # Three parts: Could be table+column+struct or dataset+table+column.
             return refs[:2]
         if (
             level == self.ObjectReferenceLevel.OBJECT.value and len(refs) >= 3

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -726,9 +726,12 @@ class ColumnReferenceSegment(ObjectReferenceSegment):  # type: ignore
             return [refs[0]]  # pragma: no cover
         if level == self.ObjectReferenceLevel.TABLE.value:
             # One part: Could be a table, e.g. TO_JSON_STRING(t)
-            # Two parts: Could be dataset+table or table+column.
-            # Three parts: Could be table+column+struct or dataset+table+column.
-            return refs[:2]
+            # Two parts: Could be dataset.table or table.column.
+            # Three parts: Could be table.column.struct or dataset.table.column.
+            # Four parts: dataset.table.column.struct
+            # Five parts: project.dataset.table.column.struct
+            # So... return the first 3 parts.
+            return refs[:3]
         if (
             level == self.ObjectReferenceLevel.OBJECT.value and len(refs) >= 3
         ):  # pragma: no cover

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -711,7 +711,7 @@ class ColumnReferenceSegment(ObjectReferenceSegment):  # type: ignore
         """Extract possible references of a given level.
 
         Overrides the parent-class function. BigQuery's support for things like
-        the following
+        the following:
         - Functions that take a table as a parameter (e.g. TO_JSON_STRING)
           https://cloud.google.com/bigquery/docs/reference/standard-sql/
           json_functions#to_json_string

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -713,10 +713,8 @@ class ColumnReferenceSegment(ObjectReferenceSegment):  # type: ignore
         refs = list(self.iter_raw_references())
         if level == self.ObjectReferenceLevel.SCHEMA.value and len(refs) >= 3:
             return [refs[0]]  # pragma: no cover
-        if level == self.ObjectReferenceLevel.TABLE.value and len(refs) >= 3:
-            # Ambiguous case: The table could be the first or second part, so
-            # return both.
-            return [refs[0], refs[1]]
+        if level == self.ObjectReferenceLevel.TABLE.value:
+            return refs[:2]
         if level == self.ObjectReferenceLevel.OBJECT.value and len(refs) >= 3:
             # Ambiguous case: The object (i.e. column) could be the first or
             # second part, so return both.

--- a/test/fixtures/rules/std_rule_cases/L025.yml
+++ b/test/fixtures/rules/std_rule_cases/L025.yml
@@ -102,3 +102,19 @@ test_pass_subselect_uses_alias_3:
     SELECT col_1
     FROM table_a AS a
     WHERE NOT EXISTS (SELECT TRUE FROM table_b AS b WHERE a.col_4 = b.col_1)
+
+test_ansi_function_not_table_parameter:
+  fail_str: |
+    SELECT TO_JSON_STRING(t)
+    FROM my_table AS t
+  fix_str: |
+    SELECT TO_JSON_STRING(t)
+    FROM my_table
+
+test_bigquery_function_takes_table_parameter:
+  pass_str: |
+    SELECT TO_JSON_STRING(t)
+    FROM my_table AS t
+  configs:
+    core:
+      dialect: bigquery

--- a/test/fixtures/rules/std_rule_cases/L025.yml
+++ b/test/fixtures/rules/std_rule_cases/L025.yml
@@ -111,9 +111,25 @@ test_ansi_function_not_table_parameter:
     SELECT TO_JSON_STRING(t)
     FROM my_table
 
-test_bigquery_function_takes_table_parameter:
+test_bigquery_function_takes_tablealias_parameter:
   pass_str: |
     SELECT TO_JSON_STRING(t)
+    FROM my_table AS t
+  configs:
+    core:
+      dialect: bigquery
+
+test_bigquery_function_takes_tablealias_column_parameter:
+  pass_str: |
+    SELECT TO_JSON_STRING(t.c)
+    FROM my_table AS t
+  configs:
+    core:
+      dialect: bigquery
+
+test_bigquery_function_takes_tablealias_column_struct_parameter:
+  pass_str: |
+    SELECT TO_JSON_STRING(t.c.structure)
     FROM my_table AS t
   configs:
     core:


### PR DESCRIPTION
### Brief summary of the change made
Fixes #2030 

BigQuery already had special code to deal with some ambiguity about which portion of an object reference was the table, schema, etc. To fix this issue (BigQuery functions that take a table as a parameter), we change it again, making it even more "accepting".

### Are there any other side effects of this change that we should be aware of?

The tradeoff of doing it this way (which we were already doing in L026) is that rules using this function to interpret a reference are given things that _may or may not_ be table references. In this case, that works fine. Generally, any rule using this function must be designed so that it behaves reasonably in spite of the ambiguity. (Generally, rules should "fail safe", i.e. don't "fix" code unless they know for sure how to do it safely, and don't warn unless they're sure there's an issue.)

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
