### PR TITLE
Fix Postgres VALUES, make Spark3 VALUES consistent

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2079,7 +2079,7 @@ class ValuesClauseSegment(BaseSegment):
                 Ref.keyword("ROW", optional=True),
                 Bracketed(
                     Delimited(
-                        "DEFAULT",  # not in `FROM` clause, rule?
+                        "DEFAULT",
                         Ref("ExpressionSegment"),
                         ephemeral_name="ValuesClauseElements",
                     )

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -478,13 +478,13 @@ class ValuesClauseSegment(BaseSegment):
             OneOf(
                 Bracketed(
                     Delimited(
-                        "DEFAULT",  # not in `FROM` clause, rule?
+                        "DEFAULT",
                         Ref("ExpressionSegment"),
                         ephemeral_name="ValuesClauseElements",
                     )
                 ),
                 Delimited(
-                    "DEFAULT",  # not in `FROM` clause, rule?
+                    "DEFAULT",
                     Ref("ExpressionSegment"),
                 ),
             ),

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -3650,79 +3650,27 @@ class CTEDefinitionSegment(BaseSegment):
     )
 
 
-@postgres_dialect.segment()
-class DelimitedValues(BaseSegment):
-    """A ``VALUES`` clause can be a sequence either of scalar values or tuple values.
-
-    We make no attempt to ensure that all records have the same number of columns
-    besides the distinction between all scalar or all tuple, so for instance
-    ``VALUES (1,2), (3,4,5)`` will parse but is not legal SQL.
-    """
-
-    type = "delimited_values"
-    match_grammar = OneOf(Delimited(Ref("ScalarValue")), Delimited(Ref("TupleValue")))
-
-
-@postgres_dialect.segment()
-class ScalarValue(BaseSegment):
-    """An element of a ``VALUES`` clause that has a single column.
-
-    Ex: ``VALUES 1,2,3``
-    """
-
-    type = "scalar_value"
-    match_grammar = Sequence(
-        OneOf(
-            Ref("LiteralGrammar"),
-            Ref("BareFunctionSegment"),
-            Ref("FunctionSegment"),
-        ),
-        AnyNumberOf(Ref("ShorthandCastSegment")),
-    )
-
-
-@postgres_dialect.segment()
-class TupleValue(BaseSegment):
-    """An element of a ``VALUES`` clause that has multiple columns.
-
-    Ex: ``VALUES (1,2), (3,4)``
-    """
-
-    type = "tuple_value"
-    match_grammar = Bracketed(
-        Delimited(
-            OneOf(
-                Ref("ScalarValue"),
-                # DEFAULT keyword used in
-                # INSERT INTO statement.
-                "DEFAULT",
-            ),
-        )
-    )
-
-
 @postgres_dialect.segment(replace=True)
 class ValuesClauseSegment(BaseSegment):
-    """A `VALUES` clause, as typically used with `INSERT` or `SELECT`.
-
-    https://www.postgresql.org/docs/13/sql-values.html
-    """
+    """A `VALUES` clause within in `WITH` or `SELECT`."""
 
     type = "values_clause"
-
     match_grammar = Sequence(
         "VALUES",
-        Ref("DelimitedValues"),
-        AnyNumberOf(
-            Ref("AliasExpressionSegment"),
-            min_times=0,
-            max_times=1,
-            exclude=OneOf("LIMIT", "ORDER"),
+        Delimited(
+            Bracketed(
+                Delimited(
+                    Ref("ExpressionSegment"),
+                    # DEFAULT keyword used in
+                    # INSERT INTO statement.
+                    "DEFAULT",
+                    ephemeral_name="ValuesClauseElements",
+                )
+            ),
         ),
+        Ref("AliasExpressionSegment", optional=True),
         Ref("OrderByClauseSegment", optional=True),
         Ref("LimitClauseSegment", optional=True),
-        # TO DO - CHECK OFFSET
-        # TO DO - FETCH
     )
 
 

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -2091,7 +2091,7 @@ class ValuesClauseSegment(BaseSegment):
             OneOf(
                 Bracketed(
                     Delimited(
-                        # DEFAULT keyword used in
+                        # NULL keyword used in
                         # INSERT INTO statement.
                         "NULL",
                         Ref("ExpressionSegment"),

--- a/test/fixtures/dialects/postgres/postgres_array.yml
+++ b/test/fixtures/dialects/postgres/postgres_array.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 65ca59f55e555b9131f0e92275b79afcadd0fd874a65d7994442680c9c738c4e
+_hash: aa1167d7941c122f0338319a714f752ee649d9c99d2f856dc896f573be65e755
 file:
 - statement:
     select_statement:
@@ -180,55 +180,53 @@ file:
         identifier: sal_emp
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'Bill'"
+        bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'Bill'"
+        - comma: ','
+        - expression:
+            keyword: ARRAY
+            array_literal:
+            - start_square_bracket: '['
+            - expression:
+                literal: '10000'
             - comma: ','
-            - scalar_value:
-                keyword: ARRAY
+            - expression:
+                literal: '10000'
+            - comma: ','
+            - expression:
+                literal: '10000'
+            - comma: ','
+            - expression:
+                literal: '10000'
+            - end_square_bracket: ']'
+        - comma: ','
+        - expression:
+            keyword: ARRAY
+            array_literal:
+            - start_square_bracket: '['
+            - expression:
                 array_literal:
                 - start_square_bracket: '['
                 - expression:
-                    literal: '10000'
+                    literal: "'meeting'"
                 - comma: ','
                 - expression:
-                    literal: '10000'
-                - comma: ','
-                - expression:
-                    literal: '10000'
-                - comma: ','
-                - expression:
-                    literal: '10000'
+                    literal: "'lunch'"
                 - end_square_bracket: ']'
             - comma: ','
-            - scalar_value:
-                keyword: ARRAY
+            - expression:
                 array_literal:
                 - start_square_bracket: '['
                 - expression:
-                    array_literal:
-                    - start_square_bracket: '['
-                    - expression:
-                        literal: "'meeting'"
-                    - comma: ','
-                    - expression:
-                        literal: "'lunch'"
-                    - end_square_bracket: ']'
+                    literal: "'training'"
                 - comma: ','
                 - expression:
-                    array_literal:
-                    - start_square_bracket: '['
-                    - expression:
-                        literal: "'training'"
-                    - comma: ','
-                    - expression:
-                        literal: "'presentation'"
-                    - end_square_bracket: ']'
+                    literal: "'presentation'"
                 - end_square_bracket: ']'
-            - end_bracket: )
+            - end_square_bracket: ']'
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_statement:
@@ -238,55 +236,53 @@ file:
         identifier: sal_emp
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'Carol'"
+        bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'Carol'"
+        - comma: ','
+        - expression:
+            keyword: ARRAY
+            array_literal:
+            - start_square_bracket: '['
+            - expression:
+                literal: '20000'
             - comma: ','
-            - scalar_value:
-                keyword: ARRAY
+            - expression:
+                literal: '25000'
+            - comma: ','
+            - expression:
+                literal: '25000'
+            - comma: ','
+            - expression:
+                literal: '25000'
+            - end_square_bracket: ']'
+        - comma: ','
+        - expression:
+            keyword: ARRAY
+            array_literal:
+            - start_square_bracket: '['
+            - expression:
                 array_literal:
                 - start_square_bracket: '['
                 - expression:
-                    literal: '20000'
+                    literal: "'breakfast'"
                 - comma: ','
                 - expression:
-                    literal: '25000'
-                - comma: ','
-                - expression:
-                    literal: '25000'
-                - comma: ','
-                - expression:
-                    literal: '25000'
+                    literal: "'consulting'"
                 - end_square_bracket: ']'
             - comma: ','
-            - scalar_value:
-                keyword: ARRAY
+            - expression:
                 array_literal:
                 - start_square_bracket: '['
                 - expression:
-                    array_literal:
-                    - start_square_bracket: '['
-                    - expression:
-                        literal: "'breakfast'"
-                    - comma: ','
-                    - expression:
-                        literal: "'consulting'"
-                    - end_square_bracket: ']'
+                    literal: "'meeting'"
                 - comma: ','
                 - expression:
-                    array_literal:
-                    - start_square_bracket: '['
-                    - expression:
-                        literal: "'meeting'"
-                    - comma: ','
-                    - expression:
-                        literal: "'lunch'"
-                    - end_square_bracket: ']'
+                    literal: "'lunch'"
                 - end_square_bracket: ']'
-            - end_bracket: )
+            - end_square_bracket: ']'
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:

--- a/test/fixtures/dialects/postgres/postgres_create_table_as.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_table_as.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 19ab0b5dc237e58df14d877fba3e66305f3d2804ae44cfeb0211b45041055ed6
+_hash: 5e591ff62620fab82564e0d081e7651aa37f62907abe67c65dc61399b9f5ca92
 file:
 - statement:
     create_table_as_statement:
@@ -454,33 +454,30 @@ file:
       - end_bracket: )
     - keyword: AS
     - values_clause:
-        keyword: VALUES
-        delimited_values:
-        - tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'val1'"
-            - comma: ','
-            - scalar_value:
-                literal: "'val2'"
-            - comma: ','
-            - scalar_value:
-                literal: "'val3'"
-            - end_bracket: )
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'val1'"
         - comma: ','
