### PR TITLE
Enforce parentheses for function definitions in T-SQL

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1414,12 +1414,15 @@ class FunctionParameterListGrammar(BaseSegment):
 
     type = "function_parameter_list"
     # Function parameter list
-    match_grammar = OptionallyBracketed(
-        Ref("FunctionParameterGrammar"),
-        AnyNumberOf(
-            Ref("CommaSegment"),
+    match_grammar = Bracketed(
+        Sequence(
             Ref("FunctionParameterGrammar"),
-        ),
+            AnyNumberOf(
+                Ref("CommaSegment"),
+                Ref("FunctionParameterGrammar"),
+            ),
+            optional=True,
+        )
     )
 
 
@@ -1622,6 +1625,27 @@ class SetStatementSegment(BaseSegment):
 
 
 @tsql_dialect.segment()
+class ProcedureParameterListGrammar(BaseSegment):
+    """The parameters for a procedure ie.
+
+    `@city_name NVARCHAR(30), @postal_code NVARCHAR(15)`.
+    """
+
+    type = "procedure_parameter_list"
+    # Function parameter list
+    match_grammar = OptionallyBracketed(
+        Sequence(
+            Ref("FunctionParameterGrammar"),
+            AnyNumberOf(
+                Ref("CommaSegment"),
+                Ref("FunctionParameterGrammar"),
+            ),
+            optional=True,
+        ),
+    )
+
+
+@tsql_dialect.segment()
 class CreateProcedureStatementSegment(BaseSegment):
     """A `CREATE OR ALTER PROCEDURE` statement.
 
@@ -1635,7 +1659,7 @@ class CreateProcedureStatementSegment(BaseSegment):
         Sequence("OR", "ALTER", optional=True),
         OneOf("PROCEDURE", "PROC"),
         Ref("ObjectReferenceSegment"),
-        Ref("FunctionParameterListGrammar", optional=True),
+        Ref("ProcedureParameterListGrammar", optional=True),
         "AS",
         Ref("ProcedureDefinitionGrammar"),
     )

--- a/test/fixtures/dialects/tsql/function_default_params.yml
+++ b/test/fixtures/dialects/tsql/function_default_params.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2501cb05d43246a910e1715a625e9329547f0246615cce94560e3f5bf18bc535
+_hash: acc3f24614cb5d6a9ddb1764aee3ce1194af95d8f2d4c31e712d8c8bbefa75a4
 file:
   batch:
     create_procedure_statement:
@@ -13,7 +13,7 @@ file:
     - keyword: procedure
     - object_reference:
         identifier: name
-    - function_parameter_list:
+    - procedure_parameter_list:
       - parameter: '@param1'
       - data_type:
           identifier: nvarchar

--- a/test/fixtures/dialects/tsql/function_no_return.yml
+++ b/test/fixtures/dialects/tsql/function_no_return.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b443a44cc8209ec2259d4dbd58a0c43d424542fa31daa22ca3517c469db8f02d
+_hash: 128c32cc75b35a57e536fa589a860292ab6b1591356a327f5cdd0c64de478e01
 file:
   batch:
     create_procedure_statement:
@@ -11,7 +11,7 @@ file:
     - keyword: PROCEDURE
     - object_reference:
         identifier: findjobs
-    - function_parameter_list:
+    - procedure_parameter_list:
         parameter: '@nm'
         data_type:
           identifier: sysname

--- a/test/fixtures/dialects/tsql/functions_a.sql
+++ b/test/fixtures/dialects/tsql/functions_a.sql
@@ -15,7 +15,12 @@ RETURNS TABLE
 AS
      RETURN
 (
-    SELECT @admit 
+    SELECT @admit
     FROM   dbo.[RandomDate]
 );
 GO
+
+CREATE FUNCTION dbo.no_paramters() RETURNS INT AS
+BEGIN
+    RETURN 2;
+END

--- a/test/fixtures/dialects/tsql/functions_a.yml
+++ b/test/fixtures/dialects/tsql/functions_a.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 08d70822633fac346a01d06416a990061c8ec012a2b9ceaadf6347e1b6858c43
+_hash: b0ab733eeb69dd6144fea2c316576014d968b8fbb71b5696384fee49a45fa450
 file:
 - batch:
     statement:
@@ -173,3 +173,31 @@ file:
               statement_terminator: ;
 - go_statement:
     keyword: GO
+- batch:
+    statement:
+      create_function_statement:
+      - keyword: CREATE
+      - keyword: FUNCTION
+      - object_reference:
+        - identifier: dbo
+        - dot: .
+        - identifier: no_paramters
+      - function_parameter_list:
+          bracketed:
+            start_bracket: (
+            end_bracket: )
+      - keyword: RETURNS
+      - data_type:
+          identifier: INT
+      - keyword: AS
+      - procedure_statement:
+          statement:
+            begin_end_block:
+            - keyword: BEGIN
+            - statement:
+                return_segment:
+                  keyword: RETURN
+                  expression:
+                    literal: '2'
+                  statement_terminator: ;
+            - keyword: END

--- a/test/fixtures/dialects/tsql/hints.yml
+++ b/test/fixtures/dialects/tsql/hints.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a9f655124a52309b72ba14cebe45b8fb218bfd7acfdd36995ca42d32f0c93e09
+_hash: c6976fb5117776ea0122563b8d98741bb6c062204c4d4d9707672ac626c7ec33
 file:
 - batch:
     statement:
@@ -78,7 +78,7 @@ file:
       - identifier: dbo
       - dot: .
       - identifier: RetrievePersonAddress
-    - function_parameter_list:
+    - procedure_parameter_list:
       - parameter: '@city_name'
       - data_type:
           identifier: NVARCHAR

--- a/test/fixtures/dialects/tsql/stored_procedure_single_statement.yml
+++ b/test/fixtures/dialects/tsql/stored_procedure_single_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 88e6ff245768b21e27b4eac19ecdfa68cc0e0aa8052a0159c201906ac9d55f62
+_hash: c3a2f44fdc765c7318aed083c7a432678affb644be77326e09d6f0b92572d0e6
 file:
   batch:
     create_procedure_statement:
@@ -15,7 +15,7 @@ file:
       - identifier: DBO
       - dot: .
       - identifier: SP_ECDC_CASES_INTER
-    - function_parameter_list:
+    - procedure_parameter_list:
         bracketed:
         - start_bracket: (
         - parameter: '@Apple'


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
In T-SQL, function definitions must have parentheses, even if they have no parameters.
On the other hand, procedures can have parentheses around parameters, but they don't need to.
To correctly lint this difference, they now use different segments.

Fixes #2472

### Are there any other side effects of this change that we should be aware of?
I don't think so

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
