### PR TITLE
Correct parsing for BigQuery `SELECT REPLACE` clauses.

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -537,18 +537,14 @@ class ReplaceClauseSegment(BaseSegment):
     type = "select_replace_clause"
     match_grammar = Sequence(
         "REPLACE",
-        OneOf(
-            # Multiple replace in brackets
-            Bracketed(
-                Delimited(
-                    # Not *really* a select target element. It behaves exactly
-                    # the same way however.
-                    Ref("SelectClauseElementSegment"),
-                    delimiter=Ref("CommaSegment"),
-                )
-            ),
-            # Single replace not in brackets.
-            Ref("SelectClauseElementSegment"),
+        # Multiple replace in brackets
+        Bracketed(
+            Delimited(
+                # Not *really* a select target element. It behaves exactly
+                # the same way however.
+                Ref("SelectClauseElementSegment"),
+                delimiter=Ref("CommaSegment"),
+            )
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -537,7 +537,6 @@ class ReplaceClauseSegment(BaseSegment):
     type = "select_replace_clause"
     match_grammar = Sequence(
         "REPLACE",
-        # Multiple replace in brackets
         Bracketed(
             Delimited(
                 # Not *really* a select target element. It behaves exactly

--- a/test/fixtures/dialects/bigquery/select_replace.sql
+++ b/test/fixtures/dialects/bigquery/select_replace.sql
@@ -1,6 +1,6 @@
 -- Single replace
 select
-  * replace 'thing' as foo
+  * replace ('thing' as foo)
 from some_table;
 
 -- Multi replace

--- a/test/fixtures/dialects/bigquery/select_replace.yml
+++ b/test/fixtures/dialects/bigquery/select_replace.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6facb1b26a9ae35c52d1c779553a5aa8f4fd4a93e865e9668f426dd30e0744ea
+_hash: 446cf0a02575aea3e776a5339ea2850dd041c1313f83fdb47bda4d54d36cace1
 file:
 - statement:
     select_statement:
@@ -15,11 +15,14 @@ file:
               star: '*'
             select_replace_clause:
               keyword: replace
-              select_clause_element:
-                literal: "'thing'"
-                alias_expression:
-                  keyword: as
-                  identifier: foo
+              bracketed:
+                start_bracket: (
+                select_clause_element:
+                  literal: "'thing'"
+                  alias_expression:
+                    keyword: as
+                    identifier: foo
+                end_bracket: )
       from_clause:
         keyword: from
         from_expression:


### PR DESCRIPTION



<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Fixes https://github.com/sqlfluff/sqlfluff/issues/2549

BQ's `SELECT REPLACE` requires parentheses around replaced fields, but the BQ dialect implementation was permittig an invalid version without it.

This implemetation had the side effect of also failing to parse a `SELECT REPLACE()` with trailing comma and no additional fields, e.g the following would not parse correctly.

```sql
SELECT * REPLACE(foo AS bar),
FROM foo
```

Removing the unparenthesised version from the dialect makes the parsing more consistent with what BQ actually accepts, requiring the parentheses, and resolves the parse error on the trailing comma.


### Are there any other side effects of this change that we should be aware of?

None that I'm aware of.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - ~`.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.~
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - ~Full autofix test cases in `test/fixtures/linter/autofix`.~
  - ~Other.~
- ~Added appropriate documentation for the change.~
- ~Created GitHub issues for any relevant followup/future enhancements if appropriate.~
