### PR TITLE
Postgres: Make AS optional in Postgres DELETE

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -3686,14 +3686,14 @@ class DeleteStatementSegment(BaseSegment):
         Ref.keyword("ONLY", optional=True),
         Ref("TableReferenceSegment"),
         Ref("StarSegment", optional=True),
-        Ref("AsAliasExpressionSegment", optional=True),
+        Ref("AliasExpressionSegment", optional=True),
         Sequence(
             "USING",
             Indent,
             Delimited(
                 Sequence(
                     Ref("TableExpressionSegment"),
-                    Ref("AsAliasExpressionSegment", optional=True),
+                    Ref("AliasExpressionSegment", optional=True),
                 ),
             ),
             Dedent,
@@ -3711,7 +3711,7 @@ class DeleteStatementSegment(BaseSegment):
                 Delimited(
                     Sequence(
                         Ref("ExpressionSegment"),
-                        Ref("AsAliasExpressionSegment", optional=True),
+                        Ref("AliasExpressionSegment", optional=True),
                     ),
                 ),
             ),

--- a/test/fixtures/dialects/postgres/postgres_delete.sql
+++ b/test/fixtures/dialects/postgres/postgres_delete.sql
@@ -39,6 +39,8 @@ DELETE FROM tasks WHERE status = 'DONE' RETURNING actor_id a_id;
 
 DELETE FROM tasks WHERE status = 'DONE' RETURNING actor_id, producer_id;
 
+DELETE FROM tasks WHERE status = 'DONE' RETURNING actor_id as a_id, producer_id as p_id;
+
 DELETE FROM tasks WHERE status = 'DONE' RETURNING actor_id a_id, producer_id p_id;
 
 WITH test as (select foo from bar)

--- a/test/fixtures/dialects/postgres/postgres_delete.sql
+++ b/test/fixtures/dialects/postgres/postgres_delete.sql
@@ -6,6 +6,8 @@ DELETE FROM films *;
 
 DELETE FROM films AS f;
 
+DELETE FROM films f;
+
 DELETE FROM films USING producers
   WHERE producer_id = producers.id AND producers.name = 'foo';
 
@@ -13,6 +15,13 @@ DELETE FROM films AS f USING producers AS p
   WHERE f.producer_id = p.id AND p.name = 'foo';
 
 DELETE FROM films AS f USING producers AS p, actors AS a
+  WHERE f.producer_id = p.id AND p.name = 'foo'
+    AND f.actor_id = a.id AND a.name = 'joe cool';
+
+DELETE FROM films f USING producers p
+  WHERE f.producer_id = p.id AND p.name = 'foo';
+
+DELETE FROM films f USING producers p, actors a
   WHERE f.producer_id = p.id AND p.name = 'foo'
     AND f.actor_id = a.id AND a.name = 'joe cool';
 
@@ -26,9 +35,11 @@ DELETE FROM tasks WHERE status = 'DONE' RETURNING actor_id;
 
 DELETE FROM tasks WHERE status = 'DONE' RETURNING actor_id as a_id;
 
+DELETE FROM tasks WHERE status = 'DONE' RETURNING actor_id a_id;
+
 DELETE FROM tasks WHERE status = 'DONE' RETURNING actor_id, producer_id;
 
-DELETE FROM tasks WHERE status = 'DONE' RETURNING actor_id as a_id, producer_id as p_id;
+DELETE FROM tasks WHERE status = 'DONE' RETURNING actor_id a_id, producer_id p_id;
 
 WITH test as (select foo from bar)
 DELETE FROM films;

--- a/test/fixtures/dialects/postgres/postgres_delete.yml
+++ b/test/fixtures/dialects/postgres/postgres_delete.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5b327c1fe9b60cfcbc55928fe2814e9839fdebf15ec9d1ab1e1340841e4471e0
+_hash: bd9673648f070ecc6cab1e746c4ac3eea2fed0f27e05cc5fe4de8891c61c44f3
 file:
 - statement:
     delete_statement:
@@ -405,6 +405,35 @@ file:
     - expression:
         column_reference:
           identifier: producer_id
