### PR TITLE
Redshift: update CREATE TABLE AS match_grammar

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -402,7 +402,7 @@ class CreateTableAsStatementSegment(BaseSegment):
         Sequence("BACKUP", OneOf("YES", "NO"), optional=True),
         Ref("TableAttributeSegment", optional=True),
         "AS",
-        Ref("SelectableGrammar"),
+        OptionallyBracketed(Ref("SelectableGrammar")),
     )
 
 

--- a/test/fixtures/dialects/redshift/redshift_create_table_as.sql
+++ b/test/fixtures/dialects/redshift/redshift_create_table_as.sql
@@ -118,3 +118,27 @@ SELECT
     , col2
 FROM t2
 ;
+
+CREATE TABLE t1 (col1, col2)
+AS (
+    SELECT
+        col1
+    FROM
+        tbl2
+);
+
+CREATE TABLE t1 (col1, col2)
+BACKUP NO
+DISTSTYLE ALL
+DISTKEY(col1)
+INTERLEAVED SORTKEY(col1, col2) 
+AS (
+    SELECT
+        col1
+    FROM
+        tbl2
+    UNION ALL SELECT
+        col2
+    FROM
+        tbl3
+);

--- a/test/fixtures/dialects/redshift/redshift_create_table_as.yml
+++ b/test/fixtures/dialects/redshift/redshift_create_table_as.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b626b558a96d40df23f321e343c52f92c2f635525488fb69fab11a78fec8889c
+_hash: 2e9303a86427e8060e11290357e4c1e7fbe8701cdeb593dfb9d24221daccf764
 file:
 - statement:
     create_table_as_statement:
@@ -511,4 +511,106 @@ file:
               table_expression:
                 table_reference:
                   identifier: t2
+- statement_terminator: ;
+- statement:
+    create_table_as_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - object_reference:
+        identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          identifier: col1
+      - comma: ','
+      - column_reference:
+          identifier: col2
+      - end_bracket: )
+    - keyword: AS
+    - bracketed:
+        start_bracket: (
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              column_reference:
+                identifier: col1
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: tbl2
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_as_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - object_reference:
+        identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          identifier: col1
+      - comma: ','
+      - column_reference:
+          identifier: col2
+      - end_bracket: )
+    - keyword: BACKUP
+    - keyword: 'NO'
+    - table_constraint_segment:
+      - keyword: DISTSTYLE
+      - keyword: ALL
+      - keyword: DISTKEY
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            identifier: col1
+          end_bracket: )
+      - keyword: INTERLEAVED
+      - keyword: SORTKEY
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            identifier: col1
+        - comma: ','
+        - column_reference:
+            identifier: col2
+        - end_bracket: )
+    - keyword: AS
+    - bracketed:
+        start_bracket: (
+        set_expression:
+        - select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                column_reference:
+                  identifier: col1
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      identifier: tbl2
+        - set_operator:
+          - keyword: UNION
+          - keyword: ALL
+        - select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                column_reference:
+                  identifier: col2
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      identifier: tbl3
+        end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->

What the title says. `SelectableGrammar` can be bracketed in a `CREATE TABLE AS` statement.

Once again something that isn't made clear in the official AWS documentation :smile:  

### Are there any other side effects of this change that we should be aware of?
Nope!

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
