### PR TITLE
Add Postgres DROP PROCEDURE support

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -766,6 +766,33 @@ class CreateProcedureStatementSegment(BaseSegment):
 
 
 @postgres_dialect.segment()
+class DropProcedureStatementSegment(BaseSegment):
+    """Drop Procedure Statement.
+
+    As Specified in https://www.postgresql.org/docs/11/sql-dropprocedure.html
+    """
+
+    type = "drop_procedure"
+
+    match_grammar = Sequence(
+        "DROP",
+        "PROCEDURE",
+        Ref("IfExistsGrammar", optional=True),
+        Delimited(
+            Sequence(
+                Ref("FunctionNameSegment"),
+                Ref("FunctionParameterListGrammar", optional=True),
+            ),
+        ),
+        OneOf(
+            "CASCADE",
+            "RESTRICT",
+            optional=True,
+        ),
+    )
+
+
+@postgres_dialect.segment()
 class WellKnownTextGeometrySegment(BaseSegment):
     """A Data Type Segment to identify Well Known Text Geometric Data Types.
 
@@ -2927,6 +2954,7 @@ class StatementSegment(BaseSegment):
             Ref("ResetStatementSegment"),
             Ref("DiscardStatementSegment"),
             Ref("CreateProcedureStatementSegment"),
+            Ref("DropProcedureStatementSegment"),
         ],
     )
 

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -767,12 +767,12 @@ class CreateProcedureStatementSegment(BaseSegment):
 
 @postgres_dialect.segment()
 class DropProcedureStatementSegment(BaseSegment):
-    """Drop Procedure Statement.
+    """A `DROP PROCEDURE` statement.
 
-    As Specified in https://www.postgresql.org/docs/11/sql-dropprocedure.html
+    https://www.postgresql.org/docs/11/sql-dropprocedure.html
     """
 
-    type = "drop_procedure"
+    type = "drop_procedure_statement"
 
     match_grammar = Sequence(
         "DROP",

--- a/test/fixtures/dialects/postgres/postgres_drop_procedure.sql
+++ b/test/fixtures/dialects/postgres/postgres_drop_procedure.sql
@@ -11,3 +11,5 @@ drop procedure delete_actor, update_actor;
 drop procedure delete_actor, update_actor CASCADE;
 
 drop procedure delete_actor(in id varchar);
+
+drop procedure insert_actor(varchar, varchar), insert_actor2(varchar, varchar);

--- a/test/fixtures/dialects/postgres/postgres_drop_procedure.sql
+++ b/test/fixtures/dialects/postgres/postgres_drop_procedure.sql
@@ -1,0 +1,13 @@
+DROP PROCEDURE do_db_maintenance();
+
+drop procedure insert_actor;
+
+drop procedure insert_actor(varchar);
+
+drop procedure insert_actor(varchar, varchar);
+
+drop procedure delete_actor, update_actor;
+
+drop procedure delete_actor, update_actor CASCADE;
+
+drop procedure delete_actor(in id varchar);

--- a/test/fixtures/dialects/postgres/postgres_drop_procedure.yml
+++ b/test/fixtures/dialects/postgres/postgres_drop_procedure.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c36ed5001f0d4f15643f604b33cf9fdfd1caa9004357f7fe487b9c21ffd33ecd
+_hash: b00221d5457567ff2b2311c96ce3cdffc9afd70fac0ceaffc8ccf313e18190a1
 file:
 - statement:
     drop_procedure_statement:
@@ -87,4 +87,32 @@ file:
           data_type:
             keyword: varchar
           end_bracket: )
