### PR TITLE
TSQL: Add support for `WAITFOR` statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -431,6 +431,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("WhileExpressionStatement"),
             Ref("BreakStatement"),
             Ref("ContinueStatement"),
+            Ref("WaitForStatementSegment"),
         ],
         remove=[
             Ref("CreateExtensionStatementSegment"),
@@ -1349,6 +1350,26 @@ class ContinueStatement(BaseSegment):
 
     match_grammar = Sequence(
         "CONTINUE",
+    )
+
+
+class WaitForStatementSegment(BaseSegment):
+    """WAITFOR statement.
+
+    https://docs.microsoft.com/en-us/sql/t-sql/language-elements/waitfor-transact-sql?view=sql-server-ver15
+    Partially implemented, lacking Receive and Get Conversation Group statements for
+    now.
+    """
+
+    type = "waitfor_statement"
+
+    match_grammar = Sequence(
+        "WAITFOR",
+        OneOf(
+            Sequence("DELAY", Ref("ExpressionSegment")),
+            Sequence("TIME", Ref("ExpressionSegment")),
+        ),
+        Sequence("TIMEOUT", Ref("NumericLiteralSegment"), optional=True),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -228,6 +228,7 @@ UNRESERVED_KEYWORDS = [
     "DATEFIRST",
     "DATEFORMAT",
     "DEADLOCK_PRIORITY",
+    "DELAY",
     "DENSE_RANK",
     "DETERMINISTIC",
     "DISABLE",
@@ -391,6 +392,7 @@ UNRESERVED_KEYWORDS = [
     "THROW",
     "TIES",
     "TIME",
+    "TIMEOUT",
     "TIMESTAMP",
     "TRANSACTION_ID",
     "TRUNCATE_TARGET",  # Azure Synapse Analytics specific
@@ -404,6 +406,7 @@ UNRESERVED_KEYWORDS = [
     "USING",
     "VALUE",
     "VIEW_METADATA",
+    "WAITFOR",
     "WAIT_AT_LOW_PRIORITY",
     "WITHIN",
     "WHILE",

--- a/test/fixtures/dialects/tsql/waitfor.sql
+++ b/test/fixtures/dialects/tsql/waitfor.sql
@@ -1,0 +1,14 @@
+EXECUTE sp_add_job @job_name = 'TestJob';
+BEGIN
+    WAITFOR TIME '22:20';
+    EXECUTE sp_update_job @job_name = 'TestJob',
+        @new_name = 'UpdatedJob';
+END;
+GO
+
+
+BEGIN
+    WAITFOR DELAY '02:00';
+    EXECUTE sp_helpdb;
+END;
+GO

--- a/test/fixtures/dialects/tsql/waitfor.yml
+++ b/test/fixtures/dialects/tsql/waitfor.yml
@@ -1,0 +1,68 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9f348e3c6e1846863afc24260acc071d326cb77715077abfa91d55a250ecd0f9
+file:
+- batch:
+  - statement:
+      execute_script_statement:
+        keyword: EXECUTE
+        object_reference:
+          identifier: sp_add_job
+        parameter: '@job_name'
+        comparison_operator:
+          raw_comparison_operator: '='
+        literal: "'TestJob'"
+        statement_terminator: ;
+  - statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          waitfor_statement:
+          - keyword: WAITFOR
+          - keyword: TIME
+          - expression:
+              literal: "'22:20'"
+      - statement_terminator: ;
+      - statement:
+          execute_script_statement:
+          - keyword: EXECUTE
+          - object_reference:
+              identifier: sp_update_job
+          - parameter: '@job_name'
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - literal: "'TestJob'"
+          - comma: ','
+          - parameter: '@new_name'
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - literal: "'UpdatedJob'"
+          - statement_terminator: ;
+      - keyword: END
+  - statement_terminator: ;
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      begin_end_block:
+      - keyword: BEGIN
+      - statement:
+          waitfor_statement:
+          - keyword: WAITFOR
+          - keyword: DELAY
+          - expression:
+              literal: "'02:00'"
+      - statement_terminator: ;
+      - statement:
+          execute_script_statement:
+            keyword: EXECUTE
+            object_reference:
+              identifier: sp_helpdb
+            statement_terminator: ;
+      - keyword: END
+    statement_terminator: ;
+- go_statement:
+    keyword: GO


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Add (partial) support for WAITFOR in T-SQL dialect.
https://docs.microsoft.com/en-us/sql/t-sql/language-elements/waitfor-transact-sql?view=sql-server-ver15

### Are there any other side effects of this change that we should be aware of?

N/A

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
