### PR TITLE
Added Snowflake Alter View Support

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -2507,15 +2507,8 @@ class AlterViewStatementSegment(BaseSegment):
                 OneOf("SET", "UNSET"),
                 "SECURE",
             ),
-            Sequence(
-                "SET",
-                Ref("TagEqualsSegment")
-            ),
-            Sequence(
-                "UNSET",
-                "TAG",
-                Delimited(Ref("NakedIdentifierSegment"))
-            ),
+            Sequence("SET", Ref("TagEqualsSegment")),
+            Sequence("UNSET", "TAG", Delimited(Ref("NakedIdentifierSegment"))),
             Delimited(
                 Sequence(
                     "ADD",
@@ -2524,9 +2517,7 @@ class AlterViewStatementSegment(BaseSegment):
                     "POLICY",
                     Ref("FunctionNameSegment"),
                     "ON",
-                    Bracketed(
-                        Delimited(Ref("ColumnReferenceSegment"))
-                    )
+                    Bracketed(Delimited(Ref("ColumnReferenceSegment"))),
                 ),
                 Sequence(
                     "DROP",
@@ -2554,31 +2545,24 @@ class AlterViewStatementSegment(BaseSegment):
                                         Bracketed(
                                             Delimited(Ref("ColumnReferenceSegment"))
                                         ),
-                                        optional=True
-                                    )
+                                        optional=True,
+                                    ),
                                 ),
-                                Sequence(
-                                    "UNSET",
-                                    "MASKING",
-                                    "POLICY"
-                                ),
-                                Sequence(
-                                    "SET",
-                                    Ref("TagEqualsSegment")
-                                )
-                            )
+                                Sequence("UNSET", "MASKING", "POLICY"),
+                                Sequence("SET", Ref("TagEqualsSegment")),
+                            ),
                         ),
                         Sequence(
                             "COLUMN",
                             Ref("ColumnReferenceSegment"),
                             "UNSET",
                             "TAG",
-                            Delimited(Ref("NakedIdentifierSegment"))
-                        )
+                            Delimited(Ref("NakedIdentifierSegment")),
+                        ),
                     ),
-                )
-            )
-        )
+                ),
+            ),
+        ),
     )
 
 

--- a/test/fixtures/dialects/snowflake/snowflake_alter_view.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_view.sql
@@ -1,0 +1,40 @@
+alter view view1 rename to view2;
+
+alter view view1 set secure;
+
+alter view view1 unset secure;
+
+-- single column
+
+alter view user_info_v modify column ssn_number set masking policy ssn_mask_v;
+
+-- multiple columns
+
+alter view user_info_v modify
+    column ssn_number set masking policy ssn_mask_v
+  , column dob set masking policy dob_mask_v
+;
+
+-- single column
+
+alter view user_info_v modify column ssn_number unset masking policy;
+
+-- multiple columns
+
+alter view user_info_v modify
+    column ssn_number unset masking policy
+  , column dob unset masking policy
+;
+
+alter view v1
+  add row access policy rap_v1 on (empl_id);
+
+alter view v1
+  drop row access policy rap_v1;
+
+alter view v1
+  drop row access policy rap_v1_version_1,
+  add row access policy rap_v1_version_2 on (empl_id);
+
+alter view v1
+  modify column foo set masking policy my.scoped.policy;

