### PR TITLE
TSQL: Add indentation for UPDATE statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2772,9 +2772,11 @@ class UpdateStatementSegment(BaseSegment):
     type = "update_statement"
     match_grammar = Sequence(
         "UPDATE",
+        Indent,
         OneOf(Ref("TableReferenceSegment"), Ref("AliasedTableReferenceGrammar")),
         Ref("PostTableExpressionGrammar", optional=True),
         Ref("SetClauseListSegment"),
+        Dedent,
         Ref("FromClauseSegment", optional=True),
         Ref("WhereClauseSegment", optional=True),
         Ref("DelimiterSegment", optional=True),

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -634,6 +634,15 @@ test_pass_ignore_templated_whitespace_4:
         {{ "      c2\n" }} AS other_id
     FROM my_table
 
+test_pass_tsql_update_indent:
+  pass_str: |
+    update Extracts.itt_parm_base
+        set DateF = convert(varchar, @from_date, 112),
+            DateT = convert(varchar, @to_date, 112)
+  configs:
+    core:
+      dialect: tsql
+
 test_pass_tsql_declare_indent:
   pass_str: |
     DECLARE @prv_qtr_1st_dt DATETIME,


### PR DESCRIPTION
### Brief summary of the change made
Adding Indent/Dedent tags for TSQL's UPDATE statement.

### Are there any other side effects of this change that we should be aware of?
None.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
