### PR TITLE
Snowflake dialect update for `MERGE INTO` predicates

### DIFF
--- a/benchmarks/bench_002/bench_002_pearson_fix.sql
+++ b/benchmarks/bench_002/bench_002_pearson_fix.sql
@@ -13,11 +13,11 @@ raw_effect_sizes AS (
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
         --  the "y variable" and uses_small_subject_line to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
-             SAFE_MULTIPLY(
+            SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_small_subject_line),
                 STDDEV_POP(open_rate_su)
             ),
-             STDDEV_POP(uses_small_subject_line)
+            STDDEV_POP(uses_small_subject_line)
         ) AS open_uses_small_subject_line,
 
         -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
@@ -25,11 +25,11 @@ raw_effect_sizes AS (
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
         --  the "y variable" and uses_personal_subject to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
-             SAFE_MULTIPLY(
+            SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_personal_subject),
                 STDDEV_POP(open_rate_su)
             ),
-             STDDEV_POP(uses_personal_subject)
+            STDDEV_POP(uses_personal_subject)
         ) AS open_uses_personal_subject,
 
         -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
@@ -37,10 +37,10 @@ raw_effect_sizes AS (
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
         --  the "y variable" and uses_timewarp to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
-             SAFE_MULTIPLY(
+            SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_timewarp), STDDEV_POP(open_rate_su)
             ),
-             STDDEV_POP(uses_timewarp)
+            STDDEV_POP(uses_timewarp)
         ) AS open_uses_timewarp,
 
         -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
@@ -48,10 +48,10 @@ raw_effect_sizes AS (
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
         --  the "y variable" and uses_small_preview to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
-             SAFE_MULTIPLY(
+            SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_small_preview), STDDEV_POP(open_rate_su)
             ),
-             STDDEV_POP(uses_small_preview)
+            STDDEV_POP(uses_small_preview)
         ) AS open_uses_small_preview,
 
         -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
@@ -59,10 +59,10 @@ raw_effect_sizes AS (
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
         --  the "y variable" and uses_personal_to to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
-             SAFE_MULTIPLY(
+            SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_personal_to), STDDEV_POP(open_rate_su)
             ),
-             STDDEV_POP(uses_personal_to)
+            STDDEV_POP(uses_personal_to)
         ) AS open_uses_personal_to,
 
         -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
@@ -70,11 +70,11 @@ raw_effect_sizes AS (
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
         --  the "y variable" and uses_ab_test_subject to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
-             SAFE_MULTIPLY(
+            SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_ab_test_subject),
                 STDDEV_POP(open_rate_su)
             ),
-             STDDEV_POP(uses_ab_test_subject)
+            STDDEV_POP(uses_ab_test_subject)
         ) AS open_uses_ab_test_subject,
 
         -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
@@ -82,11 +82,11 @@ raw_effect_sizes AS (
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
         --  the "y variable" and uses_ab_test_content to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
-             SAFE_MULTIPLY(
+            SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_ab_test_content),
                 STDDEV_POP(open_rate_su)
             ),
-             STDDEV_POP(uses_ab_test_content)
+            STDDEV_POP(uses_ab_test_content)
         ) AS open_uses_ab_test_content,
 
         -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
@@ -94,10 +94,10 @@ raw_effect_sizes AS (
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
         --  the "y variable" and uses_preview_text to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
-             SAFE_MULTIPLY(
+            SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_preview_text), STDDEV_POP(open_rate_su)
             ),
-             STDDEV_POP(uses_preview_text)
+            STDDEV_POP(uses_preview_text)
         ) AS open_uses_preview_text,
 
         -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
@@ -105,10 +105,10 @@ raw_effect_sizes AS (
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
         --  the "y variable" and uses_sto to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
-             SAFE_MULTIPLY(
+            SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_sto), STDDEV_POP(open_rate_su)
             ),
-             STDDEV_POP(uses_sto)
+            STDDEV_POP(uses_sto)
         ) AS open_uses_sto,
 
         -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
@@ -116,10 +116,10 @@ raw_effect_sizes AS (
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
         --  the "y variable" and uses_freemail_from to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
-             SAFE_MULTIPLY(
+            SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_freemail_from), STDDEV_POP(open_rate_su)
             ),
-             STDDEV_POP(uses_freemail_from)
+            STDDEV_POP(uses_freemail_from)
         ) AS open_uses_freemail_from,
 
         -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
@@ -127,11 +127,11 @@ raw_effect_sizes AS (
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
         --  the "y variable" and uses_resend_non_openers to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
-             SAFE_MULTIPLY(
+            SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_resend_non_openers),
                 STDDEV_POP(open_rate_su)
             ),
-             STDDEV_POP(uses_resend_non_openers)
+            STDDEV_POP(uses_resend_non_openers)
         ) AS open_uses_resend_non_openers,
 
         -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