+- statement_terminator: ;
+- statement:
+    delete_statement:
+    - keyword: DELETE
+    - keyword: FROM
+    - table_reference:
+        identifier: tasks
+    - where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            identifier: status
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: "'DONE'"
+    - keyword: RETURNING
+    - expression:
+        column_reference:
+          identifier: actor_id
+    - alias_expression:
+        keyword: as
+        identifier: a_id
+    - comma: ','
+    - expression:
+        column_reference:
+          identifier: producer_id
+    - alias_expression:
+        keyword: as
+        identifier: p_id
 - statement_terminator: ;
 - statement:
     delete_statement:

--- a/test/fixtures/dialects/postgres/postgres_delete.yml
+++ b/test/fixtures/dialects/postgres/postgres_delete.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6f33596d65a52bb5afc936ca0a834076f307b646e39228d695d9f86738df69dd
+_hash: 5b327c1fe9b60cfcbc55928fe2814e9839fdebf15ec9d1ab1e1340841e4471e0
 file:
 - statement:
     delete_statement:
@@ -36,6 +36,15 @@ file:
         identifier: films
     - alias_expression:
         keyword: AS
+        identifier: f
+- statement_terminator: ;
+- statement:
+    delete_statement:
+    - keyword: DELETE
+    - keyword: FROM
+    - table_reference:
+        identifier: films
+    - alias_expression:
         identifier: f
 - statement_terminator: ;
 - statement:
@@ -128,6 +137,103 @@ file:
           identifier: actors
     - alias_expression:
         keyword: AS
+        identifier: a
+    - where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - identifier: f
+          - dot: .
+          - identifier: producer_id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - identifier: p
+          - dot: .
+          - identifier: id
+        - binary_operator: AND
+        - column_reference:
+          - identifier: p
+          - dot: .
+          - identifier: name
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - literal: "'foo'"
+        - binary_operator: AND
+        - column_reference:
+          - identifier: f
+          - dot: .
+          - identifier: actor_id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - identifier: a
+          - dot: .
+          - identifier: id
+        - binary_operator: AND
+        - column_reference:
+          - identifier: a
+          - dot: .
+          - identifier: name
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - literal: "'joe cool'"
+- statement_terminator: ;
+- statement:
+    delete_statement:
+    - keyword: DELETE
+    - keyword: FROM
+    - table_reference:
+        identifier: films
+    - alias_expression:
+        identifier: f
+    - keyword: USING
+    - table_expression:
+        table_reference:
+          identifier: producers
+    - alias_expression:
+        identifier: p
+    - where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - identifier: f
+          - dot: .
+          - identifier: producer_id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - identifier: p
+          - dot: .
+          - identifier: id
+        - binary_operator: AND
+        - column_reference:
+          - identifier: p
+          - dot: .
+          - identifier: name
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - literal: "'foo'"
+- statement_terminator: ;
+- statement:
+    delete_statement:
+    - keyword: DELETE
+    - keyword: FROM
+    - table_reference:
+        identifier: films
+    - alias_expression:
+        identifier: f
+    - keyword: USING
+    - table_expression:
+        table_reference:
+          identifier: producers
+    - alias_expression:
+        identifier: p
+    - comma: ','
+    - table_expression:
+        table_reference:
+          identifier: actors
+    - alias_expression:
         identifier: a
     - where_clause:
         keyword: WHERE
@@ -274,6 +380,27 @@ file:
     - expression:
         column_reference:
           identifier: actor_id
+    - alias_expression:
+        identifier: a_id
+- statement_terminator: ;
+- statement:
+    delete_statement:
+    - keyword: DELETE
+    - keyword: FROM
+    - table_reference:
+        identifier: tasks
+    - where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            identifier: status
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: "'DONE'"
+    - keyword: RETURNING
+    - expression:
+        column_reference:
+          identifier: actor_id
     - comma: ','
     - expression:
         column_reference:
@@ -298,14 +425,12 @@ file:
         column_reference:
           identifier: actor_id
     - alias_expression:
-        keyword: as
         identifier: a_id
     - comma: ','
     - expression:
         column_reference:
           identifier: producer_id
     - alias_expression:
-        keyword: as
         identifier: p_id
 - statement_terminator: ;
 - statement:


### PR DESCRIPTION

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Quick patch to #2791. Same tweak as [this](https://github.com/sqlfluff/sqlfluff/pull/2792#pullrequestreview-901045237) comment.
AS is optional in aliases within DELETE statement

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
