### PR TITLE
added missing "t" in doc for Rule_L020

### DIFF
--- a/src/sqlfluff/rules/L020.py
+++ b/src/sqlfluff/rules/L020.py
@@ -13,7 +13,7 @@ class Rule_L020(BaseRule):
     """Table aliases should be unique within each clause.
 
     | **Anti-pattern**
-    | In this example, the alias 't' is reused for two different ables:
+    | In this example, the alias 't' is reused for two different tables:
 
     .. code-block:: sql
 


### PR DESCRIPTION


<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->

There were missing `t` for "tables" in the SQLFluff doc on the "Rules Reference" page, rule L020. 

[https://docs.sqlfluff.com/en/latest/rules.html](https://docs.sqlfluff.com/en/latest/rules.html#:~:text=for%20two%20different-,ables,-%3A)

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
