### PR TITLE
Add raiserror for T-SQL

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -402,6 +402,7 @@ class StatementSegment(ansi_dialect.get_segment("StatementSegment")):  # type: i
             Ref("TryCatchSegment"),
             Ref("MergeStatementSegment"),
             Ref("ThrowStatementSegment"),
+            Ref("RaiserrorStatementSegment"),
             Ref("ReturnStatementSegment"),
         ],
         remove=[
@@ -3363,6 +3364,31 @@ class ThrowStatementSegment(BaseSegment):
                 Ref("ParameterNameSegment"),
             ),
             optional=True,
+        ),
+    )
+
+
+@tsql_dialect.segment()
+class RaiserrorStatementSegment(BaseSegment):
+    """RAISERROR statement.
+
+    https://docs.microsoft.com/en-us/sql/t-sql/language-elements/raiserror-transact-sql?view=sql-server-ver15
+    """
+
+    type = "raiserror_statement"
+    match_grammar = Sequence(
+        "RAISERROR",
+        Bracketed(
+            Delimited(
+                OneOf(Ref("NumericLiteralSegment"), Ref("QuotedLiteralSegment")),
+                OneOf(
+                    Ref("NumericLiteralSegment"), Ref("QualifiedNumericLiteralSegment")
+                ),
+                OneOf(
+                    Ref("NumericLiteralSegment"), Ref("QualifiedNumericLiteralSegment")
+                ),
+                Ref("QuotedLiteralSegment", optional=True),
+            ),
         ),
     )
 

--- a/test/fixtures/dialects/tsql/raiserror.sql
+++ b/test/fixtures/dialects/tsql/raiserror.sql
@@ -1,0 +1,5 @@
+RAISERROR(15600, -1, -1, 'mysp_CreateCustomer');
+
+RAISERROR('This is message %s %d.', 10, 1, 'number');
+
+RAISERROR('Error raised in TRY block.', 16, 1);

--- a/test/fixtures/dialects/tsql/raiserror.yml
+++ b/test/fixtures/dialects/tsql/raiserror.yml
@@ -1,0 +1,52 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: c286f099e756eed487721ebfff75b87861ead8c85234152cde5923f82f686c70
+file:
+  batch:
+  - statement:
+      raiserror_statement:
+        keyword: RAISERROR
+        bracketed:
+        - start_bracket: (
+        - literal: '15600'
+        - comma: ','
+        - numeric_literal:
+            binary_operator: '-'
+            literal: '1'
+        - comma: ','
+        - numeric_literal:
+            binary_operator: '-'
+            literal: '1'
+        - comma: ','
+        - literal: "'mysp_CreateCustomer'"
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      raiserror_statement:
+        keyword: RAISERROR
+        bracketed:
+        - start_bracket: (
+        - literal: "'This is message %s %d.'"
+        - comma: ','
+        - literal: '10'
+        - comma: ','
+        - literal: '1'
+        - comma: ','
+        - literal: "'number'"
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      raiserror_statement:
+        keyword: RAISERROR
+        bracketed:
+        - start_bracket: (
+        - literal: "'Error raised in TRY block.'"
+        - comma: ','
+        - literal: '16'
+        - comma: ','
+        - literal: '1'
+        - end_bracket: )
+  - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This probably doesn't support the complete raiseerror syntax, but it's a start 🙂

Fixes #2367


### Are there any other side effects of this change that we should be aware of?
I don't thinks so.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
