### PR TITLE
Jinja templater: Allow "load_macros_from_path" to be a comma-separated list of paths

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -402,34 +402,44 @@ this introduces the idea of config *blocks* which could be selectively
 overwritten by other configuration files downstream as required.
 
 In addition to macros specified in the config file, macros can also be
-loaded from a file or folder. The path to this macros folder must be
-specified in the config file to function as below:
+loaded from files or folders. This is specified in the config file:
 
 .. code-block:: cfg
 
     [sqlfluff:templater:jinja]
     load_macros_from_path = my_macros
 
-In this case, SQLFluff will load macros from any :code:`.sql` file found at the
-path specified on this variable. The path is interpreted *relative to the
-config file*, and therefore if the config file above was found at
-:code:`/home/my_project/.sqlfluff` then SQLFluff will look for macros in the
-folder :code:`/home/my_project/my_macros/`. Alternatively the path can also
-be a :code:`.sql` itself. Any macros defined in the config will always take
-precedence over a macro defined in the path.
+`load_macros_from_path` is a comma-separated list of files or folders. SQLFluff
+will load macros from any :code:`.sql` file found in the specified locations.
+Locations are *relative to the config file*. For example, if the config file
+above was found at :code:`/home/my_project/.sqlfluff` then SQLFluff will look
+for macros in the folder :code:`/home/my_project/my_macros/` (but not
+subfolders). Alternatively, the path can also be a :code:`.sql` itself. Any
+macros defined in the config will always take precedence over a macro defined
+in the path.
 
