### PR TITLE
Bug: L042 modifies parse tree even during "lint"

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -513,6 +513,7 @@ class Linter:
                     ignore_mask=ignore_buff,
                     dialect=config.get("dialect_obj"),
                     fname=fname,
+                    fix=fix,
                     templated_file=templated_file,
                 )
                 all_linting_errors += linting_errors

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -357,6 +357,7 @@ class RuleContext:
     memory: Any
     dialect: Dialect
     path: Optional[pathlib.Path]
+    fix: bool
     templated_file: Optional[TemplatedFile]
 
     @cached_property
@@ -492,6 +493,7 @@ class BaseRule:
         raw_stack=None,
         memory=None,
         fname=None,
+        fix=None,
         templated_file: Optional["TemplatedFile"] = None,
     ):
         """Recursively perform the crawl operation on a given segment.
@@ -510,6 +512,7 @@ class BaseRule:
         siblings_post = siblings_post or ()
         siblings_pre = siblings_pre or ()
         memory = memory or {}
+        fix = fix or False
         vs: List[SQLLintError] = []
         fixes: List[LintFix] = []
 
@@ -529,6 +532,7 @@ class BaseRule:
             memory=memory,
             dialect=dialect,
             path=pathlib.Path(fname) if fname else None,
+            fix=fix,
             templated_file=templated_file,
         )
         try:
@@ -617,6 +621,7 @@ class BaseRule:
                 memory=memory,
                 dialect=dialect,
                 fname=fname,
+                fix=fix,
                 templated_file=templated_file,
             )
             vs += dvs

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -113,6 +113,7 @@ class Rule_L042(BaseRule):
         # If there are offending elements calculate fixes
         return _calculate_fixes(
             dialect=context.dialect,
+            fix=context.fix,
             root_select=segment,
             nested_subqueries=nested_subqueries,
         )
@@ -120,6 +121,7 @@ class Rule_L042(BaseRule):
 
 def _calculate_fixes(
     dialect: Dialect,
+    fix: bool,
     root_select: Segments,
     nested_subqueries: List[_NestedSubQuerySummary],
 ) -> List[LintResult]:
@@ -184,7 +186,7 @@ def _calculate_fixes(
         )
         lint_results.append(res)
 
-    if ctes.has_duplicate_aliases() or is_recursive:
+    if not fix or ctes.has_duplicate_aliases() or is_recursive:
         # If we have duplicate CTE names just don't fix anything
         # Return the lint warnings anyway
         return lint_results


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Makes progress on #2944.

It's a workaround, not a fix. The workaround is to let rules know if we're in "lint" or "fix" mode, so they can skip the "fix" logic when just linting. This is not a proper fix because L042 has a design flaw: It's modifying the parse tree directly, bypassing the use of `LintFix`. This will likely cause other issues in the future until it's fixed.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
