### PR TITLE
Fix #1292: nocolor and verbose can work in config files

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -7,6 +7,7 @@ import logging
 import time
 from logging import LogRecord
 from typing import (
+    Any,
     Callable,
     Tuple,
     NoReturn,
@@ -299,8 +300,19 @@ def get_config(
                 )
             )
             sys.exit(66)
+
     # Instantiate a config object (filtering out the nulls)
-    overrides = {k: kwargs[k] for k in kwargs if kwargs[k] is not None}
+    def null(key: str, val: Any) -> bool:
+        if val is None:
+            return True
+        if key == "nocolor" and val is False:
+            return True
+        if key == "verbose" and val == 0:
+            return True
+        return False
+
+    overrides = {k: kwargs[k] for k in kwargs if not null(k, kwargs[k])}
+
     try:
         return FluffConfig.from_root(
             extra_config_path=extra_config_path,

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -7,7 +7,6 @@ import logging
 import time
 from logging import LogRecord
 from typing import (
-    Any,
     Callable,
     Tuple,
     NoReturn,
@@ -151,6 +150,7 @@ def common_options(f: Callable) -> Callable:
         "-v",
         "--verbose",
         count=True,
+        default=None,
         help=(
             "Verbosity, how detailed should the output be. This is *stackable*, so `-vv`"
             " is more verbose than `-v`. For the most verbose option try `-vvvv` or `-vvvvv`."
@@ -160,6 +160,7 @@ def common_options(f: Callable) -> Callable:
         "-n",
         "--nocolor",
         is_flag=True,
+        default=None,
         help="No color - if this is set then the output will be without ANSI color codes.",
     )(f)
 
@@ -300,19 +301,8 @@ def get_config(
                 )
             )
             sys.exit(66)
-
     # Instantiate a config object (filtering out the nulls)
-    def null(key: str, val: Any) -> bool:
-        if val is None:
-            return True
-        if key == "nocolor" and val is False:
-            return True
-        if key == "verbose" and val == 0:
-            return True
-        return False
-
-    overrides = {k: kwargs[k] for k in kwargs if not null(k, kwargs[k])}
-
+    overrides = {k: kwargs[k] for k in kwargs if kwargs[k] is not None}
     try:
         return FluffConfig.from_root(
             extra_config_path=extra_config_path,

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -928,8 +928,8 @@ def test_cli_get_config():
     config = get_config(
         "test/fixtures/config/toml/pyproject.toml",
         True,
-        nocolor=False,
-        verbose=0,
+        nocolor=None,
+        verbose=None,
     )
     assert config.get("nocolor") is True
     assert config.get("verbose") == 2

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -18,7 +18,7 @@ from click.testing import CliRunner
 
 # We import the library directly here to get the version
 import sqlfluff
-from sqlfluff.cli.commands import lint, version, rules, fix, parse, dialects
+from sqlfluff.cli.commands import lint, version, rules, fix, parse, dialects, get_config
 
 
 def invoke_assert_code(
@@ -922,6 +922,17 @@ def test_cli_disable_noqa_flag():
 
     # Linting error is raised even though it is inline ignored.
     assert r"L:   5 | P:  11 | L010 |" in raw_output
+
+
+def test_cli_get_config():
+    config = get_config(
+        "test/fixtures/config/toml/pyproject.toml",
+        True,
+        nocolor=False,
+        verbose=0,
+    )
+    assert config.get("nocolor") is True
+    assert config.get("verbose") == 2
 
 
 @patch(

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -924,7 +924,8 @@ def test_cli_disable_noqa_flag():
     assert r"L:   5 | P:  11 | L010 |" in raw_output
 
 
-def test_cli_get_config():
+def test_cli_get_default_config():
+    """`nocolor` and `verbose` values loaded from config if not specified via CLI."""
     config = get_config(
         "test/fixtures/config/toml/pyproject.toml",
         True,

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -99,6 +99,8 @@ def test__config__load_toml():
     )
     assert cfg == {
         "core": {
+            "nocolor": True,
+            "verbose": 2,
             "testing_int": 5,
             "testing_bar": 7.698,
             "testing_bool": False,

--- a/test/fixtures/config/toml/pyproject.toml
+++ b/test/fixtures/config/toml/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.sqlfluff.core]
-nocolor = True
+nocolor = true
 verbose = 2
 testing_int = 5
 testing_bar = 7.698

--- a/test/fixtures/config/toml/pyproject.toml
+++ b/test/fixtures/config/toml/pyproject.toml
@@ -1,4 +1,6 @@
 [tool.sqlfluff.core]
+nocolor = True
+verbose = 2
 testing_int = 5
 testing_bar = 7.698
 testing_bool = false


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->

- Fix #1292

### Are there any other side effects of this change that we should be aware of?

The cause of this bug is that some options in Click (`--nocolor` and `--verbose`) don't have default values when not specified as CLI options. In original code, only `None` must be default value. This change should define default values for each options other than `None`.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
