### PR TITLE
Fix T-SQL's IDENTITY_INSERT syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1520,7 +1520,10 @@ class SetStatementSegment(BaseSegment):
             "CONCAT_NULL_YIELDS_NULL",
             "CURSOR_CLOSE_ON_COMMIT",
             "FIPS_FLAGGER",
-            "IDENTITY_INSERT",
+            Sequence(
+                "IDENTITY_INSERT",
+                Ref("TableReferenceSegment")
+            ),
             "LANGUAGE",
             "OFFSETS",
             "QUOTED_IDENTIFIER",

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1520,10 +1520,7 @@ class SetStatementSegment(BaseSegment):
             "CONCAT_NULL_YIELDS_NULL",
             "CURSOR_CLOSE_ON_COMMIT",
             "FIPS_FLAGGER",
-            Sequence(
-                "IDENTITY_INSERT",
-                Ref("TableReferenceSegment")
-            ),
+            Sequence("IDENTITY_INSERT", Ref("TableReferenceSegment")),
             "LANGUAGE",
             "OFFSETS",
             "QUOTED_IDENTIFIER",

--- a/test/fixtures/dialects/tsql/insert_with_identity_insert.sql
+++ b/test/fixtures/dialects/tsql/insert_with_identity_insert.sql
@@ -1,0 +1,8 @@
+SET IDENTITY_INSERT someTable ON;
+
+INSERT INTO someTable
+  (ID, Value)
+VALUES
+  (1, 2);
+
+SET IDENTITY_INSERT someTable OFF;

--- a/test/fixtures/dialects/tsql/insert_with_identity_insert.yml
+++ b/test/fixtures/dialects/tsql/insert_with_identity_insert.yml
@@ -1,0 +1,49 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 88ac913232452fff4754311171aca295f8238d34480f86b7d4fc604080c9e211
+file:
+  batch:
+  - statement:
+      set_segment:
+      - keyword: SET
+      - keyword: IDENTITY_INSERT
+      - table_reference:
+          identifier: someTable
+      - keyword: 'ON'
+      - statement_terminator: ;
+  - statement:
+      insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          identifier: someTable
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            identifier: ID
+        - comma: ','
+        - column_reference:
+            identifier: Value
+        - end_bracket: )
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              literal: '1'
+          - comma: ','
+          - expression:
+              literal: '2'
+          - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      set_segment:
+      - keyword: SET
+      - keyword: IDENTITY_INSERT
+      - table_reference:
+          identifier: someTable
+      - keyword: 'OFF'
+      - statement_terminator: ;


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
T-SQL's `IDENTITY_INSERT` needs a table name in addition to `ON`/`OFF`. So we add it.

Fixes: #2448

### Are there any other side effects of this change that we should be aware of?
I don't think so 🙂

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
