### PR TITLE
Spark3: Support for `TRANSFORM` clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -2052,25 +2052,3 @@ class FromExpressionElementSegment(BaseSegment):
     get_eventual_alias = ansi_dialect.get_segment(
         "FromExpressionElementSegment"
     ).get_eventual_alias
-
-
-@spark3_dialect.segment(replace=True)
-class SelectClauseSegment(BaseSegment):
-    """A group of elements in a select target statement."""
-
-    type = "select_clause"
-
-    match_grammar = StartsWith(
-        Sequence("SELECT", Ref("WildcardExpressionSegment", optional=True)),
-        terminator=OneOf(
-            "FROM",
-            "WHERE",
-            Sequence("ORDER", "BY"),
-            "LIMIT",
-            "OVERLAPS",
-            Ref("SetOperatorSegment"),
-        ),
-        enforce_whitespace_preceding_terminator=True,
-    )
-
-    parse_grammar = Ref("SelectClauseSegmentGrammar")

--- a/test/fixtures/dialects/spark3/select_transform_clause.sql
+++ b/test/fixtures/dialects/spark3/select_transform_clause.sql
@@ -1,0 +1,44 @@
+-- With specified output without data type
+SELECT TRANSFORM (zip_code, name, age)
+    USING 'cat' AS (a, b, c)
+FROM person
+WHERE zip_code > 94511;
+
+-- With specified output with data type
+SELECT TRANSFORM(zip_code, name, age)
+    USING 'cat' AS (a string, b string, c string)
+FROM person
+WHERE zip_code > 94511;
+
+-- Using ROW FORMAT DELIMITED
+SELECT TRANSFORM(name, age)
+    ROW FORMAT DELIMITED
+    FIELDS TERMINATED BY ','
+    LINES TERMINATED BY '\n'
+    NULL DEFINED AS 'NULL'
+    USING 'cat' AS (name_age string)
+    ROW FORMAT DELIMITED
+    FIELDS TERMINATED BY '@'
+    LINES TERMINATED BY '\n'
+    NULL DEFINED AS 'NULL'
+FROM person;
+
+-- Using Hive Serde
+SELECT TRANSFORM(zip_code, name, age)
+    ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
+    WITH SERDEPROPERTIES (
+        'field.delim' = '\t'
+    )
+    USING 'cat' AS (a string, b string, c string)
+    ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
+    WITH SERDEPROPERTIES (
+        'field.delim' = '\t'
+    )
+FROM person
+WHERE zip_code > 94511;
+
+-- Schema-less mode
+SELECT TRANSFORM(zip_code, name, age)
+    USING 'cat'
+FROM person
+WHERE zip_code > 94500;

