### PR TITLE
Postgres: Support expressions in arrays

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -438,29 +438,6 @@ class ArrayAccessorSegment(BaseSegment):
 
 
 @postgres_dialect.segment()
-class SimpleArrayContentsGrammar(BaseSegment):
-    """This Grammar is Literals in Square Brackets, comma delimited."""
-
-    type = "simple_array_contents_grammar"
-
-    match_grammar = Bracketed(Delimited(Ref("LiteralGrammar")), bracket_type="square")
-
-
-@postgres_dialect.segment(replace=True)
-class ArrayLiteralSegment(BaseSegment):
-    """Overwrites ANSI to allow for nested Arrays."""
-
-    type = "array_contents_grammar"
-
-    match_grammar = Sequence(
-        OneOf(
-            Ref("SimpleArrayContentsGrammar"),
-            Bracketed(Delimited(Ref("ArrayLiteralSegment")), bracket_type="square"),
-        )
-    )
-
-
-@postgres_dialect.segment()
 class DateTimeTypeIdentifier(BaseSegment):
     """Date Time Type."""
 

--- a/test/fixtures/dialects/postgres/postgres_array.sql
+++ b/test/fixtures/dialects/postgres/postgres_array.sql
@@ -48,3 +48,9 @@ SELECT array_position(ARRAY['sun','mon','tue','wed','thu','fri','sat'], 'mon');
 SELECT f1[1][-2][3] AS e1, f1[1][-1][5] AS e2
  FROM (SELECT '[1:1][-2:-1][3:5]={{{1,2,3},{4,5,6}}}'::int[] AS f1) AS ss;
 
+SELECT SUM(CASE
+        WHEN direction = 'forward' THEN unit
+        ELSE 0
+        END
+    ) * (MAX(ARRAY[id, vertical]))[2]
+FROM direction_with_vertical_change

--- a/test/fixtures/dialects/postgres/postgres_array.yml
+++ b/test/fixtures/dialects/postgres/postgres_array.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e0e5fbd827467af223ee59bf0f7beb727e454019bb71bdc712268dcf328f3e38
+_hash: b36104bc24392aeb07f4aa488f27cffcd046e7852b06d04df330144ff1f9a1ad
 file:
 - statement:
     select_statement:
@@ -12,22 +12,24 @@ file:
         select_clause_element:
           expression:
           - keyword: ARRAY
-          - array_contents_grammar:
-              simple_array_contents_grammar:
-              - start_square_bracket: '['
-              - literal: '1'
-              - comma: ','
-              - literal: '2'
-              - end_square_bracket: ']'
+          - array_literal:
+            - start_square_bracket: '['
+            - expression:
+                literal: '1'
+            - comma: ','
+            - expression:
+                literal: '2'
+            - end_square_bracket: ']'
           - binary_operator: '||'
           - keyword: ARRAY
-          - array_contents_grammar:
-              simple_array_contents_grammar:
-              - start_square_bracket: '['
-              - literal: '3'
-              - comma: ','
-              - literal: '4'
-              - end_square_bracket: ']'
+          - array_literal:
+            - start_square_bracket: '['
+            - expression:
+                literal: '3'
+            - comma: ','
+            - expression:
+                literal: '4'
+            - end_square_bracket: ']'
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -35,22 +37,26 @@ file:
         keyword: SELECT
         select_clause_element:
           keyword: ARRAY
-          array_contents_grammar:
+          array_literal:
           - start_square_bracket: '['
-          - array_contents_grammar:
-              simple_array_contents_grammar:
+          - expression:
+              array_literal:
               - start_square_bracket: '['
-              - literal: "'meeting'"
+              - expression:
+                  literal: "'meeting'"
               - comma: ','
-              - literal: "'lunch'"
+              - expression:
+                  literal: "'lunch'"
               - end_square_bracket: ']'
           - comma: ','
-          - array_contents_grammar:
-              simple_array_contents_grammar:
+          - expression:
+              array_literal:
               - start_square_bracket: '['
-              - literal: "'training'"
+              - expression:
+                  literal: "'training'"
               - comma: ','
-              - literal: "'presentation'"
+              - expression:
+                  literal: "'presentation'"
               - end_square_bracket: ']'
           - end_square_bracket: ']'
 - statement_terminator: ;
@@ -181,36 +187,43 @@ file:
             - comma: ','
             - scalar_value:
                 keyword: ARRAY
-                array_contents_grammar:
-                  simple_array_contents_grammar:
-                  - start_square_bracket: '['
-                  - literal: '10000'
-                  - comma: ','
-                  - literal: '10000'
-                  - comma: ','
-                  - literal: '10000'
-                  - comma: ','
-                  - literal: '10000'
-                  - end_square_bracket: ']'
+                array_literal:
+                - start_square_bracket: '['
+                - expression:
+                    literal: '10000'
+                - comma: ','
+                - expression:
+                    literal: '10000'
+                - comma: ','
+                - expression:
+                    literal: '10000'
+                - comma: ','
+                - expression:
+                    literal: '10000'
+                - end_square_bracket: ']'
             - comma: ','
             - scalar_value:
                 keyword: ARRAY
