### PR TITLE
Postgres: EXPLAIN ANALYSE allows British spelling

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1072,12 +1072,14 @@ class ExplainStatementSegment(BaseSegment):
         "EXPLAIN",
         OneOf(
             Sequence(
-                Ref.keyword("ANALYZE", optional=True),
+                OneOf(
+                    "ANALYZE",
+                    "ANALYSE",
+                    optional=True,
+                ),
                 Ref.keyword("VERBOSE", optional=True),
             ),
-            Bracketed(
-                Delimited(Ref("ExplainOptionSegment"), delimiter=Ref("CommaSegment"))
-            ),
+            Bracketed(Delimited(Ref("ExplainOptionSegment"))),
             optional=True,
         ),
         ansi_dialect.get_segment("ExplainStatementSegment").explainable_stmt,
@@ -1107,6 +1109,7 @@ class ExplainOptionSegment(BaseSegment):
         Sequence(
             OneOf(
                 "ANALYZE",
+                "ANALYSE",
                 "VERBOSE",
                 "COSTS",
                 "SETTINGS",

--- a/test/fixtures/dialects/postgres/postgres_explain.sql
+++ b/test/fixtures/dialects/postgres/postgres_explain.sql
@@ -1,5 +1,6 @@
 explain (
     analyze true,
+    analyse true,
     verbose true,
     costs true,
     settings true,
@@ -12,6 +13,7 @@ explain (
 
 explain (
     analyze false,
+    analyse false,
     verbose false,
     costs false,
     settings false,
@@ -24,6 +26,7 @@ explain (
 
 explain (
     analyze,
+    analyse,
     verbose,
     costs,
     settings,
@@ -36,7 +39,11 @@ explain (
 
 explain analyze verbose select 1;
 
+explain analyse verbose select 1;
+
 explain analyze select 1;
+
+explain analyse select 1;
 
 explain (format text) select 1;
 

--- a/test/fixtures/dialects/postgres/postgres_explain.yml
+++ b/test/fixtures/dialects/postgres/postgres_explain.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2884b5261aca756449ade39d43428e9bf617350ab2ac84ff0f6fd144a7433ba3
+_hash: 21a0a9b32e3159ef2304940cabc52cb7355f81f0a0bb0c77f6efd091d114f8f3
 file:
 - statement:
     explain_statement:
@@ -15,6 +15,10 @@ file:
           literal: 'true'
       - comma: ','
       - explain_option:
+          keyword: analyse
+          literal: 'true'
+      - comma: ','
+      - explain_option:
           keyword: verbose
           literal: 'true'
       - comma: ','
@@ -62,6 +66,10 @@ file:
           literal: 'false'
       - comma: ','
       - explain_option:
+          keyword: analyse
+          literal: 'false'
+      - comma: ','
+      - explain_option:
           keyword: verbose
           literal: 'false'
       - comma: ','
@@ -106,6 +114,9 @@ file:
       - start_bracket: (
       - explain_option:
           keyword: analyze
+      - comma: ','
+      - explain_option:
+          keyword: analyse
       - comma: ','
       - explain_option:
           keyword: verbose
@@ -152,7 +163,28 @@ file:
 - statement:
     explain_statement:
     - keyword: explain
+    - keyword: analyse
+    - keyword: verbose
+    - select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            literal: '1'
+- statement_terminator: ;
+- statement:
+    explain_statement:
+    - keyword: explain
     - keyword: analyze
+    - select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            literal: '1'
+- statement_terminator: ;
+- statement:
+    explain_statement:
+    - keyword: explain
+    - keyword: analyse
     - select_statement:
         select_clause:
           keyword: select


### PR DESCRIPTION

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Just noticed that Postgres `EXPLAIN ANALZYE` works perfectly fine with the British spelling of `ANALYSE`.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
