### PR TITLE
Spark3: Add Direct File Query

### DIFF
--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -1644,8 +1644,8 @@ class TableExpressionSegment(BaseSegment):
         Ref("ValuesClauseSegment"),
         Ref("BareFunctionSegment"),
         Ref("FunctionSegment"),
-        Ref("TableReferenceSegment"),
         Ref("FileReferenceSegment"),
+        Ref("TableReferenceSegment"),
         # Nested Selects
         Bracketed(Ref("SelectableGrammar")),
     )

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -1663,5 +1663,5 @@ class FileReferenceSegment(BaseSegment):
     match_grammar = Sequence(
         Ref("DataSourcesV2FileTypeGrammar"),
         Ref("DotSegment"),
-        Ref("QuotedIdentifierSegment"),
+        Ref("QuotedLiteralSegment"),
     )

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -1663,5 +1663,7 @@ class FileReferenceSegment(BaseSegment):
     match_grammar = Sequence(
         Ref("DataSourcesV2FileTypeGrammar"),
         Ref("DotSegment"),
-        Ref("QuotedLiteralSegment"),
+        # NB: Using `QuotedLiteralSegment` here causes `FileReferenceSegment`
+        # to match as a `TableReferenceSegment`
+        Ref("QuotedIdentifierSegment"),
     )

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -275,7 +275,7 @@ spark3_dialect.add(
         "DBPROPERTIES", Ref("BracketedPropertyListGrammar")
     ),
     DataSourcesV2FileTypeGrammar=OneOf(
-        # https://github.com/apache/spark/tree/master/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2 # noqa: E501
+        # https://github.com/apache/spark/tree/master/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2  # noqa: E501
         # Separated here because these allow for additional
         # commands such as Select From File
         # https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-file.html

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -1645,12 +1645,13 @@ class TableExpressionSegment(BaseSegment):
         Ref("BareFunctionSegment"),
         Ref("FunctionSegment"),
         Ref("TableReferenceSegment"),
+        Ref("FileReferenceSegment"),
         # Nested Selects
         Bracketed(Ref("SelectableGrammar")),
     )
 
 
