### PR TITLE
Spark3: Support for `INSERT OVERWRITE DIRECTORY` statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -838,6 +838,38 @@ class InsertStatementSegment(BaseSegment):
     )
 
 
+@spark3_dialect.segment()
+class InsertOverwriteDirectorySegment(BaseSegment):
+    """A `INSERT OVERWRITE [LOCAL] DIRECTORY` statement to insert or overwrite new rows into a table.
+
+    https://spark.apache.org/docs/latest/sql-ref-syntax-dml-insert-overwrite-directory.html
+    """
+
+    type = "insert_overwrite_directory_statement"
+
+    match_grammar = Sequence(
+        "INSERT",
+        "OVERWRITE",
+        Ref.keyword("LOCAL", optional=True),
+        "DIRECTORY",
+        Ref("QuotedLiteralSegment", optional=True),
+        "USING",
+        Ref("DataSourceFormatGrammar"),
+        Sequence(
+            "OPTIONS",
+            Ref("BracketedPropertyListGrammar"),
+            optional=True
+        ),
+        OneOf(
+            AnyNumberOf(
+                Ref("ValuesClauseSegment"),
+                min_times=1,
+            ),
+            Ref("SelectableGrammar"),
+        ),
+    )
+
+
 # Auxiliary Statements
 @spark3_dialect.segment()
 class AddExecutablePackage(BaseSegment):
@@ -924,6 +956,8 @@ class StatementSegment(BaseSegment):
             Ref("RefreshStatementSegment"),
             Ref("RefreshTableStatementSegment"),
             Ref("RefreshFunctionStatementSegment"),
+            # Data Manipulation Statements
+            Ref("InsertOverwriteDirectorySegment"),
         ],
         remove=[
             Ref("TransactionStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -840,7 +840,7 @@ class InsertStatementSegment(BaseSegment):
 
 @spark3_dialect.segment()
 class InsertOverwriteDirectorySegment(BaseSegment):
-    """A `INSERT OVERWRITE [LOCAL] DIRECTORY` statement to insert or overwrite new rows into a table.
+    """An `INSERT OVERWRITE [LOCAL] DIRECTORY` statement to insert or overwrite new rows into a table.
 
     https://spark.apache.org/docs/latest/sql-ref-syntax-dml-insert-overwrite-directory.html
     """

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -855,11 +855,7 @@ class InsertOverwriteDirectorySegment(BaseSegment):
         Ref("QuotedLiteralSegment", optional=True),
         "USING",
         Ref("DataSourceFormatGrammar"),
-        Sequence(
-            "OPTIONS",
-            Ref("BracketedPropertyListGrammar"),
-            optional=True
-        ),
+        Sequence("OPTIONS", Ref("BracketedPropertyListGrammar"), optional=True),
         OneOf(
             AnyNumberOf(
                 Ref("ValuesClauseSegment"),

--- a/test/fixtures/dialects/spark3/insert_overwrite_directory.sql
+++ b/test/fixtures/dialects/spark3/insert_overwrite_directory.sql
@@ -1,0 +1,11 @@
+INSERT OVERWRITE DIRECTORY '/tmp/destination'
+USING PARQUET
+OPTIONS ("col1" = "1", "col2" = "2", "col3" = 'test')
+SELECT * FROM test_table;
+
+INSERT OVERWRITE DIRECTORY
+USING PARQUET
+OPTIONS (
+    'path' = '/tmp/destination', "col1" = "1", "col2" = "2", "col3" = 'test'
+)
+SELECT * FROM test_table;

--- a/test/fixtures/dialects/spark3/insert_overwrite_directory.yml
+++ b/test/fixtures/dialects/spark3/insert_overwrite_directory.yml
@@ -1,0 +1,93 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 38368cb40f359609fcaf4b65fb8180e689f933cd141855f53511803de6c740ad
+file:
+- base:
+    insert_overwrite_directory_statement:
+    - keyword: INSERT
+    - keyword: OVERWRITE
+    - keyword: DIRECTORY
+    - literal: "'/tmp/destination'"
+    - keyword: USING
+    - keyword: PARQUET
+    - keyword: OPTIONS
+    - bracketed:
+      - start_bracket: (
+      - literal: '"col1"'
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - literal: '"1"'
+      - comma: ','
+      - literal: '"col2"'
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - literal: '"2"'
+      - comma: ','
+      - literal: '"col3"'
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - literal: "'test'"
+      - end_bracket: )
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: test_table
+- statement_terminator: ;
+- base:
+    insert_overwrite_directory_statement:
+    - keyword: INSERT
+    - keyword: OVERWRITE
+    - keyword: DIRECTORY
+    - keyword: USING
+    - keyword: PARQUET
+    - keyword: OPTIONS
+    - bracketed:
+      - start_bracket: (
+      - literal: "'path'"
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - literal: "'/tmp/destination'"
+      - comma: ','
+      - literal: '"col1"'
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - literal: '"1"'
+      - comma: ','
+      - literal: '"col2"'
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - literal: '"2"'
+      - comma: ','
+      - literal: '"col3"'
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - literal: "'test'"
+      - end_bracket: )
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: test_table
+- statement_terminator: ;


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Implementation of `InsertOverwriteDirectorySegment` and test cases for INSERT OVERWRITE DIRECTORY statements for spark3 dialect.

### Are there any other side effects of this change that we should be aware of?
N/A

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
