### PR TITLE
TSQL: Indent IF clause expression segments

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1330,7 +1330,10 @@ class IfClauseSegment(BaseSegment):
     type = "if_clause"
 
     match_grammar = Sequence(
-        "IF", Indent, Ref("ExpressionSegment"), Dedent,
+        "IF",
+        Indent,
+        Ref("ExpressionSegment"),
+        Dedent,
     )
 
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1329,10 +1329,8 @@ class IfClauseSegment(BaseSegment):
 
     type = "if_clause"
 
-    match_grammar = OneOf(
-        Sequence(Ref("IfNotExistsGrammar"), Ref("SelectStatementSegment")),
-        Sequence(Ref("IfExistsGrammar"), Ref("SelectStatementSegment")),
-        Sequence("IF", Ref("ExpressionSegment")),
+    match_grammar = Sequence(
+        "IF", Indent, Ref("ExpressionSegment"), Dedent,
     )
 
 

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -754,3 +754,12 @@ test_pass_tsql_set_indent_multiple_params:
   configs:
     core:
       dialect: tsql
+
+test_pass_tsql_if_indent:
+  pass_str: |
+    IF 1 > 1 AND
+        2 < 2
+        SELECT 1;
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
### Brief summary of the change made
Adding indentation tags for the expression statements within an IF for the TSQL dialect.  Additionally, removed redundant options within the if clause.

### Are there any other side effects of this change that we should be aware of?
None.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