-        - tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'val4'"
-            - comma: ','
-            - scalar_value:
-                literal: "'val5'"
-            - comma: ','
-            - scalar_value:
-                literal: "'val6'"
-            - end_bracket: )
+        - expression:
+            literal: "'val2'"
+        - comma: ','
+        - expression:
+            literal: "'val3'"
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'val4'"
+        - comma: ','
+        - expression:
+            literal: "'val5'"
+        - comma: ','
+        - expression:
+            literal: "'val6'"
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     create_table_as_statement:

--- a/test/fixtures/dialects/postgres/postgres_delete.yml
+++ b/test/fixtures/dialects/postgres/postgres_delete.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bd9673648f070ecc6cab1e746c4ac3eea2fed0f27e05cc5fe4de8891c61c44f3
+_hash: 18eae966c89e42a090d0cd0e3b7e0a92443577fcf599a5f0325205305564c68f
 file:
 - statement:
     delete_statement:
@@ -507,13 +507,11 @@ file:
           set_expression:
             values_clause:
               keyword: VALUES
-              delimited_values:
-                tuple_value:
-                  bracketed:
-                    start_bracket: (
-                    scalar_value:
-                      literal: '1'
-                    end_bracket: )
+              bracketed:
+                start_bracket: (
+                expression:
+                  literal: '1'
+                end_bracket: )
             set_operator:
             - keyword: UNION
             - keyword: ALL

--- a/test/fixtures/dialects/postgres/postgres_insert.sql
+++ b/test/fixtures/dialects/postgres/postgres_insert.sql
@@ -2,6 +2,8 @@ INSERT INTO foo (bar) VALUES(current_timestamp);
 
 INSERT INTO foo (bar, baz) VALUES(1, 2), (3, 4);
 
+INSERT INTO foo (bar, baz) VALUES(1 + 1, 2), (3, 4);
+
 INSERT INTO foo (bar) VALUES(DEFAULT);
 
 INSERT INTO distributors AS d (did, dname) VALUES (8, 'Anvil Distribution');

--- a/test/fixtures/dialects/postgres/postgres_insert.yml
+++ b/test/fixtures/dialects/postgres/postgres_insert.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1f3b55183ecaefae04fc7379f0752d3c2a7f3fe5b62cd35225267b827bbd6d66
+_hash: 4a784a8f57c80a0859cc7cfb0cc2831d0058888b0dc7073b2e87f6b31411d359
 file:
 - statement:
     insert_statement:
@@ -18,13 +18,11 @@ file:
         end_bracket: )
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-              start_bracket: (
-              scalar_value:
-                bare_function: current_timestamp
-              end_bracket: )
+        bracketed:
+          start_bracket: (
+          expression:
+            bare_function: current_timestamp
+          end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_statement:
@@ -41,27 +39,60 @@ file:
           identifier: baz
       - end_bracket: )
     - values_clause:
-        keyword: VALUES
-        delimited_values:
-        - tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: '1'
-            - comma: ','
-            - scalar_value:
-                literal: '2'
-            - end_bracket: )
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            literal: '1'
         - comma: ','
-        - tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: '3'
-            - comma: ','
-            - scalar_value:
-                literal: '4'
-            - end_bracket: )
+        - expression:
+            literal: '2'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            literal: '3'
+        - comma: ','
+        - expression:
+            literal: '4'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        identifier: foo
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          identifier: bar
+      - comma: ','
+      - column_reference:
+          identifier: baz
+      - end_bracket: )
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+          - literal: '1'
+          - binary_operator: +
+          - literal: '1'
+        - comma: ','
+        - expression:
+            literal: '2'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            literal: '3'
+        - comma: ','
+        - expression:
+            literal: '4'
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_statement:
@@ -76,12 +107,10 @@ file:
         end_bracket: )
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-              start_bracket: (
-              keyword: DEFAULT
-              end_bracket: )
+        bracketed:
+          start_bracket: (
+          keyword: DEFAULT
+          end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_statement:
@@ -102,16 +131,14 @@ file:
       - end_bracket: )
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: '8'
-            - comma: ','
-            - scalar_value:
-                literal: "'Anvil Distribution'"
-            - end_bracket: )
+        bracketed:
+        - start_bracket: (
+        - expression:
+            literal: '8'
+        - comma: ','
+        - expression:
+            literal: "'Anvil Distribution'"
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_statement:
@@ -132,16 +159,14 @@ file:
     - keyword: VALUE
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: '1'
-            - comma: ','
-            - scalar_value:
-                literal: "'val'"
-            - end_bracket: )
+        bracketed:
+        - start_bracket: (
+        - expression:
+            literal: '1'
+        - comma: ','
+        - expression:
+            literal: "'val'"
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_statement:
@@ -162,16 +187,14 @@ file:
     - keyword: VALUE
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: '1'
-            - comma: ','
-            - scalar_value:
-                literal: "'val'"
-            - end_bracket: )
+        bracketed:
+        - start_bracket: (
+        - expression:
+            literal: '1'
+        - comma: ','
+        - expression:
+            literal: "'val'"
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_statement:
@@ -229,13 +252,11 @@ file:
         end_bracket: )
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-              start_bracket: (
-              scalar_value:
-                bare_function: current_timestamp
-              end_bracket: )
+        bracketed:
+          start_bracket: (
+          expression:
+            bare_function: current_timestamp
+          end_bracket: )
     - keyword: RETURNING
     - star: '*'
 - statement_terminator: ;
@@ -252,13 +273,11 @@ file:
         end_bracket: )
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-              start_bracket: (
-              scalar_value:
-                bare_function: current_timestamp
-              end_bracket: )
+        bracketed:
+          start_bracket: (
+          expression:
+            bare_function: current_timestamp
+          end_bracket: )
     - keyword: RETURNING
     - expression:
         column_reference:
@@ -277,13 +296,11 @@ file:
         end_bracket: )
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-              start_bracket: (
-              scalar_value:
-                bare_function: current_timestamp
-              end_bracket: )
+        bracketed:
+          start_bracket: (
+          expression:
+            bare_function: current_timestamp
+          end_bracket: )
     - keyword: RETURNING
     - expression:
         column_reference:
