### PR TITLE
Snowflake dialect: Adjust snowflake array access

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -778,7 +778,13 @@ class SemiStructuredAccessorSegment(BaseSegment):
 
     type = "snowflake_semi_structured_expression"
     match_grammar = Sequence(
-        Ref("ColonSegment"),
+        OneOf(
+            # If a field is already a VARIANT, this could
+            # be initiated by a colon or a dot. This is particularly
+            # useful when a field is an ARRAY of objects.
+            Ref("DotSegment"),
+            Ref("ColonSegment"),
+        ),
         OneOf(
             Ref("NakedSemiStructuredElementSegment"),
             Ref("QuotedSemiStructuredElementSegment"),
@@ -795,9 +801,9 @@ class SemiStructuredAccessorSegment(BaseSegment):
                     Ref("NakedSemiStructuredElementSegment"),
                     Ref("QuotedSemiStructuredElementSegment"),
                 ),
-                Ref("ArrayAccessorSegment", optional=True),
                 allow_gaps=True,
             ),
+            Ref("ArrayAccessorSegment", optional=True),
             allow_gaps=True,
         ),
         allow_gaps=True,

--- a/test/fixtures/dialects/snowflake/snowflake_semi_structured.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_semi_structured.sql
@@ -5,5 +5,6 @@ SELECT
     value:id::bigint AS field_id,
     value:value::STRING AS field_val,
     value:thing[4].foo AS another_val,
-    value:thing[4].bar.baz[0].foo::bigint AS another_val
+    value:thing[4].bar.baz[0].foo::bigint AS another_val,
+    array_field[0].array_element_property as test_array_access
 FROM raw_tickets, lateral flatten(INPUT => custom_fields)

--- a/test/fixtures/dialects/snowflake/snowflake_semi_structured.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_semi_structured.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9836b4842aa75048c7da6d4d88487fed192e81f0483348796f52a031c66827d2
+_hash: 5edf576bf2b089e36689be217a273c1e9ce34b374a32e4b5357c38640ab70eb8
 file:
   statement:
     select_statement:
@@ -99,6 +99,21 @@ file:
           alias_expression:
             keyword: AS
             identifier: another_val
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              identifier: array_field
+            array_accessor:
+              start_square_bracket: '['
+              literal: '0'
+              end_square_bracket: ']'
+            snowflake_semi_structured_expression:
+              dot: .
+              semi_structured_element: array_element_property
+          alias_expression:
+            keyword: as
+            identifier: test_array_access
       from_clause:
       - keyword: FROM
       - from_expression:


### PR DESCRIPTION
I found a bug in the snowflake dialect when accessing arrays of objects. This allows direct access of semi structured data within an array, a la: `my_array[1].some_attribute` which currently raises a parsing error.