### PR TITLE
TSQL: Improve RAISERROR functionality

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3415,15 +3415,33 @@ class RaiserrorStatementSegment(BaseSegment):
         "RAISERROR",
         Bracketed(
             Delimited(
-                OneOf(Ref("NumericLiteralSegment"), Ref("QuotedLiteralSegment")),
                 OneOf(
-                    Ref("NumericLiteralSegment"), Ref("QualifiedNumericLiteralSegment")
+                    Ref("NumericLiteralSegment"),
+                    Ref("QuotedLiteralSegment"),
+                    Ref("QuotedLiteralSegmentWithN"),
                 ),
                 OneOf(
                     Ref("NumericLiteralSegment"), Ref("QualifiedNumericLiteralSegment")
                 ),
-                Ref("QuotedLiteralSegment", optional=True),
+                OneOf(
+                    Ref("NumericLiteralSegment"), Ref("QualifiedNumericLiteralSegment")
+                ),
+                AnyNumberOf(
+                    Ref("LiteralGrammar"),
+                    Ref("ParameterNameSegment"),
+                    min_times=0,
+                    max_times=20,
+                ),
             ),
+        ),
+        Sequence(
+            "WITH",
+            Delimited(
+                "LOG",
+                "NOWAIT",
+                "SETERROR",
+            ),
+            optional=True,
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -268,14 +268,15 @@ UNRESERVED_KEYWORDS = [
     "KEEPDEFAULTS",
     "KEEPFIXED",
     "KEEPIDENTITY",
+    # LABEL is an Azure Synapse Analytics specific reserved keyword
+    # but could break TSQL parsing to add there
     "LABEL",
-    # Azure Synapse Analytics specific, reserved keyword but could break TSQL parsing to
-    # add there
     "LANGUAGE",
     "LEVEL",
     "LOAD",  # listed as reserved but functionally unreserved
     "LOCATION",
     "LOCK_TIMEOUT",
+    "LOG",
     "LOOP",
     "MAX_DURATION",
     "MAX_GRANT_PERCENT",
@@ -355,6 +356,7 @@ UNRESERVED_KEYWORDS = [
     "SCHEMABINDING",
     "SECURITYAUDIT",  # listed as reserved but functionally unreserved
     "SELF",
+    "SETERROR",
     "SEQUENCE",
     "SEQUENCE_NUMBER",
     "SERIALIZABLE",

--- a/test/fixtures/dialects/tsql/raiserror.sql
+++ b/test/fixtures/dialects/tsql/raiserror.sql
@@ -3,3 +3,30 @@ RAISERROR(15600, -1, -1, 'mysp_CreateCustomer');
 RAISERROR('This is message %s %d.', 10, 1, 'number');
 
 RAISERROR('Error raised in TRY block.', 16, 1);
+
+RAISERROR (N'Unicode error', 16, 1);
+
+RAISERROR ('WITH option', 16, 1) WITH LOG;
+
+
+RAISERROR ('Error with lots of arguments %a %b %c %d %e %f %g %h %i %j %k %l %m %n %o %p %q %r %s %t', 16, 1,
+		'a',
+		N'b',
+		@c,
+		4,
+		5,
+		6,
+		7,
+		8,
+		9,
+		10,
+		11,
+		12,
+		13,
+		14,
+		15,
+		16,
+		17,
+		18,
+		19,
+		20);

--- a/test/fixtures/dialects/tsql/raiserror.sql
+++ b/test/fixtures/dialects/tsql/raiserror.sql
@@ -8,7 +8,6 @@ RAISERROR (N'Unicode error', 16, 1);
 
 RAISERROR ('WITH option', 16, 1) WITH LOG;
 
-
 RAISERROR ('Error with lots of arguments %a %b %c %d %e %f %g %h %i %j %k %l %m %n %o %p %q %r %s %t', 16, 1,
 		'a',
 		N'b',

--- a/test/fixtures/dialects/tsql/raiserror.yml
+++ b/test/fixtures/dialects/tsql/raiserror.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c286f099e756eed487721ebfff75b87861ead8c85234152cde5923f82f686c70
+_hash: 1069fe3b3596e25ff9c3cf124555a423cbc9b74f2dc739a1d7e7f6332fe98f04
 file:
   batch:
   - statement:
@@ -48,5 +48,84 @@ file:
         - literal: '16'
         - comma: ','
         - literal: '1'
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      raiserror_statement:
+        keyword: RAISERROR
+        bracketed:
+        - start_bracket: (
+        - literal: "N'Unicode error'"
+        - comma: ','
+        - literal: '16'
+        - comma: ','
+        - literal: '1'
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      raiserror_statement:
+      - keyword: RAISERROR
+      - bracketed:
+        - start_bracket: (
+        - literal: "'WITH option'"
+        - comma: ','
+        - literal: '16'
+        - comma: ','
+        - literal: '1'
+        - end_bracket: )
+      - keyword: WITH
+      - keyword: LOG
+  - statement_terminator: ;
+  - statement:
+      raiserror_statement:
+        keyword: RAISERROR
+        bracketed:
+        - start_bracket: (
+        - literal: "'Error with lots of arguments %a %b %c %d %e %f %g %h %i %j %k\
+            \ %l %m %n %o %p %q %r %s %t'"
+        - comma: ','
+        - literal: '16'
+        - comma: ','
+        - literal: '1'
+        - comma: ','
+        - literal: "'a'"
+        - comma: ','
+        - literal: "N'b'"
+        - comma: ','
+        - parameter: '@c'
+        - comma: ','
+        - literal: '4'
+        - comma: ','
+        - literal: '5'
+        - comma: ','
+        - literal: '6'
+        - comma: ','
+        - literal: '7'
+        - comma: ','
+        - literal: '8'
+        - comma: ','
+        - literal: '9'
+        - comma: ','
+        - literal: '10'
+        - comma: ','
+        - literal: '11'
+        - comma: ','
+        - literal: '12'
+        - comma: ','
+        - literal: '13'
+        - comma: ','
+        - literal: '14'
+        - comma: ','
+        - literal: '15'
+        - comma: ','
+        - literal: '16'
+        - comma: ','
+        - literal: '17'
+        - comma: ','
+        - literal: '18'
+        - comma: ','
+        - literal: '19'
+        - comma: ','
+        - literal: '20'
         - end_bracket: )
   - statement_terminator: ;


### PR DESCRIPTION
TSQL's RAISERROR command has functionality not currently reflected in the SQLFluff TSQL dialect.

This PR will add:
-Unicode support
-Full argument support
-Option support

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