@@ -308,16 +325,14 @@ file:
       - end_bracket: )
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: '1'
-            - comma: ','
-            - scalar_value:
-                literal: '2'
-            - end_bracket: )
+        bracketed:
+        - start_bracket: (
+        - expression:
+            literal: '1'
+        - comma: ','
+        - expression:
+            literal: '2'
+        - end_bracket: )
     - keyword: RETURNING
     - expression:
         column_reference:
@@ -343,16 +358,14 @@ file:
       - end_bracket: )
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: '1'
-            - comma: ','
-            - scalar_value:
-                literal: '2'
-            - end_bracket: )
+        bracketed:
+        - start_bracket: (
+        - expression:
+            literal: '1'
+        - comma: ','
+        - expression:
+            literal: '2'
+        - end_bracket: )
     - keyword: RETURNING
     - expression:
         column_reference:

--- a/test/fixtures/dialects/postgres/postgres_values_alias.yml
+++ b/test/fixtures/dialects/postgres/postgres_values_alias.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fe07ce859ecab2e6c0be2b3fcdedc0407e274d04b6da55a8dd5b9e97c14958eb
+_hash: 697ac60f631ba5b95b29b05499dfd216aa663d05c5d2edc6fb1a69e51d55a338
 file:
   statement:
     select_statement:
@@ -21,27 +21,24 @@ file:
               start_bracket: (
               table_expression:
                 values_clause:
-                  keyword: values
-                  delimited_values:
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '1'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '2'
-                      - end_bracket: )
+                - keyword: values
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '1'
                   - comma: ','
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '3'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '4'
-                      - end_bracket: )
+                  - expression:
+                      literal: '2'
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '3'
+                  - comma: ','
+                  - expression:
+                      literal: '4'
+                  - end_bracket: )
               end_bracket: )
             alias_expression:
               keyword: as

--- a/test/fixtures/dialects/postgres/postgres_values_in_subquery.yml
+++ b/test/fixtures/dialects/postgres/postgres_values_in_subquery.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8f78ff77ce8210cb0bb643a4cc034986d2843c5b147492872df6f2f57edf0034
+_hash: cfb0b25673569ea5fca5640575508daa191b21b282d81cbad46654f4f2a3b362
 file:
 - statement:
     with_compound_statement:
@@ -22,26 +22,24 @@ file:
           start_bracket: (
           values_clause:
             keyword: VALUES
-            delimited_values:
-              tuple_value:
-                bracketed:
-                - start_bracket: (
-                - scalar_value:
-                    literal: "'08RIX0'"
-                - comma: ','
-                - scalar_value:
-                    literal: '0.435'
-                    cast_expression:
-                      casting_operator: '::'
-                      data_type:
-                        keyword: NUMERIC
-                        bracketed:
-                        - start_bracket: (
-                        - literal: '4'
-                        - comma: ','
-                        - literal: '3'
-                        - end_bracket: )
-                - end_bracket: )
+            bracketed:
+            - start_bracket: (
+            - expression:
+                literal: "'08RIX0'"
+            - comma: ','
+            - expression:
+                literal: '0.435'
+                cast_expression:
+                  casting_operator: '::'
+                  data_type:
+                    keyword: NUMERIC
+                    bracketed:
+                    - start_bracket: (
+                    - literal: '4'
+                    - comma: ','
+                    - literal: '3'
+                    - end_bracket: )
+            - end_bracket: )
           end_bracket: )
       select_statement:
         select_clause:
@@ -75,13 +73,11 @@ file:
               table_expression:
                 values_clause:
                   keyword: VALUES
-                  delimited_values:
-                    tuple_value:
-                      bracketed:
-                        start_bracket: (
-                        scalar_value:
-                          literal: '1'
-                        end_bracket: )
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      literal: '1'
+                    end_bracket: )
               end_bracket: )
             alias_expression:
               keyword: AS
@@ -108,27 +104,24 @@ file:
               start_bracket: (
               table_expression:
                 values_clause:
-                  keyword: VALUES
-                  delimited_values:
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '1'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '2'
-                      - end_bracket: )
+                - keyword: VALUES
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '1'
                   - comma: ','
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '3'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '4'
-                      - end_bracket: )
+                  - expression:
+                      literal: '2'
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '3'
+                  - comma: ','
+                  - expression:
+                      literal: '4'
+                  - end_bracket: )
               end_bracket: )
             alias_expression:
               keyword: AS

--- a/test/fixtures/dialects/postgres/values.sql
+++ b/test/fixtures/dialects/postgres/values.sql
@@ -1,7 +1,17 @@
 values (1, 2);
+
+VALUES (1+1, 2);
+
+values (1+1, 2::TEXT);
+
 values (1, 2), (3, 4);
+
 values (1, 2), (3, 4), (greatest(5, 6), least(7, 8));
-values 1, 2;
-values 1;
-values 1 , 2 , 3 limit 1;
-values 3 , 2 , 1 order by 2;
+
+values (1, 2), (3, 4) limit 1;
+
+values (1, 2), (3, 4) limit 1 offset 1;
+
+values (1, 2), (3, 4) order by 1 desc;
+
+values (1, 2), (3, 4) order by 1 desc limit 1;

--- a/test/fixtures/dialects/postgres/values.yml
+++ b/test/fixtures/dialects/postgres/values.yml
@@ -3,147 +3,225 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f7acf6e6ebf18063e7a42ef80f9b33467907bf439b56c7cb624b8be1eba6b182
+_hash: 0ae7d918536a0c1d1f9b4f7fbaee31e188a8eb6fbaed984e8b52f2efbc760db6
 file:
 - statement:
     values_clause:
       keyword: values
-      delimited_values:
-        tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
-          - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
-- statement_terminator: ;
-- statement:
-    values_clause:
-      keyword: values
-      delimited_values:
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
-          - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
-      - comma: ','
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '3'
-          - comma: ','
-          - scalar_value:
-              literal: '4'
-          - end_bracket: )
-- statement_terminator: ;
-- statement:
-    values_clause:
-      keyword: values
-      delimited_values:
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
-          - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
-      - comma: ','
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '3'
-          - comma: ','
-          - scalar_value:
-              literal: '4'
-          - end_bracket: )
-      - comma: ','
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              function:
-                function_name:
-                  function_name_identifier: greatest
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    literal: '5'
-                - comma: ','
-                - expression:
-                    literal: '6'
-                - end_bracket: )
-          - comma: ','
-          - scalar_value:
-              function:
-                function_name:
-                  function_name_identifier: least
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    literal: '7'
-                - comma: ','
-                - expression:
-                    literal: '8'
-                - end_bracket: )
-          - end_bracket: )
-- statement_terminator: ;
-- statement:
-    values_clause:
-      keyword: values
-      delimited_values:
-      - scalar_value:
+      bracketed:
+      - start_bracket: (
+      - expression:
           literal: '1'
       - comma: ','
-      - scalar_value:
+      - expression:
           literal: '2'
+      - end_bracket: )
 - statement_terminator: ;
 - statement:
     values_clause:
