### PR TITLE
Emulate dbt's vars cli option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,7 +207,6 @@ Steps to use the Docker Compose environment:
 * Install Docker on your machine.
 * Run `plugins/sqlfluff-templater-dbt/docker/startup` to create the containers.
 * Run `plugins/sqlfluff-templater-dbt/docker/shell` to start a bash session in the `app` container.
-* Manually edit the `host` value in `plugins/sqlfluff-templater-dbt/test/fixtures/dbt/profiles_yml/profiles.yml`, changing it to `postgres`. (This will likely be automated somehow in the future.)
 
 Inside the container, run:
 ```

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -633,6 +633,19 @@ You can set the dbt project directory, profiles directory and profile with:
     `~/.dbt/`. On Windows, you can determine your default profile directory by
     running `dbt debug --config-dir`.
 
+If your project requires that you pass variables to dbt through command line,
+you can specify them in :config:`template:dbt:contex` section of `.sqlfluff`.
+See below configuration and its equivalend dbt command:
+
+.. code-block:: cfg
+
+    [sqlfluff:templater:dbt:context]
+    my_variable = 1
+
+.. code-block:: text
+
+    dbt run --vars '{"my_variable": 1}'
+
 Known Caveats
 ^^^^^^^^^^^^^
 

--- a/plugins/sqlfluff-templater-dbt/docker/docker-compose.yml
+++ b/plugins/sqlfluff-templater-dbt/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "2.4"
 
 services:
   app:
@@ -18,6 +18,7 @@ services:
     image: postgres:14-bullseye
     environment:
       - POSTGRES_PASSWORD=password
+      - POSTGRES_HOST=postgres
     ports:
       # NOTE: "5432:5432" makes the Postgres server accessible to both the host
       # developer machine *and* the "app" container in Docker. If you don't want

--- a/plugins/sqlfluff-templater-dbt/docker/startup
+++ b/plugins/sqlfluff-templater-dbt/docker/startup
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -ex
+export COMPOSE_DOCKER_CLI_BUILD=1
+export DOCKER_BUILDKIT=1
 my_path="$( cd "$(dirname "$0")"; pwd -P)"
 ${my_path}/shutdown
 docker-compose -f ${my_path}/docker-compose.yml build

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -52,6 +52,7 @@ class DbtConfigArgs:
     profile: Optional[str] = None
     target: Optional[str] = None
     single_threaded: bool = False
+    vars: str = ""
 
 
 class DbtTemplater(JinjaTemplater):
@@ -100,6 +101,7 @@ class DbtTemplater(JinjaTemplater):
                     project_dir=self.project_dir,
                     profiles_dir=self.profiles_dir,
                     profile=self._get_profile(),
+                    vars=self._get_cli_vars(),
                 ),
                 user_config,
             )
@@ -109,6 +111,7 @@ class DbtTemplater(JinjaTemplater):
                 profiles_dir=self.profiles_dir,
                 profile=self._get_profile(),
                 target=self._get_target(),
+                vars=self._get_cli_vars(),
             )
         )
         register_adapter(self.dbt_config)
@@ -228,6 +231,13 @@ class DbtTemplater(JinjaTemplater):
         return self.sqlfluff_config.get_section(
             (self.templater_selector, self.name, "target")
         )
+
+    def _get_cli_vars(self):
+        cli_vars = self.sqlfluff_config.get_section(
+            (self.templater_selector, self.name, "context")
+        )
+
+        return str(cli_vars) if cli_vars else "{}"
 
     def sequence_files(
         self, fnames: List[str], config=None, formatter=None

--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/dbt_project.yml
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/dbt_project.yml
@@ -14,3 +14,4 @@ vars:
   my_new_project:
     # Default date stamp of run
     ds: "2020-01-01"
+    # passed_through_cli: testing for vars passed through cli('--vars' option) rather than dbt_project

--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/models/vars_from_cli.sql
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/models/vars_from_cli.sql
@@ -1,0 +1,2 @@
+-- Issue #1262
+SELECT {{ var('passed_through_cli') }}

--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/profiles_yml/profiles.yml
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/profiles_yml/profiles.yml
@@ -3,7 +3,7 @@ default:
   outputs:
     dev:
       type: postgres
-      host: localhost
+      host: "{{ env_var('POSTGRES_HOST', 'postgres') }}"
       user: postgres
       pass: password
       port: 5432


### PR DESCRIPTION
Two small changes related to dbt plugin, both have been documented and tested, but I would be happy to take another look if something does not look right.

## Fixed issue #1262
fixes #1262

Allows sqlfluff to emulate dbt's cli calls with vars flag:
```
dbt run --vars 'variable_not_included_in_dbt_config: 1'
```

If dbt project does not have all of its vars(without defaults) in `dbt_project.yml`, dbt throws the following error:
```
Could not render {{ var('variable_not_included_in_dbt_config') }}: Required var 'variable_not_included_in_dbt_config' not found in config:
  Vars supplied to <Configuration> = {}
```

The way users can include those variables is through `.sqlfuff` in `[templates:dbt:contex]` section( similar to what we do for jinja template).

## Docker Dev container Fixes

 * `CONTRIBUTING.md` mentions that `dbt_profiles.yml` need to be manulay updated until fix comes -- this is the fix
 *  current Dockerfile uses options that require enabling Buildkit first so I added them to `startup` script
 * `docker-compose` file uses `platform` so I bumped the file to version that introduced this setting