+- statement_terminator: ;
+- statement:
+    drop_procedure_statement:
+    - keyword: drop
+    - keyword: procedure
+    - function_name:
+        function_name_identifier: insert_actor
+    - base:
+        bracketed:
+        - start_bracket: (
+        - data_type:
+            keyword: varchar
+        - comma: ','
+        - data_type:
+            keyword: varchar
+        - end_bracket: )
+    - comma: ','
+    - function_name:
+        function_name_identifier: insert_actor2
+    - base:
+        bracketed:
+        - start_bracket: (
+        - data_type:
+            keyword: varchar
+        - comma: ','
+        - data_type:
+            keyword: varchar
+        - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/postgres/postgres_drop_procedure.yml
+++ b/test/fixtures/dialects/postgres/postgres_drop_procedure.yml
@@ -1,0 +1,90 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 0e14dd4a0f1865bde044d70462c75bf652509d580d6fe9b0d8ca53f66fdc6c17
+file:
+- statement:
+    drop_procedure:
+    - keyword: DROP
+    - keyword: PROCEDURE
+    - function_name:
+        function_name_identifier: do_db_maintenance
+    - base:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    drop_procedure:
+    - keyword: drop
+    - keyword: procedure
+    - function_name:
+        function_name_identifier: insert_actor
+- statement_terminator: ;
+- statement:
+    drop_procedure:
+    - keyword: drop
+    - keyword: procedure
+    - function_name:
+        function_name_identifier: insert_actor
+    - base:
+        bracketed:
+          start_bracket: (
+          data_type:
+            keyword: varchar
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    drop_procedure:
+    - keyword: drop
+    - keyword: procedure
+    - function_name:
+        function_name_identifier: insert_actor
+    - base:
+        bracketed:
+        - start_bracket: (
+        - data_type:
+            keyword: varchar
+        - comma: ','
+        - data_type:
+            keyword: varchar
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    drop_procedure:
+    - keyword: drop
+    - keyword: procedure
+    - function_name:
+        function_name_identifier: delete_actor
+    - comma: ','
+    - function_name:
+        function_name_identifier: update_actor
+- statement_terminator: ;
+- statement:
+    drop_procedure:
+    - keyword: drop
+    - keyword: procedure
+    - function_name:
+        function_name_identifier: delete_actor
+    - comma: ','
+    - function_name:
+        function_name_identifier: update_actor
+    - keyword: CASCADE
+- statement_terminator: ;
+- statement:
+    drop_procedure:
+    - keyword: drop
+    - keyword: procedure
+    - function_name:
+        function_name_identifier: delete_actor
+    - base:
+        bracketed:
+          start_bracket: (
+          keyword: in
+          parameter: id
+          data_type:
+            keyword: varchar
+          end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/postgres/postgres_drop_procedure.yml
+++ b/test/fixtures/dialects/postgres/postgres_drop_procedure.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0e14dd4a0f1865bde044d70462c75bf652509d580d6fe9b0d8ca53f66fdc6c17
+_hash: c36ed5001f0d4f15643f604b33cf9fdfd1caa9004357f7fe487b9c21ffd33ecd
 file:
 - statement:
-    drop_procedure:
+    drop_procedure_statement:
     - keyword: DROP
     - keyword: PROCEDURE
     - function_name:
@@ -17,14 +17,14 @@ file:
           end_bracket: )
 - statement_terminator: ;
 - statement:
-    drop_procedure:
+    drop_procedure_statement:
     - keyword: drop
     - keyword: procedure
     - function_name:
         function_name_identifier: insert_actor
 - statement_terminator: ;
 - statement:
-    drop_procedure:
+    drop_procedure_statement:
     - keyword: drop
     - keyword: procedure
     - function_name:
@@ -37,7 +37,7 @@ file:
           end_bracket: )
 - statement_terminator: ;
 - statement:
-    drop_procedure:
+    drop_procedure_statement:
     - keyword: drop
     - keyword: procedure
     - function_name:
@@ -53,7 +53,7 @@ file:
         - end_bracket: )
 - statement_terminator: ;
 - statement:
-    drop_procedure:
+    drop_procedure_statement:
     - keyword: drop
     - keyword: procedure
     - function_name:
@@ -63,7 +63,7 @@ file:
         function_name_identifier: update_actor
 - statement_terminator: ;
 - statement:
-    drop_procedure:
+    drop_procedure_statement:
     - keyword: drop
     - keyword: procedure
     - function_name:
@@ -74,7 +74,7 @@ file:
     - keyword: CASCADE
 - statement_terminator: ;
 - statement:
-    drop_procedure:
+    drop_procedure_statement:
     - keyword: drop
     - keyword: procedure
     - function_name:


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->

Fixes #2091 : add support for `DROP PROCEDURE` statements in postgres

### Are there any other side effects of this change that we should be aware of?
It is not as restrictive as it should be (for example with `argmode` in `FunctionParameterListGrammar`). The tradeoff is the segment stays short and clean.

I'm not sure it warrants leaving a TODO, but happy to include one if needs be.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