-      keyword: values
-      delimited_values:
-        scalar_value:
-          literal: '1'
-- statement_terminator: ;
-- statement:
-    values_clause:
-      keyword: values
-      delimited_values:
-      - scalar_value:
-          literal: '1'
+      keyword: VALUES
+      bracketed:
+      - start_bracket: (
+      - expression:
+        - literal: '1'
+        - binary_operator: +
+        - literal: '1'
       - comma: ','
-      - scalar_value:
+      - expression:
           literal: '2'
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    values_clause:
+      keyword: values
+      bracketed:
+      - start_bracket: (
+      - expression:
+        - literal: '1'
+        - binary_operator: +
+        - literal: '1'
       - comma: ','
-      - scalar_value:
+      - expression:
+          literal: '2'
+          cast_expression:
+            casting_operator: '::'
+            data_type:
+              keyword: TEXT
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    values_clause:
+    - keyword: values
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
+      - comma: ','
+      - expression:
+          literal: '2'
+      - end_bracket: )
+    - comma: ','
+    - bracketed:
+      - start_bracket: (
+      - expression:
           literal: '3'
-      limit_clause:
+      - comma: ','
+      - expression:
+          literal: '4'
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    values_clause:
+    - keyword: values
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
+      - comma: ','
+      - expression:
+          literal: '2'
+      - end_bracket: )
+    - comma: ','
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '3'
+      - comma: ','
+      - expression:
+          literal: '4'
+      - end_bracket: )
+    - comma: ','
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          function:
+            function_name:
+              function_name_identifier: greatest
+            bracketed:
+            - start_bracket: (
+            - expression:
+                literal: '5'
+            - comma: ','
+            - expression:
+                literal: '6'
+            - end_bracket: )
+      - comma: ','
+      - expression:
+          function:
+            function_name:
+              function_name_identifier: least
+            bracketed:
+            - start_bracket: (
+            - expression:
+                literal: '7'
+            - comma: ','
+            - expression:
+                literal: '8'
+            - end_bracket: )
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    values_clause:
+    - keyword: values
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
+      - comma: ','
+      - expression:
+          literal: '2'
+      - end_bracket: )
+    - comma: ','
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '3'
+      - comma: ','
+      - expression:
+          literal: '4'
+      - end_bracket: )
+    - limit_clause:
         keyword: limit
         literal: '1'
 - statement_terminator: ;
 - statement:
     values_clause:
-      keyword: values
-      delimited_values:
-      - scalar_value:
+    - keyword: values
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
+      - comma: ','
+      - expression:
+          literal: '2'
+      - end_bracket: )
+    - comma: ','
+    - bracketed:
+      - start_bracket: (
+      - expression:
           literal: '3'
       - comma: ','
-      - scalar_value:
-          literal: '2'
-      - comma: ','
-      - scalar_value:
+      - expression:
+          literal: '4'
+      - end_bracket: )
+    - limit_clause:
+      - keyword: limit
+      - literal: '1'
+      - keyword: offset
+      - literal: '1'
+- statement_terminator: ;
+- statement:
+    values_clause:
+    - keyword: values
+    - bracketed:
+      - start_bracket: (
+      - expression:
           literal: '1'
-      orderby_clause:
+      - comma: ','
+      - expression:
+          literal: '2'
+      - end_bracket: )
+    - comma: ','
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '3'
+      - comma: ','
+      - expression:
+          literal: '4'
+      - end_bracket: )
+    - orderby_clause:
       - keyword: order
       - keyword: by
-      - literal: '2'
+      - literal: '1'
+      - keyword: desc
+- statement_terminator: ;
+- statement:
+    values_clause:
+    - keyword: values
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
+      - comma: ','
+      - expression:
+          literal: '2'
+      - end_bracket: )
+    - comma: ','
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '3'
+      - comma: ','
+      - expression:
+          literal: '4'
+      - end_bracket: )
+    - orderby_clause:
+      - keyword: order
+      - keyword: by
+      - literal: '1'
+      - keyword: desc
+    - limit_clause:
+        keyword: limit
+        literal: '1'
 - statement_terminator: ;

--- a/test/fixtures/dialects/redshift/redshift_insert_into.yml
+++ b/test/fixtures/dialects/redshift/redshift_insert_into.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 768c727987fd883d32f09d3ff1be53531de6c825f66b6d1dd5ccb7d9dd1d67d7
+_hash: 1e7af90a25a98f815f8c4dc3f2d1501dfdd6bf01f859625a09a83131239a2ef8
 file:
 - statement:
     insert_statement:
@@ -137,25 +137,22 @@ file:
           identifier: col2
       - end_bracket: )
     - values_clause:
-        keyword: VALUES
-        delimited_values:
-        - tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'V1'"
-            - comma: ','
-            - scalar_value:
-                literal: '1'
-            - end_bracket: )
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'V1'"
         - comma: ','
-        - tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'V2'"
-            - comma: ','
-            - scalar_value:
-                literal: '2'
-            - end_bracket: )
+        - expression:
+            literal: '1'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'V2'"
+        - comma: ','
+        - expression:
+            literal: '2'
+        - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/spark3/explain.yml
+++ b/test/fixtures/dialects/spark3/explain.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 75a855a4e5e9da38ec7c9e10a2e9a841ba415c0a8a25c12f756f8825696678d1
+_hash: 2c9a593bedcfd33aba499ae3e443c3b7a9514b2a4d53673a5a918f9d61b1ea91
 file:
 - statement:
     explain_statement:
@@ -396,19 +396,17 @@ file:
             identifier: students
         - values_clause:
             keyword: VALUES
-            delimited_values:
-              tuple_value:
-                bracketed:
-                - start_bracket: (
-                - scalar_value:
-                    literal: "'Amy Smith'"
-                - comma: ','
-                - scalar_value:
-                    literal: "'123 Park Ave, San Jose'"
-                - comma: ','
-                - scalar_value:
-                    literal: '111111'
-                - end_bracket: )
+            bracketed:
+            - start_bracket: (
+            - expression:
+                literal: "'Amy Smith'"
+            - comma: ','
+            - expression:
+                literal: "'123 Park Ave, San Jose'"
+            - comma: ','
+            - expression:
+                literal: '111111'
+            - end_bracket: )
 - statement_terminator: ;
 - statement:
     explain_statement:

--- a/test/fixtures/dialects/spark3/insert_table.yml
+++ b/test/fixtures/dialects/spark3/insert_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1a53ea7cfdc6d98f64d518ee4167659267dec8134d688dfd66cb91dbd6ace494
+_hash: f97e76509bb5093ba779efc9bd0627135e0e79ab2649fef5dbc0896e19769508
 file:
 - statement:
     insert_table_statement:
@@ -14,19 +14,17 @@ file:
         identifier: students
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'Amy Smith'"
-            - comma: ','
-            - scalar_value:
-                literal: "'123 Park Ave, San Jose'"
-            - comma: ','
-            - scalar_value:
-                literal: '111111'
-            - end_bracket: )
+        bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'Amy Smith'"
+        - comma: ','
+        - expression:
+            literal: "'123 Park Ave, San Jose'"
+        - comma: ','
+        - expression:
+            literal: '111111'
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_table_statement:
@@ -36,19 +34,17 @@ file:
         identifier: students
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'Amy Smith'"
-            - comma: ','
-            - scalar_value:
-                literal: "'123 Park Ave, San Jose'"
-            - comma: ','
-            - scalar_value:
-                literal: '111111'
-            - end_bracket: )
+        bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'Amy Smith'"
+        - comma: ','
+        - expression:
+            literal: "'123 Park Ave, San Jose'"
+        - comma: ','
+        - expression:
+            literal: '111111'
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_table_statement:
@@ -58,19 +54,17 @@ file:
         identifier: students
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'Amy Smith'"
-            - comma: ','
-            - scalar_value:
-                literal: "'123 Park Ave, San Jose'"
-            - comma: ','
-            - scalar_value:
-                literal: '111111'
-            - end_bracket: )
+        bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'Amy Smith'"
+        - comma: ','
+        - expression:
+            literal: "'123 Park Ave, San Jose'"
+        - comma: ','
+        - expression:
+            literal: '111111'
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_table_statement:
@@ -79,33 +73,30 @@ file:
     - table_reference:
         identifier: students
     - values_clause:
-        keyword: VALUES
-        delimited_values:
-        - tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'Bob Brown'"
-            - comma: ','
-            - scalar_value:
-                literal: "'456 Taylor St, Cupertino'"
-            - comma: ','
-            - scalar_value:
-                literal: '222222'
-            - end_bracket: )
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'Bob Brown'"
         - comma: ','
