### PR TITLE
Sparksql quoted identifier in STRUCT

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -616,22 +616,11 @@ class DatatypeSegment(PrimitiveTypeSegment):
         Sequence(
             "STRUCT",
             Bracketed(
-                # Manually rebuild Delimited.
-                # Delimited breaks futher nesting (MAP, STRUCT, ARRAY)
-                # of complex datatypes (Comma splits angle bracket blocks)
-                #
                 # CommentGrammar here is valid Spark SQL
                 # even though its not stored in Sparks Catalog
-                Sequence(
-                    Ref("NakedIdentifierSegment"),
-                    Ref("ColonSegment"),
-                    Ref("DatatypeSegment"),
-                    Ref("CommentGrammar", optional=True),
-                ),
-                AnyNumberOf(
+                Delimited(
                     Sequence(
-                        Ref("CommaSegment"),
-                        Ref("NakedIdentifierSegment"),
+                        Ref("SingleIdentifierGrammar"),
                         Ref("ColonSegment"),
                         Ref("DatatypeSegment"),
                         Ref("CommentGrammar", optional=True),

--- a/test/fixtures/dialects/sparksql/create_table_complex_datatypes.sql
+++ b/test/fixtures/dialects/sparksql/create_table_complex_datatypes.sql
@@ -9,3 +9,7 @@ CREATE TABLE table_identifier
 --Create Table with nested complex datatypes
 CREATE TABLE table_identifier
 ( a STRUCT<b: STRING, c: MAP<STRING, BOOLEAN>>, d MAP<STRING, STRUCT<e: STRING, f: MAP<STRING, BOOLEAN>>>, g ARRAY<STRUCT<h: STRING, i: MAP<STRING, BOOLEAN>>>);
+
+--Create Table with complex datatypes and quoted identifiers
+CREATE TABLE table_identifier
+( a STRUCT<`b`: STRING, c: BOOLEAN>, `d` MAP<STRING, BOOLEAN>, e ARRAY<STRING>);

--- a/test/fixtures/dialects/sparksql/create_table_complex_datatypes.yml
+++ b/test/fixtures/dialects/sparksql/create_table_complex_datatypes.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7e2cde585ebd2449087447234f57d697481af4f5ded4d07695f8641650b997fa
+_hash: 9822eb92654515e7a9ec03ff46964af3530db1f5d8a016a8547de8de0073972a
 file:
 - statement:
     create_table_statement:
@@ -211,6 +211,56 @@ file:
                     keyword: BOOLEAN
                 end_angle_bracket: '>'
             - end_angle_bracket: '>'
+            end_angle_bracket: '>'
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_identifier
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          identifier: a
+          data_type:
+          - keyword: STRUCT
+          - start_angle_bracket: <
+          - identifier: '`b`'
+          - colon: ':'
+          - data_type:
+              primitive_type:
+                keyword: STRING
+          - comma: ','
+          - identifier: c
+          - colon: ':'
+          - data_type:
+              primitive_type:
+                keyword: BOOLEAN
+          - end_angle_bracket: '>'
+      - comma: ','
+      - column_definition:
+          identifier: '`d`'
+          data_type:
+            keyword: MAP
+            start_angle_bracket: <
+            primitive_type:
+              keyword: STRING
+            comma: ','
+            data_type:
+              primitive_type:
+                keyword: BOOLEAN
+            end_angle_bracket: '>'
+      - comma: ','
+      - column_definition:
+          identifier: e
+          data_type:
+            keyword: ARRAY
+            start_angle_bracket: <
+            data_type:
+              primitive_type:
+                keyword: STRING
             end_angle_bracket: '>'
       - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
fixes #3019

### Are there any other side effects of this change that we should be aware of?
-

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
