### PR TITLE
Fix bug with Jinja and dbt "{% set %}" blocks

### DIFF
--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -535,7 +535,6 @@ class DbtTemplater(JinjaTemplater):
                         ),
                     )
                 )
-
         return (
             TemplatedFile(
                 source_str=source_dbt_sql,

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -25,7 +25,10 @@ from jinja2_simple_tags import StandaloneTag
 from sqlfluff.core.cached_property import cached_property
 from sqlfluff.core.errors import SQLTemplaterError, SQLTemplaterSkipFile
 
-from sqlfluff.core.templaters.base import TemplatedFile
+from sqlfluff.core.templaters.base import (
+    TemplatedFile,
+    TemplatedFileSlice,
+)
 from sqlfluff.core.templaters.jinja import JinjaTemplater
 
 # Instantiate the templater logger
@@ -503,8 +506,6 @@ class DbtTemplater(JinjaTemplater):
                 config=config,
                 make_template=make_template,
             )
-            # Update templated_sql as we updated the other strings above.
-            templated_sql = templated_sql + "\n" * n_trailing_newlines
 
         # :HACK: If calling compile_node() compiled any ephemeral nodes,
         # restore them to their earlier state. This prevents a runtime error
@@ -515,6 +516,25 @@ class DbtTemplater(JinjaTemplater):
         for k, v in save_ephemeral_nodes.items():
             if getattr(self.dbt_manifest.nodes[k], "compiled", False):
                 self.dbt_manifest.nodes[k] = v
+
+        if make_template and n_trailing_newlines:
+            # Update templated_sql as we updated the other strings above. Update
+            # sliced_file to reflect the mapping of the added character(s) back
+            # to the raw SQL.
+            templated_sql = templated_sql + "\n" * n_trailing_newlines
+            if sliced_file[-1].templated_slice.stop != len(templated_sql):
+                sliced_file.append(
+                    TemplatedFileSlice(
+                        slice_type="literal",
+                        source_slice=slice(
+                            len(source_dbt_sql) - n_trailing_newlines,
+                            len(source_dbt_sql),
+                        ),
+                        templated_slice=slice(
+                            len(templated_sql) - n_trailing_newlines, len(templated_sql)
+                        ),
+                    )
+                )
 
         return (
             TemplatedFile(

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -522,7 +522,9 @@ class DbtTemplater(JinjaTemplater):
             # sliced_file to reflect the mapping of the added character(s) back
             # to the raw SQL.
             templated_sql = templated_sql + "\n" * n_trailing_newlines
-            if sliced_file[-1].templated_slice.stop != len(templated_sql):
+            if sliced_file and sliced_file[-1].templated_slice.stop != len(
+                templated_sql
+            ):
                 sliced_file.append(
                     TemplatedFileSlice(
                         slice_type="literal",

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -29,6 +29,7 @@ from sqlfluff.core.templaters.base import (
     TemplatedFile,
     TemplatedFileSlice,
 )
+
 from sqlfluff.core.templaters.jinja import JinjaTemplater
 
 # Instantiate the templater logger
@@ -506,7 +507,6 @@ class DbtTemplater(JinjaTemplater):
                 config=config,
                 make_template=make_template,
             )
-
         # :HACK: If calling compile_node() compiled any ephemeral nodes,
         # restore them to their earlier state. This prevents a runtime error
         # in the dbt "_inject_ctes_into_sql()" function that occurs with

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -105,6 +105,13 @@ class TemplatedFile:
         self._source_newlines = list(iter_indices_of_newlines(self.source_str))
         self._templated_newlines = list(iter_indices_of_newlines(self.templated_str))
 
+        # NOTE: The "check_consistency" flag should always be True when using
+        # SQLFluff in real life. This flag was only added because some legacy
+        # templater tests in test/core/templaters/jinja_test.py use hardcoded
+        # test data with issues that will trigger errors here. It would be cool
+        # to fix that data someday. I (Barry H.) started looking into it, but
+        # it was much trickier than I expected, because bits of the same data
+        # are shared across multiple tests.
         if check_consistency:
             # Sanity check raw string and slices.
             pos = 0

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -104,6 +104,26 @@ class TemplatedFile:
         self._source_newlines = list(iter_indices_of_newlines(self.source_str))
         self._templated_newlines = list(iter_indices_of_newlines(self.templated_str))
 
+        # Sanity check raw string and slices.
+        pos = 0
+        rfs: RawFileSlice
+        for idx, rfs in enumerate(self.raw_sliced):
+            assert rfs.source_idx == pos
+            pos += len(rfs.raw)
+        assert pos == len(self.source_str)
+
+        # Sanity check templated string and slices.
+        previous_slice = None
+        tfs: Optional[TemplatedFileSlice] = None
+        for idx, tfs in enumerate(self.sliced_file):
+            if previous_slice:
+                assert tfs.templated_slice.start == previous_slice.templated_slice.stop
+            else:
+                assert tfs.templated_slice.start == 0
+            previous_slice = tfs
+        if self.sliced_file and templated_str is not None:
+            assert tfs.templated_slice.stop == len(templated_str)
+
     @classmethod
     def from_string(cls, raw):
         """Create TemplatedFile from a string."""

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -73,6 +73,7 @@ class TemplatedFile:
         templated_str: Optional[str] = None,
         sliced_file: Optional[List[TemplatedFileSlice]] = None,
         raw_sliced: Optional[List[RawFileSlice]] = None,
+        check_consistency=True,
     ):
         """Initialise the TemplatedFile.
 
@@ -104,25 +105,28 @@ class TemplatedFile:
         self._source_newlines = list(iter_indices_of_newlines(self.source_str))
         self._templated_newlines = list(iter_indices_of_newlines(self.templated_str))
 
-        # Sanity check raw string and slices.
-        pos = 0
-        rfs: RawFileSlice
-        for idx, rfs in enumerate(self.raw_sliced):
-            assert rfs.source_idx == pos
-            pos += len(rfs.raw)
-        assert pos == len(self.source_str)
+        if check_consistency:
+            # Sanity check raw string and slices.
+            pos = 0
+            rfs: RawFileSlice
+            for idx, rfs in enumerate(self.raw_sliced):
+                assert rfs.source_idx == pos
+                pos += len(rfs.raw)
+            assert pos == len(self.source_str)
 
-        # Sanity check templated string and slices.
-        previous_slice = None
-        tfs: Optional[TemplatedFileSlice] = None
-        for idx, tfs in enumerate(self.sliced_file):
-            if previous_slice:
-                assert tfs.templated_slice.start == previous_slice.templated_slice.stop
-            else:
-                assert tfs.templated_slice.start == 0
-            previous_slice = tfs
-        if self.sliced_file and templated_str is not None:
-            assert tfs.templated_slice.stop == len(templated_str)
+            # Sanity check templated string and slices.
+            previous_slice = None
+            tfs: Optional[TemplatedFileSlice] = None
+            for idx, tfs in enumerate(self.sliced_file):
+                if previous_slice:
+                    assert (
+                        tfs.templated_slice.start == previous_slice.templated_slice.stop
+                    )
+                else:
+                    assert tfs.templated_slice.start == 0
+                previous_slice = tfs
+            if self.sliced_file and templated_str is not None:
+                assert tfs.templated_slice.stop == len(templated_str)
 
     @classmethod
     def from_string(cls, raw):

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -347,11 +347,16 @@ class JinjaTracer:
                     # literals inside a {% set %} block require special handling
                     # during the trace.
                     trimmed_content_parts = trimmed_content.split(maxsplit=2)
-                    if len(trimmed_content_parts) <= 2 or not trimmed_content_parts[
-                        2
-                    ].startswith("="):
+                    if len(trimmed_content_parts) <= 2 or (
+                        not trimmed_content_parts[1].endswith("=")
+                        and not trimmed_content_parts[2].startswith("=")
+                    ):
                         set_idx = len(result)
-                elif block_type == "block_end" and set_idx is not None:
+                elif (
+                    block_type == "block_end"
+                    and set_idx is not None
+                    and trimmed_content.startswith("endset")
+                ):
                     # Exiting a {% set %} block. Clear the indicator variable.
                     set_idx = None
                 m = regex.search(r"\s+$", raw, regex.MULTILINE | regex.DOTALL)

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -96,7 +96,6 @@ class JinjaTracer:
             target_slice_idx = self.find_slice_index(alt_id)
             slice_length = content_info if literal else len(str(content_info))
             self.move_to_slice(target_slice_idx, slice_length)
-
         return JinjaTrace(
             self.make_template(self.raw_str).render(), self.raw_sliced, self.sliced_file
         )

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -221,6 +221,13 @@ class JinjaTracer:
         for _, elem_type, raw in self.env.lex(self.raw_str):
             # Replace literal text with a unique ID.
             if elem_type == "data":
+                result.append(
+                    RawFileSlice(
+                        raw,
+                        "literal",
+                        idx,
+                    )
+                )
                 if set_idx is None:
                     rsi = self.slice_info_for_literal(
                         len(raw), "" if set_idx is None else "set"
@@ -231,13 +238,6 @@ class JinjaTracer:
                     # queries that get sent to actual databases, thus causing
                     # errors if we tamper with it.
                     rsi = RawSliceInfo(None, None, [])
-                result.append(
-                    RawFileSlice(
-                        raw,
-                        "literal",
-                        idx,
-                    )
-                )
                 self.raw_slice_info[result[-1]] = rsi
                 idx += len(raw)
                 continue

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -97,27 +97,9 @@ class JinjaTracer:
             slice_length = content_info if literal else len(str(content_info))
             self.move_to_slice(target_slice_idx, slice_length)
 
-        # Sanity check raw string and slices.
-        pos = 0
-        rfs: RawFileSlice
-        for idx, rfs in enumerate(self.raw_sliced):
-            assert rfs.source_idx == pos
-            pos += len(rfs.raw)
-        assert pos == len(self.raw_str)
-
-        # Sanity check templated string and slices.
-        templated_str = self.make_template(self.raw_str).render()
-        previous_slice = None
-        tfs: TemplatedFileSlice
-        for idx, tfs in enumerate(self.sliced_file):
-            if previous_slice:
-                assert tfs.templated_slice.start == previous_slice.templated_slice.stop
-            else:
-                assert tfs.templated_slice.start == 0
-            previous_slice = tfs
-        assert not self.sliced_file or tfs.templated_slice.stop == len(templated_str)
-
-        return JinjaTrace(templated_str, self.raw_sliced, self.sliced_file)
+        return JinjaTrace(
+            self.make_template(self.raw_str).render(), self.raw_sliced, self.sliced_file
+        )
 
     def find_slice_index(self, slice_identifier) -> int:
         """Given a slice identifier, return its index.

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -110,7 +110,6 @@ class JinjaTracer:
         previous_slice = None
         tfs: TemplatedFileSlice
         for idx, tfs in enumerate(self.sliced_file):
-            print(f"tfs[{idx}] = {repr(templated_str[tfs.templated_slice])}")
             if previous_slice:
                 assert tfs.templated_slice.start == previous_slice.templated_slice.stop
             else:

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -244,8 +244,10 @@ class JinjaTracer:
                         len(raw), "" if set_idx is None else "set"
                     )
                 else:
-                    unique_alternate_id = None
-                    alternate_code = None
+                    # For "set" blocks, don't generate alternate ID or code.
+                    # Sometimes, dbt users use {% set %} blocks to generate
+                    # queries that get sent to actual databases, thus causing
+                    # errors if we tamper with it.
                     rsi = RawSliceInfo(None, None, [])
                 result.append(
                     RawFileSlice(
@@ -337,6 +339,11 @@ class JinjaTracer:
                         # effects, but return a unique slice ID.
                         if trimmed_content:
                             assert m_open and m_close
+                            # For "set" blocks, don't generate alternate ID or
+                            # code. Sometimes, dbt users use {% set %} blocks to
+                            # generate queries that get sent to actual
+                            # databases, thus causing errors if we tamper with
+                            # it.
                             if set_idx is None:
                                 unique_id = self.next_slice_id()
                                 unique_alternate_id = unique_id

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -355,7 +355,10 @@ class JinjaTracer:
                 elif (
                     block_type == "block_end"
                     and set_idx is not None
-                    and trimmed_content.startswith("endset")
+                    and (
+                        trimmed_content.startswith("endset")
+                        or trimmed_content.startswith("endmacro")
+                    )
                 ):
                     # Exiting a {% set %} block. Clear the indicator variable.
                     set_idx = None

--- a/test/core/templaters/base_test.py
+++ b/test/core/templaters/base_test.py
@@ -43,7 +43,7 @@ SIMPLE_SLICED_FILE = [
     for args in [
         ("literal", slice(0, 10, None), slice(0, 10, None)),
         ("templated", slice(10, 17, None), slice(10, 12, None)),
-        ("literal", slice(17, 25, None), slice(12, 20, None)),
+        ("literal", slice(17, 25, None), slice(12, 21, None)),
     ]
 ]
 SIMPLE_RAW_SLICED_FILE = [

--- a/test/core/templaters/base_test.py
+++ b/test/core/templaters/base_test.py
@@ -43,7 +43,7 @@ SIMPLE_SLICED_FILE = [
     for args in [
         ("literal", slice(0, 10, None), slice(0, 10, None)),
         ("templated", slice(10, 17, None), slice(10, 12, None)),
-        ("literal", slice(17, 25, None), slice(12, 21, None)),
+        ("literal", slice(17, 25, None), slice(12, 20, None)),
     ]
 ]
 SIMPLE_RAW_SLICED_FILE = [
@@ -134,6 +134,7 @@ def test__templated_file_get_line_pos_of_char_pos(
         templated_str=templated_str,
         sliced_file=file_slices,
         fname="test",
+        check_consistency=False,
     )
     res_line_no, res_line_pos = file.get_line_pos_of_char_pos(in_charpos)
     assert res_line_no == out_line_no
@@ -287,6 +288,7 @@ def test__templated_file_templated_slice_to_source_slice(
             for rs in raw_slices
         ],
         fname="test",
+        check_consistency=False,
     )
     source_slice = file.templated_slice_to_source_slice(in_slice)
     literal_test = file.is_source_slice_literal(source_slice)
@@ -303,5 +305,6 @@ def test__templated_file_source_only_slices():
             RawFileSlice("b" * 7, "comment", 10),
             RawFileSlice("a" * 10, "literal", 17),
         ],
+        check_consistency=False,
     )
     assert file.source_only_slices() == [RawFileSlice("b" * 7, "comment", 10)]

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -875,6 +875,45 @@ from my_table
                 ("literal", slice(312, 327, None), slice(27, 42, None)),
             ],
         ),
+        (
+            # Test for issue 2835. There's no space between "col" and "="
+            """{% set col= "col1" %}
+SELECT {{ col }}
+""",
+            None,
+            [
+                ("block_start", slice(0, 21, None), slice(0, 0, None)),
+                ("literal", slice(21, 29, None), slice(0, 8, None)),
+                ("templated", slice(29, 38, None), slice(8, 12, None)),
+                ("literal", slice(38, 39, None), slice(12, 13, None)),
+            ],
+        ),
+        (
+            # Another test for issue 2835. The {% for %} loop inside the
+            # {% set %} caused JinjaTracer to think the {% set %} ended
+            # at the {% endfor %}
+            """{% set some_part_of_the_query %}
+    {% for col in ["col1"] %}
+    {{col}}
+    {% endfor %}
+{% endset %}
+
+SELECT {{some_part_of_the_query}}
+FROM SOME_TABLE
+""",
+            None,
+            [
+                ("block_start", slice(0, 32, None), slice(0, 0, None)),
+                ("literal", slice(32, 37, None), slice(0, 0, None)),
+                ("block_start", slice(37, 62, None), slice(0, 0, None)),
+                ("block_end", slice(79, 91, None), slice(0, 0, None)),
+                ("literal", slice(91, 92, None), slice(0, 0, None)),
+                ("block_end", slice(92, 104, None), slice(0, 0, None)),
+                ("literal", slice(104, 113, None), slice(0, 9, None)),
+                ("templated", slice(113, 139, None), slice(9, 29, None)),
+                ("literal", slice(139, 156, None), slice(29, 46, None)),
+            ],
+        ),
     ],
 )
 def test__templater_jinja_slice_file(raw_file, override_context, result, caplog):

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -377,6 +377,10 @@ def test_templater_set_block_handling():
     """
 
     def run_query(sql):
+        # Prior to the bug fix, this failed. This was bad because, inside
+        # JinjaTracer, dbt templates similar to the one in this test would call
+        # the database with funky SQL (including weird strings it uses
+        # internally like: 00000000000000000000000000000002.
         assert sql == "\n\nselect 1 from foobarfoobarfoobarfoobar_dev\n\n"
         return sql
 

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -377,10 +377,10 @@ def test_templater_set_block_handling():
     """
 
     def run_query(sql):
-        # Prior to the bug fix, this failed. This was bad because, inside
-        # JinjaTracer, dbt templates similar to the one in this test would call
-        # the database with funky SQL (including weird strings it uses
-        # internally like: 00000000000000000000000000000002.
+        # Prior to the bug fix, this assertion failed. This was bad because,
+        # inside JinjaTracer, dbt templates similar to the one in this test
+        # would call the database with funky SQL (including weird strings it
+        # uses internally like: 00000000000000000000000000000002.
         assert sql == "\n\nselect 1 from foobarfoobarfoobarfoobar_dev\n\n"
         return sql
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
This PR began as a follow-on PR to #2846 to address a `JinjaTracer` bug that I previously didn't think was fixable 🎉 💯 , as well as adding assertions to catch potential future bugs where `JinjaTracer` returns incorrect results.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. 
Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #2835

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
