### PR TITLE
L060: Use COALESCE instead of IFNULL or NVL.

### DIFF
--- a/src/sqlfluff/rules/L060.py
+++ b/src/sqlfluff/rules/L060.py
@@ -1,0 +1,62 @@
+"""Implementation of Rule L060."""
+
+from typing import Optional
+
+from sqlfluff.core.parser.segments.raw import CodeSegment
+from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+
+
+@document_fix_compatible
+class Rule_L060(BaseRule):
+    """Use ``COALESCE`` instead of ``IFNULL`` or ``NVL``.
+
+    | **Anti-pattern**
+    | ``IFNULL`` or ``NVL`` are used to fill ``NULL`` values.
+
+    .. code-block:: sql
+
+        SELECT ifnull(foo, 0) AS bar,
+        FROM baz;
+
+        SELECT nvl(foo, 0) AS bar,
+        FROM baz;
+
+    | **Best practice**
+    | Use ``COALESCE`` instead.
+    | ``COALESCE`` is universally supported,
+    | whereas Redshift doesn't support ``IFNULL``
+    | and BigQuery doesn't support ``NVL``.
+    | Additionally ``COALESCE`` is more flexible
+    | and accepts an arbitrary number of arguments.
+
+    .. code-block:: sql
+
+        SELECT coalesce(foo, 0) AS bar,
+        FROM baz;
+
+    """
+
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        """Use ``COALESCE`` instead of ``IFNULL`` or ``NVL``."""
+        # We only care about function names.
+        if context.segment.name != "function_name_identifier":
+            return None
+
+        # Only care if the function is ``IFNULL`` or ``NVL``.
+        if context.segment.raw_upper not in {"IFNULL", "NVL"}:
+            return None
+
+        # Create fix to replace ``IFNULL`` or ``NVL`` with ``COALESCE``.
+        fix = LintFix.replace(
+            context.segment,
+            [
+                CodeSegment(
+                    raw="COALESCE",
+                    name="function_name_identifier",
+                    type="function_name_identifier",
+                )
+            ],
+        )
+
+        return LintResult(context.segment, [fix])

--- a/test/fixtures/rules/std_rule_cases/L060.yml
+++ b/test/fixtures/rules/std_rule_cases/L060.yml
@@ -1,0 +1,22 @@
+rule: L060
+
+test_pass_coalesce:
+  pass_str: |
+    SELECT coalesce(foo, 0) AS bar,
+    FROM baz;
+
+test_fail_ifnull:
+  fail_str: |
+    SELECT ifnull(foo, 0) AS bar,
+    FROM baz;
+  pass_str: |
+    SELECT coalesce(foo, 0) AS bar,
+    FROM baz;
+
+test_fail_nvl:
+  fail_str: |
+    SELECT nvl(foo, 0) AS bar,
+    FROM baz;
+  pass_str: |
+    SELECT coalesce(foo, 0) AS bar,
+    FROM baz;


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Closes #2392. Adds a new rule to require the use of `COALESCE` over `IFNULL` or `NVL`. See linked issue for source + motivation. 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
