### PR TITLE
Redshift: Allow Whitespace Around Cast Operators

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -911,7 +911,9 @@ class ShorthandCastSegment(BaseSegment):
 
     type = "cast_expression"
     match_grammar = Sequence(
-        Ref("CastOperatorSegment"), Ref("DatatypeSegment"), allow_gaps=False
+        Ref("CastOperatorSegment"),
+        Ref("DatatypeSegment"),
+        allow_gaps=True
     )
 
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -911,9 +911,7 @@ class ShorthandCastSegment(BaseSegment):
 
     type = "cast_expression"
     match_grammar = Sequence(
-        Ref("CastOperatorSegment"),
-        Ref("DatatypeSegment"),
-        allow_gaps=True
+        Ref("CastOperatorSegment"), Ref("DatatypeSegment"), allow_gaps=True
     )
 
 

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -182,7 +182,6 @@ class DatatypeSegment(BaseSegment):
                 optional=True,
             ),
         ),
-        allow_gaps=True
     )
 
 

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -114,77 +114,74 @@ class DatatypeSegment(BaseSegment):
     """
 
     type = "data_type"
-    match_grammar = Sequence(
-        OneOf(
-            # numeric types
-            "SMALLINT",
-            "INT2",
-            "INTEGER",
-            "INT",
-            "INT4",
-            "BIGINT",
-            "INT8",
-            "REAL",
-            "FLOAT4",
-            Sequence("DOUBLE", "PRECISION"),
-            "FLOAT8",
-            "FLOAT",
-            # numeric types [precision ["," scale])]
-            Sequence(
-                OneOf("DECIMAL", "NUMERIC"),
-                Bracketed(
-                    Delimited(Ref("NumericLiteralSegment")),
-                    optional=True,
-                ),
-            ),
-            # character types
-            OneOf(
-                Sequence(
-                    OneOf(
-                        "CHAR",
-                        "CHARACTER",
-                        "NCHAR",
-                        "VARCHAR",
-                        Sequence("CHARACTER", "VARYING"),
-                        "NVARCHAR",
-                    ),
-                    Bracketed(
-                        OneOf(
-                            Ref("NumericLiteralSegment"),
-                            "MAX",
-                        ),
-                        optional=True,
-                    ),
-                ),
-                "BPCHAR",
-                "TEXT",
-            ),
-            Ref("DateTimeTypeIdentifier"),
-            # INTERVAL is a data type *only* for conversion operations
-            "INTERVAL",
-            # boolean types
-            OneOf("BOOLEAN", "BOOL"),
-            # hllsketch type
-            "HLLSKETCH",
-            # super type
-            "SUPER",
-            # spatial data
-            "GEOMETRY",
-            "GEOGRAPHY",
-            # binary type
-            Sequence(
-                OneOf(
-                    "VARBYTE",
-                    "VARBINARY",
-                    Sequence("BINARY", "VARYING"),
-                ),
-                Bracketed(
-                    Ref("NumericLiteralSegment"),
-                    optional=True,
-                ),
+    match_grammar = OneOf(
+        # numeric types
+        "SMALLINT",
+        "INT2",
+        "INTEGER",
+        "INT",
+        "INT4",
+        "BIGINT",
+        "INT8",
+        "REAL",
+        "FLOAT4",
+        Sequence("DOUBLE", "PRECISION"),
+        "FLOAT8",
+        "FLOAT",
+        # numeric types [precision ["," scale])]
+        Sequence(
+            OneOf("DECIMAL", "NUMERIC"),
+            Bracketed(
+                Delimited(Ref("NumericLiteralSegment")),
+                optional=True,
             ),
         ),
-        allow_gaps=True,
+        # character types
+        OneOf(
+            Sequence(
+                OneOf(
+                    "CHAR",
+                    "CHARACTER",
+                    "NCHAR",
+                    "VARCHAR",
+                    Sequence("CHARACTER", "VARYING"),
+                    "NVARCHAR",
+                ),
+                Bracketed(
+                    OneOf(
+                        Ref("NumericLiteralSegment"),
+                        "MAX",
+                    ),
+                    optional=True,
+                ),
+            ),
+            "BPCHAR",
+            "TEXT",
+        ),
+        Ref("DateTimeTypeIdentifier"),
+        # INTERVAL is a data type *only* for conversion operations
+        "INTERVAL",
+        # boolean types
+        OneOf("BOOLEAN", "BOOL"),
+        # hllsketch type
+        "HLLSKETCH",
+        # super type
+        "SUPER",
+        # spatial data
+        "GEOMETRY",
+        "GEOGRAPHY",
+        # binary type
+        Sequence(
+            OneOf(
+                "VARBYTE",
+                "VARBINARY",
+                Sequence("BINARY", "VARYING"),
+            ),
+            Bracketed(
+                Ref("NumericLiteralSegment"),
+                optional=True,
+            ),
+        ),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -182,6 +182,7 @@ class DatatypeSegment(BaseSegment):
                 optional=True,
             ),
         ),
+        allow_gaps=True
     )
 
 

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -114,74 +114,77 @@ class DatatypeSegment(BaseSegment):
     """
 
     type = "data_type"
