### PR TITLE
Fix/l032 using

### DIFF
--- a/src/sqlfluff/core/rules/functional/segments.py
+++ b/src/sqlfluff/core/rules/functional/segments.py
@@ -1,9 +1,12 @@
 """Surrogate class for working with Segment collections."""
-from typing import Any, Callable, Iterator, List, Optional, overload
+from typing import Any, Callable, Iterable, Iterator, List, Optional, overload
 
 from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.templaters.base import TemplatedFile
 from sqlfluff.core.rules.functional.raw_file_slices import RawFileSlices
+
+
+PredicateType = Callable[[BaseSegment], bool]
 
 
 class Segments(tuple):
@@ -37,14 +40,14 @@ class Segments(tuple):
         except ValueError:
             return -1
 
-    def all(self, predicate: Optional[Callable[[BaseSegment], bool]] = None) -> bool:
+    def all(self, predicate: Optional[PredicateType] = None) -> bool:
         """Do all the segments match?"""
         for s in self:
             if predicate is not None and not predicate(s):
                 return False
         return True
 
-    def any(self, predicate: Optional[Callable[[BaseSegment], bool]] = None) -> bool:
+    def any(self, predicate: Optional[PredicateType] = None) -> bool:
         """Do any of the segments match?"""
         for s in self:
             if predicate is None or predicate(s):
@@ -94,7 +97,8 @@ class Segments(tuple):
         return Segments(*segments, templated_file=self.templated_file)
 
     def children(
-        self, predicate: Optional[Callable[[BaseSegment], bool]] = None
+        self,
+        predicate: Optional[PredicateType] = None,
     ) -> "Segments":
         """Returns an object with children of the segments in this object."""
         child_segments: List[BaseSegment] = []
@@ -105,7 +109,8 @@ class Segments(tuple):
         return Segments(*child_segments, templated_file=self.templated_file)
 
     def first(
-        self, predicate: Optional[Callable[[BaseSegment], bool]] = None
+        self,
+        predicate: Optional[PredicateType] = None,
     ) -> "Segments":
         """Returns the first segment (if any) that satisfies the predicates."""
         for s in self:
@@ -115,7 +120,8 @@ class Segments(tuple):
         return Segments(templated_file=self.templated_file)
 
     def last(
-        self, predicate: Optional[Callable[[BaseSegment], bool]] = None
+        self,
+        predicate: Optional[PredicateType] = None,
     ) -> "Segments":
         """Returns the last segment (if any) that satisfies the predicates."""
         for s in reversed(self):
@@ -143,6 +149,19 @@ class Segments(tuple):
         else:
             return result
 
+    def dive_last(self, max_depth=1):
+        """Move down to the last child repeatedly."""
+        # Continue moving down directly to the last element
+
+        if max_depth == 0:
+            return self
+        max_depth = max_depth - 1
+        last_child = self.children().last()
+        if not last_child:
+            return self
+
+        return last_child.dive_last(max_depth=max_depth)
+
     def get(self, index: int = 0, *, default: Any = None) -> Optional[BaseSegment]:
         """Return specified item. Returns default if index out of range."""
         try:
@@ -156,8 +175,8 @@ class Segments(tuple):
 
     def select(
         self,
-        select_if: Optional[Callable[[BaseSegment], bool]] = None,
-        loop_while: Optional[Callable[[BaseSegment], bool]] = None,
+        select_if: Optional[PredicateType] = None,
+        loop_while: Optional[PredicateType] = None,
         start_seg: Optional[BaseSegment] = None,
         stop_seg: Optional[BaseSegment] = None,
     ) -> "Segments":
@@ -175,3 +194,15 @@ class Segments(tuple):
             if select_if is None or select_if(seg):
                 buff.append(seg)
         return Segments(*buff, templated_file=self.templated_file)
+
+    def iterate_segments(
+        self,
+        predicate: Optional[PredicateType] = None,
+    ) -> Iterable["Segments"]:
+        """Loop over eaach element as a fresh segment."""
+        # Looping over Segments returns BaseEls
+        # which is sometime what we want and sometimes not
+        for base_el in self:
+            if predicate and not predicate(base_el):
+                continue
+            yield Segments(base_el, templated_file=self.templated_file)

--- a/src/sqlfluff/core/rules/functional/segments.py
+++ b/src/sqlfluff/core/rules/functional/segments.py
@@ -186,10 +186,10 @@ class Segments(tuple):
         self,
         predicate: Optional[PredicateType] = None,
     ) -> Iterable["Segments"]:
-        """Loop over eaach element as a fresh segment."""
+        """Loop over eaach element as a fresh Segments."""
         # Looping over Segments returns BaseEls
         # which is sometime what we want and sometimes not
         for base_el in self:
-            if predicate and not predicate(base_el):
+            if predicate and not predicate(base_el):  # pragma: no cover
                 continue
             yield Segments(base_el, templated_file=self.templated_file)

--- a/src/sqlfluff/core/rules/functional/segments.py
+++ b/src/sqlfluff/core/rules/functional/segments.py
@@ -186,7 +186,7 @@ class Segments(tuple):
         self,
         predicate: Optional[PredicateType] = None,
     ) -> Iterable["Segments"]:
-        """Loop over eaach element as a fresh Segments."""
+        """Loop over each element as a fresh Segments."""
         # Looping over Segments returns BaseEls
         # which is sometime what we want and sometimes not
         for base_el in self:

--- a/src/sqlfluff/core/rules/functional/segments.py
+++ b/src/sqlfluff/core/rules/functional/segments.py
@@ -149,19 +149,6 @@ class Segments(tuple):
         else:
             return result
 
-    def dive_last(self, max_depth=1):
-        """Move down to the last child repeatedly."""
-        # Continue moving down directly to the last element
-
-        if max_depth == 0:
-            return self
-        max_depth = max_depth - 1
-        last_child = self.children().last()
-        if not last_child:
-            return self
-
-        return last_child.dive_last(max_depth=max_depth)
-
     def get(self, index: int = 0, *, default: Any = None) -> Optional[BaseSegment]:
         """Return specified item. Returns default if index out of range."""
         try:

--- a/src/sqlfluff/rules/L032.py
+++ b/src/sqlfluff/rules/L032.py
@@ -82,9 +82,8 @@ class Rule_L032(BaseRule):
             sp.is_type("join_clause", "from_expression_element")
         )
 
-        # If we have more than 2 tables we won't try to fix join.
-        # TODO: if this is table 2 of 3 it is still fixable
-        if len(tables_in_join) > 2:
+        # We can only safely fix the first join clause
+        if segment.get(0) != tables_in_join.get(1):
             return unfixable_result
 
         parent_select = parent_stack.last(sp.is_type("select_statement")).get()
@@ -92,20 +91,19 @@ class Rule_L032(BaseRule):
             return unfixable_result
 
         select_info = get_select_statement_info(parent_select, context.dialect)
