### PR TITLE
Support Pascal case for L030

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -114,7 +114,7 @@ ignore_words = None
 
 [sqlfluff:rules:L030]
 # Function names
-capitalisation_policy = consistent
+extended_capitalisation_policy = consistent
 # Comma separated list of words to ignore for this rule
 ignore_words = None
 

--- a/src/sqlfluff/rules/L030.py
+++ b/src/sqlfluff/rules/L030.py
@@ -42,6 +42,10 @@ class Rule_L030(Rule_L010):
         ("type", "function_name_identifier"),
         ("type", "bare_function"),
     ]
+    config_keywords = [
+        "extended_capitalisation_policy",
+        "ignore_words",
+    ]
     _description_elem = "Function names"
 
     def _get_fix(self, segment, fixed_raw):

--- a/test/fixtures/rules/std_rule_cases/L030.yml
+++ b/test/fixtures/rules/std_rule_cases/L030.yml
@@ -3,38 +3,39 @@ rule: L030
 # Inconsistent capitalisation of functions
 test_fail_inconsistent_function_capitalisation_1:
   fail_str: SELECT MAX(id), min(id) from table
-
   fix_str: SELECT MAX(id), MIN(id) from table
 
 test_fail_inconsistent_function_capitalisation_2:
   fail_str: SELECT MAX(id), min(id) from table
-
   fix_str: SELECT max(id), min(id) from table
-
   configs:
     rules:
       L030:
-        capitalisation_policy: lower
+        extended_capitalisation_policy: lower
 
 test_bare_functions:
   fail_str: SELECT current_timestamp from table
-
   fix_str: SELECT CURRENT_TIMESTAMP from table
-
   configs:
     rules:
       L030:
-        capitalisation_policy: upper
+        extended_capitalisation_policy: upper
 
 test_bare_functions_2:
   fail_str: SELECT current_timestamp, min(a) from table
-
   fix_str: SELECT CURRENT_TIMESTAMP, MIN(a) from table
-
   configs:
     rules:
       L030:
-        capitalisation_policy: upper
+        extended_capitalisation_policy: upper
+
+test_bare_functions_3:
+  fail_str: SELECT current_timestamp, min(a) from table
+  fix_str: SELECT Current_Timestamp, Min(a) from table
+  configs:
+    rules:
+      L030:
+        extended_capitalisation_policy: pascal
 
 test_fail_capitalization_after_comma:
   fail_str: SELECT FLOOR(dt) ,count(*) FROM test
@@ -44,9 +45,8 @@ test_fail_fully_qualified_function_mixed_functions:
   fail_str: SELECT COUNT(*), project1.foo(value1) AS value2
   fix_str: SELECT COUNT(*), project1.FOO(value1) AS value2
 
-test_fail_fully_qualified_function_mixed_case:
-  fail_str: SELECT project1.FoO(value1) AS value2
-  fix_str: SELECT project1.FOO(value1) AS value2
+test_pass_fully_qualified_function_pascal_case:
+  pass_str: SELECT project1.FoO(value1) AS value2
 
 test_pass_ignore_word:
   pass_str: SELECT MAX(id), min(id) FROM TABLE1


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #2736

### Are there any other side effects of this change that we should be aware of?
This is a breaking change as L030 goes from using `capitalisation_policy` to `extended_capitalisation_policy` so anyone using it will need to change their config. Should be a 0.11.0 release.

Unfortunately it's not possible to support both for backwards compatibility.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
