### PR TITLE
Fix mistakes in rule yaml tests

### DIFF
--- a/test/fixtures/rules/std_rule_cases/L002.yml
+++ b/test/fixtures/rules/std_rule_cases/L002.yml
@@ -2,3 +2,4 @@ rule: L002
 
 test_fail_mixed_tabs_and_spaces:
   fail_str: "    \t    \t    SELECT 1"
+  fix_str: "                    SELECT 1"

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -480,7 +480,7 @@ test_fail_indented_cte:
     )
 
     SELECT 1 FROM table1
-  pass_str: |
+  fix_str: |
     WITH
         some_cte AS (
             SELECT 1 FROM table1

--- a/test/fixtures/rules/std_rule_cases/L016.yml
+++ b/test/fixtures/rules/std_rule_cases/L016.yml
@@ -42,11 +42,6 @@ test_fail_line_too_long_with_comments_4:
     c1
     ,--  the "y variable" and uses_small_subject_line to be the "x variable" in terms of the regression line.
     c2
-  fix_str: |
-    SELECT
-    c1
-    ,--  the "y variable" and uses_small_subject_line to be the "x variable" in terms of the regression line.
-    c2
   configs:
     rules:
       max_line_length: 80

--- a/test/fixtures/rules/std_rule_cases/L017.yml
+++ b/test/fixtures/rules/std_rule_cases/L017.yml
@@ -11,18 +11,10 @@ simple_fail:
   fix_str: SELECT SUM(1)
 
 complex_fail_1:
-  # NB: Unchanged fix
   fail_str: SELECT SUM /* SOMETHING */ (1)
-  fix_str: SELECT SUM /* SOMETHING */ (1)
 
 complex_fail_2:
-  # NB: Unchanged fix
   fail_str: |
-    SELECT
-      SUM
-      -- COMMENT
-      (1)
-  fix_str: |
     SELECT
       SUM
       -- COMMENT

--- a/test/fixtures/rules/std_rule_cases/L025.yml
+++ b/test/fixtures/rules/std_rule_cases/L025.yml
@@ -143,6 +143,13 @@ test_snowflake_delete_cte:
             SELECT COLUMN3 FROM MYTABLE3
         ) X
     WHERE COLUMN1 = X.COLUMN3
+  fix_str: |
+    DELETE FROM MYTABLE1
+        USING (
+            WITH MYCTE AS (SELECT COLUMN2 FROM MYTABLE3)
+            SELECT COLUMN3 FROM MYTABLE3
+        ) X
+    WHERE COLUMN1 = X.COLUMN3
   configs:
     core:
       dialect: snowflake
@@ -163,6 +170,11 @@ test_fail_exasol_values_clause:
     FROM (
         VALUES (1, 2), (3, 4)
     ) AS t(c1, c2)
+  fix_str: |
+    SELECT *
+    FROM (
+        VALUES (1, 2), (3, 4)
+    )
   configs:
     core:
       dialect: exasol
@@ -183,6 +195,11 @@ test_fail_spark3_values_clause:
     FROM (
         VALUES (1, 2), (3, 4)
     ) AS t(c1, c2)
+  fix_str: |
+    SELECT *
+    FROM (
+        VALUES (1, 2), (3, 4)
+    )
   configs:
     core:
       dialect: spark3

--- a/test/fixtures/rules/std_rule_cases/L031.yml
+++ b/test/fixtures/rules/std_rule_cases/L031.yml
@@ -197,11 +197,8 @@ issue_1639:
 test_fail_no_copy_code_out_of_template:
   # The rule wants to replace "t" with "foobar", but
   # LintFix.has_template_conflicts() correctly prevents it copying code out
-  # of the templated region. Hence, fix_str and fail_str are the same.
+  # of the templated region. Hence, the query is not modified.
   fail_str: |
-    SELECT t.repo_id
-    FROM {{ source_table }} AS t
-  fix_str: |
     SELECT t.repo_id
     FROM {{ source_table }} AS t
   configs:

