### PR TITLE
Bug fix: Defining and using Jinja macro in the same file causes runtime error

### DIFF
--- a/test/fixtures/rules/std_rule_cases/L009.yml
+++ b/test/fixtures/rules/std_rule_cases/L009.yml
@@ -21,3 +21,15 @@ test_fail_templated_plus_raw_newlines:
 test_fail_templated_plus_raw_newlines_extra_newline:
   fail_str: "{{ '\n\n' }}\n\n"
   fix_str: "{{ '\n\n' }}\n"
+
+test_pass_templated_macro_newlines:
+  # Tricky because the rendered code ends with two newlines:
+  # - Literal newline inserted by the macro
+  # - Literal newline at the end of the file
+  # The slicing algorithm should treat the first newline as "templated" because
+  # it was inserted when *expanding* the templated macro call.
+  pass_str: |
+    {% macro get_keyed_nulls(columns) %}
+      {{ columns }}
+    {% endmacro %}
+    SELECT {{ get_keyed_nulls("other_id") }}


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #2456
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
