### PR TITLE
Allow file output directly from cli

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -506,7 +506,7 @@ def lint(
 
     """
     config = get_config(extra_config_path, ignore_local_config, **kwargs)
-    non_human_output = (format != FormatType.human.value) or write_output
+    non_human_output = (format != FormatType.human.value) or (write_output is not None)
     file_output = None
     lnt, formatter = get_linter_and_formatter(config, silent=non_human_output)
 
@@ -938,7 +938,7 @@ def parse(
     c = get_config(extra_config_path, ignore_local_config, **kwargs)
     # We don't want anything else to be logged if we want json or yaml output
     # unless we're writing to a file.
-    non_human_output = (format != FormatType.human.value) or write_output
+    non_human_output = (format != FormatType.human.value) or (write_output is not None)
     file_output = None
     lnt, formatter = get_linter_and_formatter(c, silent=non_human_output)
     verbose = c.get("verbose")

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -418,6 +418,17 @@ def dialects(**kwargs) -> None:
     click.echo(format_dialects(dialect_readout), color=c.get("color"))
 
 
+def dump_file_payload(out_file: Optional[str], payload: str):
+    """Write the output file content to stdout or file."""
+    # If there's a file specified to write to, write to it.
+    if out_file:
+        with open(out_file, "w") as out_file:
+            out_file.write(payload)
+    # Otherwise write to stdout
+    else:
+        click.echo(payload)
+
+
 @cli.command()
 @common_options
 @core_options
@@ -571,13 +582,7 @@ def lint(
         file_output = json.dumps(github_result)
 
     if file_output:
-        # If there's a file specified to write to, write to it.
-        if write_output:
-            with open(write_output, "w") as out_file:
-                out_file.write(file_output)
-        # Otherwise write to stdout
-        else:
-            click.echo(file_output)
+        dump_file_payload(write_output, file_output)
 
     if bench:
         click.echo("==== overall timings ====")
@@ -1009,14 +1014,8 @@ def parse(
             elif format == FormatType.json.value:
                 file_output = json.dumps(parsed_strings_dict)
 
-        if file_output:
-            # If there's a file specified to write to, write to it.
-            if write_output:
-                with open(write_output, "w") as out_file:
-                    out_file.write(file_output)
-            # Otherwise write to stdout
-            else:
-                click.echo(file_output)
+            # Dump the output to stdout or to file as appropriate.
+            dump_file_payload(write_output, file_output)
 
     except OSError:  # pragma: no cover
         click.echo(

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -568,7 +568,7 @@ def lint(
                         "annotation_level": annotation_level,
                     }
                 )
-        click.echo(json.dumps(github_result))
+        file_output = json.dumps(github_result)
 
     if file_output:
         # If there's a file specified to write to, write to it.
@@ -1008,7 +1008,7 @@ def parse(
                 file_output = yaml.dump(parsed_strings_dict, sort_keys=False)
             elif format == FormatType.json.value:
                 file_output = json.dumps(parsed_strings_dict)
-        
+
         if file_output:
             # If there's a file specified to write to, write to it.
             if write_output:

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -12,6 +12,7 @@ from typing import (
     NoReturn,
     Optional,
     List,
+    cast
 )
 
 import yaml
@@ -418,11 +419,11 @@ def dialects(**kwargs) -> None:
     click.echo(format_dialects(dialect_readout), color=c.get("color"))
 
 
-def dump_file_payload(out_file: Optional[str], payload: str):
+def dump_file_payload(filename: Optional[str], payload: str):
     """Write the output file content to stdout or file."""
     # If there's a file specified to write to, write to it.
-    if out_file:
-        with open(out_file, "w") as out_file:
+    if filename:
+        with open(filename, "w") as out_file:
             out_file.write(payload)
     # Otherwise write to stdout
     else:
@@ -582,7 +583,7 @@ def lint(
         file_output = json.dumps(github_result)
 
     if file_output:
-        dump_file_payload(write_output, file_output)
+        dump_file_payload(write_output, cast(str, file_output))
 
     if bench:
         click.echo("==== overall timings ====")
@@ -944,7 +945,6 @@ def parse(
     # We don't want anything else to be logged if we want json or yaml output
     # unless we're writing to a file.
     non_human_output = (format != FormatType.human.value) or (write_output is not None)
-    file_output = None
     lnt, formatter = get_linter_and_formatter(c, silent=non_human_output)
     verbose = c.get("verbose")
     recurse = c.get("recurse")

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -6,14 +6,7 @@ import json
 import logging
 import time
 from logging import LogRecord
-from typing import (
-    Callable,
-    Tuple,
-    NoReturn,
-    Optional,
-    List,
-    cast
-)
+from typing import Callable, Tuple, NoReturn, Optional, List, cast
 
 import yaml
 

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -806,7 +806,6 @@ def test__cli__command_parse_serialize_from_stdin(serialize, write_file, tmp_pat
 
     Not going to test for the content of the output as that is subject to change.
     """
-
     cmd_args = ("-", "--format", serialize)
 
     if write_file:

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -798,19 +798,36 @@ def test__cli__command__fix_no_force(rule, fname, prompt, exit_code, fix_exit_co
 
 
 @pytest.mark.parametrize("serialize", ["yaml", "json"])
-def test__cli__command_parse_serialize_from_stdin(serialize):
+@pytest.mark.parametrize("write_file", [None, "outfile"])
+def test__cli__command_parse_serialize_from_stdin(serialize, write_file, tmp_path):
     """Check that the parser serialized output option is working.
+
+    This tests both output to stdout and output to file.
 
     Not going to test for the content of the output as that is subject to change.
     """
+
+    cmd_args = ("-", "--format", serialize)
+
+    if write_file:
+        target_file = os.path.join(tmp_path, write_file + "." + serialize)
+        cmd_args += ("--write-output", target_file)
+
     result = invoke_assert_code(
-        args=[parse, ("-", "--format", serialize)],
+        args=[parse, cmd_args],
         cli_input="select * from tbl",
     )
+
+    if write_file:
+        with open(target_file, "r") as payload_file:
+            result_payload = payload_file.read()
+    else:
+        result_payload = result.output
+
     if serialize == "json":
-        result = json.loads(result.output)
+        result = json.loads(result_payload)
     elif serialize == "yaml":
-        result = yaml.safe_load(result.output)
+        result = yaml.safe_load(result_payload)
     else:
         raise Exception
     result = result[0]  # only one file
@@ -880,24 +897,42 @@ def test__cli__command_fail_nice_not_found(command):
 
 
 @pytest.mark.parametrize("serialize", ["yaml", "json", "github-annotation"])
-def test__cli__command_lint_serialize_multiple_files(serialize):
-    """Check the general format of JSON output for multiple files."""
+@pytest.mark.parametrize("write_file", [None, "outfile"])
+def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_path):
+    """Check the general format of JSON output for multiple files.
+
+    This tests runs both stdout checking and file checking.
+    """
     fpath = "test/fixtures/linter/indentation_errors.sql"
+
+    cmd_args = (fpath, fpath, "--format", serialize, "--disable_progress_bar")
+
+    if write_file:
+        target_file = os.path.join(
+            tmp_path, write_file + (".yaml" if serialize == "yaml" else ".json")
+        )
+        cmd_args += ("--write-output", target_file)
 
     # note the file is in here twice. two files = two payloads.
     result = invoke_assert_code(
-        args=[lint, (fpath, fpath, "--format", serialize, "--disable_progress_bar")],
+        args=[lint, cmd_args],
         ret_code=65,
     )
 
+    if write_file:
+        with open(target_file, "r") as payload_file:
+            result_payload = payload_file.read()
+    else:
+        result_payload = result.output
+
     if serialize == "json":
-        result = json.loads(result.output)
+        result = json.loads(result_payload)
         assert len(result) == 2
     elif serialize == "yaml":
-        result = yaml.safe_load(result.output)
+        result = yaml.safe_load(result_payload)
         assert len(result) == 2
     elif serialize == "github-annotation":
-        result = json.loads(result.output)
+        result = json.loads(result_payload)
         filepaths = {r["file"] for r in result}
         assert len(filepaths) == 1
     else:


### PR DESCRIPTION
This resolves #2244 and provides a clean solution to https://github.com/sqlfluff/sqlfluff-github-actions/issues/15.

This adds a `--write-output` to the `lint` and `parse` commands so that the commands can write directly to file. In the case that file output is enabled, the stdout logging is re-enabled so that the user can get e.g. yaml output to file and still get human output to stdout.