### PR TITLE
Add ability to regenerate subsets of fixture YAMLs (by dialect, or new only)

### DIFF
--- a/test/fixtures/dialects/README.md
+++ b/test/fixtures/dialects/README.md
@@ -21,10 +21,10 @@ For best test coverage, add both a `.sql` and `.yml` file. The easiest way to
 add a `.yml` file is to run:
 
 ```
-python test/generate_parse_fixture_yml.py
+python test/generate_parse_fixture_yml.py [-dialect "$DIALECT"] [-f "$GLOB_FILTER"]
 ```
 
-which will regenerate all the parsed structure yml files.
+This will regenerate all the parsed structure yml files, or a subset based on the given filters.
 
 ## Running parser tests
 

--- a/test/fixtures/dialects/README.md
+++ b/test/fixtures/dialects/README.md
@@ -21,7 +21,7 @@ For best test coverage, add both a `.sql` and `.yml` file. The easiest way to
 add a `.yml` file is to run:
 
 ```
-python test/generate_parse_fixture_yml.py [-dialect "$DIALECT"] [-f "$GLOB_FILTER"]
+python test/generate_parse_fixture_yml.py [-dialect "$DIALECT"] [-f "$GLOB_FILTER"] [--new-only]
 ```
 
 This will regenerate all the parsed structure yml files, or a subset based on the given filters.

--- a/test/fixtures/dialects/README.md
+++ b/test/fixtures/dialects/README.md
@@ -21,7 +21,7 @@ For best test coverage, add both a `.sql` and `.yml` file. The easiest way to
 add a `.yml` file is to run:
 
 ```
-python test/generate_parse_fixture_yml.py [-dialect "$DIALECT"] [-f "$GLOB_FILTER"] [--new-only]
+python test/generate_parse_fixture_yml.py [--dialect <dialect>] [--f <glob_filter>] [--new-only]
 ```
 
 This will regenerate all the parsed structure yml files, or a subset based on the given filters.

--- a/test/generate_parse_fixture_yml.py
+++ b/test/generate_parse_fixture_yml.py
@@ -1,6 +1,11 @@
 """Utility to generate yml files for all the parsing examples."""
 import multiprocessing
 import os
+import fnmatch
+import re
+import click
+from typing import Callable, Dict, List, NamedTuple, Optional, TypeVar
+
 
 import yaml
 
@@ -8,7 +13,22 @@ from conftest import compute_parse_tree_hash, get_parse_fixtures, parse_example_
 from sqlfluff.core.errors import SQLParseError
 
 
-def generate_parse_fixture(example):
+S = TypeVar("S")
+
+
+def distribute_work(work_items: List[S], work_fn: Callable[[S], None]) -> None:
+    """Distribute work and ignore results."""
+    with multiprocessing.Pool(multiprocessing.cpu_count()) as pool:
+        for _ in pool.imap_unordered(work_fn, work_items):
+            pass
+
+
+class _ParseExample(NamedTuple):
+    dialect: str
+    sqlfile: str
+
+
+def generate_one_parse_fixture(example: _ParseExample) -> None:
     """Parse example SQL file, write parse tree to YAML file."""
     dialect, sqlfile = example
     tree = parse_example_file(dialect, sqlfile)
@@ -17,44 +37,81 @@ def generate_parse_fixture(example):
     root = sqlfile[:-4]
     path = os.path.join("test", "fixtures", "dialects", dialect, root + ".yml")
     with open(path, "w", newline="\n") as f:
-        r = None
+        r: Optional[Dict[str, Optional[str]]] = None
 
-        if tree:
-
-            # Check we don't have any base types or unparsable sections
-            types = tree.type_set()
-            if "base" in types:
-                raise SQLParseError(f"Unnamed base section when parsing: {f.name}")
-            if "unparsable" in types:
-                raise SQLParseError(f"Could not parse: {f.name}")
-
-            r = dict(
-                [("_hash", _hash)]
-                + list(tree.as_record(code_only=True, show_raw=True).items())
-            )
-            print(
-                "# YML test files are auto-generated from SQL files and should not be "
-                "edited by",
-                '# hand. To help enforce this, the "hash" field in the file must match '
-                "a hash",
-                "# computed by SQLFluff when running the tests. Please run",
-                "# `python test/generate_parse_fixture_yml.py`  to generate them after "
-                "adding or",
-                "# altering SQL files.",
-                file=f,
-                sep="\n",
-            )
-            yaml.dump(r, f, default_flow_style=False, sort_keys=False)
-        else:
+        if not tree:
             f.write("")
+            return
+
+        # Check we don't have any base types or unparsable sections
+        types = tree.type_set()
+        if "base" in types:
+            raise SQLParseError(f"Unnamed base section when parsing: {f.name}")
+        if "unparsable" in types:
+            raise SQLParseError(f"Could not parse: {f.name}")
+
+        records = tree.as_record(code_only=True, show_raw=True)
+        assert records, "TypeGuard"
+        r = dict([("_hash", _hash), *list(records.items())])
+        print(
+            "# YML test files are auto-generated from SQL files and should not be "
+            "edited by",
+            '# hand. To help enforce this, the "hash" field in the file must match '
+            "a hash",
+            "# computed by SQLFluff when running the tests. Please run",
+            "# `python test/generate_parse_fixture_yml.py`  to generate them after "
+            "adding or",
+            "# altering SQL files.",
+            file=f,
+            sep="\n",
+        )
+        yaml.dump(r, f, default_flow_style=False, sort_keys=False)
+        return
+
+
+def gather_file_list(
+    dialect: Optional[str] = None, glob_match_pattern: Optional[str] = None
+) -> List[_ParseExample]:
+    """Gather the list of files to generate fixtures for. Apply filters as required."""
+    parse_success_examples, _ = get_parse_fixtures()
+    if dialect:
+        dialect = dialect.lower()
+        parse_success_examples = [
+            example for example in parse_success_examples if example[0] == dialect
+        ]
+        if len(parse_success_examples) == 0:
+            raise ValueError(f'Unknown Dialect "{dialect}"')
+
+    if not glob_match_pattern:
+        return parse_success_examples
+
+    regex = re.compile(fnmatch.translate(glob_match_pattern))
+    return [
+        example
+        for example in parse_success_examples
+        if regex.match(example[1]) is not None
+    ]
+
+
+@click.command()
+@click.option(
+    "--filter", "-f", default=None, help="A glob filter to apply to file names."
+)
+@click.option("--dialect", "-d", default=None, help="Filter to a given dialect.")
+def generate_parse_fixtures(filter: Optional[str], dialect: Optional[str]):
+    """Generate fixture or a subset based on dialect or filename glob match."""
+    filter_str = filter or "*"
+    dialect_str = dialect or "all"
+    print(f"Match Pattern Recieved: filter={filter_str} dialect={dialect_str}")
+    parse_success_examples = gather_file_list(dialect, filter)
+    print(f"Found {len(parse_success_examples)} files to generate")
+    distribute_work(parse_success_examples, generate_one_parse_fixture)
+    print(f"Fixture rebuilt: {len(parse_success_examples)}")
 
 
 def main():
     """Find all example SQL files, parse and create YAML files."""
-    parse_success_examples, _ = get_parse_fixtures()
-    with multiprocessing.Pool(multiprocessing.cpu_count()) as pool:
-        for _ in pool.imap_unordered(generate_parse_fixture, parse_success_examples):
-            pass
+    generate_parse_fixtures()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#2844

Adds some flags for faster/ more minimal rebuilding
- `--new-only`
- `--dialect bigquery`
- `--filter *with_*`

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
- [x] Added appropriate documentation for the change.
