### PR TITLE
Make L045 (Query defines a CTE but does not use it) case insensitive

### DIFF
--- a/src/sqlfluff/core/rules/analysis/select_crawler.py
+++ b/src/sqlfluff/core/rules/analysis/select_crawler.py
@@ -133,10 +133,10 @@ class Query:
 
     def lookup_cte(self, name: str, pop: bool = True) -> Optional["Query"]:
         """Look up a CTE by name, in the current or any parent scope."""
-        cte = self.ctes.get(name)
+        cte = self.ctes.get(name.upper())
         if cte:
             if pop:
-                del self.ctes[name]
+                del self.ctes[name.upper()]
             return cte
         if self.parent:
             return self.parent.lookup_cte(name, pop)
@@ -291,7 +291,7 @@ class SelectCrawler:
                                 # to the Query later when we encounter those
                                 # child segments.
                                 pass
-                            query_stack[-1].ctes[cte_name_segment.raw] = query
+                            query_stack[-1].ctes[cte_name_segment.raw_upper] = query
                             cte_name_segment = None
                             append_query(query)
                         else:
@@ -319,7 +319,7 @@ class SelectCrawler:
                     # Beginning a "with" statement, i.e. a block of CTEs.
                     query = self.query_class(QueryType.WithCompound, dialect)
                     if cte_name_segment:
-                        query_stack[-1].ctes[cte_name_segment.raw] = query
+                        query_stack[-1].ctes[cte_name_segment.raw_upper] = query
                         cte_name_segment = None
                     append_query(query)
                 elif path[-1].is_type("common_table_expression"):

--- a/test/fixtures/rules/std_rule_cases/L045.yml
+++ b/test/fixtures/rules/std_rule_cases/L045.yml
@@ -27,6 +27,20 @@ test_pass_cte_defined_and_used_2:
     FROM cte1
     JOIN cte2
 
+test_pass_cte_defined_and_used_case_insensitive:
+  pass_str: |
+    WITH cte1 AS (
+      SELECT a
+      FROM t
+    ),
+    cte2 AS (
+      SELECT b
+      FROM u
+    )
+    SELECT *
+    FROM cte1
+    JOIN Cte2
+
 test_fail_cte_defined_but_unused_1:
   desc: Two CTEs defined but only one used in final query.
   fail_str: |


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #2675
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
