### PR TITLE
T-SQL: add support for assignment operators

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1703,6 +1703,7 @@ class AssignmentOperatorSegment(BaseSegment):
     Includes simpler equals but also +=, -=, etc.
     """
 
+    type = "assignment_operator"
     match_grammar = OneOf(
         Ref("EqualsSegment"),
         Sequence(
@@ -1715,7 +1716,6 @@ class AssignmentOperatorSegment(BaseSegment):
                 Ref("BitwiseAndSegment"),
                 Ref("BitwiseOrSegment"),
                 Ref("BitwiseXorSegment"),
-                optional=True,
             ),
             Ref("EqualsSegment"),
             allow_gaps=False,

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2835,7 +2835,7 @@ class SetClauseSegment(BaseSegment):
 
     match_grammar = Sequence(
         Ref("ColumnReferenceSegment"),
-        Ref("EqualsSegment"),
+        Ref("AssignmentOperatorSegment"),
         Ref("ExpressionSegment"),
     )
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1631,7 +1631,6 @@ class SetStatementSegment(BaseSegment):
                 ),
                 Sequence(
                     OneOf(
-                        Ref("ParameterNameSegment"),
                         "DATEFIRST",
                         "DATEFORMAT",
                         "DEADLOCK_PRIORITY",
@@ -1686,10 +1685,41 @@ class SetStatementSegment(BaseSegment):
                         ),
                     ),
                 ),
+                Sequence(
+                    Ref("ParameterNameSegment"),
+                    Ref("AssignmentOperatorSegment"),
+                    Ref("ExpressionSegment"),
+                ),
             ),
         ),
         Dedent,
         Ref("DelimiterGrammar", optional=True),
+    )
+
+
+class AssignmentOperatorSegment(BaseSegment):
+    """One of the assignment operators.
+
+    Includes simpler equals but also +=, -=, etc.
+    """
+
+    match_grammar = OneOf(
+        Ref("EqualsSegment"),
+        Sequence(
+            OneOf(
+                Ref("PlusSegment"),
+                Ref("MinusSegment"),
+                Ref("DivideSegment"),
+                Ref("MultiplySegment"),
+                Ref("ModuloSegment"),
+                Ref("BitwiseAndSegment"),
+                Ref("BitwiseOrSegment"),
+                Ref("BitwiseXorSegment"),
+                optional=True,
+            ),
+            Ref("EqualsSegment"),
+            allow_gaps=False,
+        ),
     )
 
 

--- a/test/fixtures/dialects/tsql/create_function.yml
+++ b/test/fixtures/dialects/tsql/create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 91f5b496be435d79d1edaa018a5a6b51e48a6688a7cf6005223bb3f6ac11d9d5
+_hash: e01077856e2688a875954ec5d188a6025f348a76bce33887fd715006b2ebd5f2
 file:
   batch:
     statement:
@@ -46,8 +46,9 @@ file:
                 set_segment:
                   keyword: SET
                   parameter: '@ISOweek'
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  assignment_operator:
+                    comparison_operator:
+                      raw_comparison_operator: '='
                   expression:
                   - function:
                       function_name:
@@ -122,8 +123,9 @@ file:
                     set_segment:
                       keyword: SET
                       parameter: '@ISOweek'
-                      comparison_operator:
-                        raw_comparison_operator: '='
+                      assignment_operator:
+                        comparison_operator:
+                          raw_comparison_operator: '='
                       expression:
                         function:
                           function_name:
@@ -268,8 +270,9 @@ file:
                     set_segment:
                       keyword: SET
                       parameter: '@ISOweek'
-                      comparison_operator:
-                        raw_comparison_operator: '='
+                      assignment_operator:
+                        comparison_operator:
+                          raw_comparison_operator: '='
                       expression:
                         literal: '1'
                       statement_terminator: ;

--- a/test/fixtures/dialects/tsql/declare_with_following_statements.yml
+++ b/test/fixtures/dialects/tsql/declare_with_following_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5a0177bbf18d5caa17660ef9d9c5b008832cfc620b9a6ce4a215d9e8a68560bb
+_hash: 2b15bff17b0bca2a6197eaee7bdc2da1d35fcd74e08b42e3751b8a5bf6d99201
 file:
   batch:
     create_procedure_statement:
@@ -88,8 +88,9 @@ file:
               set_segment:
                 keyword: SET
                 parameter: '@EOMONTH'
-                comparison_operator:
-                  raw_comparison_operator: '='
+                assignment_operator:
+                  comparison_operator:
+                    raw_comparison_operator: '='
                 expression:
                   bracketed:
                     start_bracket: (
@@ -100,8 +101,9 @@ file:
               set_segment:
                 keyword: SET
                 parameter: '@EOMONTH'
-                comparison_operator:
-                  raw_comparison_operator: '='
+                assignment_operator:
+                  comparison_operator:
+                    raw_comparison_operator: '='
                 expression:
                   bracketed:
                     start_bracket: (

--- a/test/fixtures/dialects/tsql/function_with_variable.yml
+++ b/test/fixtures/dialects/tsql/function_with_variable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2137a488400f722da286ecd0c649121b893d7a0b55da5ae15671b96623c4e3bc
+_hash: 7d01b9415f9535045cfbc42b3e24b0eabf423a2f52e9fa75832472f5edcc764b
 file:
   batch:
     statement:
@@ -45,8 +45,9 @@ file:
                 set_segment:
                   keyword: SET
                   parameter: '@result'
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  assignment_operator:
+                    comparison_operator:
+                      raw_comparison_operator: '='
                   expression:
                     literal: '4'
             - statement:

--- a/test/fixtures/dialects/tsql/hints.yml
+++ b/test/fixtures/dialects/tsql/hints.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9089be90f3163e1c71c8a0c6879aa774b1d4598924e60dd7832b8c12e275f957
+_hash: 5bcf24968b7d9978c558f165b2a84e3ea46a42f03558600cdad2930890852042
 file:
 - batch:
     statement:
@@ -647,8 +647,9 @@ file:
           set_clause:
             column_reference:
               identifier: ListPrice
-            comparison_operator:
-              raw_comparison_operator: '='
+            assignment_operator:
+              comparison_operator:
+                raw_comparison_operator: '='
             expression:
               column_reference:
                 identifier: ListPrice

--- a/test/fixtures/dialects/tsql/merge.yml
+++ b/test/fixtures/dialects/tsql/merge.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b415f47c240637e0941e4defed07cf29232d18b409a9b7b2c2c4d42dd47e7492
+_hash: 25f98e03f7bb5285fd55635b63f2304603af7b5e25583b065db56b35792accc6
 file:
 - batch:
     statement:
@@ -64,8 +64,9 @@ file:
                   - identifier: dst
                   - dot: .
                   - identifier: l_id
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  assignment_operator:
+                    comparison_operator:
+                      raw_comparison_operator: '='
                   expression:
                     column_reference:
                     - identifier: src
@@ -77,8 +78,9 @@ file:
                   - identifier: dst
                   - dot: .
                   - identifier: e_date_to
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  assignment_operator:
+                    comparison_operator:
+                      raw_comparison_operator: '='
                   expression:
                     column_reference:
                     - identifier: src
@@ -186,8 +188,9 @@ file:
                     - identifier: dst
                     - dot: .
                     - identifier: cc_name
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    assignment_operator:
+                      comparison_operator:
+                        raw_comparison_operator: '='
                     expression:
                       column_reference:
                       - identifier: src
@@ -199,8 +202,9 @@ file:
                     - identifier: dst
                     - dot: .
                     - identifier: cc_description
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    assignment_operator:
+                      comparison_operator:
+                        raw_comparison_operator: '='
                     expression:
                       column_reference:
                       - identifier: src
@@ -301,8 +305,9 @@ file:
                   - identifier: dst
                   - dot: .
                   - identifier: c_name
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  assignment_operator:
+                    comparison_operator:
+                      raw_comparison_operator: '='
                   expression:
                     column_reference:
                     - identifier: src
@@ -314,8 +319,9 @@ file:
                   - identifier: dst
                   - dot: .
                   - identifier: col1
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  assignment_operator:
+                    comparison_operator:
+                      raw_comparison_operator: '='
                   expression:
                     column_reference:
                     - identifier: src
@@ -327,8 +333,9 @@ file:
                   - identifier: dst
                   - dot: .
                   - identifier: col2
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  assignment_operator:
+                    comparison_operator:
+                      raw_comparison_operator: '='
                   expression:
                     column_reference:
                     - identifier: src
@@ -446,8 +453,9 @@ file:
                   - identifier: dst
                   - dot: .
                   - identifier: col1
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  assignment_operator:
+                    comparison_operator:
+                      raw_comparison_operator: '='
                   expression:
                     literal: "'N'"
               - comma: ','
@@ -456,8 +464,9 @@ file:
                   - identifier: dst
                   - dot: .
                   - identifier: col2
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  assignment_operator:
+                    comparison_operator:
+                      raw_comparison_operator: '='
                   expression:
                     column_reference:
                       identifier: col2
@@ -525,8 +534,9 @@ file:
                 set_clause:
                   column_reference:
                     identifier: Name
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  assignment_operator:
+                    comparison_operator:
+                      raw_comparison_operator: '='
                   expression:
                     column_reference:
                     - identifier: src
@@ -726,8 +736,9 @@ file:
                   - identifier: tgt
                   - dot: .
                   - identifier: Quantity
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  assignment_operator:
+                    comparison_operator:
+                      raw_comparison_operator: '='
                   expression:
                   - column_reference:
                     - identifier: tgt
@@ -744,8 +755,9 @@ file:
                   - identifier: tgt
                   - dot: .
                   - identifier: ModifiedDate
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  assignment_operator:
+                    comparison_operator:
+                      raw_comparison_operator: '='
                   expression:
                     function:
                       function_name:
@@ -924,8 +936,9 @@ file:
                   - identifier: pi
                   - dot: .
                   - identifier: Quantity
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  assignment_operator:
+                    comparison_operator:
+                      raw_comparison_operator: '='
                   expression:
                   - column_reference:
                     - identifier: pi
@@ -1078,8 +1091,9 @@ file:
                               set_clause:
                                 column_reference:
                                   identifier: columnC
-                                comparison_operator:
-                                  raw_comparison_operator: '='
+                                assignment_operator:
+                                  comparison_operator:
+                                    raw_comparison_operator: '='
                                 expression:
                                   column_reference:
                                   - identifier: src

--- a/test/fixtures/dialects/tsql/set_statements.sql
+++ b/test/fixtures/dialects/tsql/set_statements.sql
@@ -18,3 +18,14 @@ SET @param1 = "test, test",
 SET @param1 = ("test", "test"),
     @param2 = 2
 ;
+
+-- Assignment operators
+SET @param1 += 1,
+    @param2 -= 2,
+    @param3 *= 3,
+    @param4 /= 4,
+    @param5 %= 5,
+    @param5 ^= 6,
+    @param5 &= 7,
+    @param5 |= 8
+;

--- a/test/fixtures/dialects/tsql/set_statements.yml
+++ b/test/fixtures/dialects/tsql/set_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: be9458cab507215616ce34e6f09fe4ce3e75886bbfd9b590323d79dd9cd66f2c
+_hash: aa3522bdae5fe9b0041c0c9ba130967fed8399855fb5e1274a9de55f0940ff66
 file:
   batch:
   - statement:
@@ -19,8 +19,9 @@ file:
       set_segment:
         keyword: SET
         parameter: '@param1'
-        comparison_operator:
-          raw_comparison_operator: '='
+        assignment_operator:
+          comparison_operator:
+            raw_comparison_operator: '='
         expression:
           literal: '1'
         statement_terminator: ;
@@ -28,14 +29,16 @@ file:
       set_segment:
       - keyword: SET
       - parameter: '@param1'
-      - comparison_operator:
-          raw_comparison_operator: '='
+      - assignment_operator:
+          comparison_operator:
+            raw_comparison_operator: '='
       - expression:
           literal: '1'
       - comma: ','
       - parameter: '@param2'
-      - comparison_operator:
-          raw_comparison_operator: '='
+      - assignment_operator:
+          comparison_operator:
+            raw_comparison_operator: '='
       - expression:
           literal: '2'
       - statement_terminator: ;
@@ -43,15 +46,17 @@ file:
       set_segment:
       - keyword: SET
       - parameter: '@param1'
-      - comparison_operator:
-          raw_comparison_operator: '='
+      - assignment_operator:
+          comparison_operator:
+            raw_comparison_operator: '='
       - expression:
           column_reference:
             identifier: '"test, test"'
       - comma: ','
       - parameter: '@param2'
-      - comparison_operator:
-          raw_comparison_operator: '='
+      - assignment_operator:
+          comparison_operator:
+            raw_comparison_operator: '='
       - expression:
           literal: '2'
       - statement_terminator: ;
@@ -59,8 +64,9 @@ file:
       set_segment:
       - keyword: SET
       - parameter: '@param1'
-      - comparison_operator:
-          raw_comparison_operator: '='
+      - assignment_operator:
+          comparison_operator:
+            raw_comparison_operator: '='
       - expression:
           bracketed:
           - start_bracket: (
@@ -72,8 +78,78 @@ file:
           - end_bracket: )
       - comma: ','
       - parameter: '@param2'
-      - comparison_operator:
-          raw_comparison_operator: '='
+      - assignment_operator:
+          comparison_operator:
+            raw_comparison_operator: '='
       - expression:
           literal: '2'
+      - statement_terminator: ;
+  - statement:
+      set_segment:
+      - keyword: SET
+      - parameter: '@param1'
+      - assignment_operator:
+          binary_operator: +
+          comparison_operator:
+            raw_comparison_operator: '='
+      - expression:
+          literal: '1'
+      - comma: ','
+      - parameter: '@param2'
+      - assignment_operator:
+          binary_operator: '-'
+          comparison_operator:
+            raw_comparison_operator: '='
+      - expression:
+          literal: '2'
+      - comma: ','
+      - parameter: '@param3'
+      - assignment_operator:
+          binary_operator: '*'
+          comparison_operator:
+            raw_comparison_operator: '='
+      - expression:
+          literal: '3'
+      - comma: ','
+      - parameter: '@param4'
+      - assignment_operator:
+          binary_operator: /
+          comparison_operator:
+            raw_comparison_operator: '='
+      - expression:
+          literal: '4'
+      - comma: ','
+      - parameter: '@param5'
+      - assignment_operator:
+          binary_operator: '%'
+          comparison_operator:
+            raw_comparison_operator: '='
+      - expression:
+          literal: '5'
+      - comma: ','
+      - parameter: '@param5'
+      - assignment_operator:
+          binary_operator: ^
+          comparison_operator:
+            raw_comparison_operator: '='
+      - expression:
+          literal: '6'
+      - comma: ','
+      - parameter: '@param5'
+      - assignment_operator:
+          binary_operator:
+            ampersand: '&'
+          comparison_operator:
+            raw_comparison_operator: '='
+      - expression:
+          literal: '7'
+      - comma: ','
+      - parameter: '@param5'
+      - assignment_operator:
+          binary_operator:
+            pipe: '|'
+          comparison_operator:
+            raw_comparison_operator: '='
+      - expression:
+          literal: '8'
       - statement_terminator: ;

--- a/test/fixtures/dialects/tsql/stored_procedure_begin_end.yml
+++ b/test/fixtures/dialects/tsql/stored_procedure_begin_end.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 950bd695b0c4e3121a707909132e1702ff0e3899bfd13fa525d2cf4de5576191
+_hash: 43c8fe22e411c3db9e03a91c9af332ac51bbccf66cf468191b0afc271161e461
 file:
 - batch:
     create_procedure_statement:
@@ -214,8 +214,9 @@ file:
                   set_segment:
                     keyword: SET
                     parameter: '@v_nSysErrorNum'
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    assignment_operator:
+                      comparison_operator:
+                        raw_comparison_operator: '='
                     expression:
                       function:
                         function_name:
@@ -228,8 +229,9 @@ file:
                   set_segment:
                     keyword: SET
                     parameter: '@v_vchCode'
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    assignment_operator:
+                      comparison_operator:
+                        raw_comparison_operator: '='
                     expression:
                       function:
                         function_name:
@@ -242,8 +244,9 @@ file:
                   set_segment:
                     keyword: SET
                     parameter: '@v_vchMsg'
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    assignment_operator:
+                      comparison_operator:
+                        raw_comparison_operator: '='
                     expression:
                       literal: "N'Missing control type.'"
                     statement_terminator: ;
@@ -251,8 +254,9 @@ file:
                   set_segment:
                     keyword: SET
                     parameter: '@v_vchMsg'
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    assignment_operator:
+                      comparison_operator:
+                        raw_comparison_operator: '='
                     expression:
                     - parameter: '@v_vchMsg'
                     - binary_operator: +

--- a/test/fixtures/dialects/tsql/system-variables.yml
+++ b/test/fixtures/dialects/tsql/system-variables.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cffc2e1464862bc572428a78ef62aa50d33776f7b1d3ffa41bfcc72d77939705
+_hash: d393e3e90a11126937a4c44113d19671dc473533602f034b8cff55890fba89bc
 file:
 - batch:
   - statement:
@@ -18,8 +18,9 @@ file:
           set_clause:
             column_reference:
               identifier: JobTitle
-            comparison_operator:
-              raw_comparison_operator: '='
+            assignment_operator:
+              comparison_operator:
+                raw_comparison_operator: '='
             expression:
               literal: "N'Executive'"
         where_clause:

--- a/test/fixtures/dialects/tsql/triggers.yml
+++ b/test/fixtures/dialects/tsql/triggers.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2777acd1afcdfb6536d616a9c1aa629d7df656916c4713d8fc4c5a02f756ea31
+_hash: 23ac2a1432d1d9a9d3d1082d960b7377edb1c61437200d966cf7c4dd2bd5e5fc
 file:
 - batch:
     statement:
@@ -447,8 +447,9 @@ file:
               set_clause:
                 column_reference:
                   identifier: PDW_LAST_UPDATED
-                comparison_operator:
-                  raw_comparison_operator: '='
+                assignment_operator:
+                  comparison_operator:
+                    raw_comparison_operator: '='
                 expression:
                   function:
                     function_name:
@@ -536,8 +537,9 @@ file:
               set_clause:
                 column_reference:
                   identifier: PDW_LAST_UPDATED
-                comparison_operator:
-                  raw_comparison_operator: '='
+                assignment_operator:
+                  comparison_operator:
+                    raw_comparison_operator: '='
                 expression:
                   function:
                     function_name:

--- a/test/fixtures/dialects/tsql/update.sql
+++ b/test/fixtures/dialects/tsql/update.sql
@@ -2,3 +2,13 @@ update dbo.Cases
 set [Flg] = 1
 where ID in (select distinct [ID] from dbo.CX)
 OPTION (Label = 'Cases') ;
+
+update
+	tt
+set
+	tt.rn += 1
+from
+	table1 as tt
+join
+	src
+	on tt._id = src._id;

--- a/test/fixtures/dialects/tsql/update.yml
+++ b/test/fixtures/dialects/tsql/update.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c1b816e2107af6d327250f3dd97ca6d0f54e0d80d5fada0fd553fe8cc3b53249
+_hash: 266ad1644265754848038924e3318a4868944486cb5e799e2322c2a3e8276bcf
 file:
   batch:
-    statement:
+  - statement:
       update_statement:
         keyword: update
         table_reference:
@@ -18,8 +18,9 @@ file:
           set_clause:
             column_reference:
               identifier: '[Flg]'
-            comparison_operator:
-              raw_comparison_operator: '='
+            assignment_operator:
+              comparison_operator:
+                raw_comparison_operator: '='
             expression:
               literal: '1'
         where_clause:
@@ -59,3 +60,51 @@ file:
               literal: "'Cases'"
             end_bracket: )
         statement_terminator: ;
+  - statement:
+      update_statement:
+        keyword: update
+        table_reference:
+          identifier: tt
+        set_clause_list:
+          keyword: set
+          set_clause:
+            column_reference:
+            - identifier: tt
+            - dot: .
+            - identifier: rn
+            assignment_operator:
+              binary_operator: +
+              comparison_operator:
+                raw_comparison_operator: '='
+            expression:
+              literal: '1'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: table1
+              alias_expression:
+                keyword: as
+                identifier: tt
+            join_clause:
+              keyword: join
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: src
+              join_on_condition:
+                keyword: 'on'
+                expression:
+                - column_reference:
+                  - identifier: tt
+                  - dot: .
+                  - identifier: _id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - identifier: src
+                  - dot: .
+                  - identifier: _id
+          statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fixes #2008 

Add support for assignments operators such as +=

### Are there any other side effects of this change that we should be aware of?

The change restricts the accepted grammar as other SET expression do not allow = in T-SQL.
It does not cover all the cases of the SET @local_variable syntax.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
