### PR TITLE
Add Markerr to list of organizations using SQLFluff in the wild 

### DIFF
--- a/docs/source/inthewild.rst
+++ b/docs/source/inthewild.rst
@@ -54,3 +54,6 @@ Just add a section below by raising a PR on GitHub by
   contributed by Greg Clunies, with annotations on pull requests to make it
   easy for contributors to see where their SQL has failed any rules. See an
   `example pull request with SQLFluff annotations <https://github.com/brooklyn-data/dbt_artifacts/pull/74/files>`_.
+- `Markerr <https://www.markerr.com>`_ has tightly integrated SQLFluff into our CI/CD process for data model changes 
+   and process improvements. Since adopting SQLFluff across the organization, the clarity of our SQL code has risen dramatically, 
+   freeing up review time to focus on deeper data- and process-specific questions.

--- a/docs/source/inthewild.rst
+++ b/docs/source/inthewild.rst
@@ -54,6 +54,8 @@ Just add a section below by raising a PR on GitHub by
   contributed by Greg Clunies, with annotations on pull requests to make it
   easy for contributors to see where their SQL has failed any rules. See an
   `example pull request with SQLFluff annotations <https://github.com/brooklyn-data/dbt_artifacts/pull/74/files>`_.
-- `Markerr <https://www.markerr.com>`_ has tightly integrated SQLFluff into our CI/CD process for data model changes 
-   and process improvements. Since adopting SQLFluff across the organization, the clarity of our SQL code has risen dramatically, 
-   freeing up review time to focus on deeper data- and process-specific questions.
+- `Markerr <https://www.markerr.com>`_ has tightly integrated SQLFluff into our
+  CI/CD process for data model changes and process improvements. Since adopting
+  SQLFluff across the organization, the clarity of our SQL code has risen
+  dramatically, freeing up review time to focus on deeper data and
+  process-specific questions.


### PR DESCRIPTION
_Reopening because I accidentally deleted the forked repo._

### Brief summary of the change made
The maintainers have done an amazing job responding to issues that our team has noticed with SQLFluff so I figured I would pay it forward by adding some praise to the tool's docs. (I actually had to shorten this description a lot -- we love the tool and it gets better with every release!)

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
