### PR TITLE
Post-fix parse check: Prefer parse_grammar over match_grammar

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1092,43 +1092,11 @@ class BaseSegment:
 
     def _validate_segment_after_fixes(self, rule_code, dialect, fixes_applied, segment):
         """Checks correctness of new segment against match or parse grammar."""
-        found_error = False
         root_parse_context = RootParseContext(dialect=dialect)
         with root_parse_context as parse_context:
-            if getattr(segment, "match_grammar", None):
-                try:
-                    for seg in segment.segments:
-                        seg.pos_marker = replace(
-                            seg.pos_marker,
-                            templated_file=self.pos_marker.templated_file,
-                        )
-                    match_result = segment.match(
-                        deepcopy(
-                            tuple([seg for seg in segment.segments if not seg.is_meta])
-                        ),
-                        parse_context,
-                    )
-                except ValueError:  # pragma: no cover
-                    found_error = True
-                    self._log_apply_fixes_check_issue(
-                        "After %s fixes were applied, segment %r failed the "
-                        "match() parser check. Fixes: %r",
-                        rule_code,
-                        segment,
-                        fixes_applied,
-                    )
-                else:
-                    if not match_result.is_complete():  # pragma: no cover
-                        found_error = True
-                        self._log_apply_fixes_check_issue(
-                            "After %s fixes were applied, segment %r failed the "
-                            "match() parser check. Result: %r Fixes: %r",
-                            rule_code,
-                            segment,
-                            match_result,
-                            fixes_applied,
-                        )
-            if not found_error and getattr(segment, "parse_grammar", None):
+            # Check for parse_grammar first. If both are present, it is more
+            # thorough and complete.
+            if getattr(segment, "parse_grammar", None):
                 try:
                     # :HACK: Calling parse() corrupts the segment 'r'
                     # in some cases, e.g. adding additional Dedent child
@@ -1149,6 +1117,37 @@ class BaseSegment:
                         r_copy,
                         fixes_applied,
                     )
+            elif getattr(segment, "match_grammar", None):
+                try:
+                    for seg in segment.segments:
+                        seg.pos_marker = replace(
+                            seg.pos_marker,
+                            templated_file=self.pos_marker.templated_file,
+                        )
+                    match_result = segment.match(
+                        deepcopy(
+                            tuple([seg for seg in segment.segments if not seg.is_meta])
+                        ),
+                        parse_context,
+                    )
+                except ValueError:  # pragma: no cover
+                    self._log_apply_fixes_check_issue(
+                        "After %s fixes were applied, segment %r failed the "
+                        "match() parser check. Fixes: %r",
+                        rule_code,
+                        segment,
+                        fixes_applied,
+                    )
+                else:
+                    if not match_result.is_complete():  # pragma: no cover
+                        self._log_apply_fixes_check_issue(
+                            "After %s fixes were applied, segment %r failed the "
+                            "match() parser check. Result: %r Fixes: %r",
+                            rule_code,
+                            segment,
+                            match_result,
+                            fixes_applied,
+                        )
 
     @staticmethod
     def _log_apply_fixes_check_issue(message, *args):  # pragma: no cover

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -838,3 +838,42 @@ test_pass_tsql_statistics_indent:
   configs:
     core:
       dialect: tsql
+
+test_fail_snowflake_merge_statement:
+  fail_str: |
+    merge into foo.bar as tgt
+    using (
+    select
+      foo::date as bar
+    from foo.bar
+    where
+    split(foo, '|')[2] REGEXP '^\\d+\\-\\d+\\-\\d+ \\d+\\:\\d+$'
+    OR
+    foo IN ('BAR','FOO')
+    ) as src
+    on
+      src.foo = tgt.foo
+    when matched then
+    update set
+      tgt.foo = src.foo
+    ;
+  fix_str: |
+    merge into foo.bar as tgt
+    using (
+        select
+            foo::date as bar
+        from foo.bar
+        where
+            split(foo, '|')[2] REGEXP '^\\d+\\-\\d+\\-\\d+ \\d+\\:\\d+$'
+            OR
+            foo IN ('BAR','FOO')
+    ) as src
+    on
+        src.foo = tgt.foo
+    when matched then
+        update set
+            tgt.foo = src.foo
+    ;
+  configs:
+    core:
+      dialect: snowflake


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
When checking for parse errors after applying a fix, check for `parse_grammar` before `match_grammar`.
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