-        - tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'Cathy Johnson'"
-            - comma: ','
-            - scalar_value:
-                literal: "'789 Race Ave, Palo Alto'"
-            - comma: ','
-            - scalar_value:
-                literal: '333333'
-            - end_bracket: )
+        - expression:
+            literal: "'456 Taylor St, Cupertino'"
+        - comma: ','
+        - expression:
+            literal: '222222'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'Cathy Johnson'"
+        - comma: ','
+        - expression:
+            literal: "'789 Race Ave, Palo Alto'"
+        - comma: ','
+        - expression:
+            literal: '333333'
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_table_statement:
@@ -114,33 +105,30 @@ file:
     - table_reference:
         identifier: students
     - values_clause:
-        keyword: VALUES
-        delimited_values:
-        - tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'Bob Brown'"
-            - comma: ','
-            - scalar_value:
-                literal: "'456 Taylor St, Cupertino'"
-            - comma: ','
-            - scalar_value:
-                literal: '222222'
-            - end_bracket: )
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'Bob Brown'"
         - comma: ','
-        - tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'Cathy Johnson'"
-            - comma: ','
-            - scalar_value:
-                literal: "'789 Race Ave, Palo Alto'"
-            - comma: ','
-            - scalar_value:
-                literal: '333333'
-            - end_bracket: )
+        - expression:
+            literal: "'456 Taylor St, Cupertino'"
+        - comma: ','
+        - expression:
+            literal: '222222'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'Cathy Johnson'"
+        - comma: ','
+        - expression:
+            literal: "'789 Race Ave, Palo Alto'"
+        - comma: ','
+        - expression:
+            literal: '333333'
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_table_statement:
@@ -316,16 +304,14 @@ file:
         end_bracket: )
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'Amy Smith'"
-            - comma: ','
-            - scalar_value:
-                literal: "'123 Park Ave, San Jose'"
-            - end_bracket: )
+        bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'Amy Smith'"
+        - comma: ','
+        - expression:
+            literal: "'123 Park Ave, San Jose'"
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_table_statement:
@@ -345,16 +331,14 @@ file:
         end_bracket: )
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'Amy Smith'"
-            - comma: ','
-            - scalar_value:
-                literal: "'123 Park Ave, San Jose'"
-            - end_bracket: )
+        bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'Amy Smith'"
+        - comma: ','
+        - expression:
+            literal: "'123 Park Ave, San Jose'"
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_table_statement:
@@ -381,16 +365,14 @@ file:
       - end_bracket: )
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'Hangzhou, China'"
-            - comma: ','
-            - scalar_value:
-                literal: "'Kent Yao Jr.'"
-            - end_bracket: )
+        bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'Hangzhou, China'"
+        - comma: ','
+        - expression:
+            literal: "'Kent Yao Jr.'"
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     insert_table_statement:
@@ -417,14 +399,12 @@ file:
       - end_bracket: )
     - values_clause:
         keyword: VALUES
