### PR TITLE
BigQuery: support numeric aliases in `UNPIVOT` clauses

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1116,7 +1116,7 @@ class FromPivotExpressionSegment(BaseSegment):
 
 @bigquery_dialect.segment()
 class UnpivotAliasExpressionSegment(BaseSegment):
-    """In BigQuery UNPIVOT alias's can be single or double quoted."""
+    """In BigQuery UNPIVOT alias's can be single or double quoted or numeric."""
 
     type = "alias_expression"
     match_grammar = Sequence(
@@ -1124,6 +1124,7 @@ class UnpivotAliasExpressionSegment(BaseSegment):
         OneOf(
             Ref("SingleQuotedLiteralSegment"),
             Ref("DoubleQuotedLiteralSegment"),
+            Ref("NumericLiteralSegment"),
         ),
     )
 

--- a/test/fixtures/dialects/bigquery/select_unpivot.sql
+++ b/test/fixtures/dialects/bigquery/select_unpivot.sql
@@ -24,4 +24,15 @@ FROM model
 UNPIVOT(
     (A, B)
     FOR year
-    IN ((C, D) AS "year_2011", (E, F) AS "year_2012"))
+    IN ((C, D) AS "year_2011", (E, F) AS "year_2012"));
+  
+SELECT
+    *
+FROM
+    foo
+UNPIVOT(
+    (bar2, bar3, bar4)
+    FOR year
+    IN ((foo1, foo2, foo3) AS 1,
+       (foo4, foo5, foo6) AS 2,
+       (foo7, foo8, foo9) AS 3));

--- a/test/fixtures/dialects/bigquery/select_unpivot.yml
+++ b/test/fixtures/dialects/bigquery/select_unpivot.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f55c692e55c740dab5587221667627d2d4accbb6ab06bf560001fcb95e70724e
+_hash: a91da916103c91a2f99e7a739346216c8ba6cf8b602ed81e9c54a0c64c3116c1
 file:
 - statement:
     with_compound_statement:
@@ -296,3 +296,74 @@ file:
                   literal: '"year_2012"'
               - end_bracket: )
             - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: foo
+          from_unpivot_expression:
+            keyword: UNPIVOT
+            bracketed:
+            - start_bracket: (
+            - bracketed:
+              - start_bracket: (
+              - identifier: bar2
+              - comma: ','
+              - identifier: bar3
+              - comma: ','
+              - identifier: bar4
+              - end_bracket: )
+            - keyword: FOR
+            - identifier: year
+            - keyword: IN
+            - bracketed:
+              - start_bracket: (
+              - bracketed:
+                - start_bracket: (
+                - identifier: foo1
+                - comma: ','
+                - identifier: foo2
+                - comma: ','
+                - identifier: foo3
+                - end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  literal: '1'
+              - comma: ','
+              - bracketed:
+                - start_bracket: (
+                - identifier: foo4
+                - comma: ','
+                - identifier: foo5
+                - comma: ','
+                - identifier: foo6
+                - end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  literal: '2'
+              - comma: ','
+              - bracketed:
+                - start_bracket: (
+                - identifier: foo7
+                - comma: ','
+                - identifier: foo8
+                - comma: ','
+                - identifier: foo9
+                - end_bracket: )
+              - alias_expression:
+                  keyword: AS
+                  literal: '3'
+              - end_bracket: )
+            - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #2920

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
