### PR TITLE
Fix spark and hive quoted literals

### DIFF
--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -55,16 +55,6 @@ hive_dialect.sets("datetime_units").update(
 )
 
 hive_dialect.add(
-    DoubleQuotedLiteralSegment=NamedParser(
-        "double_quote",
-        CodeSegment,
-        name="quoted_literal",
-        type="literal",
-        trim_chars=('"',),
-    ),
-    SingleOrDoubleQuotedLiteralGrammar=OneOf(
-        Ref("QuotedLiteralSegment"), Ref("DoubleQuotedLiteralSegment")
-    ),
     StartAngleBracketSegment=StringParser(
         "<", SymbolSegment, name="start_angle_bracket", type="start_angle_bracket"
     ),
@@ -83,11 +73,11 @@ hive_dialect.add(
     TextfileKeywordSegment=StringParser(
         "TEXTFILE", KeywordSegment, name="text_file", type="file_format"
     ),
-    LocationGrammar=Sequence("LOCATION", Ref("SingleOrDoubleQuotedLiteralGrammar")),
+    LocationGrammar=Sequence("LOCATION", Ref("QuotedLiteralSegment")),
     PropertyGrammar=Sequence(
-        Ref("SingleOrDoubleQuotedLiteralGrammar"),
+        Ref("QuotedLiteralSegment"),
         Ref("EqualsSegment"),
-        Ref("SingleOrDoubleQuotedLiteralGrammar"),
+        Ref("QuotedLiteralSegment"),
     ),
     BracketedPropertyListGrammar=Bracketed(Delimited(Ref("PropertyGrammar"))),
     TablePropertiesGrammar=Sequence(
@@ -107,16 +97,16 @@ hive_dialect.add(
         "JSONFILE",
         Sequence(
             "INPUTFORMAT",
-            Ref("SingleOrDoubleQuotedLiteralGrammar"),
+            Ref("QuotedLiteralSegment"),
             "OUTPUTFORMAT",
-            Ref("SingleOrDoubleQuotedLiteralGrammar"),
+            Ref("QuotedLiteralSegment"),
         ),
     ),
     StoredAsGrammar=Sequence("STORED", "AS", Ref("FileFormatGrammar")),
     StoredByGrammar=Sequence(
         "STORED",
         "BY",
-        Ref("SingleOrDoubleQuotedLiteralGrammar"),
+        Ref("QuotedLiteralSegment"),
         Ref("SerdePropertiesGrammar", optional=True),
     ),
     StorageFormatGrammar=OneOf(
@@ -126,7 +116,7 @@ hive_dialect.add(
         ),
         Ref("StoredByGrammar"),
     ),
-    CommentGrammar=Sequence("COMMENT", Ref("SingleOrDoubleQuotedLiteralGrammar")),
+    CommentGrammar=Sequence("COMMENT", Ref("QuotedLiteralSegment")),
     PartitionSpecGrammar=Sequence(
         "PARTITION",
         Bracketed(
@@ -144,6 +134,10 @@ hive_dialect.add(
 # https://cwiki.apache.org/confluence/display/hive/languagemanual+joins
 hive_dialect.replace(
     JoinKeywords=Sequence(Sequence("SEMI", optional=True), "JOIN"),
+    QuotedLiteralSegment=OneOf(
+        NamedParser("single_quote", CodeSegment, name="quoted_literal", type="literal"),
+        NamedParser("double_quote", CodeSegment, name="quoted_literal", type="literal"),
+    ),
 )
 
 
@@ -159,9 +153,7 @@ class CreateDatabaseStatementSegment(BaseSegment):
         Ref("DatabaseReferenceSegment"),
         Ref("CommentGrammar", optional=True),
         Ref("LocationGrammar", optional=True),
-        Sequence(
-            "MANAGEDLOCATION", Ref("SingleOrDoubleQuotedLiteralGrammar"), optional=True
-        ),
+        Sequence("MANAGEDLOCATION", Ref("QuotedLiteralSegment"), optional=True),
         Sequence(
             "WITH", "DBPROPERTIES", Ref("BracketedPropertyListGrammar"), optional=True
         ),
@@ -410,7 +402,7 @@ class RowFormatClauseSegment(BaseSegment):
             ),
             Sequence(
                 "SERDE",
-                Ref("SingleOrDoubleQuotedLiteralGrammar"),
+                Ref("QuotedLiteralSegment"),
                 Ref("SerdePropertiesGrammar", optional=True),
             ),
         ),
@@ -432,10 +424,10 @@ class AlterDatabaseStatementSegment(BaseSegment):
             Sequence(
                 "OWNER",
                 OneOf("USER", "ROLE"),
-                Ref("SingleOrDoubleQuotedLiteralGrammar"),
+                Ref("QuotedLiteralSegment"),
             ),
             Ref("LocationGrammar"),
-            Sequence("MANAGEDLOCATION", Ref("SingleOrDoubleQuotedLiteralGrammar")),
+            Sequence("MANAGEDLOCATION", Ref("QuotedLiteralSegment")),
         ),
     )
 
@@ -516,7 +508,7 @@ class InsertStatementSegment(BaseSegment):
                     Sequence(
                         Sequence("LOCAL", optional=True),
                         "DIRECTORY",
-                        Ref("SingleOrDoubleQuotedLiteralGrammar"),
+                        Ref("QuotedLiteralSegment"),
                         Ref("RowFormatClauseSegment", optional=True),
                         Ref("StoredAsGrammar", optional=True),
                         Ref("SelectableGrammar"),

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -131,17 +131,11 @@ spark3_dialect.replace(
         type="identifier",
         trim_chars=("`",),
     ),
+    QuotedLiteralSegment=hive_dialect.get_grammar("QuotedLiteralSegment"),
 )
 
 spark3_dialect.add(
     # Add Hive Segments TODO : Is there a way to retrieve this w/o redefining?
-    DoubleQuotedLiteralSegment=NamedParser(
-        "double_quote",
-        CodeSegment,
-        name="quoted_literal",
-        type="literal",
-        trim_chars=('"',),
-    ),
     JsonfileKeywordSegment=StringParser(
         "JSONFILE",
         KeywordSegment,
@@ -187,9 +181,6 @@ spark3_dialect.add(
     StoredAsGrammar=hive_dialect.get_grammar("StoredAsGrammar"),
     StoredByGrammar=hive_dialect.get_grammar("StoredByGrammar"),
     StorageFormatGrammar=hive_dialect.get_grammar("StorageFormatGrammar"),
-    SingleOrDoubleQuotedLiteralGrammar=hive_dialect.get_grammar(
-        "SingleOrDoubleQuotedLiteralGrammar"
-    ),
     TerminatedByGrammar=hive_dialect.get_grammar("TerminatedByGrammar"),
     # Add Spark Grammar
     BucketSpecGrammar=Sequence(
@@ -241,7 +232,7 @@ spark3_dialect.add(
     ResourceLocationGrammar=Sequence(
         "USING",
         Ref("ResourceFileGrammar"),
-        Ref("SingleOrDoubleQuotedLiteralGrammar"),
+        Ref("QuotedLiteralSegment"),
     ),
     SortSpecGrammar=Sequence(
         "SORTED",
@@ -260,7 +251,7 @@ spark3_dialect.add(
         "UNSET",
         "TBLPROPERTIES",
         Ref("IfExistsGrammar", optional=True),
-        Bracketed(Delimited(Ref("SingleOrDoubleQuotedLiteralGrammar"))),
+        Bracketed(Delimited(Ref("QuotedLiteralSegment"))),
     ),
     TablePropertiesGrammar=Sequence(
         "TBLPROPERTIES", Ref("BracketedPropertyListGrammar")
@@ -475,7 +466,7 @@ class AlterTableStatementSegment(BaseSegment):
                     ),
                     Sequence(
                         "SERDE",
-                        Ref("SingleOrDoubleQuotedLiteralGrammar"),
+                        Ref("QuotedLiteralSegment"),
                         Ref("SerdePropertiesGrammar", optional=True),
                     ),
                 ),
@@ -572,7 +563,7 @@ class CreateFunctionStatementSegment(BaseSegment):
         Ref("IfNotExistsGrammar", optional=True),
         Ref("FunctionNameIdentifierSegment"),
         "AS",
-        Ref("SingleOrDoubleQuotedLiteralGrammar"),
+        Ref("QuotedLiteralSegment"),
         Ref("ResourceLocationGrammar", optional=True),
     )
 
@@ -753,7 +744,7 @@ class AddExecutablePackage(BaseSegment):
     match_grammar = Sequence(
         "ADD",
         Ref("ResourceFileGrammar"),
-        Ref("SingleOrDoubleQuotedLiteralGrammar"),
+        Ref("QuotedLiteralSegment"),
     )
 
 
@@ -768,7 +759,7 @@ class RefreshStatementSegment(BaseSegment):
 
     match_grammar = Sequence(
         "REFRESH",
-        Ref("SingleOrDoubleQuotedLiteralGrammar"),
+        Ref("QuotedLiteralSegment"),
     )
 
 

--- a/test/fixtures/dialects/hive/quoted_literal.sql
+++ b/test/fixtures/dialects/hive/quoted_literal.sql
@@ -1,0 +1,5 @@
+SELECT result
+FROM student
+WHERE
+    name = "John Smith"
+    OR name = 'Jane Doe';

--- a/test/fixtures/dialects/hive/quoted_literal.yml
+++ b/test/fixtures/dialects/hive/quoted_literal.yml
@@ -1,0 +1,36 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 84c2ac0f762ed2cf2d0c9dc3d3282219c7a34a05c30dc8aa77f0c985a59f9cae
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            identifier: result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: student
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            identifier: name
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - literal: '"John Smith"'
+        - binary_operator: OR
+        - column_reference:
+            identifier: name
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - literal: "'Jane Doe'"
+  statement_terminator: ;

--- a/test/fixtures/dialects/spark3/create_table_datasource.yml
+++ b/test/fixtures/dialects/spark3/create_table_datasource.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fbeb2346e82296c016b221a7ab6962ff396929616fea07a87519e66199df20ec
+_hash: 2e8a2a7473af740794b633ddf989f55250f697fecec012d09cf34f6a6f9c3bc9
 file:
 - base:
     create_table_statement:
@@ -21,8 +21,10 @@ file:
           data_type:
             primitive_type:
               keyword: STRING
-        keyword: COMMENT
-        literal: '"col_comment1"'
+          column_constraint_segment:
+            comment_clause:
+              keyword: COMMENT
+              literal: '"col_comment1"'
         end_bracket: )
     - keyword: USING
     - keyword: PARQUET

--- a/test/fixtures/dialects/spark3/create_table_hiveformat.yml
+++ b/test/fixtures/dialects/spark3/create_table_hiveformat.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e3654b736e37007ba92c0ac12ba5c0ec51cc2168634ecf3f632670a95f8ec888
+_hash: 1712bfa1d11d0fcf171e638b93be7f9fce3414c15bd78c7cfa7e65e522a46e92
 file:
 - base:
     create_table_statement:
@@ -22,8 +22,10 @@ file:
           data_type:
             primitive_type:
               keyword: STRING
-        keyword: COMMENT
-        literal: '"col_comment1"'
+          column_constraint_segment:
+            comment_clause:
+              keyword: COMMENT
+              literal: '"col_comment1"'
         end_bracket: )
     - keyword: COMMENT
     - literal: '"table_comment"'
@@ -36,8 +38,10 @@ file:
           data_type:
             primitive_type:
               keyword: STRING
-        keyword: COMMENT
-        literal: '"col_comment2"'
+          column_constraint_segment:
+            comment_clause:
+              keyword: COMMENT
+              literal: '"col_comment2"'
         end_bracket: )
     - keyword: CLUSTERED
     - keyword: BY

--- a/test/fixtures/dialects/spark3/quoted_literal.sql
+++ b/test/fixtures/dialects/spark3/quoted_literal.sql
@@ -1,0 +1,5 @@
+SELECT result
+FROM student
+WHERE
+    name = "John Smith"
+    OR name = 'Jane Doe';

--- a/test/fixtures/dialects/spark3/quoted_literal.yml
+++ b/test/fixtures/dialects/spark3/quoted_literal.yml
@@ -1,0 +1,36 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 668f0916babfcb35e4238006feb124a817fb0d3796b4c9e98cbf94b992aee4b3
+file:
+  base:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            identifier: result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: student
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            identifier: name
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - literal: '"John Smith"'
+        - binary_operator: OR
+        - column_reference:
+            identifier: name
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - literal: "'Jane Doe'"
+  statement_terminator: ;


### PR DESCRIPTION

<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Closes #2309. Both Spark3 and Hive can use either single or double quotes for quoted literals (quoted identifiers use backticks).
Previous implementation had added a `SingleOrDoubleQuotedLiteralGrammar` and used it in place of `QuotedLiteralSegment`, however this means that all the grammar inherited from ANSI was still only using single quotes! I've fixed both of these grammars so they properly overwrite ANSI.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
