### PR TITLE
TSQL: Add variables as options for RAISERROR parameters

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3421,12 +3421,17 @@ class RaiserrorStatementSegment(BaseSegment):
                     Ref("NumericLiteralSegment"),
                     Ref("QuotedLiteralSegment"),
                     Ref("QuotedLiteralSegmentWithN"),
+                    Ref("ParameterNameSegment"),
                 ),
                 OneOf(
-                    Ref("NumericLiteralSegment"), Ref("QualifiedNumericLiteralSegment")
+                    Ref("NumericLiteralSegment"),
+                    Ref("QualifiedNumericLiteralSegment"),
+                    Ref("ParameterNameSegment"),
                 ),
                 OneOf(
-                    Ref("NumericLiteralSegment"), Ref("QualifiedNumericLiteralSegment")
+                    Ref("NumericLiteralSegment"),
+                    Ref("QualifiedNumericLiteralSegment"),
+                    Ref("ParameterNameSegment"),
                 ),
                 AnyNumberOf(
                     Ref("LiteralGrammar"),

--- a/test/fixtures/dialects/tsql/raiserror.sql
+++ b/test/fixtures/dialects/tsql/raiserror.sql
@@ -29,3 +29,8 @@ RAISERROR ('Error with lots of arguments %a %b %c %d %e %f %g %h %i %j %k %l %m 
 		18,
 		19,
 		20);
+
+RAISERROR (@ErrorMessage, -- Message text.  
+			@ErrorSeverity, -- Severity.  
+			@ErrorState -- State.  
+			); 

--- a/test/fixtures/dialects/tsql/raiserror.yml
+++ b/test/fixtures/dialects/tsql/raiserror.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1069fe3b3596e25ff9c3cf124555a423cbc9b74f2dc739a1d7e7f6332fe98f04
+_hash: 7f2a6825244f19753b04754321ca24fd602b2509cb647cd1f3f23884d2bddc69
 file:
   batch:
   - statement:
@@ -127,5 +127,17 @@ file:
         - literal: '19'
         - comma: ','
         - literal: '20'
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      raiserror_statement:
+        keyword: RAISERROR
+        bracketed:
+        - start_bracket: (
+        - parameter: '@ErrorMessage'
+        - comma: ','
+        - parameter: '@ErrorSeverity'
+        - comma: ','
+        - parameter: '@ErrorState'
         - end_bracket: )
   - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Fixes #2695

TSQL supports variables as parameters for RAISERROR.  This PR adds this functionality to SQLFluff's TSQL dialect.

### Are there any other side effects of this change that we should be aware of?
None.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
