### PR TITLE
Spark3: Support `DISTRIBUTE BY` clause in `SELECT` statement

### DIFF
--- a/test/fixtures/dialects/spark3/select_distribute_by.sql
+++ b/test/fixtures/dialects/spark3/select_distribute_by.sql
@@ -1,0 +1,30 @@
+-- Produces rows clustered by age. Persons with same age are clustered together.
+-- Unlike `CLUSTER BY` clause, the rows are not sorted within a partition.
+SELECT
+    age,
+    name
+FROM person
+DISTRIBUTE BY
+    age;
+
+SELECT
+    age,
+    name
+FROM person
+DISTRIBUTE BY
+    1;
+
+SELECT
+    age,
+    name
+FROM person
+DISTRIBUTE BY
+    name,
+    age;
+
+SELECT
+    age,
+    name
+FROM person
+DISTRIBUTE BY
+    LEFT(SUBSTRING_INDEX(name, ' ', -1), 1);

--- a/test/fixtures/dialects/spark3/select_distribute_by.yml
+++ b/test/fixtures/dialects/spark3/select_distribute_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fa356067b70fb3f5610d7af26940652b16589d937bc0683332ceb174ff3d51be
+_hash: 0c548c15ee4145b180187a65376ac03eca89bffe027d51901a8a60da3819345c
 file:
 - base:
     select_statement:
@@ -23,11 +23,11 @@ file:
             table_expression:
               table_reference:
                 identifier: person
-            alias_expression:
-              identifier: DISTRIBUTE
-        unparsable:
-        - raw: BY
-        - raw: age
+      distribute_by_clause:
+      - keyword: DISTRIBUTE
+      - keyword: BY
+      - column_reference:
+          identifier: age
 - statement_terminator: ;
 - base:
     select_statement:
@@ -47,11 +47,10 @@ file:
             table_expression:
               table_reference:
                 identifier: person
-            alias_expression:
-              identifier: DISTRIBUTE
-        unparsable:
-        - raw: BY
-        - raw: '1'
+      distribute_by_clause:
+      - keyword: DISTRIBUTE
+      - keyword: BY
+      - literal: '1'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -71,13 +70,14 @@ file:
             table_expression:
               table_reference:
                 identifier: person
-            alias_expression:
-              identifier: DISTRIBUTE
-        unparsable:
-        - raw: BY
-        - raw: name
-        - comma: ','
-        - raw: age
+      distribute_by_clause:
+      - keyword: DISTRIBUTE
+      - keyword: BY
+      - column_reference:
+          identifier: name
+      - comma: ','
+      - column_reference:
+          identifier: age
 - statement_terminator: ;
 - base:
     select_statement:
@@ -97,24 +97,35 @@ file:
             table_expression:
               table_reference:
                 identifier: person
-            alias_expression:
-              identifier: DISTRIBUTE
-        unparsable:
-        - raw: BY
-        - raw: LEFT
-        - bracketed:
-          - start_bracket: (
-          - raw: SUBSTRING_INDEX
-          - bracketed:
+      distribute_by_clause:
+      - keyword: DISTRIBUTE
+      - keyword: BY
+      - expression:
+          function:
+            function_name:
+              function_name_identifier: LEFT
+            bracketed:
             - start_bracket: (
-            - raw: name
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: SUBSTRING_INDEX
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        identifier: name
+                  - comma: ','
+                  - expression:
+                      literal: "' '"
+                  - comma: ','
+                  - expression:
+                      numeric_literal:
+                        binary_operator: '-'
+                        literal: '1'
+                  - end_bracket: )
             - comma: ','
-            - raw: "' '"
-            - comma: ','
-            - raw: '-'
-            - raw: '1'
+            - expression:
+                literal: '1'
             - end_bracket: )
-          - comma: ','
-          - raw: '1'
-          - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/spark3/select_distribute_by.yml
+++ b/test/fixtures/dialects/spark3/select_distribute_by.yml
@@ -1,0 +1,120 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: fa356067b70fb3f5610d7af26940652b16589d937bc0683332ceb174ff3d51be
+file:
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: name
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+            alias_expression:
+              identifier: DISTRIBUTE
+        unparsable:
+        - raw: BY
+        - raw: age
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: name
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+            alias_expression:
+              identifier: DISTRIBUTE
+        unparsable:
+        - raw: BY
+        - raw: '1'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: name
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+            alias_expression:
+              identifier: DISTRIBUTE
+        unparsable:
+        - raw: BY
+        - raw: name
+        - comma: ','
+        - raw: age
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: name
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+            alias_expression:
+              identifier: DISTRIBUTE
+        unparsable:
+        - raw: BY
+        - raw: LEFT
+        - bracketed:
+          - start_bracket: (
+          - raw: SUBSTRING_INDEX
+          - bracketed:
+            - start_bracket: (
+            - raw: name
+            - comma: ','
+            - raw: "' '"
+            - comma: ','
+            - raw: '-'
+            - raw: '1'
+            - end_bracket: )
+          - comma: ','
+          - raw: '1'
+          - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This PR adds support for the DISTRIBUTE BY clause that is used in SELECT statements.

### Are there any other side effects of this change that we should be aware of?
N/A

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
