### PR TITLE
T-SQL: Add drop constraint syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2124,6 +2124,11 @@ class AlterTableStatementSegment(BaseSegment):
                     "ADD",
                     Ref("TableConstraintSegment"),
                 ),
+                Sequence(
+                    "DROP",
+                    "CONSTRAINT",
+                    Ref("ObjectReferenceSegment"),
+                ),
                 # Rename
                 Sequence(
                     "RENAME",

--- a/test/fixtures/dialects/tsql/alter_table.sql
+++ b/test/fixtures/dialects/tsql/alter_table.sql
@@ -37,3 +37,6 @@ GO
 ALTER TABLE Production.TransactionHistoryArchive
 ALTER COLUMN rec_number VARCHAR(36)
 GO
+
+ALTER TABLE Production.TransactionHistoryArchive
+DROP CONSTRAINT PK_TransactionHistoryArchive_TransactionID

--- a/test/fixtures/dialects/tsql/alter_table.yml
+++ b/test/fixtures/dialects/tsql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 194977dd4e7a4f23dcddeae27b70b085f5b0ebb8185b9c0f4097dec035246c48
+_hash: e64e8adb913de53da6a64eade1cc54d8d6ae67899b23dc6b09e1028097a7bd9f
 file:
 - batch:
     statement:
@@ -292,3 +292,16 @@ file:
               end_bracket: )
 - go_statement:
     keyword: GO
+- batch:
+    statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+        - identifier: Production
+        - dot: .
+        - identifier: TransactionHistoryArchive
+      - keyword: DROP
+      - keyword: CONSTRAINT
+      - object_reference:
+          identifier: PK_TransactionHistoryArchive_TransactionID


### PR DESCRIPTION



<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Adds the necessary syntax for `alter table X drop constraint Y` to T-SQL

fixes #2694

### Are there any other side effects of this change that we should be aware of?
I don't think so.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
