### PR TITLE
Snowflake ALTER TABLE: Drop multiple columns

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1076,7 +1076,7 @@ class AlterTableTableColumnActionSegment(BaseSegment):
             Sequence(
                 "DROP",
                 Ref.keyword("COLUMN", optional=True),
-                Ref("ColumnReferenceSegment"),
+                Delimited(Ref("ColumnReferenceSegment")),
             ),
             # @TODO: Drop columns
             # vvvvv COPIED FROM ANSI vvvvv

--- a/test/fixtures/dialects/snowflake/snowflake_alter_table_column.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_table_column.sql
@@ -54,3 +54,4 @@ alter table empl_info modify
 -- Drop column
 ALTER TABLE empl_info DROP COLUMN my_column;
 ALTER TABLE some_schema.empl_info DROP COLUMN my_column;
+ALTER TABLE my_table DROP COLUMN column_1, column_2, column_3;

--- a/test/fixtures/dialects/snowflake/snowflake_alter_table_column.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_table_column.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 02ca9441761c2d3a711a6cb836de875f72be59b8976731a689ec9b58f2ef73ff
+_hash: da05343c3524c758f1cefc015796188ef2dc202a28bed5b8817b4edb603525e5
 file:
 - statement:
     alter_table_statement:
@@ -376,4 +376,22 @@ file:
       - keyword: COLUMN
       - column_reference:
           identifier: my_column
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: my_table
+    - alter_table_table_column_action:
+      - keyword: DROP
+      - keyword: COLUMN
+      - column_reference:
+          identifier: column_1
+      - comma: ','
+      - column_reference:
+          identifier: column_2
+      - comma: ','
+      - column_reference:
+          identifier: column_3
 - statement_terminator: ;


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Closes #2344. You can drop multiple columns at once in the Snowflake ALTER TABLE statement.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
