### PR TITLE
Fix link for editing 'In The Wild' page with new base branch, `main`

### DIFF
--- a/docs/source/inthewild.rst
+++ b/docs/source/inthewild.rst
@@ -8,7 +8,7 @@ use cases? Want to brag about how you're using it? Just want to
 show solidarity with the project and provide a testimonial for it?
 
 Just add a section below by raising a PR on GitHub by
-`editing this file ✏️ <https://github.com/sqlfluff/sqlfluff/edit/master/docs/source/inthewild.rst>`_.
+`editing this file ✏️ <https://github.com/sqlfluff/sqlfluff/edit/main/docs/source/inthewild.rst>`_.
 
 - SQLFluff in production `dbt <http://www.getdbt.com/>`_ projects at
   `tails.com <https://tails.com>`_. We use the SQLFluff cli as part


### PR DESCRIPTION
### Brief summary of the change made
Fix link to a page now that the base branch is `main`.

### Are there any other side effects of this change that we should be aware of?
Nope. Did a quick grep and didn't find other pages with `master`

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
