### PR TITLE
Update L009 to operate in raw, not templated space

### DIFF
--- a/src/sqlfluff/core/rules/functional/__init__.py
+++ b/src/sqlfluff/core/rules/functional/__init__.py
@@ -12,7 +12,8 @@ lower-level classes, or a mix, but it is suggested that each rule primarily
 use one or the other for readability.
 """
 
-__all__ = ("Segments", "sp")
+__all__ = ("Segments", "rsp", "sp")
 
 from sqlfluff.core.rules.functional.segments import Segments
+import sqlfluff.core.rules.functional.raw_file_slice_predicates as rsp
 import sqlfluff.core.rules.functional.segment_predicates as sp

--- a/src/sqlfluff/core/rules/functional/segment_predicates.py
+++ b/src/sqlfluff/core/rules/functional/segment_predicates.py
@@ -143,7 +143,9 @@ def raw_slices(
 ) -> RawFileSlices:
     """Returns raw slices for a segment."""
     if not templated_file:
-        raise ValueError('raw_slices: "templated_file" parameter is required.')
+        raise ValueError(
+            'raw_slices: "templated_file" parameter is required.'
+        )  # pragma: no cover
     return RawFileSlices(
         *templated_file.raw_slices_spanning_source_slice(
             segment.pos_marker.source_slice

--- a/src/sqlfluff/core/rules/functional/segment_predicates.py
+++ b/src/sqlfluff/core/rules/functional/segment_predicates.py
@@ -8,9 +8,11 @@ This is not necessarily a complete set of predicates covering all possible
 requirements. Rule authors can define their own predicates as needed, either
 as regular functions, `lambda`, etc.
 """
-from typing import Callable
+from typing import Callable, Optional
 
 from sqlfluff.core.parser import BaseSegment
+from sqlfluff.core.rules.functional.raw_file_slices import RawFileSlices
+from sqlfluff.core.templaters.base import TemplatedFile
 
 
 def is_type(*seg_type: str) -> Callable[[BaseSegment], bool]:
@@ -133,3 +135,18 @@ def not_(fn: Callable[[BaseSegment], bool]) -> Callable[[BaseSegment], bool]:
         return not fn(segment)
 
     return _
+
+
+def raw_slices(
+    segment: BaseSegment,
+    templated_file: Optional[TemplatedFile],
+) -> RawFileSlices:
+    """Returns raw slices for a segment."""
+    if not templated_file:
+        raise ValueError('raw_slices: "templated_file" parameter is required.')
+    return RawFileSlices(
+        *templated_file.raw_slices_spanning_source_slice(
+            segment.pos_marker.source_slice
+        ),
+        templated_file=templated_file
+    )

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -116,7 +116,10 @@ class Rule_L009(BaseRule):
             )
         else:
             # There are one or more trailing newlines in templated space.
