### PR TITLE
docs: Document configuration keyword for rule L054

### DIFF
--- a/src/sqlfluff/rules/L054.py
+++ b/src/sqlfluff/rules/L054.py
@@ -2,8 +2,12 @@
 from typing import Optional
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.doc_decorators import (
+    document_configuration,
+)
 
 
+@document_configuration
 class Rule_L054(BaseRule):
     """Inconsistent column references in ``GROUP BY/ORDER BY`` clauses.
 


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->

Decorates [`Rule_L054`](https://github.com/sqlfluff/sqlfluff/blob/main/src/sqlfluff/rules/L054.py#L7) with [`document_configuration`](https://github.com/sqlfluff/sqlfluff/blob/main/src/sqlfluff/core/rules/doc_decorators.py#L21), as the configuration keyword is already present in [config_info.py](https://github.com/sqlfluff/sqlfluff/blob/main/src/sqlfluff/core/rules/config_info.py#L120).

Closes #2287

### Are there any other side effects of this change that we should be aware of?

Should be pretty harmless.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
