### PR TITLE
Allow multiple post function clauses in Postgres and Redshift

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -326,7 +326,7 @@ postgres_dialect.replace(
             "unicode_double_quote", CodeSegment, name="quoted_literal", type="literal"
         ),
     ),
-    PostFunctionGrammar=OneOf(
+    PostFunctionGrammar=AnyNumberOf(
         Ref("WithinGroupClauseSegment"),
         Ref("OverClauseSegment"),
         # Filter clause supported by both Postgres and SQLite

--- a/test/fixtures/dialects/redshift/redshift_percentile_cont.sql
+++ b/test/fixtures/dialects/redshift/redshift_percentile_cont.sql
@@ -1,0 +1,9 @@
+select
+    dataset_id,
+    (percentile_cont(0.20) within group (
+        order by tract_percent_below_poverty asc
+    ) over(partition by dataset_id)) as percentile_20,
+    percentile_cont(0.40)
+    within group (order by tract_percent_below_poverty asc)
+    over(partition by dataset_id) as percentile_40
+from dataset_with_census

--- a/test/fixtures/dialects/redshift/redshift_percentile_cont.yml
+++ b/test/fixtures/dialects/redshift/redshift_percentile_cont.yml
@@ -1,0 +1,100 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: ca9f31e8bd097609cd1ca93d1aafda7d11922f8c93c49c34fee378b46b5dded3
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: select
+      - select_clause_element:
+          column_reference:
+            identifier: dataset_id
+      - comma: ','
+      - select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: percentile_cont
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      literal: '0.20'
+                    end_bracket: )
+                  withingroup_clause:
+                  - keyword: within
+                  - keyword: group
+                  - bracketed:
+                      start_bracket: (
+                      orderby_clause:
+                      - keyword: order
+                      - keyword: by
+                      - column_reference:
+                          identifier: tract_percent_below_poverty
+                      - keyword: asc
+                      end_bracket: )
+                  over_clause:
+                    keyword: over
+                    bracketed:
+                      start_bracket: (
+                      window_specification:
+                        partitionby_clause:
+                        - keyword: partition
+                        - keyword: by
+                        - expression:
+                            column_reference:
+                              identifier: dataset_id
+                      end_bracket: )
+              end_bracket: )
+          alias_expression:
+            keyword: as
+            identifier: percentile_20
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: percentile_cont
+            bracketed:
+              start_bracket: (
+              expression:
+                literal: '0.40'
+              end_bracket: )
+            withingroup_clause:
+            - keyword: within
+            - keyword: group
+            - bracketed:
+                start_bracket: (
+                orderby_clause:
+                - keyword: order
+                - keyword: by
+                - column_reference:
+                    identifier: tract_percent_below_poverty
+                - keyword: asc
+                end_bracket: )
+            over_clause:
+              keyword: over
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: partition
+                  - keyword: by
+                  - expression:
+                      column_reference:
+                        identifier: dataset_id
+                end_bracket: )
+          alias_expression:
+            keyword: as
+            identifier: percentile_40
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: dataset_with_census


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Fixes #2951, an issue with parsing Redshift's [percentile_cont](https://docs.aws.amazon.com/redshift/latest/dg/r_WF_PERCENTILE_CONT.html#r_WF_PERCENTILE_CONT-synopsis) function.


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
