### PR TITLE
SparkSQL: Create Table Delta Lake Variant

### DIFF
--- a/test/fixtures/dialects/sparksql/delta/README.md
+++ b/test/fixtures/dialects/sparksql/delta/README.md
@@ -1,0 +1,12 @@
+# Delta Lake
+
+[Delta Lake](https://delta.io/) is an open-source storage framework that integrates
+with Spark.
+
+Since dialects in SQLFluff do not strictly adhere to their specifications and can
+contain a wider set of functionality, Delta syntax has been added to the SparkSQL
+dialect. This causes no adverse affects to the core dialect, other than the potential
+possibility of code parsing correctly that will not execute if Delta Lake is not
+configured.
+
+Test cases for Delta Lake are located here for easier identification.

--- a/test/fixtures/dialects/sparksql/delta/create_table.sql
+++ b/test/fixtures/dialects/sparksql/delta/create_table.sql
@@ -1,0 +1,69 @@
+-- Create table if not exists
+CREATE TABLE IF NOT EXISTS default.people10m (
+    id INT,
+    first_name STRING,
+    middle_name STRING,
+    last_name STRING,
+    gender STRING,
+    birth_date TIMESTAMP,
+    ssn STRING,
+    salary INT
+) USING DELTA;
+
+-- Create or replace table
+CREATE OR REPLACE TABLE default.people10m (
+    id INT,
+    first_name STRING,
+    middle_name STRING,
+    last_name STRING,
+    gender STRING,
+    birth_date TIMESTAMP,
+    ssn STRING,
+    salary INT
+) USING DELTA;
+
+-- Create or replace table with path
+CREATE OR REPLACE TABLE DELTA.`/delta/people10m` (
+    id INT,
+    first_name STRING,
+    middle_name STRING,
+    last_name STRING,
+    gender STRING,
+    birth_date TIMESTAMP,
+    ssn STRING,
+    salary INT
+) USING DELTA;
+
+-- Partition data
+CREATE TABLE default.people10m (
+    id INT,
+    first_name STRING,
+    middle_name STRING,
+    last_name STRING,
+    gender STRING,
+    birth_date TIMESTAMP,
+    ssn STRING,
+    salary INT
+)
+USING DELTA
+PARTITIONED BY (gender);
+
+-- Control data location
+CREATE TABLE default.people10m
+USING DELTA
+LOCATION '/delta/people10m';
+
+-- Generated columns
+CREATE TABLE default.people10m (
+    id INT,
+    first_name STRING,
+    middle_name STRING,
+    last_name STRING,
+    gender STRING,
+    birth_date TIMESTAMP,
+    date_of_birth DATE GENERATED ALWAYS AS (CAST(birth_date AS DATE)),
+    ssn STRING,
+    salary INT
+)
+USING DELTA
+PARTITIONED BY (gender);


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Adds additional segments to support Delta Lake `CREATE TABLE` syntax

### Are there any other side effects of this change that we should be aware of?
Additional sub-directory in `test/fixtures/dialects/sparksql` for delta related tests. It contains an README and test cases for Delta syntax. I thought this would be easier for troubleshooting and if Delta is ever split into it's own dialect.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
