### PR TITLE
Hive: added `json` type support

### DIFF
--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -307,6 +307,7 @@ class PrimitiveTypeSegment(BaseSegment):
         "DATE",
         "VARCHAR",
         "CHAR",
+        "JSON",
     )
 
 

--- a/test/fixtures/dialects/hive/select_cast.sql
+++ b/test/fixtures/dialects/hive/select_cast.sql
@@ -1,2 +1,5 @@
 select cast(row(val1, val2) as row(a bigint, b varchar))
 from sch.tbl;
+
+select cast(a as json)
+from sch.tbl;

--- a/test/fixtures/dialects/hive/select_cast.yml
+++ b/test/fixtures/dialects/hive/select_cast.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 82dd3fc29c1afdd02da8e86c0ba2b484b59b9f98629ab7aa2386075cc0c4324f
+_hash: ac0fc29642c92d4dee1e9a2048442c4e8229cc5ab7c085a66dd06a163fc940b7
 file:
-  statement:
+- statement:
     select_statement:
       select_clause:
         keyword: select
@@ -48,4 +48,32 @@ file:
               - identifier: sch
               - dot: .
               - identifier: tbl
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: cast
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: a
+              keyword: as
+              data_type:
+                primitive_type:
+                  keyword: json
+              end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: sch
+              - dot: .
+              - identifier: tbl
+- statement_terminator: ;


### PR DESCRIPTION
Extended primitive datatypes in `Hive` for `json`