### PR TITLE
Adds support for column definitions in table alias expressions

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -3195,8 +3195,20 @@ class AliasExpressionSegment(BaseSegment):
     type = "alias_expression"
     match_grammar = Sequence(
         Ref.keyword("AS", optional=True),
-        Ref("SingleIdentifierGrammar"),
-        Bracketed(Ref("SingleIdentifierListSegment"), optional=True),
+        OneOf(
+            Sequence(
+                Ref("SingleIdentifierGrammar"),
+                Bracketed(Ref("SingleIdentifierListSegment"), optional=True),
+            ),
+            Sequence(
+                Ref("SingleIdentifierGrammar", optional=True),
+                Bracketed(
+                    Delimited(
+                        Sequence(Ref("ParameterNameSegment"), Ref("DatatypeSegment"))
+                    )
+                ),
+            ),
+        ),
     )
 
 

--- a/test/fixtures/dialects/postgres/postgres_select.sql
+++ b/test/fixtures/dialects/postgres/postgres_select.sql
@@ -42,3 +42,10 @@ SELECT c_timestamp AT TIME ZONE 'Africa/Cairo' FROM t_table;
 SELECT (c_timestamp AT TIME ZONE 'Africa/Cairo')::time FROM t_table;
 
 SELECT a::double precision FROM my_table;
+
+
+SELECT
+    schema1.table1.columna,
+    t.col2
+FROM schema1.table1
+CROSS JOIN LATERAL somefunc(tb.columnb) as t(col1 text, col2 bool);

--- a/test/fixtures/dialects/postgres/postgres_select.yml
+++ b/test/fixtures/dialects/postgres/postgres_select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9c194c3f6c0f3c93a3f931e8028512183a6f489feeb1c7d3d27fdce925cf4f97
+_hash: 8f58eb5f482b7b93ccc202bc3fe82114e4ea87c66c867f5abc0562415f140015
 file:
 - statement:
     select_statement:
@@ -376,4 +376,61 @@ file:
             table_expression:
               table_reference:
                 identifier: my_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - identifier: schema1
+          - dot: .
+          - identifier: table1
+          - dot: .
+          - identifier: columna
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - identifier: t
+          - dot: .
+          - identifier: col2
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: schema1
+              - dot: .
+              - identifier: table1
+          join_clause:
+          - keyword: CROSS
+          - keyword: JOIN
+          - keyword: LATERAL
+          - from_expression_element:
+              table_expression:
+                function:
+                  function_name:
+                    function_name_identifier: somefunc
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                      - identifier: tb
+                      - dot: .
+                      - identifier: columnb
+                    end_bracket: )
+              alias_expression:
+                keyword: as
+                identifier: t
+                bracketed:
+                - start_bracket: (
+                - parameter: col1
+                - data_type:
+                    keyword: text
+                - comma: ','
+                - parameter: col2
+                - data_type:
+                    keyword: bool
+                - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Add support for column definitions in table aliases. This is commonly used when joining with functions that return result sets.

Fixes #2929 


### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
