### PR TITLE
Add guards to prevent rule crashes

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1154,7 +1154,10 @@ class FromExpressionElementSegment(BaseSegment):
         if alias_expression:
             # If it has an alias, return that
             segment = alias_expression.get_child("identifier")
-            return AliasInfo(segment.raw, segment, True, self, alias_expression, ref)
+            if segment:
+                return AliasInfo(
+                    segment.raw, segment, True, self, alias_expression, ref
+                )
 
         # If not return the object name (or None if there isn't one)
         if ref:

--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -158,7 +158,8 @@ class Rule_L031(BaseRule):
         # interested in the NUMBER of different aliases used.)
         table_aliases = defaultdict(set)
         for ai in to_check:
-            table_aliases[ai.table_ref.raw].add(ai.alias_identifier_ref.raw)
+            if ai and ai.table_ref and ai.alias_identifier_ref:
+                table_aliases[ai.table_ref.raw].add(ai.alias_identifier_ref.raw)
 
         # For each aliased table, check whether to keep or remove it.
         for alias_info in to_check:
@@ -177,11 +178,14 @@ class Rule_L031(BaseRule):
             ids_refs = []
 
             # Find all references to alias in select clause
-            alias_name = alias_info.alias_identifier_ref.raw
-            for alias_with_column in select_clause.recursive_crawl("object_reference"):
-                used_alias_ref = alias_with_column.get_child("identifier")
-                if used_alias_ref and used_alias_ref.raw == alias_name:
-                    ids_refs.append(used_alias_ref)
+            if alias_info.alias_identifier_ref:
+                alias_name = alias_info.alias_identifier_ref.raw
+                for alias_with_column in select_clause.recursive_crawl(
+                    "object_reference"
+                ):
+                    used_alias_ref = alias_with_column.get_child("identifier")
+                    if used_alias_ref and used_alias_ref.raw == alias_name:
+                        ids_refs.append(used_alias_ref)
 
             # Find all references to alias in column references
             for exp_ref in column_reference_segments:
@@ -211,6 +215,7 @@ class Rule_L031(BaseRule):
                         source=[alias_info.table_ref],
                     )
                     for alias in [alias_info.alias_identifier_ref, *ids_refs]
+                    if alias
                 ],
             ]
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
This fixes some runtime rule errors in #2245 detected by the new "Rules critical errors tests" CI check.

I recommend reviewing this PR with the "Hide whitespace" option checked.
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
