### PR TITLE
Exasol: Support value range clause within INSERT statements (7.1+)

### DIFF
--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -1671,6 +1671,7 @@ class InsertStatementSegment(BaseSegment):
         Ref("TableReferenceSegment"),
         AnyNumberOf(
             Ref("ValuesInsertClauseSegment"),
+            Ref("ValuesRangeClauseSegment"),
             Sequence("DEFAULT", "VALUES"),
             Ref("SelectableGrammar"),
             Ref("BracketedColumnReferenceListGrammar", optional=True),

--- a/test/fixtures/dialects/exasol/InsertStatement.sql
+++ b/test/fixtures/dialects/exasol/InsertStatement.sql
@@ -6,4 +6,6 @@ INSERT INTO t (i) SELECT max(j) FROM u;
 INSERT INTO t DEFAULT VALUES;
 INSERT INTO t (SELECT * FROM u);
 INSERT INTO s.t(c1, c2, c3) VALUES((SELECT x FROM y), 'val1', 'val2');
-INSERT INTO t (adate) values(current_timestamp)
+INSERT INTO t (adate) values(current_timestamp);
+INSERT INTO t VALUES BETWEEN 1 AND 100;
+INSERT INTO t (i) VALUES BETWEEN 1 AND 100 WITH STEP 4;

--- a/test/fixtures/dialects/exasol/InsertStatement.yml
+++ b/test/fixtures/dialects/exasol/InsertStatement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 831e77ba1399ccc08191952f18fbed0f383609157a4b13c99dde71152b72f371
+_hash: c5719b5cf82000e3975b78e96351da459424b578d6f22bf05a076fc8cad674ca
 file:
 - statement:
     insert_statement:
@@ -232,3 +232,38 @@ file:
           start_bracket: (
           bare_function: current_timestamp
           end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        identifier: t
+    - values_range_clause:
+      - keyword: VALUES
+      - keyword: BETWEEN
+      - literal: '1'
+      - binary_operator: AND
+      - literal: '100'
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        identifier: t
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          identifier: i
+        end_bracket: )
+    - values_range_clause:
+      - keyword: VALUES
+      - keyword: BETWEEN
+      - literal: '1'
+      - binary_operator: AND
+      - literal: '100'
+      - keyword: WITH
+      - keyword: STEP
+      - literal: '4'
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Adds support for the `VALUES BETWEEN` clause (aka value range clause) for `INSERT` statements. This was introduced in 7.1.

### Are there any other side effects of this change that we should be aware of?
nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