-            # Translate to "raw" space and count them there. Delete any extras.
+            # For any excess newlines, translate to "raw" space to determine if
+            # they are literal (rather than templated). Delete any extras.
+            # (Note that 'trailing_newlines' is ordered in reverse, i.e. from
+            # the end of the file *backwards*.)
             extra_newlines = trailing_newlines[1:].select(
                 loop_while=lambda seg: sp.raw_slices(seg, context.templated_file).all(
                     rsp.is_slice_type("literal")

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -117,15 +117,15 @@ class Rule_L009(BaseRule):
         else:
             # There are one or more trailing newlines in templated space.
             # Translate to "raw" space and count them there. Delete any extras.
-            filtered_trailing_newlines = trailing_newlines.select(
-                lambda seg: sp.raw_slices(seg, context.templated_file).all(
+            extra_newlines = trailing_newlines[1:].select(
+                loop_while=lambda seg: sp.raw_slices(seg, context.templated_file).all(
                     rsp.is_slice_type("literal")
                 )
             )
-            if len(filtered_trailing_newlines) > 1:
+            if extra_newlines:
                 return LintResult(
                     anchor=context.segment,
-                    fixes=[LintFix.delete(d) for d in filtered_trailing_newlines[1:]],
+                    fixes=[LintFix.delete(d) for d in extra_newlines],
                 )
             # Single newline, no need for fix.
             return None

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -5,8 +5,7 @@ from sqlfluff.core.parser import NewlineSegment
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible
-from sqlfluff.core.rules.functional import Segments
-from sqlfluff.core.rules.functional import segment_predicates as sp
+from sqlfluff.core.rules.functional import Segments, rsp, sp
 
 
 @document_fix_compatible
@@ -99,10 +98,7 @@ class Rule_L009(BaseRule):
             loop_while=sp.or_(sp.is_whitespace(), sp.is_type("dedent")),
         )
 
-        if len(trailing_newlines) == 1:
-            # No need for fix if single new line exists.
-            return None
-        elif len(trailing_newlines) == 0:
+        if not trailing_newlines:
             # We make an edit to create this segment after the child of the FileSegment.
             if len(parent_stack) == 1:
                 fix_anchor_segment = context.segment
@@ -119,8 +115,17 @@ class Rule_L009(BaseRule):
                 ],
             )
         else:
-            # There are excess newlines so delete all bar one.
-            return LintResult(
-                anchor=context.segment,
-                fixes=[LintFix.delete(d) for d in trailing_newlines[1:]],
+            # There are one or more trailing newlines in templated space.
+            # Translate to "raw" space and count them there. Delete any extras.
+            extra_newlines = trailing_newlines[1:].select(
+                loop_while=lambda seg: sp.raw_slices(seg, context.templated_file).all(
+                    rsp.is_slice_type("literal")
+                )
             )
+            if extra_newlines:
+                return LintResult(
+                    anchor=context.segment,
+                    fixes=[LintFix.delete(d) for d in extra_newlines],
+                )
+            # Single newline, no need for fix.
+            return None

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -117,15 +117,15 @@ class Rule_L009(BaseRule):
         else:
             # There are one or more trailing newlines in templated space.
             # Translate to "raw" space and count them there. Delete any extras.
-            extra_newlines = trailing_newlines[1:].select(
-                loop_while=lambda seg: sp.raw_slices(seg, context.templated_file).all(
+            filtered_trailing_newlines = trailing_newlines.select(
+                lambda seg: sp.raw_slices(seg, context.templated_file).all(
                     rsp.is_slice_type("literal")
                 )
             )
-            if extra_newlines:
+            if len(filtered_trailing_newlines) > 1:
                 return LintResult(
                     anchor=context.segment,
-                    fixes=[LintFix.delete(d) for d in extra_newlines],
+                    fixes=[LintFix.delete(d) for d in filtered_trailing_newlines[1:]],
                 )
             # Single newline, no need for fix.
             return None

--- a/test/fixtures/rules/std_rule_cases/L009.yml
+++ b/test/fixtures/rules/std_rule_cases/L009.yml
@@ -10,3 +10,7 @@ test_fail_no_final_newline:
 test_fail_multiple_final_newlines:
   fail_str: "SELECT foo FROM bar\n\n"
   fix_str: "SELECT foo FROM bar\n"
+
+test_pass_templated_plus_raw_newlines:
+  pass_str: |
+    {{ "\n\n" }}

--- a/test/fixtures/rules/std_rule_cases/L009.yml
+++ b/test/fixtures/rules/std_rule_cases/L009.yml
@@ -12,5 +12,4 @@ test_fail_multiple_final_newlines:
   fix_str: "SELECT foo FROM bar\n"
 
 test_pass_templated_plus_raw_newlines:
-  pass_str: |
-    {{ "\n\n" }}
+  pass_str: "{{ '\n\n' }}\n"


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
Fixes #2046 

Updates L009 to consider whether trailing newlines are in raw or templated space before reporting an issue.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
