### PR TITLE
Add basic `IS (NOT) DISTINCT FROM` support in most dialects

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -387,6 +387,8 @@ ansi_dialect.add(
         Ref("LessThanOrEqualToSegment"),
         Ref("NotEqualToSegment"),
         Ref("LikeOperatorSegment"),
+        Sequence("IS", "DISTINCT", "FROM"),
+        Sequence("IS", "NOT", "DISTINCT", "FROM"),
     ),
     # hookpoint for other dialects
     # e.g. EXASOL str to date cast with DATE '2021-01-01'

--- a/test/fixtures/dialects/bigquery/is_not_distinct.sql
+++ b/test/fixtures/dialects/bigquery/is_not_distinct.sql
@@ -1,0 +1,28 @@
+-- 1. Column distinctness in SELECT expression
+-- TODO allow this to work without brackets
+SELECT (a_column IS DISTINCT FROM b_column) FROM t_table;
+SELECT (b_column IS NOT DISTINCT FROM c_column) FROM t_table;
+
+-- 2. Column distinctness in WHERE expression
+SELECT a_column FROM t_table WHERE a_column IS DISTINCT FROM b_column;
+SELECT a_column FROM t_table WHERE a_column IS NOT DISTINCT FROM b_column;
+
+-- 3. Column distinctness in JOIN expression
+SELECT t_table_1.a_column
+FROM t_table_1
+INNER JOIN t_table_2
+    ON t_table_1.a_column IS DISTINCT FROM t_table_2.a_column;
+SELECT t_table_1.a_column
+FROM t_table_1
+INNER JOIN t_table_2
+    ON t_table_1.a_column IS NOT DISTINCT FROM t_table_2.a_column;
+
+-- 4. Column distinctness in MERGE expression
+MERGE INTO t_table_1
+USING t_table_2
+ON t_table_1.a_column IS DISTINCT FROM t_table_2.a_column
+WHEN NOT MATCHED THEN INSERT (a) VALUES (b);
+MERGE INTO t_table_1
+USING t_table_2
+ON t_table_1.a_column IS NOT DISTINCT FROM t_table_2.a_column
+WHEN NOT MATCHED THEN INSERT (a) VALUES (b);

--- a/test/fixtures/dialects/bigquery/is_not_distinct.yml
+++ b/test/fixtures/dialects/bigquery/is_not_distinct.yml
@@ -1,0 +1,277 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 8f143318d7229326056d63b0f5542396cc009909769a4e79edc53edc3c3475f8
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  identifier: a_column
+              - keyword: IS
+              - keyword: DISTINCT
+              - keyword: FROM
+              - column_reference:
+                  identifier: b_column
+              end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  identifier: b_column
+              - keyword: IS
+              - keyword: NOT
+              - keyword: DISTINCT
+              - keyword: FROM
+              - column_reference:
+                  identifier: c_column
+              end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            identifier: a_column
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t_table
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            identifier: a_column
+        - keyword: IS
+        - keyword: DISTINCT
+        - keyword: FROM
+        - column_reference:
+            identifier: b_column
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            identifier: a_column
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t_table
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            identifier: a_column
+        - keyword: IS
+        - keyword: NOT
+        - keyword: DISTINCT
+        - keyword: FROM
+        - column_reference:
+            identifier: b_column
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+          - identifier: t_table_1
+          - dot: .
+          - identifier: a_column
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t_table_1
+          join_clause:
+          - keyword: INNER
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: t_table_2
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - identifier: t_table_1
+                - dot: .
+                - identifier: a_column
+              - keyword: IS
+              - keyword: DISTINCT
+              - keyword: FROM
+              - column_reference:
+                - identifier: t_table_2
+                - dot: .
+                - identifier: a_column
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+          - identifier: t_table_1
+          - dot: .
+          - identifier: a_column
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: t_table_1
+          join_clause:
+          - keyword: INNER
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: t_table_2
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - identifier: t_table_1
+                - dot: .
+                - identifier: a_column
+              - keyword: IS
+              - keyword: NOT
+              - keyword: DISTINCT
+              - keyword: FROM
+              - column_reference:
+                - identifier: t_table_2
+                - dot: .
+                - identifier: a_column
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+        identifier: t_table_1
+    - keyword: USING
+    - table_reference:
+        identifier: t_table_2
+    - join_on_condition:
+        keyword: 'ON'
+        expression:
+        - column_reference:
+          - identifier: t_table_1
+          - dot: .
+          - identifier: a_column
+        - keyword: IS
+        - keyword: DISTINCT
+        - keyword: FROM
+        - column_reference:
+          - identifier: t_table_2
+          - dot: .
+          - identifier: a_column
+    - merge_match:
+        merge_when_not_matched_clause:
+        - keyword: WHEN
+        - keyword: NOT
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_insert_clause:
+            keyword: INSERT
+            bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: a
+              end_bracket: )
+            values_clause:
+              keyword: VALUES
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    identifier: b
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - keyword: INTO
+    - table_reference:
+        identifier: t_table_1
+    - keyword: USING
+    - table_reference:
+        identifier: t_table_2
+    - join_on_condition:
+        keyword: 'ON'
+        expression:
+        - column_reference:
+          - identifier: t_table_1
+          - dot: .
+          - identifier: a_column
+        - keyword: IS
+        - keyword: NOT
+        - keyword: DISTINCT
+        - keyword: FROM
+        - column_reference:
+          - identifier: t_table_2
+          - dot: .
+          - identifier: a_column
+    - merge_match:
+        merge_when_not_matched_clause:
+        - keyword: WHEN
+        - keyword: NOT
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_insert_clause:
+            keyword: INSERT
+            bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: a
+              end_bracket: )
+            values_clause:
+              keyword: VALUES
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    identifier: b
+                end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Makes progress on #2961 
Note we currently do not fully support this in the `SELECT` clause unless brackets are used.


### Are there any other side effects of this change that we should be aware of?

### Pull Request checklist
- [z] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
