### PR TITLE
Ignore words for various rules

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -65,6 +65,8 @@ operator_new_lines = after
 [sqlfluff:rules:L010]
 # Keywords
 capitalisation_policy = consistent
+# Comma separated list of words to ignore for this rule
+ignore_words = None
 
 [sqlfluff:rules:L011]
 # Aliasing preference for tables
@@ -77,6 +79,8 @@ aliasing = explicit
 [sqlfluff:rules:L014]
 # Unquoted identifiers
 extended_capitalisation_policy = consistent
+# Comma separated list of words to ignore for this rule
+ignore_words = None
 
 [sqlfluff:rules:L016]
 # Line length
@@ -96,10 +100,14 @@ force_enable = False
 # Keywords should not be used as identifiers.
 unquoted_identifiers_policy = aliases
 quoted_identifiers_policy = none
+# Comma separated list of words to ignore for this rule
+ignore_words = None
 
 [sqlfluff:rules:L030]
 # Function names
 capitalisation_policy = consistent
+# Comma separated list of words to ignore for this rule
+ignore_words = None
 
 [sqlfluff:rules:L038]
 # Trailing commas
@@ -108,6 +116,8 @@ select_clause_trailing_comma = forbid
 [sqlfluff:rules:L040]
 # Null & Boolean Literals
 capitalisation_policy = consistent
+# Comma separated list of words to ignore for this rule
+ignore_words = None
 
 [sqlfluff:rules:L042]
 # By default, allow subqueries in from clauses, but not join clauses

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -774,7 +774,8 @@ class BaseRule:
                 return
 
     @staticmethod
-    def _split_comma_separated_string(raw_str: str) -> List[str]:
+    def split_comma_separated_string(raw_str: str) -> List[str]:
+        """Converts comma separated string to List, stripping whitespace."""
         return [s.strip() for s in raw_str.split(",") if s.strip()]
 
 

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -773,6 +773,10 @@ class BaseRule:
                 lint_result.fixes = []
                 return
 
+    @staticmethod
+    def _split_comma_separated_string(raw_str: str) -> List[str]:
+        return [s.strip() for s in raw_str.split(",") if s.strip()]
+
 
 class RuleSet:
     """Class to define a ruleset.

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -81,6 +81,9 @@ STANDARD_CONFIG_INFO_DICT = {
             " be ignored when linting line lengths?"
         ),
     },
+    "ignore_words": {
+        "definition": ("List or words to ignore from rule"),
+    },
     "forbid_subquery_in": {
         "validation": ["join", "from", "both"],
         "definition": "Which clauses should be linted for subqueries?",

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -82,7 +82,7 @@ STANDARD_CONFIG_INFO_DICT = {
         ),
     },
     "ignore_words": {
-        "definition": ("List or words to ignore from rule"),
+        "definition": ("Comma separated list of words to ignore from rule"),
     },
     "forbid_subquery_in": {
         "validation": ["join", "from", "both"],

--- a/src/sqlfluff/rules/L010.py
+++ b/src/sqlfluff/rules/L010.py
@@ -77,9 +77,8 @@ class Rule_L010(BaseRule):
                 ignore_words_list,
             ) = self._init_capitalisation_policy()
 
-        # Skip if not an element of the specified type/name
+        # Skip if in ignore list
         if ignore_words_list and context.segment.raw.lower() in ignore_words_list:
-            print("BARRY ignorering:%s:" % context.segment.raw)
             return LintResult(memory=context.memory)
 
         memory = context.memory

--- a/src/sqlfluff/rules/L010.py
+++ b/src/sqlfluff/rules/L010.py
@@ -200,10 +200,6 @@ class Rule_L010(BaseRule):
         """
         return LintFix.replace(segment, [segment.edit(fixed_raw)])
 
-    @staticmethod
-    def _split_comma_separated_string(raw_str: str) -> List[str]:
-        return [s.strip() for s in raw_str.split(",") if s.strip()]
-
     def _init_capitalisation_policy(self):
         """Called first time rule is evaluated to fetch & cache the policy."""
         cap_policy_name = next(

--- a/src/sqlfluff/rules/L010.py
+++ b/src/sqlfluff/rules/L010.py
@@ -47,7 +47,7 @@ class Rule_L010(BaseRule):
         ("type", "date_part"),
         ("type", "data_type_identifier"),
     ]
