### PR TITLE
Assert that fix_str is set

### DIFF
--- a/src/sqlfluff/testing/rules.py
+++ b/src/sqlfluff/testing/rules.py
@@ -144,5 +144,7 @@ def rules__test_helper(test_case):
             assert res == test_case.fix_str
         else:
             # Check that tests without a fix_str do not apply any fixes.
-            # If the fix is expected, add the missing fix_str in the test case.
-            assert res == test_case.fail_str
+            assert res == test_case.fail_str, (
+                "No fix_str was provided, but the rule modified the SQL. "
+                "Where a fix can be applied by a rule, a fix_str must be supplied in the test."
+            )

--- a/src/sqlfluff/testing/rules.py
+++ b/src/sqlfluff/testing/rules.py
@@ -145,6 +145,6 @@ def rules__test_helper(test_case):
         else:
             # Check that tests without a fix_str do not apply any fixes.
             assert res == test_case.fail_str, (
-                "No fix_str was provided, but the rule modified the SQL. "
-                "Where a fix can be applied by a rule, a fix_str must be supplied in the test."
+                "No fix_str was provided, but the rule modified the SQL. Where a fix "
+                "can be applied by a rule, a fix_str must be supplied in the test."
             )

--- a/src/sqlfluff/testing/rules.py
+++ b/src/sqlfluff/testing/rules.py
@@ -142,3 +142,7 @@ def rules__test_helper(test_case):
         # If a `fixed` value is provided then check it matches
         if test_case.fix_str:
             assert res == test_case.fix_str
+        else:
+            # Check that tests without a fix_str do not apply any fixes.
+            # If the fix is expected, add the missing fix_str in the test case.
+            assert res == test_case.fail_str


### PR DESCRIPTION
### Brief summary of the change made

Assert in yaml rule tests that if only `fail_str` is given, then the rule violation is detected but original query is not modified at all.

If this new check fails but some fixing is expected, then the test case can be passed by adding the missing `fix_str`.

So this just helps in keeping the test coverage better for fixing. 

This doesn't find any issues in the existing tests now, because those were just fixed in https://github.com/sqlfluff/sqlfluff/pull/2658.

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
