### PR TITLE
Exasol: Allow CROSS joins

### DIFF
--- a/src/sqlfluff/dialects/dialect_exasol_keywords.py
+++ b/src/sqlfluff/dialects/dialect_exasol_keywords.py
@@ -78,6 +78,7 @@ RESERVED_KEYWORDS = [
     "CONVERT",
     "CORRESPONDING",
     "CREATE",
+    "CROSS",  # a unreserved keyword but needed to be reserved to make join clause work
     "CS",
     "CSV",
     "CUBE",
@@ -530,7 +531,6 @@ UNRESERVED_KEYWORDS = [
     "COVAR_POP",
     "COVAR_SAMP",
     "CREATED",
-    "CROSS",
     "CURDATE",
     "DATABASE",
     "DATE_TRUNC",

--- a/test/fixtures/dialects/exasol/SelectStatement.sql
+++ b/test/fixtures/dialects/exasol/SelectStatement.sql
@@ -121,3 +121,9 @@ SELECT a, b, c FROM x
 union
 SELECT a, b, c FROM y
 ORDER BY a;
+----
+SELECT -1 * row_number() OVER() AS nummer
+FROM sys.exa_sql_keywords
+CROSS JOIN sys.exa_sql_keywords
+UNION ALL
+SELECT 0;

--- a/test/fixtures/dialects/exasol/SelectStatement.yml
+++ b/test/fixtures/dialects/exasol/SelectStatement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: dd6b6e2f270c8eed1a4a5e86a7b672259efad9235ca65d17044520867bda7da7
+_hash: 1208cf90d7540d5d3e7e6f9ecebfc72942c61993e206e64dbd3e20ed02ade181
 file:
 - statement:
     select_statement:
@@ -1573,4 +1573,56 @@ file:
       - keyword: BY
       - column_reference:
           identifier: a
+- statement_terminator: ;
+- statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              numeric_literal:
+                binary_operator: '-'
+                literal: '1'
+              binary_operator: '*'
+              function:
+                function_name:
+                  function_name_identifier: row_number
+                bracketed:
+                  start_bracket: (
+                  end_bracket: )
+                over_clause:
+                  keyword: OVER
+                  bracketed:
+                    start_bracket: (
+                    end_bracket: )
+            alias_expression:
+              keyword: AS
+              identifier: nummer
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - identifier: sys
+                - dot: .
+                - identifier: exa_sql_keywords
+            join_clause:
+            - keyword: CROSS
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                  - identifier: sys
+                  - dot: .
+                  - identifier: exa_sql_keywords
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            literal: '0'
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Currently the `CROSS` keyword within a `JOIN` clause is handled as an alias of the previous table. This breaks code after formatting because `sqlfluff` fixes the `JOIN` condition to `INNER JOIN` and removes the `CROSS` because it wasn't used as an alias. To solve this I moved the `CROSS` keyword from unreserved to reserved to make it work.

![image](https://user-images.githubusercontent.com/18382402/154569259-889840a7-43ac-4772-b318-f2065f512177.png)

```sql
-- before I executed fix
SELECT -1 * row_number() OVER() AS nummer
FROM sys.exa_sql_keywords
CROSS JOIN sys.exa_sql_keywords
UNION ALL
SELECT 0;

-- after I executed fix => broken sql
SELECT -1 * row_number() OVER() AS nummer
FROM sys.exa_sql_keywords INNER JOIN sys.exa_sql_keywords
UNION ALL
SELECT 0;
```

### Are there any other side effects of this change that we should be aware of?
nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
