### PR TITLE
Spark3: Support for `WINDOW` functions

### DIFF
--- a/test/fixtures/dialects/spark3/window_functions.sql
+++ b/test/fixtures/dialects/spark3/window_functions.sql
@@ -1,0 +1,102 @@
+SELECT
+    name,
+    dept,
+    RANK() OVER (
+        PARTITION BY dept
+        ORDER BY salary
+    ) AS row_rank
+FROM employees;
+
+SELECT
+    name,
+    dept,
+    DENSE_RANK() OVER (
+        PARTITION BY dept
+        ORDER BY salary
+        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS row_dense_rank
+FROM employees;
+
+SELECT
+    name,
+    dept,
+    age,
+    CUME_DIST() OVER (
+        PARTITION BY dept
+        ORDER BY age
+        RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS data_cume_dist
+FROM employees;
+
+SELECT
+    name,
+    dept,
+    salary,
+    MIN(salary) OVER (
+        PARTITION BY dept
+        ORDER BY salary
+    ) AS salary_min
+FROM employees;
+
+SELECT
+    name,
+    salary,
+    LAG(salary) OVER (
+        PARTITION BY dept
+        ORDER BY salary
+    ) AS salary_lag,
+    LEAD(salary, 1, 0) OVER (
+        PARTITION BY dept
+        ORDER BY salary
+    ) AS salary_lead
+FROM employees;
+
+SELECT
+    name,
+    salary,
+    LAG(salary) IGNORE NULLS OVER (
+        PARTITION BY dept
+        ORDER BY salary
+    ) AS salary_lag,
+    LEAD(salary, 1, 0) IGNORE NULLS OVER (
+        PARTITION BY dept
+        ORDER BY salary
+    ) AS salary_lead
+FROM employees;
+
+SELECT
+    name,
+    salary,
+    LAG(salary) RESPECT NULLS OVER (
+        PARTITION BY dept
+        ORDER BY salary
+    ) AS salary_lag,
+    LEAD(salary, 1, 0) RESPECT NULLS OVER (
+        PARTITION BY dept
+        ORDER BY salary
+    ) AS salary_lead
+FROM employees;
+
+SELECT
+    id,
+    v,
+    LEAD(v, 0) IGNORE NULLS OVER w AS v_lead,
+    LAG(v, 0) IGNORE NULLS OVER w AS v_lag,
+    NTH_VALUE(v, 2) IGNORE NULLS OVER w AS v_nth_value,
+    FIRST_VALUE(v) IGNORE NULLS OVER w AS v_first_value,
+    LAST_VALUE(v) IGNORE NULLS OVER w AS v_last_value
+FROM test_ignore_null
+WINDOW w AS (ORDER BY id)
+ORDER BY id;
+
+SELECT
+    id,
+    v,
+    LEAD(v, 0) RESPECT NULLS OVER w AS v_lead,
+    LAG(v, 0) RESPECT NULLS OVER w AS v_lag,
+    NTH_VALUE(v, 2) RESPECT NULLS OVER w AS v_nth_value,
+    FIRST_VALUE(v) RESPECT NULLS OVER w AS v_first_value,
+    LAST_VALUE(v) RESPECT NULLS OVER w AS v_last_value
+FROM test_ignore_null
+WINDOW w AS (ORDER BY id)
+ORDER BY id;

--- a/test/fixtures/dialects/spark3/window_functions.yml
+++ b/test/fixtures/dialects/spark3/window_functions.yml
@@ -1,0 +1,775 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 2eccc034b540fd65e367038f57767c8fb9db161421f0f7c947bec97454264e17
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: dept
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: RANK
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: dept
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: salary
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: row_rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: employees
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: dept
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: DENSE_RANK
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: dept
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: salary
+                  frame_clause:
+                  - keyword: ROWS
+                  - keyword: BETWEEN
+                  - keyword: UNBOUNDED
+                  - keyword: PRECEDING
+                  - binary_operator: AND
+                  - keyword: CURRENT
+                  - keyword: ROW
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: row_dense_rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: employees
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: dept
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: age
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CUME_DIST
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: dept
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: age
+                  frame_clause:
+                  - keyword: RANGE
+                  - keyword: BETWEEN
+                  - keyword: UNBOUNDED
+                  - keyword: PRECEDING
+                  - binary_operator: AND
+                  - keyword: CURRENT
+                  - keyword: ROW
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: data_cume_dist
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: employees
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: dept
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: salary
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: MIN
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: salary
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: dept
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: salary
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: salary_min
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: employees
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: salary
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LAG
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: salary
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: dept
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: salary
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: salary_lag
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LEAD
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  identifier: salary
+            - comma: ','
+            - expression:
+                literal: '1'
+            - comma: ','
+            - expression:
+                literal: '0'
+            - end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: dept
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: salary
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: salary_lead
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: employees
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: salary
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LAG
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: salary
+              end_bracket: )
+            over_clause:
+            - keyword: IGNORE
+            - keyword: NULLS
+            - keyword: OVER
+            - bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: dept
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: salary
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: salary_lag
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LEAD
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  identifier: salary
+            - comma: ','
+            - expression:
+                literal: '1'
+            - comma: ','
+            - expression:
+                literal: '0'
+            - end_bracket: )
+            over_clause:
+            - keyword: IGNORE
+            - keyword: NULLS
+            - keyword: OVER
+            - bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: dept
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: salary
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: salary_lead
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: employees
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: salary
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LAG
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: salary
+              end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: dept
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: salary
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: salary_lag
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LEAD
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  identifier: salary
+            - comma: ','
+            - expression:
+                literal: '1'
+            - comma: ','
+            - expression:
+                literal: '0'
+            - end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        identifier: dept
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      identifier: salary
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            identifier: salary_lead
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: employees
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: v
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LEAD
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  identifier: v
+            - comma: ','
+            - expression:
+                literal: '0'
+            - end_bracket: )
+            over_clause:
+            - keyword: IGNORE
+            - keyword: NULLS
+            - keyword: OVER
+            - identifier: w
+          alias_expression:
+            keyword: AS
+            identifier: v_lead
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LAG
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  identifier: v
+            - comma: ','
+            - expression:
+                literal: '0'
+            - end_bracket: )
+            over_clause:
+            - keyword: IGNORE
+            - keyword: NULLS
+            - keyword: OVER
+            - identifier: w
+          alias_expression:
+            keyword: AS
+            identifier: v_lag
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: NTH_VALUE
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  identifier: v
+            - comma: ','
+            - expression:
+                literal: '2'
+            - end_bracket: )
+            over_clause:
+            - keyword: IGNORE
+            - keyword: NULLS
+            - keyword: OVER
+            - identifier: w
+          alias_expression:
+            keyword: AS
+            identifier: v_nth_value
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: FIRST_VALUE
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: v
+              end_bracket: )
+            over_clause:
+            - keyword: IGNORE
+            - keyword: NULLS
+            - keyword: OVER
+            - identifier: w
+          alias_expression:
+            keyword: AS
+            identifier: v_first_value
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LAST_VALUE
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: v
+              end_bracket: )
+            over_clause:
+            - keyword: IGNORE
+            - keyword: NULLS
+            - keyword: OVER
+            - identifier: w
+          alias_expression:
+            keyword: AS
+            identifier: v_last_value
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: test_ignore_null
+            named_window:
+              keyword: WINDOW
+              named_window_expression:
+                identifier: w
+                keyword: AS
+                bracketed:
+                  start_bracket: (
+                  window_specification:
+                    orderby_clause:
+                    - keyword: ORDER
+                    - keyword: BY
+                    - column_reference:
+                        identifier: id
+                  end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          identifier: id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: v
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LEAD
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  identifier: v
+            - comma: ','
+            - expression:
+                literal: '0'
+            - end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - identifier: w
+          alias_expression:
+            keyword: AS
+            identifier: v_lead
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LAG
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  identifier: v
+            - comma: ','
+            - expression:
+                literal: '0'
+            - end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - identifier: w
+          alias_expression:
+            keyword: AS
+            identifier: v_lag
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: NTH_VALUE
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  identifier: v
+            - comma: ','
+            - expression:
+                literal: '2'
+            - end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - identifier: w
+          alias_expression:
+            keyword: AS
+            identifier: v_nth_value
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: FIRST_VALUE
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: v
+              end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - identifier: w
+          alias_expression:
+            keyword: AS
+            identifier: v_first_value
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LAST_VALUE
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: v
+              end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - identifier: w
+          alias_expression:
+            keyword: AS
+            identifier: v_last_value
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: test_ignore_null
+            named_window:
+              keyword: WINDOW
+              named_window_expression:
+                identifier: w
+                keyword: AS
+                bracketed:
+                  start_bracket: (
+                  window_specification:
+                    orderby_clause:
+                    - keyword: ORDER
+                    - keyword: BY
+                    - column_reference:
+                        identifier: id
+                  end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          identifier: id
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Changes to spark3 dialect so `WINDOW` functions would properly parse, specifically redefining `OverClauseSegment` and adding `NamedWindowSegment` as an optional segment to `FromExpressionElementSegment`

### Are there any other side effects of this change that we should be aware of?
N/A

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
