### PR TITLE
Support indenting WINDOWS clauses and (optionally) CTEs

### DIFF
--- a/docs/source/indentation.rst
+++ b/docs/source/indentation.rst
@@ -186,7 +186,7 @@ Then the expected indentation will be:
          USING(a)
 
 However if no value for :code:`indented_joins` is set, or if it is set to
-:code:`false` then then following indentation will be expected:
+:code:`False` then then following indentation will be expected:
 
 .. code-block:: sql
 
@@ -196,8 +196,8 @@ However if no value for :code:`indented_joins` is set, or if it is set to
    JOIN another_table
       USING(a)
 
-There is a similar :code:`indented_using_on` config (defaulted to :code:`true`)
-which can be set to :code:`false` to prevent the :code:`using` clause from
+There is a similar :code:`indented_using_on` config (defaulted to :code:`True`)
+which can be set to :code:`False` to prevent the :code:`using` clause from
 being indented, in which case above SQL would become:
 
 .. code-block:: sql
@@ -208,6 +208,27 @@ being indented, in which case above SQL would become:
    JOIN another_table
    USING(a)
 
+There is also a similar :code:`indented_ctes` config (defaulted to
+:code:`False`) which can be set to :code:`True` to enforce CTEs to be
+indented within the :code:`WITH` clause:
+
+.. code-block:: sql
+
+   WITH
+      some_cte AS (
+         SELECT 1 FROM table1
+      ),
+
+      some_other_cte AS (
+         SELECT 1 FROM table1
+      )
+
+   SELECT 1 FROM some_cte
+
+Note that using :code:`indented_ctes` may clash with `Rule L018`_ (`"WITH
+clause closing bracket should be aligned with WITH keyword."``), so if using
+this option you will likely want to disable that rule.
+
 By default, *SQLFluff* aims to follow the indentation most common approach
 to indentation. However, if you have other versions of indentation which are
 supported by published style guides, then please submit an issue on GitHub
@@ -216,3 +237,4 @@ to have that variation supported by *SQLFluff*.
 .. _`dbt Labs SQL style guide`: https://github.com/dbt-labs/corp/blob/master/dbt_style_guide.md
 .. _`Mozilla SQL style guide`: https://docs.telemetry.mozilla.org/concepts/sql_style.html#joins
 .. _`Baron Schwartz`: https://www.xaprb.com/blog/2006/04/26/sql-coding-standards/
+.. _`Rule L018`: ./rules.html#sqlfluff.core.rules.Rule_L018

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -38,6 +38,7 @@ fix_even_unparsable = False
 [sqlfluff:indentation]
 # See https://docs.sqlfluff.com/en/stable/indentation.html
 indented_joins = False
+indented_ctes = False
 indented_using_on = True
 template_blocks_indent = True
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2012,9 +2012,11 @@ class NamedWindowSegment(BaseSegment):
     type = "named_window"
     match_grammar = Sequence(
         "WINDOW",
+        Indent,
         Delimited(
             Ref("NamedWindowExpressionSegment"),
         ),
+        Dedent,
     )
 
 
@@ -2208,10 +2210,12 @@ class WithCompoundStatementSegment(BaseSegment):
     parse_grammar = Sequence(
         "WITH",
         Ref.keyword("RECURSIVE", optional=True),
+        Conditional(Indent, indented_ctes=True),
         Delimited(
             Ref("CTEDefinitionSegment"),
             terminator=Ref.keyword("SELECT"),
         ),
+        Conditional(Dedent, indented_ctes=True),
         OneOf(
             Ref("NonWithSelectableGrammar"),
             Ref("NonWithNonSelectableGrammar"),

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -23,6 +23,7 @@ from sqlfluff.core.parser import (
     AnyNumberOf,
     CommentSegment,
     SegmentGenerator,
+    Conditional,
 )
 
 from sqlfluff.core.dialects import load_raw_dialect
@@ -592,10 +593,12 @@ class WithCompoundStatementSegment(BaseSegment):
     match_grammar = Sequence(
         "WITH",
         Ref.keyword("RECURSIVE", optional=True),
+        Conditional(Indent, indented_ctes=True),
         Delimited(
             Ref("CTEDefinitionSegment"),
             terminator=Ref.keyword("SELECT"),
         ),
+        Conditional(Dedent, indented_ctes=True),
         OneOf(
             Ref("NonWithSelectableGrammar"),
             Ref("NonWithNonSelectableGrammar"),

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -405,8 +405,8 @@ test_jinja_nested_blocks:
     )
     SELECT 1
 
-# LIMIT and QUALIFY both indent
-test_limit_and_qualify_indent:
+# LIMIT, QUALIFY, and WINDOW both indent
+test_limit_and_qualify_and_window_indent:
   fail_str: |
     SELECT
         a,
@@ -417,6 +417,8 @@ test_limit_and_qualify_indent:
     1
     LIMIT
     1
+    WINDOW
+    some_window AS (PARTITION BY 1)
   fix_str: |
     SELECT
         a,
@@ -427,12 +429,14 @@ test_limit_and_qualify_indent:
         1
     LIMIT
         1
+    WINDOW
+        some_window AS (PARTITION BY 1)
   configs:
     core:
       dialect: bigquery
 
-# LIMIT and QUALIFY both acceptable on single line
-test_limit_and_qualify_single_line:
+# LIMIT, QUALIFY and WINDOW both acceptable on single line
+test_limit_and_qualify_and_window_single_line:
   pass_str: |
     SELECT
         a,
@@ -441,9 +445,57 @@ test_limit_and_qualify_single_line:
         my_tbl
     QUALIFY 1
     LIMIT 1
+    WINDOW some_window AS (PARTITION BY 1)
   configs:
     core:
       dialect: bigquery
+
+# By default CTEs should not be indented
+test_pass_cte:
+  pass_str: |
+    WITH
+    some_cte AS (
+        SELECT 1 FROM table1
+    ),
+
+    some_other_cte AS (
+        SELECT 1 FROM table1
+    )
+
+    SELECT 1 FROM table1
+  configs:
+    core:
+      dialect: bigquery
+
+# CTEs can be configured to be indented
+test_fail_indented_cte:
+  fail_str: |
+    WITH
+    some_cte AS (
+        SELECT 1 FROM table1
+    ),
+
+    some_other_cte AS (
+        SELECT 1 FROM table1
+    )
+
+    SELECT 1 FROM table1
+  pass_str: |
+    WITH
+        some_cte AS (
+            SELECT 1 FROM table1
+        ),
+
+        some_other_cte AS (
+            SELECT 1 FROM table1
+        )
+
+    SELECT 1 FROM table1
+  configs:
+    core:
+      dialect: bigquery
+    indentation:
+      indented_ctes: true
 
 # Exasol LUA script
 test_exasol_script:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #2600

### Are there any other side effects of this change that we should be aware of?
WINDOWS clauses will now indent (similar to other main clauses) which may cause some extra rules to flag for those that don't indent them.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