@@ -139,10 +139,10 @@ raw_effect_sizes AS (
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
         --  the "y variable" and uses_promo_code to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
-             SAFE_MULTIPLY(
+            SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_promo_code), STDDEV_POP(open_rate_su)
             ),
-             STDDEV_POP(uses_promo_code)
+            STDDEV_POP(uses_promo_code)
         ) AS open_uses_promo_code,
 
         -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
@@ -150,10 +150,10 @@ raw_effect_sizes AS (
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
         --  the "y variable" and uses_prex to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
-             SAFE_MULTIPLY(
+            SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_prex), STDDEV_POP(open_rate_su)
             ),
-             STDDEV_POP(uses_prex)
+            STDDEV_POP(uses_prex)
         ) AS open_uses_prex,
 
         -- The following is the slope of the regression line. Note that CORR (which is the Pearson's correlation
@@ -161,10 +161,10 @@ raw_effect_sizes AS (
         --  numerator this is the slope of the regression line considering STDDEV_POP(open_rate_su) to be
         --  the "y variable" and uses_ab_test_from to be the "x variable" in terms of the regression line.
         SAFE_DIVIDE(
-             SAFE_MULTIPLY(
+            SAFE_MULTIPLY(
                 CORR(open_rate_su, uses_ab_test_from), STDDEV_POP(open_rate_su)
             ),
-             STDDEV_POP(uses_ab_test_from)
+            STDDEV_POP(uses_ab_test_from)
         ) AS open_uses_ab_test_from
 
     FROM
@@ -184,12 +184,12 @@ imputed_effect_sizes AS (
         --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
-             IF(
+            IF(
                 IS_NAN(open_uses_small_subject_line),
                 0,
                 open_uses_small_subject_line
             ),
-             0
+            0
         ) AS open_uses_small_subject_line,
 
         -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
@@ -197,7 +197,7 @@ imputed_effect_sizes AS (
         --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
-             IF(
+            IF(
                 IS_NAN(open_uses_personal_subject),
                 0,
                 open_uses_personal_subject
@@ -210,7 +210,7 @@ imputed_effect_sizes AS (
         --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
-             IF(IS_NAN(open_uses_timewarp), 0, open_uses_timewarp), 0
+            IF(IS_NAN(open_uses_timewarp), 0, open_uses_timewarp), 0
         ) AS open_uses_timewarp,
 
         -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
@@ -218,7 +218,7 @@ imputed_effect_sizes AS (
         --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
-             IF(IS_NAN(open_uses_small_preview), 0, open_uses_small_preview), 0
+            IF(IS_NAN(open_uses_small_preview), 0, open_uses_small_preview), 0
         ) AS open_uses_small_preview,
 
         -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
@@ -226,7 +226,7 @@ imputed_effect_sizes AS (
         --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
-             IF(IS_NAN(open_uses_personal_to), 0, open_uses_personal_to), 0
+            IF(IS_NAN(open_uses_personal_to), 0, open_uses_personal_to), 0
         ) AS open_uses_personal_to,
 
         -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
@@ -234,9 +234,7 @@ imputed_effect_sizes AS (
         --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
-             IF(
-                IS_NAN(open_uses_ab_test_subject), 0, open_uses_ab_test_subject
-            ),
+            IF(IS_NAN(open_uses_ab_test_subject), 0, open_uses_ab_test_subject),
             0
         ) AS open_uses_ab_test_subject,
 
@@ -245,9 +243,7 @@ imputed_effect_sizes AS (
         --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
-             IF(
-                IS_NAN(open_uses_ab_test_content), 0, open_uses_ab_test_content
-            ),
+            IF(IS_NAN(open_uses_ab_test_content), 0, open_uses_ab_test_content),
             0
         ) AS open_uses_ab_test_content,
 
@@ -256,7 +252,7 @@ imputed_effect_sizes AS (
         --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
-             IF(IS_NAN(open_uses_preview_text), 0, open_uses_preview_text), 0
+            IF(IS_NAN(open_uses_preview_text), 0, open_uses_preview_text), 0
         ) AS open_uses_preview_text,
 
         -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
@@ -272,7 +268,7 @@ imputed_effect_sizes AS (
         --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
-             IF(IS_NAN(open_uses_freemail_from), 0, open_uses_freemail_from), 0
+            IF(IS_NAN(open_uses_freemail_from), 0, open_uses_freemail_from), 0
         ) AS open_uses_freemail_from,
 
         -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
@@ -280,12 +276,12 @@ imputed_effect_sizes AS (
         --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
-             IF(
+            IF(
                 IS_NAN(open_uses_resend_non_openers),
                 0,
                 open_uses_resend_non_openers
             ),
-             0
+            0
         ) AS open_uses_resend_non_openers,
 
         -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
@@ -293,7 +289,7 @@ imputed_effect_sizes AS (
         --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
-             IF(IS_NAN(open_uses_promo_code), 0, open_uses_promo_code), 0
+            IF(IS_NAN(open_uses_promo_code), 0, open_uses_promo_code), 0
         ) AS open_uses_promo_code,
 
         -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
@@ -301,7 +297,7 @@ imputed_effect_sizes AS (
         --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
-             IF(IS_NAN(open_uses_prex), 0, open_uses_prex), 0
+            IF(IS_NAN(open_uses_prex), 0, open_uses_prex), 0
         ) AS open_uses_prex,
 
         -- We now impute the value of the effect size to 0 if it was NaN or NULL. This is to
@@ -309,7 +305,7 @@ imputed_effect_sizes AS (
         --  action. In these cases, we assume that campaign outcome is uncorrelated with 
         --  the action because we do not have evidence otherwise.
         COALESCE(
-             IF(IS_NAN(open_uses_ab_test_from), 0, open_uses_ab_test_from), 0
+            IF(IS_NAN(open_uses_ab_test_from), 0, open_uses_ab_test_from), 0
         ) AS open_uses_ab_test_from
 
     FROM

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -3251,8 +3251,6 @@ class MergeNotMatchedClauseSegment(BaseSegment):
             "WHEN",
             "NOT",
             "MATCHED",
-            Sequence("AND", Ref("ExpressionSegment"), optional=True),
-            "THEN",
         ),
     )
     parse_grammar = Sequence(

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -3251,6 +3251,7 @@ class MergeNotMatchedClauseSegment(BaseSegment):
             "WHEN",
             "NOT",
             "MATCHED",
+            Sequence("AND", Ref("ExpressionSegment"), optional=True),
             "THEN",
         ),
     )
@@ -3258,6 +3259,7 @@ class MergeNotMatchedClauseSegment(BaseSegment):
         "WHEN",
         "NOT",
         "MATCHED",
+        Sequence("AND", Ref("ExpressionSegment"), optional=True),
         "THEN",
         Ref("MergeInsertClauseSegment"),
     )

--- a/test/fixtures/dialects/snowflake/snowflake_merge_into.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_merge_into.sql
@@ -9,4 +9,4 @@ merge into t1 using t2 on t1.t1key = t2.t2key
     when matched and t2.marked = 1 then delete;
 
 merge into t1 using t2 on t1.t1key = t2.t2key
-    when not matched and t2.marked = 1 then insert (marked) values (1)
+    when not matched and t2.marked = 1 then insert (marked) values (1);

--- a/test/fixtures/dialects/snowflake/snowflake_merge_into.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_merge_into.sql
@@ -6,4 +6,7 @@ merge into target_table using source_table
         update set target_table.description = source_table.description;
 
 merge into t1 using t2 on t1.t1key = t2.t2key
-    when matched and t2.marked = 1 then delete  
+    when matched and t2.marked = 1 then delete;
+
+merge into t1 using t2 on t1.t1key = t2.t2key
+    when not matched and t2.marked = 1 then insert (marked) values (1)

--- a/test/fixtures/dialects/snowflake/snowflake_merge_into.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_merge_into.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d07738df29bf8bdf14d50d018e4d4109a741356e621c628c6161f181165ba097
+_hash: 18fd458b5690b193777a1dbe281dd3e0ad4d1646dcefe1b5991c2f33b9832f80
 file:
 - statement:
     alter_table_statement:
@@ -102,3 +102,53 @@ file:
       - keyword: then
       - merge_delete_clause:
           keyword: delete
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: merge
+    - keyword: into
+    - table_reference:
+        identifier: t1
+    - keyword: using
+    - table_reference:
+        identifier: t2
+    - join_on_condition:
+        keyword: 'on'
+        expression:
+        - column_reference:
+          - identifier: t1
+          - dot: .
+          - identifier: t1key
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - identifier: t2
+          - dot: .
+          - identifier: t2key
+    - merge_when_not_matched_clause:
+      - keyword: when
+      - keyword: not
+      - keyword: matched
+      - binary_operator: and
+      - expression:
+          column_reference:
+          - identifier: t2
+          - dot: .
+          - identifier: marked
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: '1'
+      - keyword: then
+      - merge_insert_clause:
+        - keyword: insert
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              identifier: marked
+            end_bracket: )
+        - keyword: values
+        - bracketed:
+            start_bracket: (
+            expression:
+              literal: '1'
+            end_bracket: )

--- a/test/fixtures/dialects/snowflake/snowflake_merge_into.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_merge_into.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 18fd458b5690b193777a1dbe281dd3e0ad4d1646dcefe1b5991c2f33b9832f80
+_hash: 875e32f8f894d6371606ead067c30eee14e9db5ca2e11874ab48e668d470c55f
 file:
 - statement:
     alter_table_statement:
@@ -152,3 +152,4 @@ file:
             expression:
               literal: '1'
             end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
Fix for #2666 
Updated the snowflake dialect file to handle `AND` within the `WHEN NOT MATCHED` clause.

Updated snowflake merge dialect test to include an example.

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
