### PR TITLE
Redshift: Support DATETIME as a valid datatype

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -85,6 +85,7 @@ class ColumnReferenceSegment(ObjectReferenceSegment):  # type: ignore
         allow_gaps=False,
     )
 
+
 @redshift_dialect.segment(replace=True)
 class DateTimeTypeIdentifier(BaseSegment):
     """A Date Time type."""
@@ -101,6 +102,7 @@ class DateTimeTypeIdentifier(BaseSegment):
         # INTERVAL types are not Datetime types under Redshift:
         # https://docs.aws.amazon.com/redshift/latest/dg/r_Datetime_types.html
     )
+
 
 @redshift_dialect.segment(replace=True)
 class DatatypeSegment(BaseSegment):

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -85,6 +85,22 @@ class ColumnReferenceSegment(ObjectReferenceSegment):  # type: ignore
         allow_gaps=False,
     )
 
+@redshift_dialect.segment(replace=True)
+class DateTimeTypeIdentifier(BaseSegment):
+    """A Date Time type."""
+
+    type = "datetime_type_identifier"
+    match_grammar = OneOf(
+        "DATE",
+        "DATETIME",
+        Sequence(
+            OneOf("TIME", "TIMESTAMP"),
+            Sequence(OneOf("WITH", "WITHOUT"), "TIME", "ZONE", optional=True),
+        ),
+        OneOf("TIMETZ", "TIMESTAMPTZ"),
+        # INTERVAL types are not Datetime types under Redshift:
+        # https://docs.aws.amazon.com/redshift/latest/dg/r_Datetime_types.html
+    )
 
 @redshift_dialect.segment(replace=True)
 class DatatypeSegment(BaseSegment):
@@ -140,13 +156,7 @@ class DatatypeSegment(BaseSegment):
             "BPCHAR",
             "TEXT",
         ),
-        # datetime types
-        "DATE",
-        Sequence(
-            OneOf("TIME", "TIMESTAMP"),
-            Sequence(OneOf("WITH", "WITHOUT"), "TIME", "ZONE", optional=True),
-        ),
-        OneOf("TIMETZ", "TIMESTAMPTZ"),
+        Ref("DateTimeTypeIdentifier"),
         # INTERVAL is a data type *only* for conversion operations
         "INTERVAL",
         # boolean types

--- a/test/fixtures/dialects/postgres/postgres_datatypes.sql
+++ b/test/fixtures/dialects/postgres/postgres_datatypes.sql
@@ -140,3 +140,20 @@ create type public.c AS ENUM ('foo', 'bar');
 create table r(
     a public.c
 );
+
+-- DATETIME is a valid datatype, but is not a date_time_identifier; it is only
+-- potentially a user-defined type (i.e. a data_type_identifier).
+CREATE TABLE a (
+    b DATE,
+    c DATETIME
+);
+
+-- from https://github.com/sqlfluff/sqlfluff/issues/2649
+SELECT
+    b::DATETIME
+FROM a;
+
+SELECT
+    b,
+    c::DATE
+FROM a;

--- a/test/fixtures/dialects/postgres/postgres_datatypes.yml
+++ b/test/fixtures/dialects/postgres/postgres_datatypes.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 06cbe08b85a8adb092da007496aaf19e61895a9071b04a70609953e0139e7b72
+_hash: d7648994cc6e09b2890a11eda0ecead1b48fd70a81791ffc7236b9315468faa3
 file:
 - statement:
     create_table_statement:
@@ -747,4 +747,69 @@ file:
           dot: .
           data_type_identifier: c
         end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: a
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          identifier: b
+      - data_type:
+          datetime_type_identifier:
+            keyword: DATE
+      - comma: ','
+      - column_reference:
+          identifier: c
+      - data_type:
+          data_type_identifier: DATETIME
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: b
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: DATETIME
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: a
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: b
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              identifier: c
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                  keyword: DATE
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: a
 - statement_terminator: ;

--- a/test/fixtures/dialects/redshift/redshift_cast_conversion.yml
+++ b/test/fixtures/dialects/redshift/redshift_cast_conversion.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 757a0eb6de8f8048cc83e8bd4af2b0a253fb56c9fa79451d48c8eb822f82b922
+_hash: d88e5f09aebf827225e0e8212e0629860009f8d5ac1bdb6f8df8abbd37bcbda4
 file:
 - statement:
     select_statement:
@@ -91,7 +91,8 @@ file:
                   identifier: col1
               keyword: as
               data_type:
-                keyword: timestamptz
+                datetime_type_identifier:
+                  keyword: timestamptz
               end_bracket: )
       from_clause:
         keyword: from
