### PR TITLE
Ensure ordering of fix compatible and config in rules docs

### DIFF
--- a/src/sqlfluff/core/rules/doc_decorators.py
+++ b/src/sqlfluff/core/rules/doc_decorators.py
@@ -69,10 +69,15 @@ def document_configuration(cls, ruleset="std"):
         return cls
     # Add final blank line
     config_doc += "\n"
-    # Match `**Anti-pattern**`, then insert configuration before the first occurrences
-    pattern = re.compile("(\\s{4}\\*\\*Anti-pattern\\*\\*)", flags=re.MULTILINE)
 
-    cls.__doc__ = pattern.sub(f"\n{config_doc}\n\\1", cls.__doc__, count=1)
+    if "**Anti-pattern**" in cls.__doc__:
+        # Match `**Anti-pattern**`, then insert configuration before the first occurrences
+        pattern = re.compile("(\\s{4}\\*\\*Anti-pattern\\*\\*)", flags=re.MULTILINE)
+        cls.__doc__ = pattern.sub(f"\n{config_doc}\n\\1", cls.__doc__, count=1)
+    else:
+        # Match last `\n` or `.`, then append configuration
+        pattern = re.compile("(\\.|\\n)$", flags=re.MULTILINE)
+        cls.__doc__ = pattern.sub(f"\\1\n{config_doc}\n", cls.__doc__, count=1)
     return cls
 
 

--- a/src/sqlfluff/core/rules/doc_decorators.py
+++ b/src/sqlfluff/core/rules/doc_decorators.py
@@ -2,6 +2,7 @@
 
 from sqlfluff.core.rules.config_info import get_config_info
 from sqlfluff.core.rules.base import rules_logger  # noqa
+import re
 
 
 FIX_COMPATIBLE = "    This rule is ``sqlfluff fix`` compatible."
@@ -9,7 +10,14 @@ FIX_COMPATIBLE = "    This rule is ``sqlfluff fix`` compatible."
 
 def document_fix_compatible(cls):
     """Mark the rule as fixable in the documentation."""
-    cls.__doc__ = cls.__doc__.replace("\n", f"\n\n{FIX_COMPATIBLE}\n\n", 1)
+    # Match `**Anti-pattern**`, `.. note::` and `**Configuration**`,
+    # then insert fix_compatible before the first occurrences.
+    # We match `**Configuration**` here to make it work in all order of doc decorators
+    pattern = re.compile(
+        "(\\s{4}\\*\\*Anti-pattern\\*\\*|\\s{4}\\.\\. note::|\\s{4}\\*\\*Configuration\\*\\*)",
+        flags=re.MULTILINE,
+    )
+    cls.__doc__ = pattern.sub(f"\n\n{FIX_COMPATIBLE}\n\n\\1", cls.__doc__, count=1)
     return cls
 
 
@@ -60,12 +68,10 @@ def document_configuration(cls, ruleset="std"):
         return cls
     # Add final blank line
     config_doc += "\n"
-    # Add the configuration section immediately after the class description
-    # docstring by inserting after the first line break, or first period,
-    # if there is no line break.
-    end_of_class_description = "." if "\n" not in cls.__doc__ else "\n"
+    # Match `**Anti-pattern**`, then insert configuration before the first occurrences
+    pattern = re.compile("(\\s{4}\\*\\*Anti-pattern\\*\\*)", flags=re.MULTILINE)
 
-    cls.__doc__ = cls.__doc__.replace(end_of_class_description, "\n" + config_doc, 1)
+    cls.__doc__ = pattern.sub(f"\n{config_doc}\n\\1", cls.__doc__, count=1)
     return cls
 
 

--- a/src/sqlfluff/core/rules/doc_decorators.py
+++ b/src/sqlfluff/core/rules/doc_decorators.py
@@ -71,7 +71,8 @@ def document_configuration(cls, ruleset="std"):
     config_doc += "\n"
 
     if "**Anti-pattern**" in cls.__doc__:
-        # Match `**Anti-pattern**`, then insert configuration before the first occurrences
+        # Match `**Anti-pattern**`, then insert configuration before
+        # the first occurrences
         pattern = re.compile("(\\s{4}\\*\\*Anti-pattern\\*\\*)", flags=re.MULTILINE)
         cls.__doc__ = pattern.sub(f"\n{config_doc}\n\\1", cls.__doc__, count=1)
     else:

--- a/src/sqlfluff/core/rules/doc_decorators.py
+++ b/src/sqlfluff/core/rules/doc_decorators.py
@@ -14,7 +14,8 @@ def document_fix_compatible(cls):
     # then insert fix_compatible before the first occurrences.
     # We match `**Configuration**` here to make it work in all order of doc decorators
     pattern = re.compile(
-        "(\\s{4}\\*\\*Anti-pattern\\*\\*|\\s{4}\\.\\. note::|\\s{4}\\*\\*Configuration\\*\\*)",
+        "(\\s{4}\\*\\*Anti-pattern\\*\\*|\\s{4}\\.\\. note::|"
+        "\\s{4}\\*\\*Configuration\\*\\*)",
         flags=re.MULTILINE,
     )
     cls.__doc__ = pattern.sub(f"\n\n{FIX_COMPATIBLE}\n\n\\1", cls.__doc__, count=1)


### PR DESCRIPTION
### Brief summary of the change made

This patch try to strict the order of rule's hand
writing docstring, fix_compatible, note, Configuration
and example pattern.

* Rule's hand writing docstring(expect example pattern
  and note) is always in the fist place
* (Optional) Fix compatible in the second place
* (Optional) Note in the third place
* (Optional) Configuration in the fourth place
* Example pattern would always in the tail

### Are there any other side effects of this change that we should be aware of?

It is compatible all orders of doc decorators

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
