### PR TITLE
BigQuery: Better `STRUCT` Array Support

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -206,6 +206,11 @@ bigquery_dialect.replace(
     ),
     NaturalJoinKeywords=Nothing(),
     MergeIntoLiteralGrammar=Sequence("MERGE", Ref.keyword("INTO", optional=True)),
+    Accessor_Grammar=AnyNumberOf(
+        Ref("ArrayAccessorSegment"),
+        # Add in semi structured expressions
+        Ref("SemiStructuredAccessorSegment"),
+    ),
 )
 
 
@@ -463,21 +468,9 @@ class FunctionSegment(BaseSegment):
                     )
                 ),
             ),
-            # Functions returning ARRYS in BigQuery can have optional
-            # OFFSET or ORDINAL clauses
-            Sequence(
-                Bracketed(
-                    OneOf(
-                        "OFFSET",
-                        "ORDINAL",
-                    ),
-                    Bracketed(
-                        Ref("NumericLiteralSegment"),
-                    ),
-                    bracket_type="square",
-                ),
-                optional=True,
-            ),
+            # Functions returning ARRAYS in BigQuery can have optional
+            # Array Accessor clauses
+            Ref("ArrayAccessorSegment", optional=True),
             # Functions returning STRUCTs in BigQuery can have the fields
             # elements referenced (e.g. ".a"), including wildcards (e.g. ".*")
             # or multiple nested fields (e.g. ".a.b", or ".a.b.c")
@@ -721,6 +714,28 @@ class LiteralCoercionSegment(BaseSegment):
 # get a reference to the ANSI ObjectReferenceSegment this way so we can inherit
 # from it.
 ObjectReferenceSegment = ansi_dialect.get_segment("ObjectReferenceSegment")
+
+
+@bigquery_dialect.segment()
+class SemiStructuredAccessorSegment(BaseSegment):
+    """A semi-structured data accessor segment."""
+
+    type = "semi_structured_expression"
+    match_grammar = Sequence(
+        Ref("DotSegment"),
+        Ref("SingleIdentifierGrammar"),
+        Ref("ArrayAccessorSegment", optional=True),
+        AnyNumberOf(
+            Sequence(
+                Ref("DotSegment"),
+                Ref("SingleIdentifierGrammar"),
+                allow_gaps=True,
+            ),
+            Ref("ArrayAccessorSegment", optional=True),
+            allow_gaps=True,
+        ),
+        allow_gaps=True,
+    )
 
 
 @bigquery_dialect.segment(replace=True)

--- a/test/fixtures/dialects/bigquery/select_function_object_fields.sql
+++ b/test/fixtures/dialects/bigquery/select_function_object_fields.sql
@@ -4,5 +4,7 @@ SELECT
   testFunction(a).b.c AS field_with_field,
   testFunction(a).b.* AS field_with_wildcard,
   testFunction(a)[OFFSET(0)].* AS field_with_offset_wildcard,
-  testFunction(a)[ORDINAL(1)].* AS field_with_ordinal_wildcard
+  testFunction(a)[SAFE_OFFSET(0)].* AS field_with_safe_offset_wildcard,
+  testFunction(a)[ORDINAL(1)].* AS field_with_ordinal_wildcard,
+  testFunction(a)[ORDINAL(1)].a AS field_with_ordinal_field
 FROM table1

--- a/test/fixtures/dialects/bigquery/select_function_object_fields.yml
+++ b/test/fixtures/dialects/bigquery/select_function_object_fields.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4778c8399c5a81295beeb012658e4bb670224d00c385f76b4288844c041c2625
+_hash: 180e33bf259724317583dab3e78b19c1f51ed36022b5309a35e1bc0c4f58eb8c
 file:
   statement:
     select_statement:
@@ -79,49 +79,115 @@ file:
       - comma: ','
       - select_clause_element:
           function:
-          - function_name:
+            function_name:
               function_name_identifier: testFunction
