### PR TITLE
Adds new rule to allow blocking of certain words

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -146,4 +146,4 @@ additional_allowed_characters = ""
 
 [sqlfluff:rules:L062]
 # Blocked phrases
-block_word_list = None
+blocked_words = None

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -145,5 +145,5 @@ allow_space_in_identifier = False
 additional_allowed_characters = ""
 
 [sqlfluff:rules:L062]
-# Comma separated list of blocked phrases
+# Comma separated list of blocked words that should not be used
 blocked_words = None

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -146,4 +146,4 @@ additional_allowed_characters = ""
 
 [sqlfluff:rules:L062]
 # Blocked phrases
-block_word_list = ""
+block_word_list = None

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -145,5 +145,5 @@ allow_space_in_identifier = False
 additional_allowed_characters = ""
 
 [sqlfluff:rules:L062]
-# Blocked phrases
+# Comma separated list of blocked phrases
 blocked_words = None

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -143,3 +143,7 @@ unquoted_identifiers_policy = all
 quoted_identifiers_policy = all
 allow_space_in_identifier = False
 additional_allowed_characters = ""
+
+[sqlfluff:rules:L062]
+# Blocked phrases
+block_word_list = ""

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -137,7 +137,7 @@ STANDARD_CONFIG_INFO_DICT = {
             "in addition to alphanumerics (A-Z, a-z, 0-9) and underscores."
         ),
     },
-    "block_word_list": {
+    "blocked_words": {
         "definition": (
             "Optional list of blocked words which should not be used in statements."
         ),

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -137,6 +137,11 @@ STANDARD_CONFIG_INFO_DICT = {
             "in addition to alphanumerics (A-Z, a-z, 0-9) and underscores."
         ),
     },
+    "block_word_list": {
+        "definition": (
+            "Optional list of blocked words which should not be used in statements."
+        ),
+    },
 }
 
 

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -82,7 +82,7 @@ STANDARD_CONFIG_INFO_DICT = {
         ),
     },
     "ignore_words": {
-        "definition": ("Comma-separated list of words to ignore from rule"),
+        "definition": ("Comma separated list of words to ignore from rule"),
     },
     "forbid_subquery_in": {
         "validation": ["join", "from", "both"],

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -82,7 +82,7 @@ STANDARD_CONFIG_INFO_DICT = {
         ),
     },
     "ignore_words": {
-        "definition": ("Comma separated list of words to ignore from rule"),
+        "definition": ("Comma-separated list of words to ignore from rule"),
     },
     "forbid_subquery_in": {
         "validation": ["join", "from", "both"],
@@ -139,7 +139,8 @@ STANDARD_CONFIG_INFO_DICT = {
     },
     "blocked_words": {
         "definition": (
-            "Optional list of blocked words which should not be used in statements."
+            "Optional comma-separated list of blocked words which should not be used "
+            "in statements."
         ),
     },
 }

--- a/src/sqlfluff/rules/L062.py
+++ b/src/sqlfluff/rules/L062.py
@@ -39,7 +39,11 @@ class Rule_L062(BaseRule):
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         # Config type hints
-        self.block_word_list: str
+        self.block_word_list: Optional[str]
+
+        # Exit early if no block list set
+        if not self.block_word_list:
+            return None
 
         # Only look at child elements
         # Note: we do not need to ignore comments or meta types

--- a/src/sqlfluff/rules/L062.py
+++ b/src/sqlfluff/rules/L062.py
@@ -80,7 +80,7 @@ class Rule_L062(BaseRule):
     def _init_blocked_words(self):
         """Called first time rule is evaluated to fetch & cache the blocked_words."""
         # Use str() in case bools are passed which might otherwise be read as bool
