### PR TITLE
Reduce unnecessary setting run ci

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -70,14 +70,9 @@ jobs:
     - name: Install dependencies
       run: |
         pip install tox
-    - name: Set Tox Python Param
-      run: |
-        echo 'TOXENV<<EOF' >> $GITHUB_ENV
-        echo "${{ matrix.python-version }}" | sed "s/\.//" | sed "s/^/py/" >> $GITHUB_ENV
-        echo 'EOF' >> $GITHUB_ENV
     - name: Run the tests
       run: |
-        tox -e ${{ env.TOXENV }} -- -n 2 test
+        tox -e py -- -n 2 test
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1
       with:
@@ -97,14 +92,11 @@ jobs:
     - name: Install dependencies
       run: |
         pip install tox
-    - name: Set Tox Params
-      run: |
-        echo "TOXENV=${{ matrix.jobs }}" >> $GITHUB_ENV
     - name: Run the tests
       env:
         SQLFLUFF_BENCHMARK_API_KEY: ${{ secrets.SQLFLUFF_BENCHMARK_API_KEY }}
       run: |
-        tox -e ${{ env.TOXENV }}
+        tox -e ${{ matrix.jobs }}
   examples:
     runs-on: ubuntu-latest
     name: example tests


### PR DESCRIPTION
* In job `python-version-tests`, we already told the version we
  setup in step `Set up Python`, so we could simply run command
  `tox -e py` to trigger the job, so we could remove the
  `Set Tox Python Param` step
* In job `other-tests` we just set an unused variable by one step
  and I think we should directly remove it.
