### PR TITLE
Doc a better choice for default env

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,9 +94,11 @@ tox -e dbt021-py38 --devenv .venv
 source .venv/bin/activate
 ```
 (The `dbt021-py38` environment is a good default choice.
-However any version can be installed by replacing `dbt021-py38` with `py`, `py37`, `py39`, `dbt020-py38`, etc.
+However any version can be installed by replacing `dbt021-py38` with
+`py`, `py37`, `py39`, `dbt020-py38`, etc.
 `py` defaults to the python version that was used to install tox.
-However, to be able to run all tests including the dbt templater, choose one of the dbt environments.)
+However, to be able to run all tests including the dbt templater,
+choose one of the dbt environments.)
 
 Windows users should call `.venv\Scripts\activate` rather than `source .venv/bin/activate`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,14 +90,13 @@ python3 -m pip install -U tox
 
 A virtual environment can then be created and activated by running:
 ```shell
-tox -e py --devenv .venv
+tox -e dbt021-py38 --devenv .venv
 source .venv/bin/activate
 ```
-(The `py` environment defaults to the python version used
-to install tox, however any version you want can be installed
-by replacing `py` with `py37`, `py39`, `dbt020-py38`, etc. If
-you are planning development on or using the dbt templater
-you may wish to chose one of the dbt environments.)
+(The `dbt021-py38` environment is a good default choice.
+However any version can be installed by replacing `dbt021-py38` with `py`, `py37`, `py39`, `dbt020-py38`, etc.
+`py` defaults to the python version that was used to install tox.
+However, to be able to run all tests including the dbt templater, choose one of the dbt environments.)
 
 Windows users should call `.venv\Scripts\activate` rather than `source .venv/bin/activate`.
 


### PR DESCRIPTION
### Brief summary of the change made

Changing the doc about local virtual environment to primarily suggest one that includes dbt dependencies.

The `py` environment doesn't include dbt dependencies, so developing the project with that venv can eventually hit a wall, like I did. After all, dbt templater tests are part of the PR checks and can fail as a result of changes in sqlfluff core. So to fully develop sqlfluff local dev setup should include the dbt deps. 

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
