### PR TITLE
Spark3: Support for `EXPLAIN` statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -3374,9 +3374,7 @@ class ExplainStatementSegment(BaseSegment):
         Ref("DeleteStatementSegment"),
     )
 
-    match_grammar = StartsWith("EXPLAIN")
-
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "EXPLAIN",
         explainable_stmt,
     )

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1097,9 +1097,7 @@ class ExplainStatementSegment(BaseSegment):
 
     type = "explain_statement"
 
-    match_grammar = ansi_dialect.get_segment("ExplainStatementSegment").match_grammar
-
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "EXPLAIN",
         OneOf(
             Sequence(
@@ -1113,7 +1111,7 @@ class ExplainStatementSegment(BaseSegment):
             Bracketed(Delimited(Ref("ExplainOptionSegment"))),
             optional=True,
         ),
-        ansi_dialect.get_segment("ExplainStatementSegment").explainable_stmt,
+        ansi_dialect.get_segment("ExplainStatementSegment",).explainable_stmt,
     )
 
 

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1111,7 +1111,9 @@ class ExplainStatementSegment(BaseSegment):
             Bracketed(Delimited(Ref("ExplainOptionSegment"))),
             optional=True,
         ),
-        ansi_dialect.get_segment("ExplainStatementSegment",).explainable_stmt,
+        ansi_dialect.get_segment(
+            "ExplainStatementSegment",
+        ).explainable_stmt,
     )
 
 

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -2938,7 +2938,7 @@ class ExplainStatementSegment(
     https://docs.snowflake.com/en/sql-reference/sql/explain.html
     """
 
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "EXPLAIN",
         Sequence(
             "USING",

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -1692,36 +1692,9 @@ class ExplainStatementSegment(BaseSegment):
 
     type = "explain_statement"
 
-    explainable_stmt = ansi_dialect.get_segment(
-        "ExplainStatementSegment"
-    ).explainable_stmt.copy(
-        insert=[
-            Ref("AlterDatabaseStatementSegment"),
-            Ref("AlterTableStatementSegment"),
-            Ref("AlterViewStatementSegment"),
-            Ref("CreateDatabaseStatementSegment"),
-            Ref("CreateFunctionStatementSegment"),
-            Ref("CreateTableStatementSegment"),
-            Ref("CreateViewStatementSegment"),
-            ansi_dialect.get_segment("DropDatabaseStatementSegment"),
-            Ref("DropFunctionStatementSegment"),
-            ansi_dialect.get_segment(
-                "DropViewStatementSegment",
-            ),
-            Ref("UseDatabaseStatementSegment"),
-            Ref("TruncateStatementSegment"),
-            Ref("MsckRepairTableStatementSegment"),
-            Ref("RefreshTableStatementSegment"),
-            Ref("RefreshFunctionStatementSegment"),
-            Ref("LoadDataSegment"),
-            Ref("InsertOverwriteDirectorySegment"),
-            Ref("InsertOverwriteDirectoryHiveFmtSegment"),
-        ],
-    )
+    explainable_stmt = Ref("StatementSegment")
 
-    match_grammar = StartsWith("EXPLAIN")
-
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "EXPLAIN",
         OneOf(
             "EXTENDED",

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -1679,6 +1679,61 @@ class TransformClauseSegment(BaseSegment):
     )
 
 
+@spark3_dialect.segment(replace=True)
+class ExplainStatementSegment(BaseSegment):
+    """An `Explain` statement.
+
+    Enhanced from ANSI dialect to allow for additonal parameters.
+
+    EXPLAIN [ EXTENDED | CODEGEN | COST | FORMATTED ] explainable_stmt
+
+    https://spark.apache.org/docs/latest/sql-ref-syntax-qry-explain.html
+    """
+
+    type = "explain_statement"
+
+    explainable_stmt = ansi_dialect.get_segment(
+        "ExplainStatementSegment"
+    ).explainable_stmt.copy(
+        insert=[
+            Ref("AlterDatabaseStatementSegment"),
+            Ref("AlterTableStatementSegment"),
+            Ref("AlterViewStatementSegment"),
+            Ref("CreateDatabaseStatementSegment"),
+            Ref("CreateFunctionStatementSegment"),
+            Ref("CreateTableStatementSegment"),
+            Ref("CreateViewStatementSegment"),
+            ansi_dialect.get_segment("DropDatabaseStatementSegment"),
+            Ref("DropFunctionStatementSegment"),
+            ansi_dialect.get_segment(
+                "DropViewStatementSegment",
+            ),
+            Ref("UseDatabaseStatementSegment"),
+            Ref("TruncateStatementSegment"),
+            Ref("MsckRepairTableStatementSegment"),
+            Ref("RefreshTableStatementSegment"),
+            Ref("RefreshFunctionStatementSegment"),
+            Ref("LoadDataSegment"),
+            Ref("InsertOverwriteDirectorySegment"),
+            Ref("InsertOverwriteDirectoryHiveFmtSegment"),
+        ],
+    )
+
+    match_grammar = StartsWith("EXPLAIN")
+
+    parse_grammar = Sequence(
+        "EXPLAIN",
+        OneOf(
+            "EXTENDED",
+            "CODEGEN",
+            "COST",
+            "FORMATTED",
+            optional=True,
+        ),
+        explainable_stmt,
+    )
+
+
 # Auxiliary Statements
 @spark3_dialect.segment()
 class AddExecutablePackage(BaseSegment):

--- a/test/fixtures/dialects/spark3/explain.sql
+++ b/test/fixtures/dialects/spark3/explain.sql
@@ -1,0 +1,63 @@
+EXPLAIN SELECT
+    a,
+    b
+FROM person;
+
+EXPLAIN SELECT TRANSFORM (zip_code, name, age)
+    USING 'cat' AS (a, b, c)
+FROM person
+WHERE zip_code > 94511;
+
+EXPLAIN ALTER DATABASE inventory SET DBPROPERTIES (
+    'Edited-by' = 'John'
+);
+
+EXPLAIN ALTER TABLE student RENAME TO studentinfo;
+
+EXPLAIN ALTER VIEW view_identifier RENAME TO view_identifier;
+
+EXPLAIN CREATE DATABASE IF NOT EXISTS database_name
+COMMENT "database_comment"
+LOCATION "root/database_directory"
+WITH DBPROPERTIES ( "property_name" = "property_value");
+
+EXPLAIN CREATE OR REPLACE TEMPORARY FUNCTION IF NOT EXISTS
+function_name AS "class_name" USING FILE "resource_locations";
+
+EXPLAIN CREATE TABLE student (id INT, student_name STRING, age INT) USING CSV;
+
+EXPLAIN
+CREATE TABLE student (id INT, student_name STRING, age INT)
+STORED AS ORC;
+
+EXPLAIN CREATE TABLE student_dupli LIKE student
+ROW FORMAT DELIMITED FIELDS TERMINATED BY ','
+STORED AS TEXTFILE
+TBLPROPERTIES ('owner' = 'xxxx');
+
+EXPLAIN
+CREATE VIEW experienced_employee_extended
+AS SELECT a
+FROM experienced_employee;
+
+EXPLAIN DROP DATABASE IF EXISTS dbname;
+
+EXPLAIN DROP FUNCTION test_avg;
+
+EXPLAIN USE database_name;
+
+EXPLAIN TRUNCATE TABLE student PARTITION(age = 10);
+
+EXPLAIN MSCK REPAIR TABLE table_identifier ADD PARTITIONS;
+
+EXPLAIN REFRESH TABLE tbl1;
+
+EXPLAIN REFRESH FUNCTION func1;
+
+EXPLAIN LOAD DATA LOCAL INPATH '/user/hive/warehouse/students'
+OVERWRITE INTO TABLE test_load;
+
+EXPLAIN INSERT INTO TABLE students VALUES
+('Amy Smith', '123 Park Ave, San Jose', 111111);
+
+EXPLAIN DROP VIEW IF EXISTS view_identifier;

--- a/test/fixtures/dialects/spark3/explain.yml
+++ b/test/fixtures/dialects/spark3/explain.yml
@@ -1,0 +1,403 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 872432c149c5b018f4c107e63cafd561695036d641f31bc5e4b957a8a1f79c74
+file:
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: person
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          transform_clause:
+          - keyword: TRANSFORM
+          - bracketed:
+            - start_bracket: (
+            - identifier: zip_code
+            - comma: ','
+            - identifier: name
+            - comma: ','
+            - identifier: age
+            - end_bracket: )
+          - keyword: USING
+          - literal: "'cat'"
+          - keyword: AS
+          - bracketed:
+            - start_bracket: (
+            - identifier: a
+            - comma: ','
+            - identifier: b
+            - comma: ','
+            - identifier: c
+            - end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: person
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              identifier: zip_code
+            comparison_operator:
+              raw_comparison_operator: '>'
+            literal: '94511'
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      alter_database_statement:
+      - keyword: ALTER
+      - keyword: DATABASE
+      - database_reference:
+          identifier: inventory
+      - keyword: SET
+      - keyword: DBPROPERTIES
+      - bracketed:
+        - start_bracket: (
+        - literal: "'Edited-by'"
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - literal: "'John'"
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          identifier: student
+      - keyword: RENAME
+      - keyword: TO
+      - table_reference:
+          identifier: studentinfo
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      alter_view_statement:
+      - keyword: ALTER
+      - keyword: VIEW
+      - table_reference:
+          identifier: view_identifier
+      - keyword: RENAME
+      - keyword: TO
+      - table_reference:
+          identifier: view_identifier
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      create_database_statement:
+      - keyword: CREATE
+      - keyword: DATABASE
+      - keyword: IF
+      - keyword: NOT
+      - keyword: EXISTS
+      - database_reference:
+          identifier: database_name
+      - keyword: COMMENT
+      - literal: '"database_comment"'
+      - keyword: LOCATION
+      - literal: '"root/database_directory"'
+      - keyword: WITH
+      - keyword: DBPROPERTIES
+      - bracketed:
+        - start_bracket: (
+        - literal: '"property_name"'
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - literal: '"property_value"'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      create_function_statement:
+      - keyword: CREATE
+      - binary_operator: OR
+      - keyword: REPLACE
+      - keyword: TEMPORARY
+      - keyword: FUNCTION
+      - keyword: IF
+      - keyword: NOT
+      - keyword: EXISTS
+      - function_name_identifier: function_name
+      - keyword: AS
+      - literal: '"class_name"'
+      - keyword: USING
+      - file_type: FILE
+      - literal: '"resource_locations"'
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          identifier: student
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: id
+            data_type:
+              primitive_type:
+                keyword: INT
+        - comma: ','
+        - column_definition:
+            identifier: student_name
+            data_type:
+              primitive_type:
+                keyword: STRING
+        - comma: ','
+        - column_definition:
+            identifier: age
+            data_type:
+              primitive_type:
+                keyword: INT
+        - end_bracket: )
+      - keyword: USING
+      - keyword: CSV
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          identifier: student
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: id
+            data_type:
+              primitive_type:
+                keyword: INT
+        - comma: ','
+        - column_definition:
+            identifier: student_name
+            data_type:
+              primitive_type:
+                keyword: STRING
+        - comma: ','
+        - column_definition:
+            identifier: age
+            data_type:
+              primitive_type:
+                keyword: INT
+        - end_bracket: )
+      - keyword: STORED
+      - keyword: AS
+      - keyword: ORC
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          identifier: student_dupli
+      - keyword: LIKE
+      - table_reference:
+          identifier: student
+      - row_format_clause:
+        - keyword: ROW
+        - keyword: FORMAT
+        - keyword: DELIMITED
+        - keyword: FIELDS
+        - keyword: TERMINATED
+        - keyword: BY
+        - literal: "','"
+      - keyword: STORED
+      - keyword: AS
+      - file_format: TEXTFILE
+      - keyword: TBLPROPERTIES
+      - bracketed:
+        - start_bracket: (
+        - literal: "'owner'"
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - literal: "'xxxx'"
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: VIEW
+      - table_reference:
+          identifier: experienced_employee_extended
+      - keyword: AS
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              column_reference:
+                identifier: a
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: experienced_employee
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      drop_database_statement:
+      - keyword: DROP
+      - keyword: DATABASE
+      - keyword: IF
+      - keyword: EXISTS
+      - database_reference:
+          identifier: dbname
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      drop_function_statement:
+      - keyword: DROP
+      - keyword: FUNCTION
+      - function_name:
+          function_name_identifier: test_avg
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      use_database_statement:
+        keyword: USE
+        database_reference:
+          identifier: database_name
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      truncate_table_statement:
+      - keyword: TRUNCATE
+      - keyword: TABLE
+      - table_reference:
+          identifier: student
+      - keyword: PARTITION
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            identifier: age
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: '10'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      msck_repair_table_statement:
+      - keyword: MSCK
+      - keyword: REPAIR
+      - keyword: TABLE
+      - table_reference:
+          identifier: table_identifier
+      - keyword: ADD
+      - keyword: PARTITIONS
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      refresh_table_statement:
+      - keyword: REFRESH
+      - keyword: TABLE
+      - table_reference:
+          identifier: tbl1
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      refresh_function_statement:
+      - keyword: REFRESH
+      - keyword: FUNCTION
+      - function_name:
+          function_name_identifier: func1
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      load_data_statement:
+      - keyword: LOAD
+      - keyword: DATA
+      - keyword: LOCAL
+      - keyword: INPATH
+      - literal: "'/user/hive/warehouse/students'"
+      - keyword: OVERWRITE
+      - keyword: INTO
+      - keyword: TABLE
+      - table_reference:
+          identifier: test_load
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      insert_table_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - keyword: TABLE
+      - table_reference:
+          identifier: students
+      - values_clause:
+          keyword: VALUES
+          delimited_values:
+            tuple_value:
+              bracketed:
+              - start_bracket: (
+              - scalar_value:
+                  literal: "'Amy Smith'"
+              - comma: ','
+              - scalar_value:
+                  literal: "'123 Park Ave, San Jose'"
+              - comma: ','
+              - scalar_value:
+                  literal: '111111'
+              - end_bracket: )
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      drop_view_statement:
+      - keyword: DROP
+      - keyword: VIEW
+      - keyword: IF
+      - keyword: EXISTS
+      - table_reference:
+          identifier: view_identifier
+- statement_terminator: ;

--- a/test/fixtures/dialects/spark3/explain.yml
+++ b/test/fixtures/dialects/spark3/explain.yml
@@ -3,401 +3,422 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 872432c149c5b018f4c107e63cafd561695036d641f31bc5e4b957a8a1f79c74
+_hash: 91c3c5d1f04023d225b7917117ea6f36460026926151f116bfeb528d1ad761ed
 file:
 - statement:
     explain_statement:
       keyword: EXPLAIN
-      select_statement:
-        select_clause:
-        - keyword: SELECT
-        - select_clause_element:
-            column_reference:
-              identifier: a
-        - comma: ','
-        - select_clause_element:
-            column_reference:
-              identifier: b
-        from_clause:
-          keyword: FROM
-          from_expression:
-            from_expression_element:
-              table_expression:
-                table_reference:
-                  identifier: person
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      select_statement:
-        select_clause:
-          keyword: SELECT
-          transform_clause:
-          - keyword: TRANSFORM
-          - bracketed:
-            - start_bracket: (
-            - identifier: zip_code
-            - comma: ','
-            - identifier: name
-            - comma: ','
-            - identifier: age
-            - end_bracket: )
-          - keyword: USING
-          - literal: "'cat'"
-          - keyword: AS
-          - bracketed:
-            - start_bracket: (
-            - identifier: a
-            - comma: ','
-            - identifier: b
-            - comma: ','
-            - identifier: c
-            - end_bracket: )
-        from_clause:
-          keyword: FROM
-          from_expression:
-            from_expression_element:
-              table_expression:
-                table_reference:
-                  identifier: person
-        where_clause:
-          keyword: WHERE
-          expression:
-            column_reference:
-              identifier: zip_code
-            comparison_operator:
-              raw_comparison_operator: '>'
-            literal: '94511'
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      alter_database_statement:
-      - keyword: ALTER
-      - keyword: DATABASE
-      - database_reference:
-          identifier: inventory
-      - keyword: SET
-      - keyword: DBPROPERTIES
-      - bracketed:
-        - start_bracket: (
-        - literal: "'Edited-by'"
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - literal: "'John'"
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      alter_table_statement:
-      - keyword: ALTER
-      - keyword: TABLE
-      - table_reference:
-          identifier: student
-      - keyword: RENAME
-      - keyword: TO
-      - table_reference:
-          identifier: studentinfo
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      alter_view_statement:
-      - keyword: ALTER
-      - keyword: VIEW
-      - table_reference:
-          identifier: view_identifier
-      - keyword: RENAME
-      - keyword: TO
-      - table_reference:
-          identifier: view_identifier
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      create_database_statement:
-      - keyword: CREATE
-      - keyword: DATABASE
-      - keyword: IF
-      - keyword: NOT
-      - keyword: EXISTS
-      - database_reference:
-          identifier: database_name
-      - keyword: COMMENT
-      - literal: '"database_comment"'
-      - keyword: LOCATION
-      - literal: '"root/database_directory"'
-      - keyword: WITH
-      - keyword: DBPROPERTIES
-      - bracketed:
-        - start_bracket: (
-        - literal: '"property_name"'
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - literal: '"property_value"'
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      create_function_statement:
-      - keyword: CREATE
-      - binary_operator: OR
-      - keyword: REPLACE
-      - keyword: TEMPORARY
-      - keyword: FUNCTION
-      - keyword: IF
-      - keyword: NOT
-      - keyword: EXISTS
-      - function_name_identifier: function_name
-      - keyword: AS
-      - literal: '"class_name"'
-      - keyword: USING
-      - file_type: FILE
-      - literal: '"resource_locations"'
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      create_table_statement:
-      - keyword: CREATE
-      - keyword: TABLE
-      - table_reference:
-          identifier: student
-      - bracketed:
-        - start_bracket: (
-        - column_definition:
-            identifier: id
-            data_type:
-              primitive_type:
-                keyword: INT
-        - comma: ','
-        - column_definition:
-            identifier: student_name
-            data_type:
-              primitive_type:
-                keyword: STRING
-        - comma: ','
-        - column_definition:
-            identifier: age
-            data_type:
-              primitive_type:
-                keyword: INT
-        - end_bracket: )
-      - keyword: USING
-      - keyword: CSV
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      create_table_statement:
-      - keyword: CREATE
-      - keyword: TABLE
-      - table_reference:
-          identifier: student
-      - bracketed:
-        - start_bracket: (
-        - column_definition:
-            identifier: id
-            data_type:
-              primitive_type:
-                keyword: INT
-        - comma: ','
-        - column_definition:
-            identifier: student_name
-            data_type:
-              primitive_type:
-                keyword: STRING
-        - comma: ','
-        - column_definition:
-            identifier: age
-            data_type:
-              primitive_type:
-                keyword: INT
-        - end_bracket: )
-      - keyword: STORED
-      - keyword: AS
-      - keyword: ORC
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      create_table_statement:
-      - keyword: CREATE
-      - keyword: TABLE
-      - table_reference:
-          identifier: student_dupli
-      - keyword: LIKE
-      - table_reference:
-          identifier: student
-      - row_format_clause:
-        - keyword: ROW
-        - keyword: FORMAT
-        - keyword: DELIMITED
-        - keyword: FIELDS
-        - keyword: TERMINATED
-        - keyword: BY
-        - literal: "','"
-      - keyword: STORED
-      - keyword: AS
-      - file_format: TEXTFILE
-      - keyword: TBLPROPERTIES
-      - bracketed:
-        - start_bracket: (
-        - literal: "'owner'"
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - literal: "'xxxx'"
-        - end_bracket: )
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      create_view_statement:
-      - keyword: CREATE
-      - keyword: VIEW
-      - table_reference:
-          identifier: experienced_employee_extended
-      - keyword: AS
-      - select_statement:
+      statement:
+        select_statement:
           select_clause:
-            keyword: SELECT
-            select_clause_element:
+          - keyword: SELECT
+          - select_clause_element:
               column_reference:
                 identifier: a
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: b
           from_clause:
             keyword: FROM
             from_expression:
               from_expression_element:
                 table_expression:
                   table_reference:
-                    identifier: experienced_employee
+                    identifier: person
 - statement_terminator: ;
 - statement:
     explain_statement:
       keyword: EXPLAIN
-      drop_database_statement:
-      - keyword: DROP
-      - keyword: DATABASE
-      - keyword: IF
-      - keyword: EXISTS
-      - database_reference:
-          identifier: dbname
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      drop_function_statement:
-      - keyword: DROP
-      - keyword: FUNCTION
-      - function_name:
-          function_name_identifier: test_avg
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      use_database_statement:
-        keyword: USE
-        database_reference:
-          identifier: database_name
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      truncate_table_statement:
-      - keyword: TRUNCATE
-      - keyword: TABLE
-      - table_reference:
-          identifier: student
-      - keyword: PARTITION
-      - bracketed:
-          start_bracket: (
-          column_reference:
-            identifier: age
-          comparison_operator:
-            raw_comparison_operator: '='
-          literal: '10'
-          end_bracket: )
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      msck_repair_table_statement:
-      - keyword: MSCK
-      - keyword: REPAIR
-      - keyword: TABLE
-      - table_reference:
-          identifier: table_identifier
-      - keyword: ADD
-      - keyword: PARTITIONS
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      refresh_table_statement:
-      - keyword: REFRESH
-      - keyword: TABLE
-      - table_reference:
-          identifier: tbl1
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      refresh_function_statement:
-      - keyword: REFRESH
-      - keyword: FUNCTION
-      - function_name:
-          function_name_identifier: func1
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      load_data_statement:
-      - keyword: LOAD
-      - keyword: DATA
-      - keyword: LOCAL
-      - keyword: INPATH
-      - literal: "'/user/hive/warehouse/students'"
-      - keyword: OVERWRITE
-      - keyword: INTO
-      - keyword: TABLE
-      - table_reference:
-          identifier: test_load
-- statement_terminator: ;
-- statement:
-    explain_statement:
-      keyword: EXPLAIN
-      insert_table_statement:
-      - keyword: INSERT
-      - keyword: INTO
-      - keyword: TABLE
-      - table_reference:
-          identifier: students
-      - values_clause:
-          keyword: VALUES
-          delimited_values:
-            tuple_value:
-              bracketed:
+      statement:
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            transform_clause:
+            - keyword: TRANSFORM
+            - bracketed:
               - start_bracket: (
-              - scalar_value:
-                  literal: "'Amy Smith'"
+              - identifier: zip_code
               - comma: ','
-              - scalar_value:
-                  literal: "'123 Park Ave, San Jose'"
+              - identifier: name
               - comma: ','
-              - scalar_value:
-                  literal: '111111'
+              - identifier: age
               - end_bracket: )
+            - keyword: USING
+            - literal: "'cat'"
+            - keyword: AS
+            - bracketed:
+              - start_bracket: (
+              - identifier: a
+              - comma: ','
+              - identifier: b
+              - comma: ','
+              - identifier: c
+              - end_bracket: )
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: person
+          where_clause:
+            keyword: WHERE
+            expression:
+              column_reference:
+                identifier: zip_code
+              comparison_operator:
+                raw_comparison_operator: '>'
+              literal: '94511'
 - statement_terminator: ;
 - statement:
     explain_statement:
       keyword: EXPLAIN
-      drop_view_statement:
-      - keyword: DROP
-      - keyword: VIEW
-      - keyword: IF
-      - keyword: EXISTS
-      - table_reference:
-          identifier: view_identifier
+      statement:
+        alter_database_statement:
+        - keyword: ALTER
+        - keyword: DATABASE
+        - database_reference:
+            identifier: inventory
+        - keyword: SET
+        - keyword: DBPROPERTIES
+        - bracketed:
+          - start_bracket: (
+          - literal: "'Edited-by'"
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - literal: "'John'"
+          - end_bracket: )
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        alter_table_statement:
+        - keyword: ALTER
+        - keyword: TABLE
+        - table_reference:
+            identifier: student
+        - keyword: RENAME
+        - keyword: TO
+        - table_reference:
+            identifier: studentinfo
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        alter_view_statement:
+        - keyword: ALTER
+        - keyword: VIEW
+        - table_reference:
+            identifier: view_identifier
+        - keyword: RENAME
+        - keyword: TO
+        - table_reference:
+            identifier: view_identifier
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        create_database_statement:
+        - keyword: CREATE
+        - keyword: DATABASE
+        - keyword: IF
+        - keyword: NOT
+        - keyword: EXISTS
+        - database_reference:
+            identifier: database_name
+        - keyword: COMMENT
+        - literal: '"database_comment"'
+        - keyword: LOCATION
+        - literal: '"root/database_directory"'
+        - keyword: WITH
+        - keyword: DBPROPERTIES
+        - bracketed:
+          - start_bracket: (
+          - literal: '"property_name"'
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - literal: '"property_value"'
+          - end_bracket: )
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        create_function_statement:
+        - keyword: CREATE
+        - binary_operator: OR
+        - keyword: REPLACE
+        - keyword: TEMPORARY
+        - keyword: FUNCTION
+        - keyword: IF
+        - keyword: NOT
+        - keyword: EXISTS
+        - function_name_identifier: function_name
+        - keyword: AS
+        - literal: '"class_name"'
+        - keyword: USING
+        - file_type: FILE
+        - literal: '"resource_locations"'
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        create_table_statement:
+        - keyword: CREATE
+        - keyword: TABLE
+        - table_reference:
+            identifier: student
+        - bracketed:
+          - start_bracket: (
+          - column_definition:
+              identifier: id
+              data_type:
+                primitive_type:
+                  keyword: INT
+          - comma: ','
+          - column_definition:
+              identifier: student_name
+              data_type:
+                primitive_type:
+                  keyword: STRING
+          - comma: ','
+          - column_definition:
+              identifier: age
+              data_type:
+                primitive_type:
+                  keyword: INT
+          - end_bracket: )
+        - keyword: USING
+        - keyword: CSV
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        create_table_statement:
+        - keyword: CREATE
+        - keyword: TABLE
+        - table_reference:
+            identifier: student
+        - bracketed:
+          - start_bracket: (
+          - column_definition:
+              identifier: id
+              data_type:
+                primitive_type:
+                  keyword: INT
+          - comma: ','
+          - column_definition:
+              identifier: student_name
+              data_type:
+                primitive_type:
+                  keyword: STRING
+          - comma: ','
+          - column_definition:
+              identifier: age
+              data_type:
+                primitive_type:
+                  keyword: INT
+          - end_bracket: )
+        - keyword: STORED
+        - keyword: AS
+        - keyword: ORC
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        create_table_statement:
+        - keyword: CREATE
+        - keyword: TABLE
+        - table_reference:
+            identifier: student_dupli
+        - keyword: LIKE
+        - table_reference:
+            identifier: student
+        - row_format_clause:
+          - keyword: ROW
+          - keyword: FORMAT
+          - keyword: DELIMITED
+          - keyword: FIELDS
+          - keyword: TERMINATED
+          - keyword: BY
+          - literal: "','"
+        - keyword: STORED
+        - keyword: AS
+        - file_format: TEXTFILE
+        - keyword: TBLPROPERTIES
+        - bracketed:
+          - start_bracket: (
+          - literal: "'owner'"
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - literal: "'xxxx'"
+          - end_bracket: )
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        create_view_statement:
+        - keyword: CREATE
+        - keyword: VIEW
+        - table_reference:
+            identifier: experienced_employee_extended
+        - keyword: AS
+        - select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                column_reference:
+                  identifier: a
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      identifier: experienced_employee
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        drop_database_statement:
+        - keyword: DROP
+        - keyword: DATABASE
+        - keyword: IF
+        - keyword: EXISTS
+        - database_reference:
+            identifier: dbname
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        drop_function_statement:
+        - keyword: DROP
+        - keyword: FUNCTION
+        - function_name:
+            function_name_identifier: test_avg
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        use_statement:
+          keyword: USE
+          database_reference:
+            identifier: database_name
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        truncate_table_statement:
+        - keyword: TRUNCATE
+        - keyword: TABLE
+        - table_reference:
+            identifier: student
+        - keyword: PARTITION
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              identifier: age
+            comparison_operator:
+              raw_comparison_operator: '='
+            literal: '10'
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        msck_repair_table_statement:
+        - keyword: MSCK
+        - keyword: REPAIR
+        - keyword: TABLE
+        - table_reference:
+            identifier: table_identifier
+        - keyword: ADD
+        - keyword: PARTITIONS
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        refresh_table_statement:
+        - keyword: REFRESH
+        - keyword: TABLE
+        - table_reference:
+            identifier: tbl1
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        refresh_function_statement:
+        - keyword: REFRESH
+        - keyword: FUNCTION
+        - function_name:
+            function_name_identifier: func1
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        load_data_statement:
+        - keyword: LOAD
+        - keyword: DATA
+        - keyword: LOCAL
+        - keyword: INPATH
+        - literal: "'/user/hive/warehouse/students'"
+        - keyword: OVERWRITE
+        - keyword: INTO
+        - keyword: TABLE
+        - table_reference:
+            identifier: test_load
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        insert_table_statement:
+        - keyword: INSERT
+        - keyword: INTO
+        - keyword: TABLE
+        - table_reference:
+            identifier: students
+        - values_clause:
+            keyword: VALUES
+            delimited_values:
+              tuple_value:
+                bracketed:
+                - start_bracket: (
+                - scalar_value:
+                    literal: "'Amy Smith'"
+                - comma: ','
+                - scalar_value:
+                    literal: "'123 Park Ave, San Jose'"
+                - comma: ','
+                - scalar_value:
+                    literal: '111111'
+                - end_bracket: )
+- statement_terminator: ;
+- statement:
+    explain_statement:
+      keyword: EXPLAIN
+      statement:
+        drop_view_statement:
+        - keyword: DROP
+        - keyword: VIEW
+        - keyword: IF
+        - keyword: EXISTS
+        - table_reference:
+            identifier: view_identifier
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Replace `ExplainStatementSegment` from ANSI to allow for additional parameters and an expanded list of explainable statements.

### Are there any other side effects of this change that we should be aware of?
Removed `parse_grammar` from `ExplainStatementSegment` in ANSI and re-assigned `parse_grammar` to `match_grammar` in Postgres and Snowflake dialects.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