-                array_contents_grammar:
+                array_literal:
                 - start_square_bracket: '['
-                - array_contents_grammar:
-                    simple_array_contents_grammar:
+                - expression:
+                    array_literal:
                     - start_square_bracket: '['
-                    - literal: "'meeting'"
+                    - expression:
+                        literal: "'meeting'"
                     - comma: ','
-                    - literal: "'lunch'"
+                    - expression:
+                        literal: "'lunch'"
                     - end_square_bracket: ']'
                 - comma: ','
-                - array_contents_grammar:
-                    simple_array_contents_grammar:
+                - expression:
+                    array_literal:
                     - start_square_bracket: '['
-                    - literal: "'training'"
+                    - expression:
+                        literal: "'training'"
                     - comma: ','
-                    - literal: "'presentation'"
+                    - expression:
+                        literal: "'presentation'"
                     - end_square_bracket: ']'
                 - end_square_bracket: ']'
             - end_bracket: )
@@ -232,36 +245,43 @@ file:
             - comma: ','
             - scalar_value:
                 keyword: ARRAY
-                array_contents_grammar:
-                  simple_array_contents_grammar:
-                  - start_square_bracket: '['
-                  - literal: '20000'
-                  - comma: ','
-                  - literal: '25000'
-                  - comma: ','
-                  - literal: '25000'
-                  - comma: ','
-                  - literal: '25000'
-                  - end_square_bracket: ']'
+                array_literal:
+                - start_square_bracket: '['
+                - expression:
+                    literal: '20000'
+                - comma: ','
+                - expression:
+                    literal: '25000'
+                - comma: ','
+                - expression:
+                    literal: '25000'
+                - comma: ','
+                - expression:
+                    literal: '25000'
+                - end_square_bracket: ']'
             - comma: ','
             - scalar_value:
                 keyword: ARRAY
-                array_contents_grammar:
+                array_literal:
                 - start_square_bracket: '['
-                - array_contents_grammar:
-                    simple_array_contents_grammar:
+                - expression:
+                    array_literal:
                     - start_square_bracket: '['
-                    - literal: "'breakfast'"
+                    - expression:
+                        literal: "'breakfast'"
                     - comma: ','
-                    - literal: "'consulting'"
+                    - expression:
+                        literal: "'consulting'"
                     - end_square_bracket: ']'
                 - comma: ','
-                - array_contents_grammar:
-                    simple_array_contents_grammar:
+                - expression:
+                    array_literal:
                     - start_square_bracket: '['
-                    - literal: "'meeting'"
+                    - expression:
+                        literal: "'meeting'"
                     - comma: ','
-                    - literal: "'lunch'"
+                    - expression:
+                        literal: "'lunch'"
                     - end_square_bracket: ']'
                 - end_square_bracket: ']'
             - end_bracket: )