-        if not select_info:  # pragma: no cover
+        if not select_info or len(select_info.table_aliases) < 2:  # pragma: no cover
             return unfixable_result
 
-        to_delete, insert_after_anchor = _extract_deletion_sequence_and_anchor(
-            tables_in_join.last()
-        )
-        table_a, table_b = select_info.table_aliases
+        to_delete, insert_after_anchor = _extract_deletion_sequence_and_anchor(segment)
+
+        table_a, table_b = select_info.table_aliases[:2]
         edit_segments = [
             KeywordSegment(raw="ON"),
             WhitespaceSegment(raw=" "),
         ] + _generate_join_conditions(
             table_a.ref_str,
             table_b.ref_str,
-            select_info.using_cols,
+            _extract_cols_from_using(segment, using_anchor),
         )
 
         fixes = [
@@ -122,7 +120,20 @@ class Rule_L032(BaseRule):
         )
 
 
+def _extract_cols_from_using(join_clause: Segments, using_segs: Segments) -> List[str]:
+    # First bracket after the USING keyword, then find ids
+    using_cols: List[str] = (
+        join_clause.children()
+        .select(start_seg=using_segs[0], select_if=sp.is_type("bracketed"))
+        .first()
+        .children(sp.is_type("identifier"))
+        .apply(lambda el: el.raw)
+    )
+    return using_cols
+
+
 def _generate_join_conditions(table_a_ref: str, table_b_ref: str, columns: List[str]):
