### PR TITLE
Prevent L031 throwing exception on unparsable code

### DIFF
--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -196,6 +196,8 @@ class Rule_L031(BaseRule):
                     ids_refs.append(used_alias_ref)
 
             # Fixes for deleting ` as sth` and for editing references to aliased tables
+            # Note unparsable errors have cause the delete to fail (see #2484)
+            # so check there is a d before doing deletes.
             fixes = [
                 *[
                     LintFix.delete(d)

--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -200,6 +200,7 @@ class Rule_L031(BaseRule):
                 *[
                     LintFix.delete(d)
                     for d in [alias_info.alias_exp_ref, alias_info.whitespace_ref]
+                    if d
                 ],
                 *[
                     LintFix.replace(


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Makes progress on #2484 by preventing exception being thrown on unparsable code.

I've not added a test case for this as 1) it's stupidly simple, and 2) it only happens for unparsable code which should in theory never happen. Let me know if you really think it needs it.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
