### PR TITLE
L009: Handle adding newline after `{% endif %}` at end of file

### DIFF
--- a/src/sqlfluff/core/linter/common.py
+++ b/src/sqlfluff/core/linter/common.py
@@ -67,21 +67,3 @@ class ParsedString(NamedTuple):
     config: FluffConfig
     fname: str
     source_str: str
-
-
-class EnrichedFixPatch(NamedTuple):
-    """An edit patch for a source file."""
-
-    source_slice: slice
-    templated_slice: slice
-    fixed_raw: str
-    # The patch category, functions mostly for debugging and explanation
-    # than for function. It allows traceability of *why* this patch was
-    # generated.
-    patch_category: str
-    templated_str: str
-    source_str: str
-
-    def dedupe_tuple(self):
-        """Generate a tuple of this fix for deduping."""
-        return (self.source_slice, self.fixed_raw)

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -286,7 +286,8 @@ class LintedFile(NamedTuple):
             linter_logger.debug("  %s Yielded patch: %s", idx, patch)
             self._log_hints(patch, self.templated_file)
 
-            # Attempt to convert to source space.
+            # Get source_slice if provided. Otherise, Attempt to convert from
+            # templated to source space.
             source_slice = getattr(patch, "source_slice", None)
             if source_slice is None:
                 try:

--- a/src/sqlfluff/core/parser/lexer.py
+++ b/src/sqlfluff/core/parser/lexer.py
@@ -535,9 +535,9 @@ class Lexer:
                 )
             )
 
-            # Handle any source-only slices that follow the last element. This can
-            # happen, for example, if a Jinja templated file ends with "{% endif %}",
-            # and there's no trailing newline.
+            # Generate placeholders for any source-only slices that *follow*
+            # the last element. This happens, for example, if a Jinja templated
+            # file ends with "{% endif %}", and there's no trailing newline.
             if idx == len(elements) - 1:
                 so_slices = [
                     so

--- a/src/sqlfluff/core/parser/lexer.py
+++ b/src/sqlfluff/core/parser/lexer.py
@@ -535,6 +535,31 @@ class Lexer:
                 )
             )
 
+            # Handle any source-only slices that follow the last element. This can
+            # happen, for example, if a Jinja templated file ends with "{% endif %}",
+            # and there's no trailing newline.
+            if idx == len(elements) - 1:
+                so_slices = [
+                    so
+                    for so in source_only_slices
+                    if so.source_idx >= source_slice.stop
+                ]
+                for so_slice in so_slices:
+                    segment_buffer.append(
+                        TemplateSegment(
+                            pos_marker=PositionMarker(
+                                slice(so_slice.source_idx, so_slice.end_source_idx()),
+                                slice(
+                                    element.template_slice.stop,
+                                    element.template_slice.stop,
+                                ),
+                                templated_file,
+                            ),
+                            source_str=so_slice.raw,
+                            block_type=so_slice.slice_type,
+                        )
+                    )
+
         # Convert to tuple before return
         return tuple(segment_buffer)
 

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -62,10 +62,18 @@ class FixPatch:
     # generated. It has no significance for processing.
     patch_category: str
 