--- a/test/fixtures/rules/std_rule_cases/L037.yml
+++ b/test/fixtures/rules/std_rule_cases/L037.yml
@@ -10,6 +10,7 @@ test_unspecified_unspecified:
 
 test_unspecified_desc:
   fail_str: SELECT * FROM t ORDER BY a, b DESC
+  fix_str: SELECT * FROM t ORDER BY a ASC, b DESC
 
 
 test_asc_desc:
@@ -18,6 +19,7 @@ test_asc_desc:
 
 test_desc_unspecified:
   fail_str: SELECT * FROM t ORDER BY a DESC, b
+  fix_str: SELECT * FROM t ORDER BY a DESC, b ASC
 
 
 test_desc_asc:

--- a/test/fixtures/rules/std_rule_cases/L043.yml
+++ b/test/fixtures/rules/std_rule_cases/L043.yml
@@ -247,17 +247,8 @@ test_fail_unnecessary_case_11:
 test_fail_no_copy_code_out_of_template:
   # The rule wants to replace the case statement with coalesce(), but
   # LintFix.has_template_conflicts() correctly prevents it copying code out
-  # of the templated region. Hence, fix_str and fail_str are the same.
+  # of the templated region. Hence, the query is not modified.
   fail_str: |
-    select
-        foo,
-        case
-            when
-                bar is null then {{ result }}
-            else bar
-        end as test
-    from baz;
-  fix_str: |
     select
         foo,
         case

--- a/test/fixtures/rules/std_rule_cases/L048.yml
+++ b/test/fixtures/rules/std_rule_cases/L048.yml
@@ -81,6 +81,7 @@ test_fail_tsql_unicode_single_quote:
 
 test_fail_ansi_unicode_single_quote:
   fail_str: "SELECT a + N'b' + N'c' FROM tbl;"
+  fix_str: "SELECT a + N 'b' + N 'c' FROM tbl;"
   configs:
     core:
       dialect: ansi

--- a/test/fixtures/rules/std_rule_cases/L058.yml
+++ b/test/fixtures/rules/std_rule_cases/L058.yml
@@ -27,7 +27,7 @@ test_fail_1:
                 END
         END AS sound
     FROM mytable
-  pass_str: |
+  fix_str: |
     SELECT
         c1,
         CASE
@@ -118,7 +118,7 @@ test_fail_5:
                 CASE WHEN species = 'Dog' THEN 'Woof' END
         END AS sound
     FROM mytable
-  pass_str: |
+  fix_str: |
     SELECT
         c1,
         CASE
@@ -142,16 +142,16 @@ test_double_nesting_1:
                 END
         END AS sound
     FROM mytable
-  pass_str: |
+  fix_str: |
     SELECT
-    c1,
-    CASE
-        WHEN species = 'Rat' THEN
-            CASE
-                WHEN species = 'Dog' THEN 'Woof'
-                WHEN species = 'Bird' THEN 'tweet'
-            END
-    END AS sound
+        c1,
+        CASE
+            WHEN species = 'Rat' THEN
+                CASE
+                    WHEN species = 'Dog' THEN 'Woof'
+                    WHEN species = 'Bird' THEN 'tweet'
+                END
+        END AS sound
     FROM mytable
 
 test_double_nesting_2:
@@ -192,19 +192,8 @@ test_double_nesting_2:
 test_fail_no_copy_code_out_of_template:
   # The rule wants to replace the case statement with coalesce(), but
   # LintFix.has_template_conflicts() correctly prevents it copying code out
-  # of the templated region. Hence, fix_str and fail_str are the same.
+  # of the templated region. Hence, the query is not modified.
   fail_str: |
-    SELECT
-        c1,
-        CASE
-            WHEN species = 'Rat' THEN 'Squeak'
-            ELSE
-                CASE
-                    {{ inner_when }}
-                END
-        END AS sound
-    FROM mytable
-  fix_str: |
     SELECT
         c1,
         CASE

