### PR TITLE
Added Support For Snowflake Inline Comments

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -13,6 +13,7 @@ from sqlfluff.core.parser import (
     BaseSegment,
     Bracketed,
     CodeSegment,
+    CommentSegment,
     Dedent,
     Delimited,
     Indent,
@@ -42,6 +43,12 @@ snowflake_dialect.patch_lexer_matchers(
         # In snowflake, a double single quote resolves as a single quote in the string.
         # https://docs.snowflake.com/en/sql-reference/data-types-text.html#single-quoted-string-constants
         RegexLexer("single_quote", r"'([^'\\]|\\.|'')*'", CodeSegment),
+        RegexLexer(
+            "inline_comment",
+            r"(--|#|//)[^\n]*",
+            CommentSegment,
+            segment_kwargs={"trim_start": ("--", "#")},
+        ),
     ]
 )
 

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -47,7 +47,7 @@ snowflake_dialect.patch_lexer_matchers(
             "inline_comment",
             r"(--|#|//)[^\n]*",
             CommentSegment,
-            segment_kwargs={"trim_start": ("--", "#")},
+            segment_kwargs={"trim_start": ("--", "#", "//")},
         ),
     ]
 )

--- a/test/fixtures/dialects/snowflake/snowflake_inline_comment.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_inline_comment.sql
@@ -1,0 +1,6 @@
+//Snowflake Inline Comment
+
+SELECT 1;
+
+SELECT 1//Snowflake Inline
+;

--- a/test/fixtures/dialects/snowflake/snowflake_inline_comment.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_inline_comment.sql
@@ -1,6 +1,6 @@
 //Snowflake Inline Comment
-
+-- Classic Inline Comment
 SELECT 1;
-
+# Classic Inline Comment
 SELECT 1//Snowflake Inline
 ;

--- a/test/fixtures/dialects/snowflake/snowflake_inline_comment.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_inline_comment.sql
@@ -1,6 +1,7 @@
-//Snowflake Inline Comment
--- Classic Inline Comment
-SELECT 1;
 # Classic Inline Comment
-SELECT 1//Snowflake Inline
-;
+SELECT 1; -- Classic Inline Comment
+SELECT 1; # Classic Inline Comment
+SELECT 1; //Snowflake Inline Comment
+SELECT 1;-- Classic Inline Comment No Space
+SELECT 1;# Classic Inline Comment No Space
+SELECT 1//Snowflake Inline Comment No Space

--- a/test/fixtures/dialects/snowflake/snowflake_inline_comment.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_inline_comment.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ba8c9747adf3f7b9c56d759076002d3fff2f2d2030891c6ac888d481af4ad4ec
+_hash: fb0237f465e56168d8ba8ac593554aae9b34f89c1e0ef09236ea28a524ab4dfe
 file:
 - statement:
     select_statement:
@@ -19,3 +19,30 @@ file:
         select_clause_element:
           literal: '1'
 - statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          literal: '1'

--- a/test/fixtures/dialects/snowflake/snowflake_inline_comment.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_inline_comment.yml
@@ -1,0 +1,21 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: ba8c9747adf3f7b9c56d759076002d3fff2f2d2030891c6ac888d481af4ad4ec
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          literal: '1'
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Snowflake supports inline comments starting with `//`. This PR adds support to SQLFluff for the same

Fixes #2918

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
