### PR TITLE
Postgres: INSERT DEFAULT value

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -3691,7 +3691,12 @@ class TupleValue(BaseSegment):
     type = "tuple_value"
     match_grammar = Bracketed(
         Delimited(
-            Ref("ScalarValue"),
+            OneOf(
+                Ref("ScalarValue"),
+                # DEFAULT keyword used in
+                # INSERT INTO statement.
+                "DEFAULT",
+            ),
         )
     )
 

--- a/test/fixtures/dialects/postgres/postgres_insert.sql
+++ b/test/fixtures/dialects/postgres/postgres_insert.sql
@@ -2,6 +2,8 @@ INSERT INTO foo (bar) VALUES(current_timestamp);
 
 INSERT INTO foo (bar, baz) VALUES(1, 2), (3, 4);
 
+INSERT INTO foo (bar) VALUES(DEFAULT);
+
 INSERT INTO distributors AS d (did, dname) VALUES (8, 'Anvil Distribution');
 
 INSERT INTO test (id, col1) OVERRIDING SYSTEM VALUE VALUES (1, 'val');

--- a/test/fixtures/dialects/postgres/postgres_insert.yml
+++ b/test/fixtures/dialects/postgres/postgres_insert.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9bc6913c62254aa125c674ce1c0100cd0d587849fa99369531f7f06dcfc757be
+_hash: 1f3b55183ecaefae04fc7379f0752d3c2a7f3fe5b62cd35225267b827bbd6d66
 file:
 - statement:
     insert_statement:
@@ -62,6 +62,26 @@ file:
             - scalar_value:
                 literal: '4'
             - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        identifier: foo
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          identifier: bar
+        end_bracket: )
+    - values_clause:
+        keyword: VALUES
+        delimited_values:
+          tuple_value:
+            bracketed:
+              start_bracket: (
+              keyword: DEFAULT
+              end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
A column in a Postgres table can be assigned a default value. This default value can then be specified when inserting into a table via a values clause.
<img width="721" alt="image" src="https://user-images.githubusercontent.com/80432516/156931092-bbd6f38b-7203-4c34-9571-9fc5edb89139.png">

This PR allows the DEFAULT keyword to be specified in a values clause

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
