### PR TITLE
Document python requirement for tox/mypy & remove basepython from conf

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ First ensure that you have tox installed:
 ```shell
 python3.8 -m pip install -U tox
 ```
-**IMPORTANT:** `tox` must be installed using Python 3.8 or newer. Otherwise `mypy` checks may fail. Depending on your setup and personal preference, replace `python3.8` as necessary, but make sure that the python version is new enough.
+**IMPORTANT:** `tox` must be installed with a minimum of Python 3.8 as the `mypy` checks are incompatible with 3.7. Those using newer versions of Python may replace `python3.8` as necessary (the test suite runs primarily under 3.10 for example).
 
 <!-- Hopefully when tox 4 is released it will be possible to set `basepython = python3.10, python3.9, python3.8` to enforce a working version for running mypy checks. For now it's only possible to set it to a single version which is too restrictive. On the other hand for now there is a requirement for contributors to install tox with a new enough Python version. -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,13 +82,20 @@ changes.
 
 ### Developing and Running SQLFluff Locally
 
-The simplest way to set up a development environment is to use `tox`.
-First ensure that you have tox installed (windows users may have to replace `python3` with `py`):
-```shell
-python3 -m pip install -U tox
-```
+#### Requirements
 
-A virtual environment can then be created and activated by running:
+The simplest way to set up a development environment is to use `tox`.
+First ensure that you have tox installed:
+```shell
+python3.8 -m pip install -U tox
+```
+**IMPORTANT:** `tox` must be installed using Python 3.8 or newer. Otherwise `mypy` checks may fail. Depending on your setup and personal preference, replace `python3.8` as necessary, but make sure that the python version is new enough.
+
+<!-- Hopefully when tox 4 is released it will be possible to set `basepython = python3.10, python3.9, python3.8` to enforce a working version for running mypy checks. For now it's only possible to set it to a single version which is too restrictive. On the other hand for now there is a requirement for contributors to install tox with a new enough Python version. -->
+
+#### Creating a virtual environment
+
+A virtual environment can then be created and activated by running (check the [requirements](#requirements) before running this):
 ```shell
 tox -e dbt021-py38 --devenv .venv
 source .venv/bin/activate
@@ -130,7 +137,7 @@ pip install -e plugins/sqlfluff-templater-dbt/.
 
 ### Testing
 
-To test locally, SQLFluff uses `tox`. The test suite can be run via:
+To test locally, SQLFluff uses `tox` (check the [requirements](#requirements)!). The test suite can be run via:
 
 ```shell
 tox
@@ -209,7 +216,13 @@ py.test -v plugins/sqlfluff-templater-dbt/test/
 
 ### Pre-Commit Config
 
-For development convenience we also provide a `.pre-commit-config.yaml` file to allow the user to install a selection of pre-commit hooks via `tox -e pre-commit -- install`. These hooks can help the user identify and fix potential linting/typing violations prior to committing their code and therefore reduce having to deal with these sort of issues during code review.
+For development convenience we also provide a `.pre-commit-config.yaml` file to allow the user to install a selection of pre-commit hooks by running (check the [requirements](#requirements) before running this):
+
+```
+tox -e pre-commit -- install
+```
+
+These hooks can help the user identify and fix potential linting/typing violations prior to committing their code and therefore reduce having to deal with these sort of issues during code review.
 
 ### Documentation Website
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ python3.8 -m pip install -U tox
 ```
 **IMPORTANT:** `tox` must be installed with a minimum of Python 3.8 as the `mypy` checks are incompatible with 3.7. Those using newer versions of Python may replace `python3.8` as necessary (the test suite runs primarily under 3.10 for example).
 
-<!-- Hopefully when tox 4 is released it will be possible to set `basepython = python3.10, python3.9, python3.8` to enforce a working version for running mypy checks. For now it's only possible to set it to a single version which is too restrictive. On the other hand for now there is a requirement for contributors to install tox with a new enough Python version. -->
+Note: Unfortunately tox does not currently support setting just a minimum Python version (though this may be be coming in tox 4!).
 
 #### Creating a virtual environment
 

--- a/tox.ini
+++ b/tox.ini
@@ -122,6 +122,7 @@ commands =
     twine upload --skip-existing {toxinidir}/dist/*
 
 [testenv:pre-commit]
+basepython = python3.10
 skip_install = true
 deps = pre-commit
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,6 @@ deps =
 commands = make -C {toxinidir}/docs html
 
 [testenv:mypy]
-basepython = python3.10
 skip_install = true
 commands = mypy {toxinidir}/src/sqlfluff
 
@@ -122,7 +121,6 @@ commands =
     twine upload --skip-existing {toxinidir}/dist/*
 
 [testenv:pre-commit]
-basepython = python3.10
 skip_install = true
 deps = pre-commit
 commands =


### PR DESCRIPTION
### Brief summary of the change made

~~Pin python version for pre-commit hooks.~~

~~Most notably this pins python version for the mypy pre-commit hook so that it's aligned.~~

~~So this is the same as https://github.com/sqlfluff/sqlfluff/pull/2629, but for pre-commit.~~

Document that tox must be installed with Python 3.8+ for mypy checks to work. That concerns both `tox -e mypy` and the mypy pre-commit hook.

Maybe it's worth mentioning that when user runs for example `tox -e pre-commit -- install`, a virtual environment is created at `.tox/pre-commit/lib/python3.10` (assuming that tox was installed with 3.10). Or if one runs `tox -e mypy` for the first time, another virtual environment is created at `.tox/mypy/lib/python3.8` (assuming that tox installation is with 3.8). And then, the version that was installed in the relevant `.tox` subfolder will be used for the mypy checks from that point onwards, no matter what kind of virtual environment user has activated.

This PR includes reverting https://github.com/sqlfluff/sqlfluff/pull/2629.

Hopefully when tox 4 is released it will be possible to set `basepython = python3.10, python3.9, python3.8` to enforce a working version for running mypy checks in a flexible enough manner. For now it's only possible to set `basepython` with a single version, which is too restrictive. On the other hand for now there is a requirement for contributors to install tox with a new enough Python version.

#### Manual testing

Tested the pre-commit hook manually by running:
```
.git/hooks/pre-commit
```

I had installed pre-commit hooks with Python 3.7, so it failed:
```
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
black....................................................................Passed
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

src/sqlfluff/core/cached_property.py:7: error: Library stubs not installed for "backports.cached_property" (or incompatible with Python 3.7)
src/sqlfluff/core/cached_property.py:7: note: Hint: "python3 -m pip install types-backports"
src/sqlfluff/core/cached_property.py:7: note: (or run "mypy --install-types" to install all missing stub packages)
src/sqlfluff/core/cached_property.py:7: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)

flake8...................................................................Passed
doc8.................................................(no files to check)Skipped
yamllint.............................................(no files to check)Skipped
```

After – success (I tested setting `basepython = 3.10` in `tox.ini`):
```
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
black....................................................................Passed
mypy.....................................................................Passed
flake8...................................................................Passed
doc8.................................................(no files to check)Skipped
yamllint.............................................(no files to check)Skipped
```

But didn't end up pinning `basepython` here – instead removing it also from `tox -e mypy`.

The pre-commit also succeeds after installing pre-commit hooks with `tox` again after reinstalled tox using Python 3.8.

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
