### PR TITLE
Disable L031 on BigQuery due to complex backtick / project name behavior

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -118,6 +118,11 @@ extended_capitalisation_policy = consistent
 # Comma separated list of words to ignore for this rule
 ignore_words = None
 
+[sqlfluff:rules:L031]
+# Avoid table aliases in from clauses and join conditions.
+# Disabled for some dialects (e.g. bigquery)
+force_enable = False
+
 [sqlfluff:rules:L038]
 # Trailing commas
 select_clause_trailing_comma = forbid

--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -85,6 +85,9 @@ class Rule_L031(BaseRule):
         Find base table, table expressions in join, and other expressions in select
         clause and decide if it's needed to report them.
         """
+        # Config type hints
+        self.force_enable: bool
+
         # Issue 2810: BigQuery has some tricky expectations (apparently not
         # documented, but subject to change, e.g.:
         # https://www.reddit.com/r/bigquery/comments/fgk31y/new_in_bigquery_no_more_backticks_around_table/)
@@ -94,9 +97,6 @@ class Rule_L031(BaseRule):
         # to BigQuery when it is looking at the query, it would be complex for
         # this rule to do the right thing. For now, the rule simply disables
         # itself.
-        # Config type hints
-        self.force_enable: bool
-
         if (
             context.dialect.name in self._dialects_disabled_by_default
             and not self.force_enable

--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -97,7 +97,10 @@ class Rule_L031(BaseRule):
         # Config type hints
         self.force_enable: bool
 
-        if context.dialect.name in self. _dialects_disabled_by_default  and not self.force_enable:
+        if (
+            context.dialect.name in self._dialects_disabled_by_default
+            and not self.force_enable
+        ):
             return LintResult()
 
         if context.segment.is_type("select_statement"):

--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -33,6 +33,12 @@ class Rule_L031(BaseRule):
        This rule is controversial and for many larger databases avoiding alias is
        neither realistic nor desirable. In this case this rule should be disabled.
 
+    .. note::
+       This rule is disabled by default for BigQuery due to the complexity of
+       backtick requirements and determining whether a name refers to a project
+       or dataset, and automated fixes can potentially break working SQL code..
+       It can be enabled with the ``force_enable = True`` flag.
+
     **Anti-pattern**
 
     In this example, alias ``o`` is used for the orders table, and ``c`` is used for
@@ -71,6 +77,8 @@ class Rule_L031(BaseRule):
 
     """
 
+    config_keywords = ["force_enable"]
+
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Identify aliases in from clause and join conditions.
 
@@ -86,7 +94,10 @@ class Rule_L031(BaseRule):
         # to BigQuery when it is looking at the query, it would be complex for
         # this rule to do the right thing. For now, the rule simply disables
         # itself.
-        if context.dialect.name == "bigquery":
+        # Config type hints
+        self.force_enable: bool
+
+        if context.dialect.name in ["bigquery"] and not self.force_enable:
             return LintResult()
 
         if context.segment.is_type("select_statement"):

--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -33,7 +33,6 @@ class Rule_L031(BaseRule):
        This rule is controversial and for many larger databases avoiding alias is
        neither realistic nor desirable. In this case this rule should be disabled.
 
-    .. note::
        This rule is disabled by default for BigQuery due to the complexity of
        backtick requirements and determining whether a name refers to a project
        or dataset, and automated fixes can potentially break working SQL code..

--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -5,7 +5,11 @@ from typing import Generator, NamedTuple, Optional
 
 from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import (
+    document_configuration,
+    document_fix_compatible,
+)
+
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
 
@@ -19,6 +23,7 @@ class TableAliasInfo(NamedTuple):
 
 
 @document_fix_compatible
+@document_configuration
 class Rule_L031(BaseRule):
     """Avoid table aliases in from clauses and join conditions.
 

--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -77,6 +77,7 @@ class Rule_L031(BaseRule):
     """
 
     config_keywords = ["force_enable"]
+    _dialects_disabled_by_default = ["bigquery"]
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Identify aliases in from clause and join conditions.
@@ -96,7 +97,7 @@ class Rule_L031(BaseRule):
         # Config type hints
         self.force_enable: bool
 
-        if context.dialect.name in ["bigquery"] and not self.force_enable:
+        if context.dialect.name in self. _dialects_disabled_by_default  and not self.force_enable:
             return LintResult()
 
         if context.segment.is_type("select_statement"):

--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -77,6 +77,18 @@ class Rule_L031(BaseRule):
         Find base table, table expressions in join, and other expressions in select
         clause and decide if it's needed to report them.
         """
+        # Issue 2810: BigQuery has some tricky expectations (apparently not
+        # documented, but subject to change, e.g.:
+        # https://www.reddit.com/r/bigquery/comments/fgk31y/new_in_bigquery_no_more_backticks_around_table/)
+        # about whether backticks are required (and whether the query is valid
+        # or not, even with them), depending on whether the GCP project name is
+        # present, or just the dataset name. Since SQLFluff doesn't have access
+        # to BigQuery when it is looking at the query, it would be complex for
+        # this rule to do the right thing. For now, the rule simply disables
+        # itself.
+        if context.dialect.name == "bigquery":
+            return LintResult()
+
         if context.segment.is_type("select_statement"):
             children = context.functional.segment.children()
             from_clause_segment = children.select(sp.is_type("from_clause")).first()

--- a/test/fixtures/rules/std_rule_cases/L031.yml
+++ b/test/fixtures/rules/std_rule_cases/L031.yml
@@ -206,3 +206,11 @@ test_fail_no_copy_code_out_of_template:
       jinja:
         context:
           source_table: foobar
+
+test_bigquery_skip_multipart_names:
+  pass_str: |
+    SELECT t.col1
+    FROM shema1.table1 AS t
+  configs:
+    core:
+      dialect: bigquery

--- a/test/fixtures/rules/std_rule_cases/L031.yml
+++ b/test/fixtures/rules/std_rule_cases/L031.yml
@@ -214,3 +214,21 @@ test_bigquery_skip_multipart_names:
   configs:
     core:
       dialect: bigquery
+
+test_bigquery_force_enable:
+  fail_str: |
+    SELECT t.col1
+    FROM schema1.table1 AS t
+  # TRICKY: The fix_str does not parse in the real BigQuery, due to backtick
+  # requirements. That's why the rule is disabled by default.
+  # TODO (low priority): Update this test to test for a case where the rule
+  # produces valid SQL.
+  fix_str: |
+    SELECT schema1.table1.col1
+    FROM schema1.table1
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L031:
+        force_enable: true


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #2810

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
