### PR TITLE
Spark3: Refactor `REFRESH` statements into one class

### DIFF
--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -1929,8 +1929,8 @@ class RefreshStatementSegment(BaseSegment):
             Sequence(
                 "FUNCTION",
                 Ref("FunctionNameSegment"),
-            )
-        )
+            ),
+        ),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -1906,46 +1906,31 @@ class ListJarSegment(BaseSegment):
 class RefreshStatementSegment(BaseSegment):
     """A `REFRESH` statement for given data source path.
 
+    NB: These are similar enough that it makes sense to include them in a
+    common class, especially since there wouldn't be any specific rules that
+    would apply to one refresh vs another, but they could be broken out to
+    one class per refresh statement type.
+
     https://spark.apache.org/docs/latest/sql-ref-syntax-aux-cache-refresh.html
+    https://spark.apache.org/docs/latest/sql-ref-syntax-aux-cache-refresh-table.html
+    https://spark.apache.org/docs/latest/sql-ref-syntax-aux-cache-refresh-function.html
     """
 
     type = "refresh_statement"
 
     match_grammar = Sequence(
         "REFRESH",
-        Ref("QuotedLiteralSegment"),
-    )
-
-
-@spark3_dialect.segment()
-class RefreshTableStatementSegment(BaseSegment):
-    """A `REFRESH TABLE` statement.
-
-    https://spark.apache.org/docs/latest/sql-ref-syntax-aux-cache-refresh-table.html
-    """
-
-    type = "refresh_table_statement"
-
-    match_grammar = Sequence(
-        "REFRESH",
-        Ref.keyword("TABLE", optional=True),
-        Ref("TableReferenceSegment"),
-    )
-
-
-@spark3_dialect.segment()
-class RefreshFunctionStatementSegment(BaseSegment):
-    """A `REFRESH FUNCTION` statement.
-
-    https://spark.apache.org/docs/latest/sql-ref-syntax-aux-cache-refresh-function.html
-    """
-
-    type = "refresh_function_statement"
-
-    match_grammar = Sequence(
-        "REFRESH",
-        "FUNCTION",
-        Ref("FunctionNameSegment"),
+        OneOf(
+            Ref("QuotedLiteralSegment"),
+            Sequence(
+                Ref.keyword("TABLE", optional=True),
+                Ref("TableReferenceSegment"),
+            ),
+            Sequence(
+                "FUNCTION",
+                Ref("FunctionNameSegment"),
+            )
+        )
     )
 
 
@@ -1993,8 +1978,6 @@ class StatementSegment(BaseSegment):
             Ref("ListFileSegment"),
             Ref("ListJarSegment"),
             Ref("RefreshStatementSegment"),
-            Ref("RefreshTableStatementSegment"),
-            Ref("RefreshFunctionStatementSegment"),
             Ref("UncacheTableSegment"),
             # Data Manipulation Statements
             Ref("InsertOverwriteDirectorySegment"),

--- a/test/fixtures/dialects/spark3/explain.yml
+++ b/test/fixtures/dialects/spark3/explain.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2c9a593bedcfd33aba499ae3e443c3b7a9514b2a4d53673a5a918f9d61b1ea91
+_hash: dd2b822a76422d42cf6051e1bd61c54576b89c003716d7140a8e3b335a24b2d7
 file:
 - statement:
     explain_statement:
@@ -352,7 +352,7 @@ file:
     explain_statement:
       keyword: EXPLAIN
       statement:
-        refresh_table_statement:
+        refresh_statement:
         - keyword: REFRESH
         - keyword: TABLE
         - table_reference:
@@ -362,7 +362,7 @@ file:
     explain_statement:
       keyword: EXPLAIN
       statement:
-        refresh_function_statement:
+        refresh_statement:
         - keyword: REFRESH
         - keyword: FUNCTION
         - function_name:

--- a/test/fixtures/dialects/spark3/refresh_function.yml
+++ b/test/fixtures/dialects/spark3/refresh_function.yml
@@ -3,17 +3,17 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a81b85cd6a349651265d9239459c0c8ae14217e23b9e77b70ab9d8620ec6edd5
+_hash: 2c83c6f0e405945fbf41dec580984e5712a33e0003b24bce65eb9f43c1182f30
 file:
 - statement:
-    refresh_function_statement:
+    refresh_statement:
     - keyword: REFRESH
     - keyword: FUNCTION
     - function_name:
         function_name_identifier: func1
 - statement_terminator: ;
 - statement:
-    refresh_function_statement:
+    refresh_statement:
     - keyword: REFRESH
     - keyword: FUNCTION
     - function_name:

--- a/test/fixtures/dialects/spark3/refresh_table.yml
+++ b/test/fixtures/dialects/spark3/refresh_table.yml
@@ -3,23 +3,23 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e67f6762a3441e4f33ac76ac6e4ba1fde9080771bb0645cfcb7050176b414a75
+_hash: cd04fcecc0e40a2526dc60b1be6a2b71cb38ddfc29bbdba5501e556f427f5416
 file:
 - statement:
-    refresh_table_statement:
+    refresh_statement:
     - keyword: REFRESH
     - keyword: TABLE
     - table_reference:
         identifier: tbl1
 - statement_terminator: ;
 - statement:
-    refresh_table_statement:
+    refresh_statement:
       keyword: REFRESH
       table_reference:
         identifier: tbl1
 - statement_terminator: ;
 - statement:
-    refresh_table_statement:
+    refresh_statement:
     - keyword: REFRESH
     - keyword: TABLE
     - table_reference:
@@ -28,7 +28,7 @@ file:
       - identifier: view1
 - statement_terminator: ;
 - statement:
-    refresh_table_statement:
+    refresh_statement:
       keyword: REFRESH
       table_reference:
       - identifier: tempdb


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Refactor `RefreshFunctionStatementSegment`, `RefreshTableStatementSegment`, `RefreshStatementSegment` into a single class (`RefreshStatementSegment`) 

### Are there any other side effects of this change that we should be aware of?
N/A

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
