### PR TITLE
L023 to also fix extra newlines in CTE

### DIFF
--- a/test/fixtures/rules/std_rule_cases/L023.yml
+++ b/test/fixtures/rules/std_rule_cases/L023.yml
@@ -1,6 +1,41 @@
 rule: L023
 
 test_fail_cte_no_space_after_as:
-  # Check fixing of single space rules
+  # Check fixing of single space rule when space is missing
   fail_str: WITH a AS(select 1) select * from a
   fix_str: WITH a AS (select 1) select * from a
+
+test_fail_multiple_spaces_after_as:
+  # Check fixing of single space rule on multiple spaces
+  fail_str: WITH a AS  (select 1) select * from a
+  fix_str: WITH a AS (select 1) select * from a
+
+test_fail_cte_newline_after_as:
+  # Check fixing of replacing newline with space
+  fail_str: |
+    WITH a AS
+    (
+      select 1
+    )
+    select * from a
+  fix_str: |
+    WITH a AS (
+      select 1
+    )
+    select * from a
+
+test_fail_cte_newline_and_spaces_after_as:
+  # Check stripping newlines and extra whitespace
+  fail_str: |
+    WITH a AS
+
+
+        (
+      select 1
+    )
+    select * from a
+  fix_str: |
+    WITH a AS (
+      select 1
+    )
+    select * from a


### PR DESCRIPTION
### Brief summary of the change made

fixes https://github.com/sqlfluff/sqlfluff/issues/2617

### Are there any other side effects of this change that we should be aware of?

No.

Any amount of whitespace & newlines are now covered.

Caveats:
- At least a comment section between `AS` and `(` can result in an unfixable error.
- postgres dialect seems to have some extensions to the CTE syntax. Some of those dialect specific cases may not be still fixable after this change.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