-    match_grammar = OneOf(
-        # numeric types
-        "SMALLINT",
-        "INT2",
-        "INTEGER",
-        "INT",
-        "INT4",
-        "BIGINT",
-        "INT8",
-        "REAL",
-        "FLOAT4",
-        Sequence("DOUBLE", "PRECISION"),
-        "FLOAT8",
-        "FLOAT",
-        # numeric types [precision ["," scale])]
-        Sequence(
-            OneOf("DECIMAL", "NUMERIC"),
-            Bracketed(
-                Delimited(Ref("NumericLiteralSegment")),
-                optional=True,
-            ),
-        ),
-        # character types
+    match_grammar = Sequence(
         OneOf(
+            # numeric types
+            "SMALLINT",
+            "INT2",
+            "INTEGER",
+            "INT",
+            "INT4",
+            "BIGINT",
+            "INT8",
+            "REAL",
+            "FLOAT4",
+            Sequence("DOUBLE", "PRECISION"),
+            "FLOAT8",
+            "FLOAT",
+            # numeric types [precision ["," scale])]
             Sequence(
-                OneOf(
-                    "CHAR",
-                    "CHARACTER",
-                    "NCHAR",
-                    "VARCHAR",
-                    Sequence("CHARACTER", "VARYING"),
-                    "NVARCHAR",
-                ),
+                OneOf("DECIMAL", "NUMERIC"),
                 Bracketed(
-                    OneOf(
-                        Ref("NumericLiteralSegment"),
-                        "MAX",
-                    ),
+                    Delimited(Ref("NumericLiteralSegment")),
                     optional=True,
                 ),
             ),
-            "BPCHAR",
-            "TEXT",
-        ),
-        Ref("DateTimeTypeIdentifier"),
-        # INTERVAL is a data type *only* for conversion operations
-        "INTERVAL",
-        # boolean types
-        OneOf("BOOLEAN", "BOOL"),
-        # hllsketch type
-        "HLLSKETCH",
-        # super type
-        "SUPER",
-        # spatial data
-        "GEOMETRY",
-        "GEOGRAPHY",
-        # binary type
-        Sequence(
+            # character types
             OneOf(
-                "VARBYTE",
-                "VARBINARY",
-                Sequence("BINARY", "VARYING"),
+                Sequence(
+                    OneOf(
+                        "CHAR",
+                        "CHARACTER",
+                        "NCHAR",
+                        "VARCHAR",
+                        Sequence("CHARACTER", "VARYING"),
+                        "NVARCHAR",
+                    ),
+                    Bracketed(
+                        OneOf(
+                            Ref("NumericLiteralSegment"),
+                            "MAX",
+                        ),
+                        optional=True,
+                    ),
+                ),
+                "BPCHAR",
+                "TEXT",
             ),
-            Bracketed(
-                Ref("NumericLiteralSegment"),
-                optional=True,
+            Ref("DateTimeTypeIdentifier"),
+            # INTERVAL is a data type *only* for conversion operations
+            "INTERVAL",
+            # boolean types
+            OneOf("BOOLEAN", "BOOL"),
+            # hllsketch type
+            "HLLSKETCH",
+            # super type
+            "SUPER",
+            # spatial data
+            "GEOMETRY",
+            "GEOGRAPHY",
+            # binary type
+            Sequence(
+                OneOf(
+                    "VARBYTE",
+                    "VARBINARY",
+                    Sequence("BINARY", "VARYING"),
+                ),
+                Bracketed(
+                    Ref("NumericLiteralSegment"),
+                    optional=True,
+                ),
             ),
         ),
+        allow_gaps=True,
     )
 
 

--- a/test/fixtures/dialects/ansi/ansi_cast_with_whitespaces.sql
+++ b/test/fixtures/dialects/ansi/ansi_cast_with_whitespaces.sql
@@ -1,0 +1,42 @@
+-- ansi_cast_with_whitespaces.sql
+/* Several valid queries where there is whitespace surrounding the ANSI
+cast operator (::) */
+
+-- query from https://github.com/sqlfluff/sqlfluff/issues/2720
+SELECT amount_of_honey :: FLOAT
+FROM bear_inventory;
+
+
+-- should be able to support an arbitrary amount of whitespace
+SELECT amount_of_honey        ::        FLOAT
+FROM bear_inventory;
+
+SELECT amount_of_honey::    FLOAT
+FROM bear_inventory;
+
+SELECT amount_of_honey        ::FLOAT
+FROM bear_inventory;
+
+-- should support a wide variety of typecasts
+SELECT amount_of_honey :: time
+FROM bear_inventory;
+
+SELECT amount_of_honey :: text
+FROM bear_inventory;
+
+SELECT amount_of_honey     :: VARCHAR( 512 )
+FROM bear_inventory;
+
+SELECT amount_of_honey ::        TIMESTAMPTZ
+FROM bear_inventory;
+
+SELECT amount_of_honey    ::        TIMESTAMP WITHOUT TIME ZONE
+FROM bear_inventory;
+
+-- should support casts with arbitrary amount of whitespace in join statements
+SELECT
+    bi.amount_of_honey
+FROM bear_inventory bi
+LEFT JOIN favorite_cola fc
+    ON fc.bear_id ::   VARCHAR(512) = bi.bear_id    ::VARCHAR(512)
+WHERE fc.favorite_cola = 'RC Cola';

--- a/test/fixtures/dialects/ansi/ansi_cast_with_whitespaces.yml
+++ b/test/fixtures/dialects/ansi/ansi_cast_with_whitespaces.yml
@@ -1,0 +1,264 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9d97ccca45ece815d21281b83904579d9a0624d5ddcdf0c4ab523008a98edf36
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: FLOAT
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: FLOAT
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: FLOAT
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: FLOAT
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: time
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: text
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: VARCHAR
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    literal: '512'
+                  end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: TIMESTAMPTZ
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+              - keyword: TIMESTAMP
+              - keyword: WITHOUT
+              - keyword: TIME
+              - keyword: ZONE
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+          - identifier: bi
+          - dot: .
+          - identifier: amount_of_honey
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+            alias_expression:
+              identifier: bi
+          join_clause:
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: favorite_cola
+              alias_expression:
+                identifier: fc
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - identifier: fc
+                - dot: .
+                - identifier: bear_id
+              - cast_expression:
+                  casting_operator: '::'
+                  data_type:
+                    data_type_identifier: VARCHAR
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        literal: '512'
+                      end_bracket: )
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - identifier: bi
+                - dot: .
+                - identifier: bear_id
+              - cast_expression:
+                  casting_operator: '::'
+                  data_type:
+                    data_type_identifier: VARCHAR
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        literal: '512'
+                      end_bracket: )
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+          - identifier: fc
+          - dot: .
+          - identifier: favorite_cola
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: "'RC Cola'"
+- statement_terminator: ;

