### PR TITLE
SparkSQL: Test cases for Delta Variation of Writing a table

### DIFF
--- a/test/fixtures/dialects/sparksql/delta_write_table.sql
+++ b/test/fixtures/dialects/sparksql/delta_write_table.sql
@@ -1,0 +1,9 @@
+-- append
+INSERT INTO default.people10m SELECT * FROM more_people;
+
+-- overwrite
+INSERT OVERWRITE TABLE default.people10m SELECT * FROM more_people;
+
+-- with user-defined commit metadata
+SET spark.databricks.delta.commitInfo.userMetadata = "overwritten-for-fixing-incorrect-data";
+INSERT OVERWRITE default.people10m SELECT * FROM more_people;

--- a/test/fixtures/dialects/sparksql/delta_write_table.yml
+++ b/test/fixtures/dialects/sparksql/delta_write_table.yml
@@ -1,0 +1,94 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e461676f523407410601287c4d1cacd6abf67ccfa6fb204241a1a4742f02bce7
+file:
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+      - identifier: default
+      - dot: .
+      - identifier: people10m
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: more_people
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OVERWRITE
+    - keyword: TABLE
+    - table_reference:
+      - identifier: default
+      - dot: .
+      - identifier: people10m
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: more_people
+- statement_terminator: ;
+- statement:
+    set_statement:
+      keyword: SET
+      property_name_identifier:
+      - identifier: spark
+      - dot: .
+      - identifier: databricks
+      - dot: .
+      - identifier: delta
+      - dot: .
+      - identifier: commitInfo
+      - dot: .
+      - identifier: userMetadata
+      comparison_operator:
+        raw_comparison_operator: '='
+      literal: '"overwritten-for-fixing-incorrect-data"'
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OVERWRITE
+    - table_reference:
+      - identifier: default
+      - dot: .
+      - identifier: people10m
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: more_people
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Additional test cases for SparkSQL

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
