### PR TITLE
Add L049 test for T-SQL alternate alias syntax (=)

### DIFF
--- a/test/fixtures/rules/std_rule_cases/L049.yml
+++ b/test/fixtures/rules/std_rule_cases/L049.yml
@@ -67,13 +67,22 @@ test_set_clause:
     UPDATE table1 SET col = NULL
     WHERE col = ""
 
-test_exec_clause:
+test_tsql_exec_clause:
   pass_str: |
     exec something
       @param1 = 'blah',
       @param2 = 'blah',
       @param3 = null,
       @param4 = 'blah';
+  configs:
+    core:
+      dialect: tsql
+
+test_tsql_alternate_alias_syntax:
+  pass_str: |
+    select
+      name = null
+    from t
   configs:
     core:
       dialect: tsql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #2708. (Actually, it's already fixed, but this adds a `.yml` test for it.)
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
