### PR TITLE
BigQuery: Parse `CREATE TABLE` with trailing comma

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1048,6 +1048,7 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
                         Ref("TableConstraintSegment"),
                         Ref("ColumnDefinitionSegment"),
                     ),
+                    allow_trailing=True,
                 )
             ),
             Ref("CommentClauseSegment", optional=True),

--- a/test/fixtures/dialects/bigquery/create_table_trailing_comma.sql
+++ b/test/fixtures/dialects/bigquery/create_table_trailing_comma.sql
@@ -1,0 +1,10 @@
+-- Basic example of trailing comma
+CREATE TABLE t_table (
+    col1 STRING,
+);
+
+-- Complex example with other variants
+CREATE TABLE t_table (
+    col1 STRING,
+    x INT64 NOT NULL OPTIONS(description="An INTEGER field that is NOT NULL"),
+);

--- a/test/fixtures/dialects/bigquery/create_table_trailing_comma.yml
+++ b/test/fixtures/dialects/bigquery/create_table_trailing_comma.yml
@@ -1,0 +1,54 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: c9bb3144ff80289d82f0717754a2bb9fa552a8fa37324a3e54f188055049eb94
+file:
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: t_table
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          identifier: col1
+          data_type:
+            data_type_identifier: STRING
+        comma: ','
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: t_table
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          identifier: col1
+          data_type:
+            data_type_identifier: STRING
+      - comma: ','
+      - column_definition:
+          identifier: x
+          data_type:
+            data_type_identifier: INT64
+          column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+          options_segment:
+            keyword: OPTIONS
+            bracketed:
+              start_bracket: (
+              parameter: description
+              comparison_operator:
+                raw_comparison_operator: '='
+              literal: '"An INTEGER field that is NOT NULL"'
+              end_bracket: )
+      - comma: ','
+      - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fixes #3011

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
