### PR TITLE
TSQL: Add indentation for CREATE INDEX/STATISTICS

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -670,6 +670,7 @@ class CreateIndexStatementSegment(BaseSegment):
     type = "create_index_statement"
     match_grammar = Sequence(
         "CREATE",
+        Indent,
         Ref("OrReplaceGrammar", optional=True),
         Sequence("UNIQUE", optional=True),
         OneOf("CLUSTERED", "NONCLUSTERED", optional=True),
@@ -689,6 +690,7 @@ class CreateIndexStatementSegment(BaseSegment):
         Ref("OnPartitionOrFilegroupOptionSegment", optional=True),
         Ref("FilestreamOnOptionSegment", optional=True),
         Ref("DelimiterSegment", optional=True),
+        Dedent,
     )
 
 

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -763,3 +763,20 @@ test_pass_tsql_if_indent:
   configs:
     core:
       dialect: tsql
+
+
+test_pass_tsql_index_indent:
+  pass_str: |
+    CREATE UNIQUE INDEX AK_UnitMeasure_Name
+      ON Production.UnitMeasure(Name);
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_tsql_statistics_indent:
+  pass_str: |
+    CREATE STATISTICS [stat_ccode]
+        ON [dbo].[CodeValues]([ccode]);
+  configs:
+    core:
+      dialect: tsql

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -768,7 +768,7 @@ test_pass_tsql_if_indent:
 test_pass_tsql_index_indent:
   pass_str: |
     CREATE UNIQUE INDEX AK_UnitMeasure_Name
-      ON Production.UnitMeasure(Name);
+        ON Production.UnitMeasure(Name);
   configs:
     core:
       dialect: tsql


### PR DESCRIPTION
### Brief summary of the change made
Adding indentation so that multi-line CREATE STATISTICS and CREATE INDEX commands are indented on succeeding lines.

### Are there any other side effects of this change that we should be aware of?
None.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `[x] .yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