@@ -138,7 +139,8 @@ file:
             cast_expression:
               casting_operator: '::'
               data_type:
-                keyword: timestamptz
+                datetime_type_identifier:
+                  keyword: timestamptz
       from_clause:
         keyword: from
         from_expression:

--- a/test/fixtures/dialects/redshift/redshift_create_external_table.yml
+++ b/test/fixtures/dialects/redshift/redshift_create_external_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 36bd34e1f1f2b3bc5c1c0eddcc058a1f01320389deeef61ed468064008dc3765
+_hash: 246bfa215d4aa569d960e471df5fb06b8bf2199d565174e24023853ee479822c
 file:
 - statement:
     create_external_table_statement:
@@ -269,7 +269,8 @@ file:
       - column_reference:
           identifier: saledate
       - data_type:
-          keyword: date
+          datetime_type_identifier:
+            keyword: date
       - comma: ','
       - column_reference:
           identifier: qtysold
@@ -290,7 +291,8 @@ file:
       - column_reference:
           identifier: saletime
       - data_type:
-          keyword: timestamp
+          datetime_type_identifier:
+            keyword: timestamp
       - end_bracket: )
     - keyword: row
     - keyword: format
@@ -339,7 +341,8 @@ file:
       - column_reference:
           identifier: event_time
       - data_type:
-          keyword: timestamp
+          datetime_type_identifier:
+            keyword: timestamp
       - comma: ','
       - column_reference:
           identifier: event_type

--- a/test/fixtures/dialects/redshift/redshift_create_external_table_as.yml
+++ b/test/fixtures/dialects/redshift/redshift_create_external_table_as.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 10a3c69ef88358f1bd04d72cdc8331fac3cb5404cc63ba066af6c8ba1a866656
+_hash: 50802757c0d2dd34fc1ddfef97d82c6b5884eaf3f24c7276bb7b7481b971dac8
 file:
 - statement:
     create_external_table_statement:
@@ -497,7 +497,8 @@ file:
         - column_reference:
             identifier: l_shipdate
         - data_type:
-            keyword: date
+            datetime_type_identifier:
+              keyword: date
         - comma: ','
         - column_reference:
             identifier: l_shipmode

--- a/test/fixtures/dialects/redshift/redshift_create_table.yml
+++ b/test/fixtures/dialects/redshift/redshift_create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0ed9021513963f7c9c2743481e932c7cacf51b2ddb67fa5aafc23c43cb00098b
+_hash: fa2d8015a7151ea7d4ad7bd600e4899131fc8da399fce245e158e2079f593707
 file:
 - statement:
     create_table_statement:

--- a/test/fixtures/dialects/redshift/redshift_create_table.yml
+++ b/test/fixtures/dialects/redshift/redshift_create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0d29b2d1e17ca192e9c4d341673b99de87cd573a5f6634fac950e65c698d315b
+_hash: 0ed9021513963f7c9c2743481e932c7cacf51b2ddb67fa5aafc23c43cb00098b
 file:
 - statement:
     create_table_statement:
@@ -549,7 +549,8 @@ file:
       - column_reference:
           identifier: col2
       - data_type:
-          keyword: DATE
+          datetime_type_identifier:
+            keyword: DATE
       - comma: ','
       - column_reference:
           identifier: col3
@@ -606,7 +607,8 @@ file:
       - column_reference:
           identifier: col2
       - data_type:
-          keyword: DATE
+          datetime_type_identifier:
+            keyword: DATE
       - comma: ','
       - column_reference:
           identifier: col3
@@ -668,7 +670,8 @@ file:
       - column_reference:
           identifier: col2
       - data_type:
-          keyword: DATE
+          datetime_type_identifier:
+            keyword: DATE
       - comma: ','
       - column_reference:
           identifier: col3

--- a/test/fixtures/dialects/redshift/redshift_datetime_cast.sql
+++ b/test/fixtures/dialects/redshift/redshift_datetime_cast.sql
@@ -1,0 +1,33 @@
+-- redshift_datetime_cast.sql
+/* Example that casts a column to several DATETIME types */
+
+-- from https://github.com/sqlfluff/sqlfluff/issues/2649
+SELECT b::DATETIME
+FROM a;
+
+-- DATE
+SELECT b::DATE
+FROM a;
+
+-- TIME
+SELECT
+    b::TIME,
+    c::TIME WITH TIME ZONE,
+    d::TIME WITHOUT TIME ZONE
+FROM a;
+
+-- TIMETZ
+SELECT b::TIMETZ
+FROM a;
+
+-- TIMESTAMP
+SELECT
+    b::TIMESTAMP,
+    c::TIMESTAMP WITHOUT TIME ZONE,
+    d::TIMESTAMP WITH TIME ZONE
+FROM a;
+
+-- TIMESTAMPTZ
+SELECT
+    b::TIMESTAMPTZ
+FROM a;