-    def get_source_slice(self, templated_file: TemplatedFile):
-        """Attempt to convert from templated to source space."""
-        return templated_file.templated_slice_to_source_slice(
+    def enrich(self, templated_file: TemplatedFile) -> "EnrichedFixPatch":
+        """Convert patch to source space."""
+        source_slice = templated_file.templated_slice_to_source_slice(
             self.templated_slice,
+        )
+        return EnrichedFixPatch(
+            source_slice=source_slice,
+            templated_slice=self.templated_slice,
+            patch_category=self.patch_category,
+            fixed_raw=self.fixed_raw,
+            templated_str=templated_file.templated_str[self.templated_slice],
+            source_str=templated_file.source_str[source_slice],
         )
 
 
@@ -77,9 +85,9 @@ class EnrichedFixPatch(FixPatch):
     templated_str: str
     source_str: str
 
-    def get_source_slice(self, templated_file: TemplatedFile):
-        """Return source_slice. Base function for subclasses to override."""
-        return self.source_slice
+    def enrich(self, templated_file: TemplatedFile) -> "EnrichedFixPatch":
+        """No-op override of base class function."""
+        return self
 
     def dedupe_tuple(self):
         """Generate a tuple of this fix for deduping."""

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -20,7 +20,6 @@ from typing import (
     Optional,
     List,
     Tuple,
-    NamedTuple,
     Iterator,
     Union,
 )
@@ -46,12 +45,14 @@ from sqlfluff.core.parser.helpers import (
 from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.markers import PositionMarker
 from sqlfluff.core.parser.context import ParseContext
+from sqlfluff.core.templaters.base import TemplatedFile
 
 # Instantiate the linter logger (only for use in methods involved with fixing.)
 linter_logger = logging.getLogger("sqlfluff.linter")
 
 
-class FixPatch(NamedTuple):
+@dataclass
+class FixPatch:
     """An edit patch for a templated file."""
 
     templated_slice: slice
@@ -61,19 +62,24 @@ class FixPatch(NamedTuple):
     # generated. It has no significance for processing.
     patch_category: str
 
+    def get_source_slice(self, templated_file: TemplatedFile):
+        """Attempt to convert from templated to source space."""
+        return templated_file.templated_slice_to_source_slice(
+            self.templated_slice,
+        )
 
-class EnrichedFixPatch(NamedTuple):
+
+@dataclass
+class EnrichedFixPatch(FixPatch):
     """An edit patch for a source file."""
 
     source_slice: slice
-    templated_slice: slice
-    fixed_raw: str
-    # The patch category, functions mostly for debugging and explanation
-    # than for function. It allows traceability of *why* this patch was
-    # generated.
-    patch_category: str
     templated_str: str
     source_str: str
+
+    def get_source_slice(self, templated_file: TemplatedFile):
+        """Return source_slice. Base function for subclasses to override."""
+        return self.source_slice
 
     def dedupe_tuple(self):
         """Generate a tuple of this fix for deduping."""
@@ -1205,7 +1211,7 @@ class BaseSegment:
         linter_logger.critical(message, *args)
 
     def iter_patches(
-        self, templated_str: str
+        self, templated_file: TemplatedFile
     ) -> Iterator[Union[EnrichedFixPatch, FixPatch]]:
         """Iterate through the segments generating fix patches.
 
@@ -1218,6 +1224,7 @@ class BaseSegment:
         """
         # Does it match? If so we can ignore it.
         assert self.pos_marker
+        templated_str = templated_file.templated_str
         matches = self.raw == templated_str[self.pos_marker.templated_slice]
         if matches:
             return
@@ -1286,7 +1293,7 @@ class BaseSegment:
                     insert_buff = ""
 
                 # Now we deal with any changes *within* the segment itself.
-                yield from segment.iter_patches(templated_str=templated_str)
+                yield from segment.iter_patches(templated_file=templated_file)
 
                 # Once we've dealt with any patches from the segment, update
                 # our position markers.
@@ -1304,17 +1311,14 @@ class BaseSegment:
                 # By returning an EnrichedFixPatch (rather than FixPatch), which
                 # includes a source_slice field, we ensure that fixes adjacent
                 # to source-only slices (e.g. {% endif %}) are placed
-                # appropriately relative to source-only slices..
+                # appropriately relative to source-only slices.
                 yield EnrichedFixPatch(
                     source_slice=source_slice,
                     templated_slice=templated_slice,
                     patch_category="end_point",
                     fixed_raw=insert_buff,
-                    # TODO: We could provide templated_str and source_str if we
-                    # had access to the TemplatedFile -- just use the slices
-                    # above.
-                    templated_str="",
-                    source_str="",
+                    templated_str=templated_file.templated_str[templated_slice],
+                    source_str=templated_file.source_str[source_slice],
                 )
 
     def edit(self, raw):

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1301,6 +1301,10 @@ class BaseSegment:
                     self.pos_marker.templated_slice.stop - end_diff,
                     self.pos_marker.templated_slice.stop,
                 )
+                # By returning an EnrichedFixPatch (rather than FixPatch), which
+                # includes a source_slice field, we ensure that fixes adjacent
+                # to source-only slices (e.g. {% endif %}) are placed
+                # appropriately relative to source-only slices..
                 yield EnrichedFixPatch(
                     source_slice=source_slice,
                     templated_slice=templated_slice,

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1250,6 +1250,7 @@ class BaseSegment:
             templated_idx = self.pos_marker.templated_slice.start
             insert_buff = ""
             for seg_idx, segment in enumerate(self.segments):
+
                 # First check for insertions.
                 # We know it's an insertion if it has length but not in the templated
                 # file.

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -656,7 +656,7 @@ class BaseRule:
         space = " "
         return space * self.tab_space_size if self.indent_unit == "space" else tab
 
-    def is_final_segment(self, context: RuleContext, filter_meta=True) -> bool:
+    def is_final_segment(self, context: RuleContext, filter_meta: bool = True) -> bool:
         """Is the current segment the final segment in the parse tree."""
         siblings_post = context.siblings_post
         if filter_meta:

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -656,16 +656,18 @@ class BaseRule:
         space = " "
         return space * self.tab_space_size if self.indent_unit == "space" else tab
 
-    def is_final_segment(self, context: RuleContext) -> bool:
+    def is_final_segment(self, context: RuleContext, filter_meta=True) -> bool:
         """Is the current segment the final segment in the parse tree."""
-        if len(self.filter_meta(context.siblings_post)) > 0:
+        siblings_post = context.siblings_post
+        if filter_meta:
+            siblings_post = self.filter_meta(siblings_post)
+        if len(siblings_post) > 0:
             # This can only fail on the last segment
             return False
         elif len(context.segment.segments) > 0:
             # This can only fail on the last base segment
             return False
-        elif context.segment.is_meta:
-            # We can't fail on a meta segment
+        elif filter_meta and context.segment.is_meta:
             return False
         else:
             # We know we are at a leaf of the tree but not necessarily at the end of the
@@ -674,9 +676,9 @@ class BaseRule:
             # one.
             child_segment = context.segment
             for parent_segment in context.parent_stack[::-1]:
-                possible_children = [
-                    s for s in parent_segment.segments if not s.is_meta
-                ]
+                possible_children = parent_segment.segments
+                if filter_meta:
+                    possible_children = [s for s in possible_children if not s.is_meta]
                 if len(possible_children) > possible_children.index(child_segment) + 1:
                     return False
                 child_segment = parent_segment

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -289,7 +289,6 @@ class JinjaTracer:
             # parts of the tag at a time.
             unique_alternate_id = None
             alternate_code = None
-            trimmed_content = ""
             if elem_type.endswith("_end") or elem_type == "raw_begin":
                 block_type = block_types[elem_type]
                 block_subtype = None
@@ -436,6 +435,13 @@ class JinjaTracer:
                     "endfor",
                     "endif",
                 ):
+                    # Replace RawSliceInfo for this slice with one that has
+                    # alternate ID and code for tracking.
+                    unique_alternate_id = self.next_slice_id()
+                    alternate_code = f"{result[-1].raw}\0{unique_alternate_id}_0"
+                    self.raw_slice_info[result[-1]] = RawSliceInfo(
+                        unique_alternate_id, alternate_code, []
+                    )
                     # Record potential forward jump over this block.
                     self.raw_slice_info[result[stack[-1]]].next_slice_indices.append(
                         block_idx

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -436,7 +436,10 @@ class JinjaTracer:
                     "endif",
                 ):
                     # Replace RawSliceInfo for this slice with one that has
-                    # alternate ID and code for tracking.
+                    # alternate ID and code for tracking. This ensures, for
+                    # instance, that if a file ends with "{% endif %} (with
+                    # no newline following), that we still generate a
+                    # TemplateSliceInfo for it.
                     unique_alternate_id = self.next_slice_id()
                     alternate_code = f"{result[-1].raw}\0{unique_alternate_id}_0"
                     self.raw_slice_info[result[-1]] = RawSliceInfo(

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -91,7 +91,7 @@ class Rule_L009(BaseRule):
 
         """
         # We only care about the final segment of the parse tree.
-        if not self.is_final_segment(context):
+        if not self.is_final_segment(context, filter_meta=False):
             return None
 
         # Include current segment for complete stack and reverse.

--- a/test/api/simple_test.py
+++ b/test/api/simple_test.py
@@ -72,16 +72,16 @@ lint_result = [
         "description": "Keywords must be consistently upper case.",
     },
     {
-        "code": "L009",
-        "line_no": 1,
-        "line_pos": 34,
-        "description": "Files must end with a single trailing newline.",
-    },
-    {
         "code": "L014",
         "line_no": 1,
         "line_pos": 34,
         "description": "Unquoted identifiers must be consistently lower case.",
+    },
+    {
+        "code": "L009",
+        "line_no": 1,
+        "line_pos": 41,
+        "description": "Files must end with a single trailing newline.",
     },
 ]
 

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -822,6 +822,10 @@ SELECT
                 ("block_end", slice(113, 127, None), slice(11, 11, None)),
                 ("block_start", slice(27, 46, None), slice(11, 11, None)),
                 ("literal", slice(46, 57, None), slice(11, 22, None)),
+                ("block_end", slice(57, 70, None), slice(22, 22, None)),
+                ("block_start", slice(70, 89, None), slice(22, 22, None)),
+                ("block_end", slice(100, 113, None), slice(22, 22, None)),
+                ("block_end", slice(113, 127, None), slice(22, 22, None)),
             ],
         ),
         (
@@ -910,8 +914,20 @@ FROM SOME_TABLE
                 ("literal", slice(91, 92, None), slice(0, 0, None)),
                 ("block_end", slice(92, 104, None), slice(0, 0, None)),
                 ("literal", slice(104, 113, None), slice(0, 9, None)),
-                ("templated", slice(113, 139, None), slice(9, 29, None)),
-                ("literal", slice(139, 156, None), slice(29, 46, None)),
+                ("templated", slice(113, 139, None), slice(9, 28, None)),
+                ("literal", slice(139, 156, None), slice(28, 28, None)),
+            ],
+        ),
+        (
+            # Test for issue 2822: Handle slicing when there's no newline after
+            # the Jinja block end.
+            "{% if true %}\nSELECT 1 + 1\n{%- endif %}",
+            None,
+            [
+                ("block_start", slice(0, 13, None), slice(0, 0, None)),
+                ("literal", slice(13, 26, None), slice(0, 13, None)),
+                ("literal", slice(26, 27, None), slice(13, 13, None)),
+                ("block_end", slice(27, 39, None), slice(13, 13, None)),
             ],
         ),
     ],

--- a/test/fixtures/rules/std_rule_cases/L009.yml
+++ b/test/fixtures/rules/std_rule_cases/L009.yml
@@ -33,3 +33,9 @@ test_pass_templated_macro_newlines:
       {{ columns }}
     {% endmacro %}
     SELECT {{ get_keyed_nulls("other_id") }}
+
+test_fail_templated_no_newline:
+  # Tricky because there's no newline at the end of the file (following the
+  # templated code).
+  fail_str: "{% if true %}\nSELECT 1 + 1\n{%- endif %}"
+  fix_str: "{% if true %}\nSELECT 1 + 1\n{%- endif %}\n"


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #2822

OMG, this is the deepest bug I've seen in a long time. Fixing it has required changes to:
* Core lexer (placeholder generation)
* Core parser: How BaseSegment generates patches
* Core linter (patch application)
* Updating `JinjaTracer` with better handling of `{% endif %}` and `{% endfor %}`
* Updating `is_final_segment()` to optionally consider meta segments and updating L009 to use it

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
