### PR TITLE
Hive: fix to align with L027 rule (rowtype attribute name)

### DIFF
--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -695,7 +695,7 @@ class FunctionSegment(BaseSegment):
             Bracketed(
                 Delimited(
                     Sequence(
-                        Ref("BaseExpressionElementGrammar"),
+                        Ref("SingleIdentifierGrammar"),
                         Ref("DatatypeIdentifierSegment", optional=True),
                     ),
                 ),

--- a/test/fixtures/dialects/hive/select_cast.yml
+++ b/test/fixtures/dialects/hive/select_cast.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 82dd3fc29c1afdd02da8e86c0ba2b484b59b9f98629ab7aa2386075cc0c4324f
+_hash: a84e5136fdafc2664bfee64e48d7a0b4ee19f41d495a1ecd389bd1f723313233
 file:
   statement:
     select_statement:
@@ -30,12 +30,10 @@ file:
                 - keyword: row
                 - bracketed:
                   - start_bracket: (
-                  - column_reference:
-                      identifier: a
+                  - identifier: a
                   - data_type_identifier: bigint
                   - comma: ','
-                  - column_reference:
-                      identifier: b
+                  - identifier: b
                   - data_type_identifier: varchar
                   - end_bracket: )
               end_bracket: )

--- a/test/fixtures/rules/std_rule_cases/L027.yml
+++ b/test/fixtures/rules/std_rule_cases/L027.yml
@@ -208,3 +208,15 @@ test_pass_column_and_alias_same_name_2_tsql:
   configs:
     core:
       dialect: tsql
+
+test_pass_rowtype_with_join:
+  # Wrongly interpret rowtype attributes as field alias
+  # when more than one tables in join
+  pass_str: |
+    select
+        cast(row(t1.attr, t2.attr) as row(fld1 double, fld2 double)) as flds
+    from sch.tab1 as t1
+    join sch.tab2 as t2 on t2.id = t1.id
+  configs:
+    core:
+      dialect: hive

--- a/test/fixtures/rules/std_rule_cases/L027.yml
+++ b/test/fixtures/rules/std_rule_cases/L027.yml
@@ -210,8 +210,8 @@ test_pass_column_and_alias_same_name_2_tsql:
       dialect: tsql
 
 test_pass_rowtype_with_join:
-  # Wrongly interpret rowtype attributes as field alias
-  # when more than one tables in join
+  # Check we don't wrongly interpret rowtype attributes
+  # as field alias when more than one tables in join
   pass_str: |
     select
         cast(row(t1.attr, t2.attr) as row(fld1 double, fld2 double)) as flds


### PR DESCRIPTION
In `Hive` dialect there is a false positive violation detected in `rowtype` definition when query/subquery operates with join
```sql
select cast(row(t1.attr, t2.attr) as row(fld1 double, fld2 double)) as flds
from sch.tab1 as t1
join sch.tab2 as t2 on t2.id = t1.id
```
`fld1`, `fld2` interpret as table column alias rather than rowtype attribute name