### PR TITLE
Rolls back some code cleanup that caused coverage report to show gaps

### DIFF
--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -26,10 +26,12 @@ from sqlfluff.core.cached_property import cached_property
 from sqlfluff.core.errors import SQLTemplaterError, SQLTemplaterSkipFile
 
 from sqlfluff.core.templaters.base import (
+    RawFileSlice,
     TemplatedFile,
     TemplatedFileSlice,
 )
 
+from sqlfluff.core.templaters.slicers.heuristic import slice_template
 from sqlfluff.core.templaters.jinja import JinjaTemplater
 
 # Instantiate the templater logger
@@ -540,6 +542,11 @@ class DbtTemplater(JinjaTemplater):
             # No violations returned in this way.
             [],
         )
+
+        def _slice_template(self, in_str: str) -> List[RawFileSlice]:
+            # DbtTemplater uses the original heuristic-based template slicer.
+            # TODO: Can it be updated to use TemplateTracer?
+            return slice_template(in_str, self._get_jinja_env())
 
     @contextmanager
     def connection(self):


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made

PR #2382 (merged a few minutes ago) introduced some coverage issues by removing some code that I **thought** was unused. This PR undoes those changes to avoid breaking CI builds for other people.

<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