--- a/test/fixtures/dialects/snowflake/snowflake_alter_view.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_view.yml
@@ -1,0 +1,190 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 5cf8b1381604d7794427cb4837459f8302c565ff4e86346ebbbd9898dbbf2de4
+file:
+- statement:
+    alter_view_statement:
+    - keyword: alter
+    - keyword: view
+    - table_reference:
+        identifier: view1
+    - keyword: rename
+    - keyword: to
+    - table_reference:
+        identifier: view2
+- statement_terminator: ;
+- statement:
+    alter_view_statement:
+    - keyword: alter
+    - keyword: view
+    - table_reference:
+        identifier: view1
+    - keyword: set
+    - keyword: secure
+- statement_terminator: ;
+- statement:
+    alter_view_statement:
+    - keyword: alter
+    - keyword: view
+    - table_reference:
+        identifier: view1
+    - keyword: unset
+    - keyword: secure
+- statement_terminator: ;
+- statement:
+    alter_view_statement:
+    - keyword: alter
+    - keyword: view
+    - table_reference:
+        identifier: user_info_v
+    - keyword: modify
+    - keyword: column
+    - column_reference:
+        identifier: ssn_number
+    - keyword: set
+    - keyword: masking
+    - keyword: policy
+    - function_name:
+        function_name_identifier: ssn_mask_v
+- statement_terminator: ;
+- statement:
+    alter_view_statement:
+    - keyword: alter
+    - keyword: view
+    - table_reference:
+        identifier: user_info_v
+    - keyword: modify
+    - keyword: column
+    - column_reference:
+        identifier: ssn_number
+    - keyword: set
+    - keyword: masking
+    - keyword: policy
+    - function_name:
+        function_name_identifier: ssn_mask_v
+    - comma: ','
+    - keyword: column
+    - column_reference:
+        identifier: dob
+    - keyword: set
+    - keyword: masking
+    - keyword: policy
+    - function_name:
+        function_name_identifier: dob_mask_v
+- statement_terminator: ;
+- statement:
+    alter_view_statement:
+    - keyword: alter
+    - keyword: view
+    - table_reference:
+        identifier: user_info_v
+    - keyword: modify
+    - keyword: column
+    - column_reference:
+        identifier: ssn_number
+    - keyword: unset
+    - keyword: masking
+    - keyword: policy
+- statement_terminator: ;
+- statement:
+    alter_view_statement:
+    - keyword: alter
+    - keyword: view
+    - table_reference:
+        identifier: user_info_v
+    - keyword: modify
+    - keyword: column
+    - column_reference:
+        identifier: ssn_number
+    - keyword: unset
+    - keyword: masking
+    - keyword: policy
+    - comma: ','
+    - keyword: column
+    - column_reference:
+        identifier: dob
+    - keyword: unset
+    - keyword: masking
+    - keyword: policy
+- statement_terminator: ;
+- statement:
+    alter_view_statement:
+    - keyword: alter
+    - keyword: view
+    - table_reference:
+        identifier: v1
+    - keyword: add
+    - keyword: row
+    - keyword: access
+    - keyword: policy
+    - function_name:
+        function_name_identifier: rap_v1
+    - keyword: 'on'
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          identifier: empl_id
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_view_statement:
+    - keyword: alter
+    - keyword: view
+    - table_reference:
+        identifier: v1
+    - keyword: drop
+    - keyword: row
+    - keyword: access
+    - keyword: policy
+    - function_name:
+        function_name_identifier: rap_v1
+- statement_terminator: ;
+- statement:
+    alter_view_statement:
+    - keyword: alter
+    - keyword: view
+    - table_reference:
+        identifier: v1
+    - keyword: drop
+    - keyword: row
+    - keyword: access
+    - keyword: policy
+    - function_name:
+        function_name_identifier: rap_v1_version_1
+    - comma: ','
+    - keyword: add
+    - keyword: row
+    - keyword: access
+    - keyword: policy
+    - function_name:
+        function_name_identifier: rap_v1_version_2
+    - keyword: 'on'
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          identifier: empl_id
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_view_statement:
+    - keyword: alter
+    - keyword: view
+    - table_reference:
+        identifier: v1
+    - keyword: modify
+    - keyword: column
+    - column_reference:
+        identifier: foo
+    - keyword: set
+    - keyword: masking
+    - keyword: policy
+    - function_name:
+      - identifier: my
+      - dot: .
+      - identifier: scoped
+      - dot: .
+      - function_name_identifier: policy
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Adds support in Snowflake for `ALTER VIEW` statements

Fixes #2910 

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
