### PR TITLE
INTO is optional within T-SQL INSERT statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -597,7 +597,7 @@ class InsertStatementSegment(BaseSegment):
     type = "insert_statement"
     match_grammar = Sequence(
         "INSERT",
-        "INTO",
+        Ref.keyword("INTO", optional=True),
         Ref("TableReferenceSegment"),
         Ref("BracketedColumnReferenceListGrammar", optional=True),
         OneOf(Ref("SelectableGrammar"), Ref("ExecuteScriptSegment")),

--- a/test/fixtures/dialects/tsql/insert_statement.sql
+++ b/test/fixtures/dialects/tsql/insert_statement.sql
@@ -48,3 +48,9 @@ GO
 INSERT INTO HumanResources.NewEmployee
   EXEC FindEmployeesFunc @lastName = 'Picard'
 GO
+
+INSERT HumanResources.NewEmployee
+  (LastName, FirstName)
+  values
+  ('Kirk', 'James')
+GO

--- a/test/fixtures/dialects/tsql/insert_statement.yml
+++ b/test/fixtures/dialects/tsql/insert_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 814aafde54c3d35236c51d85ffb120760d66ad8d8a2e795bedaad2f706936af6
+_hash: 6d1af97addb2c950720adfb03fa75afe4ec3281114b6df0a8b7df7b316261795
 file:
 - batch:
     statement:
@@ -401,5 +401,33 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           literal: "'Picard'"
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      insert_statement:
+        keyword: INSERT
+        table_reference:
+        - identifier: HumanResources
+        - dot: .
+        - identifier: NewEmployee
+        bracketed:
+        - start_bracket: (
+        - column_reference:
+            identifier: LastName
+        - comma: ','
+        - column_reference:
+            identifier: FirstName
+        - end_bracket: )
+        values_clause:
+          keyword: values
+          bracketed:
+          - start_bracket: (
+          - expression:
+              literal: "'Kirk'"
+          - comma: ','
+          - expression:
+              literal: "'James'"
+          - end_bracket: )
 - go_statement:
     keyword: GO


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

INTO keyword is optional in INSERT statements in T-SQL.
See: https://docs.microsoft.com/en-us/sql/t-sql/statements/insert-transact-sql?view=sql-server-ver15

### Are there any other side effects of this change that we should be aware of?

N/A

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.

sqlfluff is already documented as supporting T-SQL dialect.

- Created GitHub issues for any relevant followup/future enhancements if appropriate.
