### PR TITLE
Allow pyproject.toml as extra_config_path

### DIFF
--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -310,7 +310,10 @@ class ConfigLoader:
             return self._config_cache[str(extra_config_path)]
 
         configs: dict = {}
-        elems = self._get_config_elems_from_file(extra_config_path)
+        if extra_config_path.endswith("pyproject.toml"):
+            elems = self._get_config_elems_from_toml(extra_config_path)
+        else:
+            elems = self._get_config_elems_from_file(extra_config_path)
         configs = self._incorporate_vals(configs, elems)
 
         # Store in the cache

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -291,6 +291,14 @@ def test__cli__command_lint_stdin(command):
                 "test/fixtures/cli/extra_config_tsql.sql",
             ],
         ),
+        (
+            lint,
+            [
+                "--config",
+                "test/fixtures/cli/extra_configs/pyproject.toml",
+                "test/fixtures/cli/extra_config_tsql.sql",
+            ],
+        ),
     ],
 )
 def test__cli__command_lint_parse(command):

--- a/test/fixtures/cli/extra_configs/pyproject.toml
+++ b/test/fixtures/cli/extra_configs/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.sqlfluff.core]
+dialect = "tsql"


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Unblocks #2300. Originally `extra_config_path` only allowed custom paths for `ini/cfg` files (added #1986), this PR allows custom paths for `pyproject.toml` files as well.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
