### PR TITLE
Postgres specific CTEDefinitionSegment

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -3512,3 +3512,51 @@ class DoStatementSegment(BaseSegment):
             ),
         ),
     )
+
+
+@postgres_dialect.segment(replace=True)
+class CTEDefinitionSegment(BaseSegment):
+    """A CTE Definition from a WITH statement.
+
+    https://www.postgresql.org/docs/14/queries-with.html
+
+    TODO: Data-Modifying Statements (INSERT, UPDATE, DELETE) in WITH
+    """
+
+    type = "common_table_expression"
+    match_grammar = Sequence(
+        Ref("SingleIdentifierGrammar"),
+        Bracketed(
+            Ref("SingleIdentifierListSegment"),
+            optional=True,
+        ),
+        "AS",
+        Sequence("NOT", "MATERIALIZED", optional=True),
+        Bracketed(
+            # Ephemeral here to subdivide the query.
+            Ref("SelectableGrammar", ephemeral_name="SelectableGrammar")
+        ),
+        OneOf(
+            Sequence(
+                "SEARCH",
+                OneOf(
+                    "BREADTH",
+                    "DEPTH",
+                ),
+                "FIRST",
+                "BY",
+                Ref("ColumnReferenceSegment"),
+                "SET",
+                Ref("ColumnReferenceSegment"),
+            ),
+            Sequence(
+                "CYCLE",
+                Ref("ColumnReferenceSegment"),
+                "SET",
+                Ref("ColumnReferenceSegment"),
+                "USING",
+                Ref("ColumnReferenceSegment"),
+            ),
+            optional=True,
+        ),
+    )

