### PR TITLE
L032 bug fix and fix improvement

### DIFF
--- a/src/sqlfluff/rules/L032.py
+++ b/src/sqlfluff/rules/L032.py
@@ -82,9 +82,8 @@ class Rule_L032(BaseRule):
             sp.is_type("join_clause", "from_expression_element")
         )
 
-        # If we have more than 2 tables we won't try to fix join.
-        # TODO: if this is table 2 of 3 it is still fixable
-        if len(tables_in_join) > 2:
+        # We can only safely fix the first join clause
+        if segment.get(0) != tables_in_join.get(1):
             return unfixable_result
 
         parent_select = parent_stack.last(sp.is_type("select_statement")).get()
@@ -92,20 +91,19 @@ class Rule_L032(BaseRule):
             return unfixable_result
 
         select_info = get_select_statement_info(parent_select, context.dialect)
-        if not select_info:  # pragma: no cover
+        if not select_info or len(select_info.table_aliases) < 2:  # pragma: no cover
             return unfixable_result
 
-        to_delete, insert_after_anchor = _extract_deletion_sequence_and_anchor(
-            tables_in_join.last()
-        )
-        table_a, table_b = select_info.table_aliases
+        to_delete, insert_after_anchor = _extract_deletion_sequence_and_anchor(segment)
+
+        table_a, table_b = select_info.table_aliases[:2]
         edit_segments = [
             KeywordSegment(raw="ON"),
             WhitespaceSegment(raw=" "),
         ] + _generate_join_conditions(
             table_a.ref_str,
             table_b.ref_str,
-            select_info.using_cols,
+            _extract_cols_from_using(segment, using_anchor),
         )
 
         fixes = [
@@ -122,7 +120,20 @@ class Rule_L032(BaseRule):
         )
 
 
+def _extract_cols_from_using(join_clause: Segments, using_segs: Segments) -> List[str]:
+    # First bracket after the USING keyword, then find ids
+    using_cols: List[str] = (
+        join_clause.children()
+        .select(start_seg=using_segs[0], select_if=sp.is_type("bracketed"))
+        .first()
+        .children(sp.is_type("identifier"))
+        .apply(lambda el: el.raw)
+    )
+    return using_cols
+
+
 def _generate_join_conditions(table_a_ref: str, table_b_ref: str, columns: List[str]):
+    print(columns)
     edit_segments: List[BaseSegment] = []
     for col in columns:
         edit_segments = edit_segments + [

--- a/src/sqlfluff/rules/L032.py
+++ b/src/sqlfluff/rules/L032.py
@@ -133,7 +133,6 @@ def _extract_cols_from_using(join_clause: Segments, using_segs: Segments) -> Lis
 
 
 def _generate_join_conditions(table_a_ref: str, table_b_ref: str, columns: List[str]):
-    print(columns)
     edit_segments: List[BaseSegment] = []
     for col in columns:
         edit_segments = edit_segments + [

--- a/test/fixtures/rules/std_rule_cases/L032.yml
+++ b/test/fixtures/rules/std_rule_cases/L032.yml
@@ -22,3 +22,28 @@ test_fail_specify_join_keys_1_with_multi_using:
 test_fail_specify_join_keys_2:
   desc: Keys were specified for first join but not the second one.
   fail_str: select x.a from x inner join y on x.id = y.id inner join z using (id)
+
+test_partial_fixed_up_to_2nd_join:
+  fail_str: |
+    select x.a 
+    from x 
+    inner join y using(id, foo)
+    inner join z using(id)
+  fix_str: |
+    select x.a 
+    from x 
+    inner join y ON x.id = y.id AND x.foo = y.foo
+    inner join z using(id)
+  violations_after_fix:
+    - description: Found USING statement. Expected only ON statements.
+      line_no: 4
+      line_pos: 14
+
+select_using_fail:
+  fail_str: |
+    SELECT *
+    FROM A_TABLE
+    INNER JOIN (
+        SELECT margin
+        FROM B_TABLE
+    ) USING (SOME_COLUMN)


### PR DESCRIPTION
- L032 was failing on unaliased subqueries due to runtime error
- L032 now fixes up to the first join (rather than only where there is exactly one join)


### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.

