### PR TITLE
Fix L044 exception when final statement has no SELECT

### DIFF
--- a/src/sqlfluff/rules/L044.py
+++ b/src/sqlfluff/rules/L044.py
@@ -83,7 +83,8 @@ class Rule_L044(BaseRule):
         # Recursively walk from the given query (select_info_list) to any
         # wildcard columns in the select targets. If every wildcard evdentually
         # resolves to a query without wildcards, all is well. Otherwise, warn.
-        assert query.selectables
+        if not query.selectables:
+            return
         for selectable in query.selectables:
             self.logger.debug(f"Analyzing query: {selectable.selectable.raw}")
             for wildcard in selectable.get_wildcard_info():

--- a/test/fixtures/rules/std_rule_cases/L044.yml
+++ b/test/fixtures/rules/std_rule_cases/L044.yml
@@ -550,3 +550,18 @@ test_pass_exasol_values_clause:
   configs:
     core:
       dialect: exasol
+
+test_pass_cte_no_select_final_statement:
+  pass_str:
+    WITH mycte AS (
+      SELECT
+          foo,
+          bar
+      FROM mytable1
+    )
+
+    UPDATE sometable
+    SET
+        sometable.baz = mycte.bar
+    FROM
+        mycte;


### PR DESCRIPTION
<!--Firstly, thanks for adding this feature! Secondly, please check the key steps against the checklist below to make your contribution easy to merge.-->

<!--Please give the Pull Request a meaningful title (including the dialect this PR is for if it is dialect specific), as this will automatically be added to the release notes, and then the Change Log.-->

### Brief summary of the change made
<!--If there is an open issue for this, then please include `fixes #XXXX` or `closes #XXXX` replacing `XXXX` with the issue number and it will automatically close the issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX` to create a link on that issue without closing it.-->
Fizes #2467

Originally part of #2464 but decided to pull out separately for easier review.

L044 expects a FROM statement to have a SELECT clause. This causes problems when using UPDATE with a FROM clause - especially when using a CTE that has a SELECT (otherwise L044 would be ignored).
Change `assert` into `if not` to fix.

### Are there any other side effects of this change that we should be aware of?
Shouldn't be

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
