### PR TITLE
Automated tests should fail if a lint fix introduces a parse error

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -518,7 +518,9 @@ class Linter:
                         cls._warn_unfixable(crawler.code)
                     else:
                         last_fixes = fixes
-                        new_tree, _ = tree.apply_fixes(config.get("dialect_obj"), fixes)
+                        new_tree, _ = tree.apply_fixes(
+                            config.get("dialect_obj"), crawler.code, fixes
+                        )
                         # Check for infinite loops
                         if new_tree.raw not in previous_versions:
                             # We've not seen this version of the file so far. Continue.

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1148,7 +1148,7 @@ class BaseSegment:
                     )
 
     @staticmethod
-    def _log_apply_fixes_check_issue(message, *args):
+    def _log_apply_fixes_check_issue(message, *args):  # pragma: no cover
         linter_logger.warning(message, *args)
 
     def iter_patches(self, templated_str: str) -> Iterator[FixPatch]:

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1110,7 +1110,7 @@ class BaseSegment:
                     )
                 except ValueError:  # pragma: no cover
                     found_error = True
-                    linter_logger.warning(
+                    self._log_apply_fixes_check_issue(
                         "After fixes were applied, segment %r failed the "
                         "match() parser check. Fixes: %r",
                         segment,
@@ -1119,7 +1119,7 @@ class BaseSegment:
                 else:
                     if not match_result.is_complete():  # pragma: no cover
                         found_error = True
-                        linter_logger.warning(
+                        self._log_apply_fixes_check_issue(
                             "After fixes were applied, segment %r failed the "
                             "match() parser check. Result: %r Fixes: %r",
                             segment,
@@ -1140,12 +1140,16 @@ class BaseSegment:
                         )
                     r_copy.parse(parse_context)
                 except ValueError:  # pragma: no cover
-                    linter_logger.warning(
+                    self._log_apply_fixes_check_issue(
                         "After fixes were applied, segment %r failed the "
                         "parse() check. Fixes: %r",
                         r_copy,
                         fixes_applied,
                     )
+
+    @staticmethod
+    def _log_apply_fixes_check_issue(message, *args):
+        linter_logger.warning(message, *args)
 
     def iter_patches(self, templated_str: str) -> Iterator[FixPatch]:
         """Iterate through the segments generating fix patches.

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -982,7 +982,7 @@ class BaseSegment:
 
         return self
 
-    def apply_fixes(self, dialect, fixes):
+    def apply_fixes(self, dialect, rule_code, fixes):
         """Apply an iterable of fixes to this segment.
 
         Used in applying fixes if we're fixing linting errors.
@@ -1070,7 +1070,7 @@ class BaseSegment:
             seg_queue = seg_buffer
             seg_buffer = []
             for seg in seg_queue:
-                s, fixes = seg.apply_fixes(dialect, fixes)
+                s, fixes = seg.apply_fixes(dialect, rule_code, fixes)
                 seg_buffer.append(s)
 
             # Reform into a new segment
@@ -1084,13 +1084,13 @@ class BaseSegment:
                 **{k: getattr(self, k) for k in self.additional_kwargs},
             )
             if fixes_applied:
-                self._validate_segment_after_fixes(dialect, fixes_applied, r)
+                self._validate_segment_after_fixes(rule_code, dialect, fixes_applied, r)
             # Return the new segment with any unused fixes.
             return r, fixes
         else:
             return self, fixes
 
-    def _validate_segment_after_fixes(self, dialect, fixes_applied, segment):
+    def _validate_segment_after_fixes(self, rule_code, dialect, fixes_applied, segment):
         """Checks correctness of new segment against match or parse grammar."""
         found_error = False
         root_parse_context = RootParseContext(dialect=dialect)
@@ -1111,8 +1111,9 @@ class BaseSegment:
                 except ValueError:  # pragma: no cover
                     found_error = True
                     self._log_apply_fixes_check_issue(
-                        "After fixes were applied, segment %r failed the "
+                        "After %s fixes were applied, segment %r failed the "
                         "match() parser check. Fixes: %r",
+                        rule_code,
                         segment,
                         fixes_applied,
                     )
@@ -1120,8 +1121,9 @@ class BaseSegment:
                     if not match_result.is_complete():  # pragma: no cover
                         found_error = True
                         self._log_apply_fixes_check_issue(
-                            "After fixes were applied, segment %r failed the "
+                            "After %s fixes were applied, segment %r failed the "
                             "match() parser check. Result: %r Fixes: %r",
+                            rule_code,
                             segment,
                             match_result,
                             fixes_applied,
@@ -1141,8 +1143,9 @@ class BaseSegment:
                     r_copy.parse(parse_context)
                 except ValueError:  # pragma: no cover
                     self._log_apply_fixes_check_issue(
-                        "After fixes were applied, segment %r failed the "
+                        "After %s fixes were applied, segment %r failed the "
                         "parse() check. Fixes: %r",
+                        rule_code,
                         r_copy,
                         fixes_applied,
                     )

--- a/src/sqlfluff/rules/L052.py
+++ b/src/sqlfluff/rules/L052.py
@@ -161,9 +161,8 @@ class Rule_L052(BaseRule):
         else:
             return self._handle_semicolon_newline(context, info)
 
-    @staticmethod
     def _handle_semicolon_same_line(
-        context: RuleContext, info: SegmentMoveContext
+        self, context: RuleContext, info: SegmentMoveContext
     ) -> Optional[LintResult]:
         if not info.before_segment:
             return None
@@ -172,10 +171,11 @@ class Rule_L052(BaseRule):
         # semi-colon and its preceding whitespace and then insert
         # the semi-colon in the correct location.
         fixes = [
-            LintFix.replace(
-                info.anchor_segment,
+            LintFix.create_after(
+                self._choose_anchor_segment(
+                    context, "create_after", info.anchor_segment
+                ),
                 [
-                    info.anchor_segment,
                     SymbolSegment(raw=";", type="symbol", name="semicolon"),
                 ],
             ),

--- a/src/sqlfluff/rules/L052.py
+++ b/src/sqlfluff/rules/L052.py
@@ -225,10 +225,11 @@ class Rule_L052(BaseRule):
         else:
             fixes.extend(
                 [
-                    LintFix.replace(
-                        anchor_segment,
+                    LintFix.create_after(
+                        self._choose_anchor_segment(
+                            context, "create_after", anchor_segment
+                        ),
                         [
-                            anchor_segment,
                             NewlineSegment(),
                             SymbolSegment(raw=";", type="symbol", name="semicolon"),
                         ],
@@ -277,10 +278,11 @@ class Rule_L052(BaseRule):
             # Semi-colon on same line.
             if not semicolon_newline:
                 fixes = [
-                    LintFix.replace(
-                        anchor_segment,
+                    LintFix.create_after(
+                        self._choose_anchor_segment(
+                            context, "create_after", anchor_segment
+                        ),
                         [
-                            anchor_segment,
                             SymbolSegment(raw=";", type="symbol", name="semicolon"),
                         ],
                     )
@@ -296,10 +298,11 @@ class Rule_L052(BaseRule):
                     before_segment, anchor_segment
                 )
                 fixes = [
-                    LintFix.replace(
-                        anchor_segment,
+                    LintFix.create_after(
+                        self._choose_anchor_segment(
+                            context, "create_after", anchor_segment
+                        ),
                         [
-                            anchor_segment,
                             NewlineSegment(),
                             SymbolSegment(raw=";", type="symbol", name="semicolon"),
                         ],

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -236,7 +236,7 @@ def fail_on_parse_error_after_fix(monkeypatch):
 
     @staticmethod
     def raise_error_apply_fixes_check_issue(message, *args):  # pragma: no cover
-        raise ValueError(message.format(*args))
+        raise ValueError(message % args)
 
     monkeypatch.setattr(
         BaseSegment, "_log_apply_fixes_check_issue", raise_error_apply_fixes_check_issue

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,6 +18,7 @@ from sqlfluff.core.parser.segments import (
     SymbolSegment,
     CommentSegment,
     CodeSegment,
+    BaseSegment,
 )
 from sqlfluff.core.templaters import TemplatedFile
 
@@ -221,3 +222,22 @@ def generate_test_segments():
 
     # Return the function
     return generate_test_segments_func
+
+
+@pytest.fixture(autouse=True)
+def fail_on_parse_error_after_fix(monkeypatch):
+    """Cause tests to fail if a lint fix introduces a parse error.
+
+    In production, the function _log_apply_fixes_check_issue() just logs a
+    warning. To catch bugs in new or modified rules, We want to be more strict
+    during dev and CI/CD testing. Here, we patch in a different function which
+    raises a runtime error, causing tests to fail if this happens.
+    """
+
+    @staticmethod
+    def raise_error_apply_fixes_check_issue(message, *args):  # pragma: no cover
+        raise ValueError(message.format(*args))
+
+    monkeypatch.setattr(
+        BaseSegment, "_log_apply_fixes_check_issue", raise_error_apply_fixes_check_issue
+    )


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
We recently modified SQLFluff to log a warning if a lint fix makes illegal changes to
the parse tree. This is the appropriate behavior. for _production_. However, in order
to catch new bugs in new or modified rules, we need to be more strict when running
automated tests. This PR changes the behavior during tests to raise an exception
rather than simply logging. This notifies rule authors of issues and forces them to
be addressed during PR review.

This PR also fixes some issues with L052 fixes. These had been fixed, but the fixes
were lost when we reverted a recent PR (to address other bugs).
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