-        blocked_words_config = str(getattr(self, "blocked_words"))
+        blocked_words_config = getattr(self, "blocked_words")
         if blocked_words_config and blocked_words_config != "None":
             self.blocked_words_list = self.split_comma_separated_string(
                 blocked_words_config.upper()
@@ -88,5 +88,4 @@ class Rule_L062(BaseRule):
         else:
             self.blocked_words_list = []
 
-        blocked_words_list = self.blocked_words_list
-        return blocked_words_list
+        return self.blocked_words_list

--- a/src/sqlfluff/rules/L062.py
+++ b/src/sqlfluff/rules/L062.py
@@ -1,0 +1,58 @@
+"""Implementation of Rule L062."""
+
+from typing import Optional
+
+from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.doc_decorators import document_configuration
+
+
+@document_configuration
+class Rule_L062(BaseRule):
+    """Block a list of configurable phrases from being used.
+
+    This generic rule can be useful to prevent certain keywords, functions, or objects
+    from being used. Only whole words can be blocked, not phrases.
+
+    This block list is case insensitive.
+
+    Example use cases:
+
+    * We prefer ``BOOL`` over ``BOOLEAN`` and there is no existing rule to enforce
+      this. We can add ``BOOLEAN`` to the deny list until such a rule is written to
+      cause a linting error.
+    * We have deprecated a schema/table/function and want to prevent it being used
+      in future. We can add that to the denylist and then add a ``-- noqa: L062`` for
+      the few exceptions that still need to be in the code base.
+
+    | **Anti-pattern**
+    | If the deny_phrases includes ``deprecated_table`` then the following will flag
+
+    .. code-block:: sql
+
+        SELECT * FROM deprecated_table WHERE 1 <> 2;
+
+    """
+
+    config_keywords = [
+        "block_word_list",
+    ]
+
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        # Config type hints
+        self.block_word_list: str
+
+        # Only look at child elements
+        # Note: we do not need to ignore comments or meta types
+        # or the like as they will not have single word raws
+        if context.segment.segments:
+            return None
+
+        if str(context.segment.raw_upper) in (
+            self.split_comma_separated_string(self.block_word_list.upper())
+        ):
+            return LintResult(
+                anchor=context.segment,
+                description=f"Use of blocked word '{context.segment.raw}'.",
+            )
+
+        return None

--- a/src/sqlfluff/rules/L062.py
+++ b/src/sqlfluff/rules/L062.py
@@ -81,11 +81,12 @@ class Rule_L062(BaseRule):
         """Called first time rule is evaluated to fetch & cache the blocked_words."""
         # Use str() in case bools are passed which might otherwise be read as bool
         blocked_words_config = getattr(self, "blocked_words")
-        if blocked_words_config and blocked_words_config != "None":
+        if blocked_words_config:
             self.blocked_words_list = self.split_comma_separated_string(
                 blocked_words_config.upper()
             )
-        else:
+        else:  # pragma: no cover
+            # Shouldn't get here as we exit error if not block list
             self.blocked_words_list = []
 
         return self.blocked_words_list

--- a/src/sqlfluff/rules/L062.py
+++ b/src/sqlfluff/rules/L062.py
@@ -18,11 +18,11 @@ class Rule_L062(BaseRule):
     Example use cases:
 
     * We prefer ``BOOL`` over ``BOOLEAN`` and there is no existing rule to enforce
-      this. We can add ``BOOLEAN`` to the deny list until such a rule is written to
-      cause a linting error.
+      this. Until such a rule is written, we can add ``BOOLEAN`` to the deny list
+      to cause a linting error to flag this.
     * We have deprecated a schema/table/function and want to prevent it being used
       in future. We can add that to the denylist and then add a ``-- noqa: L062`` for
-      the few exceptions that still need to be in the code base.
+      the few exceptions that still need to be in the code base for now.
 
     | **Anti-pattern**
     | If the ``blocked_words`` config is set to ``deprecated_table,bool`` then the
@@ -34,7 +34,7 @@ class Rule_L062(BaseRule):
         CREATE TABLE myschema.t1 (a BOOL);
 
     | **Best practice**
-    | Do not used any blocked words
+    | Do not used any blocked words:
 
     .. code-block:: sql
 
@@ -79,14 +79,13 @@ class Rule_L062(BaseRule):
 
     def _init_blocked_words(self):
         """Called first time rule is evaluated to fetch & cache the blocked_words."""
-        # Use str() in case bools are passed which might otherwise be read as bool
         blocked_words_config = getattr(self, "blocked_words")
         if blocked_words_config:
             self.blocked_words_list = self.split_comma_separated_string(
                 blocked_words_config.upper()
             )
         else:  # pragma: no cover
-            # Shouldn't get here as we exit error if not block list
+            # Shouldn't get here as we exit early if no block list
             self.blocked_words_list = []
 
         return self.blocked_words_list

--- a/src/sqlfluff/rules/L062.py
+++ b/src/sqlfluff/rules/L062.py
@@ -69,7 +69,7 @@ class Rule_L062(BaseRule):
         if context.segment.segments:
             return None
 
-        if str(context.segment.raw_upper) in blocked_words_list:
+        if context.segment.raw_upper in blocked_words_list:
             return LintResult(
                 anchor=context.segment,
                 description=f"Use of blocked word '{context.segment.raw}'.",

--- a/src/sqlfluff/rules/L062.py
+++ b/src/sqlfluff/rules/L062.py
@@ -11,7 +11,7 @@ class Rule_L062(BaseRule):
     """Block a list of configurable phrases from being used.
 
     This generic rule can be useful to prevent certain keywords, functions, or objects
-    from being used. Only whole words can be blocked, not phrases.
+    from being used. Only whole words can be blocked, not phrases, nor parts of words.
 
     This block list is case insensitive.
 
@@ -25,11 +25,21 @@ class Rule_L062(BaseRule):
       the few exceptions that still need to be in the code base.
 
     | **Anti-pattern**
-    | If the deny_phrases includes ``deprecated_table`` then the following will flag
+    | If the block_word_list is set to ``deprecated_table,bool`` then the following
+    | will flag:
 
     .. code-block:: sql
 
-        SELECT * FROM deprecated_table WHERE 1 <> 2;
+        SELECT * FROM deprecated_table WHERE 1 = 1;
+        CREATE TABLE myschema.t1 (a BOOL);
+
+    | **Best practice**
+    | Do not used any blocked words
+
+    .. code-block:: sql
+
+        SELECT * FROM another_table WHERE 1 = 1;
+        CREATE TABLE myschema.t1 (a BOOLEAN);
 
     """
 

--- a/src/sqlfluff/rules/L062.py
+++ b/src/sqlfluff/rules/L062.py
@@ -8,7 +8,7 @@ from sqlfluff.core.rules.doc_decorators import document_configuration
 
 @document_configuration
 class Rule_L062(BaseRule):
-    """Block a list of configurable phrases from being used.
+    """Block a list of configurable words from being used.
 
     This generic rule can be useful to prevent certain keywords, functions, or objects
     from being used. Only whole words can be blocked, not phrases, nor parts of words.

--- a/test/fixtures/rules/std_rule_cases/L062.yml
+++ b/test/fixtures/rules/std_rule_cases/L062.yml
@@ -1,5 +1,9 @@
 rule: L062
 
+test_pass_default:
+  pass_str: |
+    SELECT col1 FROM deprecated_table
+
 test_fail_deny_word:
   fail_str: |
     SELECT col1 FROM deprecated_table

--- a/test/fixtures/rules/std_rule_cases/L062.yml
+++ b/test/fixtures/rules/std_rule_cases/L062.yml
@@ -1,8 +1,8 @@
 rule: L062
 
-test_pass_default:
+test_pass_default_none:
   pass_str: |
-    SELECT col1 FROM deprecated_table
+    SELECT col1 FROM None
 
 test_fail_deny_word:
   fail_str: |

--- a/test/fixtures/rules/std_rule_cases/L062.yml
+++ b/test/fixtures/rules/std_rule_cases/L062.yml
@@ -1,0 +1,87 @@
+rule: L062
+
+test_fail_deny_word:
+  fail_str: |
+    SELECT col1 FROM deprecated_table
+  configs:
+    rules:
+      L062:
+        block_word_list: deprecated_table
+
+test_fail_deny_word_case_difference1:
+  fail_str: |
+    SELECT col1 FROM deprecated_table
+  configs:
+    rules:
+      L062:
+        block_word_list: Deprecated_Table
+
+test_fail_deny_word_case_difference2:
+  fail_str: |
+    SELECT col1 FROM Deprecated_Table
+  configs:
+    rules:
+      L062:
+        block_word_list: deprecated_table
+
+test_fail_multiple_deny_words1:
+  fail_str: |
+    SELECT myOldFunction(col1) FROM table1
+  configs:
+    rules:
+      L062:
+        block_word_list: deprecated_table,myoldFunction
+
+test_fail_multiple_deny_words2:
+  fail_str: |
+    SELECT col1 FROM deprecated_table
+  configs:
+    rules:
+      L062:
+        block_word_list: deprecated_table,myoldFunction
+
+test_pass_not_complete_match:
+  pass_str: |
+    SELECT col1 FROM deprecated_table1
+  configs:
+    rules:
+      L062:
+        block_word_list: deprecated_table
+
+test_pass_is_comment:
+  pass_str: |
+    -- deprecated_table
+    SELECT col1 FROM new_table
+  configs:
+    rules:
+      L062:
+        block_word_list: deprecated_table
+
+test_pass_in_comment:
+  pass_str: |
+    -- This used to use the deprecated_table
+    SELECT col1 FROM new_table
+  configs:
+    rules:
+      L062:
+        block_word_list: deprecated_table
+
+test_fail_bool:
+  fail_str: |
+    CREATE TABLE myschema.t1 (a BOOL);
+  configs:
+    core:
+      dialect: exasol
+    rules:
+      L062:
+        block_word_list: bool
+
+test_pass_bool:
+  pass_str: |
+    CREATE TABLE myschema.t1 (a BOOLEAN);
+  configs:
+    core:
+      dialect: exasol
+    rules:
+      L062:
+        block_word_list: bool

--- a/test/fixtures/rules/std_rule_cases/L062.yml
+++ b/test/fixtures/rules/std_rule_cases/L062.yml
@@ -10,7 +10,7 @@ test_fail_deny_word:
   configs:
     rules:
       L062:
-        block_word_list: deprecated_table
+        blocked_words: deprecated_table
 
 test_fail_deny_word_case_difference1:
   fail_str: |
@@ -18,7 +18,7 @@ test_fail_deny_word_case_difference1:
   configs:
     rules:
       L062:
-        block_word_list: Deprecated_Table
+        blocked_words: Deprecated_Table
 
 test_fail_deny_word_case_difference2:
   fail_str: |
@@ -26,7 +26,7 @@ test_fail_deny_word_case_difference2:
   configs:
     rules:
       L062:
-        block_word_list: deprecated_table
+        blocked_words: deprecated_table
 
 test_fail_multiple_deny_words1:
   fail_str: |
@@ -34,7 +34,7 @@ test_fail_multiple_deny_words1:
   configs:
     rules:
       L062:
-        block_word_list: deprecated_table,myoldFunction
+        blocked_words: deprecated_table,myoldFunction
 
 test_fail_multiple_deny_words2:
   fail_str: |
@@ -42,7 +42,7 @@ test_fail_multiple_deny_words2:
   configs:
     rules:
       L062:
-        block_word_list: deprecated_table,myoldFunction
+        blocked_words: deprecated_table,myoldFunction
 
 test_pass_not_complete_match:
   pass_str: |
@@ -50,7 +50,7 @@ test_pass_not_complete_match:
   configs:
     rules:
       L062:
-        block_word_list: deprecated_table
+        blocked_words: deprecated_table
 
 test_pass_is_comment:
   pass_str: |
@@ -59,7 +59,7 @@ test_pass_is_comment:
   configs:
     rules:
       L062:
-        block_word_list: deprecated_table
+        blocked_words: deprecated_table
 
 test_pass_in_comment:
   pass_str: |
@@ -68,7 +68,7 @@ test_pass_in_comment:
   configs:
     rules:
       L062:
-        block_word_list: deprecated_table
+        blocked_words: deprecated_table
 
 test_fail_bool:
   fail_str: |
@@ -78,7 +78,7 @@ test_fail_bool:
       dialect: exasol
     rules:
       L062:
-        block_word_list: bool
+        blocked_words: bool
 
 test_pass_bool:
   pass_str: |
@@ -88,4 +88,4 @@ test_pass_bool:
       dialect: exasol
     rules:
       L062:
-        block_word_list: bool
+        blocked_words: bool

--- a/test/rules/std_L062_test.py
+++ b/test/rules/std_L062_test.py
@@ -1,0 +1,20 @@
+"""Tests the python routines within L062."""
+from sqlfluff.core import FluffConfig
+from sqlfluff.core import Linter
+
+
+def test__rules__std_L062_raised() -> None:
+    """L062 is raised for use of blocked words with correct error message."""
+    sql = "SELECT MYOLDFUNCTION(col1) FROM deprecated_table;\n"
+    cfg = FluffConfig()
+    cfg.set_value(
+        config_path=["rules", "L062", "blocked_words"],
+        val="myoldfunction,deprecated_table",
+    )
+    linter = Linter(config=cfg)
+    result_records = linter.lint_string_wrapped(sql).as_records()
+    result = result_records[0]["violations"]
+
+    assert len(result) == 2
+    assert result[0]["description"] == "Use of blocked word 'MYOLDFUNCTION'."
+    assert result[1]["description"] == "Use of blocked word 'deprecated_table'."


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #362
Fixes #1800 
Follow on from #2507

This adds a very configurable new rule to allow blocking of certain terms. To quote from the rule docstring:

    This generic rule can be useful to prevent certain keywords, functions, or objects
    from being used. Only whole words can be blocked, not phrases.

    This block list is case insensitive.

    Example use cases:

    * We prefer ``BOOL`` over ``BOOLEAN`` and there is no existing rule to enforce
      this. We can add ``BOOLEAN`` to the deny list until such a rule is written to
      cause a linting error.
    * We have deprecated a schema/table/function and want to prevent it being used
      in future. We can add that to the denylist and then add a ``-- noqa: L062`` for
      the few exceptions that still need to be in the code base.


### Are there any other side effects of this change that we should be aware of?
Can't think of any. Obviously people shouldn't block certain words (e.g. `SELECT`) but that's up to them.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