--- a/test/fixtures/rules/std_rule_cases/L059.yml
+++ b/test/fixtures/rules/std_rule_cases/L059.yml
@@ -7,7 +7,7 @@ test_pass_column_reference:
 test_fail_column_reference:
   fail_str: |
     SELECT 123 AS "foo";
-  pass_str: |
+  fix_str: |
     SELECT 123 AS foo;
 
 test_pass_table_reference:
@@ -59,8 +59,6 @@ test_pass_column_reference_prefer_quoted_ansi:
 test_fail_column_reference_prefer_quoted_ansi:
   fail_str: |
     SELECT 123 AS foo;
-  pass_str: |
-    SELECT 123 AS "foo";
   configs:
     rules:
       L059:
@@ -79,9 +77,6 @@ test_fail_table_reference_prefer_quoted_ansi:
   fail_str: |
     SELECT "foo"
     FROM bar;
-  pass_str: |
-    SELECT "foo"
-    FROM "bar";
   configs:
     rules:
       L059:
@@ -100,9 +95,6 @@ test_fail_multiple_references_prefer_quoted_ansi:
   fail_str: |
     SELECT "foo"
     FROM bar.baz;
-  pass_str: |
-    SELECT "foo"
-    FROM "bar"."baz";
   configs:
     rules:
       L059:
@@ -145,8 +137,6 @@ test_pass_column_reference_prefer_quoted_backticks:
 test_fail_column_reference_prefer_quoted_backticks:
   fail_str: |
     SELECT 123 AS foo;
-  pass_str: |
-    SELECT 123 AS `foo`;
   configs:
     core:
       dialect: bigquery
@@ -169,9 +159,6 @@ test_fail_table_reference_prefer_quoted_backticks:
   fail_str: |
     SELECT `foo`
     FROM bar;
-  pass_str: |
-    SELECT `foo`
-    FROM `bar`;
   configs:
     core:
       dialect: bigquery
@@ -194,9 +181,6 @@ test_fail_multiple_references_prefer_quoted_backticks:
   fail_str: |
     SELECT `foo`
     FROM bar.baz;
-  pass_str: |
-    SELECT `foo`
-    FROM `bar`.`baz`;
   configs:
     core:
       dialect: bigquery

--- a/test/fixtures/rules/std_rule_cases/L060.yml
+++ b/test/fixtures/rules/std_rule_cases/L060.yml
@@ -9,14 +9,14 @@ test_fail_ifnull:
   fail_str: |
     SELECT ifnull(foo, 0) AS bar,
     FROM baz;
-  pass_str: |
-    SELECT coalesce(foo, 0) AS bar,
+  fix_str: |
+    SELECT COALESCE(foo, 0) AS bar,
     FROM baz;
 
 test_fail_nvl:
   fail_str: |
     SELECT nvl(foo, 0) AS bar,
     FROM baz;
-  pass_str: |
-    SELECT coalesce(foo, 0) AS bar,
+  fix_str: |
+    SELECT COALESCE(foo, 0) AS bar,
     FROM baz;


### PR DESCRIPTION
### Brief summary of the change made

Fixes some common mistakes in rule yaml tests.

Covers these type of mistakes:
- Successful fix, but `fix_str` missing to assert the result -> add the missing `fix_str`
- `pass_str` used instead of `fix_str`, ie. fix result would not be asserted -> change `pass_str` to `fix_str`
- Unfixable failure, but `fix_str` is used with the same value as `fail_str`. Doesn't make sense to do that -> remove `fix_str`.

These mistakes were revealed by the pending additional assertions to testing/rules.py in https://github.com/sqlfluff/sqlfluff/pull/2624/files

### Are there any other side effects of this change that we should be aware of?

No.

But note that a yaml rule test with only `fail_str` should always mean that there's an unfixable error and the query is not modified as a result. Or at least how I understood, but there's an open question about it: https://github.com/sqlfluff/sqlfluff/pull/2624#issuecomment-1040524243. There are still some cases in the repo where there's a partial fix ie. the result after fix is modified query + raising an error. Those are not yet fixed in this PR, I plan to deal with those separately. 

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
