### PR TITLE
Make extenstion case insensitive

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -914,9 +914,11 @@ class Linter:
                 # that the ignore file is processed after the sql file.
 
                 # Scan for remaining files
-                for ext in self.config.get("sql_file_exts", default=".sql").split(","):
+                for ext in (
+                    self.config.get("sql_file_exts", default=".sql").lower().split(",")
+                ):
                     # is it a sql file?
-                    if fname.endswith(ext):
+                    if fname.lower().endswith(ext):
                         buffer.append(fpath)
 
         if not ignore_files:

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -49,6 +49,7 @@ def test__linter__path_from_paths__default():
     lntr = Linter()
     paths = normalise_paths(lntr.paths_from_path("test/fixtures/linter"))
     assert "test.fixtures.linter.passing.sql" in paths
+    assert "test.fixtures.linter.passing_cap_extension.SQL" in paths
     assert "test.fixtures.linter.discovery_file.txt" not in paths
 
 
@@ -57,6 +58,7 @@ def test__linter__path_from_paths__exts():
     lntr = Linter(config=FluffConfig(overrides={"sql_file_exts": ".txt"}))
     paths = normalise_paths(lntr.paths_from_path("test/fixtures/linter"))
     assert "test.fixtures.linter.passing.sql" not in paths
+    assert "test.fixtures.linter.passing_cap_extension.SQL" not in paths
     assert "test.fixtures.linter.discovery_file.txt" in paths
 
 

--- a/test/fixtures/linter/passing_cap_extension.SQL
+++ b/test/fixtures/linter/passing_cap_extension.SQL
@@ -1,0 +1,1 @@
+select a from b


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes issues raised in chat, whereby a file with a `.SQL` extension was completely ignored by SQLFluff and caused confusion as to why for user.

### Are there any other side effects of this change that we should be aware of?
If you were previously expecting .SQL files to be ignored then you'll be surprised now. Can't see that being an issue though.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
