### PR TITLE
Snowflake: Add support for column rename

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -959,7 +959,14 @@ class AlterTableTableColumnActionSegment(BaseSegment):
     match_grammar = Sequence(
         OneOf(
             # @TODO: Add Column
-            # @TODO: Rename column
+            # Rename column
+            Sequence(
+                "RENAME",
+                "COLUMN",
+                Ref("ColumnReferenceSegment"),
+                "TO",
+                Ref("ColumnReferenceSegment"),
+            ),
             # Alter/Modify column(s)
             Sequence(
                 OneOf("ALTER", "MODIFY"),

--- a/test/fixtures/dialects/snowflake/snowflake_alter_table_column.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_table_column.sql
@@ -33,3 +33,7 @@ alter table empl_info modify
 -- DROP COLUMN
 ALTER TABLE empl_info DROP COLUMN my_column;
 ALTER TABLE some_schema.empl_info DROP COLUMN my_column;
+
+
+-- Rename column
+ALTER TABLE empl_info RENAME COLUMN old_col_name TO new_col_name;

--- a/test/fixtures/dialects/snowflake/snowflake_alter_table_column.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_table_column.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ceacb0017f29185609aade7a85afc1b23121f52bd2080202295cdb5d58d83cd0
+_hash: 4db9f464f87c27464350e4314b93708eeda0b3c5b6d44a95cd0984edd9b01dbb
 file:
 - statement:
     alter_table_statement:
@@ -201,4 +201,19 @@ file:
       - keyword: COLUMN
       - column_reference:
           identifier: my_column
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: empl_info
+    - alter_table_table_column_action:
+      - keyword: RENAME
+      - keyword: COLUMN
+      - column_reference:
+          identifier: old_col_name
+      - keyword: TO
+      - column_reference:
+          identifier: new_col_name
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Snowflake: Add support for column rename

fixes #2206

* #2206 has 2 issues. The first issue (`SELECT TOP 1 *`) has been fixed in https://github.com/sqlfluff/sqlfluff/pull/2222, and this PR should fix the second issue.
* This is part 2 of the overall plan to get `tableColumnAction` implemented Snowflake, as defined in https://github.com/sqlfluff/sqlfluff/issues/2206#issuecomment-1004038513.

### Are there any other side effects of this change that we should be aware of?

* None that I can think of.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