-    config_keywords = ["capitalisation_policy"]
+    config_keywords = ["capitalisation_policy", "ignore_words"]
     # Human readable target elem for description
     _description_elem = "Keywords"
 
@@ -67,10 +67,20 @@ class Rule_L010(BaseRule):
         try:
             cap_policy = self.cap_policy
             cap_policy_opts = self.cap_policy_opts
+            ignore_words_list = self.ignore_words_list
         except AttributeError:
             # First-time only, read the settings from configuration. This is
             # very slow.
-            cap_policy, cap_policy_opts = self._init_capitalisation_policy()
+            (
+                cap_policy,
+                cap_policy_opts,
+                ignore_words_list,
+            ) = self._init_capitalisation_policy()
+
+        # Skip if not an element of the specified type/name
+        if ignore_words_list and context.segment.raw.lower() in ignore_words_list:
+            print("BARRY ignorering:%s:" % context.segment.raw)
+            return LintResult(memory=context.memory)
 
         memory = context.memory
         refuted_cases = memory.get("refuted_cases", set())
@@ -191,6 +201,10 @@ class Rule_L010(BaseRule):
         """
         return LintFix.replace(segment, [segment.edit(fixed_raw)])
 
+    @staticmethod
+    def _split_comma_separated_string(raw_str: str) -> List[str]:
+        return [s.strip() for s in raw_str.split(",") if s.strip()]
+
     def _init_capitalisation_policy(self):
         """Called first time rule is evaluated to fetch & cache the policy."""
         cap_policy_name = next(
@@ -202,10 +216,19 @@ class Rule_L010(BaseRule):
             for opt in get_config_info()[cap_policy_name]["validation"]
             if opt != "consistent"
         ]
+        # Use str() as L040 uses bools which might otherwise be read as bool
+        ignore_words_config = str(getattr(self, "ignore_words"))
+        if ignore_words_config and ignore_words_config != "None":
+            self.ignore_words_list = self._split_comma_separated_string(
+                ignore_words_config.lower()
+            )
+        else:
+            self.ignore_words_list = []
         self.logger.debug(
             f"Selected '{cap_policy_name}': '{self.cap_policy}' from options "
             f"{self.cap_policy_opts}"
         )
         cap_policy = self.cap_policy
         cap_policy_opts = self.cap_policy_opts
-        return cap_policy, cap_policy_opts
+        ignore_words_list = self.ignore_words_list
+        return cap_policy, cap_policy_opts, ignore_words_list

--- a/src/sqlfluff/rules/L010.py
+++ b/src/sqlfluff/rules/L010.py
@@ -214,7 +214,7 @@ class Rule_L010(BaseRule):
         # Use str() as L040 uses bools which might otherwise be read as bool
         ignore_words_config = str(getattr(self, "ignore_words"))
         if ignore_words_config and ignore_words_config != "None":
-            self.ignore_words_list = self._split_comma_separated_string(
+            self.ignore_words_list = self.split_comma_separated_string(
                 ignore_words_config.lower()
             )
         else:

--- a/src/sqlfluff/rules/L014.py
+++ b/src/sqlfluff/rules/L014.py
@@ -68,7 +68,11 @@ class Rule_L014(Rule_L010):
     """
 
     _target_elems: List[Tuple[str, str]] = [("name", "naked_identifier")]
-    config_keywords = ["extended_capitalisation_policy", "unquoted_identifiers_policy"]
+    config_keywords = [
+        "extended_capitalisation_policy",
+        "unquoted_identifiers_policy",
+        "ignore_words",
+    ]
     _description_elem = "Unquoted identifiers"
 
     def _eval(self, context: RuleContext) -> LintResult:

--- a/src/sqlfluff/rules/L029.py
+++ b/src/sqlfluff/rules/L029.py
@@ -100,7 +100,7 @@ class Rule_L029(BaseRule):
         # Use str() in case bools are passed which might otherwise be read as bool
         ignore_words_config = str(getattr(self, "ignore_words"))
         if ignore_words_config and ignore_words_config != "None":