--- a/test/fixtures/dialects/postgres/postgres_cast_with_whitespaces.sql
+++ b/test/fixtures/dialects/postgres/postgres_cast_with_whitespaces.sql
@@ -1,0 +1,42 @@
+-- postgres_cast_with_whitespaces.sql
+/* Several valid queries where there is whitespace surrounding the Postgres
+cast operator (::) */
+
+-- query from https://github.com/sqlfluff/sqlfluff/issues/2720
+SELECT amount_of_honey :: FLOAT
+FROM bear_inventory;
+
+
+-- should be able to support an arbitrary amount of whitespace
+SELECT amount_of_honey        ::        FLOAT
+FROM bear_inventory;
+
+SELECT amount_of_honey::    FLOAT
+FROM bear_inventory;
+
+SELECT amount_of_honey        ::FLOAT
+FROM bear_inventory;
+
+-- should support a wide variety of typecasts
+SELECT amount_of_honey :: time
+FROM bear_inventory;
+
+SELECT amount_of_honey :: text
+FROM bear_inventory;
+
+SELECT amount_of_honey     :: VARCHAR( 512 )
+FROM bear_inventory;
+
+SELECT amount_of_honey ::        TIMESTAMPTZ
+FROM bear_inventory;
+
+SELECT amount_of_honey    ::        TIMESTAMP WITHOUT TIME ZONE
+FROM bear_inventory;
+
+-- should support casts with arbitrary amount of whitespace in join statements
+SELECT
+    bi.amount_of_honey
+FROM bear_inventory bi
+LEFT JOIN favorite_cola fc
+    ON fc.bear_id ::   VARCHAR(512) = bi.bear_id    ::VARCHAR(512)
+WHERE fc.favorite_cola = 'RC Cola';