+    print(columns)
     edit_segments: List[BaseSegment] = []
     for col in columns:
         edit_segments = edit_segments + [

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -1,6 +1,6 @@
 """Implementation of Rule L042."""
 from functools import partial
-from typing import Generator, List, Literal, Optional, Tuple, Union
+from typing import Generator, List, Optional, Tuple, Union
 
 from sqlfluff.core.parser.segments.base import BaseSegment
 from sqlfluff.core.parser.segments.raw import (
@@ -320,7 +320,7 @@ class _CTEChecker:
 
 
 def _segmentify(
-    input_el: Union[str, BaseSegment], casing: Literal["UPPER", "LOWER"]
+    input_el: Union[str, BaseSegment], casing: str
 ) -> BaseSegment:
     """Apply casing an convert strings to Keywords or Whitespace."""
     if isinstance(input_el, BaseSegment):

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -190,19 +190,18 @@ def _calculate_fixes(
 
 def _is_child(maybe_parent: Segments, maybe_child: Segments) -> bool:
     """Is the child actually between the start and end markers of the parent."""
-    if len(maybe_child) > 1:
-        raise ValueError("Cannot assess Childness of multiple Segments")
+    assert len(maybe_child) == 1, "Cannot assess Childness of multiple Segments"
 
     child_markers = maybe_child[0].pos_marker
     if not child_markers:
-        return False
+        return False  # pragma: no cover
     for segement in maybe_parent:
         parent_pos = segement.pos_marker
         if not parent_pos:
-            continue
+            continue  # pragma: no cover
 
         if child_markers < parent_pos.start_point_marker():
-            continue
+            continue  # pragma: no cover
 
         if child_markers > parent_pos.end_point_marker():
             continue
@@ -284,7 +283,7 @@ class _CTEChecker:
         # This should still have the position markers of its true position
         inbound_subquery = Segments(cte).children().last()
         for el in self.ctes:
-            if cte in output:
+            if cte in output:  # pragma: no cover
                 output.append(el)
                 continue
             if _is_child(Segments(el).children().last(), inbound_subquery):
@@ -320,14 +319,9 @@ class _CTEChecker:
 
 
 def _segmentify(
-    input_el: Union[str, BaseSegment], casing: str
+    input_el: str, casing: str
 ) -> BaseSegment:
-    """Apply casing an convert strings to Keywords or Whitespace."""
-    if isinstance(input_el, BaseSegment):
-        return input_el
-
-    if input_el[0] == " ":
-        return WhitespaceSegment(raw=input_el)
+    """Apply casing an convert strings to Keywords."""
 
     input_el = input_el.lower()
     if casing == "UPPER":

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -149,21 +149,21 @@ def _calculate_fixes(
     TableReferenceSeg = Seg(TableReferenceSegment)
     for parent_type, _, this_seg, subquery in nested_subqueries:
         alias_name = ctes.get_name(this_seg.children(is_type("alias_expression")))
-        ctes.insert_cte(
-            CTESegment(
-                segments=(
-                    CodeSegment(
-                        raw=alias_name,
-                        name="naked_identifier",
-                        type="identifier",
-                    ),
-                    WhitespaceSegment(),
-                    segmentify("AS"),
-                    WhitespaceSegment(),
-                    subquery,
-                )
+        new_cte = CTESegment(
+            segments=(
+                CodeSegment(
+                    raw=alias_name,
+                    name="naked_identifier",
+                    type="identifier",
+                ),
+                WhitespaceSegment(),
+                segmentify("AS"),
+                WhitespaceSegment(),
+                subquery,
             )
         )
+        # (mypy is not understanding the generic)
+        ctes.insert_cte(new_cte)  # type: ignore
         # TODO: Create non-mutative helper function.
         # We will replace the whole tree, mutate the table expression.
         this_seg[0].segments = (

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -263,12 +263,11 @@ class _CTEChecker:
     """Buffer CTE movements, so they can be applied in bulk without a recrawl."""
 
     def __init__(self) -> None:
-        self.used_names = []
+        self.used_names: List[str] = []
         self.ctes: List[BaseSegment] = []
         self.name_idx = 0
 
     def has_duplicates(self) -> bool:
-        print(self.used_names)
         return len(set(self.used_names)) != len(self.used_names)
 
     def insert_cte(self, cte: BaseSegment):
@@ -304,7 +303,7 @@ class _CTEChecker:
 
     def get_segements(self) -> List[BaseSegment]:
         """Return a valid list of CTES with required padding Segements."""
-        cte_segments = []
+        cte_segments: List[BaseSegment] = []
         for cte in self.ctes:
             cte_segments = cte_segments + [
                 cte,

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -379,7 +379,7 @@ def _create_table_ref(table_name: str, dialect: Dialect) -> TableExpressionSegme
             ),
         )
     )
-    return table_seg
+    return table_seg  # type: ignore
 
 
 def _get_case_preference(root_select: Segments):

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -20,6 +20,8 @@ from sqlfluff.core.rules.functional.segment_predicates import is_name, is_type
 from sqlfluff.core.rules.functional.segments import Segments
 from sqlfluff.dialects.dialect_ansi import (
     CTEDefinitionSegment,
+    TableExpressionSegment,
+    TableReferenceSegment,
     WithCompoundStatementSegment,
 )
 
@@ -152,11 +154,19 @@ def _calculate_fixes(
         # TODO: Create non-mutative helper function.
         # We will replace the whole tree, mutate the table expression.
         this_seg[0].segments = (
-            CodeSegment(
-                raw=alias_name,
-                name="naked_identifier",
-                type="identifier",
-            ),
+            TableExpressionSegment(
+                segments=(
+                    TableReferenceSegment(
+                        segments=(
+                            CodeSegment(
+                                raw=alias_name,
+                                name="naked_identifier",
+                                type="identifier",
+                            ),
+                        )
+                    ),
+                )
+            ), 
         )
         res = LintResult(
             anchor=subquery,

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -362,7 +362,7 @@ def _create_cte_seg(
     return element
 
 
-def _create_table_ref(table_name: str, dialect: Dialect):
+def _create_table_ref(table_name: str, dialect: Dialect) -> TableExpressionSegment:
     Seg = partial(_get_seg, dialect=dialect)
     TableExpressionSeg = Seg(TableExpressionSegment)
     TableReferenceSeg = Seg(TableReferenceSegment)
@@ -394,7 +394,7 @@ def _get_case_preference(root_select: Segments):
 
 
 def _segmentify(input_el: str, casing: str) -> BaseSegment:
-    """Apply casing an convert strings to Keywords."""
+    """Apply casing and convert strings to Keywords."""
     input_el = input_el.lower()
     if casing == "UPPER":
         input_el = input_el.upper()

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -1,6 +1,6 @@
 """Implementation of Rule L042."""
 from functools import partial
-from typing import Generator, List, Optional, Tuple, Union
+from typing import Generator, List, Optional, Tuple
 
 from sqlfluff.core.parser.segments.base import BaseSegment
 from sqlfluff.core.parser.segments.raw import (
@@ -318,9 +318,7 @@ class _CTEChecker:
         return cte_segments[:-2]
 
 
-def _segmentify(
-    input_el: str, casing: str
-) -> BaseSegment:
+def _segmentify(input_el: str, casing: str) -> BaseSegment:
     """Apply casing an convert strings to Keywords."""
 
     input_el = input_el.lower()

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -1,5 +1,8 @@
 """Implementation of Rule L042."""
-from typing import List, Optional, Union
+from functools import partial
+from multiprocessing.sharedctypes import Value
+from typing import Generator, List, Literal, Optional, Tuple, Union
+from sqlfluff.core.dialects.base import Dialect
 
 from sqlfluff.core.parser.segments.base import BaseSegment
 from sqlfluff.core.parser.segments.raw import (
@@ -9,14 +12,19 @@ from sqlfluff.core.parser.segments.raw import (
     SymbolSegment,
     WhitespaceSegment,
 )
+from sqlfluff.core.rules.analysis.select_crawler import SelectCrawler
 
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
 )
-from sqlfluff.core.rules.functional.segment_predicates import is_type
+from sqlfluff.core.rules.functional.segment_predicates import is_name, is_type
 from sqlfluff.core.rules.functional.segments import Segments
+from sqlfluff.dialects.dialect_ansi import (
+    CTEDefinitionSegment,
+    WithCompoundStatementSegment,
+)
 
 
 @document_fix_compatible
@@ -66,137 +74,221 @@ class Rule_L042(BaseRule):
         "both": ["join_clause", "from_expression_element"],
     }
 
-    def _eval(self, context: RuleContext) -> Optional[LintResult]:
-        """Join/From clauses should not contain subqueries. Use CTEs instead.
-
-        NB: No fix for this routine because it would be very complex to
-        implement reliably.
-        """
-        self.forbid_subquery_in: str
-        parent_types = self._config_mapping[self.forbid_subquery_in]
-        segment = context.functional.segment
-        memory = context.memory
-
-        if memory and memory.flush_anchor == segment:
-            # If we reach the "final" segment in the top most select
-            # then we can finalise our lints/fixes
-            return memory.flush()
-
+    def _eval(self, context: RuleContext) -> Optional[List[LintResult]]:
+        """Join/From clauses should not contain subqueries. Use CTEs instead."""
         select_types = [
             "with_compound_statement",
             "set_expression",
             "select_statement",
         ]
-        if not segment.all(is_type(*select_types)):
-            # If its not a select just keep crawling
-            return LintResult(memory=memory)
+        self.forbid_subquery_in: str
+        parent_types = self._config_mapping[self.forbid_subquery_in]
+        segment = context.functional.segment
+        parent_stack = context.functional.parent_stack
+        is_select = segment.all(is_type(*select_types))
+        is_select_child = parent_stack.any(is_type(*select_types))
+        if not is_select or is_select_child:
+            # Subvert the Crawler
+            return None
 
-        children = segment.children()
-        if not memory:
-            # memory always anchors us to the top most Select
-            # this allows us to hoist CTEs to the top instead of just one above
-            memory = _MyMemory(segment)
+        root_select = segment
+        nested_subqueries: List[Tuple[str, Segments, Segments, BaseSegment]] = []
+        selects = segment.recursive_crawl(*select_types, recurse_into=True)
+        for select in selects.iterate_segments():
+            for res in _find_nested_subqueries(select):
+                clause_type = res[0]
+                if clause_type not in parent_types:
+                    continue
+                nested_subqueries.append(res)
 
-        from_clause = children.first(is_type("from_clause")).children()
-        # Match any of the types we care about
-        for this_seg in from_clause.children(is_type(*parent_types)).iterate_segments():
-            parent_type = this_seg[0].get_type()
-            # Ensure we are at the right depth (from_expression_element)
-            if not this_seg.all(is_type("from_expression_element")):
-                this_seg = this_seg.children(
-                    is_type("from_expression_element"),
-                )
+        if not nested_subqueries:
+            return None
 
-            table_expression_el = this_seg.children(
-                is_type("table_expression"),
+        return _calculate_fixes(root_select, nested_subqueries)
+
+
+def _calculate_fixes(
+    root_select: Segments,
+    nested_subqueries: List[Tuple[str, Segments, Segments, BaseSegment]],
+):
+    """Given the Root select and the offending subqueries calculate fixes."""
+
+    ctes = _CTEChecker()
+    is_with = root_select.all(is_type("with_compound_statement"))
+    # TODO: consider if we can fix recursive CTEs
+    is_recursive = is_with and len(root_select.children(is_name("recursive"))) > 0
+    output_select = root_select
+    casing_prefrence = _get_casing_preference(root_select)
+    segmentify = partial(_segmentify, casing=casing_prefrence)
+    if is_with:
+        output_select = root_select.children(
+            is_type(
+                "set_expression",
+                "select_statement",
             )
+        )
+        for cte in root_select.children(is_type("common_table_expression")):
+            ctes.insert_cte(cte)
 
-            # Is it bracketed? If so, lint that instead.
-            bracketed_expression = table_expression_el.children(
-                is_type("bracketed"),
-            )
-            nested_select = bracketed_expression or table_expression_el
-            # If we find a child with a "problem" type, raise an issue.
-            # If not, we're fine.
-            seg = nested_select.children(is_type(*select_types))
-            if not seg:
-                # If there is no match there is no error
-                continue
-
-            # We buffer up errors in so that we can apply later as a batch
-            # taking care of order and duplicate CTE names
-            alias_if_exists = this_seg.children(is_type("alias_expression"))
-            subquery = table_expression_el[0]
-            alias_name = memory.buffer_fix(
-                subquery,
-                alias_if_exists,
-            )
-
-            # Remove "AS x" if it exists (new CTE will be called "x") anyway
-            rest_els = this_seg.children().select(
-                start_seg=subquery,
-            )
-
-            res = LintResult(
-                anchor=seg[0],
-                description=f"{parent_type} clauses should not contain "
-                "subqueries. Use CTEs instead",
-                fixes=[
-                    LintFix.replace(
-                        subquery,
-                        edit_segments=[
-                            CodeSegment(
-                                raw=alias_name,
-                                name="naked_identifier",
-                                type="identifier",
-                            )
-                        ],
+    lint_results: List[LintResult] = []
+    for parent_type, _, this_seg, subquery in nested_subqueries:
+        alias_name = ctes.get_name(this_seg.children(is_type("alias_expression")))
+        ctes.insert_cte(
+            CTEDefinitionSegment(
+                segments=(
+                    CodeSegment(
+                        raw=alias_name,
+                        name="naked_identifier",
+                        type="identifier",
                     ),
-                    *rest_els.apply(LintFix.delete),
-                ],
-                memory=memory,
+                    WhitespaceSegment(),
+                    segmentify("AS"),
+                    WhitespaceSegment(),
+                    subquery,
+                )
             )
-            memory.buffer_result(res)
+        )
+        # TODO: Create non-mutative helper function.
+        # We will replace the whole tree, mutate the table expression.
+        this_seg[0].segments = (
+            CodeSegment(
+                raw=alias_name,
+                name="naked_identifier",
+                type="identifier",
+            ),
+        )
+        res = LintResult(
+            anchor=subquery,
+            description=f"{parent_type} clauses should not contain "
+            "subqueries. Use CTEs instead",
+            fixes=[],
+        )
+        lint_results.append(res)
 
-        return LintResult(memory=memory)
+    if ctes.has_duplicates() or is_recursive:
+        # If we have duplicate CTE names just don't fix anything
+        return lint_results
+
+    new_select = WithCompoundStatementSegment(
+        segments=tuple(
+            [
+                segmentify("WITH"),
+                WhitespaceSegment(),
+                *ctes.get_segements(),
+                NewlineSegment(),
+                output_select[0],
+            ]
+        )
+    )
+    # Add fixes to the last result only
+    res = lint_results.pop()
+    res.fixes = [LintFix.replace(root_select[0], edit_segments=[new_select])]
+    lint_results.append(res)
+    return lint_results
 
 
-class _MyMemory:
+def _is_child(maybe_parent: Segments, maybe_child: Segments) -> bool:
+    """Is the child actually between the start and end markers of the parent."""
+    if len(maybe_child) > 1:
+        raise ValueError("Cannot assess Childness of multiple Segments")
+
+    child_markers = maybe_child[0].pos_marker
+    if not child_markers:
+        return False
+    for segement in maybe_parent:
+        parent_pos = segement.pos_marker
+        if not parent_pos:
+            continue
+
+        if child_markers < parent_pos.start_point_marker():
+            continue
+
+        if child_markers > parent_pos.end_point_marker():
+            continue
+
+        return True
+
+    return False
+
+
+def _find_nested_subqueries(
+    select: Segments,
+) -> Generator[Tuple[str, Segments, Segments, BaseSegment], None, None]:
+    select_types = [
+        "with_compound_statement",
+        "set_expression",
+        "select_statement",
+    ]
+    from_clause = select.children().first(is_type("from_clause")).children()
+    offending_types = ["join_clause", "from_expression_element"]
+    # Match any of the types we care about
+    for this_seg in from_clause.children(is_type(*offending_types)).iterate_segments():
+        parent_type = this_seg[0].get_type()
+        # Ensure we are at the right depth (from_expression_element)
+        if not this_seg.all(is_type("from_expression_element")):
+            this_seg = this_seg.children(
+                is_type("from_expression_element"),
+            )
+
+        table_expression_el = this_seg.children(
+            is_type("table_expression"),
+        )
+
+        # Is it bracketed? If so, lint that instead.
+        bracketed_expression = table_expression_el.children(
+            is_type("bracketed"),
+        )
+        nested_select = bracketed_expression or table_expression_el
+        # If we find a child with a "problem" type, raise an issue.
+        # If not, we're fine.
+        seg = nested_select.children(is_type(*select_types))
+        if not seg:
+            # If there is no match there is no error
+            continue
+        # Type, parent_select, parent_sequence
+        yield (parent_type, select, this_seg, table_expression_el[0])
+
+
+def _get_casing_preference(root_select: Segments):
+    first_keyword = root_select.recursive_crawl("keyword", recurse_into=False).first()[
+        0
+    ]
+    if first_keyword.raw[0] == first_keyword.raw[0].lower():
+        return "LOWER"
+
+    return "UPPER"
+
+
+class _CTEChecker:
     """Buffer CTE movements, so they can be applied in bulk without a recrawl."""
 
-    def __init__(self, root_select_anchor: Segments) -> None:
-        self.root_select_anchor = root_select_anchor
-        self.is_with = root_select_anchor.all(is_type("with_compound_statement"))
-        # Gather the last possible segment in this select
-        self.flush_anchor = root_select_anchor.dive_last(max_depth=6)
-        first_keyword = (
-            root_select_anchor.children().children().first(is_type("keyword")).get(0)
-        )
-        assert first_keyword, "TypeGaurd"
-        self.anchor: BaseSegment = first_keyword
-        if self.is_with:
-            self.anchor = root_select_anchor.children().children().first()[0]
-
-        self.first_keyword = first_keyword.raw.lower()
-        self.casing_prefrence = (
-            "LOWER" if first_keyword.raw[0] == self.first_keyword[0] else "UPPER"
-        )
-        self.used_names: List[str] = []
-        # TODO: fix duplicate names (in bound from existing CTE)
+    def __init__(self) -> None:
+        self.used_names = []
+        self.ctes: List[BaseSegment] = []
         self.name_idx = 0
-        self.fixes = -1
-        self.edit_segments: List[BaseSegment] = []
-        self.lint_results: List[LintResult] = []
 
-    @property
-    def needs_with(self) -> bool:
-        if self.is_with:
-            return False
+    def has_duplicates(self) -> bool:
+        print(self.used_names)
+        return len(set(self.used_names)) != len(self.used_names)
 
-        if self.first_keyword == "with":
-            return False
+    def insert_cte(self, cte: BaseSegment):
+        """Add a new CTE to the list as late as possible but before all its parents."""
+        output: List[BaseSegment] = []
+        # This should still have the position markers of its true position
+        inbound_subquery = Segments(cte).children().last()
+        for el in self.ctes:
+            if cte in output:
+                output.append(el)
+                continue
+            if _is_child(Segments(el).children().last(), inbound_subquery):
+                output.append(cte)
 
-        return self.fixes == 0
+            output.append(el)
+
+        if cte not in output:
+            output.append(cte)
+
+        self.ctes = output
 
     def get_name(self, alias_segment: Optional[Segments] = None) -> str:
         """Find or create the name for the next CTE."""
@@ -210,65 +302,21 @@ class _MyMemory:
         self.used_names.append(name)
         return name
 
-    def buffer_result(self, res: LintResult):
-        # We buffer fixes so as not to trigger a crawl and memory wipe
-        self.lint_results.append(res)
-
-    def buffer_fix(self, subquery: BaseSegment, alias_segment: Segments) -> str:
-        """Create and ordering for Segments that should be moved to CTEs."""
-        alias_name = self.get_name(alias_segment)
-        self.fixes = self.fixes + 1
-
-        start_stmt: List[Union[str, BaseSegment]] = [
-            "WITH",
-            " ",
-        ]
-        if not self.needs_with:
-            start_stmt = [
+    def get_segements(self) -> List[BaseSegment]:
+        """Return a valid list of CTES with required padding Segements."""
+        cte_segments = []
+        for cte in self.ctes:
+            cte_segments = cte_segments + [
+                cte,
                 SymbolSegment(",", name="comma", type="comma"),
                 NewlineSegment(),
             ]
-
-        edits: List[Union[str, BaseSegment]] = [
-            *start_stmt,
-            CodeSegment(raw=alias_name, name="naked_identifier", type="identifier"),
-            " ",
-            "AS",
-            " ",
-            subquery,
-            NewlineSegment(),
-        ]
-
-        if self.fixes > 0:
-            # Always remove the newline
-            # of the previous CTE
-            self.edit_segments.pop()
-
-        # utility to calc
-        self.edit_segments = self.edit_segments + [
-            _segmentify(el, self.casing_prefrence) for el in edits
-        ]
-
-        return alias_name
-
-    def flush(self) -> List[LintResult]:
-        edit = self.edit_segments
-        if self.is_with and edit:
-            edit = edit[2:-1] + [
-                SymbolSegment(",", name="comma", type="comma"),
-                NewlineSegment(),
-            ]
-        res = LintResult(
-            memory=None,
-            fixes=[
-                LintFix("create_before", self.anchor, edit=edit),
-            ],
-        )
-        print(edit)
-        return self.lint_results + [res]
+        return cte_segments[:-2]
 
 
-def _segmentify(input_el: Union[str, BaseSegment], casing: str) -> BaseSegment:
+def _segmentify(
+    input_el: Union[str, BaseSegment], casing: Literal["UPPER", "LOWER"]
+) -> BaseSegment:
     """Apply casing an convert strings to Keywords or Whitespace."""
     if isinstance(input_el, BaseSegment):
         return input_el

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -1,11 +1,25 @@
 """Implementation of Rule L042."""
-from typing import Optional
+from typing import List, Optional, Union
 
-from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_configuration
+from sqlfluff.core.parser.segments.base import BaseSegment
+from sqlfluff.core.parser.segments.raw import (
+    CodeSegment,
+    KeywordSegment,
+    NewlineSegment,
+    SymbolSegment,
+    WhitespaceSegment,
+)
+
+from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
+from sqlfluff.core.rules.doc_decorators import (
+    document_configuration,
+    document_fix_compatible,
+)
 from sqlfluff.core.rules.functional.segment_predicates import is_type
+from sqlfluff.core.rules.functional.segments import Segments
 
 
+@document_fix_compatible
 @document_configuration
 class Rule_L042(BaseRule):
     """Join/From clauses should not contain subqueries. Use CTEs instead.
@@ -48,8 +62,8 @@ class Rule_L042(BaseRule):
 
     _config_mapping = {
         "join": ["join_clause"],
-        "from": ["from_expression"],
-        "both": ["join_clause", "from_expression"],
+        "from": ["from_expression_element"],
+        "both": ["join_clause", "from_expression_element"],
     }
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
@@ -58,34 +72,212 @@ class Rule_L042(BaseRule):
         NB: No fix for this routine because it would be very complex to
         implement reliably.
         """
-        parent_types = self._config_mapping[self.forbid_subquery_in]  # type: ignore
-        for parent_type in parent_types:
-            if context.segment.is_type(parent_type):
-                # Get the referenced table segment
-                from_expression_element = context.functional.segment.children(
-                    is_type("from_expression_element")
-                ).children(is_type("table_expression"))
+        self.forbid_subquery_in: str
+        parent_types = self._config_mapping[self.forbid_subquery_in]
+        segment = context.functional.segment
+        memory = context.memory
 
-                # Is it bracketed? If so, lint that instead.
-                bracketed_expression = from_expression_element.children(
-                    is_type("bracketed")
-                )
-                if bracketed_expression:
-                    from_expression_element = bracketed_expression
+        if memory and memory.flush_anchor == segment:
+            # If we reach the "final" segment in the top most select
+            # then we can finalise our lints/fixes
+            return memory.flush()
 
-                # If we find a child with a "problem" type, raise an issue.
-                # If not, we're fine.
-                seg = from_expression_element.children(
-                    is_type(
-                        "with_compound_statement",
-                        "set_expression",
-                        "select_statement",
-                    )
+        select_types = [
+            "with_compound_statement",
+            "set_expression",
+            "select_statement",
+        ]
+        if not segment.all(is_type(*select_types)):
+            # If its not a select just keep crawling
+            return LintResult(memory=memory)
+
+        children = segment.children()
+        if not memory:
+            # memory always anchors us to the top most Select
+            # this allows us to hoist CTEs to the top instead of just one above
+            memory = _MyMemory(segment)
+
+        from_clause = children.first(is_type("from_clause")).children()
+        # Match any of the types we care about
+        for this_seg in from_clause.children(is_type(*parent_types)).iterate_segments():
+            parent_type = this_seg[0].get_type()
+            # Ensure we are at the right depth (from_expression_element)
+            if not this_seg.all(is_type("from_expression_element")):
+                this_seg = this_seg.children(
+                    is_type("from_expression_element"),
                 )
-                if seg:
-                    return LintResult(
-                        anchor=seg[0],
-                        description=f"{parent_type} clauses should not contain "
-                        "subqueries. Use CTEs instead",
-                    )
-        return None
+
+            table_expression_el = this_seg.children(
+                is_type("table_expression"),
+            )
+
+            # Is it bracketed? If so, lint that instead.
+            bracketed_expression = table_expression_el.children(
+                is_type("bracketed"),
+            )
+            nested_select = bracketed_expression or table_expression_el
+            # If we find a child with a "problem" type, raise an issue.
+            # If not, we're fine.
+            seg = nested_select.children(is_type(*select_types))
+            if not seg:
+                # If there is no match there is no error
+                continue
+
+            # We buffer up errors in so that we can apply later as a batch
+            # taking care of order and duplicate CTE names
+            alias_if_exists = this_seg.children(is_type("alias_expression"))
+            subquery = table_expression_el[0]
+            alias_name = memory.buffer_fix(
+                subquery,
+                alias_if_exists,
+            )
+
+            # Remove "AS x" if it exists (new CTE will be called "x") anyway
+            rest_els = this_seg.children().select(
+                start_seg=subquery,
+            )
+
+            res = LintResult(
+                anchor=seg[0],
+                description=f"{parent_type} clauses should not contain "
+                "subqueries. Use CTEs instead",
+                fixes=[
+                    LintFix.replace(
+                        subquery,
+                        edit_segments=[
+                            CodeSegment(
+                                raw=alias_name,
+                                name="naked_identifier",
+                                type="identifier",
+                            )
+                        ],
+                    ),
+                    *rest_els.apply(LintFix.delete),
+                ],
+                memory=memory,
+            )
+            memory.buffer_result(res)
+
+        return LintResult(memory=memory)
+
+
+class _MyMemory:
+    """Buffer CTE movements, so they can be applied in bulk without a recrawl."""
+
+    def __init__(self, root_select_anchor: Segments) -> None:
+        self.root_select_anchor = root_select_anchor
+        self.is_with = root_select_anchor.all(is_type("with_compound_statement"))
+        # Gather the last possible segment in this select
+        self.flush_anchor = root_select_anchor.dive_last(max_depth=6)
+        first_keyword = (
+            root_select_anchor.children().children().first(is_type("keyword")).get(0)
+        )
+        assert first_keyword, "TypeGaurd"
+        self.anchor: BaseSegment = first_keyword
+        if self.is_with:
+            self.anchor = root_select_anchor.children().children().first()[0]
+
+        self.first_keyword = first_keyword.raw.lower()
+        self.casing_prefrence = (
+            "LOWER" if first_keyword.raw[0] == self.first_keyword[0] else "UPPER"
+        )
+        self.used_names: List[str] = []
+        # TODO: fix duplicate names (in bound from existing CTE)
+        self.name_idx = 0
+        self.fixes = -1
+        self.edit_segments: List[BaseSegment] = []
+        self.lint_results: List[LintResult] = []
+
+    @property
+    def needs_with(self) -> bool:
+        if self.is_with:
+            return False
+
+        if self.first_keyword == "with":
+            return False
+
+        return self.fixes == 0
+
+    def get_name(self, alias_segment: Optional[Segments] = None) -> str:
+        """Find or create the name for the next CTE."""
+        if alias_segment:
+            name = alias_segment.children().last()[0].raw
+            self.used_names.append(name)
+            return name
+
+        self.name_idx = self.name_idx + 1
+        name = f"prep_{self.name_idx}"
+        self.used_names.append(name)
+        return name
+
+    def buffer_result(self, res: LintResult):
+        # We buffer fixes so as not to trigger a crawl and memory wipe
+        self.lint_results.append(res)
+
+    def buffer_fix(self, subquery: BaseSegment, alias_segment: Segments) -> str:
+        """Create and ordering for Segments that should be moved to CTEs."""
+        alias_name = self.get_name(alias_segment)
+        self.fixes = self.fixes + 1
+
+        start_stmt: List[Union[str, BaseSegment]] = [
+            "WITH",
+            " ",
+        ]
+        if not self.needs_with:
+            start_stmt = [
+                SymbolSegment(",", name="comma", type="comma"),
+                NewlineSegment(),
+            ]
+
+        edits: List[Union[str, BaseSegment]] = [
+            *start_stmt,
+            CodeSegment(raw=alias_name, name="naked_identifier", type="identifier"),
+            " ",
+            "AS",
+            " ",
+            subquery,
+            NewlineSegment(),
+        ]
+
+        if self.fixes > 0:
+            # Always remove the newline
+            # of the previous CTE
+            self.edit_segments.pop()
+
+        # utility to calc
+        self.edit_segments = self.edit_segments + [
+            _segmentify(el, self.casing_prefrence) for el in edits
+        ]
+
+        return alias_name
+
+    def flush(self) -> List[LintResult]:
+        edit = self.edit_segments
+        if self.is_with and edit:
+            edit = edit[2:-1] + [
+                SymbolSegment(",", name="comma", type="comma"),
+                NewlineSegment(),
+            ]
+        res = LintResult(
+            memory=None,
+            fixes=[
+                LintFix("create_before", self.anchor, edit=edit),
+            ],
+        )
+        print(edit)
+        return self.lint_results + [res]
+
+
+def _segmentify(input_el: Union[str, BaseSegment], casing: str) -> BaseSegment:
+    """Apply casing an convert strings to Keywords or Whitespace."""
+    if isinstance(input_el, BaseSegment):
+        return input_el
+
+    if input_el[0] == " ":
+        return WhitespaceSegment(raw=input_el)
+
+    input_el = input_el.lower()
+    if casing == "UPPER":
+        input_el = input_el.upper()
+
+    return KeywordSegment(raw=input_el)

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -166,7 +166,7 @@ def _calculate_fixes(
                         )
                     ),
                 )
-            ), 
+            ),
         )
         res = LintResult(
             anchor=subquery,

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -1,8 +1,6 @@
 """Implementation of Rule L042."""
 from functools import partial
-from multiprocessing.sharedctypes import Value
-from typing import Generator, List, Literal, Optional, Tuple, Union, cast
-from sqlfluff.core.dialects.base import Dialect
+from typing import Generator, List, Literal, Optional, Tuple, Union
 
 from sqlfluff.core.parser.segments.base import BaseSegment
 from sqlfluff.core.parser.segments.raw import (
@@ -12,7 +10,6 @@ from sqlfluff.core.parser.segments.raw import (
     SymbolSegment,
     WhitespaceSegment,
 )
-from sqlfluff.core.rules.analysis.select_crawler import SelectCrawler
 
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
@@ -112,7 +109,6 @@ def _calculate_fixes(
     nested_subqueries: List[Tuple[str, Segments, Segments, BaseSegment]],
 ):
     """Given the Root select and the offending subqueries calculate fixes."""
-
     ctes = _CTEChecker()
     is_with = root_select.all(is_type("with_compound_statement"))
     # TODO: consider if we can fix recursive CTEs

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -320,7 +320,6 @@ class _CTEChecker:
 
 def _segmentify(input_el: str, casing: str) -> BaseSegment:
     """Apply casing an convert strings to Keywords."""
-
     input_el = input_el.lower()
     if casing == "UPPER":
         input_el = input_el.upper()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -263,6 +263,7 @@ def fail_on_parse_error_after_fix(monkeypatch):
     monkeypatch.setattr(
         BaseSegment, "_log_apply_fixes_check_issue", raise_error_apply_fixes_check_issue
     )
+
     monkeypatch.setattr(
         Linter,
         "_report_conflicting_fixes_same_anchor",

--- a/test/dialects/dialects_test.py
+++ b/test/dialects/dialects_test.py
@@ -42,21 +42,33 @@ def lex_and_parse(config_overrides: Dict[str, Any], raw: str) -> Optional[BaseSe
     return Parser(config=config).parse(tokens)
 
 
-@pytest.mark.integration_test
 @pytest.mark.parametrize("dialect,file", parse_success_examples)
-def test__dialect__base_broad_fix(dialect, file, raise_critical_errors_after_fix):
-    """Run a full fix with all rules, in search of critical errors."""
+def test__dialect__base_file_parse(dialect, file):
+    """For given test examples, check successful parsing."""
     raw = load_file(dialect, file)
     config_overides = dict(dialect=dialect)
-    # Lean on the cached result of the above test if possible
+    # Use the helper function to avoid parsing twice
     parsed: Optional[BaseSegment] = lex_and_parse(config_overides, raw)
     if not parsed:
         return
 
-    config = FluffConfig(overrides=config_overides)
-    # Due to "raise_critical_errors_after_fix" fixure "fix",
-    # will now throw.
-    Linter(config=config).lint_string(raw, fix=True)
+    print(f"Post-parse structure: {parsed.to_tuple(show_raw=True)}")
+    print(f"Post-parse structure: {parsed.stringify()}")
+    # Check we're all there.
+    assert parsed.raw == raw
+    # Check that there's nothing unparsable
+    typs = parsed.type_set()
+    assert "unparsable" not in typs
+
+
+@pytest.mark.integration_test
+@pytest.mark.parametrize("dialect,file", parse_success_examples)
+def test__dialect__base_broad_fix(dialect, file, raise_critical_errors_after_fix):
+    """For given test examples, check successful parsing."""
+    raw = load_file(dialect, file)
+    # Load the right dialect
+    config = FluffConfig(overrides=dict(dialect=dialect))
+    Linter(config=config).lint_string_wrapped(raw, fix=True)
 
 
 @pytest.mark.parametrize("dialect,sqlfile,code_only,yamlfile", parse_structure_examples)

--- a/test/dialects/dialects_test.py
+++ b/test/dialects/dialects_test.py
@@ -42,25 +42,6 @@ def lex_and_parse(config_overrides: Dict[str, Any], raw: str) -> Optional[BaseSe
     return Parser(config=config).parse(tokens)
 
 
-@pytest.mark.parametrize("dialect,file", parse_success_examples)
-def test__dialect__base_file_parse(dialect, file):
-    """For given test examples, check successful parsing."""
-    raw = load_file(dialect, file)
-    config_overides = dict(dialect=dialect)
-    # Use the helper function to avoid parsing twice
-    parsed: Optional[BaseSegment] = lex_and_parse(config_overides, raw)
-    if not parsed:
-        return
-
-    print(f"Post-parse structure: {parsed.to_tuple(show_raw=True)}")
-    print(f"Post-parse structure: {parsed.stringify()}")
-    # Check we're all there.
-    assert parsed.raw == raw
-    # Check that there's nothing unparsable
-    typs = parsed.type_set()
-    assert "unparsable" not in typs
-
-
 @pytest.mark.integration_test
 @pytest.mark.parametrize("dialect,file", parse_success_examples)
 def test__dialect__base_broad_fix(dialect, file, raise_critical_errors_after_fix):

--- a/test/fixtures/dialects/ansi/with_nested_in_with_statement.sql
+++ b/test/fixtures/dialects/ansi/with_nested_in_with_statement.sql
@@ -1,5 +1,4 @@
-(
-    WITH mycte2 AS (
+(WITH mycte2 AS (
         WITH mycte1 AS (
             SELECT
                 foo,
@@ -17,5 +16,4 @@
         foo,
         bar,
         baz
-    FROM mycte2
-);
+    FROM mycte2);

--- a/test/fixtures/rules/std_rule_cases/L032.yml
+++ b/test/fixtures/rules/std_rule_cases/L032.yml
@@ -22,3 +22,28 @@ test_fail_specify_join_keys_1_with_multi_using:
 test_fail_specify_join_keys_2:
   desc: Keys were specified for first join but not the second one.
   fail_str: select x.a from x inner join y on x.id = y.id inner join z using (id)
+
+test_partial_fixed_up_to_2nd_join:
+  fail_str: |
+    select x.a 
+    from x 
+    inner join y using(id, foo)
+    inner join z using(id)
+  fix_str: |
+    select x.a 
+    from x 
+    inner join y ON x.id = y.id AND x.foo = y.foo
+    inner join z using(id)
+  violations_after_fix:
+    - description: Found USING statement. Expected only ON statements.
+      line_no: 4
+      line_pos: 14
+
+select_fail:
+  fail_str: |
+    SELECT *
+    FROM A_TABLE
+    INNER JOIN (
+        SELECT margin
+        FROM B_TABLE
+    ) USING (SOME_COLUMN)

--- a/test/fixtures/rules/std_rule_cases/L042.yml
+++ b/test/fixtures/rules/std_rule_cases/L042.yml
@@ -91,6 +91,24 @@ double_nested_unfixable_cte_clash:
       L042:
         forbid_subquery_in: both
 
+unfixable_cte_clash:
+  fail_str: |
+    with "b" as (
+      select x, z from p_cte
+    )
+    select
+        a.x, a.y, b.z
+    from a
+    join (
+      select x, z from (
+        select 1
+      ) as b
+    ) as c on (a.x = b.x)
+  configs:
+    rules:
+      L042:
+        forbid_subquery_in: both
+
 with_recursive_fail_no_fix:
   fail_str: |
     with recursive p_cte as (

--- a/test/fixtures/rules/std_rule_cases/L042.yml
+++ b/test/fixtures/rules/std_rule_cases/L042.yml
@@ -40,6 +40,29 @@ cte_select_fail:
     from a
     join b on (a.x = b.x)
 
+cte_with_clashing_name:
+  fail_str: |
+    with prep_1 as (
+      select 1 as x, 2 as z
+    )
+    select
+        a.x, a.y, z
+    from a
+    join (
+        select x, z from b
+    ) on a.x = z
+  fix_str: |
+    with prep_1 as (
+      select 1 as x, 2 as z
+    ),
+    prep_2 as (
+        select x, z from b
+    )
+    select
+        a.x, a.y, z
+    from a
+    join prep_2 on a.x = z
+
 double_nested_fail:
   fail_str: |
     with p_cte as (

--- a/test/fixtures/rules/std_rule_cases/L042.yml
+++ b/test/fixtures/rules/std_rule_cases/L042.yml
@@ -29,11 +29,11 @@ cte_select_fail:
         select x, z from b
     ) as b on (a.x = b.x)
   fix_str: |
-    with b as (
-        select x, z from b
-    ),
-    prep as (
+    with prep as (
       select 1 as x, 2 as z
+    ),
+    b as (
+        select x, z from b
     )
     select
         a.x, a.y, b.z
@@ -42,20 +42,30 @@ cte_select_fail:
 
 double_nested_fail:
   fail_str: |
+    with p_cte as (
+      select 1 as x, 2 as z
+      UNION ALL
+      select 1 as x, 2 as z
+    )
     select
         a.x, a.y, b.z
     from a
     join (
-        select x, z from (
-          select 1 as x, 2 as z
-        )
+      select x, z from (
+        select x, z from p_cte
+      ) as c
     ) as b on (a.x = b.x)
   fix_str: |
-    with prep_1 as (
+    with p_cte as (
+      select 1 as x, 2 as z
+      UNION ALL
       select 1 as x, 2 as z
     ),
+    c as (
+        select x, z from p_cte
+      ),
     b as (
-      select x, z from prep_1
+      select x, z from c
     )
     select
         a.x, a.y, b.z
@@ -65,6 +75,33 @@ double_nested_fail:
     rules:
       L042:
         forbid_subquery_in: both
+
+double_nested_unfixable_cte_clash:
+  fail_str: |
+    select
+        a.x, a.y, b.z
+    from a
+    join (
+      select x, z from (
+        select x, z from p_cte
+      ) as b
+    ) as b on (a.x = b.x)
+  configs:
+    rules:
+      L042:
+        forbid_subquery_in: both
+
+with_recursive_fail_no_fix:
+  fail_str: |
+    with recursive p_cte as (
+      select 1 from tbl_foo
+    )
+    select
+        a.x, a.y, b.z
+    from a
+    join (
+      select x, z from p_cte
+    ) as b on a.x = b.x
 
 select_multijoin_fail:
   fail_str: |

--- a/test/fixtures/rules/std_rule_cases/L042.yml
+++ b/test/fixtures/rules/std_rule_cases/L042.yml
@@ -7,17 +7,88 @@ select_fail:
     from a
     join (
         select x, z from b
-    ) on (a.x = b.x)
+    ) as b on (a.x = b.x)
+  fix_str: |
+    with b as (
+        select x, z from b
+    )
+    select
+        a.x, a.y, b.z
+    from a
+    join b on (a.x = b.x)
+
+cte_select_fail:
+  fail_str: |
+    with prep as (
+      select 1 as x, 2 as z
+    )
+    select
+        a.x, a.y, b.z
+    from a
+    join (
+        select x, z from b
+    ) as b on (a.x = b.x)
+  fix_str: |
+    with b as (
+        select x, z from b
+    ),
+    prep as (
+      select 1 as x, 2 as z
+    )
+    select
+        a.x, a.y, b.z
+    from a
+    join b on (a.x = b.x)
+
+double_nested_fail:
+  fail_str: |
+    select
+        a.x, a.y, b.z
+    from a
+    join (
+        select x, z from (
+          select 1 as x, 2 as z
+        )
+    ) as b on (a.x = b.x)
+  fix_str: |
+    with prep_1 as (
+      select 1 as x, 2 as z
+    ),
+    b as (
+      select x, z from prep_1
+    )
+    select
+        a.x, a.y, b.z
+    from a
+    join b on (a.x = b.x)
+  configs:
+    rules:
+      L042:
+        forbid_subquery_in: both
 
 select_multijoin_fail:
   fail_str: |
     select
         a.x, d.x as foo, a.y, b.z
-    from a
+    from (select a, x from foo) a
     join d using(x)
     join (
         select x, z from b
-    ) using (x)
+    ) as b using (x)
+  fix_str: |
+    with a as (select a, x from foo),
+    b as (
+        select x, z from b
+    )
+    select
+        a.x, d.x as foo, a.y, b.z
+    from a
+    join d using(x)
+    join b using (x)
+  configs:
+    rules:
+      L042:
+        forbid_subquery_in: both
 
 with_fail:
   fail_str: |
@@ -30,17 +101,38 @@ with_fail:
         )
         select * from d
     ) using (x)
-
-set_fail:
-  fail_str: |
+  fix_str: |
+    with prep_1 as (
+        with d as (
+            select x, z from b
+        )
+        select * from d
+    )
     select
         a.x, a.y, b.z
     from a
-    join (
+    join prep_1 using (x)
+
+set_fail:
+  fail_str: |
+    SELECT
+        a.x, a.y, b.z
+    FROM a
+    JOIN (
         select x, z from b
         union
         select x, z from d
-    ) using (x)
+    ) USING (x)
+  fix_str: |
+    WITH prep_1 AS (
+        select x, z from b
+        union
+        select x, z from d
+    )
+    SELECT
+        a.x, a.y, b.z
+    FROM a
+    JOIN prep_1 USING (x)
 
 simple_pass:
   pass_str: |
@@ -71,6 +163,13 @@ from_clause_fail:
     from (
         select * from b
     ) as a
+  fix_str: |
+    with a as (
+        select * from b
+    )
+    select
+        a.x, a.y
+    from a
   configs:
     rules:
       L042:
@@ -83,6 +182,13 @@ both_clause_fail:
     from (
         select * from b
     ) as a
+  fix_str: |
+    with a as (
+        select * from b
+    )
+    select
+        a.x, a.y
+    from a
   configs:
     rules:
       L042:


### PR DESCRIPTION
Fixes error noticed due to `L042`

```

CRITICAL   [L032] Applying rule L032 threw an Exception: not enough values to unpack (expected 2, got 1)                                                                                                

Traceback (most recent call last):

  File "/Users/bhart/dev/sqlfluff/src/sqlfluff/core/rules/base.py", line 535, in crawl

    res = self._eval(context=context)

  File "/Users/bhart/dev/sqlfluff/src/sqlfluff/rules/L032.py", line 101, in _eval

    table_a, table_b = select_info.table_aliases

ValueError: not enough values to unpack (expected 2, got 1)
```

An unnamed subquery produced no table_alias when performing select analysis leading to a run time error.

Fixed and added an improvement to the algo

- Old Algo: only fixes joins with a max of one other table
- new Algo: Fixes regardless of the number of joins but only the first joined table (where the join condition is clear)

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x]`.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.