--- a/test/fixtures/dialects/redshift/redshift_datetime_cast.yml
+++ b/test/fixtures/dialects/redshift/redshift_datetime_cast.yml
@@ -1,0 +1,185 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 0ad5cc35e1e142e2004ca5dc13465cd2802ab45b443948ff017d1357050c2340
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: b
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                  keyword: DATETIME
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: a
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: b
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                  keyword: DATE
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: a
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+            column_reference:
+              identifier: b
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                  keyword: TIME
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              identifier: c
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                - keyword: TIME
+                - keyword: WITH
+                - keyword: TIME
+                - keyword: ZONE
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              identifier: d
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                - keyword: TIME
+                - keyword: WITHOUT
+                - keyword: TIME
+                - keyword: ZONE
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: a
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: b
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                  keyword: TIMETZ
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: a
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+            column_reference:
+              identifier: b
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                  keyword: TIMESTAMP
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              identifier: c
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                - keyword: TIMESTAMP
+                - keyword: WITHOUT
+                - keyword: TIME
+                - keyword: ZONE
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              identifier: d
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                - keyword: TIMESTAMP
+                - keyword: WITH
+                - keyword: TIME
+                - keyword: ZONE
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: a
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: b
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                  keyword: TIMESTAMPTZ
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: a
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

fixes #2649 .

- **Added support for `DATETIME` as a valid datatype in the `redshift` Dialect**. I did this by replacing the `DateTimeTypeIdentifier` segment in the `redshift` dialect (that was inherited from the `postgres` dialect), and adding `DATETIME` identifier as a possible `DateTimeTypeIdentifier`. The `DataTypeSegment` segment in the `redshift` dialect was then adjusted so that a `DateTimeTypeIdentifier` is a valid component of a `DataTypeSegment`. I added test cases to show support for `DateTimeTypeIdentifier`s (and `DATETIME` as a valid datatype) in the Redshift dialect with the `test/fixtures/dialects/redshift/redshift_datetime_cast.sql` file and the `test/fixtures/dialects/redshift/redshift_datetime_cast.yml` file.
- **Added test cases to show how `DATETIME` is parsed as a datatype in the `postgres` Dialect**. While `DATETIME` is not a natively-supported type in the `postgres` dialect, is has the potential to be a [user-defined type](https://www.postgresql.org/docs/9.5/xtypes.html) in `postgres`. Thus, it has the potential to be a valid datatype in the `postgres` dialect. I added some examples to  `test/fixtures/dialects/postgres/postgres_datatypes.sql` and `test/fixtures/dialects/postgres/postgres_datatypes.yml` that show that `DATETIME` can be a component of a `data_type` segment, but is labeled as a generic `data_type_identifier` instead of a native `datetime_type_identifier`.

### Are there any other side effects of this change that we should be aware of?

- Adjusts the following `.yml` fixtures in the `redshift` dialect to indicate `datetime_type_identifiers`:
  * `test/fixtures/dialects/redshift/redshift_create_table.yml`
  * `test/fixtures/dialects/redshift/redshift_cast_conversion.yml`
  * `test/fixtures/dialects/redshift/redshift_create_external_table.yml`
  * `test/fixtures/dialects/redshift/redshift_create_external_table_as.yml`

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`. **(N/A for this change)**
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`). **(DONE)**:
    * `test/fixtures/dialects/redshift/redshift_datetime_cast.sql`
    * `test/fixtures/dialects/redshift/redshift_datetime_cast.yml`
    * `test/fixtures/dialects/postgres/postgres_datatypes.sql`
    * `test/fixtures/dialects/postgres/postgres_datatypes.yml`
    * `test/fixtures/dialects/redshift/redshift_create_table.yml`
    * `test/fixtures/dialects/redshift/redshift_cast_conversion.yml`
    * `test/fixtures/dialects/redshift/redshift_create_external_table.yml`
    * `test/fixtures/dialects/redshift/redshift_create_external_table_as.yml`
  - Full autofix test cases in `test/fixtures/linter/autofix`. **(N/A for this change)**
  - Other. **(N/A for this change)**
- Added appropriate documentation for the change. **(DONE)**
- Created GitHub issues for any relevant followup/future enhancements if appropriate. **(N/A for this change)**
