### PR TITLE
Separate slow CI job to it's own workflow

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -2,8 +2,6 @@
 ## GitHub Actions CI Tests ##
 #############################
 #
-# Based on our old CircleCI config
-#
 # This can be kicked off manually in the Actions tab of GitHub
 # It will also run nightly at 2pm
 # It will run on any pull request, except non-code changes
@@ -39,22 +37,6 @@ jobs:
     - name: Run the tests
       run: |
         tox -e ${{ matrix.jobs }}
-  ruleslinting:
-    runs-on: ubuntu-latest
-    name: Rules critical errors tests
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        pip install tox
-        pip install .
-    - name: Run the tests
-      run: |
-        tox -e ruleslinting -- -n 2 test
   python-version-tests:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/critical-rules-test.yml
+++ b/.github/workflows/critical-rules-test.yml
@@ -12,6 +12,9 @@
 name: Critical CI Tests
 on:
   workflow_dispatch:
+  schedule:
+    # 2am each night
+    - cron: '00 2 * * *'
   pull_request:
   push:
     branches:

--- a/.github/workflows/critical-rules-test.yml
+++ b/.github/workflows/critical-rules-test.yml
@@ -1,0 +1,36 @@
+#############################
+## GitHub Actions CI Tests ##
+#############################
+#
+# This lints all our dialect fixtures to check rules can handle a variety
+# of SQL and don't error out badly.
+#
+# It's run as a separate job as takes longer than the CI jobs and allows
+# them to be rerun separately if GitHub Actions or Coverage is experiencing
+# issues.
+#
+name: Critical CI Tests
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  ruleslinting:
+    runs-on: ubuntu-latest
+    name: Rules critical errors tests
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        pip install tox
+        pip install .
+    - name: Run the tests
+      run: |
+        tox -e ruleslinting -- -n 2 test


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
When GitHub Actions or Coverage experiences issues (as they are want to do!) we sometimes have to rerun the CI jobs. The Critical Rules Test is slow to run, but doesn't impact Coverage, so separate that out to it's own job so it doesn't need to be rerun if it passes.

### Are there any other side effects of this change that we should be aware of?
Nope.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
