### PR TITLE
TSQL: allow leading GO

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2542,16 +2542,19 @@ class FileSegment(BaseFileSegment):
 
     # NB: We don't need a match_grammar here because we're
     # going straight into instantiating it directly usually.
-    parse_grammar = Delimited(
-        Ref("BatchSegment"),
-        delimiter=AnyNumberOf(
-            Sequence(
-                Ref("DelimiterGrammar", optional=True), Ref("BatchDelimiterGrammar")
+    parse_grammar = Sequence(
+        AnyNumberOf(Ref("BatchDelimiterGrammar")),
+        Delimited(
+            Ref("BatchSegment"),
+            delimiter=AnyNumberOf(
+                Sequence(
+                    Ref("DelimiterGrammar", optional=True), Ref("BatchDelimiterGrammar")
+                ),
+                min_times=1,
             ),
-            min_times=1,
+            allow_gaps=True,
+            allow_trailing=True,
         ),
-        allow_gaps=True,
-        allow_trailing=True,
     )
 
 

--- a/test/fixtures/dialects/tsql/go_delimiters.sql
+++ b/test/fixtures/dialects/tsql/go_delimiters.sql
@@ -1,3 +1,5 @@
+-- It's possible to have a file starting with GO
+GO
 -- It's possible to have multiple GO between batches.
 SELECT foo FROM bar GO GO
 SELECT foo FROM bar GO

--- a/test/fixtures/dialects/tsql/go_delimiters.yml
+++ b/test/fixtures/dialects/tsql/go_delimiters.yml
@@ -3,8 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 48ee8f3f556e82816f06c2f0155e2eb39630f07d23a9a0a7cf961d58d58df5eb
+_hash: bd36bce2e40fe28989cdc56078defe2ddae2d528b37e5b717984c9a6e64041af
 file:
+- go_statement:
+    keyword: GO
 - batch:
     statement:
       select_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

T-SQL files may start with a leading GO

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
