### PR TITLE
Capitalization rules (L010, L014, L030, L040) should ignore templated code

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -260,7 +260,7 @@ class BaseSegment:
         # return [seg.raw_upper for seg in self.raw_segments]
 
     @cached_property
-    def templated(self) -> bool:
+    def is_templated(self) -> bool:
         """Returns True if the segment includes any templated code.
 
         This is a simple, very efficient check that doesn't require looking up

--- a/src/sqlfluff/rules/L003.py
+++ b/src/sqlfluff/rules/L003.py
@@ -72,7 +72,7 @@ class Rule_L003(BaseRule):
 
         # If it's whitespace, it might be a mixture of literal and templated
         # whitespace. Check for this.
-        if elem.is_type("whitespace") and elem.templated:
+        if elem.is_type("whitespace") and elem.is_templated:
             # Templated case: Find the leading *literal* whitespace.
             templated_file = elem.pos_marker.templated_file
             # Extract the leading literal whitespace, slice by slice.
@@ -142,7 +142,7 @@ class Rule_L003(BaseRule):
                 # newline that ended the *current* line was in templated space.
                 # Reason: We want to ignore indentation of lines that are not
                 # present in the raw (pre-templated) code.
-                templated_line = elem.templated
+                templated_line = elem.is_templated
                 indent_buffer = []
                 line_buffer = []
                 indent_size = 0

--- a/src/sqlfluff/rules/L010.py
+++ b/src/sqlfluff/rules/L010.py
@@ -83,6 +83,10 @@ class Rule_L010(BaseRule):
         if ignore_words_list and context.segment.raw.lower() in ignore_words_list:
             return LintResult(memory=context.memory)
 
+        # Skip if templated.
+        if context.segment.is_templated:
+            return LintResult(memory=context.memory)
+
         memory = context.memory
         refuted_cases = memory.get("refuted_cases", set())
 

--- a/test/fixtures/rules/std_rule_cases/L010.yml
+++ b/test/fixtures/rules/std_rule_cases/L010.yml
@@ -171,3 +171,9 @@ test_pass_ignore_words:
       L010:
         capitalisation_policy: upper
         ignore_words: select,from
+
+test_pass_ignore_templated_code:
+  pass_str: |
+    {{ "select" }} a
+    FROM foo
+    WHERE 1

--- a/test/fixtures/rules/std_rule_cases/L030.yml
+++ b/test/fixtures/rules/std_rule_cases/L030.yml
@@ -54,3 +54,9 @@ test_pass_ignore_word:
     rules:
       L030:
         ignore_words: min
+
+test_pass_ignore_templated_code:
+  pass_str: |
+    SELECT
+        {{ "greatest(a, b)" }},
+        GREATEST(i, j)


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #2565
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
