### PR TITLE
Bug fix: L025 overlooking JOIN ON clause if join expression in parentheses

### DIFF
--- a/src/sqlfluff/core/rules/analysis/select.py
+++ b/src/sqlfluff/core/rules/analysis/select.py
@@ -30,7 +30,7 @@ def get_select_statement_info(
     # Iterate through all the references, both in the select clause, but also
     # potential others.
     sc = segment.get_child("select_clause")
-    # Sometimes there is no select clause (e.g. "SELECT *" is a seleect_clause_element)
+    # Sometimes there is no select clause (e.g. "SELECT *" is a select_clause_element)
     if not sc:
         return None
     reference_buffer = list(sc.recursive_crawl("object_reference"))
@@ -64,7 +64,7 @@ def get_select_statement_info(
                     seen_using = True
                 elif seg.is_type("join_on_condition"):
                     for on_seg in seg.segments:
-                        if on_seg.is_type("expression"):
+                        if on_seg.is_type("bracketed", "expression"):
                             # Deal with expressions
                             reference_buffer += list(
                                 seg.recursive_crawl("object_reference")

--- a/test/fixtures/rules/std_rule_cases/L025.yml
+++ b/test/fixtures/rules/std_rule_cases/L025.yml
@@ -186,3 +186,11 @@ test_fail_spark3_values_clause:
   configs:
     core:
       dialect: spark3
+
+test_pass_join_on_expression_in_parentheses:
+  pass_str: |
+    SELECT table1.c1
+    FROM
+        table1 AS tbl1
+    INNER JOIN table2 AS tbl2 ON (tbl2.col2 = tbl1.col2)
+    INNER JOIN table3 AS tbl3 ON (tbl3.col3 = tbl2.col3)


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #2613 
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