-        delimited_values:
-          tuple_value:
-            bracketed:
-            - start_bracket: (
-            - scalar_value:
-                literal: "'Hangzhou, China'"
-            - comma: ','
-            - scalar_value:
-                literal: "'Kent Yao Jr.'"
-            - end_bracket: )
+        bracketed:
+        - start_bracket: (
+        - expression:
+            literal: "'Hangzhou, China'"
+        - comma: ','
+        - expression:
+            literal: "'Kent Yao Jr.'"
+        - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/spark3/pivot_clause.yml
+++ b/test/fixtures/dialects/spark3/pivot_clause.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4311848553f9c4cd3c1a4854f1f517e9912fe79c210f32d54cf22ddc2ae316f0
+_hash: 5f41f160aaf03561963146f4dd64842aeb6173bcd360561fcf7a9fa81f762027
 file:
 - statement:
     select_statement:
@@ -40,7 +40,7 @@ file:
               - keyword: IN
               - bracketed:
                   start_bracket: (
-                  scalar_value:
+                  expression:
                     literal: "'John'"
                   alias_expression:
                     keyword: AS
@@ -83,13 +83,13 @@ file:
               - keyword: IN
               - bracketed:
                 - start_bracket: (
-                - scalar_value:
+                - expression:
                     literal: "'John'"
                 - alias_expression:
                     keyword: AS
                     identifier: john
                 - comma: ','
-                - scalar_value:
+                - expression:
                     literal: "'Mike'"
                 - alias_expression:
                     keyword: AS
@@ -135,13 +135,13 @@ file:
               - keyword: IN
               - bracketed:
                 - start_bracket: (
-                - scalar_value:
+                - expression:
                     literal: "'John'"
                 - alias_expression:
                     keyword: AS
                     identifier: john
                 - comma: ','
-                - scalar_value:
+                - expression:
                     literal: "'Mike'"
                 - alias_expression:
                     keyword: AS
@@ -184,13 +184,13 @@ file:
               - keyword: IN
               - bracketed:
                 - start_bracket: (
-                - scalar_value:
+                - expression:
                     literal: "'John'"
                 - alias_expression:
                     keyword: AS
                     identifier: john
                 - comma: ','
-                - scalar_value:
+                - expression:
                     literal: "'Mike'"
                 - alias_expression:
                     keyword: AS
@@ -250,13 +250,13 @@ file:
               - keyword: IN
               - bracketed:
                 - start_bracket: (
-                - scalar_value:
+                - expression:
                     literal: "'John'"
                 - alias_expression:
                     keyword: AS
                     identifier: john
                 - comma: ','
-                - scalar_value:
+                - expression:
                     literal: "'Mike'"
                 - alias_expression:
                     keyword: AS
@@ -316,13 +316,13 @@ file:
               - keyword: IN
               - bracketed:
                 - start_bracket: (
-                - scalar_value:
+                - expression:
                     literal: "'John'"
                 - alias_expression:
                     keyword: AS
                     identifier: john
                 - comma: ','
-                - scalar_value:
+                - expression:
                     literal: "'Mike'"
                 - alias_expression:
                     keyword: AS
@@ -384,28 +384,26 @@ file:
               - keyword: IN
               - bracketed:
                 - start_bracket: (
-                - tuple_value:
-                    bracketed:
-                    - start_bracket: (
-                    - scalar_value:
-                        literal: "'John'"
-                    - comma: ','
-                    - scalar_value:
-                        literal: '30'
-                    - end_bracket: )
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: "'John'"
+                  - comma: ','
+                  - expression:
+                      literal: '30'
+                  - end_bracket: )
                 - alias_expression:
                     keyword: AS
                     identifier: c1
                 - comma: ','
-                - tuple_value:
-                    bracketed:
-                    - start_bracket: (
-                    - scalar_value:
-                        literal: "'Mike'"
-                    - comma: ','
-                    - scalar_value:
-                        literal: '40'
-                    - end_bracket: )
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: "'Mike'"
+                  - comma: ','
+                  - expression:
+                      literal: '40'
+                  - end_bracket: )
                 - alias_expression:
                     keyword: AS
                     identifier: c2
@@ -473,28 +471,26 @@ file:
               - keyword: IN
               - bracketed:
                 - start_bracket: (
-                - tuple_value:
-                    bracketed:
-                    - start_bracket: (
-                    - scalar_value:
-                        literal: "'John'"
-                    - comma: ','
-                    - scalar_value:
-                        literal: '30'
-                    - end_bracket: )
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: "'John'"
+                  - comma: ','
+                  - expression:
+                      literal: '30'
+                  - end_bracket: )
                 - alias_expression:
                     keyword: AS
                     identifier: c1
                 - comma: ','
-                - tuple_value:
-                    bracketed:
-                    - start_bracket: (
-                    - scalar_value:
-                        literal: "'Mike'"
-                    - comma: ','
-                    - scalar_value:
-                        literal: '40'
-                    - end_bracket: )
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: "'Mike'"
+                  - comma: ','
+                  - expression:
+                      literal: '40'
+                  - end_bracket: )
                 - alias_expression:
                     keyword: AS
                     identifier: c2
@@ -558,21 +554,20 @@ file:
               - keyword: IN
               - bracketed:
                 - start_bracket: (
-                - scalar_value:
+                - expression:
                     literal: "'John'"
                 - alias_expression:
                     keyword: AS
                     identifier: c1
                 - comma: ','
-                - tuple_value:
-                    bracketed:
-                    - start_bracket: (
-                    - scalar_value:
-                        literal: "'Mike'"
-                    - comma: ','
-                    - scalar_value:
-                        literal: '40'
-                    - end_bracket: )
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: "'Mike'"
+                  - comma: ','
+                  - expression:
+                      literal: '40'
+                  - end_bracket: )
                 - alias_expression:
                     keyword: AS
                     identifier: c2

--- a/test/fixtures/dialects/spark3/select_from_multiple_values_clauses.yml
+++ b/test/fixtures/dialects/spark3/select_from_multiple_values_clauses.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8663738dbff79ccc296b32646fde49c6c853b650722ab332e2cfa641a7279124
+_hash: 97c76bc8ec2e59cad0e783f33a41d3021ab5e8f1a304c8a70b8df36037ffde13
 file:
 - statement:
     select_statement:
@@ -20,18 +20,16 @@ file:
             table_expression:
               values_clause:
                 keyword: values
-                delimited_values:
-                  scalar_value:
-                    literal: '1'
+                expression:
+                  literal: '1'
       - comma: ','
       - from_expression:
           from_expression_element:
             table_expression:
               values_clause:
                 keyword: values
-                delimited_values:
-                  scalar_value:
-                    literal: '2'
+                expression:
+                  literal: '2'
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -49,13 +47,12 @@ file:
               start_bracket: (
               table_expression:
                 values_clause:
-                  keyword: values
-                  delimited_values:
-                  - scalar_value:
-                      literal: '1'
-                  - comma: ','
-                  - scalar_value:
-                      literal: '2'
+                - keyword: values
+                - expression:
+                    literal: '1'
+                - comma: ','
+                - expression:
+                    literal: '2'
               end_bracket: )
       - comma: ','
       - from_expression:
@@ -64,12 +61,11 @@ file:
               start_bracket: (
               table_expression:
                 values_clause:
-                  keyword: values
-                  delimited_values:
-                  - scalar_value:
-                      literal: '2'
-                  - comma: ','
-                  - scalar_value:
-                      literal: '3'
+                - keyword: values
+                - expression:
+                    literal: '2'
+                - comma: ','
+                - expression:
+                    literal: '3'
               end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/spark3/select_from_values.yml
+++ b/test/fixtures/dialects/spark3/select_from_values.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4e7a97cdc6ec29644c755516e6f89f66998a87aefeb8c8a4f58ff1fd161e240c
+_hash: 46f24fca3fa4fd6a2ea62ee21448e93e801ea77cf49b21b89723e4347dbe6e15
 file:
 - statement:
     select_statement:
@@ -20,9 +20,29 @@ file:
             table_expression:
               values_clause:
                 keyword: values
-                delimited_values:
-                  scalar_value:
+                expression:
+                  literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              values_clause:
+                keyword: values
+                bracketed:
+                  start_bracket: (
+                  expression:
                     literal: '1'
+                  end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -39,174 +59,139 @@ file:
             table_expression:
               values_clause:
                 keyword: values
-                delimited_values:
-                  tuple_value:
-                    bracketed:
-                      start_bracket: (
-                      scalar_value:
-                        literal: '1'
-                      end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            table_expression:
-              values_clause:
-                keyword: values
-                delimited_values:
-                  tuple_value:
-                    bracketed:
-                    - start_bracket: (
-                    - scalar_value:
-                        literal: '1'
-                    - comma: ','
-                    - scalar_value:
-                        literal: '2'
-                    - end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            bracketed:
-              start_bracket: (
-              table_expression:
-                values_clause:
-                  keyword: values
-                  delimited_values:
-                  - scalar_value:
-                      literal: '1'
-                  - comma: ','
-                  - scalar_value:
-                      literal: '2'
-                  - comma: ','
-                  - scalar_value:
-                      literal: '3'
-              end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            bracketed:
-              start_bracket: (
-              table_expression:
-                values_clause:
-                  keyword: values
-                  delimited_values:
-                  - tuple_value:
-                      bracketed:
-                        start_bracket: (
-                        scalar_value:
-                          literal: '1'
-                        end_bracket: )
-                  - comma: ','
-                  - tuple_value:
-                      bracketed:
-                        start_bracket: (
-                        scalar_value:
-                          literal: '2'
-                        end_bracket: )
-                  - comma: ','
-                  - tuple_value:
-                      bracketed:
-                        start_bracket: (
-                        scalar_value:
-                          literal: '3'
-                        end_bracket: )
-              end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            bracketed:
-              start_bracket: (
-              table_expression:
-                values_clause:
-                  keyword: values
-                  delimited_values:
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '1'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '2'
-                      - end_bracket: )
-                  - comma: ','
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '3'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '4'
-                      - end_bracket: )
-              end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-      - keyword: from
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              values_clause:
-                keyword: values
-                delimited_values:
-                  scalar_value:
+                bracketed:
+                - start_bracket: (
+                - expression:
                     literal: '1'
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              values_clause:
-                keyword: values
-                delimited_values:
-                  scalar_value:
+                - comma: ','
+                - expression:
                     literal: '2'
+                - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: values
+                - expression:
+                    literal: '1'
+                - comma: ','
+                - expression:
+                    literal: '2'
+                - comma: ','
+                - expression:
+                    literal: '3'
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: values
+                - bracketed:
+                    start_bracket: (
+                    expression:
+                      literal: '1'
+                    end_bracket: )
+                - comma: ','
+                - bracketed:
+                    start_bracket: (
+                    expression:
+                      literal: '2'
+                    end_bracket: )
+                - comma: ','
+                - bracketed:
+                    start_bracket: (
+                    expression:
+                      literal: '3'
+                    end_bracket: )
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: values
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '1'
+                  - comma: ','
+                  - expression:
+                      literal: '2'
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '3'
+                  - comma: ','
+                  - expression:
+                      literal: '4'
+                  - end_bracket: )
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+      - keyword: from
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              values_clause:
+                keyword: values
+                expression:
+                  literal: '1'
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              values_clause:
+                keyword: values
+                expression:
+                  literal: '2'
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -224,27 +209,24 @@ file:
               start_bracket: (
               table_expression:
                 values_clause:
-                  keyword: values
-                  delimited_values:
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '1'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '2'
-                      - end_bracket: )
+                - keyword: values
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '1'
                   - comma: ','
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '3'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '4'
-                      - end_bracket: )
+                  - expression:
+                      literal: '2'
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '3'
+                  - comma: ','
+                  - expression:
+                      literal: '4'
+                  - end_bracket: )
               end_bracket: )
       - comma: ','
       - from_expression:
@@ -253,75 +235,71 @@ file:
               start_bracket: (
               table_expression:
                 values_clause:
-                  keyword: values
-                  delimited_values:
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '1'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '2'
-                      - end_bracket: )
-                  - comma: ','
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '3'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '4'
-                      - end_bracket: )
-              end_bracket: )
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: select
-        select_clause_element:
-          wildcard_expression:
-            wildcard_identifier:
-              star: '*'
-      from_clause:
-        keyword: from
-        from_expression:
-          from_expression_element:
-            bracketed:
-              start_bracket: (
-              table_expression:
-                values_clause:
-                  keyword: values
-                  delimited_values:
-                  - scalar_value:
+                - keyword: values
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
                       literal: '1'
                   - comma: ','
-                  - scalar_value:
-                      function:
-                        function_name:
-                          function_name_identifier: least
-                        bracketed:
-                        - start_bracket: (
-                        - expression:
-                            literal: '2'
-                        - comma: ','
-                        - expression:
-                            literal: '3'
-                        - end_bracket: )
+                  - expression:
+                      literal: '2'
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '3'
                   - comma: ','
-                  - scalar_value:
-                      function:
-                        function_name:
-                          function_name_identifier: greatest
-                        bracketed:
-                        - start_bracket: (
-                        - expression:
-                            literal: '4'
-                        - comma: ','
-                        - expression:
-                            literal: '5'
-                        - end_bracket: )
+                  - expression:
+                      literal: '4'
+                  - end_bracket: )
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: values
+                - expression:
+                    literal: '1'
+                - comma: ','
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: least
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          literal: '2'
+                      - comma: ','
+                      - expression:
+                          literal: '3'
+                      - end_bracket: )
+                - comma: ','
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: greatest
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          literal: '4'
+                      - comma: ','
+                      - expression:
+                          literal: '5'
+                      - end_bracket: )
               end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -339,9 +317,8 @@ file:
             table_expression:
               values_clause:
                 keyword: values
-                delimited_values:
-                  scalar_value:
-                    literal: '1'
+                expression:
+                  literal: '1'
                 alias_expression:
                   keyword: as
                   identifier: t
@@ -361,16 +338,14 @@ file:
             table_expression:
               values_clause:
                 keyword: values
-                delimited_values:
-                  tuple_value:
-                    bracketed:
-                    - start_bracket: (
-                    - scalar_value:
-                        literal: '1'
-                    - comma: ','
-                    - scalar_value:
-                        literal: '2'
-                    - end_bracket: )
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    literal: '1'
+                - comma: ','
+                - expression:
+                    literal: '2'
+                - end_bracket: )
                 alias_expression:
                   keyword: as
                   identifier: t
@@ -398,27 +373,24 @@ file:
               start_bracket: (
               table_expression:
                 values_clause:
-                  keyword: values
-                  delimited_values:
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '1'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '2'
-                      - end_bracket: )
+                - keyword: values
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '1'
                   - comma: ','
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '3'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '4'
-                      - end_bracket: )
+                  - expression:
+                      literal: '2'
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '3'
+                  - comma: ','
+                  - expression:
+                      literal: '4'
+                  - end_bracket: )
               end_bracket: )
             alias_expression:
               keyword: as
