### PR TITLE
BigQuery: Add support for column `OPTIONS` in `STRUCT` definitions

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -628,6 +628,7 @@ class DatatypeSegment(ansi.DatatypeSegment):
                     Sequence(
                         Ref("ParameterNameSegment"),
                         Ref("DatatypeSegment"),
+                        Ref("OptionsSegment", optional=True),
                     ),
                     delimiter=Ref("CommaSegment"),
                     bracket_pairs_set="angle_bracket_pairs",

--- a/test/fixtures/dialects/bigquery/create_table_column_options.sql
+++ b/test/fixtures/dialects/bigquery/create_table_column_options.sql
@@ -7,3 +7,13 @@ CREATE TABLE t_table1
 (
     x INT64 NOT NULL OPTIONS(description="An INTEGER field that is NOT NULL")
 );
+
+CREATE TABLE t_table1
+(
+    x STRUCT<
+        col1 STRING OPTIONS(description="An INTEGER field in a STRUCT")
+    >,
+    y ARRAY<STRUCT<
+        col1 STRING OPTIONS(description="An INTEGER field in a REPEATED STRUCT")
+    >>
+);

--- a/test/fixtures/dialects/bigquery/create_table_column_options.sql
+++ b/test/fixtures/dialects/bigquery/create_table_column_options.sql
@@ -11,9 +11,9 @@ CREATE TABLE t_table1
 CREATE TABLE t_table1
 (
     x STRUCT<
-        col1 STRING OPTIONS(description="An INTEGER field in a STRUCT")
+        col1 INT64 OPTIONS(description="An INTEGER field in a STRUCT")
     >,
     y ARRAY<STRUCT<
-        col1 STRING OPTIONS(description="An INTEGER field in a REPEATED STRUCT")
+        col1 INT64 OPTIONS(description="An INTEGER field in a REPEATED STRUCT")
     >>
 );

--- a/test/fixtures/dialects/bigquery/create_table_column_options.yml
+++ b/test/fixtures/dialects/bigquery/create_table_column_options.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 587b2f2c1638492d64b29d16922b066f65ccabc761430da0c12c21874421ce3f
+_hash: b676e9e9f8d50f91f2421f24f18cd6ee001c52d9f394cad7684b9e1f9d3c98d3
 file:
 - statement:
     create_table_statement:
@@ -53,4 +53,55 @@ file:
               literal: '"An INTEGER field that is NOT NULL"'
               end_bracket: )
         end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: t_table1
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          identifier: x
+          data_type:
+            keyword: STRUCT
+            start_angle_bracket: <
+            parameter: col1
+            data_type:
+              data_type_identifier: STRING
+            options_segment:
+              keyword: OPTIONS
+              bracketed:
+                start_bracket: (
+                parameter: description
+                comparison_operator:
+                  raw_comparison_operator: '='
+                literal: '"An INTEGER field in a STRUCT"'
+                end_bracket: )
+            end_angle_bracket: '>'
+      - comma: ','
+      - column_definition:
+          identifier: y
+          data_type:
+            keyword: ARRAY
+            start_angle_bracket: <
+            data_type:
+              keyword: STRUCT
+              start_angle_bracket: <
+              parameter: col1
+              data_type:
+                data_type_identifier: STRING
+              options_segment:
+                keyword: OPTIONS
+                bracketed:
+                  start_bracket: (
+                  parameter: description
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  literal: '"An INTEGER field in a REPEATED STRUCT"'
+                  end_bracket: )
+              end_angle_bracket: '>'
+            end_angle_bracket: '>'
+      - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/create_table_column_options.yml
+++ b/test/fixtures/dialects/bigquery/create_table_column_options.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b676e9e9f8d50f91f2421f24f18cd6ee001c52d9f394cad7684b9e1f9d3c98d3
+_hash: a3429a7470b5a9294bf9bb8d383cee02dcccb9235466218d16da77f6df7fabd2
 file:
 - statement:
     create_table_statement:
@@ -69,7 +69,7 @@ file:
             start_angle_bracket: <
             parameter: col1
             data_type:
-              data_type_identifier: STRING
+              data_type_identifier: INT64
             options_segment:
               keyword: OPTIONS
               bracketed:
@@ -91,7 +91,7 @@ file:
               start_angle_bracket: <
               parameter: col1
               data_type:
-                data_type_identifier: STRING
+                data_type_identifier: INT64
               options_segment:
                 keyword: OPTIONS
                 bracketed:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Adds the possibility for SQLFluff to parse `STRUCT` definitions that utilises "column" `OPTIONS`.

```sql
CREATE TABLE t_table1
(
    x STRUCT<
        col1 STRING OPTIONS(description="An INTEGER field in a STRUCT")
    >,
    y ARRAY<STRUCT<
        col1 STRING OPTIONS(description="An INTEGER field in a REPEATED STRUCT")
    >>
);
``` 



### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
