### PR TITLE
TSQL: Support nested joins

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1456,18 +1456,20 @@ class JoinClauseSegment(BaseSegment):
     def get_eventual_aliases(self) -> List[Tuple[BaseSegment, AliasInfo]]:
         """Return the eventual table name referred to by this join clause."""
         buff = []
-        join_clauses = []
 
         from_expression = self.get_child("from_expression_element")
-        # In some dialects, like TSQL, join clauses can have nested join clauses
-        join_clauses = self.get_children("join_clause")
-
-        # Iterate through the potential sources of aliases
         alias: AliasInfo = from_expression.get_eventual_alias()
+        # Only append if non null. A None reference, may
+        # indicate a generator expression or similar.
         if alias:
             buff.append((from_expression, alias))
-        for clause in join_clauses:
-            aliases: List[Tuple[BaseSegment, AliasInfo]] = clause.get_eventual_aliases()
+
+        # In some dialects, like TSQL, join clauses can have nested join clauses
+        join_clause = self.get_child("join_clause")
+        if join_clause:
+            aliases: List[
+                Tuple[BaseSegment, AliasInfo]
+            ] = join_clause.get_eventual_aliases()
             # Only append if non null. A None reference, may
             # indicate a generator expression or similar.
             if aliases:

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1463,8 +1463,8 @@ class JoinClauseSegment(BaseSegment):
         join_clauses = self.get_children("join_clause")
 
         # Iterate through the potential sources of aliases
-        if from_expression:
-            alias: AliasInfo = from_expression.get_eventual_alias()
+        alias: AliasInfo = from_expression.get_eventual_alias()
+        if alias:
             buff.append((from_expression, alias))
         for clause in join_clauses:
             aliases: List[Tuple[BaseSegment, AliasInfo]] = clause.get_eventual_aliases()

--- a/src/sqlfluff/dialects/dialect_spark3.py
+++ b/src/sqlfluff/dialects/dialect_spark3.py
@@ -2341,9 +2341,9 @@ class JoinClauseSegment(BaseSegment):
         ),
     )
 
-    get_eventual_alias = ansi_dialect.get_segment(
+    get_eventual_aliases = ansi_dialect.get_segment(
         "JoinClauseSegment"
-    ).get_eventual_alias
+    ).get_eventual_aliases
 
 
 @spark3_dialect.segment(replace=True)

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -348,6 +348,11 @@ tsql_dialect.replace(
     ),
     JoinKeywords=OneOf("JOIN", "APPLY", Sequence("OUTER", "APPLY")),
     NaturalJoinKeywords=Nothing(),
+    NestedJoinSegment=Sequence(
+        Indent,
+        Ref("JoinClauseSegment"),
+        Dedent,
+    ),
     # Replace Expression_D_Grammar to remove casting syntax invalid in TSQL
     Expression_D_Grammar=Sequence(
         OneOf(

--- a/test/fixtures/dialects/tsql/inner_joins.sql
+++ b/test/fixtures/dialects/tsql/inner_joins.sql
@@ -1,0 +1,7 @@
+SELECT
+    1 AS RegionCode
+FROM BA 
+LEFT OUTER JOIN I 
+	LEFT OUTER JOIN P 
+		ON I.Pcd = P.Iid 
+	ON BA.Iid = I.Bcd 

--- a/test/fixtures/dialects/tsql/inner_joins.yml
+++ b/test/fixtures/dialects/tsql/inner_joins.yml
@@ -1,0 +1,66 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 1f8b7e378b1ee858340c7a0e8d5c4a09f0a07661eb45899a5a04067a81349c9e
+file:
+  batch:
+    statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            literal: '1'
+            alias_expression:
+              keyword: AS
+              identifier: RegionCode
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: BA
+            join_clause:
+            - keyword: LEFT
+            - keyword: OUTER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: I
+            - join_clause:
+              - keyword: LEFT
+              - keyword: OUTER
+              - keyword: JOIN
+              - from_expression_element:
+                  table_expression:
+                    table_reference:
+                      identifier: P
+              - join_on_condition:
+                  keyword: 'ON'
+                  expression:
+                  - column_reference:
+                    - identifier: I
+                    - dot: .
+                    - identifier: Pcd
+                  - comparison_operator:
+                      raw_comparison_operator: '='
+                  - column_reference:
+                    - identifier: P
+                    - dot: .
+                    - identifier: Iid
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - identifier: BA
+                  - dot: .
+                  - identifier: Iid
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - identifier: I
+                  - dot: .
+                  - identifier: Bcd

--- a/test/fixtures/rules/std_rule_cases/L026.yml
+++ b/test/fixtures/rules/std_rule_cases/L026.yml
@@ -207,3 +207,16 @@ test_mysql_select_no_from_should_not_except:
   configs:
     core:
       dialect: mysql
+
+test_inner_join_clauses_does_not_flag:
+  pass_str: |
+    SELECT
+        1 AS RegionCode
+    FROM BA
+    LEFT OUTER JOIN I
+      LEFT OUTER JOIN P
+        ON I.Pcd = P.Iid
+      ON BA.Iid = I.Bcd
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #2676 

### Are there any other side effects of this change that we should be aware of?
This change means a `JOIN` clause can now have multiple tables, so multiple aliases. So we had to change `get_eventual_alias` to `get_eventual_aliases`.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