@@ -447,27 +419,24 @@ file:
               start_bracket: (
               table_expression:
                 values_clause:
-                  keyword: values
-                  delimited_values:
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '1'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '2'
-                      - end_bracket: )
+                - keyword: values
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '1'
                   - comma: ','
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '3'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '4'
-                      - end_bracket: )
+                  - expression:
+                      literal: '2'
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '3'
+                  - comma: ','
+                  - expression:
+                      literal: '4'
+                  - end_bracket: )
               end_bracket: )
             alias_expression:
               keyword: as
@@ -494,9 +463,8 @@ file:
             table_expression:
               values_clause:
                 keyword: values
-                delimited_values:
-                  scalar_value:
-                    literal: '1'
+                expression:
+                  literal: '1'
                 alias_expression:
                   identifier: t
 - statement_terminator: ;
@@ -515,16 +483,14 @@ file:
             table_expression:
               values_clause:
                 keyword: values
-                delimited_values:
-                  tuple_value:
-                    bracketed:
-                    - start_bracket: (
-                    - scalar_value:
-                        literal: '1'
-                    - comma: ','
-                    - scalar_value:
-                        literal: '2'
-                    - end_bracket: )
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    literal: '1'
+                - comma: ','
+                - expression:
+                    literal: '2'
+                - end_bracket: )
                 alias_expression:
                   identifier: t
                   bracketed:
@@ -551,27 +517,24 @@ file:
               start_bracket: (
               table_expression:
                 values_clause:
-                  keyword: values
-                  delimited_values:
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '1'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '2'
-                      - end_bracket: )
+                - keyword: values
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '1'
                   - comma: ','
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '3'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '4'
-                      - end_bracket: )
+                  - expression:
+                      literal: '2'
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '3'
+                  - comma: ','
+                  - expression:
+                      literal: '4'
+                  - end_bracket: )
               end_bracket: )
             alias_expression:
               identifier: t
@@ -599,27 +562,24 @@ file:
               start_bracket: (
               table_expression:
                 values_clause:
-                  keyword: values
-                  delimited_values:
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '1'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '2'
-                      - end_bracket: )
+                - keyword: values
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '1'
                   - comma: ','
-                  - tuple_value:
-                      bracketed:
-                      - start_bracket: (
-                      - scalar_value:
-                          literal: '3'
-                      - comma: ','
-                      - scalar_value:
-                          literal: '4'
-                      - end_bracket: )
+                  - expression:
+                      literal: '2'
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '3'
+                  - comma: ','
+                  - expression:
+                      literal: '4'
+                  - end_bracket: )
               end_bracket: )
             alias_expression:
               bracketed:

--- a/test/fixtures/dialects/spark3/values.yml
+++ b/test/fixtures/dialects/spark3/values.yml
@@ -3,146 +3,133 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f7acf6e6ebf18063e7a42ef80f9b33467907bf439b56c7cb624b8be1eba6b182
+_hash: 4a0283df0cf7eccbe4720d12e4c330933ff69c105eddf1bfde5894b08eeb3dae
 file:
 - statement:
     values_clause:
       keyword: values
-      delimited_values:
-        tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
-          - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
-- statement_terminator: ;
-- statement:
-    values_clause:
-      keyword: values
-      delimited_values:
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
-          - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
-      - comma: ','
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '3'
-          - comma: ','
-          - scalar_value:
-              literal: '4'
-          - end_bracket: )
-- statement_terminator: ;
-- statement:
-    values_clause:
-      keyword: values
-      delimited_values:
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
-          - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
-      - comma: ','
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '3'
-          - comma: ','
-          - scalar_value:
-              literal: '4'
-          - end_bracket: )
-      - comma: ','
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              function:
-                function_name:
-                  function_name_identifier: greatest
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    literal: '5'
-                - comma: ','
-                - expression:
-                    literal: '6'
-                - end_bracket: )
-          - comma: ','
-          - scalar_value:
-              function:
-                function_name:
-                  function_name_identifier: least
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    literal: '7'
-                - comma: ','
-                - expression:
-                    literal: '8'
-                - end_bracket: )
-          - end_bracket: )
-- statement_terminator: ;
-- statement:
-    values_clause:
-      keyword: values
-      delimited_values:
-      - scalar_value:
+      bracketed:
+      - start_bracket: (
+      - expression:
           literal: '1'
       - comma: ','
-      - scalar_value:
+      - expression:
           literal: '2'
+      - end_bracket: )
 - statement_terminator: ;
 - statement:
     values_clause:
