### PR TITLE
Spark3: test cases for Common Table Expressions

### DIFF
--- a/test/fixtures/dialects/spark3/common_table_expressions.sql
+++ b/test/fixtures/dialects/spark3/common_table_expressions.sql
@@ -1,0 +1,60 @@
+-- CTE with multiple column aliases
+WITH t(x, y) AS (
+    SELECT
+        1,
+        2
+)
+
+SELECT * FROM t WHERE x = 1 AND y = 2;
+
+-- CTE in CTE definition
+WITH t AS (
+    WITH t2 AS (SELECT 1)
+
+    SELECT * FROM t2
+)
+
+SELECT * FROM t;
+
+-- CTE in subquery
+SELECT max(c) FROM (
+    WITH t(c) AS (SELECT 1)
+
+    SELECT * FROM t
+);
+
+-- CTE in subquery expression
+SELECT (
+    WITH t AS (SELECT 1)
+
+    SELECT * FROM t
+);
+
+-- CTE in CREATE VIEW statement
+CREATE VIEW v AS
+WITH t(a, b, c, d) AS (
+    SELECT
+        1,
+        2,
+        3,
+        4
+)
+
+SELECT * FROM t;
+SELECT * FROM v;
+
+-- If name conflict is detected in nested CTE, then AnalysisException is thrown by default.
+-- SET spark.sql.legacy.ctePrecedencePolicy = CORRECTED (which is recommended),
+-- inner CTE definitions take precedence over outer definitions.
+WITH
+t AS (
+    SELECT 1
+),
+
+t2 AS (
+    WITH t AS (SELECT 2)
+
+    SELECT * FROM t
+)
+
+SELECT * FROM t2;

--- a/test/fixtures/dialects/spark3/common_table_expressions.yml
+++ b/test/fixtures/dialects/spark3/common_table_expressions.yml
@@ -1,0 +1,337 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 8cdecb88c8fcbbd731095683c83501deb36e39584984bc33dfe134993348fb24
+file:
+- base:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+      - identifier: t
+      - bracketed:
+          start_bracket: (
+          identifier_list:
+          - identifier: x
+          - comma: ','
+          - identifier: y
+          end_bracket: )
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                literal: '1'
+            - comma: ','
+            - select_clause_element:
+                literal: '2'
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: t
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+              identifier: x
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - literal: '1'
+          - binary_operator: AND
+          - column_reference:
+              identifier: y
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - literal: '2'
+- statement_terminator: ;
+- base:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        identifier: t
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          with_compound_statement:
+            keyword: WITH
+            common_table_expression:
+              identifier: t2
+              keyword: AS
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      literal: '1'
+                end_bracket: )
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  wildcard_expression:
+                    wildcard_identifier:
+                      star: '*'
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: t2
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: t
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: max
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: c
+              end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                with_compound_statement:
+                  keyword: WITH
+                  common_table_expression:
+                  - identifier: t
+                  - bracketed:
+                      start_bracket: (
+                      identifier_list:
+                        identifier: c
+                      end_bracket: )
+                  - keyword: AS
+                  - bracketed:
+                      start_bracket: (
+                      select_statement:
+                        select_clause:
+                          keyword: SELECT
+                          select_clause_element:
+                            literal: '1'
+                      end_bracket: )
+                  select_statement:
+                    select_clause:
+                      keyword: SELECT
+                      select_clause_element:
+                        wildcard_expression:
+                          wildcard_identifier:
+                            star: '*'
+                    from_clause:
+                      keyword: FROM
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              identifier: t
+                end_bracket: )
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              with_compound_statement:
+                keyword: WITH
+                common_table_expression:
+                  identifier: t
+                  keyword: AS
+                  bracketed:
+                    start_bracket: (
+                    select_statement:
+                      select_clause:
+                        keyword: SELECT
+                        select_clause_element:
+                          literal: '1'
+                    end_bracket: )
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      wildcard_expression:
+                        wildcard_identifier:
+                          star: '*'
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            identifier: t
+              end_bracket: )
+- statement_terminator: ;
+- base:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: VIEW
+    - table_reference:
+        identifier: v
+    - keyword: AS
+    - with_compound_statement:
+        keyword: WITH
+        common_table_expression:
+        - identifier: t
+        - bracketed:
+            start_bracket: (
+            identifier_list:
+            - identifier: a
+            - comma: ','
+            - identifier: b
+            - comma: ','
+            - identifier: c
+            - comma: ','
+            - identifier: d
+            end_bracket: )
+        - keyword: AS
+        - bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  literal: '1'
+              - comma: ','
+              - select_clause_element:
+                  literal: '2'
+              - comma: ','
+              - select_clause_element:
+                  literal: '3'
+              - comma: ','
+              - select_clause_element:
+                  literal: '4'
+            end_bracket: )
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: t
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: v
+- statement_terminator: ;
+- base:
+    with_compound_statement:
+    - keyword: WITH
+    - common_table_expression:
+        identifier: t
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                literal: '1'
+          end_bracket: )
+    - comma: ','
+    - common_table_expression:
+        identifier: t2
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          with_compound_statement:
+            keyword: WITH
+            common_table_expression:
+              identifier: t
+              keyword: AS
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      literal: '2'
+                end_bracket: )
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  wildcard_expression:
+                    wildcard_identifier:
+                      star: '*'
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: t
+          end_bracket: )
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: t2
+- statement_terminator: ;


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
From what I've found so far, CTEs work without any additional code for spark3 dialect but thought I would open PR for the test cases to help identify any regressions in the future.

### Are there any other side effects of this change that we should be aware of?
N/A

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
