### PR TITLE
Postgres: Fix Values alias regression

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -3055,6 +3055,7 @@ class AliasExpressionSegment(BaseSegment):
     match_grammar = Sequence(
         Ref.keyword("AS", optional=True),
         Ref("SingleIdentifierGrammar"),
+        Bracketed(Ref("SingleIdentifierListSegment"), optional=True),
     )
 
 

--- a/test/fixtures/dialects/postgres/postgres_values_alias.sql
+++ b/test/fixtures/dialects/postgres/postgres_values_alias.sql
@@ -1,0 +1,4 @@
+select *
+from (
+    values (1, 2), (3, 4)
+) as t(c1, c2);

--- a/test/fixtures/dialects/postgres/postgres_values_alias.yml
+++ b/test/fixtures/dialects/postgres/postgres_values_alias.yml
@@ -1,0 +1,51 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 3475e6eaa6561bd4a8d47a205be01c2450639c9d394891771741b2685a491619
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                values_clause:
+                - keyword: values
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '1'
+                  - comma: ','
+                  - expression:
+                      literal: '2'
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - literal: '3'
+                  - comma: ','
+                  - literal: '4'
+                  - end_bracket: )
+                end_bracket: )
+            alias_expression:
+              keyword: as
+              identifier: t
+              bracketed:
+                start_bracket: (
+                identifier_list:
+                - identifier: c1
+                - comma: ','
+                - identifier: c2
+                end_bracket: )
+  statement_terminator: ;


### PR DESCRIPTION

<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Fixes parsing issue noted [here](https://github.com/sqlfluff/sqlfluff/pull/2400/files#r789723089).
In #2353 I tidied up the postgres alias expression to remove quoted literal alias which are invalid. At the time I also thought the bracketed segment was also not valid, but have since realised I was wrong there! :)
This adds the values alias back in to the dialect.

N.B. I also checked the syntax that I spotted this issue in and it's not valid MySQL so I think the MySQL changes in #2353 are still valid.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