@@ -399,24 +419,27 @@ file:
               start_bracket: (
               expression:
               - keyword: ARRAY
-              - array_contents_grammar:
-                  simple_array_contents_grammar:
-                  - start_square_bracket: '['
-                  - literal: '1'
-                  - comma: ','
-                  - literal: '2'
-                  - end_square_bracket: ']'
+              - array_literal:
+                - start_square_bracket: '['
+                - expression:
+                    literal: '1'
+                - comma: ','
+                - expression:
+                    literal: '2'
+                - end_square_bracket: ']'
               - binary_operator: '||'
               - keyword: ARRAY
-              - array_contents_grammar:
-                  simple_array_contents_grammar:
-                  - start_square_bracket: '['
-                  - literal: '3'
-                  - comma: ','
-                  - literal: '4'
-                  - comma: ','
-                  - literal: '5'
-                  - end_square_bracket: ']'
+              - array_literal:
+                - start_square_bracket: '['
+                - expression:
+                    literal: '3'
+                - comma: ','
+                - expression:
+                    literal: '4'
+                - comma: ','
+                - expression:
+                    literal: '5'
+                - end_square_bracket: ']'
               end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -431,31 +454,36 @@ file:
               start_bracket: (
               expression:
               - keyword: ARRAY
-              - array_contents_grammar:
-                  simple_array_contents_grammar:
-                  - start_square_bracket: '['
-                  - literal: '1'
-                  - comma: ','
-                  - literal: '2'
-                  - end_square_bracket: ']'
+              - array_literal:
+                - start_square_bracket: '['
+                - expression:
+                    literal: '1'
+                - comma: ','
+                - expression:
+                    literal: '2'
+                - end_square_bracket: ']'
               - binary_operator: '||'
               - keyword: ARRAY
-              - array_contents_grammar:
+              - array_literal:
                 - start_square_bracket: '['
-                - array_contents_grammar:
-                    simple_array_contents_grammar:
+                - expression:
+                    array_literal:
                     - start_square_bracket: '['
-                    - literal: '3'
+                    - expression:
+                        literal: '3'
                     - comma: ','
-                    - literal: '4'
+                    - expression:
+                        literal: '4'
                     - end_square_bracket: ']'
                 - comma: ','
-                - array_contents_grammar:
-                    simple_array_contents_grammar:
+                - expression:
+                    array_literal:
                     - start_square_bracket: '['
-                    - literal: '5'
+                    - expression:
+                        literal: '5'
                     - comma: ','
-                    - literal: '6'
+                    - expression:
+                        literal: '6'
                     - end_square_bracket: ']'
                 - end_square_bracket: ']'
               end_bracket: )
@@ -467,13 +495,14 @@ file:
         select_clause_element:
           expression:
             keyword: ARRAY
-            array_contents_grammar:
-              simple_array_contents_grammar:
-              - start_square_bracket: '['
-              - literal: '1'
-              - comma: ','
-              - literal: '2'
-              - end_square_bracket: ']'
+            array_literal:
+            - start_square_bracket: '['
+            - expression:
+                literal: '1'
+            - comma: ','
+            - expression:
+                literal: '2'
+            - end_square_bracket: ']'
             binary_operator: '||'
             literal: "'{3, 4}'"
 - statement_terminator: ;
@@ -489,23 +518,29 @@ file:
             - start_bracket: (
             - expression:
                 keyword: ARRAY
-                array_contents_grammar:
-                  simple_array_contents_grammar:
-                  - start_square_bracket: '['
-                  - literal: "'sun'"
-                  - comma: ','
-                  - literal: "'mon'"
-                  - comma: ','
-                  - literal: "'tue'"
-                  - comma: ','
-                  - literal: "'wed'"
-                  - comma: ','
-                  - literal: "'thu'"
-                  - comma: ','
-                  - literal: "'fri'"
-                  - comma: ','
-                  - literal: "'sat'"
-                  - end_square_bracket: ']'
+                array_literal:
+                - start_square_bracket: '['
+                - expression:
+                    literal: "'sun'"
+                - comma: ','
+                - expression:
+                    literal: "'mon'"
+                - comma: ','
+                - expression:
+                    literal: "'tue'"
+                - comma: ','
+                - expression:
+                    literal: "'wed'"
+                - comma: ','
+                - expression:
+                    literal: "'thu'"
+                - comma: ','
+                - expression:
+                    literal: "'fri'"
+                - comma: ','
+                - expression:
+                    literal: "'sat'"
+                - end_square_bracket: ']'
             - comma: ','
             - expression:
                 literal: "'mon'"
@@ -579,3 +614,69 @@ file:
               keyword: AS
               identifier: ss
 - statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            function:
+              function_name:
+                function_name_identifier: SUM
+              bracketed:
+                start_bracket: (
+                expression:
+                  case_expression:
+                  - keyword: CASE
+                  - when_clause:
+                    - keyword: WHEN
+                    - expression:
+                        column_reference:
+                          identifier: direction
+                        comparison_operator:
+                          raw_comparison_operator: '='
+                        literal: "'forward'"
+                    - keyword: THEN
+                    - expression:
+                        column_reference:
+                          identifier: unit
+                  - else_clause:
+                      keyword: ELSE
+                      expression:
+                        literal: '0'
+                  - keyword: END
+                end_bracket: )
+            binary_operator: '*'
+            bracketed:
+              start_bracket: (
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: MAX
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      keyword: ARRAY
+                      array_literal:
+                      - start_square_bracket: '['
+                      - expression:
+                          column_reference:
+                            identifier: id
+                      - comma: ','
+                      - expression:
+                          column_reference:
+                            identifier: vertical
+                      - end_square_bracket: ']'
+                    end_bracket: )
+              end_bracket: )
+            array_accessor:
+              start_square_bracket: '['
+              literal: '2'
+              end_square_bracket: ']'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: direction_with_vertical_change

--- a/test/fixtures/dialects/postgres/postgres_datatypes.yml
+++ b/test/fixtures/dialects/postgres/postgres_datatypes.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 83c03a52f51f850655eaee86a6852f5467231783feb962f0d766d325d2e826c9
+_hash: 06cbe08b85a8adb092da007496aaf19e61895a9071b04a70609953e0139e7b72
 file:
 - statement:
     create_table_statement:
@@ -679,11 +679,11 @@ file:
       - data_type:
         - keyword: money
         - keyword: ARRAY
-        - array_contents_grammar:
-            simple_array_contents_grammar:
-              start_square_bracket: '['
+        - array_literal:
+            start_square_bracket: '['
+            expression:
               literal: '7'
-              end_square_bracket: ']'
+            end_square_bracket: ']'
       - end_bracket: )
 - statement_terminator: ;
 - statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #2036 

### Are there any other side effects of this change that we should be aware of?
Not sure why Postgres overrode the ansi definition. It says it was to allow nested arrays, but they are supported with ANSI. Looks like @WittierDinosaur added this in #1722 but I don't think it's necessary.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
