### PR TITLE
TSQL: Add ASA Clustered Index functionality

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2202,6 +2202,20 @@ class TableIndexClause(BaseSegment):
                 "COLUMNSTORE",
                 "INDEX",
             ),
+            Sequence(
+                "CLUSTERED",
+                "INDEX",
+                Bracketed(
+                    Delimited(
+                        Ref("ColumnReferenceSegment"),
+                        OneOf(
+                            "ASC",
+                            "DESC",
+                            optional=True,
+                        ),
+                    ),
+                ),
+            ),
         ),
     )
 

--- a/test/fixtures/dialects/tsql/create_table_with_distribution.sql
+++ b/test/fixtures/dialects/tsql/create_table_with_distribution.sql
@@ -38,3 +38,13 @@ WITH (CLUSTERED COLUMNSTORE INDEX, LOCATION = USER_DB, DISTRIBUTION = HASH([Colu
 GO
 DROP TABLE [dbo].[EC DC]
 GO
+
+CREATE TABLE [dbo].[EC DC] (
+    [Column B] [varchar](100),
+    [ColumnC] varchar(100),
+    [ColumnDecimal] decimal(10,3)
+)
+WITH (CLUSTERED INDEX ([Column B]), DISTRIBUTION = HASH([Column B]));
+GO
+DROP TABLE [dbo].[EC DC];
+GO

--- a/test/fixtures/dialects/tsql/create_table_with_distribution.yml
+++ b/test/fixtures/dialects/tsql/create_table_with_distribution.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 42e1e329ac17a3f3ec33f8751749c5cac976dac10442b8fbff01d4dbc84af5dd
+_hash: 8ed6d6d595f463143c633b704a3b3337aae789a9bc8d20c29c3766db28e335a5
 file:
 - batch:
     statement:
@@ -310,5 +310,88 @@ file:
         - identifier: '[dbo]'
         - dot: .
         - identifier: '[EC DC]'
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - identifier: '[dbo]'
+        - dot: .
+        - identifier: '[EC DC]'
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: '[Column B]'
+            data_type:
+              identifier: '[varchar]'
+              bracketed:
+                start_bracket: (
+                expression:
+                  literal: '100'
+                end_bracket: )
+        - comma: ','
+        - column_definition:
+            identifier: '[ColumnC]'
+            data_type:
+              identifier: varchar
+              bracketed:
+                start_bracket: (
+                expression:
+                  literal: '100'
+                end_bracket: )
+        - comma: ','
+        - column_definition:
+            identifier: '[ColumnDecimal]'
+            data_type:
+              identifier: decimal
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  literal: '10'
+              - comma: ','
+              - expression:
+                  literal: '3'
+              - end_bracket: )
+        - end_bracket: )
+      - table_distribution_index_clause:
+          keyword: WITH
+          bracketed:
+            start_bracket: (
+            table_index_clause:
+            - keyword: CLUSTERED
+            - keyword: INDEX
+            - bracketed:
+                start_bracket: (
+                column_reference:
+                  identifier: '[Column B]'
+                end_bracket: )
+            comma: ','
+            table_distribution_clause:
+            - keyword: DISTRIBUTION
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - keyword: HASH
+            - bracketed:
+                start_bracket: (
+                column_reference:
+                  identifier: '[Column B]'
+                end_bracket: )
+            end_bracket: )
+      - statement_terminator: ;
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      drop_table_statement:
+      - keyword: DROP
+      - keyword: TABLE
+      - table_reference:
+        - identifier: '[dbo]'
+        - dot: .
+        - identifier: '[EC DC]'
+      - statement_terminator: ;
 - go_statement:
     keyword: GO


### PR DESCRIPTION
### Brief summary of the change made
Azure Synapse Analytics allows for tables to be created with clustered indexes.  This PR allows SqlFluff to parse this type of table definition.

### Are there any other side effects of this change that we should be aware of?

None.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
