### PR TITLE
Spark3: Coverage for `REFRESH` auxiliary statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -757,6 +757,22 @@ class RefreshStatementSegment(BaseSegment):
     )
 
 
+@spark3_dialect.segment()
+class RefreshTableStatementSegment(BaseSegment):
+    """A `REFRESH TABLE` statement.
+
+    https://spark.apache.org/docs/latest/sql-ref-syntax-aux-cache-refresh-table.html
+    """
+
+    type = "refresh_table_statement"
+
+    match_grammar = Sequence(
+        "REFRESH",
+        Ref.keyword("TABLE", optional=True),
+        Ref("TableReferenceSegment"),
+    )
+
+
 @spark3_dialect.segment(replace=True)
 class StatementSegment(BaseSegment):
     """Overriding StatementSegment to allow for additional segment parsing."""
@@ -776,6 +792,7 @@ class StatementSegment(BaseSegment):
             # Auxiliary Statements
             Ref("AddExecutablePackage"),
             Ref("RefreshStatementSegment"),
+            Ref("RefreshTableStatementSegment"),
         ],
         remove=[
             Ref("TransactionStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -742,6 +742,21 @@ class AddExecutablePackage(BaseSegment):
     )
 
 
+@spark3_dialect.segment()
+class RefreshStatementSegment(BaseSegment):
+    """A `REFRESH` statement for given data source path.
+
+    https://spark.apache.org/docs/latest/sql-ref-syntax-aux-cache-refresh.html
+    """
+
+    type = "refresh_statement"
+
+    match_grammar = Sequence(
+        "REFRESH",
+        Ref("SingleOrDoubleQuotedLiteralGrammar"),
+    )
+
+
 @spark3_dialect.segment(replace=True)
 class StatementSegment(BaseSegment):
     """Overriding StatementSegment to allow for additional segment parsing."""
@@ -760,6 +775,7 @@ class StatementSegment(BaseSegment):
             Ref("MsckRepairTableStatementSegment"),
             # Auxiliary Statements
             Ref("AddExecutablePackage"),
+            Ref("RefreshStatementSegment"),
         ],
         remove=[
             Ref("TransactionStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -775,12 +775,12 @@ class RefreshTableStatementSegment(BaseSegment):
 
 @spark3_dialect.segment()
 class RefreshFunctionStatementSegment(BaseSegment):
-    """A `REFRESH FUNCTINO` statement.
+    """A `REFRESH FUNCTION` statement.
 
     https://spark.apache.org/docs/latest/sql-ref-syntax-aux-cache-refresh-function.html
     """
 
-    type = "refresh_table_statement"
+    type = "refresh_function_statement"
 
     match_grammar = Sequence(
         "REFRESH",

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -773,6 +773,22 @@ class RefreshTableStatementSegment(BaseSegment):
     )
 
 
+@spark3_dialect.segment()
+class RefreshFunctionStatementSegment(BaseSegment):
+    """A `REFRESH FUNCTINO` statement.
+
+    https://spark.apache.org/docs/latest/sql-ref-syntax-aux-cache-refresh-function.html
+    """
+
+    type = "refresh_table_statement"
+
+    match_grammar = Sequence(
+        "REFRESH",
+        "FUNCTION",
+        Ref("FunctionNameSegment"),
+    )
+
+
 @spark3_dialect.segment(replace=True)
 class StatementSegment(BaseSegment):
     """Overriding StatementSegment to allow for additional segment parsing."""
@@ -793,6 +809,7 @@ class StatementSegment(BaseSegment):
             Ref("AddExecutablePackage"),
             Ref("RefreshStatementSegment"),
             Ref("RefreshTableStatementSegment"),
+            Ref("RefreshFunctionStatementSegment"),
         ],
         remove=[
             Ref("TransactionStatementSegment"),

--- a/test/fixtures/dialects/spark3/refresh.sql
+++ b/test/fixtures/dialects/spark3/refresh.sql
@@ -1,0 +1,2 @@
+-- The Path is resolved using the datasource's File Index.
+REFRESH "hdfs://path/to/table";

--- a/test/fixtures/dialects/spark3/refresh.yml
+++ b/test/fixtures/dialects/spark3/refresh.yml
@@ -1,0 +1,12 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e1491fda3158262959913d0e9339763d75e4bdb8f1296c273a0bdfced2aa038e
+file:
+  base:
+    refresh_statement:
+      keyword: REFRESH
+      literal: '"hdfs://path/to/table"'
+  statement_terminator: ;

--- a/test/fixtures/dialects/spark3/refresh_function.sql
+++ b/test/fixtures/dialects/spark3/refresh_function.sql
@@ -1,0 +1,9 @@
+-- The cached entry of the function will be refreshed
+-- The function is resolved from the current database
+--   as the function name is unqualified.
+REFRESH FUNCTION func1;
+
+-- The cached entry of the function will be refreshed
+-- The function is resolved from tempDB database as the
+--   function name is qualified.
+REFRESH FUNCTION db1.func1;

--- a/test/fixtures/dialects/spark3/refresh_function.yml
+++ b/test/fixtures/dialects/spark3/refresh_function.yml
@@ -1,0 +1,23 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9b53d7d1cd07231e9c05f3a1137b5eb7d5441f99abd2ca93a56638f5bb722af0
+file:
+- base:
+    refresh_table_statement:
+    - keyword: REFRESH
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: func1
+- statement_terminator: ;
+- base:
+    refresh_table_statement:
+    - keyword: REFRESH
+    - keyword: FUNCTION
+    - function_name:
+        identifier: db1
+        dot: .
+        function_name_identifier: func1
+- statement_terminator: ;

--- a/test/fixtures/dialects/spark3/refresh_function.yml
+++ b/test/fixtures/dialects/spark3/refresh_function.yml
@@ -3,17 +3,17 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9b53d7d1cd07231e9c05f3a1137b5eb7d5441f99abd2ca93a56638f5bb722af0
+_hash: 1243bb8be622939f3614af18852629f95ea0e90872dbeb789835773cd716ed7b
 file:
 - base:
-    refresh_table_statement:
+    refresh_function_statement:
     - keyword: REFRESH
     - keyword: FUNCTION
     - function_name:
         function_name_identifier: func1
 - statement_terminator: ;
 - base:
-    refresh_table_statement:
+    refresh_function_statement:
     - keyword: REFRESH
     - keyword: FUNCTION
     - function_name:

--- a/test/fixtures/dialects/spark3/refresh_table.sql
+++ b/test/fixtures/dialects/spark3/refresh_table.sql
@@ -1,0 +1,11 @@
+-- The cached entries of the table will be refreshed
+-- The table is resolved from the current database as
+--   the table name is unqualified.
+REFRESH TABLE tbl1;
+REFRESH tbl1;
+
+-- The cached entries of the view will be refreshed or invalidated
+-- The view is resolved from tempDB database, as the view
+--   name is qualified.
+REFRESH TABLE tempdb.view1;
+REFRESH tempdb.view1;

--- a/test/fixtures/dialects/spark3/refresh_table.yml
+++ b/test/fixtures/dialects/spark3/refresh_table.yml
@@ -1,0 +1,37 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 73a5a39d2989bb24385996db20301724bb72b504c9044dcda86d7ce7cfd26fd2
+file:
+- base:
+    refresh_table_statement:
+    - keyword: REFRESH
+    - keyword: TABLE
+    - table_reference:
+        identifier: tbl1
+- statement_terminator: ;
+- base:
+    refresh_table_statement:
+      keyword: REFRESH
+      table_reference:
+        identifier: tbl1
+- statement_terminator: ;
+- base:
+    refresh_table_statement:
+    - keyword: REFRESH
+    - keyword: TABLE
+    - table_reference:
+      - identifier: tempdb
+      - dot: .
+      - identifier: view1
+- statement_terminator: ;
+- base:
+    refresh_table_statement:
+      keyword: REFRESH
+      table_reference:
+      - identifier: tempdb
+      - dot: .
+      - identifier: view1
+- statement_terminator: ;


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Add implementation to match on and test cases for `REFRESH` statements in spark3 dialect.

Fixes #1934 

### Are there any other side effects of this change that we should be aware of?
N/A

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