-@ansi_dialect.segment()
+@spark3_dialect.segment()
 class FileReferenceSegment(BaseSegment):
     """A reference to an table, CTE, subquery or alias."""
 

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -223,23 +223,16 @@ spark3_dialect.add(
         "RCFILE", KeywordSegment, name="rc_file", type="file_format"
     ),
     SequencefileKeywordSegment=StringParser(
-        "SEQUENCEFILE",
-        KeywordSegment,
-        name="sequence_file",
-        type="file_format"
+        "SEQUENCEFILE", KeywordSegment, name="sequence_file", type="file_format"
     ),
     TextfileKeywordSegment=StringParser(
         "TEXTFILE", KeywordSegment, name="text_file", type="file_format"
     ),
     StartAngleBracketSegment=StringParser(
-        "<", SymbolSegment,
-        name="start_angle_bracket",
-        type="start_angle_bracket"
+        "<", SymbolSegment, name="start_angle_bracket", type="start_angle_bracket"
     ),
     EndAngleBracketSegment=StringParser(
-        ">", SymbolSegment,
-        name="end_angle_bracket",
-        type="end_angle_bracket"
+        ">", SymbolSegment, name="end_angle_bracket", type="end_angle_bracket"
     ),
     # Add Spark Segments
     EqualsSegment_a=StringParser(
@@ -251,12 +244,8 @@ spark3_dialect.add(
     FileKeywordSegment=StringParser(
         "FILE", KeywordSegment, name="file", type="file_type"
     ),
-    JarKeywordSegment=StringParser(
-        "JAR", KeywordSegment, name="jar", type="file_type"
-    ),
-    WhlKeywordSegment=StringParser(
-        "WHL", KeywordSegment, name="whl", type="file_type"
-    ),
+    JarKeywordSegment=StringParser("JAR", KeywordSegment, name="jar", type="file_type"),
+    WhlKeywordSegment=StringParser("WHL", KeywordSegment, name="whl", type="file_type"),
     # Add relevant Hive Grammar
     BracketedPropertyListGrammar=hive_dialect.get_grammar(
         "BracketedPropertyListGrammar"

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -309,7 +309,7 @@ spark3_dialect.add(
     DataSourceFormatGrammar=OneOf(
         Ref("FileFormatGrammar"),
         # NB: JDBC is part of DataSourceV2 but not included
-        # there since there are no no significant syntax changes
+        # there since there are no significant syntax changes
         "JDBC",
     ),
     # Adding Hint related segments so they are not treated as generic comments

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -1653,7 +1653,10 @@ class TableExpressionSegment(BaseSegment):
 
 @spark3_dialect.segment()
 class FileReferenceSegment(BaseSegment):
-    """A reference to an table, CTE, subquery or alias."""
+    """A reference to a file for direct query.
+
+    https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-file.html
+    """
 
     type = "file_reference"
 

--- a/src/sqlfluff/rules/L003.py
+++ b/src/sqlfluff/rules/L003.py
@@ -882,11 +882,15 @@ class Rule_L003(BaseRule):
         if not cls._single_placeholder_line(current_line):
             return False
         for idx in range(1, len(current_line)):
-            if segment_info(idx - 1) in (
-                ("placeholder", "block_start"),
-                ("placeholder", "compound"),
-                ("placeholder", "block_mid"),
-            ) and segment_info(idx) == ("indent", None):
+            if (
+                segment_info(idx - 1)
+                in (
+                    ("placeholder", "block_start"),
+                    ("placeholder", "compound"),
+                    ("placeholder", "block_mid"),
+                )
+                and segment_info(idx) == ("indent", None)
+            ):
                 return True
         return False
 

--- a/src/sqlfluff/rules/L003.py
+++ b/src/sqlfluff/rules/L003.py
@@ -882,15 +882,11 @@ class Rule_L003(BaseRule):
         if not cls._single_placeholder_line(current_line):
             return False
         for idx in range(1, len(current_line)):
-            if (
-                segment_info(idx - 1)
-                in (
-                    ("placeholder", "block_start"),
-                    ("placeholder", "compound"),
-                    ("placeholder", "block_mid"),
-                )
-                and segment_info(idx) == ("indent", None)
-            ):
+            if segment_info(idx - 1) in (
+                ("placeholder", "block_start"),
+                ("placeholder", "compound"),
+                ("placeholder", "block_mid"),
+            ) and segment_info(idx) == ("indent", None):
                 return True
         return False
 

--- a/src/sqlfluff/rules/L057.py
+++ b/src/sqlfluff/rules/L057.py
@@ -90,30 +90,13 @@ class Rule_L057(BaseRule):
                 identifier = identifier.replace(".", "")
 
             # Spark3 file references for direct file query
-            # are quoted in back ticks to allow for dots and regex patterns
+            # are quoted in back ticks to allow for identfiers common
+            # in file paths and regex patterns for path globbing
             # https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-file.html
             #
             # Path Glob Filters (done inline for SQL direct file query)
             # https://spark.apache.org/docs/latest/sql-data-sources-generic-options.html#path-global-filter  # noqa: E501
             #
-            # Paths also allow for "/" and "."
-
-            # Strip out special characters before testing the identifier
-            spark3_allowed_identifiers = [
-                ".",
-                "/",
-                "\\",
-                "*",
-                "?",
-                "[",
-                "]",
-                "^",
-                "-",
-                "{",
-                "}",
-                ",",
-                " ",
-            ]
 
             if (
                 context.dialect.name in ["spark3"]

--- a/src/sqlfluff/rules/L057.py
+++ b/src/sqlfluff/rules/L057.py
@@ -120,9 +120,7 @@ class Rule_L057(BaseRule):
                 and context.parent_stack
                 and context.parent_stack[-1].name == "FileReferenceSegment"
             ):
-                for allowed in spark3_allowed_identifiers:
-                    if allowed in identifier:
-                        identifier = identifier.replace(allowed, "")
+                return None
 
             # Strip spaces if allowed (note a separate config as only valid for quoted
             # identifiers)

--- a/src/sqlfluff/rules/L057.py
+++ b/src/sqlfluff/rules/L057.py
@@ -95,7 +95,7 @@ class Rule_L057(BaseRule):
             # https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-file.html
             #
             # Path Glob Filters (done inline for SQL direct file query)
-            # https://spark.apache.org/docs/latest/sql-data-sources-generic-options.html#path-global-filter  # noqa: E501
+            # https://spark.apache.org/docs/latest/sql-data-sources-generic-options.html#path-global-filter
             #
 
             if (

--- a/src/sqlfluff/rules/L057.py
+++ b/src/sqlfluff/rules/L057.py
@@ -100,8 +100,19 @@ class Rule_L057(BaseRule):
 
             # Strip out special characters before testing the identifier
             spark3_allowed_identifiers = [
-                ".", "/", "\\", "*", "?", "[", "]",
-                "^", "-", "{", "}", ",", " "
+                ".",
+                "/",
+                "\\",
+                "*",
+                "?",
+                "[",
+                "]",
+                "^",
+                "-",
+                "{",
+                "}",
+                ",",
+                " ",
             ]
 
             if (

--- a/test/fixtures/dialects/spark3/select_from_file.sql
+++ b/test/fixtures/dialects/spark3/select_from_file.sql
@@ -47,56 +47,56 @@ SELECT
     a,
     b,
     c
-FROM text.`//root/*.txt`
+FROM text.`//root/*.txt`;
 
 -- Inline Path Filter using Question mark (?)
 SELECT
     a,
     b,
     c
-FROM text.`//root/200?.txt`
+FROM text.`//root/200?.txt`;
 
 -- Inline Path Filter using Character Class ([ab])
 SELECT
     a,
     b,
     c
-FROM text.`//root/200[23].txt`
+FROM text.`//root/200[23].txt`;
 
 -- Inline Path Filter using Negated Character Class ([^ab])
 SELECT
     a,
     b,
     c
-FROM text.`//root/200[^23].txt`
+FROM text.`//root/200[^23].txt`;
 
 -- Inline Path Filter using Character Range ([a-b])
 SELECT
     a,
     b,
     c
-FROM text.`//root/200[2-5].txt`
+FROM text.`//root/200[2-5].txt`;
 
 -- Inline Path Filter using Negated Character Range ([^a-b])
 SELECT
     a,
     b,
     c
-FROM text.`//root/200[^2-5].txt`
+FROM text.`//root/200[^2-5].txt`;
 
 -- Inline Path Filter using Negated Character Range ([^a-b])
 SELECT
     a,
     b,
     c
-FROM text.`//root/200[^2-5].txt`
+FROM text.`//root/200[^2-5].txt`;
 
 -- Inline Path Filter using Alternation ({a,b})
 SELECT
     a,
     b,
     c
-FROM text.`//root/20{04, 05}.txt`
+FROM text.`//root/20{04, 05}.txt`;
 
 -- JSON treated as Text File
 SELECT

--- a/test/fixtures/dialects/spark3/select_from_file.sql
+++ b/test/fixtures/dialects/spark3/select_from_file.sql
@@ -40,6 +40,64 @@ SELECT
     c
 FROM text.`examples/src/main/resources/people.txt`;
 
+-- Tests for Inline Path Glob Filter
+-- https://spark.apache.org/docs/latest/sql-data-sources-generic-options.html#path-global-filter
+-- Inline Path Filter using Asterisk (*)
+SELECT
+    a,
+    b,
+    c
+FROM text.`//root/*.txt`
+
+-- Inline Path Filter using Question mark (?)
+SELECT
+    a,
+    b,
+    c
+FROM text.`//root/200?.txt`
+
+-- Inline Path Filter using Character Class ([ab])
+SELECT
+    a,
+    b,
+    c
+FROM text.`//root/200[23].txt`
+
+-- Inline Path Filter using Negated Character Class ([^ab])
+SELECT
+    a,
+    b,
+    c
+FROM text.`//root/200[^23].txt`
+
+-- Inline Path Filter using Character Range ([a-b])
+SELECT
+    a,
+    b,
+    c
+FROM text.`//root/200[2-5].txt`
+
+-- Inline Path Filter using Negated Character Range ([^a-b])
+SELECT
+    a,
+    b,
+    c
+FROM text.`//root/200[^2-5].txt`
+
+-- Inline Path Filter using Negated Character Range ([^a-b])
+SELECT
+    a,
+    b,
+    c
+FROM text.`//root/200[^2-5].txt`
+
+-- Inline Path Filter using Alternation ({a,b})
+SELECT
+    a,
+    b,
+    c
+FROM text.`//root/20{04, 05}.txt`
+
 -- JSON treated as Text File
 SELECT
     a,

--- a/test/fixtures/dialects/spark3/select_from_file.sql
+++ b/test/fixtures/dialects/spark3/select_from_file.sql
@@ -1,0 +1,76 @@
+-- PARQUET file
+SELECT
+    a,
+    b,
+    c
+FROM parquet.`examples/src/main/resources/users.parquet`;
+
+-- Directory of Parquet Files
+SELECT
+    a,
+    b,
+    c
+FROM parquet.`examples/src/main/resources/users`;
+
+-- ORC file
+SELECT
+    a,
+    b,
+    c
+FROM orc.`examples/src/main/resources/users.orc`;
+
+-- JSON file
+SELECT
+    a,
+    b,
+    c
+FROM json.`examples/src/main/resources/people.json`;
+
+-- Directory of JSON files
+SELECT
+    a,
+    b,
+    c
+FROM json.`examples/src/main/resources/people`;
+
+-- Text File
+SELECT
+    a,
+    b,
+    c
+FROM text.`examples/src/main/resources/people.txt`;
+
+-- JSON treated as Text File
+SELECT
+    a,
+    b,
+    c
+FROM text.`examples/src/main/resources/people.json`;
+
+-- BinaryFile
+SELECT
+    a,
+    b,
+    c
+FROM binaryfile.`/events/events-kafka.json`;
+
+-- Directory of BinaryFiles
+SELECT
+    a,
+    b,
+    c
+FROM binaryfile.`/events/events-kafka`;
+
+-- CSV File
+SELECT
+    a,
+    b,
+    c
+FROM csv.`/sales/sales.csv`;
+
+-- Delta File; test for Issue #602
+SELECT
+    a,
+    b,
+    c
+FROM delta.`/mnt/datalake/table`;

--- a/test/fixtures/dialects/spark3/select_from_file.sql
+++ b/test/fixtures/dialects/spark3/select_from_file.sql
@@ -3,42 +3,42 @@ SELECT
     a,
     b,
     c
-FROM parquet.`examples/src/main/resources/users.parquet`;
+FROM PARQUET.`examples/src/main/resources/users.parquet`;
 
 -- Directory of Parquet Files
 SELECT
     a,
     b,
     c
-FROM parquet.`examples/src/main/resources/users`;
+FROM PARQUET.`examples/src/main/resources/users`;
 
 -- ORC file
 SELECT
     a,
     b,
     c
-FROM orc.`examples/src/main/resources/users.orc`;
+FROM ORC.`examples/src/main/resources/users.orc`;
 
 -- JSON file
 SELECT
     a,
     b,
     c
-FROM json.`examples/src/main/resources/people.json`;
+FROM JSON.`examples/src/main/resources/people.json`;
 
 -- Directory of JSON files
 SELECT
     a,
     b,
     c
-FROM json.`examples/src/main/resources/people`;
+FROM JSON.`examples/src/main/resources/people`;
 
 -- Text File
 SELECT
     a,
     b,
     c
-FROM text.`examples/src/main/resources/people.txt`;
+FROM TEXT.`examples/src/main/resources/people.txt`;
 
 -- Tests for Inline Path Glob Filter
 -- https://spark.apache.org/docs/latest/sql-data-sources-generic-options.html#path-global-filter  --noqa: L016
@@ -47,88 +47,88 @@ SELECT
     a,
     b,
     c
-FROM text.`//root/*.txt`;
+FROM TEXT.`//root/*.txt`;
 
 -- Inline Path Filter using Question mark (?)
 SELECT
     a,
     b,
     c
-FROM text.`//root/200?.txt`;
+FROM TEXT.`//root/200?.txt`;
 
 -- Inline Path Filter using Character Class ([ab])
 SELECT
     a,
     b,
     c
-FROM text.`//root/200[23].txt`;
+FROM TEXT.`//root/200[23].txt`;
 
 -- Inline Path Filter using Negated Character Class ([^ab])
 SELECT
     a,
     b,
     c
-FROM text.`//root/200[^23].txt`;
+FROM TEXT.`//root/200[^23].txt`;
 
 -- Inline Path Filter using Character Range ([a-b])
 SELECT
     a,
     b,
     c
-FROM text.`//root/200[2-5].txt`;
+FROM TEXT.`//root/200[2-5].txt`;
 
 -- Inline Path Filter using Negated Character Range ([^a-b])
 SELECT
     a,
     b,
     c
-FROM text.`//root/200[^2-5].txt`;
+FROM TEXT.`//root/200[^2-5].txt`;
 
 -- Inline Path Filter using Negated Character Range ([^a-b])
 SELECT
     a,
     b,
     c
-FROM text.`//root/200[^2-5].txt`;
+FROM TEXT.`//root/200[^2-5].txt`;
 
 -- Inline Path Filter using Alternation ({a,b})
 SELECT
     a,
     b,
     c
-FROM text.`//root/20{04, 05}.txt`;
+FROM TEXT.`//root/20{04, 05}.txt`;
 
 -- JSON treated as Text File
 SELECT
     a,
     b,
     c
-FROM text.`examples/src/main/resources/people.json`;
+FROM TEXT.`examples/src/main/resources/people.json`;
 
 -- BinaryFile
 SELECT
     a,
     b,
     c
-FROM binaryfile.`/events/events-kafka.json`;
+FROM BINARYFILE.`/events/events-kafka.json`;
 
 -- Directory of BinaryFiles
 SELECT
     a,
     b,
     c
-FROM binaryfile.`/events/events-kafka`;
+FROM BINARYFILE.`/events/events-kafka`;
 
 -- CSV File
 SELECT
     a,
     b,
     c
-FROM csv.`/sales/sales.csv`;
+FROM CSV.`/sales/sales.csv`;
 
 -- Delta File; test for Issue #602
 SELECT
     a,
     b,
     c
-FROM delta.`/mnt/datalake/table`;
+FROM DELTA.`/mnt/datalake/table`;

--- a/test/fixtures/dialects/spark3/select_from_file.sql
+++ b/test/fixtures/dialects/spark3/select_from_file.sql
@@ -84,13 +84,6 @@ SELECT
     c
 FROM TEXT.`//root/200[^2-5].txt`;
 
--- Inline Path Filter using Negated Character Range ([^a-b])
-SELECT
-    a,
-    b,
-    c
-FROM TEXT.`//root/200[^2-5].txt`;
-
 -- Inline Path Filter using Alternation ({a,b})
 SELECT
     a,

--- a/test/fixtures/dialects/spark3/select_from_file.sql
+++ b/test/fixtures/dialects/spark3/select_from_file.sql
@@ -3,74 +3,74 @@ SELECT
     a,
     b,
     c
-FROM PARQUET.`examples/src/main/resources/users.parquet`;
+FROM parquet.`examples/src/main/resources/users.parquet`;
 
 -- Directory of Parquet Files
 SELECT
     a,
     b,
     c
-FROM PARQUET.`examples/src/main/resources/users`;
+FROM parquet.`examples/src/main/resources/users`;
 
 -- ORC file
 SELECT
     a,
     b,
     c
-FROM ORC.`examples/src/main/resources/users.orc`;
+FROM orc.`examples/src/main/resources/users.orc`;
 
 -- JSON file
 SELECT
     a,
     b,
     c
-FROM JSON.`examples/src/main/resources/people.json`;
+FROM json.`examples/src/main/resources/people.json`;
 
 -- Directory of JSON files
 SELECT
     a,
     b,
     c
-FROM JSON.`examples/src/main/resources/people`;
+FROM json.`examples/src/main/resources/people`;
 
 -- Text File
 SELECT
     a,
     b,
     c
-FROM TEXT.`examples/src/main/resources/people.txt`;
+FROM text.`examples/src/main/resources/people.txt`;
 
 -- JSON treated as Text File
 SELECT
     a,
     b,
     c
-FROM TEXT.`examples/src/main/resources/people.json`;
+FROM text.`examples/src/main/resources/people.json`;
 
 -- BinaryFile
 SELECT
     a,
     b,
     c
-FROM BINARYFILE.`/events/events-kafka.json`;
+FROM binaryfile.`/events/events-kafka.json`;
 
 -- Directory of BinaryFiles
 SELECT
     a,
     b,
     c
-FROM BINARYFILE.`/events/events-kafka`;
+FROM binaryfile.`/events/events-kafka`;
 
 -- CSV File
 SELECT
     a,
     b,
     c
-FROM CSV.`/sales/sales.csv`;
+FROM csv.`/sales/sales.csv`;
 
 -- Delta File; test for Issue #602
 SELECT
     a,
     b,
     c
-FROM DELTA.`/mnt/datalake/table`;
+FROM delta.`/mnt/datalake/table`;

--- a/test/fixtures/dialects/spark3/select_from_file.sql
+++ b/test/fixtures/dialects/spark3/select_from_file.sql
@@ -3,74 +3,74 @@ SELECT
     a,
     b,
     c
-FROM parquet.`examples/src/main/resources/users.parquet`;
+FROM PARQUET.`examples/src/main/resources/users.parquet`;
 
 -- Directory of Parquet Files
 SELECT
     a,
     b,
     c
-FROM parquet.`examples/src/main/resources/users`;
+FROM PARQUET.`examples/src/main/resources/users`;
 
 -- ORC file
 SELECT
     a,
     b,
     c
-FROM orc.`examples/src/main/resources/users.orc`;
+FROM ORC.`examples/src/main/resources/users.orc`;
 
 -- JSON file
 SELECT
     a,
     b,
     c
-FROM json.`examples/src/main/resources/people.json`;
+FROM JSON.`examples/src/main/resources/people.json`;
 
 -- Directory of JSON files
 SELECT
     a,
     b,
     c
-FROM json.`examples/src/main/resources/people`;
+FROM JSON.`examples/src/main/resources/people`;
 
 -- Text File
 SELECT
     a,
     b,
     c
-FROM text.`examples/src/main/resources/people.txt`;
+FROM TEXT.`examples/src/main/resources/people.txt`;
 
 -- JSON treated as Text File
 SELECT
     a,
     b,
     c
-FROM text.`examples/src/main/resources/people.json`;
+FROM TEXT.`examples/src/main/resources/people.json`;
 
 -- BinaryFile
 SELECT
     a,
     b,
     c
-FROM binaryfile.`/events/events-kafka.json`;
+FROM BINARYFILE.`/events/events-kafka.json`;
 
 -- Directory of BinaryFiles
 SELECT
     a,
     b,
     c
-FROM binaryfile.`/events/events-kafka`;
+FROM BINARYFILE.`/events/events-kafka`;
 
 -- CSV File
 SELECT
     a,
     b,
     c
-FROM csv.`/sales/sales.csv`;
+FROM CSV.`/sales/sales.csv`;
 
 -- Delta File; test for Issue #602
 SELECT
     a,
     b,
     c
-FROM delta.`/mnt/datalake/table`;
+FROM DELTA.`/mnt/datalake/table`;

--- a/test/fixtures/dialects/spark3/select_from_file.sql
+++ b/test/fixtures/dialects/spark3/select_from_file.sql
@@ -41,7 +41,7 @@ SELECT
 FROM text.`examples/src/main/resources/people.txt`;
 
 -- Tests for Inline Path Glob Filter
--- https://spark.apache.org/docs/latest/sql-data-sources-generic-options.html#path-global-filter
+-- https://spark.apache.org/docs/latest/sql-data-sources-generic-options.html#path-global-filter  --noqa: L016
 -- Inline Path Filter using Asterisk (*)
 SELECT
     a,

--- a/test/fixtures/dialects/spark3/select_from_file.yml
+++ b/test/fixtures/dialects/spark3/select_from_file.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 09ec825990c2d64c9450de28fcd3140c99a431ebda1d8eb68fd31f5b500078ac
+_hash: 72432be0024d6d35c89fc8f63024ab78271ac1187b19925a0fae2de3c90eae26
 file:
 - base:
     select_statement:
@@ -25,10 +25,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              file_reference:
-                keyword: PARQUET
-                dot: .
-                identifier: '`examples/src/main/resources/users.parquet`'
+              table_reference:
+              - identifier: parquet
+              - dot: .
+              - identifier: '`examples/src/main/resources/users.parquet`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -50,10 +50,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              file_reference:
-                keyword: PARQUET
-                dot: .
-                identifier: '`examples/src/main/resources/users`'
+              table_reference:
+              - identifier: parquet
+              - dot: .
+              - identifier: '`examples/src/main/resources/users`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -75,10 +75,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              file_reference:
-                keyword: ORC
-                dot: .
-                identifier: '`examples/src/main/resources/users.orc`'
+              table_reference:
+              - identifier: orc
+              - dot: .
+              - identifier: '`examples/src/main/resources/users.orc`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -100,10 +100,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              file_reference:
-                keyword: JSON
-                dot: .
-                identifier: '`examples/src/main/resources/people.json`'
+              table_reference:
+              - identifier: json
+              - dot: .
+              - identifier: '`examples/src/main/resources/people.json`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -125,10 +125,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              file_reference:
-                keyword: JSON
-                dot: .
-                identifier: '`examples/src/main/resources/people`'
+              table_reference:
+              - identifier: json
+              - dot: .
+              - identifier: '`examples/src/main/resources/people`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -150,10 +150,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              file_reference:
-                keyword: TEXT
-                dot: .
-                identifier: '`examples/src/main/resources/people.txt`'
+              table_reference:
+              - identifier: text
+              - dot: .
+              - identifier: '`examples/src/main/resources/people.txt`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -175,10 +175,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              file_reference:
-                keyword: TEXT
-                dot: .
-                identifier: '`examples/src/main/resources/people.json`'
+              table_reference:
+              - identifier: text
+              - dot: .
+              - identifier: '`examples/src/main/resources/people.json`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -200,10 +200,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              file_reference:
-                file_format: BINARYFILE
-                dot: .
-                identifier: '`/events/events-kafka.json`'
+              table_reference:
+              - identifier: binaryfile
+              - dot: .
+              - identifier: '`/events/events-kafka.json`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -225,10 +225,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              file_reference:
-                file_format: BINARYFILE
-                dot: .
-                identifier: '`/events/events-kafka`'
+              table_reference:
+              - identifier: binaryfile
+              - dot: .
+              - identifier: '`/events/events-kafka`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -250,10 +250,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              file_reference:
-                keyword: CSV
-                dot: .
-                identifier: '`/sales/sales.csv`'
+              table_reference:
+              - identifier: csv
+              - dot: .
+              - identifier: '`/sales/sales.csv`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -275,8 +275,8 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              file_reference:
-                keyword: DELTA
-                dot: .
-                identifier: '`/mnt/datalake/table`'
+              table_reference:
+              - identifier: delta
+              - dot: .
+              - identifier: '`/mnt/datalake/table`'
 - statement_terminator: ;

--- a/test/fixtures/dialects/spark3/select_from_file.yml
+++ b/test/fixtures/dialects/spark3/select_from_file.yml
@@ -1,0 +1,282 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 72432be0024d6d35c89fc8f63024ab78271ac1187b19925a0fae2de3c90eae26
+file:
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: parquet
+              - dot: .
+              - identifier: '`examples/src/main/resources/users.parquet`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: parquet
+              - dot: .
+              - identifier: '`examples/src/main/resources/users`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: orc
+              - dot: .
+              - identifier: '`examples/src/main/resources/users.orc`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: json
+              - dot: .
+              - identifier: '`examples/src/main/resources/people.json`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: json
+              - dot: .
+              - identifier: '`examples/src/main/resources/people`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: text
+              - dot: .
+              - identifier: '`examples/src/main/resources/people.txt`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: text
+              - dot: .
+              - identifier: '`examples/src/main/resources/people.json`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: binaryfile
+              - dot: .
+              - identifier: '`/events/events-kafka.json`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: binaryfile
+              - dot: .
+              - identifier: '`/events/events-kafka`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: csv
+              - dot: .
+              - identifier: '`/sales/sales.csv`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: delta
+              - dot: .
+              - identifier: '`/mnt/datalake/table`'
+- statement_terminator: ;

--- a/test/fixtures/dialects/spark3/select_from_file.yml
+++ b/test/fixtures/dialects/spark3/select_from_file.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 72432be0024d6d35c89fc8f63024ab78271ac1187b19925a0fae2de3c90eae26
+_hash: 09ec825990c2d64c9450de28fcd3140c99a431ebda1d8eb68fd31f5b500078ac
 file:
 - base:
     select_statement:
@@ -25,10 +25,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: parquet
-              - dot: .
-              - identifier: '`examples/src/main/resources/users.parquet`'
+              file_reference:
+                keyword: PARQUET
+                dot: .
+                identifier: '`examples/src/main/resources/users.parquet`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -50,10 +50,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: parquet
-              - dot: .
-              - identifier: '`examples/src/main/resources/users`'
+              file_reference:
+                keyword: PARQUET
+                dot: .
+                identifier: '`examples/src/main/resources/users`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -75,10 +75,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: orc
-              - dot: .
-              - identifier: '`examples/src/main/resources/users.orc`'
+              file_reference:
+                keyword: ORC
+                dot: .
+                identifier: '`examples/src/main/resources/users.orc`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -100,10 +100,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: json
-              - dot: .
-              - identifier: '`examples/src/main/resources/people.json`'
+              file_reference:
+                keyword: JSON
+                dot: .
+                identifier: '`examples/src/main/resources/people.json`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -125,10 +125,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: json
-              - dot: .
-              - identifier: '`examples/src/main/resources/people`'
+              file_reference:
+                keyword: JSON
+                dot: .
+                identifier: '`examples/src/main/resources/people`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -150,10 +150,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: text
-              - dot: .
-              - identifier: '`examples/src/main/resources/people.txt`'
+              file_reference:
+                keyword: TEXT
+                dot: .
+                identifier: '`examples/src/main/resources/people.txt`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -175,10 +175,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: text
-              - dot: .
-              - identifier: '`examples/src/main/resources/people.json`'
+              file_reference:
+                keyword: TEXT
+                dot: .
+                identifier: '`examples/src/main/resources/people.json`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -200,10 +200,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: binaryfile
-              - dot: .
-              - identifier: '`/events/events-kafka.json`'
+              file_reference:
+                file_format: BINARYFILE
+                dot: .
+                identifier: '`/events/events-kafka.json`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -225,10 +225,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: binaryfile
-              - dot: .
-              - identifier: '`/events/events-kafka`'
+              file_reference:
+                file_format: BINARYFILE
+                dot: .
+                identifier: '`/events/events-kafka`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -250,10 +250,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: csv
-              - dot: .
-              - identifier: '`/sales/sales.csv`'
+              file_reference:
+                keyword: CSV
+                dot: .
+                identifier: '`/sales/sales.csv`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -275,8 +275,8 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: delta
-              - dot: .
-              - identifier: '`/mnt/datalake/table`'
+              file_reference:
+                keyword: DELTA
+                dot: .
+                identifier: '`/mnt/datalake/table`'
 - statement_terminator: ;

--- a/test/fixtures/dialects/spark3/select_from_file.yml
+++ b/test/fixtures/dialects/spark3/select_from_file.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 72432be0024d6d35c89fc8f63024ab78271ac1187b19925a0fae2de3c90eae26
+_hash: 0a1df40992801c71346df1913666b0296bb870c41a36bbb9729fc121ab01b207
 file:
 - base:
     select_statement:
@@ -25,10 +25,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: parquet
-              - dot: .
-              - identifier: '`examples/src/main/resources/users.parquet`'
+              file_reference:
+                keyword: PARQUET
+                dot: .
+                identifier: '`examples/src/main/resources/users.parquet`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -50,10 +50,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: parquet
-              - dot: .
-              - identifier: '`examples/src/main/resources/users`'
+              file_reference:
+                keyword: PARQUET
+                dot: .
+                identifier: '`examples/src/main/resources/users`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -75,10 +75,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: orc
-              - dot: .
-              - identifier: '`examples/src/main/resources/users.orc`'
+              file_reference:
+                keyword: ORC
+                dot: .
+                identifier: '`examples/src/main/resources/users.orc`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -100,10 +100,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: json
-              - dot: .
-              - identifier: '`examples/src/main/resources/people.json`'
+              file_reference:
+                keyword: JSON
+                dot: .
+                identifier: '`examples/src/main/resources/people.json`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -125,10 +125,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: json
-              - dot: .
-              - identifier: '`examples/src/main/resources/people`'
+              file_reference:
+                keyword: JSON
+                dot: .
+                identifier: '`examples/src/main/resources/people`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -150,10 +150,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: text
-              - dot: .
-              - identifier: '`examples/src/main/resources/people.txt`'
+              file_reference:
+                keyword: TEXT
+                dot: .
+                identifier: '`examples/src/main/resources/people.txt`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -175,10 +175,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: text
-              - dot: .
-              - identifier: '`examples/src/main/resources/people.json`'
+              file_reference:
+                keyword: TEXT
+                dot: .
+                identifier: '`//root/*.txt`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -200,10 +200,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: binaryfile
-              - dot: .
-              - identifier: '`/events/events-kafka.json`'
+              file_reference:
+                keyword: TEXT
+                dot: .
+                identifier: '`//root/200?.txt`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -225,10 +225,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: binaryfile
-              - dot: .
-              - identifier: '`/events/events-kafka`'
+              file_reference:
+                keyword: TEXT
+                dot: .
+                identifier: '`//root/200[23].txt`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -250,10 +250,10 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: csv
-              - dot: .
-              - identifier: '`/sales/sales.csv`'
+              file_reference:
+                keyword: TEXT
+                dot: .
+                identifier: '`//root/200[^23].txt`'
 - statement_terminator: ;
 - base:
     select_statement:
@@ -275,8 +275,208 @@ file:
         from_expression:
           from_expression_element:
             table_expression:
-              table_reference:
-              - identifier: delta
-              - dot: .
-              - identifier: '`/mnt/datalake/table`'
+              file_reference:
+                keyword: TEXT
+                dot: .
+                identifier: '`//root/200[2-5].txt`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              file_reference:
+                keyword: TEXT
+                dot: .
+                identifier: '`//root/200[^2-5].txt`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              file_reference:
+                keyword: TEXT
+                dot: .
+                identifier: '`//root/200[^2-5].txt`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              file_reference:
+                keyword: TEXT
+                dot: .
+                identifier: '`//root/20{04, 05}.txt`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              file_reference:
+                keyword: TEXT
+                dot: .
+                identifier: '`examples/src/main/resources/people.json`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              file_reference:
+                file_format: BINARYFILE
+                dot: .
+                identifier: '`/events/events-kafka.json`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              file_reference:
+                file_format: BINARYFILE
+                dot: .
+                identifier: '`/events/events-kafka`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              file_reference:
+                keyword: CSV
+                dot: .
+                identifier: '`/sales/sales.csv`'
+- statement_terminator: ;
+- base:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              file_reference:
+                keyword: DELTA
+                dot: .
+                identifier: '`/mnt/datalake/table`'
 - statement_terminator: ;

--- a/test/fixtures/dialects/spark3/select_from_file.yml
+++ b/test/fixtures/dialects/spark3/select_from_file.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0a1df40992801c71346df1913666b0296bb870c41a36bbb9729fc121ab01b207
+_hash: aa188759fc7de79e364f0c5c76c8c99d4eb147e549e072fbd1d28afeb5555b32
 file:
 - base:
     select_statement:
@@ -279,31 +279,6 @@ file:
                 keyword: TEXT
                 dot: .
                 identifier: '`//root/200[2-5].txt`'
-- statement_terminator: ;
-- base:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-            identifier: a
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            identifier: b
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-            identifier: c
-      from_clause:
-        keyword: FROM
-        from_expression:
-          from_expression_element:
-            table_expression:
-              file_reference:
-                keyword: TEXT
-                dot: .
-                identifier: '`//root/200[^2-5].txt`'
 - statement_terminator: ;
 - base:
     select_statement:

--- a/test/fixtures/rules/std_rule_cases/L057.yml
+++ b/test/fixtures/rules/std_rule_cases/L057.yml
@@ -276,3 +276,67 @@ test_pass_single_quote2_bigquery:
     rules:
       L057:
         additional_allowed_characters: "-'."
+
+test_pass_dot_slash_identifier_in_file_reference_spark3:
+  pass_str:
+    SELECT a
+    FROM TEXT.`examples/src/main/resources/people.txt`
+  configs:
+    core:
+      dialect: spark3
+
+test_pass_star_identifier_in_file_reference_spark3:
+  pass_str:
+    SELECT a
+    FROM TEXT.`//root/*.txt`;
+  configs:
+    core:
+      dialect: spark3
+
+test_pass_question_mark_identifier_in_file_reference_spark3:
+  pass_str:
+    SELECT a
+    FROM TEXT.`//root/200?.txt`;
+  configs:
+    core:
+      dialect: spark3
+
+test_pass_character_class_identifier_in_file_reference_spark3:
+  pass_str:
+    SELECT a
+    FROM TEXT.`//root/200[23].txt`;
+  configs:
+    core:
+      dialect: spark3
+
+test_pass_negated_character_class_identifier_in_file_reference_spark3:
+  pass_str:
+    SELECT a
+    FROM TEXT.`//root/200[^23].txt`;
+  configs:
+    core:
+      dialect: spark3
+
+test_pass_character_range_identifier_in_file_reference_spark3:
+  pass_str:
+    SELECT a
+    FROM TEXT.`//root/200[2-5].txt`;
+  configs:
+    core:
+      dialect: spark3
+
+test_pass_negated_character_range_identifier_in_file_reference_spark3:
+  pass_str:
+    SELECT a
+    FROM TEXT.`//root/200[^2-5].txt`;
+  configs:
+    core:
+      dialect: spark3
+
+test_pass_alteration_identifier_in_file_reference_spark3:
+  pass_str:
+    SELECT a
+    FROM TEXT.`//root/20{04, 05}.txt`;
+  configs:
+    core:
+      dialect: spark3


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
- Adds support to directly query files of supported types.
- Fixes #602 

### Are there any other side effects of this change that we should be aware of?
- Reorganized some grammar for Files to isolate File keywords that support this clause.
- Removed "XML" File format. No test cases and requires additional work before it will parse correctly.


- Linting fails due to special characters in identifiers (L057). These special keywords are required so would be an exception to L057. I've not yet worked on rules so would appreciate any guidance on where to get started on fixing this particular bug.

```bash
> sqlfluff lint --dialect spark3 test/fixtures/dialects/spark3/select_from_file.sql
== [test/fixtures/dialects/spark3/select_from_file.sql] FAIL
L:   6 | P:  14 | L057 | Do not use special characters in identifiers.
L:  13 | P:  14 | L057 | Do not use special characters in identifiers.
L:  20 | P:  10 | L057 | Do not use special characters in identifiers.
L:  27 | P:  11 | L057 | Do not use special characters in identifiers.
L:  34 | P:  11 | L057 | Do not use special characters in identifiers.
L:  41 | P:  11 | L057 | Do not use special characters in identifiers.
L:  48 | P:  11 | L057 | Do not use special characters in identifiers.
L:  55 | P:  17 | L057 | Do not use special characters in identifiers.
L:  62 | P:  17 | L057 | Do not use special characters in identifiers.
L:  69 | P:  10 | L057 | Do not use special characters in identifiers.
L:  76 | P:  12 | L057 | Do not use special characters in identifiers.
All Finished 📜 🎉!
```

```bash
[L: 76, P:  6]      |                from_expression:
[L: 76, P:  6]      |                    [META] indent:
[L: 76, P:  6]      |                    from_expression_element:
[L: 76, P:  6]      |                        table_expression:
[L: 76, P:  6]      |                            file_reference:
[L: 76, P:  6]      |                                keyword:                      'DELTA'
[L: 76, P: 11]      |                                dot:                          '.'
[L: 76, P: 12]      |                                identifier:                   '`/mnt/datalake/table`'
[L: 76, P: 33]      |                    [META] dedent:
[L: 76, P: 33]      |    statement_terminator:                                     ';'
[L: 76, P: 34]      |    newline:                                                  '\n'
```

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
