### PR TITLE
Simple API: Fix bug where omitted parameters still override .sqlfluff

### DIFF
--- a/src/sqlfluff/api/simple.py
+++ b/src/sqlfluff/api/simple.py
@@ -11,26 +11,28 @@ from sqlfluff.core import (
 
 
 def get_simple_config(
-    dialect: str = "ansi",
+    dialect: Optional[str] = None,
     rules: Optional[List[str]] = None,
     exclude_rules: Optional[List[str]] = None,
     config_path: Optional[str] = None,
 ) -> FluffConfig:
     """Get a config object from simple API arguments."""
-    # Check the requested dialect exists and is valid.
-    try:
-        dialect_selector(dialect)
-    except SQLFluffUserError as err:  # pragma: no cover
-        raise SQLFluffUserError(f"Error loading dialect '{dialect}': {str(err)}")
-    except KeyError:
-        raise SQLFluffUserError(f"Error: Unknown dialect '{dialect}'")
-
     # Create overrides for simple API arguments.
-    overrides = {
-        "dialect": dialect,
-        "rules": ",".join(rules) if rules is not None else None,
-        "exclude_rules": ",".join(exclude_rules) if exclude_rules is not None else None,
-    }
+    overrides = {}
+    if dialect is not None:
+        # Check the requested dialect exists and is valid.
+        try:
+            dialect_selector(dialect)
+        except SQLFluffUserError as err:  # pragma: no cover
+            raise SQLFluffUserError(f"Error loading dialect '{dialect}': {str(err)}")
+        except KeyError:
+            raise SQLFluffUserError(f"Error: Unknown dialect '{dialect}'")
+
+        overrides["dialect"] = dialect
+    if rules is not None:
+        overrides["rules"] = ",".join(rules)
+    if exclude_rules is not None:
+        overrides["exclude_rules"] = ",".join(exclude_rules)
 
     # Instantiate a config object.
     try:

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -248,7 +248,7 @@ class AuthorizationSegment(BaseSegment):
 
     type = "authorization_segment"
 
-    match_grammar = AnyNumberOf(
+    match_grammar = AnySetOf(
         OneOf(
             Sequence(
                 "IAM_ROLE",
@@ -299,7 +299,7 @@ class ColumnAttributeSegment(BaseSegment):
 
     type = "column_attribute_segment"
 
-    match_grammar = AnyNumberOf(
+    match_grammar = AnySetOf(
         Sequence("DEFAULT", Ref("ExpressionSegment")),
         Sequence(
             "IDENTITY",
@@ -330,7 +330,7 @@ class ColumnConstraintSegment(BaseSegment):
 
     type = "column_constraint_segment"
 
-    match_grammar = AnyNumberOf(
+    match_grammar = AnySetOf(
         OneOf(Sequence("NOT", "NULL"), "NULL"),
         OneOf("UNIQUE", Sequence("PRIMARY", "KEY")),
         Sequence(
@@ -351,7 +351,7 @@ class TableAttributeSegment(BaseSegment):
 
     type = "table_constraint_segment"
 
-    match_grammar = AnyNumberOf(
+    match_grammar = AnySetOf(
         Sequence("DISTSTYLE", OneOf("AUTO", "EVEN", "KEY", "ALL"), optional=True),
         Sequence("DISTKEY", Bracketed(Ref("ColumnReferenceSegment")), optional=True),
         OneOf(
@@ -377,7 +377,7 @@ class TableConstraintSegment(BaseSegment):
 
     type = "table_constraint_segment"
 
-    match_grammar = AnyNumberOf(
+    match_grammar = AnySetOf(
         Sequence("UNIQUE", Bracketed(Delimited(Ref("ColumnReferenceSegment")))),
         Sequence(
             "PRIMARY",
@@ -796,7 +796,7 @@ class CreateLibraryStatementSegment(BaseSegment):
         "PLPYTHONU",
         "FROM",
         Ref("QuotedLiteralSegment"),
-        AnyNumberOf(
+        AnySetOf(
             Ref("AuthorizationSegment", optional=False),
             Sequence(
                 "REGION",
@@ -822,7 +822,7 @@ class UnloadStatementSegment(BaseSegment):
         Bracketed(Ref("QuotedLiteralSegment")),
         "TO",
         Ref("QuotedLiteralSegment"),
-        AnyNumberOf(
+        AnySetOf(
             Ref("AuthorizationSegment", optional=False),
             Sequence(
                 "REGION",
@@ -892,7 +892,7 @@ class UnloadStatementSegment(BaseSegment):
                 Ref("QuotedLiteralSegment"),
                 optional=True,
             ),
-            AnyNumberOf(
+            AnySetOf(
                 OneOf(
                     "MAXFILESIZE",
                     "ROWGROUPSIZE",
@@ -936,7 +936,7 @@ class CopyStatementSegment(BaseSegment):
         Ref("BracketedColumnReferenceListGrammar", optional=True),
         "FROM",
         Ref("QuotedLiteralSegment"),
-        AnyNumberOf(
+        AnySetOf(
             Ref("AuthorizationSegment", optional=False),
             Sequence(
                 "REGION",
@@ -1529,7 +1529,7 @@ class CreateUserSegment(BaseSegment):
         Ref.keyword("WITH", optional=True),
         "PASSWORD",
         OneOf(Ref("QuotedLiteralSegment"), "DISABLE"),
-        AnyNumberOf(
+        AnySetOf(
             OneOf(
                 "CREATEDB",
                 "NOCREATEDB",
@@ -1603,7 +1603,7 @@ class AlterUserSegment(BaseSegment):
         "USER",
         Ref("ObjectReferenceSegment"),
         Ref.keyword("WITH", optional=True),
-        AnyNumberOf(
+        AnySetOf(
             OneOf(
                 "CREATEDB",
                 "NOCREATEDB",

--- a/test/api/simple_test.py
+++ b/test/api/simple_test.py
@@ -1,7 +1,6 @@
 """Tests for simple use cases of the public api."""
 
 import json
-import pathlib
 
 import pytest
 
@@ -258,38 +257,28 @@ def test__api__config_path():
 
 
 @pytest.mark.parametrize(
-    "exclude_sqlfluff,kwargs,expected",
+    "kwargs,expected",
     [
         (
             # No override from API, so uses .sqlfluff value
-            "L027,L029",
             {},
             set(),
         ),
         (
             # API overrides, so it uses that
-            "L027,L029",
             dict(exclude_rules=["L027"]),
             {"L029"},
         ),
     ],
 )
-def test__api__config_override(exclude_sqlfluff, kwargs, expected, tmpdir):
+def test__api__config_override(kwargs, expected, tmpdir):
     """Test that parameters to lint() override .sqlfluff correctly (or not)."""
-    tmp_path = pathlib.Path(str(tmpdir))
-    config_path = tmp_path / ".sqlfluff"
-    with tmpdir.as_cwd():
-        config_path.write_text(
-            """[sqlfluff]
-exclude_rules = {}""".format(
-                exclude_sqlfluff
-            )
-        )
-        sql = "SELECT TRIM(name) AS name FROM some_table"
-        lint_results = sqlfluff.lint(sql, config_path=str(config_path), **kwargs)
-        assert expected == {"L027", "L029"}.intersection(
-            {lr["code"] for lr in lint_results}
-        )
+    config_path = "test/fixtures/api/config_override/.sqlfluff"
+    sql = "SELECT TRIM(name) AS name FROM some_table"
+    lint_results = sqlfluff.lint(sql, config_path=config_path, **kwargs)
+    assert expected == {"L027", "L029"}.intersection(
+        {lr["code"] for lr in lint_results}
+    )
 
 
 def test__api__invalid_dialect():

--- a/test/fixtures/api/config_override/.sqlfluff
+++ b/test/fixtures/api/config_override/.sqlfluff
@@ -1,0 +1,2 @@
+[sqlfluff]
+exclude_rules = L027,L029


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #2560
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
