### PR TITLE
Hitting the linter loop limit should be treated as an error

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -484,7 +484,7 @@ class Linter:
             ignore_buff = []
 
         save_tree = tree
-        for loop in range(loop_limit):
+        for loop in range(loop_limit + 1):
             changed = False
 
             progress_bar_crawler = tqdm(
@@ -552,17 +552,21 @@ class Linter:
                 linter_logger.warning(f"Loop limit on fixes reached [{loop_limit}].")
 
                 # Discard any fixes for the linting errors, since they caused a
-                # loop. IMPORTANT: Unfixable linting errors also cause
-                # "sqlfluff fix" to exit with a "failure" exit code, which is
-                # the desired outcome in this situation.
+                # loop. IMPORTANT: By doing this, we are telling SQLFluff that
+                # these linting errors are "unfixable". This is important,
+                # because when "sqlfluff fix" encounters unfixable lint errors,
+                # it exits with a "failure" exit code, which is exactly what we
+                # want in this situation. (Reason: Although this is more of an
+                # internal SQLFluff issue, users deserve to know about it,
+                # because it means their file(s) weren't fixed.
                 for violation in initial_linting_errors:
                     if isinstance(violation, SQLLintError):
                         violation.fixes = []
 
-                # Return the original file. We do this because if the linter
-                # hit the loop limit, the file is probably messy, e.g. some of
-                # the fixes were applied repeatedly, possibly other strange
-                # things. We don't want the user to see this junk.
+                # Return the original parse tree, before any fixes were applied.
+                # Reason: When the linter hits the loop limit, the file is often
+                # messy, e.g. some of the fixes were applied repeatedly, possibly
+                # other weird things. We don't want the user to see this junk!
                 return save_tree, initial_linting_errors, ignore_buff
 
         if config.get("ignore_templated_areas", default=True):

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -1011,7 +1011,7 @@ class Linter:
         for i, linted_file in enumerate(runner.run(fnames, fix), start=1):
             linted_path.add(linted_file)
             # If any fatal errors, then stop iteration.
-            if any(v.fatal for v in linted_file.violations):
+            if any(v.fatal for v in linted_file.violations):  # pragma: no cover
                 linter_logger.error("Fatal linting error. Halting further linting.")
                 break
 

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -484,7 +484,7 @@ class Linter:
             ignore_buff = []
 
         save_tree = tree
-        for loop in range(loop_limit + 1):
+        for loop in range(loop_limit):
             changed = False
 
             progress_bar_crawler = tqdm(

--- a/test/core/rules/config_test.py
+++ b/test/core/rules/config_test.py
@@ -56,9 +56,8 @@ def test__rules__runaway_fail_catch():
     # In theory this step should result in an infinite
     # loop, but the loop limit should catch it.
     linted = linter.lint_string(my_query, fix=True)
-    # We should have a lot of newlines in there.
-    # The number should equal the runaway limit
-    assert linted.tree.raw.count("\n") == runaway_limit
+    # When the linter hits the runaway limit, it returns the original SQL tree.
+    assert linted.tree.raw == my_query
 
 
 def test_rules_cannot_be_instantiated_without_declared_configs():

--- a/test/fixtures/rules/std_rule_cases/L019.yml
+++ b/test/fixtures/rules/std_rule_cases/L019.yml
@@ -230,10 +230,10 @@ trailing_comma_move_past_several_comment_lines:
     global_actions_states
   configs:
     core:
-      # Set runaway_limit=1 to verify the fix only requires one pass. In an
+      # Set runaway_limit=2 to verify the fix only requires one pass. In an
       # earlier version, the comma before "SAFE_DIVIDE()" was being moved one
       # line per pass. Too lazy!
-      runaway_limit: 1
+      runaway_limit: 2
 
 
 leading_comma_move_past_several_comment_lines:
@@ -267,10 +267,10 @@ leading_comma_move_past_several_comment_lines:
     global_actions_states
   configs:
     core:
-      # Set runaway_limit=1 to verify the fix only requires one pass. In an
+      # Set runaway_limit=2 to verify the fix only requires one pass. In an
       # earlier version for the trailing comma case, commas were being moved
       # "through" comment blocks one line per pass. Too lazy!
-      runaway_limit: 1
+      runaway_limit: 2
     rules:
       L019:
         comma_style: leading


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #1386
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
