### PR TITLE
Row typecasting in hive `cast` function

### DIFF
--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -667,7 +667,6 @@ class FunctionSegment(BaseSegment):
                     ),
                 ),
             ),
-            ),
             "AS",
             "ROW",
             Bracketed(

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -656,16 +656,17 @@ class FunctionSegment(BaseSegment):
             ),
         ),
         Sequence(
-            Sequence(
-                "ROW",
-                Bracketed(
-                    Delimited(
-                        Sequence(
-                            Ref("BaseExpressionElementGrammar"),
-                            Ref("DatatypeIdentifierSegment", optional=True),
-                        ),
+            # This unusual syntax is used to cast the Keyword ROW to
+            # to the function_name to avoid rule linting exceptions
+            StringParser("ROW", KeywordSegment, type="function_name"),
+            Bracketed(
+                Delimited(
+                    Sequence(
+                        Ref("BaseExpressionElementGrammar"),
+                        Ref("DatatypeIdentifierSegment", optional=True),
                     ),
                 ),
+            ),
             ),
             "AS",
             "ROW",

--- a/test/fixtures/dialects/hive/select_cast.sql
+++ b/test/fixtures/dialects/hive/select_cast.sql
@@ -1,0 +1,2 @@
+select cast(row(val1, val2) as row(a bigint, b varchar))
+from sch.tbl;

--- a/test/fixtures/dialects/hive/select_cast.yml
+++ b/test/fixtures/dialects/hive/select_cast.yml
@@ -1,0 +1,51 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 4712a1509ee6f7e2e83bb0ea3002113be4251a91a5603ea79ec917bc462acedf
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: cast
+            bracketed:
+              start_bracket: (
+              expression:
+                function:
+                - keyword: row
+                - bracketed:
+                  - start_bracket: (
+                  - column_reference:
+                      identifier: val1
+                  - comma: ','
+                  - column_reference:
+                      identifier: val2
+                  - end_bracket: )
+                - keyword: as
+                - keyword: row
+                - bracketed:
+                  - start_bracket: (
+                  - column_reference:
+                      identifier: a
+                  - data_type_identifier: bigint
+                  - comma: ','
+                  - column_reference:
+                      identifier: b
+                  - data_type_identifier: varchar
+                  - end_bracket: )
+              end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: sch
+              - dot: .
+              - identifier: tbl
+  statement_terminator: ;

--- a/test/fixtures/dialects/hive/select_cast.yml
+++ b/test/fixtures/dialects/hive/select_cast.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4712a1509ee6f7e2e83bb0ea3002113be4251a91a5603ea79ec917bc462acedf
+_hash: 82dd3fc29c1afdd02da8e86c0ba2b484b59b9f98629ab7aa2386075cc0c4324f
 file:
   statement:
     select_statement:
@@ -17,7 +17,7 @@ file:
               start_bracket: (
               expression:
                 function:
-                - keyword: row
+                - function_name: row
                 - bracketed:
                   - start_bracket: (
                   - column_reference:


### PR DESCRIPTION
### Brief summary of the change made
Extended version of ansi's `FunctionSegment` to add support of row typecasting
```
cast(row(val1, val2) as row(a integer, b integer))
```