### PR TITLE
Allow L059 to be configured to always prefer quoted identifiers

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -143,3 +143,8 @@ unquoted_identifiers_policy = all
 quoted_identifiers_policy = all
 allow_space_in_identifier = False
 additional_allowed_characters = ""
+
+[sqlfluff:rules:L059]
+# Policy on quoted and unquoted identifiers
+force_quote_identifier = False
+preferred_quote_identifier = '"'

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -147,7 +147,6 @@ additional_allowed_characters = ""
 [sqlfluff:rules:L059]
 # Policy on quoted and unquoted identifiers
 force_quote_identifier = False
-preferred_quote_identifier = '"'
 
 [sqlfluff:rules:L062]
 # Comma separated list of blocked words that should not be used

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -146,7 +146,7 @@ additional_allowed_characters = ""
 
 [sqlfluff:rules:L059]
 # Policy on quoted and unquoted identifiers
-force_quote_identifier = False
+prefer_quoted_identifiers = False
 
 [sqlfluff:rules:L062]
 # Comma separated list of blocked words that should not be used

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -144,12 +144,6 @@ STANDARD_CONFIG_INFO_DICT = {
             "Defaults to ``False``."
         ),
     },
-    "preferred_quote_identifier": {
-        "definition": (
-            "Expected character used to quote identifiers when necessary, "
-            "or when ``force_quote_identifier`` is evaluated to ``True``"
-        ),
-    },
     "blocked_words": {
         "definition": (
             "Optional comma-separated list of blocked words which should not be used "

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -139,7 +139,7 @@ STANDARD_CONFIG_INFO_DICT = {
     },
     "force_quote_identifier": {
         "validation": [True, False],
-        "definition": ("If True, forces every identifier to be quoted. Defaults to False."),
+        "definition": ("If ``True``, forces every identifier to be quoted. Defaults to ``False``."),
     },
     "preferred_quote_identifier": {
         "definition": (

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -137,10 +137,10 @@ STANDARD_CONFIG_INFO_DICT = {
             "in addition to alphanumerics (A-Z, a-z, 0-9) and underscores."
         ),
     },
-    "force_quote_identifier": {
+    "prefer_quoted_identifiers": {
         "validation": [True, False],
         "definition": (
-            "If ``True``, forces every identifier to be quoted. "
+            "If ``True``, requires every identifier to be quoted. "
             "Defaults to ``False``."
         ),
     },

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -139,7 +139,10 @@ STANDARD_CONFIG_INFO_DICT = {
     },
     "force_quote_identifier": {
         "validation": [True, False],
-        "definition": ("If ``True``, forces every identifier to be quoted. Defaults to ``False``."),
+        "definition": (
+            "If ``True``, forces every identifier to be quoted. "
+            "Defaults to ``False``."
+        ),
     },
     "preferred_quote_identifier": {
         "definition": (

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -137,6 +137,16 @@ STANDARD_CONFIG_INFO_DICT = {
             "in addition to alphanumerics (A-Z, a-z, 0-9) and underscores."
         ),
     },
+    "force_quote_identifier": {
+        "validation": [True, False],
+        "definition": ("If True, forces every identifier to be quoted. Defaults to False."),
+    },
+    "preferred_quote_identifier": {
+        "definition": (
+            "Expected character used to quote identifiers when necessary, "
+            "or when ``force_quote_identifier`` is evaluated to True"
+        ),
+    },
 }
 
 

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -144,7 +144,7 @@ STANDARD_CONFIG_INFO_DICT = {
     "preferred_quote_identifier": {
         "definition": (
             "Expected character used to quote identifiers when necessary, "
-            "or when ``force_quote_identifier`` is evaluated to True"
+            "or when ``force_quote_identifier`` is evaluated to ``True``"
         ),
     },
 }

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -90,7 +90,7 @@ class Rule_L059(BaseRule):
             )
 
         # Now we only deal with NOT forced quoted identifiers configuration
-        # (meaning force_quote_identifier=False).
+        # (meaning prefer_quoted_identifiers=False).
 
         # Extract contents of outer quotes.
         quoted_identifier_contents = context.segment.raw[1:-1]

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -69,10 +69,10 @@ class Rule_L059(BaseRule):
         self.force_quote_identifier: bool
 
         if self.force_quote_identifier:
-            context_policy = ("naked_identifier")
+            context_policy = "naked_identifier"
             identifier_contents = context.segment.raw
         else:
-            context_policy = ("quoted_identifier")
+            context_policy = "quoted_identifier"
             identifier_contents = context.segment.raw[1:-1]
 
         # Ignore the segments that are not of the same type as the defined policy above.

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -6,12 +6,21 @@ import regex
 
 from sqlfluff.core.parser.segments.raw import CodeSegment
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import (
+    document_configuration,
+    document_fix_compatible,
+)
 
-
+@document_configuration
 @document_fix_compatible
 class Rule_L059(BaseRule):
     """Unnecessary quoted identifier.
+    
+    This rule will fail if the quotes used to quote an identifier are unnecessary, 
+    or wrong considering the configuration.
+    
+    By default, the quotes are optional, but required to double-quotes when identifier 
+    is named as a keyword, or contains special characters.
 
     | **Anti-pattern**
     | In this example, a valid unquoted identifier,
@@ -22,16 +31,35 @@ class Rule_L059(BaseRule):
         SELECT 123 as "foo"
 
     | **Best practice**
+    | If ``force_quote_identifier = False`` and ``preferred_quote_identifier = '"'`` (or unspecified, as these are the default)
     | Use unquoted identifiers where possible.
 
     .. code-block:: sql
 
         SELECT 123 as foo
 
+    | If ``force_quote_identifier = True`` and ``preferred_quote_identifier = "`"``
+    | Use preferred quote identifiers any time.
+    
+    .. code-block:: sql
+
+        SELECT 123 as `foo`
+
     """
 
+    config_keywords = [
+        "force_quote_identifier",
+        "preferred_quote_identifier"
+    ]
+    
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Unnecessary quoted identifier."""
+        # Config type hints
+        self.force_quote_identifier: bool
+        self.preferred_quote_identifier: str
+        
+        # TODO: take care of default values for config
+        
         # We only care about quoted identifiers.
         if context.segment.name != "quoted_identifier":
             return None

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -73,7 +73,7 @@ class Rule_L059(BaseRule):
         if context.segment.name not in context_policy:
             return None
         
-        # Manage simplest case of quoted identifiers must be forced first.
+        # Manage cases of quoted identifiers must be forced first.
         if self.force_quote_identifier == True:
             if context.segment.name == "naked_identifier":
                 identifier_contents = context.segment.raw

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -28,7 +28,9 @@ class Rule_L059(BaseRule):
 
     .. code-block:: sql
 
-        SELECT 123 as "foo", 'sum'
+        SELECT 123 as "foo"
+        
+        SELECT 123 as foo, 'sum'
 
     | **Best practice**
     | If ``force_quote_identifier = False`` and ``preferred_quote_identifier = '"'`` (or unspecified, as these are the default)

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -20,8 +20,8 @@ class Rule_L059(BaseRule):
     This rule will fail if the quotes used to quote an identifier are (un)necessary
     depending on the ``force_quote_identifier`` configuration.
 
-    When ``force_quote_identifier = False`` (default behavior), the quotes are
-    unnecessary, except for reserved keywords and special charcters in identifiers.
+    When ``prefer_quoted_identifiers = False`` (default behaviour), the quotes are
+    unnecessary, except for reserved keywords and special characters in identifiers.
 
     | **Anti-pattern**
     | In this example, a valid unquoted identifier,

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -66,9 +66,9 @@ class Rule_L059(BaseRule):
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Unnecessary quoted identifier."""
         # Config type hints
-        self.force_quote_identifier: bool
+        self.prefer_quoted_identifiers: bool
 
-        if self.force_quote_identifier:
+        if self.prefer_quoted_identifiers:
             context_policy = "naked_identifier"
             identifier_contents = context.segment.raw
         else:

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -61,7 +61,7 @@ class Rule_L059(BaseRule):
 
     """
 
-    config_keywords = ["force_quote_identifier"]
+    config_keywords = ["prefer_quoted_identifiers"]
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Unnecessary quoted identifier."""

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -79,12 +79,11 @@ class Rule_L059(BaseRule):
         if context.segment.name not in context_policy:
             return None
 
-        # Manage cases of quoted identifiers must be forced first.
+        # Manage cases of identifiers must be quoted first.
         # Naked identifiers are _de facto_ making this rule fail as configuration forces
         # them to be quoted.
-        # In this case, it cannot be fixed as quote to use is dialect and DBMS
-        # configuration dependent.
-        if self.force_quote_identifier:
+        # In this case, it cannot be fixed as which quote to use is dialect dependent
+        if self.prefer_quoted_identifiers:
             return LintResult(
                 context.segment,
                 description=f"Missing quoted identifier {identifier_contents}.",

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -32,6 +32,7 @@ class Rule_L059(BaseRule):
         SELECT 123 as "foo"
 
     | **Best practice**
+    | Use unquoted identifiers where possible.
 
     .. code-block:: sql
 
@@ -50,6 +51,7 @@ class Rule_L059(BaseRule):
         SELECT 123 as foo
 
     | **Best practice**
+    | Use quoted identifiers.
 
     .. code-block:: sql
 

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -38,9 +38,9 @@ class Rule_L059(BaseRule):
 
         SELECT 123 as foo
 
-    When ``force_quote_identifier = True``, the quotes are always necessary, no
+    When ``prefer_quoted_identifiers = True``, the quotes are always necessary, no
     matter if the identifier is valid, a reserved keyword, or contains special
-    characters.
+    characters. Note due to different quotes this mode is not `sqlfluff fix` compatible.
 
     | **Anti-pattern**
     | In this example, a valid unquoted identifier,

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -66,9 +66,10 @@ class Rule_L059(BaseRule):
 
         # If the configuration says to not force the identifier quoting, then
         # simply care about the quoted identifiers.
-        context_policy = ("quoted_identifier")
         if self.force_quote_identifier:
             context_policy = ("naked_identifier", "quoted_identifier")
+        else:
+            context_policy = ("quoted_identifier")
 
         # We only care about quoted identifiers and possibly naked identifiers if
         # the configuration setting is forcing identifiers to be quoted.

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -122,6 +122,13 @@ class Rule_L059(BaseRule):
             
         # Extract contents of outer quotes.
         quoted_identifier_contents = context.segment.raw[1:-1]
+        
+        # If the identifier contents contains any occurrence of the preferred quote,
+        # ignore this rule for now.
+        if quote in quoted_identifier_contents:
+            # TODO: if different levels of criticity can be set, this case should
+            #       trigger an `info` level.
+            return None
 
         # Retrieve NakedIdentifierSegment RegexParser for the dialect.
         naked_identifier_parser = context.dialect._library["NakedIdentifierSegment"]
@@ -164,13 +171,6 @@ class Rule_L059(BaseRule):
         # ensure the quote used is the preferred one.
         expected = f"{quote}{quoted_identifier_contents}{quote}"
         if expected != context.segment.raw:
-            # If the identifier contents contains any occurrence of the preferred quote,
-            # ignore this rule for now.
-            if quote in quoted_identifier_contents:
-                # TODO: if different levels of criticity can be set, this case should
-                #       trigger an `info` level.
-                return None
-            
             return LintResult(
                 context.segment,
                 fixes=[

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -61,9 +61,7 @@ class Rule_L059(BaseRule):
 
     """
 
-    config_keywords = [
-        "force_quote_identifier"
-    ]
+    config_keywords = ["force_quote_identifier"]
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Unnecessary quoted identifier."""

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -20,7 +20,7 @@ class Rule_L059(BaseRule):
     This rule will fail if the quotes used to quote an identifier are (un)necessary
     depending on the ``force_quote_identifier`` configuration.
 
-    When ``force_quote_identifier = False`` (default behavior), the quotes are 
+    When ``force_quote_identifier = False`` (default behavior), the quotes are
     unnecessary, except for reserved keywords and special charcters in identifiers.
 
     | **Anti-pattern**
@@ -81,7 +81,7 @@ class Rule_L059(BaseRule):
         if context.segment.name not in context_policy:
             return None
 
-        # Manage cases of quoted identifiers must be forced first. 
+        # Manage cases of quoted identifiers must be forced first.
         # Naked identifiers are _de facto_ making this rule fail as configuration forces
         # them to be quoted.
         # In this case, it cannot be fixed as quote to use is dialect and DBMS
@@ -92,7 +92,7 @@ class Rule_L059(BaseRule):
                 description=f"Missing quoted identifier {identifier_contents}.",
             )
 
-        # Now we only deal with NOT forced quoted identifiers configuration 
+        # Now we only deal with NOT forced quoted identifiers configuration
         # (meaning force_quote_identifier=False).
 
         # Extract contents of outer quotes.

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -34,7 +34,7 @@ class Rule_L059(BaseRule):
 
     | **Best practice**
     | If ``force_quote_identifier = False`` and ``preferred_quote_identifier = '"'`` (or unspecified, as these are the default)
-    | Use unquoted identifiers where possible, and use '"' whevener necessary.
+    | Use unquoted identifiers where possible, and use '"' whenever necessary.
 
     .. code-block:: sql
 

--- a/test/fixtures/rules/std_rule_cases/L059.yml
+++ b/test/fixtures/rules/std_rule_cases/L059.yml
@@ -1,38 +1,25 @@
 rule: L059
 
 # Configuration test matrix
-# Pass/Fail Forced  Preferred       Test
-# Pass      False   Double quote    test_pass_column_reference
-# Fail      False   Double quote    test_fail_column_reference
-# Pass      False   Double quote    test_pass_table_reference
-# Fail      False   Double quote    test_fail_table_reference
-# Pass      False   Double quote    test_pass_multiple_references
-# Fail      False   Double quote    test_fail_multiple_references
-# Pass      False   Double quote    test_pass_whitespace
-# Pass      False   Double quote    test_pass_special_symbols
-# Pass      False   Double quote    test_pass_reserved_keyword
-# Pass      False   Backtick        test_pass_column_reference_backtick
-# Fail      False   Backtick        test_fail_column_reference_backtick
-# Pass      False   Backtick        test_pass_table_reference_backtick
-# Fail      False   Backtick        test_fail_table_reference_backtick
-# Pass      False   Backtick        test_pass_multiple_references_backtick
-# Fail      False   Backtick        test_fail_multiple_references_backtick
-# Pass      False   Backtick        test_pass_whitespace_backtick
-# Pass      False   Backtick        test_pass_special_symbols_backtick
-# Pass      False   Backtick        test_pass_reserved_keyword_backtick
-# Pass      False   Backtick        test_pass_ignored_as_contains_backtick
-# Pass      True    Backtick        test_pass_column_reference_backtick_forced
-# Fail      True    Backtick        test_fail_column_reference_backtick_forced
-# Pass      True    Backtick        test_pass_table_reference_backtick_forced
-# Fail      True    Backtick        test_fail_table_reference_backtick_forced
-# Pass      True    Backtick        test_pass_multiple_references_backtick_forced
-# Pass      True    Backtick        test_pass_multiple_references_backtick_forced_bigquery
-# Fail      True    Backtick        test_fail_multiple_references_backtick_forced
-# Fail      True    Backtick        test_fail_multiple_references_backtick_forced_bigquery
-# Pass      True    Backtick        test_pass_whitespace_backtick_forced
-# Pass      True    Backtick        test_pass_special_symbols_backtick_forced
-# Pass      True    Backtick        test_pass_reserved_keyword_backtick_forced
-# Pass      True    Backtick        test_pass_ignored_as_contains_backtick_forced
+# Pass/Fail Forced  Test
+# Pass      False   test_pass_column_reference
+# Fail      False   test_fail_column_reference
+# Pass      False   test_pass_table_reference
+# Fail      False   test_fail_table_reference
+# Pass      False   test_pass_multiple_references
+# Fail      False   test_fail_multiple_references
+# Pass      False   test_pass_whitespace
+# Pass      False   test_pass_special_symbols
+# Pass      False   test_pass_reserved_keyword
+# Pass      True    test_pass_column_reference_forced
+# Fail      True    test_fail_column_reference_forced
+# Pass      True    test_pass_table_reference_forced
+# Fail      True    test_fail_table_reference_forced
+# Pass      True    test_pass_multiple_references_forced
+# Fail      True    test_fail_multiple_references_forced
+# Pass      True    test_pass_whitespace_forced
+# Pass      True    test_pass_special_symbols_forced
+# Pass      True    test_pass_reserved_keyword_forced
 
 test_pass_column_reference:
   pass_str: |
@@ -82,108 +69,15 @@ test_pass_reserved_keyword:
   pass_str: |
     SELECT 123 AS "SELECT"
 
-test_pass_column_reference_backtick:
-  pass_str: |
-    SELECT 123 AS foo;
-  configs:
-    rules:
-      L059:
-        preferred_quote_identifier: "`"
-
-test_fail_column_reference_backtick:
-  fail_str: |
-    SELECT 123 AS "foo";
-  pass_str: |
-    SELECT 123 AS `foo`;
-  configs:
-    rules:
-      L059:
-        preferred_quote_identifier: "`"
-
-test_pass_table_reference_backtick:
-  pass_str: |
-    SELECT foo
-    FROM bar;
-  configs:
-    rules:
-      L059:
-        preferred_quote_identifier: "`"
-
-test_fail_table_reference_backtick:
-  fail_str: |
-    SELECT foo
-    FROM "bar";
-  fix_str: |
-    SELECT foo
-    FROM `bar`;
-  configs:
-    rules:
-      L059:
-        preferred_quote_identifier: "`"
-
-test_pass_multiple_references_backtick:
-  pass_str: |
-    SELECT foo
-    FROM bar.baz;
-  configs:
-    rules:
-      L059:
-        preferred_quote_identifier: "`"
-
-test_fail_multiple_references_backtick:
-  fail_str: |
-    SELECT foo
-    FROM "bar"."baz";
-  fix_str: |
-    SELECT foo
-    FROM `bar`.`baz`;
-  configs:
-    rules:
-      L059:
-        preferred_quote_identifier: "`"
-
-test_pass_whitespace_backtick:
-  pass_str: |
-    SELECT 123 AS `I cannot be unquoted`
-  configs:
-    rules:
-      L059:
-        preferred_quote_identifier: "`"
-
-test_pass_special_symbols_backtick:
-  pass_str: |
-    SELECT 123 AS `I-c@nn0t-be~un-quoted`
-  configs:
-    rules:
-      L059:
-        preferred_quote_identifier: "`"
-
-test_pass_reserved_keyword_backtick:
-  pass_str: |
-    SELECT 123 AS `SELECT`
-  configs:
-    rules:
-      L059:
-        preferred_quote_identifier: "`"
-
-test_pass_ignored_as_contains_backtick:
-  pass_str: |
-    SELECT 123 AS "Ignored`as`contains`backticks"
-  configs:
-    rules:
-      L059:
-        preferred_quote_identifier: "`"
-
-test_pass_column_reference_backtick_forced:
+test_pass_column_reference_forced:
   pass_str: |
     SELECT 123 AS `foo`;
   configs:
     rules:
       L059:
         force_quote_identifier: True
-        preferred_quote_identifier: "`"
 
-test_fail_column_reference_backtick_forced:
+test_fail_column_reference_forced:
   fail_str: |
     SELECT 123 AS foo;
   pass_str: |
@@ -192,9 +86,8 @@ test_fail_column_reference_backtick_forced:
     rules:
       L059:
         force_quote_identifier: True
-        preferred_quote_identifier: "`"
 
-test_pass_table_reference_backtick_forced:
+test_pass_table_reference_forced:
   pass_str: |
     SELECT `foo`
     FROM `bar`;
@@ -202,22 +95,20 @@ test_pass_table_reference_backtick_forced:
     rules:
       L059:
         force_quote_identifier: True
-        preferred_quote_identifier: "`"
 
-test_fail_table_reference_backtick_forced:
+test_fail_table_reference_forced:
   fail_str: |
     SELECT `foo`
     FROM bar;
-  fix_str: |
+  pass_str: |
     SELECT `foo`
     FROM `bar`;
   configs:
     rules:
       L059:
         force_quote_identifier: True
-        preferred_quote_identifier: "`"
 
-test_pass_multiple_references_backtick_forced:
+test_pass_multiple_references_forced:
   pass_str: |
     SELECT `foo`
     FROM `bar`.`baz`;
@@ -225,80 +116,39 @@ test_pass_multiple_references_backtick_forced:
     rules:
       L059:
         force_quote_identifier: True
-        preferred_quote_identifier: "`"
 
-test_pass_multiple_references_backtick_forced_bigquery:
+test_fail_multiple_references_forced:
+  fail_str: |
+    SELECT `foo`
+    FROM bar.baz;
   pass_str: |
     SELECT `foo`
     FROM `bar`.`baz`;
   configs:
-    core:
-      dialect: bigquery
     rules:
       L059:
         force_quote_identifier: True
-        preferred_quote_identifier: "`"
 
-test_fail_multiple_references_backtick_forced:
-  fail_str: |
-    SELECT `foo`
-    FROM bar.baz;
-  fix_str: |
-    SELECT `foo`
-    FROM `bar`.`baz`;
-  configs:
-    rules:
-      L059:
-        force_quote_identifier: True
-        preferred_quote_identifier: "`"
-
-test_fail_multiple_references_backtick_forced_bigquery:
-  fail_str: |
-    SELECT `foo`
-    FROM bar.baz;
-  fix_str: |
-    SELECT `foo`
-    FROM `bar`.`baz`;
-  configs:
-    core:
-      dialect: bigquery
-    rules:
-      L059:
-        force_quote_identifier: True
-        preferred_quote_identifier: "`"
-
-test_pass_whitespace_backtick_forced:
+test_pass_whitespace_forced:
   pass_str: |
     SELECT 123 AS `I cannot be unquoted`
   configs:
     rules:
       L059:
         force_quote_identifier: True
-        preferred_quote_identifier: "`"
 
-test_pass_special_symbols_backtick_forced:
+test_pass_special_symbols_forced:
   pass_str: |
     SELECT 123 AS `I-c@nn0t-be~un-quoted`
   configs:
     rules:
       L059:
         force_quote_identifier: True
-        preferred_quote_identifier: "`"
 
-test_pass_reserved_keyword_backtick_forced:
+test_pass_reserved_keyword_forced:
   pass_str: |
     SELECT 123 AS `SELECT`
   configs:
     rules:
       L059:
         force_quote_identifier: True
-        preferred_quote_identifier: "`"
-
-test_pass_ignored_as_contains_backtick_forced:
-  pass_str: |
-    SELECT 123 AS "Ignored`as`contains`backticks"
-  configs:
-    rules:
-      L059:
-        force_quote_identifier: True
-        preferred_quote_identifier: "`"

--- a/test/fixtures/rules/std_rule_cases/L059.yml
+++ b/test/fixtures/rules/std_rule_cases/L059.yml
@@ -1,38 +1,5 @@
 rule: L059
 
-# Configuration test matrix
-# Pass/Fail Forced  Test
-# -- Identifiers must be unquoted (default configuration)
-# Pass      False   test_pass_column_reference
-# Fail      False   test_fail_column_reference
-# Pass      False   test_pass_table_reference
-# Fail      False   test_fail_table_reference
-# Pass      False   test_pass_multiple_references
-# Fail      False   test_fail_multiple_references
-# Pass      False   test_pass_whitespace
-# Pass      False   test_pass_special_symbols
-# Pass      False   test_pass_reserved_keyword
-# -- Identifiers must be quoted and preferred quote is double-quotes (SQL-92 ANSI, ...)
-# Pass      True    test_pass_column_reference_prefer_quoted_ansi
-# Fail      True    test_fail_column_reference_prefer_quoted_ansi
-# Pass      True    test_pass_table_reference_prefer_quoted_ansi
-# Fail      True    test_fail_table_reference_prefer_quoted_ansi
-# Pass      True    test_pass_multiple_references_prefer_quoted_ansi
-# Fail      True    test_fail_multiple_references_prefer_quoted_ansi
-# Pass      True    test_pass_whitespace_prefer_quoted_ansi
-# Pass      True    test_pass_special_symbols_prefer_quoted_ansi
-# Pass      True    test_pass_reserved_keyword_prefer_quoted_ansi
-# -- Identifiers must be quoted and preferred quote is backtick (BigQuery, MySql, ...)
-# Pass      True    test_pass_column_reference_prefer_quoted_backticks
-# Fail      True    test_fail_column_reference_prefer_quoted_backticks
-# Pass      True    test_pass_table_reference_prefer_quoted_backticks
-# Fail      True    test_fail_table_reference_prefer_quoted_backticks
-# Pass      True    test_pass_multiple_references_prefer_quoted_backticks
-# Fail      True    test_fail_multiple_references_prefer_quoted_backticks
-# Pass      True    test_pass_whitespace_prefer_quoted_backticks
-# Pass      True    test_pass_special_symbols_prefer_quoted_backticks
-# Pass      True    test_pass_reserved_keyword_prefer_quoted_backticks
-
 test_pass_column_reference:
   pass_str: |
     SELECT 123 AS foo;

--- a/test/fixtures/rules/std_rule_cases/L059.yml
+++ b/test/fixtures/rules/std_rule_cases/L059.yml
@@ -12,26 +12,26 @@ rule: L059
 # Pass      False   test_pass_whitespace
 # Pass      False   test_pass_special_symbols
 # Pass      False   test_pass_reserved_keyword
-# -- Identifiers must be quoted and expected quote is double-quotes (SQL-92 ANSI, ...)
-# Pass      True    test_pass_column_reference_forced_ansi
-# Fail      True    test_fail_column_reference_forced_ansi
-# Pass      True    test_pass_table_reference_forced_ansi
-# Fail      True    test_fail_table_reference_forced_ansi
-# Pass      True    test_pass_multiple_references_forced_ansi
-# Fail      True    test_fail_multiple_references_forced_ansi
-# Pass      True    test_pass_whitespace_forced_ansi
-# Pass      True    test_pass_special_symbols_forced_ansi
-# Pass      True    test_pass_reserved_keyword_forced_ansi
-# -- Identifiers must be quoted and expected quote is backtick (BigQuery, MySql, ...)
-# Pass      True    test_pass_column_reference_forced_backticks
-# Fail      True    test_fail_column_reference_forced_backticks
-# Pass      True    test_pass_table_reference_forced_backticks
-# Fail      True    test_fail_table_reference_forced_backticks
-# Pass      True    test_pass_multiple_references_forced_backticks
-# Fail      True    test_fail_multiple_references_forced_backticks
-# Pass      True    test_pass_whitespace_forced_backticks
-# Pass      True    test_pass_special_symbols_forced_backticks
-# Pass      True    test_pass_reserved_keyword_forced_backticks
+# -- Identifiers must be quoted and preferred quote is double-quotes (SQL-92 ANSI, ...)
+# Pass      True    test_pass_column_reference_prefer_quoted_ansi
+# Fail      True    test_fail_column_reference_prefer_quoted_ansi
+# Pass      True    test_pass_table_reference_prefer_quoted_ansi
+# Fail      True    test_fail_table_reference_prefer_quoted_ansi
+# Pass      True    test_pass_multiple_references_prefer_quoted_ansi
+# Fail      True    test_fail_multiple_references_prefer_quoted_ansi
+# Pass      True    test_pass_whitespace_prefer_quoted_ansi
+# Pass      True    test_pass_special_symbols_prefer_quoted_ansi
+# Pass      True    test_pass_reserved_keyword_prefer_quoted_ansi
+# -- Identifiers must be quoted and preferred quote is backtick (BigQuery, MySql, ...)
+# Pass      True    test_pass_column_reference_prefer_quoted_backticks
+# Fail      True    test_fail_column_reference_prefer_quoted_backticks
+# Pass      True    test_pass_table_reference_prefer_quoted_backticks
+# Fail      True    test_fail_table_reference_prefer_quoted_backticks
+# Pass      True    test_pass_multiple_references_prefer_quoted_backticks
+# Fail      True    test_fail_multiple_references_prefer_quoted_backticks
+# Pass      True    test_pass_whitespace_prefer_quoted_backticks
+# Pass      True    test_pass_special_symbols_prefer_quoted_backticks
+# Pass      True    test_pass_reserved_keyword_prefer_quoted_backticks
 
 test_pass_column_reference:
   pass_str: |
@@ -81,15 +81,15 @@ test_pass_reserved_keyword:
   pass_str: |
     SELECT 123 AS "SELECT"
 
-test_pass_column_reference_forced_ansi:
+test_pass_column_reference_prefer_quoted_ansi:
   pass_str: |
     SELECT 123 AS "foo";
   configs:
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_fail_column_reference_forced_ansi:
+test_fail_column_reference_prefer_quoted_ansi:
   fail_str: |
     SELECT 123 AS foo;
   pass_str: |
@@ -97,18 +97,18 @@ test_fail_column_reference_forced_ansi:
   configs:
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_pass_table_reference_forced_ansi:
+test_pass_table_reference_prefer_quoted_ansi:
   pass_str: |
     SELECT "foo"
     FROM "bar";
   configs:
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_fail_table_reference_forced_ansi:
+test_fail_table_reference_prefer_quoted_ansi:
   fail_str: |
     SELECT "foo"
     FROM bar;
@@ -118,18 +118,18 @@ test_fail_table_reference_forced_ansi:
   configs:
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_pass_multiple_references_forced_ansi:
+test_pass_multiple_references_prefer_quoted_ansi:
   pass_str: |
     SELECT "foo"
     FROM "bar"."baz";
   configs:
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_fail_multiple_references_forced_ansi:
+test_fail_multiple_references_prefer_quoted_ansi:
   fail_str: |
     SELECT "foo"
     FROM bar.baz;
@@ -139,33 +139,33 @@ test_fail_multiple_references_forced_ansi:
   configs:
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_pass_whitespace_forced_ansi:
+test_pass_whitespace_prefer_quoted_ansi:
   pass_str: |
     SELECT 123 AS "I cannot be unquoted"
   configs:
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_pass_special_symbols_forced_ansi:
+test_pass_special_symbols_prefer_quoted_ansi:
   pass_str: |
     SELECT 123 AS "I-c@nn0t-be~un-quoted"
   configs:
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_pass_reserved_keyword_forced_ansi:
+test_pass_reserved_keyword_prefer_quoted_ansi:
   pass_str: |
     SELECT 123 AS "SELECT"
   configs:
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_pass_column_reference_forced_backticks:
+test_pass_column_reference_prefer_quoted_backticks:
   pass_str: |
     SELECT 123 AS `foo`;
   configs:
@@ -173,9 +173,9 @@ test_pass_column_reference_forced_backticks:
       dialect: bigquery
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_fail_column_reference_forced_backticks:
+test_fail_column_reference_prefer_quoted_backticks:
   fail_str: |
     SELECT 123 AS foo;
   pass_str: |
@@ -185,9 +185,9 @@ test_fail_column_reference_forced_backticks:
       dialect: bigquery
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_pass_table_reference_forced_backticks:
+test_pass_table_reference_prefer_quoted_backticks:
   pass_str: |
     SELECT `foo`
     FROM `bar`;
@@ -196,9 +196,9 @@ test_pass_table_reference_forced_backticks:
       dialect: bigquery
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_fail_table_reference_forced_backticks:
+test_fail_table_reference_prefer_quoted_backticks:
   fail_str: |
     SELECT `foo`
     FROM bar;
@@ -210,9 +210,9 @@ test_fail_table_reference_forced_backticks:
       dialect: bigquery
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_pass_multiple_references_forced_backticks:
+test_pass_multiple_references_prefer_quoted_backticks:
   pass_str: |
     SELECT `foo`
     FROM `bar`.`baz`;
@@ -221,9 +221,9 @@ test_pass_multiple_references_forced_backticks:
       dialect: bigquery
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_fail_multiple_references_forced_backticks:
+test_fail_multiple_references_prefer_quoted_backticks:
   fail_str: |
     SELECT `foo`
     FROM bar.baz;
@@ -235,9 +235,9 @@ test_fail_multiple_references_forced_backticks:
       dialect: bigquery
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_pass_whitespace_forced_backticks:
+test_pass_whitespace_prefer_quoted_backticks:
   pass_str: |
     SELECT 123 AS `I cannot be unquoted`
   configs:
@@ -245,9 +245,9 @@ test_pass_whitespace_forced_backticks:
       dialect: bigquery
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_pass_special_symbols_forced_backticks:
+test_pass_special_symbols_prefer_quoted_backticks:
   pass_str: |
     SELECT 123 AS `I-c@nn0t-be~un-quoted`
   configs:
@@ -255,9 +255,9 @@ test_pass_special_symbols_forced_backticks:
       dialect: bigquery
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True
 
-test_pass_reserved_keyword_forced_backticks:
+test_pass_reserved_keyword_prefer_quoted_backticks:
   pass_str: |
     SELECT 123 AS `SELECT`
   configs:
@@ -265,4 +265,4 @@ test_pass_reserved_keyword_forced_backticks:
       dialect: bigquery
     rules:
       L059:
-        force_quote_identifier: True
+        prefer_quoted_identifiers: True

--- a/test/fixtures/rules/std_rule_cases/L059.yml
+++ b/test/fixtures/rules/std_rule_cases/L059.yml
@@ -26,7 +26,9 @@ rule: L059
 # Pass      True    Backtick        test_pass_table_reference_backtick_forced
 # Fail      True    Backtick        test_fail_table_reference_backtick_forced
 # Pass      True    Backtick        test_pass_multiple_references_backtick_forced
+# Pass      True    Backtick        test_pass_multiple_references_backtick_forced_bigquery
 # Fail      True    Backtick        test_fail_multiple_references_backtick_forced
+# Fail      True    Backtick        test_fail_multiple_references_backtick_forced_bigquery
 # Pass      True    Backtick        test_pass_whitespace_backtick_forced
 # Pass      True    Backtick        test_pass_special_symbols_backtick_forced
 # Pass      True    Backtick        test_pass_reserved_keyword_backtick_forced
@@ -225,6 +227,18 @@ test_pass_multiple_references_backtick_forced:
         force_quote_identifier: True
         preferred_quote_identifier: "`"
 
+test_pass_multiple_references_backtick_forced_bigquery:
+  pass_str: |
+    SELECT `foo`
+    FROM `bar`.`baz`;
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L059:
+        force_quote_identifier: True
+        preferred_quote_identifier: "`"
+
 test_fail_multiple_references_backtick_forced:
   fail_str: |
     SELECT `foo`
@@ -233,6 +247,21 @@ test_fail_multiple_references_backtick_forced:
     SELECT `foo`
     FROM `bar`.`baz`;
   configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+        preferred_quote_identifier: "`"
+
+test_fail_multiple_references_backtick_forced_bigquery:
+  fail_str: |
+    SELECT `foo`
+    FROM bar.baz;
+  fix_str: |
+    SELECT `foo`
+    FROM `bar`.`baz`;
+  configs:
+    core:
+      dialect: bigquery
     rules:
       L059:
         force_quote_identifier: True

--- a/test/fixtures/rules/std_rule_cases/L059.yml
+++ b/test/fixtures/rules/std_rule_cases/L059.yml
@@ -2,6 +2,7 @@ rule: L059
 
 # Configuration test matrix
 # Pass/Fail Forced  Test
+# -- Identifiers must be unquoted (default configuration)
 # Pass      False   test_pass_column_reference
 # Fail      False   test_fail_column_reference
 # Pass      False   test_pass_table_reference
@@ -11,15 +12,26 @@ rule: L059
 # Pass      False   test_pass_whitespace
 # Pass      False   test_pass_special_symbols
 # Pass      False   test_pass_reserved_keyword
-# Pass      True    test_pass_column_reference_forced
-# Fail      True    test_fail_column_reference_forced
-# Pass      True    test_pass_table_reference_forced
-# Fail      True    test_fail_table_reference_forced
-# Pass      True    test_pass_multiple_references_forced
-# Fail      True    test_fail_multiple_references_forced
-# Pass      True    test_pass_whitespace_forced
-# Pass      True    test_pass_special_symbols_forced
-# Pass      True    test_pass_reserved_keyword_forced
+# -- Identifiers must be quoted and expected quote is double-quotes (SQL-92 ANSI, ...)
+# Pass      True    test_pass_column_reference_forced_ansi
+# Fail      True    test_fail_column_reference_forced_ansi
+# Pass      True    test_pass_table_reference_forced_ansi
+# Fail      True    test_fail_table_reference_forced_ansi
+# Pass      True    test_pass_multiple_references_forced_ansi
+# Fail      True    test_fail_multiple_references_forced_ansi
+# Pass      True    test_pass_whitespace_forced_ansi
+# Pass      True    test_pass_special_symbols_forced_ansi
+# Pass      True    test_pass_reserved_keyword_forced_ansi
+# -- Identifiers must be quoted and expected quote is backtick (BigQuery, MySql, ...)
+# Pass      True    test_pass_column_reference_forced_backticks
+# Fail      True    test_fail_column_reference_forced_backticks
+# Pass      True    test_pass_table_reference_forced_backticks
+# Fail      True    test_fail_table_reference_forced_backticks
+# Pass      True    test_pass_multiple_references_forced_backticks
+# Fail      True    test_fail_multiple_references_forced_backticks
+# Pass      True    test_pass_whitespace_forced_backticks
+# Pass      True    test_pass_special_symbols_forced_backticks
+# Pass      True    test_pass_reserved_keyword_forced_backticks
 
 test_pass_column_reference:
   pass_str: |
@@ -69,34 +81,124 @@ test_pass_reserved_keyword:
   pass_str: |
     SELECT 123 AS "SELECT"
 
-test_pass_column_reference_forced:
+test_pass_column_reference_forced_ansi:
   pass_str: |
-    SELECT 123 AS `foo`;
+    SELECT 123 AS "foo";
   configs:
     rules:
       L059:
         force_quote_identifier: True
 
-test_fail_column_reference_forced:
+test_fail_column_reference_forced_ansi:
+  fail_str: |
+    SELECT 123 AS foo;
+  pass_str: |
+    SELECT 123 AS "foo";
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+
+test_pass_table_reference_forced_ansi:
+  pass_str: |
+    SELECT "foo"
+    FROM "bar";
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+
+test_fail_table_reference_forced_ansi:
+  fail_str: |
+    SELECT "foo"
+    FROM bar;
+  pass_str: |
+    SELECT "foo"
+    FROM "bar";
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+
+test_pass_multiple_references_forced_ansi:
+  pass_str: |
+    SELECT "foo"
+    FROM "bar"."baz";
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+
+test_fail_multiple_references_forced_ansi:
+  fail_str: |
+    SELECT "foo"
+    FROM bar.baz;
+  pass_str: |
+    SELECT "foo"
+    FROM "bar"."baz";
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+
+test_pass_whitespace_forced_ansi:
+  pass_str: |
+    SELECT 123 AS "I cannot be unquoted"
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+
+test_pass_special_symbols_forced_ansi:
+  pass_str: |
+    SELECT 123 AS "I-c@nn0t-be~un-quoted"
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+
+test_pass_reserved_keyword_forced_ansi:
+  pass_str: |
+    SELECT 123 AS "SELECT"
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+
+test_pass_column_reference_forced_backticks:
+  pass_str: |
+    SELECT 123 AS `foo`;
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L059:
+        force_quote_identifier: True
+
+test_fail_column_reference_forced_backticks:
   fail_str: |
     SELECT 123 AS foo;
   pass_str: |
     SELECT 123 AS `foo`;
   configs:
+    core:
+      dialect: bigquery
     rules:
       L059:
         force_quote_identifier: True
 
-test_pass_table_reference_forced:
+test_pass_table_reference_forced_backticks:
   pass_str: |
     SELECT `foo`
     FROM `bar`;
   configs:
+    core:
+      dialect: bigquery
     rules:
       L059:
         force_quote_identifier: True
 
-test_fail_table_reference_forced:
+test_fail_table_reference_forced_backticks:
   fail_str: |
     SELECT `foo`
     FROM bar;
@@ -104,20 +206,24 @@ test_fail_table_reference_forced:
     SELECT `foo`
     FROM `bar`;
   configs:
+    core:
+      dialect: bigquery
     rules:
       L059:
         force_quote_identifier: True
 
-test_pass_multiple_references_forced:
+test_pass_multiple_references_forced_backticks:
   pass_str: |
     SELECT `foo`
     FROM `bar`.`baz`;
   configs:
+    core:
+      dialect: bigquery
     rules:
       L059:
         force_quote_identifier: True
 
-test_fail_multiple_references_forced:
+test_fail_multiple_references_forced_backticks:
   fail_str: |
     SELECT `foo`
     FROM bar.baz;
@@ -125,30 +231,38 @@ test_fail_multiple_references_forced:
     SELECT `foo`
     FROM `bar`.`baz`;
   configs:
+    core:
+      dialect: bigquery
     rules:
       L059:
         force_quote_identifier: True
 
-test_pass_whitespace_forced:
+test_pass_whitespace_forced_backticks:
   pass_str: |
     SELECT 123 AS `I cannot be unquoted`
   configs:
+    core:
+      dialect: bigquery
     rules:
       L059:
         force_quote_identifier: True
 
-test_pass_special_symbols_forced:
+test_pass_special_symbols_forced_backticks:
   pass_str: |
     SELECT 123 AS `I-c@nn0t-be~un-quoted`
   configs:
+    core:
+      dialect: bigquery
     rules:
       L059:
         force_quote_identifier: True
 
-test_pass_reserved_keyword_forced:
+test_pass_reserved_keyword_forced_backticks:
   pass_str: |
     SELECT 123 AS `SELECT`
   configs:
+    core:
+      dialect: bigquery
     rules:
       L059:
         force_quote_identifier: True

--- a/test/fixtures/rules/std_rule_cases/L059.yml
+++ b/test/fixtures/rules/std_rule_cases/L059.yml
@@ -1,5 +1,37 @@
 rule: L059
 
+# Configuration test matrix
+# Pass/Fail Forced  Preferred       Test
+# Pass      False   Double quote    test_pass_column_reference
+# Fail      False   Double quote    test_fail_column_reference
+# Pass      False   Double quote    test_pass_table_reference
+# Fail      False   Double quote    test_fail_table_reference
+# Pass      False   Double quote    test_pass_multiple_references
+# Fail      False   Double quote    test_fail_multiple_references
+# Pass      False   Double quote    test_pass_whitespace
+# Pass      False   Double quote    test_pass_special_symbols
+# Pass      False   Double quote    test_pass_reserved_keyword
+# Pass      False   Backtick        test_pass_column_reference_backtick
+# Fail      False   Backtick        test_fail_column_reference_backtick
+# Pass      False   Backtick        test_pass_table_reference_backtick
+# Fail      False   Backtick        test_fail_table_reference_backtick
+# Pass      False   Backtick        test_pass_multiple_references_backtick
+# Fail      False   Backtick        test_fail_multiple_references_backtick
+# Pass      False   Backtick        test_pass_whitespace_backtick
+# Pass      False   Backtick        test_pass_special_symbols_backtick
+# Pass      False   Backtick        test_pass_reserved_keyword_backtick
+# Pass      False   Backtick        test_pass_ignored_as_contains_backtick
+# Pass      True    Backtick        test_pass_column_reference_backtick_forced
+# Fail      True    Backtick        test_fail_column_reference_backtick_forced
+# Pass      True    Backtick        test_pass_table_reference_backtick_forced
+# Fail      True    Backtick        test_fail_table_reference_backtick_forced
+# Pass      True    Backtick        test_pass_multiple_references_backtick_forced
+# Fail      True    Backtick        test_fail_multiple_references_backtick_forced
+# Pass      True    Backtick        test_pass_whitespace_backtick_forced
+# Pass      True    Backtick        test_pass_special_symbols_backtick_forced
+# Pass      True    Backtick        test_pass_reserved_keyword_backtick_forced
+# Pass      True    Backtick        test_pass_ignored_as_contains_backtick_forced
+
 test_pass_column_reference:
   pass_str: |
     SELECT 123 AS foo;
@@ -47,3 +79,197 @@ test_pass_special_symbols:
 test_pass_reserved_keyword:
   pass_str: |
     SELECT 123 AS "SELECT"
+
+test_pass_column_reference_backtick:
+  pass_str: |
+    SELECT 123 AS foo;
+  configs:
+    rules:
+      L059:
+        preferred_quote_identifier: "`"
+
+test_fail_column_reference_backtick:
+  fail_str: |
+    SELECT 123 AS "foo";
+  pass_str: |
+    SELECT 123 AS `foo`;
+  configs:
+    rules:
+      L059:
+        preferred_quote_identifier: "`"
+
+test_pass_table_reference_backtick:
+  pass_str: |
+    SELECT foo
+    FROM bar;
+  configs:
+    rules:
+      L059:
+        preferred_quote_identifier: "`"
+
+test_fail_table_reference_backtick:
+  fail_str: |
+    SELECT foo
+    FROM "bar";
+  fix_str: |
+    SELECT foo
+    FROM `bar`;
+  configs:
+    rules:
+      L059:
+        preferred_quote_identifier: "`"
+
+test_pass_multiple_references_backtick:
+  pass_str: |
+    SELECT foo
+    FROM bar.baz;
+  configs:
+    rules:
+      L059:
+        preferred_quote_identifier: "`"
+
+test_fail_multiple_references_backtick:
+  fail_str: |
+    SELECT foo
+    FROM "bar"."baz";
+  fix_str: |
+    SELECT foo
+    FROM `bar`.`baz`;
+  configs:
+    rules:
+      L059:
+        preferred_quote_identifier: "`"
+
+test_pass_whitespace_backtick:
+  pass_str: |
+    SELECT 123 AS `I cannot be unquoted`
+  configs:
+    rules:
+      L059:
+        preferred_quote_identifier: "`"
+
+test_pass_special_symbols_backtick:
+  pass_str: |
+    SELECT 123 AS `I-c@nn0t-be~un-quoted`
+  configs:
+    rules:
+      L059:
+        preferred_quote_identifier: "`"
+
+test_pass_reserved_keyword_backtick:
+  pass_str: |
+    SELECT 123 AS `SELECT`
+  configs:
+    rules:
+      L059:
+        preferred_quote_identifier: "`"
+
+test_pass_ignored_as_contains_backtick:
+  pass_str: |
+    SELECT 123 AS "Ignored`as`contains`backticks"
+  configs:
+    rules:
+      L059:
+        preferred_quote_identifier: "`"
+
+test_pass_column_reference_backtick_forced:
+  pass_str: |
+    SELECT 123 AS `foo`;
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+        preferred_quote_identifier: "`"
+
+test_fail_column_reference_backtick_forced:
+  fail_str: |
+    SELECT 123 AS foo;
+  pass_str: |
+    SELECT 123 AS `foo`;
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+        preferred_quote_identifier: "`"
+
+test_pass_table_reference_backtick_forced:
+  pass_str: |
+    SELECT `foo`
+    FROM `bar`;
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+        preferred_quote_identifier: "`"
+
+test_fail_table_reference_backtick_forced:
+  fail_str: |
+    SELECT `foo`
+    FROM bar;
+  fix_str: |
+    SELECT `foo`
+    FROM `bar`;
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+        preferred_quote_identifier: "`"
+
+test_pass_multiple_references_backtick_forced:
+  pass_str: |
+    SELECT `foo`
+    FROM `bar`.`baz`;
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+        preferred_quote_identifier: "`"
+
+test_fail_multiple_references_backtick_forced:
+  fail_str: |
+    SELECT `foo`
+    FROM bar.baz;
+  fix_str: |
+    SELECT `foo`
+    FROM `bar`.`baz`;
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+        preferred_quote_identifier: "`"
+
+test_pass_whitespace_backtick_forced:
+  pass_str: |
+    SELECT 123 AS `I cannot be unquoted`
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+        preferred_quote_identifier: "`"
+
+test_pass_special_symbols_backtick_forced:
+  pass_str: |
+    SELECT 123 AS `I-c@nn0t-be~un-quoted`
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+        preferred_quote_identifier: "`"
+
+test_pass_reserved_keyword_backtick_forced:
+  pass_str: |
+    SELECT 123 AS `SELECT`
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+        preferred_quote_identifier: "`"
+
+test_pass_ignored_as_contains_backtick_forced:
+  pass_str: |
+    SELECT 123 AS "Ignored`as`contains`backticks"
+  configs:
+    rules:
+      L059:
+        force_quote_identifier: True
+        preferred_quote_identifier: "`"


### PR DESCRIPTION
### Brief summary of the change made
fixes #2527 by providing a configuration option on the L059 rule.

### Are there any other side effects of this change that we should be aware of?
No side effects expected as the default values for the newly added configuration are respecting the previous L059 behavior.

### Pull Request checklist
- [x] Included test cases to demonstrate any code changes:  `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
- [x] Added appropriate documentation for the change.
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate.


Even though I think I have fulfilled the requirements in terms of development, tests, documentation, please do not hesitate to help me ensuring this PR is OK, as I didn't wrote anything in python since a decade (literally), and I'm not 100% sure I respected the code of conduct (and if I failed, I'm sorry, I'll fix my mistakes).
