### PR TITLE
Update click version requirement in setup.cfg to match that in requirements.txt

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ install_requires =
     backports.cached-property; python_version < '3.8'
     # To get the encoding of files.
     chardet
-    click>=7.1
+    click>=8.0
     colorama>=0.3
     # Used for diffcover plugin
     diff-cover>=2.5.0


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #2519

Address the Megalinter issue discussed here: https://sqlfluff.slack.com/archives/C01GX4L213J/p1643566502596369. The issue was, the required version of `click` needed to be newer in order to ensure that the `click.shell_completion` module was present.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
