### PR TITLE
Support database links in Oracle

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -4,14 +4,25 @@ This inherits from the ansi dialect.
 """
 from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
+    AnyNumberOf,
+    BaseFileSegment,
     BaseSegment,
+    CodeSegment,
     CommentSegment,
+    Delimited,
+    GreedyUntil,
+    Matchable,
     Ref,
     RegexLexer,
     Sequence,
     StartsWith,
+    StringLexer,
+    StringParser,
+    SymbolSegment,
     OneOf,
 )
+
+from sqlfluff.core.parser.segments.base import BracketedSegment
 
 ansi_dialect = load_raw_dialect("ansi")
 oracle_dialect = ansi_dialect.copy_as("oracle")
@@ -29,19 +40,37 @@ oracle_dialect.insert_lexer_matchers(
             r"PROMPT([^(\r\n)])*((?=\n)|(?=\r\n))?",
             CommentSegment,
         ),
-        RegexLexer(
-            "double_execution_sign",
-            r"@@([^(\r\n)])*((?=\n)|(?=\r\n))?",
-            CommentSegment,
-        ),
-        RegexLexer(
-            "execution_sign",
-            r"@([^(\r\n)])*((?=\n)|(?=\r\n))?",
-            CommentSegment,
-        ),
+        StringLexer("at_sign", "@", CodeSegment),
     ],
     before="code",
 )
+
+oracle_dialect.add(
+    AtSignSegment=StringParser("@", SymbolSegment, name="atsign", type="at_sign"),
+)
+
+
+@oracle_dialect.segment()
+class ExecuteFileSegment(BaseSegment):
+    """A reference to an indextype."""
+
+    type = "execute_file_statement"
+
+    match_grammar = Sequence(
+        OneOf(
+            Sequence(
+                Ref("AtSignSegment"),
+                Ref("AtSignSegment", optional=True),
+            ),
+            "START",
+        ),
+        # Probably should have a better file definition but this will do for now
+        AnyNumberOf(
+            Ref("SingleIdentifierGrammar"),
+            Ref("DotSegment"),
+            Ref("DivideSegment"),
+        ),
+    )
 
 
 @oracle_dialect.segment()
@@ -58,17 +87,46 @@ class IndexTypeReferenceSegment(BaseSegment):
 # Adding Oracle specific statements.
 @oracle_dialect.segment(replace=True)
 class StatementSegment(BaseSegment):
-    """A generic segment, to any of its child subsegments."""
+    """A generic segment, to any of its child subsegments.
+
+    Override ANSI to allow exclusion of ExecuteFileSegment.
+    """
 
     type = "statement"
 
+    match_grammar = OneOf(
+        GreedyUntil(Ref("DelimiterSegment")), exclude=Ref("ExecuteFileSegment")
+    )
     parse_grammar = ansi_dialect.get_segment("StatementSegment").parse_grammar.copy(
         insert=[
             Ref("CommentStatementSegment"),
         ],
     )
 
-    match_grammar = ansi_dialect.get_segment("StatementSegment").match_grammar.copy()
+
+@oracle_dialect.segment(replace=True)
+class FileSegment(BaseFileSegment):
+    """A segment representing a whole file or script.
+
+    This is also the default "root" segment of the dialect,
+    and so is usually instantiated directly. It therefore
+    has no match_grammar.
+
+    Override ANSI to allow addition of ExecuteFileSegment without
+    ending in DelimiterSegment
+    """
+
+    # NB: We don't need a match_grammar here because we're
+    # going straight into instantiating it directly usually.
+    parse_grammar = AnyNumberOf(
+        Ref("ExecuteFileSegment"),
+        Delimited(
+            Ref("StatementSegment"),
+            delimiter=AnyNumberOf(Ref("DelimiterSegment"), min_times=1),
+            allow_gaps=True,
+            allow_trailing=True,
+        ),
+    )
 
 
 @oracle_dialect.segment()
@@ -112,4 +170,46 @@ class CommentStatementSegment(BaseSegment):
             ),
             Sequence("IS", OneOf(Ref("QuotedLiteralSegment"), "NULL")),
         ),
+    )
+
+
+# Dialects should not use Python "import" to access other dialects. Instead,
+# get a reference to the ANSI ObjectReferenceSegment this way so we can inherit
+# from it.
+ObjectReferenceSegment = ansi_dialect.get_segment("ObjectReferenceSegment")
+
+
+# need to ignore type due to mypy rules on type variables
+# see https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
+# for details
+@oracle_dialect.segment(replace=True)
+class TableReferenceSegment(ObjectReferenceSegment):  # type: ignore
+    """A reference to an table, CTE, subquery or alias.
+
+    Extended from ANSI to allow Database Link syntax using AtSignSegment
+    """
+
+    type = "table_reference"
+    match_grammar: Matchable = Delimited(
+        Ref("SingleIdentifierGrammar"),
+        delimiter=OneOf(
+            Ref("DotSegment"),
+            Sequence(Ref("DotSegment"), Ref("DotSegment")),
+            Ref("AtSignSegment"),
+        ),
+        terminator=OneOf(
+            "ON",
+            "AS",
+            "USING",
+            Ref("CommaSegment"),
+            Ref("CastOperatorSegment"),
+            Ref("StartSquareBracketSegment"),
+            Ref("StartBracketSegment"),
+            Ref("BinaryOperatorGrammar"),
+            Ref("ColonSegment"),
+            Ref("DelimiterSegment"),
+            Ref("JoinLikeClauseGrammar"),
+            BracketedSegment,
+        ),
+        allow_gaps=False,
     )

--- a/test/fixtures/dialects/oracle/at_signs.yml
+++ b/test/fixtures/dialects/oracle/at_signs.yml
@@ -3,9 +3,37 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a3e85b165a4d3c6728dddc8257816236fe4bad74db6e1e93316a6f1a4a73e7bb
+_hash: 60284384705beb18d09cd14422636d65e8b4f5af2718a3acf4a99518a08473ba
 file:
-  statement:
+- execute_file_statement:
+  - at_sign: '@'
+  - at_sign: '@'
+  - identifier: some_other_sql_file
+  - dot: .
+  - identifier: sql
+- execute_file_statement:
+  - at_sign: '@'
+  - at_sign: '@'
+  - identifier: some_other_sql_file_with_args
+  - dot: .
+  - identifier: sql
+  - identifier: foo
+  - identifier: bar
+  - identifier: baz
+- execute_file_statement:
+  - at_sign: '@'
+  - identifier: some_other_sql_file
+  - dot: .
+  - identifier: sql
+- execute_file_statement:
+  - at_sign: '@'
+  - identifier: some_other_sql_file_with_args
+  - dot: .
+  - identifier: sql
+  - identifier: foo
+  - identifier: bar
+  - identifier: baz
+- statement:
     select_statement:
       select_clause:
         keyword: SELECT
@@ -20,4 +48,4 @@ file:
             table_expression:
               table_reference:
                 identifier: some_table
-  statement_terminator: ;
+- statement_terminator: ;

--- a/test/fixtures/dialects/oracle/database_link.sql
+++ b/test/fixtures/dialects/oracle/database_link.sql
@@ -1,0 +1,3 @@
+select * from foo@bar where 1 = 1;
+
+select baz.name from foo@bar baz where 1 = 1;

--- a/test/fixtures/dialects/oracle/database_link.yml
+++ b/test/fixtures/dialects/oracle/database_link.yml
@@ -1,0 +1,60 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 3ef4ac8b9d6730d4cad98cc0505ea2b312391b70ed7e4cc88685cefcea03071f
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: foo
+              - at_sign: '@'
+              - identifier: bar
+      where_clause:
+        keyword: where
+        expression:
+        - literal: '1'
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          column_reference:
+          - identifier: baz
+          - dot: .
+          - identifier: name
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: foo
+              - at_sign: '@'
+              - identifier: bar
+            alias_expression:
+              identifier: baz
+      where_clause:
+        keyword: where
+        expression:
+        - literal: '1'
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - literal: '1'
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #2705 

### Are there any other side effects of this change that we should be aware of?
This required a rewrite of the executes added by @r0fls in #2608 as the `@` used for database links was getting swallowed by that as a comment. This in turn required some jiggy-pokery with the `StatementSegment` and `FileSegment` since the execute statements do not end in the usual semi-colons.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
