### PR TITLE
Exasol: Fix `LOCAL.ALIAS` Syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1706,6 +1706,7 @@ ansi_dialect.add(
                     Ref("DateTimeLiteralGrammar"),
                 ),
             ),
+            Ref("LocalAliasSegment"),
         ),
         Ref("Accessor_Grammar", optional=True),
         allow_gaps=True,
@@ -3533,3 +3534,14 @@ class SamplingExpressionSegment(BaseSegment):
             optional=True,
         ),
     )
+
+
+@ansi_dialect.segment()
+class LocalAliasSegment(BaseSegment):
+    """The `LOCAL.ALIAS` syntax allows to use a alias name of a column within clauses.
+
+    A hookpoint for other dialects e.g. Exasol.
+    """
+
+    type = "local_alias_segment"
+    match_grammar = Nothing()

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -547,7 +547,7 @@ class GroupByClauseSegment(BaseSegment):
                 Ref("ExpressionSegment"),
                 Ref("CubeRollupClauseSegment"),
                 Ref("GroupingSetsClauseSegment"),
-                Bracketed(),  # Allows empty parentheses,
+                Bracketed(),  # Allows empty parentheses
             ),
             terminator=OneOf(
                 Sequence("ORDER", "BY"),

--- a/test/fixtures/dialects/exasol/SelectStatement.sql
+++ b/test/fixtures/dialects/exasol/SelectStatement.sql
@@ -90,3 +90,15 @@ SELECT  JSON_EXTRACT(json_str, '$."@id"', '$.error()')
 FROM t;
 ----
 SELECT 10 / 2;
+----
+select count(*) as a, local.a*10 from x;
+----
+SELECT ABS(x) AS x FROM t WHERE local.x>10;
+----
+SELECT c1 as cx, count(*) as cc FROM x GROUP BY local.cx;
+----
+SELECT c1 as cx FROM x ORDER BY local.cx;
+----
+SELECT c1, count(*) as c FROM x GROUP BY 1 HAVING local.c > 1;
+----
+SELECT S_ID, C_ID, PRICE, ROW_NUMBER() OVER (PARTITION BY C_ID ORDER BY PRICE DESC) NUM FROM SALES QUALIFY local.NUM = 1;

--- a/test/fixtures/dialects/exasol/SelectStatement.yml
+++ b/test/fixtures/dialects/exasol/SelectStatement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 10212e48be4f10127632451e354d6137d235f9ec9eed510b15de50cbdf73c2ca
+_hash: 689a2eba84bc996fcc6fe1a33850143e5d15a923b93b5da140d84b91f884d0fd
 file:
 - statement:
     select_statement:
@@ -1019,4 +1019,237 @@ file:
           - literal: '10'
           - binary_operator: /
           - literal: '2'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: select
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            bracketed:
+              start_bracket: (
+              star: '*'
+              end_bracket: )
+          alias_expression:
+            keyword: as
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          expression:
+            local_alias_segment:
+              keyword: local
+              dot: .
+              identifier: a
+            binary_operator: '*'
+            literal: '10'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: x
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: ABS
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: x
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: x
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t
+      where_clause:
+        keyword: WHERE
+        expression:
+          local_alias_segment:
+            keyword: local
+            dot: .
+            identifier: x
+          comparison_operator:
+            raw_comparison_operator: '>'
+          literal: '10'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: c1
+          alias_expression:
+            keyword: as
+            identifier: cx
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            bracketed:
+              start_bracket: (
+              star: '*'
+              end_bracket: )
+          alias_expression:
+            keyword: as
+            identifier: cc
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: x
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - expression:
+          local_alias_segment:
+            keyword: local
+            dot: .
+            identifier: cx
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            identifier: c1
+          alias_expression:
+            keyword: as
+            identifier: cx
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: x
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - expression:
+          local_alias_segment:
+            keyword: local
+            dot: .
+            identifier: cx
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: c1
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            bracketed:
+              start_bracket: (
+              star: '*'
+              end_bracket: )
+          alias_expression:
+            keyword: as
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: x
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - literal: '1'
+      having_clause:
+        keyword: HAVING
+        expression:
+          local_alias_segment:
+            keyword: local
+            dot: .
+            identifier: c
+          comparison_operator:
+            raw_comparison_operator: '>'
+          literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: S_ID
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: C_ID
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: PRICE
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: ROW_NUMBER
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: C_ID
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: PRICE
+                  - keyword: DESC
+                end_bracket: )
+          alias_expression:
+            identifier: NUM
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: SALES
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          local_alias_segment:
+            keyword: local
+            dot: .
+            identifier: NUM
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: '1'
 - statement_terminator: ;


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->

Currently the `LOCAL.ALIAS` syntax is parsed by `sqlfluff`. But it parses `LOCAL` as an identifier rather than a keyword. Furthermore there are things like `SELECT local.local FROM x` possible. This isn't valid code.

I added a new `LocalAliasSegment` to the `ansi` dialect as a hookpoint because it's necessary to add it to the `ExpressionSegment`. Also added various test cases for the different possibilities.

### Are there any other side effects of this change that we should be aware of?
none

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
