### PR TITLE
jinja and dbt templaters: More robust handling of whitespace control

### DIFF
--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -354,6 +354,10 @@ class JinjaTracer:
                     # returns, it has simply grouped them differently than we
                     # want.
                     trailing_chars = len(m.group(0))
+                    if block_type.startswith("block_"):
+                        alternate_code = self._remove_block_whitespace_control(
+                            str_buff[:-trailing_chars]
+                        )
                     result.append(
                         RawFileSlice(
                             str_buff[:-trailing_chars],
@@ -377,6 +381,8 @@ class JinjaTracer:
                     self.raw_slice_info[result[-1]] = RawSliceInfo("", "", [])
                     idx += trailing_chars
                 else:
+                    if block_type.startswith("block_"):
+                        alternate_code = self._remove_block_whitespace_control(str_buff)
                     result.append(
                         RawFileSlice(
                             str_buff,
@@ -418,3 +424,17 @@ class JinjaTracer:
                     stack.pop()
                 str_buff = ""
         return result
+
+    @classmethod
+    def _remove_block_whitespace_control(cls, in_str: str) -> Optional[str]:
+        """Removes whitespace control from a Jinja fragment.
+
+        Use of Jinja whitespace stripping (e.g. `{%-` or `-%}`) causes the
+        template to produce less output. This makes JinjaTracer's job harder,
+        because it uses the "bread crumb trail" of output to deduce the
+        execution path through the template. This change has no impact on the
+        actual Jinja output, which uses the original, unmodified code.
+        """
+        result = regex.sub(r"^{%-", "{%", in_str)
+        result = regex.sub(r"-%}$", "%}", result)
+        return result if result != in_str else None

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -427,7 +427,7 @@ class JinjaTracer:
 
     @classmethod
     def _remove_block_whitespace_control(cls, in_str: str) -> Optional[str]:
-        """Removes whitespace control from a Jinja fragment.
+        """Removes whitespace control from a Jinja block start or end.
 
         Use of Jinja whitespace stripping (e.g. `{%-` or `-%}`) causes the
         template to produce less output. This makes JinjaTracer's job harder,

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -769,6 +769,33 @@ SELECT
                 ("literal", slice(92, 93, None), slice(30, 31, None)),
             ],
         ),
+        (
+            # Similar to the test above for issue 2541, but it's even trickier:
+            # whitespace control everywhere and NO NEWLINES or other characters
+            # between Jinja segments. In order to get a thorough-enough trace,
+            # JinjaTracer has to build the alternate template with whitespace
+            # control removed, as this increases the amount of trace output.
+            "{%- for x in ['A', 'B'] -%}"
+            "{%- if x == 'B' -%}"
+            "SELECT 'B';"
+            "{%- endif -%}"
+            "{%- if x == 'A' -%}"
+            "SELECT 'A';"
+            "{%- endif -%}"
+            "{%- endfor -%}",
+            None,
+            [
+                ("block_start", slice(0, 27, None), slice(0, 0, None)),
+                ("block_start", slice(27, 46, None), slice(0, 0, None)),
+                ("block_end", slice(57, 70, None), slice(0, 0, None)),
+                ("block_start", slice(70, 89, None), slice(0, 0, None)),
+                ("literal", slice(89, 100, None), slice(0, 11, None)),
+                ("block_end", slice(100, 113, None), slice(11, 11, None)),
+                ("block_end", slice(113, 127, None), slice(11, 11, None)),
+                ("block_start", slice(27, 46, None), slice(11, 11, None)),
+                ("literal", slice(46, 57, None), slice(11, 22, None)),
+            ],
+        ),
     ],
 )
 def test__templater_jinja_slice_file(raw_file, override_context, result, caplog):

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -552,26 +552,6 @@ select 1 from foobarfoobarfoobarfoobar_{{ "dev" }}
                 ("\n", "literal", 97),
             ],
         ),
-        (
-            # Tests issue 2541, a bug where the {%- endfor %} was causing
-            # IndexError: list index out of range.
-            """{% for x in ['A', 'B'] %}
-    {% if x != 'A' %}
-    SELECT 'E'
-    {% endif %}
-{%- endfor %}
-""",
-            [
-                ("{% for x in ['A', 'B'] %}", "block_start", 0),
-                ("\n    ", "literal", 25),
-                ("{% if x != 'A' %}", "block_start", 30),
-                ("\n    SELECT 'E'\n    ", "literal", 47),
-                ("{% endif %}", "block_end", 67),
-                ("\n", "literal", 78),
-                ("{%- endfor %}", "block_end", 79),
-                ("\n", "literal", 92),
-            ],
-        ),
     ],
 )
 def test__templater_jinja_slice_template(test, result):
@@ -760,6 +740,33 @@ SELECT
                 ("literal", slice(105, 111, None), slice(19, 25, None)),
                 ("templated", slice(111, 132, None), slice(25, 34, None)),
                 ("literal", slice(132, 133, None), slice(34, 35, None)),
+            ],
+        ),
+        (
+            # Tests issue 2541, a bug where the {%- endfor %} was causing
+            # IndexError: list index out of range.
+            """{% for x in ['A', 'B'] %}
+    {% if x != 'A' %}
+    SELECT 'E'
+    {% endif %}
+{%- endfor %}
+""",
+            None,
+            [
+                ("block_start", slice(0, 25, None), slice(0, 0, None)),
+                ("literal", slice(25, 30, None), slice(0, 5, None)),
+                ("block_start", slice(30, 47, None), slice(5, 5, None)),
+                ("literal", slice(47, 67, None), slice(5, 5, None)),
+                ("block_end", slice(67, 78, None), slice(5, 5, None)),
+                ("literal", slice(78, 79, None), slice(5, 5, None)),
+                ("block_end", slice(79, 92, None), slice(5, 5, None)),
+                ("literal", slice(25, 30, None), slice(5, 10, None)),
+                ("block_start", slice(30, 47, None), slice(10, 10, None)),
+                ("literal", slice(47, 67, None), slice(10, 30, None)),
+                ("block_end", slice(67, 78, None), slice(30, 30, None)),
+                ("literal", slice(78, 79, None), slice(30, 30, None)),
+                ("block_end", slice(79, 92, None), slice(30, 30, None)),
+                ("literal", slice(92, 93, None), slice(30, 31, None)),
             ],
         ),
     ],


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Followon to PR #2555 that fixes a likely source of future issues. That PR avoided the crash mentioned in issue #2541, but there's a deeper issue: when whitespace control is used, `JinjaTracer` gets less output from the "alternate template". If a user's SQL file makes extensive use of whitespace control, we may get so little output from the "alternate template" that `JinjaTracer._slice_template()` may deduce an execution path that doesn't reflect what actually happened. This PR fixes that by reviving our old trick of disabling whitespace control (but only in the invisible "alternate" template).

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
