### PR TITLE
L059: Exasol: Allow quotes around passwords in CREATE USER

### DIFF
--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -83,6 +83,14 @@ class Rule_L059(BaseRule):
             context_policy = "quoted_identifier"
             identifier_contents = context.segment.raw[1:-1]
 
+        # Ignore "password_auth" type to allow quotes around passwords within
+        # `CREATE USER` statements in Exasol dialect.
+        # e.g. CREATE USER user_1 IDENTIFIED BY "h12_xhz";
+        if context.segment.is_type("password_auth") or (
+            context.parent_stack and context.parent_stack[-1].is_type("password_auth")
+        ):
+            return None
+
         # Ignore the segments that are not of the same type as the defined policy above.
         # Also TSQL has a keyword called QUOTED_IDENTIFIER which maps to the name so
         # need to explicity check for that.

--- a/test/fixtures/rules/std_rule_cases/L059.yml
+++ b/test/fixtures/rules/std_rule_cases/L059.yml
@@ -245,3 +245,19 @@ test_pass_quoted_identifier_keyword_tsql:
   configs:
     core:
       dialect: tsql
+
+test_pass_create_user_quoted_password_exasol:
+  pass_str: |
+    CREATE USER user_1 IDENTIFIED BY "h12_xhz";
+  configs:
+    core:
+      dialect: exasol
+
+test_fail_create_quoted_user_exasol:
+  fail_str: |
+    CREATE USER "USER1" IDENTIFIED BY "h12_xhz";
+  fix_str: |
+    CREATE USER USER1 IDENTIFIED BY "h12_xhz";
+  configs:
+    core:
+      dialect: exasol


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
L059 removes the quotes around passwords within `CREATE USER` statements in Exasol dialect.

```sql
CREATE USER user_1 IDENTIFIED BY "h12_xhz";

--> after fix
CREATE USER user_1 IDENTIFIED BY h12_xhz;
```

```
L:   1 | P:  34 | L059 | Unnecessary quoted identifier "h12_xhz".
L:   1 | P:  43 | L009 | Files must end with a single trailing newline.
==== fixing violations ====
2 fixable linting violations found
Are you sure you wish to attempt to fix these? [Y/n] ...
Attempting fixes...
Persisting Changes...
```

This fixes this bug and ignores the `password_auth` segment type.

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