-            self.ignore_words_list = self._split_comma_separated_string(
+            self.ignore_words_list = self.split_comma_separated_string(
                 ignore_words_config.lower()
             )
         else:

--- a/src/sqlfluff/rules/L029.py
+++ b/src/sqlfluff/rules/L029.py
@@ -53,7 +53,7 @@ class Rule_L029(BaseRule):
         if len(context.segment.raw) == 1:
             return LintResult(memory=context.memory)
 
-        # Get the Quoted policy configuration.
+        # Get the ignore list configuration and cache it
         try:
             ignore_words_list = self.ignore_words_list
         except AttributeError:
@@ -61,7 +61,7 @@ class Rule_L029(BaseRule):
             # So we can cache them for next time for speed.
             ignore_words_list = self._init_ignore_string()
 
-        # Skip if not an element of the specified type/name
+        # Skip if in ignore list
         if ignore_words_list and context.segment.raw.lower() in ignore_words_list:
             return LintResult(memory=context.memory)
 

--- a/src/sqlfluff/rules/L029.py
+++ b/src/sqlfluff/rules/L029.py
@@ -95,10 +95,6 @@ class Rule_L029(BaseRule):
         else:
             return None
 
-    @staticmethod
-    def _split_comma_separated_string(raw_str: str) -> List[str]:
-        return [s.strip() for s in raw_str.split(",") if s.strip()]
-
     def _init_ignore_string(self):
         """Called first time rule is evaluated to fetch & cache the ignore_words."""
         # Use str() in case bools are passed which might otherwise be read as bool

--- a/test/fixtures/rules/std_rule_cases/L010.yml
+++ b/test/fixtures/rules/std_rule_cases/L010.yml
@@ -155,3 +155,19 @@ test_pass_bigquery_date:
     rules:
       L010:
         capitalisation_policy: upper
+
+test_pass_ignore_word:
+  pass_str: SeleCT 1
+  configs:
+    rules:
+      L010:
+        capitalisation_policy: upper
+        ignore_words: select
+
+test_pass_ignore_words:
+  pass_str: SeleCT 1
+  configs:
+    rules:
+      L010:
+        capitalisation_policy: upper
+        ignore_words: select,from

--- a/test/fixtures/rules/std_rule_cases/L014.yml
+++ b/test/fixtures/rules/std_rule_cases/L014.yml
@@ -209,3 +209,11 @@ test_policy_unquoted_identifiers_aliases_2:
     rules:
       L014:
         unquoted_identifiers_policy: column_aliases
+
+test_pass_ignore_word:
+  pass_str: SELECT A, b
+  configs:
+    rules:
+      L014:
+        capitalisation_policy: upper
+        ignore_words: b

--- a/test/fixtures/rules/std_rule_cases/L028.yml
+++ b/test/fixtures/rules/std_rule_cases/L028.yml
@@ -174,3 +174,13 @@ test_pass_tsql_parameter:
   configs:
     core:
       dialect: tsql
+
+
+test_pass_ignore_word:
+  pass_str: SELECT d.col1 FROM table1 d
+  configs:
+    core:
+      dialect: Snowflake
+    rules:
+      L028:
+        ignore_words: d

--- a/test/fixtures/rules/std_rule_cases/L028.yml
+++ b/test/fixtures/rules/std_rule_cases/L028.yml
@@ -174,13 +174,3 @@ test_pass_tsql_parameter:
   configs:
     core:
       dialect: tsql
-
-
-test_pass_ignore_word:
-  pass_str: SELECT d.col1 FROM table1 d
-  configs:
-    core:
-      dialect: Snowflake
-    rules:
-      L028:
-        ignore_words: d

--- a/test/fixtures/rules/std_rule_cases/L029.yml
+++ b/test/fixtures/rules/std_rule_cases/L029.yml
@@ -135,4 +135,4 @@ test_pass_one_character_identifier:
   pass_str: SELECT d.col1 FROM table1 d
   configs:
     core:
-      dialect: Snowflake
+      dialect: snowflake

--- a/test/fixtures/rules/std_rule_cases/L029.yml
+++ b/test/fixtures/rules/std_rule_cases/L029.yml
@@ -114,3 +114,10 @@ test_fail_keyword_as_quoted_identifier_column_alias_config:
         quoted_identifiers_policy: column_aliases
     core:
       dialect: tsql
+
+test_pass_ignore_word:
+  fail_str: CREATE TABLE artist(create TEXT)
+  configs:
+    rules:
+      L029:
+        ignore_word: create

--- a/test/fixtures/rules/std_rule_cases/L029.yml
+++ b/test/fixtures/rules/std_rule_cases/L029.yml
@@ -116,11 +116,11 @@ test_fail_keyword_as_quoted_identifier_column_alias_config:
       dialect: tsql
 
 test_pass_ignore_word1:
-  fail_str: CREATE TABLE artist(create TEXT)
+  pass_str: CREATE TABLE artist(create TEXT)
   configs:
     rules:
       L029:
-        ignore_word: create
+        ignore_words: create
 
 
 test_pass_ignore_word2:
@@ -128,7 +128,7 @@ test_pass_ignore_word2:
   configs:
     rules:
       L029:
-        ignore_word: date
+        ignore_words: date
 
 
 test_pass_one_character_identifier:

--- a/test/fixtures/rules/std_rule_cases/L029.yml
+++ b/test/fixtures/rules/std_rule_cases/L029.yml
@@ -115,9 +115,24 @@ test_fail_keyword_as_quoted_identifier_column_alias_config:
     core:
       dialect: tsql
 
-test_pass_ignore_word:
+test_pass_ignore_word1:
   fail_str: CREATE TABLE artist(create TEXT)
   configs:
     rules:
       L029:
         ignore_word: create
+
+
+test_pass_ignore_word2:
+  pass_str: SELECT col1 AS date FROM table1
+  configs:
+    rules:
+      L029:
+        ignore_word: date
+
+
+test_pass_one_character_identifier:
+  pass_str: SELECT d.col1 FROM table1 d
+  configs:
+    core:
+      dialect: Snowflake

--- a/test/fixtures/rules/std_rule_cases/L030.yml
+++ b/test/fixtures/rules/std_rule_cases/L030.yml
@@ -47,3 +47,10 @@ test_fail_fully_qualified_function_mixed_functions:
 test_fail_fully_qualified_function_mixed_case:
   fail_str: SELECT project1.FoO(value1) AS value2
   fix_str: SELECT project1.FOO(value1) AS value2
+
+test_pass_ignore_word:
+  pass_str: SELECT MAX(id), min(id) FROM TABLE1
+  configs:
+    rules:
+      L028:
+        ignore_words: min

--- a/test/fixtures/rules/std_rule_cases/L030.yml
+++ b/test/fixtures/rules/std_rule_cases/L030.yml
@@ -52,5 +52,5 @@ test_pass_ignore_word:
   pass_str: SELECT MAX(id), min(id) FROM TABLE1
   configs:
     rules:
-      L028:
+      L030:
         ignore_words: min

--- a/test/fixtures/rules/std_rule_cases/L040.yml
+++ b/test/fixtures/rules/std_rule_cases/L040.yml
@@ -3,3 +3,10 @@ rule: L040
 test_fail_inconsistent_boolean_capitalisation:
   fail_str: SeLeCt true, FALSE, NULL
   fix_str: SeLeCt true, false, null
+
+test_pass_ignore_word:
+  pass_str: SELECT true, FALSE, NULL
+  configs:
+    rules:
+      L028:
+        ignore_words: true

--- a/test/fixtures/rules/std_rule_cases/L040.yml
+++ b/test/fixtures/rules/std_rule_cases/L040.yml
@@ -8,5 +8,5 @@ test_pass_ignore_word:
   pass_str: SELECT true, FALSE, NULL
   configs:
     rules:
-      L028:
+      L040:
         ignore_words: true


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->

As raised on Slack 0.9.2 introduced a lot of keywords to Snowflake, including a lot of single word short alias's for dates (e.g. `d` for `day`).

This PR introduces the concept of `ignore_words` to allow the rules that check identifiers to be ignored for certain "allowed words". This is a good feature for feature to have anyway as allows users to handle bugs without waiting for the next release or turning off a rule entirely.

I've also excluded single letter chars from L026 and did some clean up in there for performance.

Adds an optional `ignore_words` parameter to the following rules:
- L010 - Inconsistent capitalisation of keywords.
- L014 - Inconsistent capitalisation of unquoted identifiers.
- L029 - Keywords should not be used as identifiers (rule inherits this from L010).
- L030 - Inconsistent capitalisation of function names (rule inherits this from L010).
- L040 - Inconsistent capitalisation of boolean/null literal (rule inherits this from L010).

I've also made some further changes to L029:
- Exit early if not an identifier
- Exit if 1 character identifier (sometimes these are keywords - like `d` in Snowflake, but people expect to be able to use them)
- Cache cleaned up `ignore_words` list (similar to how L010 caches it's config).

### Are there any other side effects of this change that we should be aware of?
Shouldn't be

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
