### PR TITLE
Fix L039 for T-SQL comparison operator using space

### DIFF
--- a/src/sqlfluff/rules/L039.py
+++ b/src/sqlfluff/rules/L039.py
@@ -94,7 +94,7 @@ class Rule_L039(BaseRule):
                 if delete_fixes:
                     violations.append(
                         LintResult(
-                            anchor=child_seg,
+                            anchor=delete_fixes[0].anchor,
                             fixes=delete_fixes,
                         )
                     )

--- a/test/fixtures/rules/std_rule_cases/L039.yml
+++ b/test/fixtures/rules/std_rule_cases/L039.yml
@@ -66,3 +66,12 @@ test_casting_operator_pass:
   configs:
     core:
       dialect: postgres
+
+test_fix_tsql_spaced_chars:
+  fail_str: |
+    SELECT col1 FROM table1 WHERE 1 > = 1
+  fix_str: |
+    SELECT col1 FROM table1 WHERE 1 >= 1
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes final bug preventing #2473 from being merge

```
% echo "SELECT col1 FROM table1 WHERE 1 > = 1" | sqlfluff lint --dialect tsql -
CRITICAL   [L039] Applying rule L039 threw an Exception: local variable 'child_seg' referenced before assignment                                                                   
Traceback (most recent call last):
  File "/Users/barry/sqlfluff/src/sqlfluff/core/rules/base.py", line 519, in crawl
    res = self._eval(
  File "/Users/barry/sqlfluff/src/sqlfluff/rules/L039.py", line 97, in _eval
    anchor=child_seg,
UnboundLocalError: local variable 'child_seg' referenced before assignment
== [stdin] FAIL                                                                                                                                                                    
L:   1 | P:  31 | L039 | Unexpected exception: local variable 'child_seg'
                       | referenced before assignment; Could you open an issue at
                       | https://github.com/sqlfluff/sqlfluff/issues ? You can
                       | ignore this exception for now, by adding '-- noqa: L039'
                       | at the end of line 1
All Finished 📜 🎉!
```

### Are there any other side effects of this change that we should be aware of?
Nope. Looks like rule was incorrectly written for this case.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