-          - bracketed:
+            bracketed:
               start_bracket: (
               expression:
                 column_reference:
                   identifier: a
               end_bracket: )
-          - start_square_bracket: '['
-          - keyword: OFFSET
-          - bracketed:
-              start_bracket: (
-              literal: '0'
-              end_bracket: )
-          - end_square_bracket: ']'
-          - dot: .
-          - star: '*'
+            array_accessor:
+              start_square_bracket: '['
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: OFFSET
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      literal: '0'
+                    end_bracket: )
+              end_square_bracket: ']'
+            dot: .
+            star: '*'
           alias_expression:
             keyword: AS
             identifier: field_with_offset_wildcard
       - comma: ','
       - select_clause_element:
           function:
-          - function_name:
+            function_name:
               function_name_identifier: testFunction
-          - bracketed:
+            bracketed:
               start_bracket: (
               expression:
                 column_reference:
                   identifier: a
               end_bracket: )
-          - start_square_bracket: '['
-          - keyword: ORDINAL
-          - bracketed:
+            array_accessor:
+              start_square_bracket: '['
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: SAFE_OFFSET
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      literal: '0'
+                    end_bracket: )
+              end_square_bracket: ']'
+            dot: .
+            star: '*'
+          alias_expression:
+            keyword: AS
+            identifier: field_with_safe_offset_wildcard
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: testFunction
+            bracketed:
               start_bracket: (
-              literal: '1'
+              expression:
+                column_reference:
+                  identifier: a
               end_bracket: )
-          - end_square_bracket: ']'
-          - dot: .
-          - star: '*'
+            array_accessor:
+              start_square_bracket: '['
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: ORDINAL
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      literal: '1'
+                    end_bracket: )
+              end_square_bracket: ']'
+            dot: .
+            star: '*'
           alias_expression:
             keyword: AS
             identifier: field_with_ordinal_wildcard
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: testFunction
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: a
+              end_bracket: )
+            array_accessor:
+              start_square_bracket: '['
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: ORDINAL
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      literal: '1'
+                    end_bracket: )
+              end_square_bracket: ']'
+            dot: .
+            parameter: a
+          alias_expression:
+            keyword: AS
+            identifier: field_with_ordinal_field
       from_clause:
         keyword: FROM
         from_expression:

--- a/test/fixtures/dialects/bigquery/select_mixture_of_array_literals.sql
+++ b/test/fixtures/dialects/bigquery/select_mixture_of_array_literals.sql
@@ -11,4 +11,5 @@ SELECT
     ARRAY<string>['b'] AS strcol2,
     [1.0] AS numcol1,
     ARRAY<NUMERIC>[1.4] AS numcol2,
-    [STRUCT("Rudisha" AS name, [23.4, 26.3, 26.4, 26.1] AS splits)] AS struct1
+    [STRUCT("Rudisha" AS name, [23.4, 26.3, 26.4, 26.1] AS splits)] AS struct1,
+    col1.obj1[safe_offset(1)].a AS struct_safe_offset

--- a/test/fixtures/dialects/bigquery/select_mixture_of_array_literals.yml
+++ b/test/fixtures/dialects/bigquery/select_mixture_of_array_literals.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: df03b8df0f299cc91c3c77702151611d8060a88043ceb0b4d1da19c62185218d
+_hash: 19fbec07f08aad273d0e46f92f426e3d90cd51654588e1747070639a26787256
 file:
   statement:
     select_statement:
@@ -127,3 +127,28 @@ file:
           alias_expression:
             keyword: AS
             identifier: struct1
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+            - identifier: col1
+            - dot: .
+            - identifier: obj1
+            array_accessor:
+              start_square_bracket: '['
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: safe_offset
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      literal: '1'
+                    end_bracket: )
+              end_square_bracket: ']'
+            semi_structured_expression:
+              dot: .
+              identifier: a
+          alias_expression:
+            keyword: AS
+            identifier: struct_safe_offset


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #2876

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
