### PR TITLE
MySQL Add BINARY support

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -193,6 +193,7 @@ mysql_dialect.replace(
         Ref.keyword("KEY", optional=True),
     ),
     # Odd syntax, but pr
+    CharCharacterSetSegment=Ref.keyword("BINARY"),
 )
 
 mysql_dialect.add(

--- a/test/fixtures/dialects/mysql/create_table.sql
+++ b/test/fixtures/dialects/mysql/create_table.sql
@@ -1,4 +1,5 @@
 CREATE TABLE `foo` (
+  b VARCHAR(255) BINARY,
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/test/fixtures/dialects/mysql/create_table.yml
+++ b/test/fixtures/dialects/mysql/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 01500ad217b7b1edea1858dbc6e283a8e78c31337a666c2af3c94a466fcf9c14
+_hash: b112f8616e59e95d286cf8e894bca3dc4379cd9aff40996b57fb04b2ed4d879a
 file:
   statement:
     create_table_statement:
@@ -12,8 +12,19 @@ file:
     - table_reference:
         identifier: '`foo`'
     - bracketed:
-        start_bracket: (
-        column_definition:
+      - start_bracket: (
+      - column_definition:
+          identifier: b
+          data_type:
+            data_type_identifier: VARCHAR
+            bracketed:
+              start_bracket: (
+              expression:
+                literal: '255'
+              end_bracket: )
+            keyword: BINARY
+      - comma: ','
+      - column_definition:
         - identifier: '`id`'
         - data_type:
             data_type_identifier: int
@@ -29,8 +40,8 @@ file:
           - keyword: 'NULL'
         - column_constraint_segment:
             keyword: AUTO_INCREMENT
-        comma: ','
-        table_constraint_segment:
+      - comma: ','
+      - table_constraint_segment:
         - keyword: PRIMARY
         - keyword: KEY
         - bracketed:
@@ -38,7 +49,7 @@ file:
             column_reference:
               identifier: '`id`'
             end_bracket: )
-        end_bracket: )
+      - end_bracket: )
     - parameter: ENGINE
     - comparison_operator:
         raw_comparison_operator: '='


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #2496 by reusing the `CharCharacterSetSegment` segment introduced for Exasol

### Are there any other side effects of this change that we should be aware of?
Nope.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
