### PR TITLE
Add Oracle at and double at sign (execution symbol)

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -31,19 +31,18 @@ oracle_dialect.insert_lexer_matchers(
             r"PROMPT([^(\r\n)])*((?=\n)|(?=\r\n))?",
             CommentSegment,
         ),
-        #RegexLexer(
-        #    "execution_sign",
-        #    r"^@@(?i).*\.sql(\s)(.*)$",
-        #    CodeSegment
-        #)
+        RegexLexer(
+            "double_execution_sign",
+            r"@@([^(\r\n)])*((?=\n)|(?=\r\n))?",
+           CommentSegment, 
+        ),
+        RegexLexer(
+            "execution_sign",
+            r"@@([^(\r\n)])*((?=\n)|(?=\r\n))?",
+           CommentSegment, 
+        )
     ],
     before="code",
-)
-
-oracle_dialect.add(
-    ExecutionSegment=RegexParser(
-        r"^@@(?i).*\.sql(\s)(.*)$", CodeSegment, name="execution_symbol", type="execution_symbol"
-    ),
 )
 
 

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -5,9 +5,11 @@ This inherits from the ansi dialect.
 from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
     BaseSegment,
+    CodeSegment,
     CommentSegment,
     Ref,
     RegexLexer,
+    RegexParser,
     Sequence,
     StartsWith,
     OneOf,
@@ -28,9 +30,20 @@ oracle_dialect.insert_lexer_matchers(
             "prompt_command",
             r"PROMPT([^(\r\n)])*((?=\n)|(?=\r\n))?",
             CommentSegment,
-        )
+        ),
+        #RegexLexer(
+        #    "execution_sign",
+        #    r"^@@(?i).*\.sql(\s)(.*)$",
+        #    CodeSegment
+        #)
     ],
     before="code",
+)
+
+oracle_dialect.add(
+    ExecutionSegment=RegexParser(
+        r"^@@(?i).*\.sql(\s)(.*)$", CodeSegment, name="execution_symbol", type="execution_symbol"
+    ),
 )
 
 

--- a/test/fixtures/dialects/oracle/double_at.sql
+++ b/test/fixtures/dialects/oracle/double_at.sql
@@ -1,0 +1,3 @@
+@@some_other_sql_file.sql
+@@some_other_sql_file_with_args.sql foo bar baz
+SELECT * from some_table;

--- a/test/fixtures/dialects/oracle/double_at.yml
+++ b/test/fixtures/dialects/oracle/double_at.yml
@@ -1,0 +1,23 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 40bf5dac2e67ec85570b43e40d2b240ff7b126eea65cfe3254bce71284473ccf
+file:
+  statement:
+    unparsable:
+    - unlexable: '@@some_other_sql_file'
+    - raw: .
+    - raw: sql
+    - unlexable: '@@some_other_sql_file_with_args'
+    - raw: .
+    - raw: sql
+    - raw: foo
+    - raw: bar
+    - raw: baz
+    - raw: SELECT
+    - raw: '*'
+    - raw: from
+    - raw: some_table
+  statement_terminator: ;


### PR DESCRIPTION
### Summary
This adds support for the Oracle `@` and `@@` syntax. This is only "loosely" supported at this time, namely it treats these like comments, so they aren't invalid, but won't really benefit from full on parsing/validation at this point. However, it's an improvement versus having these appear invalid altogether.