### PR TITLE
Add new rule L063 to allow separate capitalisation policy for Datatypes

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -171,3 +171,9 @@ ignore_words = None
 [sqlfluff:rules:L062]
 # Comma separated list of blocked words that should not be used
 blocked_words = None
+
+[sqlfluff:rules:L063]
+# Data Types
+extended_capitalisation_policy = consistent
+# Comma separated list of words to ignore for this rule
+ignore_words = None

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -723,11 +723,24 @@ class BaseRule:
         return None
 
     @staticmethod
-    def matches_target_tuples(seg: BaseSegment, target_tuples: List[Tuple[str, str]]):
+    def matches_target_tuples(
+        seg: BaseSegment,
+        target_tuples: List[Tuple[str, str]],
+        parent: Optional[BaseSegment] = None,
+    ):
         """Does the given segment match any of the given type tuples."""
         if seg.name in [elem[1] for elem in target_tuples if elem[0] == "name"]:
             return True
         elif seg.is_type(*[elem[1] for elem in target_tuples if elem[0] == "type"]):
+            return True
+        # At the moment we only check the immeadiate parent and only for RawSegments
+        elif (
+            isinstance(seg, RawSegment)
+            and parent
+            and parent.is_type(
+                *[elem[1] for elem in target_tuples if elem[0] == "parenttype"]
+            )
+        ):
             return True
         return False
 

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -738,6 +738,7 @@ class BaseRule:
         elif (
             not seg.is_meta
             and not seg.is_templated
+            and not seg.is_whitespace
             and isinstance(seg, RawSegment)
             and len(seg.raw) > 0
             and parent

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -733,9 +733,12 @@ class BaseRule:
             return True
         elif seg.is_type(*[elem[1] for elem in target_tuples if elem[0] == "type"]):
             return True
-        # At the moment we only check the immeadiate parent and only for RawSegments
+        # For parent type checks, there's a higher risk of getting an incorrect
+        # segment, so we add some additional guards
         elif (
-            isinstance(seg, RawSegment)
+            not seg.is_meta
+            and not seg.is_templated
+            and isinstance(seg, RawSegment)
             and len(seg.raw) > 0
             and parent
             and parent.is_type(

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -736,6 +736,7 @@ class BaseRule:
         # At the moment we only check the immeadiate parent and only for RawSegments
         elif (
             isinstance(seg, RawSegment)
+            and len(seg.raw) > 0
             and parent
             and parent.is_type(
                 *[elem[1] for elem in target_tuples if elem[0] == "parenttype"]

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -621,7 +621,7 @@ class DatatypeSegment(BaseSegment):
     type = "data_type"
     match_grammar = OneOf(
         Sequence(
-            OneOf("time", "timestamp"),
+            OneOf("TIME", "TIMESTAMP"),
             Bracketed(Ref("NumericLiteralSegment"), optional=True),
             Sequence(OneOf("WITH", "WITHOUT"), "TIME", "ZONE", optional=True),
         ),

--- a/src/sqlfluff/rules/L010.py
+++ b/src/sqlfluff/rules/L010.py
@@ -55,6 +55,8 @@ class Rule_L010(BaseRule):
         ("name", "null_literal"),
         ("name", "boolean_literal"),
         ("parenttype", "data_type"),
+        ("parenttype", "datetime_type_identifier"),
+        ("parenttype", "primitive_type"),
     ]
     config_keywords = ["capitalisation_policy", "ignore_words"]
     # Human readable target elem for description

--- a/src/sqlfluff/rules/L010.py
+++ b/src/sqlfluff/rules/L010.py
@@ -1,7 +1,8 @@
 """Implementation of Rule L010."""
 
 import regex
-from typing import Tuple, List
+from typing import Tuple, List, Optional
+from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.config_info import get_config_info
 from sqlfluff.core.rules.doc_decorators import (
@@ -47,13 +48,13 @@ class Rule_L010(BaseRule):
         ("type", "keyword"),
         ("type", "binary_operator"),
         ("type", "date_part"),
-        ("type", "data_type_identifier"),
     ]
     # Skip boolean and null literals (which are also keywords)
     # as they have their own rule (L040)
     _exclude_elements: List[Tuple[str, str]] = [
         ("name", "null_literal"),
         ("name", "boolean_literal"),
+        ("parenttype", "data_type"),
     ]
     config_keywords = ["capitalisation_policy", "ignore_words"]
     # Human readable target elem for description
@@ -68,9 +69,14 @@ class Rule_L010(BaseRule):
 
         """
         # Skip if not an element of the specified type/name
+        parent: Optional[BaseSegment] = (
+            context.parent_stack[-1] if context.parent_stack else None
+        )
         if not self.matches_target_tuples(
-            context.segment, self._target_elems
-        ) or self.matches_target_tuples(context.segment, self._exclude_elements):
+            context.segment, self._target_elems, parent
+        ) or self.matches_target_tuples(
+            context.segment, self._exclude_elements, parent
+        ):
             return LintResult(memory=context.memory)
 
         # Get the capitalisation policy configuration.

--- a/src/sqlfluff/rules/L063.py
+++ b/src/sqlfluff/rules/L063.py
@@ -1,0 +1,65 @@
+"""Implementation of Rule L063."""
+
+from typing import Tuple, List
+
+from sqlfluff.core.rules.doc_decorators import (
+    document_configuration,
+    document_fix_compatible,
+)
+from sqlfluff.rules.L010 import Rule_L010
+
+
+@document_configuration
+@document_fix_compatible
+class Rule_L063(Rule_L010):
+    """Inconsistent capitalisation of datatypes.
+
+    **Anti-pattern**
+
+    In this example, ``null`` and ``false`` are in lower-case whereas ``TRUE`` is in
+    upper-case.
+
+    .. code-block:: sql
+
+        select
+            a,
+            null,
+            TRUE,
+            false
+        from foo
+
+    **Best practice**
+
+    Ensure all literal ``null``/``true``/``false`` literals are consistently
+    upper or lower case
+
+    .. code-block:: sql
+
+        select
+            a,
+            NULL,
+            TRUE,
+            FALSE
+        from foo
+
+        -- Also good
+
+        select
+            a,
+            null,
+            true,
+            false
+        from foo
+
+    """
+
+    _target_elems: List[Tuple[str, str]] = [
+        ("parenttype", "data_type"),
+        ("type", "data_type_identifier"),
+    ]
+    config_keywords = [
+        "extended_capitalisation_policy",
+        "ignore_words",
+    ]
+    _exclude_elements: List[Tuple[str, str]] = []
+    _description_elem = "Datatypes"

--- a/src/sqlfluff/rules/L063.py
+++ b/src/sqlfluff/rules/L063.py
@@ -55,11 +55,16 @@ class Rule_L063(Rule_L010):
 
     _target_elems: List[Tuple[str, str]] = [
         ("parenttype", "data_type"),
+        ("parenttype", "datetime_type_identifier"),
+        ("parenttype", "primitive_type"),
         ("type", "data_type_identifier"),
+    ]
+    _exclude_elements: List[Tuple[str, str]] = [
+        ("type", "identifier"),
+        ("type", "literal"),
     ]
     config_keywords = [
         "extended_capitalisation_policy",
         "ignore_words",
     ]
-    _exclude_elements: List[Tuple[str, str]] = []
     _description_elem = "Datatypes"

--- a/test/fixtures/linter/autofix/ansi/009_keyword_capitalisation/after.sql
+++ b/test/fixtures/linter/autofix/ansi/009_keyword_capitalisation/after.sql
@@ -18,7 +18,7 @@ from (
 		punter_id,
 		credit_amount,
 		promo_punter_reward_id,
-		NULLIF(SUBSTRING(regexp_substr(cr.description,'Ticket ref: [0-9]*'), 13), '') ::int as ticket_id,
+		NULLIF(SUBSTRING(regexp_substr(cr.description,'Ticket ref: [0-9]*'), 13), '') ::INT as ticket_id,
 		case when cr.description like 'Requesting Punter: %'
 			then left(
 				SUBSTRING(regexp_substr(cr.description,'Requesting Punter: [^/]*'), 18),

--- a/test/fixtures/rules/std_rule_cases/L010.yml
+++ b/test/fixtures/rules/std_rule_cases/L010.yml
@@ -63,85 +63,10 @@ test_pass_date_part_consistent_capitalisation:
   # Test that correctly capitalized time units are left unchanged
   pass_str: SELECT dt + INTERVAL 2 DAY, INTERVAL 3 HOUR
 
-test_fail_data_type_inconsistent_capitalisation_1:
+
+test_pass_data_type_inconsistent_capitalisation:
   # Test that we don't have the "inconsistent" bug
-  fail_str: CREATE TABLE table1 (account_id BiGinT);
-  fix_str: CREATE TABLE table1 (account_id BIGINT);
-  configs:
-    rules:
-      L010:
-        capitalisation_policy: upper
-
-test_fail_data_type_inconsistent_capitalisation_2:
-  fail_str: CREATE TABLE table1 (account_id BiGinT);
-  fix_str: create table table1 (account_id bigint);
-  configs:
-    rules:
-      L010:
-        capitalisation_policy: lower
-
-test_fail_data_type_inconsistent_capitalisation_3:
-  fail_str: CREATE TABLE table1 (account_id BiGinT);
-  fix_str: Create Table table1 (account_id Bigint);
-  configs:
-    rules:
-      L010:
-        capitalisation_policy: capitalise
-
-test_fail_data_type_capitalisation_policy_lower:
-  fail_str: CREATE TABLE table1 (account_id BIGINT);
-  fix_str: create table table1 (account_id bigint);
-  configs:
-    rules:
-      L010:
-        capitalisation_policy: lower
-
-test_fail_data_type_capitalisation_policy_lower_2:
-  fail_str: CREATE TABLE table1 (account_id BIGINT, column_two varchar(255));
-  fix_str: create table table1 (account_id bigint, column_two varchar(255));
-  configs:
-    rules:
-      L010:
-        capitalisation_policy: lower
-
-test_fail_data_type_capitalisation_policy_upper:
-  fail_str: CREATE TABLE table1 (account_id bigint);
-  fix_str: CREATE TABLE table1 (account_id BIGINT);
-  configs:
-    rules:
-      L010:
-        capitalisation_policy: upper
-
-test_fail_data_type_capitalisation_policy_upper_2:
-  fail_str: CREATE TABLE table1 (account_id BIGINT, column_two varchar(255));
-  fix_str: CREATE TABLE table1 (account_id BIGINT, column_two VARCHAR(255));
-  configs:
-    rules:
-      L010:
-        capitalisation_policy: upper
-
-test_fail_data_type_capitalisation_policy_capitalise:
-  # Test for capitalised casing
-  fail_str: CREATE TABLE table1 (account_id BIGINT);
-  fix_str: Create Table table1 (account_id Bigint);
-  configs:
-    rules:
-      L010:
-        capitalisation_policy: capitalise
-
-test_fail_data_type_capitalisation_policy_keywords_1:
-  # Test cases where data types are keywords, not data_type_identifiers
-  # See: https://github.com/sqlfluff/sqlfluff/pull/2121
-  fail_str: CREATE TABLE table1 (account_id BIGINT, column_two timestamp);
-  fix_str: CREATE TABLE table1 (account_id BIGINT, column_two TIMESTAMP);
-  configs:
-    rules:
-      L010:
-        capitalisation_policy: upper
-
-test_fail_data_type_capitalisation_policy_keywords_2:
-  fail_str: CREATE TABLE table1 (account_id BIGINT, column_two timestamp with time zone);
-  fix_str: CREATE TABLE table1 (account_id BIGINT, column_two TIMESTAMP WITH TIME ZONE);
+  pass_str: CREATE TABLE table1 (account_id bigint);
   configs:
     rules:
       L010:

--- a/test/fixtures/rules/std_rule_cases/L063.yml
+++ b/test/fixtures/rules/std_rule_cases/L063.yml
@@ -18,6 +18,23 @@ test_pass_default_consistent_upper:
         ts TIME WITH TIME ZONE
     );
 
+test_pass_default_consistent_capitalised:
+  # Test that we don't have the "inconsistent" bug
+  pass_str: |
+    CREATE TABLE distributors (
+        did Integer,
+        name Varchar(40),
+        ts Time With Time Zone
+    );
+
+test_pass_default_consistent_pascal:
+  # Test that we don't have the "inconsistent" bug
+  pass_str: |
+    CREATE TABLE distributors (
+        did Integer,
+        name VarChar(40),
+        ts Time With Time Zone
+    );
 
 test_fail_data_type_inconsistent_capitalisation_1:
   # Test that we don't have the "inconsistent" bug
@@ -99,6 +116,21 @@ test_fail_data_type_capitalisation_policy_keywords_2:
   fail_str: CREATE TABLE table1 (account_id BIGINT, column_two timestamp with time zone);
   fix_str: CREATE TABLE table1 (account_id BIGINT, column_two TIMESTAMP WITH TIME ZONE);
   configs:
+    rules:
+      L063:
+        extended_capitalisation_policy: upper
+
+
+test_pass_spark3_complex_data_types:
+  pass_str: |
+    CREATE TABLE table_identifier(
+      a STRUCT<b: STRING COMMENT 'struct_comment', c: BOOLEAN> COMMENT 'col_comment',
+      d MAP<STRING, BOOLEAN> COMMENT 'col_comment',
+      e ARRAY<STRING> COMMENT 'col_comment'
+    );
+  configs:
+    core:
+      dialect: spark3
     rules:
       L063:
         extended_capitalisation_policy: upper

--- a/test/fixtures/rules/std_rule_cases/L063.yml
+++ b/test/fixtures/rules/std_rule_cases/L063.yml
@@ -1,0 +1,104 @@
+rule: L063
+
+test_pass_default_consistent_lower:
+  # Test that we don't have the "inconsistent" bug
+  pass_str: |
+    CREATE TABLE distributors (
+        did integer,
+        name varchar(40),
+        ts time with time zone
+    );
+
+test_pass_default_consistent_upper:
+  # Test that we don't have the "inconsistent" bug
+  pass_str: |
+    CREATE TABLE distributors (
+        did INTEGER,
+        name VARCHAR(40),
+        ts TIME WITH TIME ZONE
+    );
+
+
+test_fail_data_type_inconsistent_capitalisation_1:
+  # Test that we don't have the "inconsistent" bug
+  fail_str: CREATE TABLE table1 (account_id BiGinT);
+  fix_str: CREATE TABLE table1 (account_id BIGINT);
+  configs:
+    rules:
+      L063:
+        extended_capitalisation_policy: upper
+
+test_fail_data_type_inconsistent_capitalisation_2:
+  fail_str: CREATE TABLE table1 (account_id BiGinT);
+  fix_str: CREATE TABLE table1 (account_id bigint);
+  configs:
+    rules:
+      L063:
+        extended_capitalisation_policy: lower
+
+test_fail_data_type_inconsistent_capitalisation_3:
+  fail_str: CREATE TABLE table1 (account_id BiGinT);
+  fix_str: CREATE TABLE table1 (account_id Bigint);
+  configs:
+    rules:
+      L063:
+        extended_capitalisation_policy: capitalise
+
+test_fail_data_type_capitalisation_policy_lower:
+  fail_str: CREATE TABLE table1 (account_id BIGINT);
+  fix_str: CREATE TABLE table1 (account_id bigint);
+  configs:
+    rules:
+      L063:
+        extended_capitalisation_policy: lower
+
+test_fail_data_type_capitalisation_policy_lower_2:
+  fail_str: CREATE TABLE table1 (account_id BIGINT, column_two varchar(255));
+  fix_str: CREATE TABLE table1 (account_id bigint, column_two varchar(255));
+  configs:
+    rules:
+      L063:
+        extended_capitalisation_policy: lower
+
+test_fail_data_type_capitalisation_policy_upper:
+  fail_str: CREATE TABLE table1 (account_id bigint);
+  fix_str: CREATE TABLE table1 (account_id BIGINT);
+  configs:
+    rules:
+      L063:
+        extended_capitalisation_policy: upper
+
+test_fail_data_type_capitalisation_policy_upper_2:
+  fail_str: CREATE TABLE table1 (account_id BIGINT, column_two varchar(255));
+  fix_str: CREATE TABLE table1 (account_id BIGINT, column_two VARCHAR(255));
+  configs:
+    rules:
+      L010:
+        extended_capitalisation_policy: upper
+
+test_fail_data_type_capitalisation_policy_capitalise:
+  # Test for capitalised casing
+  fail_str: CREATE TABLE table1 (account_id BIGINT);
+  fix_str: CREATE TABLE table1 (account_id Bigint);
+  configs:
+    rules:
+      L063:
+        extended_capitalisation_policy: capitalise
+
+test_fail_data_type_capitalisation_policy_keywords_1:
+  # Test cases where data types are keywords, not data_type_identifiers
+  # See: https://github.com/sqlfluff/sqlfluff/pull/2121
+  fail_str: CREATE TABLE table1 (account_id BIGINT, column_two timestamp);
+  fix_str: CREATE TABLE table1 (account_id BIGINT, column_two TIMESTAMP);
+  configs:
+    rules:
+      L063:
+        extended_capitalisation_policy: upper
+
+test_fail_data_type_capitalisation_policy_keywords_2:
+  fail_str: CREATE TABLE table1 (account_id BIGINT, column_two timestamp with time zone);
+  fix_str: CREATE TABLE table1 (account_id BIGINT, column_two TIMESTAMP WITH TIME ZONE);
+  configs:
+    rules:
+      L063:
+        extended_capitalisation_policy: upper


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #2556 by adding a new rule (L063) for datatypes, and removing datatypes from L010.
The new rule uses `extended_capitalisation_policy` to allow PascalCase (e.g. VarChar)

It also added a new, optional `parent` param for `matches_target_tuples` as they are often parsed like this:

```
[L:  4, P:  8]      |                    data_type:
[L:  4, P:  8]      |                        keyword:                              'time'
```

### Are there any other side effects of this change that we should be aware of?
L010 can no longer be consistent between Datatypes and other Keywords.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
