### PR TITLE
Fix Quoted Literals for Postgres and Redshift affecting rule L039

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -240,15 +240,24 @@ postgres_dialect.replace(
         # Postgres allows newline-concatenated string literals (#1488).
         # Since these string literals can have comments between them,
         # we use grammar to handle this.
-        Delimited(
+        # Note we CANNOT use Delimited as it's greedy and swallows the
+        # last Newline - see #2495
+        Sequence(
             NamedParser(
                 "single_quote",
                 CodeSegment,
                 name="quoted_literal",
                 type="literal",
             ),
-            delimiter=Ref("MultilineConcatenateDelimiterGrammar"),
-            allow_trailing=True,
+            AnyNumberOf(
+                Ref("MultilineConcatenateDelimiterGrammar"),
+                NamedParser(
+                    "single_quote",
+                    CodeSegment,
+                    name="quoted_literal",
+                    type="literal",
+                ),
+            ),
         ),
         Delimited(
             NamedParser(
@@ -257,8 +266,15 @@ postgres_dialect.replace(
                 name="quoted_literal",
                 type="literal",
             ),
-            delimiter=Ref("MultilineConcatenateDelimiterGrammar"),
-            allow_trailing=True,
+            AnyNumberOf(
+                Ref("MultilineConcatenateDelimiterGrammar"),
+                NamedParser(
+                    "unicode_single_quote",
+                    CodeSegment,
+                    name="quoted_literal",
+                    type="literal",
+                ),
+            ),
         ),
         Delimited(
             NamedParser(
@@ -267,8 +283,15 @@ postgres_dialect.replace(
                 name="quoted_literal",
                 type="literal",
             ),
-            delimiter=Ref("MultilineConcatenateDelimiterGrammar"),
-            allow_trailing=True,
+            AnyNumberOf(
+                Ref("MultilineConcatenateDelimiterGrammar"),
+                NamedParser(
+                    "escaped_single_quote",
+                    CodeSegment,
+                    name="quoted_literal",
+                    type="literal",
+                ),
+            ),
         ),
     ),
     QuotedIdentifierSegment=OneOf(

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -184,9 +184,6 @@ postgres_dialect.add(
     JsonOperatorSegment=NamedParser(
         "json_operator", SymbolSegment, name="json_operator", type="binary_operator"
     ),
-    DollarQuotedLiteralSegment=NamedParser(
-        "dollar_quote", CodeSegment, name="dollar_quoted_literal", type="literal"
-    ),
     SimpleGeometryGrammar=AnyNumberOf(Ref("NumericLiteralSegment")),
     # N.B. this MultilineConcatenateDelimiterGrammar is only created
     # to parse multiline-concatenated string literals
@@ -287,6 +284,23 @@ postgres_dialect.replace(
                 Ref("MultilineConcatenateDelimiterGrammar"),
                 NamedParser(
                     "escaped_single_quote",
+                    CodeSegment,
+                    name="quoted_literal",
+                    type="literal",
+                ),
+            ),
+        ),
+        Delimited(
+            NamedParser(
+                "dollar_quote",
+                CodeSegment,
+                name="quoted_literal",
+                type="literal",
+            ),
+            AnyNumberOf(
+                Ref("MultilineConcatenateDelimiterGrammar"),
+                NamedParser(
+                    "dollar_quote",
                     CodeSegment,
                     name="quoted_literal",
                     type="literal",
@@ -911,7 +925,6 @@ class FunctionDefinitionGrammar(BaseSegment):
                 "AS",
                 OneOf(
                     Ref("QuotedLiteralSegment"),
-                    Ref("DollarQuotedLiteralSegment"),
                     Sequence(
                         Ref("QuotedLiteralSegment"),
                         Ref("CommaSegment"),
@@ -3521,16 +3534,10 @@ class DoStatementSegment(BaseSegment):
         OneOf(
             Sequence(
                 Ref("LanguageClauseSegment", optional=True),
-                OneOf(
-                    Ref("QuotedLiteralSegment"),
-                    Ref("DollarQuotedLiteralSegment"),
-                ),
+                Ref("QuotedLiteralSegment"),
             ),
             Sequence(
-                OneOf(
-                    Ref("QuotedLiteralSegment"),
-                    Ref("DollarQuotedLiteralSegment"),
-                ),
+                Ref("QuotedLiteralSegment"),
                 Ref("LanguageClauseSegment", optional=True),
             ),
         ),

--- a/test/fixtures/rules/std_rule_cases/L039.yml
+++ b/test/fixtures/rules/std_rule_cases/L039.yml
@@ -75,3 +75,19 @@ test_fix_tsql_spaced_chars:
   configs:
     core:
       dialect: tsql
+
+# Check CASE Statment parses with newlines properly
+# See https://github.com/sqlfluff/sqlfluff/issues/2495
+test_pass_postgres_case_statement:
+  pass_str: |
+    SELECT
+        a,
+        CASE
+            WHEN 1 THEN 'one'
+            WHEN 2 THEN 'two'
+            ELSE 'other'
+        END AS b
+    FROM test;
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #2495 - prevent final comma being swallowed up
Fixes #2516 - move DollarQuotedLiteralSegment into QuotedLiteralSegment

A potential nicer fix to #2495 would be to have an alternative to `allow_trailing` option, which doesn't error when there is a trailing delimiter, but recognised this is not part of this Grammar. But had a quick look and can't figure out how to do that.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
