### PR TITLE
Spark3: Support for `PIVOT` clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -181,7 +181,6 @@ spark3_dialect.replace(
         Sequence("CLUSTER", "BY"),
         Sequence("DISTRIBUTE", "BY"),
         Sequence("SORT", "BY"),
-        # TODO Add PIVOT, and DISTRIBUTE BY clauses
         "HAVING",
         Ref("SetOperatorSegment"),
         Ref("WithNoSchemaBindingClauseSegment"),
@@ -1280,7 +1279,6 @@ class UnorderedSelectStatementSegment(BaseSegment):
     parse_grammar = ansi_dialect.get_segment(
         "UnorderedSelectStatementSegment"
     ).parse_grammar.copy(
-        # TODO Insert: PIVOT clause
         # Removing non-valid clauses that exist in ANSI dialect
         remove=[Ref("OverlapsClauseSegment", optional=True)]
     )
@@ -1555,6 +1553,7 @@ class OverClauseSegment(BaseSegment):
     """
 
     type = "over_clause"
+
     match_grammar = Sequence(
         Sequence(OneOf("IGNORE", "RESPECT"), "NULLS", optional=True),
         "OVER",
@@ -1564,6 +1563,62 @@ class OverClauseSegment(BaseSegment):
                 Ref("WindowSpecificationSegment", optional=True),
             ),
         ),
+    )
+
+
+@spark3_dialect.segment()
+class PivotClauseSegment(BaseSegment):
+    """A `PIVOT` clause as using in FROM clause
+
+    https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-pivot.html
+    """
+
+    type = "pivot_clause"
+
+    match_grammar = Sequence(
+        Indent,
+        "PIVOT",
+        Bracketed(
+            Indent,
+            Delimited(
+                Sequence(
+                    Ref("FunctionSegment"),
+                    Ref("AliasExpressionSegment", optional=True),
+                ),
+            ),
+            "FOR",
+            OptionallyBracketed(
+                OneOf(
+                    Ref("SingleIdentifierGrammar"),
+                    Delimited(
+                        Ref("SingleIdentifierGrammar"),
+                    ),
+                ),
+            ),
+            "IN",
+            Bracketed(
+                OneOf(
+                    Sequence(
+                        OneOf(
+                            Ref("ScalarValue"),
+                            Ref("TupleValue"),
+                        ),
+                        Ref("AliasExpressionSegment", optional=True),
+                    ),
+                    Delimited(
+                        Sequence(
+                            OneOf(
+                                Ref("ScalarValue"),
+                                Ref("TupleValue"),
+                            ),
+                            Ref("AliasExpressionSegment", optional=True),
+                        ),
+                    ),
+                ),
+            ),
+            Dedent,
+        ),
+        Dedent,
     )
 
 
@@ -1661,6 +1716,8 @@ class StatementSegment(BaseSegment):
             # Data Retrieval Statements
             Ref("ClusterByClauseSegment"),
             Ref("DistributeByClauseSegment"),
+            # Other
+            Ref("DelimitedValues"),
         ],
         remove=[
             Ref("TransactionStatementSegment"),
@@ -1782,6 +1839,7 @@ class AliasExpressionSegment(BaseSegment):
                 "LATERAL",
                 Ref("JoinTypeKeywords"),
                 "WINDOW",
+                "PIVOT",
             ),
         ),
     )
@@ -1797,7 +1855,11 @@ class DelimitedValues(BaseSegment):
     """
 
     type = "delimited_values"
-    match_grammar = OneOf(Delimited(Ref("ScalarValue")), Delimited(Ref("TupleValue")))
+
+    match_grammar = OneOf(
+        Delimited(Ref("ScalarValue")),
+        Delimited(Ref("TupleValue")),
+    )
 
 
 @spark3_dialect.segment()
@@ -1809,6 +1871,7 @@ class ScalarValue(BaseSegment):
 
     type = "scalar_value"
     match_grammar = OneOf(
+        Ref("QuotedLiteralSegment"),
         Ref("LiteralGrammar"),
         Ref("BareFunctionSegment"),
         Ref("FunctionSegment"),
@@ -1913,8 +1976,6 @@ class FromExpressionElementSegment(BaseSegment):
     match_grammar = Sequence(
         Ref("PreTableFunctionKeywordsGrammar", optional=True),
         OptionallyBracketed(Ref("TableExpressionSegment")),
-        AnyNumberOf(Ref("LateralViewClauseSegment")),
-        Ref("NamedWindowSegment", optional=True),
         OneOf(
             Sequence(
                 Ref("AliasExpressionSegment"),
@@ -1924,6 +1985,12 @@ class FromExpressionElementSegment(BaseSegment):
             Ref("AliasExpressionSegment"),
             optional=True,
         ),
+        # NB: `LateralViewClauseSegment`, `NamedWindowSegment`,
+        # and `PivotClauseSegment should come after Alias/Sampling
+        # expressions so those are matched before
+        AnyNumberOf(Ref("LateralViewClauseSegment")),
+        Ref("NamedWindowSegment", optional=True),
+        Ref("PivotClauseSegment", optional=True),
         Ref("PostTableExpressionGrammar", optional=True),
     )
 

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -1568,7 +1568,7 @@ class OverClauseSegment(BaseSegment):
 
 @spark3_dialect.segment()
 class PivotClauseSegment(BaseSegment):
-    """A `PIVOT` clause as using in FROM clause
+    """A `PIVOT` clause as using in FROM clause.
 
     https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-pivot.html
     """

--- a/test/fixtures/dialects/spark3/pivot_clause.sql
+++ b/test/fixtures/dialects/spark3/pivot_clause.sql
@@ -1,0 +1,73 @@
+SELECT a
+FROM person
+    PIVOT (
+        SUM(age) AS a
+        FOR name IN ('John' AS john)
+    );
+
+SELECT a
+FROM person
+    PIVOT (
+        SUM(age) AS a
+        FOR name IN ('John' AS john, 'Mike' AS mike)
+    );
+
+SELECT a
+FROM person
+    PIVOT (
+        SUM(age) AS a
+        FOR (name) IN ('John' AS john, 'Mike' AS mike)
+    );
+
+SELECT a
+FROM person
+    PIVOT (
+        SUM(age) AS a
+        FOR name IN ('John' AS john, 'Mike' AS mike)
+    );
+
+SELECT
+    a,
+    c
+FROM person
+    PIVOT (
+        SUM(age) AS a, AVG(class) AS c
+        FOR name IN ('John' AS john, 'Mike' AS mike)
+    );
+
+SELECT
+    a,
+    c
+FROM person
+    PIVOT (
+        SUM(age) AS a, AVG(class) AS c
+        FOR name IN ('John' AS john, 'Mike' AS mike)
+    );
+
+SELECT
+    a,
+    c
+FROM person
+    PIVOT (
+        SUM(age) AS a, AVG(class) AS c
+        FOR name, age IN (('John', 30) AS c1, ('Mike', 40) AS c2)
+    );
+
+SELECT
+    p.a,
+    p.c
+FROM person AS p
+    PIVOT (
+        SUM(age) AS a, AVG(class) AS c
+        FOR name, age IN (('John', 30) AS c1, ('Mike', 40) AS c2)
+    );
+
+-- Will throw error when executed but should parse
+SELECT
+    a,
+    c
+FROM person
+    PIVOT (
+        SUM(age) AS a, AVG(class) AS c
+        FOR (name, age) IN ('John' AS c1, ('Mike', 40) AS c2)
+    );

--- a/test/fixtures/dialects/spark3/pivot_clause.yml
+++ b/test/fixtures/dialects/spark3/pivot_clause.yml
@@ -1,0 +1,581 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 4311848553f9c4cd3c1a4854f1f517e9912fe79c210f32d54cf22ddc2ae316f0
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+            pivot_clause:
+              keyword: PIVOT
+              bracketed:
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: SUM
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: age
+                    end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  identifier: a
+              - keyword: FOR
+              - identifier: name
+              - keyword: IN
+              - bracketed:
+                  start_bracket: (
+                  scalar_value:
+                    literal: "'John'"
+                  alias_expression:
+                    keyword: AS
+                    identifier: john
+                  end_bracket: )
+              - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+            pivot_clause:
+              keyword: PIVOT
+              bracketed:
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: SUM
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: age
+                    end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  identifier: a
+              - keyword: FOR
+              - identifier: name
+              - keyword: IN
+              - bracketed:
+                - start_bracket: (
+                - scalar_value:
+                    literal: "'John'"
+                - alias_expression:
+                    keyword: AS
+                    identifier: john
+                - comma: ','
+                - scalar_value:
+                    literal: "'Mike'"
+                - alias_expression:
+                    keyword: AS
+                    identifier: mike
+                - end_bracket: )
+              - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+            pivot_clause:
+              keyword: PIVOT
+              bracketed:
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: SUM
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: age
+                    end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  identifier: a
+              - keyword: FOR
+              - bracketed:
+                  start_bracket: (
+                  identifier: name
+                  end_bracket: )
+              - keyword: IN
+              - bracketed:
+                - start_bracket: (
+                - scalar_value:
+                    literal: "'John'"
+                - alias_expression:
+                    keyword: AS
+                    identifier: john
+                - comma: ','
+                - scalar_value:
+                    literal: "'Mike'"
+                - alias_expression:
+                    keyword: AS
+                    identifier: mike
+                - end_bracket: )
+              - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+            pivot_clause:
+              keyword: PIVOT
+              bracketed:
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: SUM
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: age
+                    end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  identifier: a
+              - keyword: FOR
+              - identifier: name
+              - keyword: IN
+              - bracketed:
+                - start_bracket: (
+                - scalar_value:
+                    literal: "'John'"
+                - alias_expression:
+                    keyword: AS
+                    identifier: john
+                - comma: ','
+                - scalar_value:
+                    literal: "'Mike'"
+                - alias_expression:
+                    keyword: AS
+                    identifier: mike
+                - end_bracket: )
+              - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+            pivot_clause:
+              keyword: PIVOT
+              bracketed:
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: SUM
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: age
+                    end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  identifier: a
+              - comma: ','
+              - function:
+                  function_name:
+                    function_name_identifier: AVG
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: class
+                    end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  identifier: c
+              - keyword: FOR
+              - identifier: name
+              - keyword: IN
+              - bracketed:
+                - start_bracket: (
+                - scalar_value:
+                    literal: "'John'"
+                - alias_expression:
+                    keyword: AS
+                    identifier: john
+                - comma: ','
+                - scalar_value:
+                    literal: "'Mike'"
+                - alias_expression:
+                    keyword: AS
+                    identifier: mike
+                - end_bracket: )
+              - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+            pivot_clause:
+              keyword: PIVOT
+              bracketed:
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: SUM
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: age
+                    end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  identifier: a
+              - comma: ','
+              - function:
+                  function_name:
+                    function_name_identifier: AVG
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: class
+                    end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  identifier: c
+              - keyword: FOR
+              - identifier: name
+              - keyword: IN
+              - bracketed:
+                - start_bracket: (
+                - scalar_value:
+                    literal: "'John'"
+                - alias_expression:
+                    keyword: AS
+                    identifier: john
+                - comma: ','
+                - scalar_value:
+                    literal: "'Mike'"
+                - alias_expression:
+                    keyword: AS
+                    identifier: mike
+                - end_bracket: )
+              - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+            pivot_clause:
+              keyword: PIVOT
+              bracketed:
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: SUM
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: age
+                    end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  identifier: a
+              - comma: ','
+              - function:
+                  function_name:
+                    function_name_identifier: AVG
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: class
+                    end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  identifier: c
+              - keyword: FOR
+              - identifier: name
+              - comma: ','
+              - identifier: age
+              - keyword: IN
+              - bracketed:
+                - start_bracket: (
+                - tuple_value:
+                    bracketed:
+                    - start_bracket: (
+                    - scalar_value:
+                        literal: "'John'"
+                    - comma: ','
+                    - scalar_value:
+                        literal: '30'
+                    - end_bracket: )
+                - alias_expression:
+                    keyword: AS
+                    identifier: c1
+                - comma: ','
+                - tuple_value:
+                    bracketed:
+                    - start_bracket: (
+                    - scalar_value:
+                        literal: "'Mike'"
+                    - comma: ','
+                    - scalar_value:
+                        literal: '40'
+                    - end_bracket: )
+                - alias_expression:
+                    keyword: AS
+                    identifier: c2
+                - end_bracket: )
+              - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: p
+          - dot: .
+          - identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - identifier: p
+          - dot: .
+          - identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+            alias_expression:
+              keyword: AS
+              identifier: p
+            pivot_clause:
+              keyword: PIVOT
+              bracketed:
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: SUM
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: age
+                    end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  identifier: a
+              - comma: ','
+              - function:
+                  function_name:
+                    function_name_identifier: AVG
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: class
+                    end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  identifier: c
+              - keyword: FOR
+              - identifier: name
+              - comma: ','
+              - identifier: age
+              - keyword: IN
+              - bracketed:
+                - start_bracket: (
+                - tuple_value:
+                    bracketed:
+                    - start_bracket: (
+                    - scalar_value:
+                        literal: "'John'"
+                    - comma: ','
+                    - scalar_value:
+                        literal: '30'
+                    - end_bracket: )
+                - alias_expression:
+                    keyword: AS
+                    identifier: c1
+                - comma: ','
+                - tuple_value:
+                    bracketed:
+                    - start_bracket: (
+                    - scalar_value:
+                        literal: "'Mike'"
+                    - comma: ','
+                    - scalar_value:
+                        literal: '40'
+                    - end_bracket: )
+                - alias_expression:
+                    keyword: AS
+                    identifier: c2
+                - end_bracket: )
+              - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: a
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: c
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+            pivot_clause:
+              keyword: PIVOT
+              bracketed:
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: SUM
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: age
+                    end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  identifier: a
+              - comma: ','
+              - function:
+                  function_name:
+                    function_name_identifier: AVG
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: class
+                    end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  identifier: c
+              - keyword: FOR
+              - bracketed:
+                - start_bracket: (
+                - identifier: name
+                - comma: ','
+                - identifier: age
+                - end_bracket: )
+              - keyword: IN
+              - bracketed:
+                - start_bracket: (
+                - scalar_value:
+                    literal: "'John'"
+                - alias_expression:
+                    keyword: AS
+                    identifier: c1
+                - comma: ','
+                - tuple_value:
+                    bracketed:
+                    - start_bracket: (
+                    - scalar_value:
+                        literal: "'Mike'"
+                    - comma: ','
+                    - scalar_value:
+                        literal: '40'
+                    - end_bracket: )
+                - alias_expression:
+                    keyword: AS
+                    identifier: c2
+                - end_bracket: )
+              - end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/spark3/select_from_lateral_view.sql
+++ b/test/fixtures/dialects/spark3/select_from_lateral_view.sql
@@ -45,4 +45,12 @@ SELECT
     exploded_people.age,
     exploded_people.state
 FROM person
-    LATERAL VIEW INLINE(array_of_structs) exploded_people AS name, age, state
+    LATERAL VIEW INLINE(array_of_structs) exploded_people AS name, age, state;
+
+SELECT
+    p.id,
+    exploded_people.name,
+    exploded_people.age,
+    exploded_people.state
+FROM person AS p
+    LATERAL VIEW INLINE(array_of_structs) exploded_people AS name, age, state;

--- a/test/fixtures/dialects/spark3/select_from_lateral_view.yml
+++ b/test/fixtures/dialects/spark3/select_from_lateral_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2b40cbec8aa6b74c002db500e86cb2328b45922c8825f5cd609ddfe5e9da50b3
+_hash: 92c7629469d93f3cdce9721a92255044be48602d518e04f3795ce44c0248fee1
 file:
 - statement:
     select_statement:
@@ -343,3 +343,69 @@ file:
             table_expression:
               table_reference:
                 identifier: state
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: p
+          - dot: .
+          - identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - identifier: exploded_people
+          - dot: .
+          - identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - identifier: exploded_people
+          - dot: .
+          - identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - identifier: exploded_people
+          - dot: .
+          - identifier: state
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+            alias_expression:
+              keyword: AS
+              identifier: p
+            lateral_view_clause:
+            - keyword: LATERAL
+            - keyword: VIEW
+            - function:
+                function_name:
+                  function_name_identifier: INLINE
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      identifier: array_of_structs
+                  end_bracket: )
+            - identifier: exploded_people
+            - keyword: AS
+            - identifier: name
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: age
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: state
+- statement_terminator: ;

--- a/test/fixtures/dialects/spark3/window_functions.sql
+++ b/test/fixtures/dialects/spark3/window_functions.sql
@@ -86,7 +86,7 @@ SELECT
     FIRST_VALUE(v) IGNORE NULLS OVER w AS v_first_value,
     LAST_VALUE(v) IGNORE NULLS OVER w AS v_last_value
 FROM test_ignore_null
-WINDOW w AS (ORDER BY id)
+    WINDOW w AS (ORDER BY id)
 ORDER BY id;
 
 SELECT
@@ -98,5 +98,17 @@ SELECT
     FIRST_VALUE(v) RESPECT NULLS OVER w AS v_first_value,
     LAST_VALUE(v) RESPECT NULLS OVER w AS v_last_value
 FROM test_ignore_null
-WINDOW w AS (ORDER BY id)
+    WINDOW w AS (ORDER BY id)
 ORDER BY id;
+
+SELECT
+    ignore_nulls.id,
+    ignore_nulls.v,
+    LEAD(ignore_nulls.v, 0) RESPECT NULLS OVER w AS v_lead,
+    LAG(ignore_nulls.v, 0) RESPECT NULLS OVER w AS v_lag,
+    NTH_VALUE(ignore_nulls.v, 2) RESPECT NULLS OVER w AS v_nth_value,
+    FIRST_VALUE(ignore_nulls.v) RESPECT NULLS OVER w AS v_first_value,
+    LAST_VALUE(ignore_nulls.v) RESPECT NULLS OVER w AS v_last_value
+FROM test_ignore_null AS ignore_nulls
+    WINDOW w AS (ORDER BY ignore_nulls.id)
+ORDER BY ignore_nulls.id;

--- a/test/fixtures/dialects/spark3/window_functions.yml
+++ b/test/fixtures/dialects/spark3/window_functions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2eccc034b540fd65e367038f57767c8fb9db161421f0f7c947bec97454264e17
+_hash: 0f03068e5eaa35880b0e4e0d5b627652afeb0cb5e7ade98dff3f04c77e9def60
 file:
 - statement:
     select_statement:
@@ -772,4 +772,167 @@ file:
       - keyword: BY
       - column_reference:
           identifier: id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: ignore_nulls
+          - dot: .
+          - identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - identifier: ignore_nulls
+          - dot: .
+          - identifier: v
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LEAD
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                - identifier: ignore_nulls
+                - dot: .
+                - identifier: v
+            - comma: ','
+            - expression:
+                literal: '0'
+            - end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - identifier: w
+          alias_expression:
+            keyword: AS
+            identifier: v_lead
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LAG
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                - identifier: ignore_nulls
+                - dot: .
+                - identifier: v
+            - comma: ','
+            - expression:
+                literal: '0'
+            - end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - identifier: w
+          alias_expression:
+            keyword: AS
+            identifier: v_lag
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: NTH_VALUE
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                - identifier: ignore_nulls
+                - dot: .
+                - identifier: v
+            - comma: ','
+            - expression:
+                literal: '2'
+            - end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - identifier: w
+          alias_expression:
+            keyword: AS
+            identifier: v_nth_value
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: FIRST_VALUE
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                - identifier: ignore_nulls
+                - dot: .
+                - identifier: v
+              end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - identifier: w
+          alias_expression:
+            keyword: AS
+            identifier: v_first_value
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LAST_VALUE
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                - identifier: ignore_nulls
+                - dot: .
+                - identifier: v
+              end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - identifier: w
+          alias_expression:
+            keyword: AS
+            identifier: v_last_value
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: test_ignore_null
+            alias_expression:
+              keyword: AS
+              identifier: ignore_nulls
+            named_window:
+              keyword: WINDOW
+              named_window_expression:
+                identifier: w
+                keyword: AS
+                bracketed:
+                  start_bracket: (
+                  window_specification:
+                    orderby_clause:
+                    - keyword: ORDER
+                    - keyword: BY
+                    - column_reference:
+                      - identifier: ignore_nulls
+                      - dot: .
+                      - identifier: id
+                  end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+        - identifier: ignore_nulls
+        - dot: .
+        - identifier: id
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Add support for `PIVOT` clause through `PivotClauseSegment`.

### Are there any other side effects of this change that we should be aware of?
N/A

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