-      keyword: values
-      delimited_values:
-        scalar_value:
-          literal: '1'
-- statement_terminator: ;
-- statement:
-    values_clause:
-      keyword: values
-      delimited_values:
-      - scalar_value:
+    - keyword: values
+    - bracketed:
+      - start_bracket: (
+      - expression:
           literal: '1'
       - comma: ','
-      - scalar_value:
+      - expression:
           literal: '2'
-      - comma: ','
-      - scalar_value:
+      - end_bracket: )
+    - comma: ','
+    - bracketed:
+      - start_bracket: (
+      - expression:
           literal: '3'
-      limit_clause:
+      - comma: ','
+      - expression:
+          literal: '4'
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    values_clause:
+    - keyword: values
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
+      - comma: ','
+      - expression:
+          literal: '2'
+      - end_bracket: )
+    - comma: ','
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '3'
+      - comma: ','
+      - expression:
+          literal: '4'
+      - end_bracket: )
+    - comma: ','
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          function:
+            function_name:
+              function_name_identifier: greatest
+            bracketed:
+            - start_bracket: (
+            - expression:
+                literal: '5'
+            - comma: ','
+            - expression:
+                literal: '6'
+            - end_bracket: )
+      - comma: ','
+      - expression:
+          function:
+            function_name:
+              function_name_identifier: least
+            bracketed:
+            - start_bracket: (
+            - expression:
+                literal: '7'
+            - comma: ','
+            - expression:
+                literal: '8'
+            - end_bracket: )
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    values_clause:
+    - keyword: values
+    - expression:
+        literal: '1'
+    - comma: ','
+    - expression:
+        literal: '2'
+- statement_terminator: ;
+- statement:
+    values_clause:
+      keyword: values
+      expression:
+        literal: '1'
+- statement_terminator: ;
+- statement:
+    values_clause:
+    - keyword: values
+    - expression:
+        literal: '1'
+    - comma: ','
+    - expression:
+        literal: '2'
+    - comma: ','
+    - expression:
+        literal: '3'
+    - limit_clause:
         keyword: limit
         literal: '1'
 - statement_terminator: ;
 - statement:
     values_clause:
-      keyword: values
-      delimited_values:
-      - scalar_value:
-          literal: '3'
-      - comma: ','
-      - scalar_value:
-          literal: '2'
-      - comma: ','
-      - scalar_value:
-          literal: '1'
-      orderby_clause:
+    - keyword: values
+    - expression:
+        literal: '3'
+    - comma: ','
+    - expression:
+        literal: '2'
+    - comma: ','
+    - expression:
+        literal: '1'
+    - orderby_clause:
       - keyword: order
       - keyword: by
       - literal: '2'

--- a/test/fixtures/dialects/spark3/values_with_alias.yml
+++ b/test/fixtures/dialects/spark3/values_with_alias.yml
@@ -3,88 +3,48 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1359d8be6bbbd128387df329b92ccf812cb139dec945bea54405e6c8f309a013
+_hash: c19b9865f7bc29197359f871b57e66d4f12bccb6f3241c8e68e6c9502c39b0a9
 file:
 - statement:
     values_clause:
       keyword: values
-      delimited_values:
-        tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
-          - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
-      alias_expression:
-        keyword: as
-        identifier: t
-- statement_terminator: ;
-- statement:
-    values_clause:
-      keyword: values
-      delimited_values:
-        tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
-          - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
-      alias_expression:
-        identifier: t
-- statement_terminator: ;
-- statement:
-    values_clause:
-      keyword: values
-      delimited_values:
-        tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
-          - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
-      alias_expression:
-        keyword: as
-        identifier: t
-        bracketed:
-          start_bracket: (
-          identifier_list:
-          - identifier: a
-          - comma: ','
-          - identifier: b
-          end_bracket: )
-- statement_terminator: ;
-- statement:
-    values_clause:
-      keyword: values
-      delimited_values:
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
-          - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
+      bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
       - comma: ','
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '3'
-          - comma: ','
-          - scalar_value:
-              literal: '4'
-          - end_bracket: )
+      - expression:
+          literal: '2'
+      - end_bracket: )
+      alias_expression:
+        keyword: as
+        identifier: t
+- statement_terminator: ;
+- statement:
+    values_clause:
+      keyword: values
+      bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
+      - comma: ','
+      - expression:
+          literal: '2'
+      - end_bracket: )
+      alias_expression:
+        identifier: t
+- statement_terminator: ;
+- statement:
+    values_clause:
+      keyword: values
+      bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
+      - comma: ','
+      - expression:
+          literal: '2'
+      - end_bracket: )
       alias_expression:
         keyword: as
         identifier: t
@@ -98,17 +58,46 @@ file:
 - statement_terminator: ;
 - statement:
     values_clause:
-      keyword: values
-      delimited_values:
-        tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
+    - keyword: values
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
+      - comma: ','
+      - expression:
+          literal: '2'
+      - end_bracket: )
+    - comma: ','
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '3'
+      - comma: ','
+      - expression:
+          literal: '4'
+      - end_bracket: )
+    - alias_expression:
+        keyword: as
+        identifier: t
+        bracketed:
+          start_bracket: (
+          identifier_list:
+          - identifier: a
           - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
+          - identifier: b
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    values_clause:
+      keyword: values
+      bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
+      - comma: ','
+      - expression:
+          literal: '2'
+      - end_bracket: )
       alias_expression:
         keyword: as
         bracketed:
@@ -122,16 +111,14 @@ file:
 - statement:
     values_clause:
       keyword: values
-      delimited_values:
-        tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
-          - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
+      bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
+      - comma: ','
+      - expression:
+          literal: '2'
+      - end_bracket: )
       alias_expression:
         identifier: t
         bracketed:
@@ -145,16 +132,14 @@ file:
 - statement:
     values_clause:
       keyword: values
-      delimited_values:
-        tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
-          - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
+      bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
+      - comma: ','
+      - expression:
+          literal: '2'
+      - end_bracket: )
       alias_expression:
         bracketed:
           start_bracket: (
@@ -166,28 +151,25 @@ file:
 - statement_terminator: ;
 - statement:
     values_clause:
-      keyword: values
-      delimited_values:
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
-          - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
+    - keyword: values
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
       - comma: ','
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '3'
-          - comma: ','
-          - scalar_value:
-              literal: '4'
-          - end_bracket: )
-      alias_expression:
+      - expression:
+          literal: '2'
+      - end_bracket: )
+    - comma: ','
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '3'
+      - comma: ','
+      - expression:
+          literal: '4'
+      - end_bracket: )
+    - alias_expression:
         keyword: as
         bracketed:
           start_bracket: (
@@ -199,28 +181,25 @@ file:
 - statement_terminator: ;
 - statement:
     values_clause:
-      keyword: values
-      delimited_values:
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
-          - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
+    - keyword: values
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
       - comma: ','
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '3'
-          - comma: ','
-          - scalar_value:
-              literal: '4'
-          - end_bracket: )
-      alias_expression:
+      - expression:
+          literal: '2'
+      - end_bracket: )
+    - comma: ','
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '3'
+      - comma: ','
+      - expression:
+          literal: '4'
+      - end_bracket: )
+    - alias_expression:
         identifier: t
         bracketed:
           start_bracket: (
@@ -232,28 +211,25 @@ file:
 - statement_terminator: ;
 - statement:
     values_clause:
-      keyword: values
-      delimited_values:
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '1'
-          - comma: ','
-          - scalar_value:
-              literal: '2'
-          - end_bracket: )
+    - keyword: values
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '1'
       - comma: ','
-      - tuple_value:
-          bracketed:
-          - start_bracket: (
-          - scalar_value:
-              literal: '3'
-          - comma: ','
-          - scalar_value:
-              literal: '4'
-          - end_bracket: )
-      alias_expression:
+      - expression:
+          literal: '2'
+      - end_bracket: )
+    - comma: ','
+    - bracketed:
+      - start_bracket: (
+      - expression:
+          literal: '3'
+      - comma: ','
+      - expression:
+          literal: '4'
+      - end_bracket: )
+    - alias_expression:
         bracketed:
           start_bracket: (
           identifier_list:


### PR DESCRIPTION

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Couple things fixed here:
- Fixes regression in Postgres VALUES clause caused by copying of Spark3 grammar in #2590. Expression segments are all that are required in a values clause. Spark grammar didn't account for them and tried to define the individual literal/function/... types.
- Spark3 VALUES grammar is different from every other grammar. This is because I fixed these in #2404 and Spark3 later got overwritten unnecessarily.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
