### PR TITLE
Add "TRANS" keyword for TSQL

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -139,6 +139,10 @@ tsql_dialect.add(
     QuotedLiteralSegmentWithN=NamedParser(
         "single_quote_with_n", CodeSegment, name="quoted_literal", type="literal"
     ),
+    TransactionGrammar=OneOf(
+        "TRANSACTION",
+        "TRANS",
+    ),
 )
 
 tsql_dialect.replace(
@@ -2345,24 +2349,26 @@ class TransactionStatementSegment(BaseSegment):
 
     type = "transaction_statement"
     match_grammar = OneOf(
-        # BEGIN | SAVE TRANSACTION
-        # COMMIT [ TRANSACTION | WORK ]
-        # ROLLBACK [ TRANSACTION | WORK ]
+        # [ BEGIN | SAVE ] [ TRANSACTION | TRANS ]
+        # COMMIT [ TRANSACTION | TRANS | WORK ]
+        # ROLLBACK [ TRANSACTION | TRANS | WORK ]
         # https://docs.microsoft.com/en-us/sql/t-sql/language-elements/begin-transaction-transact-sql?view=sql-server-ver15
         Sequence(
             "BEGIN",
             Sequence("DISTRIBUTED", optional=True),
-            "TRANSACTION",
+            Ref("TransactionGrammar"),
             Ref("SingleIdentifierGrammar", optional=True),
             Sequence("WITH", "MARK", Ref("QuotedIdentifierSegment"), optional=True),
             Ref("DelimiterSegment", optional=True),
         ),
         Sequence(
             OneOf("COMMIT", "ROLLBACK"),
-            OneOf("TRANSACTION", "WORK", optional=True),
+            OneOf(Ref("TransactionGrammar"), "WORK", optional=True),
             Ref("DelimiterSegment", optional=True),
         ),
-        Sequence("SAVE", "TRANSACTION", Ref("DelimiterSegment", optional=True)),
+        Sequence(
+            "SAVE", Ref("TransactionGrammar"), Ref("DelimiterSegment", optional=True)
+        ),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -163,6 +163,7 @@ RESERVED_KEYWORDS = [
     "TOP",
     "TRAN",
     "TRANSACTION",
+    "TRANS",
     "TRIGGER",
     "TRUNCATE",
     "TRY_CONVERT",

--- a/test/fixtures/dialects/tsql/transaction.sql
+++ b/test/fixtures/dialects/tsql/transaction.sql
@@ -2,3 +2,11 @@ BEGIN TRANSACTION;
 DELETE FROM HumanResources.JobCandidate  
     WHERE JobCandidateID = 13;  
 COMMIT;  
+
+BEGIN TRANS;
+DELETE FROM HumanResources.JobCandidate
+  WHERE JobCandidateID = 13;
+ROLLBACK TRANS;
+
+BEGIN TRANS;
+SAVE TRANSACTION;

--- a/test/fixtures/dialects/tsql/transaction.yml
+++ b/test/fixtures/dialects/tsql/transaction.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a8669d8c6b157e579cbe389c09d9a940e94bf5b48dcde9cf26c0714a32251a5a
+_hash: 3919bfedcabdc1566ca430dfbf7efdc1599c9ca3453cb853a4a19cb05f74d37a
 file:
   batch:
   - statement:
@@ -36,3 +36,44 @@ file:
       transaction_statement:
         keyword: COMMIT
         statement_terminator: ;
+  - statement:
+      transaction_statement:
+      - keyword: BEGIN
+      - keyword: TRANS
+      - statement_terminator: ;
+  - statement:
+      delete_statement:
+        keyword: DELETE
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - identifier: HumanResources
+                - dot: .
+                - identifier: JobCandidate
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              identifier: JobCandidateID
+            comparison_operator:
+              raw_comparison_operator: '='
+            literal: '13'
+        statement_terminator: ;
+  - statement:
+      transaction_statement:
+      - keyword: ROLLBACK
+      - keyword: TRANS
+      - statement_terminator: ;
+  - statement:
+      transaction_statement:
+      - keyword: BEGIN
+      - keyword: TRANS
+      - statement_terminator: ;
+  - statement:
+      transaction_statement:
+      - keyword: SAVE
+      - keyword: TRANSACTION
+      - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
In T-SQL, "TRANS" is also a synonym for "TRANSACTION". Since this is
different in each dialect, this just changes the TSQL parser.

fixes #2368

### Are there any other side effects of this change that we should be aware of?
None that I expect 🙂

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
