### PR TITLE
Hive: support for complex types in `cast` `rowtype` definition

### DIFF
--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -687,7 +687,6 @@ class FunctionSegment(BaseSegment):
                 Delimited(
                     Sequence(
                         Ref("BaseExpressionElementGrammar"),
-                        Ref("DatatypeIdentifierSegment", optional=True),
                     ),
                 ),
             ),
@@ -697,7 +696,7 @@ class FunctionSegment(BaseSegment):
                 Delimited(
                     Sequence(
                         Ref("SingleIdentifierGrammar"),
-                        Ref("DatatypeIdentifierSegment", optional=True),
+                        Ref("DatatypeSegment", optional=True),
                     ),
                 ),
             ),

--- a/test/fixtures/dialects/hive/select_cast.sql
+++ b/test/fixtures/dialects/hive/select_cast.sql
@@ -1,4 +1,5 @@
-select cast(row(val1, val2) as row(a bigint, b varchar))
+select
+    cast(row(col1, col2) as row(a bigint, b decimal(23, 2)))
 from sch.tbl;
 
 select cast(a as json)

--- a/test/fixtures/dialects/hive/select_cast.yml
+++ b/test/fixtures/dialects/hive/select_cast.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7b850f574b2615cdce6359f6ef7fa3fd6610bb3cf66e3f059df9036c98428188
+_hash: 2a811f9295ae2559923d50d009a33928cf2684212c54b5d5639512dbc69a0794
 file:
 - statement:
     select_statement:
@@ -21,20 +21,30 @@ file:
                 - bracketed:
                   - start_bracket: (
                   - column_reference:
-                      identifier: val1
+                      identifier: col1
                   - comma: ','
                   - column_reference:
-                      identifier: val2
+                      identifier: col2
                   - end_bracket: )
                 - keyword: as
                 - keyword: row
                 - bracketed:
                   - start_bracket: (
                   - identifier: a
-                  - data_type_identifier: bigint
+                  - data_type:
+                      primitive_type:
+                        keyword: bigint
                   - comma: ','
                   - identifier: b
-                  - data_type_identifier: varchar
+                  - data_type:
+                      primitive_type:
+                        keyword: decimal
+                        bracketed:
+                        - start_bracket: (
+                        - literal: '23'
+                        - comma: ','
+                        - literal: '2'
+                        - end_bracket: )
                   - end_bracket: )
               end_bracket: )
       from_clause:


### PR DESCRIPTION
Adding support for complex datatypes in `cast` `rowtype` definition:
```
select
    cast(row(col1, col2) as row(a bigint, b decimal(23, 2)))
from sch.tbl;
```