--- a/src/sqlfluff/dialects/dialect_postgres_keywords.py
+++ b/src/sqlfluff/dialects/dialect_postgres_keywords.py
@@ -914,11 +914,13 @@ postgres_docs_keywords = [
 
 postgres_nondocs_keywords = [
     ("ALLOW_CONNECTIONS", "non-reserved"),
+    ("BREADTH", "non-reserved"),
     ("BUFFERS", "non-reserved"),
     ("CONNECT", "reserved"),
     ("COSTS", "non-reserved"),
     ("CURRENT_USER", "non-reserved"),
     ("DATE", "non-reserved"),
+    ("DEPTH", "non-reserved"),
     ("DESCRIBE", "non-reserved"),
     ("EXTENDED", "non-reserved"),
     ("FILE", "non-reserved"),

--- a/test/fixtures/dialects/postgres/postgres_with.sql
+++ b/test/fixtures/dialects/postgres/postgres_with.sql
@@ -1,0 +1,35 @@
+WITH w AS NOT MATERIALIZED (
+    SELECT * FROM big_table
+)
+SELECT * FROM w AS w1 JOIN w AS w2 ON w1.key = w2.ref
+WHERE w2.key = 123;
+
+WITH RECURSIVE search_tree(id, link, data) AS (
+    SELECT t.id, t.link, t.data
+    FROM tree t
+  UNION ALL
+    SELECT t.id, t.link, t.data
+    FROM tree t, search_tree st
+    WHERE t.id = st.link
+) SEARCH DEPTH FIRST BY id SET ordercol
+SELECT * FROM search_tree ORDER BY ordercol;
+
+WITH RECURSIVE search_tree(id, link, data) AS (
+    SELECT t.id, t.link, t.data
+    FROM tree t
+  UNION ALL
+    SELECT t.id, t.link, t.data
+    FROM tree t, search_tree st
+    WHERE t.id = st.link
+) SEARCH BREADTH FIRST BY id SET ordercol
+SELECT * FROM search_tree ORDER BY ordercol;
+
+WITH RECURSIVE search_graph(id, link, data, depth) AS (
+    SELECT g.id, g.link, g.data, 1
+    FROM graph g
+  UNION ALL
+    SELECT g.id, g.link, g.data, sg.depth + 1
+    FROM graph g, search_graph sg
+    WHERE g.id = sg.link
+) CYCLE id SET is_cycle USING path
+SELECT * FROM search_graph;

--- a/test/fixtures/dialects/postgres/postgres_with.yml
+++ b/test/fixtures/dialects/postgres/postgres_with.yml
@@ -1,0 +1,484 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9186a2b9abd8dddb08b72c4faee9e10c8c91b2f86a4d3e005a00470a92269f25
+file:
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+      - identifier: w
+      - keyword: AS
+      - keyword: NOT
+      - keyword: MATERIALIZED
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      identifier: big_table
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: w
+              alias_expression:
+                keyword: AS
+                identifier: w1
+            join_clause:
+              keyword: JOIN
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: w
+                alias_expression:
+                  keyword: AS
+                  identifier: w2
+              join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - identifier: w1
+                  - dot: .
+                  - identifier: key
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - identifier: w2
+                  - dot: .
+                  - identifier: ref
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+            - identifier: w2
+            - dot: .
+            - identifier: key
+            comparison_operator:
+              raw_comparison_operator: '='
+            literal: '123'
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+    - keyword: WITH
+    - keyword: RECURSIVE
+    - common_table_expression:
+      - identifier: search_tree
+      - bracketed:
+          start_bracket: (
+          identifier_list:
+          - identifier: id
+          - comma: ','
+          - identifier: link
+          - comma: ','
+          - identifier: data
+          end_bracket: )
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          set_expression:
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                  - identifier: t
+                  - dot: .
+                  - identifier: id
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - identifier: t
+                  - dot: .
+                  - identifier: link
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - identifier: t
+                  - dot: .
+                  - identifier: data
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: tree
+                    alias_expression:
+                      identifier: t
+          - set_operator:
+            - keyword: UNION
+            - keyword: ALL
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                  - identifier: t
+                  - dot: .
+                  - identifier: id
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - identifier: t
+                  - dot: .
+                  - identifier: link
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - identifier: t
+                  - dot: .
+                  - identifier: data
+              from_clause:
+              - keyword: FROM
+              - from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: tree
+                    alias_expression:
+                      identifier: t
+              - comma: ','
+              - from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: search_tree
+                    alias_expression:
+                      identifier: st
+              where_clause:
+                keyword: WHERE
+                expression:
+                - column_reference:
+                  - identifier: t
+                  - dot: .
+                  - identifier: id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - identifier: st
+                  - dot: .
+                  - identifier: link
+          end_bracket: )
+      - keyword: SEARCH
+      - keyword: DEPTH
+      - keyword: FIRST
+      - keyword: BY
+      - column_reference:
+          identifier: id
+      - keyword: SET
+      - column_reference:
+          identifier: ordercol
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: search_tree
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            identifier: ordercol
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+    - keyword: WITH
+    - keyword: RECURSIVE
+    - common_table_expression:
+      - identifier: search_tree
+      - bracketed:
+          start_bracket: (
+          identifier_list:
+          - identifier: id
+          - comma: ','
+          - identifier: link
+          - comma: ','
+          - identifier: data
+          end_bracket: )
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          set_expression:
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                  - identifier: t
+                  - dot: .
+                  - identifier: id
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - identifier: t
+                  - dot: .
+                  - identifier: link
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - identifier: t
+                  - dot: .
+                  - identifier: data
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: tree
+                    alias_expression:
+                      identifier: t
+          - set_operator:
+            - keyword: UNION
+            - keyword: ALL
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                  - identifier: t
+                  - dot: .
+                  - identifier: id
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - identifier: t
+                  - dot: .
+                  - identifier: link
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - identifier: t
+                  - dot: .
+                  - identifier: data
+              from_clause:
+              - keyword: FROM
+              - from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: tree
+                    alias_expression:
+                      identifier: t
+              - comma: ','
+              - from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: search_tree
+                    alias_expression:
+                      identifier: st
+              where_clause:
+                keyword: WHERE
+                expression:
+                - column_reference:
+                  - identifier: t
+                  - dot: .
+                  - identifier: id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - identifier: st
+                  - dot: .
+                  - identifier: link
+          end_bracket: )
+      - keyword: SEARCH
+      - keyword: BREADTH
+      - keyword: FIRST
+      - keyword: BY
+      - column_reference:
+          identifier: id
+      - keyword: SET
+      - column_reference:
+          identifier: ordercol
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: search_tree
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            identifier: ordercol
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+    - keyword: WITH
+    - keyword: RECURSIVE
+    - common_table_expression:
+      - identifier: search_graph
+      - bracketed:
+          start_bracket: (
+          identifier_list:
+          - identifier: id
+          - comma: ','
+          - identifier: link
+          - comma: ','
+          - identifier: data
+          - comma: ','
+          - identifier: depth
+          end_bracket: )
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          set_expression:
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                  - identifier: g
+                  - dot: .
+                  - identifier: id
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - identifier: g
+                  - dot: .
+                  - identifier: link
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - identifier: g
+                  - dot: .
+                  - identifier: data
+              - comma: ','
+              - select_clause_element:
+                  literal: '1'
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: graph
+                    alias_expression:
+                      identifier: g
+          - set_operator:
+            - keyword: UNION
+            - keyword: ALL
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                  - identifier: g
+                  - dot: .
+                  - identifier: id
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - identifier: g
+                  - dot: .
+                  - identifier: link
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                  - identifier: g
+                  - dot: .
+                  - identifier: data
+              - comma: ','
+              - select_clause_element:
+                  expression:
+                    column_reference:
+                    - identifier: sg
+                    - dot: .
+                    - identifier: depth
+                    binary_operator: +
+                    literal: '1'
+              from_clause:
+              - keyword: FROM
+              - from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: graph
+                    alias_expression:
+                      identifier: g
+              - comma: ','
+              - from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: search_graph
+                    alias_expression:
+                      identifier: sg
+              where_clause:
+                keyword: WHERE
+                expression:
+                - column_reference:
+                  - identifier: g
+                  - dot: .
+                  - identifier: id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - identifier: sg
+                  - dot: .
+                  - identifier: link
+          end_bracket: )
+      - keyword: CYCLE
+      - column_reference:
+          identifier: id
+      - keyword: SET
+      - column_reference:
+          identifier: is_cycle
+      - keyword: USING
+      - column_reference:
+          identifier: path
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: search_graph
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Adds `NOT MATERIALIZED`, `SEARCH BREADTH/DEPTH FIRST`, and `CYCLE` clauses to Postgres CTEDefinitionSegment.
Closes #2523 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
