### PR TITLE
dbt templater: Fix bug where profile wasn't found if DBT_PROFILES_DIR contained uppercase letters

### DIFF
--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -92,6 +92,12 @@ class DbtTemplater(JinjaTemplater):
     def dbt_config(self):
         """Loads the dbt config."""
         if self.dbt_version_tuple >= (1, 0):
+            # Here, we read flags.PROFILE_DIR directly, prior to calling
+            # set_from_args(). Apparently, set_from_args() sets PROFILES_DIR
+            # to a lowercase version of the value, and the profile wouldn't be
+            # found if the directory name contained uppercase letters. This fix
+            # was suggested and described here:
+            # https://github.com/sqlfluff/sqlfluff/issues/2253#issuecomment-1018722979
             user_config = read_user_config(flags.PROFILES_DIR)
             flags.set_from_args(
                 DbtConfigArgs(

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from functools import partial
 
 from dbt.version import get_installed_version
+from dbt.config import read_user_config
 from dbt.config.runtime import RuntimeConfig as DbtRuntimeConfig
 from dbt.adapters.factory import register_adapter, get_adapter
 from dbt.compilation import Compiler as DbtCompiler
@@ -91,14 +92,14 @@ class DbtTemplater(JinjaTemplater):
     def dbt_config(self):
         """Loads the dbt config."""
         if self.dbt_version_tuple >= (1, 0):
+            user_config = read_user_config(flags.PROFILES_DIR)
             flags.set_from_args(
-                "",
                 DbtConfigArgs(
                     project_dir=self.project_dir,
                     profiles_dir=self.profiles_dir,
                     profile=self._get_profile(),
-                    target=self._get_target(),
                 ),
+                user_config,
             )
         self.dbt_config = DbtRuntimeConfig.from_args(
             DbtConfigArgs(

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -80,31 +80,22 @@ def test__templater_dbt_templating_result(
     project_dir, dbt_templater, fname  # noqa: F811
 ):
     """Test that input sql file gets templated into output sql file."""
-    templated_file, _ = dbt_templater.process(
-        in_str="",
-        fname=os.path.join(project_dir, "models/my_new_project/", fname),
-        config=FluffConfig(configs=DBT_FLUFF_CONFIG),
-    )
-    template_output_folder_path = Path(
-        "plugins/sqlfluff-templater-dbt/test/fixtures/dbt/templated_output/"
-    )
-    fixture_path = _get_fixture_path(template_output_folder_path, fname)
-    assert str(templated_file) == fixture_path.read_text()
+    _run_templater_and_verify_result(dbt_templater, project_dir, fname)
 
 
 def test_dbt_profiles_dir_env_var_uppercase(
     project_dir, dbt_templater, tmpdir, monkeypatch  # noqa: F811
 ):
-    """Tests specifying the dbt profile dir with env var.
-
-    Based on test__templater_dbt_templating_result().
-    """
-    fname = "use_dbt_utils.sql"
+    """Tests specifying the dbt profile dir with env var."""
     profiles_dir = tmpdir.mkdir("SUBDIR")  # Use uppercase to test issue 2253
     monkeypatch.setenv("DBT_PROFILES_DIR", str(profiles_dir))
     shutil.copy(
         os.path.join(project_dir, "../profiles_yml/profiles.yml"), str(profiles_dir)
     )
+    _run_templater_and_verify_result(dbt_templater, project_dir, "use_dbt_utils.sql")
+
+
+def _run_templater_and_verify_result(dbt_templater, project_dir, fname):  # noqa: F811
     templated_file, _ = dbt_templater.process(
         in_str="",
         fname=os.path.join(project_dir, "models/my_new_project/", fname),


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #2253. Tests the behavior mentioned as broken in #1468.
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