+**Note:** The `load_macros_from_path` also defines the search path for Jinja
+[include](https://jinja.palletsprojects.com/en/3.0.x/templates/#include) or
+[import](https://jinja.palletsprojects.com/en/3.0.x/templates/#import).
+Unlike with macros (as noted above), subdirectories are supported. For example,
+if `load_macros_from_path` is set to `my_macros`, and there is a file
+`my_macros/subdir/my_file.sql`, you can do:
+
+.. code-block:: jinja
+
+   {% include 'subdir/include_comment.sql' %}
 
 .. note::
 
     Throughout the templating process **whitespace** will still be treated
     rigorously, and this includes **newlines**. In particular you may choose
-    to provide your *dummy* macros in your configuration with different to
-    the actual macros you may be using in production.
+    to provide *dummy* macros in your configuration different from the actual
+    macros used in production.
 
-    **REMEMBER:** The purpose of providing the option of macros is to *enable*
-    the parsing of templated sql without it being a blocker. It shouldn't
-    be a requirement that the *templating* is accurate - only so far as that
-    is required to enable the *parsing* and *linting* to be helpful.
+    **REMEMBER:** The reason SQLFluff supports macros is to *enable* it to parse
+    templated sql without it being a blocker. It shouldn't be a requirement that
+    the *templating* is accurate - it only needs to work well enough that
+    *parsing* and *linting* are helpful.
 
 Builtin Macro Blocks
 ^^^^^^^^^^^^^^^^^^^^
@@ -440,8 +450,8 @@ repositories of sql files which could potentially benefit from some linting.
 
 .. note::
     *SQLFluff* has now a tighter integration with dbt through the "dbt" templater.
-    It is the recommended templater for dbt projects and removes the need for the
-    overwrites described in this section.
+    It is the recommended templater for dbt projects. If used, it eliminates the
+    need for the overrides described in this section.
 
     To use the dbt templater, go to `dbt Project Configuration`_.
 
@@ -482,7 +492,7 @@ config option:
     library_path = sqlfluff_libs
 
 This will pull in any python modules from that directory and allow sqlfluff
-to use them for templated. In the above example, you might define a file at
+to use them in templates. In the above example, you might define a file at
 `sqlfluff_libs/dbt_utils.py` as:
 
 .. code-block:: python
@@ -527,9 +537,9 @@ dbt Project Configuration
 
 .. note::
     From sqlfluff version 0.7.0 onwards, the dbt templater has been moved
-    to a separate plugin and python package. You may find that projects
-    already using the templater may initially fail after an upgrade to
-    0.7.0+. See install instructions below to install the dbt templater.
+    to a separate plugin and python package. Projects that were already using
+    the dbt templater may initially fail after an upgrade to 0.7.0+. See the
+    installation instructions below to install the dbt templater.
 
     dbt templating is still a relatively new feature added in 0.4.0 and
     is still in very active development! If you encounter an issue, please

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -223,12 +223,14 @@ class ConfigLoader:
 
                 # Attempt to resolve paths
                 if name.lower() == "load_macros_from_path":
+                    # Comma-separated list of paths.
                     paths = _split_comma_separated_string(val)
                     v_temp = []
                     for path in paths:
                         v_temp.append(cls._resolve_path(fpath, path))
                     v = ",".join(v_temp)
                 elif name.lower().endswith(("_path", "_dir")):
+                    # One path
                     v = cls._resolve_path(fpath, val)
                 # Add the name to the end of the key
                 buff.append((key + (name,), v))
@@ -236,7 +238,7 @@ class ConfigLoader:
 
     @classmethod
     def _resolve_path(cls, fpath, val):
-        # Try to resolve the path.
+        """Try to resolve a path."""
         # Make the referenced path.
         ref_path = os.path.join(os.path.dirname(fpath), val)
         # Check if it exists, and if it does, replace the value with the path.

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -673,7 +673,7 @@ class FluffConfig:
 
         return section_dict.get(val, default)
 
-    def get_section(self, section: Union[str, Iterable[str]]) -> Union[dict, None]:
+    def get_section(self, section: Union[str, Iterable[str]]) -> Any:
         """Return a whole section of config as a dict.
 
         If the element found at the address is a value and not

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -242,9 +242,7 @@ class ConfigLoader:
         # Make the referenced path.
         ref_path = os.path.join(os.path.dirname(fpath), val)
         # Check if it exists, and if it does, replace the value with the path.
-        if os.path.exists(ref_path):
-            return ref_path
-        return val
+        return ref_path if os.path.exists(ref_path) else val
 
     @staticmethod
     def _incorporate_vals(ctx: dict, vals: List[Tuple[Tuple[str, ...], Any]]) -> dict:

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -69,8 +69,8 @@ class JinjaTemplater(PythonTemplater):
         """Take a path and extract macros from it."""
         for path_entry in path:
             # Does it exist? It should as this check was done on config load.
-            if not os.path.exists(path_entry):  # pragma: no cover
-                raise ValueError(f"Path does not exist: {path}")
+            if not os.path.exists(path_entry):
+                raise ValueError(f"Path does not exist: {path_entry}")
 
             macro_ctx = {}
             if os.path.isfile(path_entry):
@@ -220,7 +220,7 @@ class JinjaTemplater(PythonTemplater):
                 (self.templater_selector, self.name, "load_macros_from_path")
             )
             if macros_path:
-                result = [s.strip() for s in macros_path.split(",") if s.strip()]  # type: ignore
+                result = [s.strip() for s in macros_path.split(",") if s.strip()]
                 if result:
                     return result
         return None

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -16,6 +16,7 @@ from jinja2 import (
 from jinja2.environment import Template
 from jinja2.sandbox import SandboxedEnvironment
 
+from sqlfluff.core.config import FluffConfig
 from sqlfluff.core.errors import SQLTemplaterError
 from sqlfluff.core.templaters.base import (
     RawFileSlice,
@@ -64,31 +65,32 @@ class JinjaTemplater(PythonTemplater):
         return context
 
     @classmethod
-    def _extract_macros_from_path(cls, path, env, ctx):
+    def _extract_macros_from_path(cls, path: List[str], env: Environment, ctx: Dict):
         """Take a path and extract macros from it."""
-        # Does the path exist? It should as this check was done on config load.
-        if not os.path.exists(path):  # pragma: no cover
-            raise ValueError(f"Path does not exist: {path}")
+        for path_entry in path:
+            # Does it exist? It should as this check was done on config load.
+            if not os.path.exists(path_entry):  # pragma: no cover
+                raise ValueError(f"Path does not exist: {path}")
 
-        macro_ctx = {}
-        if os.path.isfile(path):
-            # It's a file. Extract macros from it.
-            with open(path) as opened_file:
-                template = opened_file.read()
-            # Update the context with macros from the file.
-            macro_ctx.update(
-                cls._extract_macros_from_template(template, env=env, ctx=ctx)
-            )
-        else:
-            # It's a directory. Iterate through files in it and extract from them.
-            for dirpath, _, files in os.walk(path):
-                for fname in files:
-                    if fname.endswith(".sql"):
-                        macro_ctx.update(
-                            cls._extract_macros_from_path(
-                                os.path.join(dirpath, fname), env=env, ctx=ctx
+            macro_ctx = {}
+            if os.path.isfile(path_entry):
+                # It's a file. Extract macros from it.
+                with open(path_entry) as opened_file:
+                    template = opened_file.read()
+                # Update the context with macros from the file.
+                macro_ctx.update(
+                    cls._extract_macros_from_template(template, env=env, ctx=ctx)
+                )
+            else:
+                # It's a directory. Iterate through files in it and extract from them.
+                for dirpath, _, files in os.walk(path_entry):
+                    for fname in files:
+                        if fname.endswith(".sql"):
+                            macro_ctx.update(
+                                cls._extract_macros_from_path(
+                                    [os.path.join(dirpath, fname)], env=env, ctx=ctx
+                                )
                             )
-                        )
         return macro_ctx
 
     def _extract_macros_from_config(self, config, env, ctx):
@@ -212,13 +214,16 @@ class JinjaTemplater(PythonTemplater):
             loader=FileSystemLoader(macros_path) if macros_path else None,
         )
 
-    def _get_macros_path(self, config):
-        macros_path = None
+    def _get_macros_path(self, config: FluffConfig) -> Optional[List[str]]:
         if config:
             macros_path = config.get_section(
                 (self.templater_selector, self.name, "load_macros_from_path")
             )
-        return macros_path
+            if macros_path:
+                result = [s.strip() for s in macros_path.split(",") if s.strip()]  # type: ignore
+                if result:
+                    return result
+        return None
 
     def get_context(self, fname=None, config=None, **kw) -> Dict:
         """Get the templating context from the config."""

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -3,6 +3,7 @@
 import os
 import sys
 
+from sqlfluff.core import config
 from sqlfluff.core.config import ConfigLoader, nested_combine, dict_diff
 from sqlfluff.core import Linter, FluffConfig
 from sqlfluff.core.templaters import (
@@ -207,7 +208,7 @@ def test__config__load_user_appdir_config(
 )
 def test__config__split_comma_separated_string(raw_str, expected):
     """Tests that comma separated string config is handled correctly."""
-    assert FluffConfig._split_comma_separated_string(raw_str) == expected
+    assert config._split_comma_separated_string(raw_str) == expected
 
 
 def test__config__templater_selection():

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -694,15 +694,22 @@ SELECT 1
         (
             # Tests Jinja "from import" directive..
             """{% from 'echo.sql' import echo %}
+{% from 'echoecho.sql' import echoecho %}
 
-SELECT {{ echo("foo") }}
+SELECT
+    {{ echo("foo") }},
+    {{ echoecho("bar") }}
 """,
             None,
             [
                 ("block_start", slice(0, 33, None), slice(0, 0, None)),
-                ("literal", slice(33, 42, None), slice(0, 9, None)),
-                ("templated", slice(42, 59, None), slice(9, 14, None)),
-                ("literal", slice(59, 60, None), slice(14, 15, None)),
+                ("literal", slice(33, 34, None), slice(0, 1, None)),
+                ("block_start", slice(34, 75, None), slice(1, 1, None)),
+                ("literal", slice(75, 88, None), slice(1, 14, None)),
+                ("templated", slice(88, 105, None), slice(14, 19, None)),
+                ("literal", slice(105, 111, None), slice(19, 25, None)),
+                ("templated", slice(111, 132, None), slice(25, 34, None)),
+                ("literal", slice(132, 133, None), slice(34, 35, None)),
             ],
         ),
     ],
@@ -721,7 +728,7 @@ def test__templater_jinja_slice_file(raw_file, override_context, result, caplog)
         _, resp, _ = templater.slice_file(
             raw_file, templated_file, make_template=make_template
         )
-    # Check contigious on the TEMPLATED VERSION
+    # Check contiguous on the TEMPLATED VERSION
     print(resp)
     prev_slice = None
     for elem in resp:

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -386,13 +386,24 @@ def test__templater_jinja_error_syntax():
     assert any(v.rule_code() == "TMP" and v.line_no == 1 for v in vs)
 
 
-def test__templater_jinja_error_catatrophic():
+def test__templater_jinja_error_catastrophic():
     """Test error handling in the jinja templater."""
     t = JinjaTemplater(override_context=dict(blah=7))
     instr = JINJA_STRING
     outstr, vs = t.process(in_str=instr, fname="test", config=FluffConfig())
     assert not outstr
     assert len(vs) > 0
+
+
+def test__templater_jinja_error_macro_path_does_not_exist():
+    """Tests that an error is raised if macro path doesn't exist."""
+    with pytest.raises(ValueError) as e:
+        JinjaTemplater().template_builder(
+            config=FluffConfig.from_path(
+                "test/fixtures/templater/jinja_macro_path_does_not_exist"
+            )
+        )
+    assert str(e.value).startswith("Path does not exist")
 
 
 def test__templater_jinja_lint_empty():

--- a/test/fixtures/templater/jinja_macro_path_does_not_exist/.sqlfluff
+++ b/test/fixtures/templater/jinja_macro_path_does_not_exist/.sqlfluff
@@ -1,0 +1,2 @@
+[sqlfluff:templater:jinja]
+load_macros_from_path=nonexistent_macro_directory

--- a/test/fixtures/templater/jinja_slice_template_macros/.sqlfluff
+++ b/test/fixtures/templater/jinja_slice_template_macros/.sqlfluff
@@ -1,2 +1,2 @@
 [sqlfluff:templater:jinja]
-load_macros_from_path=macros
+load_macros_from_path=macros,more_macros

--- a/test/fixtures/templater/jinja_slice_template_macros/more_macros/echoecho.sql
+++ b/test/fixtures/templater/jinja_slice_template_macros/more_macros/echoecho.sql
@@ -1,0 +1,3 @@
+{% macro echoecho(text) %}
+{{text}} {{text}}
+{% endmacro %}


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
Fixes #829

<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