--- a/test/fixtures/dialects/postgres/postgres_cast_with_whitespaces.yml
+++ b/test/fixtures/dialects/postgres/postgres_cast_with_whitespaces.yml
@@ -1,0 +1,264 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: d7d64b9fe8b44c2db5d36f0eb0eb5c3ee3c0845fcd66392bc7a59b1162068264
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: FLOAT
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: FLOAT
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: FLOAT
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: FLOAT
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                  keyword: time
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: text
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: VARCHAR
+                bracketed:
+                  start_bracket: (
+                  literal: '512'
+                  end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                  keyword: TIMESTAMPTZ
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                - keyword: TIMESTAMP
+                - keyword: WITHOUT
+                - keyword: TIME
+                - keyword: ZONE
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+          - identifier: bi
+          - dot: .
+          - identifier: amount_of_honey
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+            alias_expression:
+              identifier: bi
+          join_clause:
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: favorite_cola
+              alias_expression:
+                identifier: fc
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - identifier: fc
+                - dot: .
+                - identifier: bear_id
+              - cast_expression:
+                  casting_operator: '::'
+                  data_type:
+                    keyword: VARCHAR
+                    bracketed:
+                      start_bracket: (
+                      literal: '512'
+                      end_bracket: )
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - identifier: bi
+                - dot: .
+                - identifier: bear_id
+              - cast_expression:
+                  casting_operator: '::'
+                  data_type:
+                    keyword: VARCHAR
+                    bracketed:
+                      start_bracket: (
+                      literal: '512'
+                      end_bracket: )
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+          - identifier: fc
+          - dot: .
+          - identifier: favorite_cola
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: "'RC Cola'"
+- statement_terminator: ;

--- a/test/fixtures/dialects/redshift/redshift_cast_with_whitespaces.sql
+++ b/test/fixtures/dialects/redshift/redshift_cast_with_whitespaces.sql
@@ -1,0 +1,42 @@
+-- redshift_cast_with_whitespaces.sql
+/* Several valid queries where there is whitespace surrounding the Redshift
+cast operator (::) */
+
+-- query from https://github.com/sqlfluff/sqlfluff/issues/2720
+SELECT amount_of_honey :: FLOAT
+FROM bear_inventory;
+
+
+-- should be able to support an arbitrary amount of whitespace
+SELECT amount_of_honey        ::        FLOAT
+FROM bear_inventory;
+
+SELECT amount_of_honey::    FLOAT
+FROM bear_inventory;
+
+SELECT amount_of_honey        ::FLOAT
+FROM bear_inventory;
+
+-- should support a wide variety of typecasts
+SELECT amount_of_honey :: time
+FROM bear_inventory;
+
+SELECT amount_of_honey :: text
+FROM bear_inventory;
+
+SELECT amount_of_honey     :: VARCHAR( 512 )
+FROM bear_inventory;
+
+SELECT amount_of_honey ::        TIMESTAMPTZ
+FROM bear_inventory;
+
+SELECT amount_of_honey    ::        TIMESTAMP WITHOUT TIME ZONE
+FROM bear_inventory;
+
+-- should support casts with arbitrary amount of whitespace in join statements
+SELECT
+    bi.amount_of_honey
+FROM bear_inventory bi
+LEFT JOIN favorite_cola fc
+    ON fc.bear_id ::   VARCHAR(512) = bi.bear_id    ::VARCHAR(512)
+WHERE fc.favorite_cola = 'RC Cola';

--- a/test/fixtures/dialects/redshift/redshift_cast_with_whitespaces.yml
+++ b/test/fixtures/dialects/redshift/redshift_cast_with_whitespaces.yml
@@ -1,0 +1,264 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: d7d64b9fe8b44c2db5d36f0eb0eb5c3ee3c0845fcd66392bc7a59b1162068264
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: FLOAT
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: FLOAT
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: FLOAT
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: FLOAT
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                  keyword: time
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: text
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: VARCHAR
+                bracketed:
+                  start_bracket: (
+                  literal: '512'
+                  end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                  keyword: TIMESTAMPTZ
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: amount_of_honey
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                datetime_type_identifier:
+                - keyword: TIMESTAMP
+                - keyword: WITHOUT
+                - keyword: TIME
+                - keyword: ZONE
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+          - identifier: bi
+          - dot: .
+          - identifier: amount_of_honey
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: bear_inventory
+            alias_expression:
+              identifier: bi
+          join_clause:
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: favorite_cola
+              alias_expression:
+                identifier: fc
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - identifier: fc
+                - dot: .
+                - identifier: bear_id
+              - cast_expression:
+                  casting_operator: '::'
+                  data_type:
+                    keyword: VARCHAR
+                    bracketed:
+                      start_bracket: (
+                      literal: '512'
+                      end_bracket: )
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - identifier: bi
+                - dot: .
+                - identifier: bear_id
+              - cast_expression:
+                  casting_operator: '::'
+                  data_type:
+                    keyword: VARCHAR
+                    bracketed:
+                      start_bracket: (
+                      literal: '512'
+                      end_bracket: )
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+          - identifier: fc
+          - dot: .
+          - identifier: favorite_cola
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: "'RC Cola'"
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fixes #2720 .

- **Allows whitespace around cast operators (`::`) in the `redshift` dialect.** I allowed this by adjusting the `DatatypeSegment` in the `redshift` dialect to match grammar using a `Sequence` parser instead of just a `OneOf` parser, and allowed that `Sequence` to have gaps (`allow_gaps=True`). This aligns the parsing logic of `DatatypeSegment`s in the `redshift` dialect to with its ancestor dialects (`postgres`, `ansi`); both of this ancestor dialects parse `DatatypeSegment`s using a `Sequence` parser. I demonstrated that `sqlfluff` now allows for whitespaces around cast operators in the `redshift` dialect with `test/fixtures/dialects/redshift/redshift_cast_with_whitespaces.sql` and `test/fixtures/dialects/redshift/redshift_cast_with_whitespaces.yml`.

### Are there any other side effects of this change that we should be aware of?

This change will allow whitespace around any `DataTypeSegment` in the `redshift` dialect. This is a good thing, as data type definitions across the Redshift specification are flexible to surrounding whitespace.

### Pull Request checklist
- [x ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`. **(N/A for this change)**
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`). **(DONE, see `test/fixtures/dialects/redshift/redshift_cast_with_whitespaces.sql` and `test/fixtures/dialects/redshift/redshift_cast_with_whitespaces.yml`)**
  - Full autofix test cases in `test/fixtures/linter/autofix`. **(N/A for this change)**
  - Other. **(N/A for this change)**
- Added appropriate documentation for the change. **(DONE)**
- Created GitHub issues for any relevant followup/future enhancements if appropriate. **(N/A for this change)**