--- a/test/fixtures/dialects/spark3/select_transform_clause.yml
+++ b/test/fixtures/dialects/spark3/select_transform_clause.yml
@@ -1,0 +1,256 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 0ecdc88e97e1c6ebbb9dedf9a7b0a5726283d5afe8a54f9c318f661dcca7b121
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        transform_clause:
+        - keyword: TRANSFORM
+        - bracketed:
+          - start_bracket: (
+          - identifier: zip_code
+          - comma: ','
+          - identifier: name
+          - comma: ','
+          - identifier: age
+          - end_bracket: )
+        - keyword: USING
+        - literal: "'cat'"
+        - keyword: AS
+        - bracketed:
+          - start_bracket: (
+          - identifier: a
+          - comma: ','
+          - identifier: b
+          - comma: ','
+          - identifier: c
+          - end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            identifier: zip_code
+          comparison_operator:
+            raw_comparison_operator: '>'
+          literal: '94511'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        transform_clause:
+        - keyword: TRANSFORM
+        - bracketed:
+          - start_bracket: (
+          - identifier: zip_code
+          - comma: ','
+          - identifier: name
+          - comma: ','
+          - identifier: age
+          - end_bracket: )
+        - keyword: USING
+        - literal: "'cat'"
+        - keyword: AS
+        - bracketed:
+          - start_bracket: (
+          - identifier: a
+          - identifier: string
+          - comma: ','
+          - identifier: b
+          - identifier: string
+          - comma: ','
+          - identifier: c
+          - identifier: string
+          - end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            identifier: zip_code
+          comparison_operator:
+            raw_comparison_operator: '>'
+          literal: '94511'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        transform_clause:
+        - keyword: TRANSFORM
+        - bracketed:
+          - start_bracket: (
+          - identifier: name
+          - comma: ','
+          - identifier: age
+          - end_bracket: )
+        - row_format_clause:
+          - keyword: ROW
+          - keyword: FORMAT
+          - keyword: DELIMITED
+          - keyword: FIELDS
+          - keyword: TERMINATED
+          - keyword: BY
+          - literal: "','"
+          - keyword: LINES
+          - keyword: TERMINATED
+          - keyword: BY
+          - literal: "'\\n'"
+          - keyword: 'NULL'
+          - keyword: DEFINED
+          - keyword: AS
+          - literal: "'NULL'"
+        - keyword: USING
+        - literal: "'cat'"
+        - keyword: AS
+        - bracketed:
+          - start_bracket: (
+          - identifier: name_age
+          - identifier: string
+          - end_bracket: )
+        - row_format_clause:
+          - keyword: ROW
+          - keyword: FORMAT
+          - keyword: DELIMITED
+          - keyword: FIELDS
+          - keyword: TERMINATED
+          - keyword: BY
+          - literal: "'@'"
+          - keyword: LINES
+          - keyword: TERMINATED
+          - keyword: BY
+          - literal: "'\\n'"
+          - keyword: 'NULL'
+          - keyword: DEFINED
+          - keyword: AS
+          - literal: "'NULL'"
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        transform_clause:
+        - keyword: TRANSFORM
+        - bracketed:
+          - start_bracket: (
+          - identifier: zip_code
+          - comma: ','
+          - identifier: name
+          - comma: ','
+          - identifier: age
+          - end_bracket: )
+        - row_format_clause:
+          - keyword: ROW
+          - keyword: FORMAT
+          - keyword: SERDE
+          - literal: "'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'"
+          - keyword: WITH
+          - keyword: SERDEPROPERTIES
+          - bracketed:
+            - start_bracket: (
+            - literal: "'field.delim'"
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - literal: "'\\t'"
+            - end_bracket: )
+        - keyword: USING
+        - literal: "'cat'"
+        - keyword: AS
+        - bracketed:
+          - start_bracket: (
+          - identifier: a
+          - identifier: string
+          - comma: ','
+          - identifier: b
+          - identifier: string
+          - comma: ','
+          - identifier: c
+          - identifier: string
+          - end_bracket: )
+        - row_format_clause:
+          - keyword: ROW
+          - keyword: FORMAT
+          - keyword: SERDE
+          - literal: "'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'"
+          - keyword: WITH
+          - keyword: SERDEPROPERTIES
+          - bracketed:
+            - start_bracket: (
+            - literal: "'field.delim'"
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - literal: "'\\t'"
+            - end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            identifier: zip_code
+          comparison_operator:
+            raw_comparison_operator: '>'
+          literal: '94511'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        transform_clause:
+        - keyword: TRANSFORM
+        - bracketed:
+          - start_bracket: (
+          - identifier: zip_code
+          - comma: ','
+          - identifier: name
+          - comma: ','
+          - identifier: age
+          - end_bracket: )
+        - keyword: USING
+        - literal: "'cat'"
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: person
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            identifier: zip_code
+          comparison_operator:
+            raw_comparison_operator: '>'
+          literal: '94500'
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Add support for transform clause through redefining `SelectClauseSegmentGrammar` in Spark3 dialect and creating `TransformClauseSegment` 

### Are there any other side effects of this change that we should be aware of?
N/A

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
