### PR TITLE
Add `exclude` option for `Ref` grammar

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -947,7 +947,7 @@ ansi_dialect.add(
         # Trim function
         Sequence(
             Ref("TrimParametersGrammar"),
-            OneOf(Ref("ExpressionSegment"), optional=True, exclude=Ref.keyword("FROM")),
+            Ref("ExpressionSegment", optional=True, exclude=Ref.keyword("FROM")),
             "FROM",
             Ref("ExpressionSegment"),
         ),
@@ -1081,10 +1081,8 @@ class FunctionSegment(BaseSegment):
         ),
         Sequence(
             Sequence(
-                AnyNumberOf(
-                    Ref("FunctionNameSegment"),
-                    max_times=1,
-                    min_times=1,
+                Ref(
+                    "FunctionNameSegment",
                     exclude=OneOf(
                         Ref("DatePartFunctionNameSegment"),
                         Ref("ValuesClauseSegment"),
@@ -1158,8 +1156,8 @@ class FromExpressionElementSegment(BaseSegment):
     match_grammar: Matchable = Sequence(
         Ref("PreTableFunctionKeywordsGrammar", optional=True),
         OptionallyBracketed(Ref("TableExpressionSegment")),
-        OneOf(
-            Ref("AliasExpressionSegment"),
+        Ref(
+            "AliasExpressionSegment",
             exclude=OneOf(
                 Ref("SamplingExpressionSegment"),
                 Ref("JoinLikeClauseGrammar"),
@@ -3098,7 +3096,7 @@ class UpdateStatementSegment(BaseSegment):
         Ref("TableReferenceSegment"),
         # SET is not a resevered word in all dialects (e.g. RedShift)
         # So specifically exclude as an allowed implict alias to avoid parsing errors
-        OneOf(Ref("AliasExpressionSegment"), exclude=Ref.keyword("SET"), optional=True),
+        Ref("AliasExpressionSegment", exclude=Ref.keyword("SET"), optional=True),
         Ref("SetClauseListSegment"),
         Ref("FromClauseSegment", optional=True),
         Ref("WhereClauseSegment", optional=True),

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -459,8 +459,8 @@ class FunctionSegment(ansi.FunctionSegment):
             # Treat functions which take date parts separately
             # So those functions parse date parts as DatetimeUnitSegment
             # rather than identifiers.
-            OneOf(
-                Ref("DatePartFunctionNameSegment"),
+            Ref(
+                "DatePartFunctionNameSegment",
                 exclude=Ref("ExtractFunctionNameSegment"),
             ),
             Bracketed(
@@ -475,10 +475,8 @@ class FunctionSegment(ansi.FunctionSegment):
         ),
         Sequence(
             Sequence(
-                AnyNumberOf(
-                    Ref("FunctionNameSegment"),
-                    max_times=1,
-                    min_times=1,
+                Ref(
+                    "FunctionNameSegment",
                     exclude=OneOf(
                         Ref("DatePartFunctionNameSegment"),
                         Ref("ValuesClauseSegment"),

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -1214,14 +1214,13 @@ class TableInlineConstraintSegment(BaseSegment):
     parse_grammar = Sequence(
         Sequence(
             "CONSTRAINT",
-            AnyNumberOf(
-                Ref("SingleIdentifierGrammar"),
-                max_times=1,
-                min_times=0,
+            Ref(
+                "SingleIdentifierGrammar",
                 # exclude UNRESERVED_KEYWORDS which could used as NakedIdentifier
                 # to make e.g. `id NUMBER CONSTRAINT PRIMARY KEY` work (which is equal
                 # to just `id NUMBER PRIMARY KEY`)
                 exclude=OneOf("NOT", "NULL", "PRIMARY", "FOREIGN"),
+                optional=True,
             ),
             optional=True,
         ),
@@ -1248,14 +1247,13 @@ class TableOutOfLineConstraintSegment(BaseSegment):
     parse_grammar = Sequence(
         Sequence(
             "CONSTRAINT",
-            AnyNumberOf(
-                Ref("SingleIdentifierGrammar"),
-                max_times=1,
-                min_times=0,
+            Ref(
+                "SingleIdentifierGrammar",
                 # exclude UNRESERVED_KEYWORDS which could used as NakedIdentifier
                 # to make e.g. `id NUMBER, CONSTRAINT PRIMARY KEY(id)` work (which is
                 # equal to just `id NUMBER, PRIMARY KEY(id)`)
                 exclude=OneOf("NOT", "NULL", "PRIMARY", "FOREIGN"),
+                optional=True,
             ),
             optional=True,
         ),

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -692,10 +692,8 @@ class FunctionSegment(BaseSegment):
         ),
         Sequence(
             Sequence(
-                AnyNumberOf(
-                    Ref("FunctionNameSegment"),
-                    max_times=1,
-                    min_times=1,
+                Ref(
+                    "FunctionNameSegment",
                     exclude=OneOf(
                         Ref("DatePartFunctionNameSegment"),
                         Ref("ValuesClauseSegment"),

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -239,10 +239,8 @@ class ColumnDefinitionSegment(BaseSegment):
         Ref("SingleIdentifierGrammar"),  # Column name
         OneOf(  # Column type
             # DATETIME and TIMESTAMP take special logic
-            AnyNumberOf(
-                Ref("DatatypeSegment"),
-                max_times=1,
-                min_times=1,
+            Ref(
+                "DatatypeSegment",
                 exclude=OneOf("DATETIME", "TIMESTAMP"),
             ),
             Sequence(

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -1404,8 +1404,8 @@ class ProcedureParameterListSegment(BaseSegment):
     match_grammar = Bracketed(
         Sequence(
             AnyNumberOf(
-                OneOf(
-                    Ref("ParameterNameSegment"),
+                Ref(
+                    "ParameterNameSegment",
                     exclude=OneOf(_param_type, Ref("ArgModeGrammar")),
                     optional=True,
                 ),
@@ -1417,8 +1417,8 @@ class ProcedureParameterListSegment(BaseSegment):
                 Sequence(
                     Ref("CommaSegment"),
                     AnyNumberOf(
-                        OneOf(
-                            Ref("ParameterNameSegment"),
+                        Ref(
+                            "ParameterNameSegment",
                             exclude=OneOf(_param_type, Ref("ArgModeGrammar")),
                             optional=True,
                         ),

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -881,8 +881,8 @@ class FromExpressionElementSegment(ansi.FromExpressionElementSegment):
         Sequence(
             Ref("PreTableFunctionKeywordsGrammar", optional=True),
             OptionallyBracketed(Ref("TableExpressionSegment")),
-            OneOf(
-                Ref("AliasExpressionSegment"),
+            Ref(
+                "AliasExpressionSegment",
                 exclude=OneOf(
                     Ref("SamplingExpressionSegment"),
                     Ref("ChangesClauseSegment"),

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -2348,11 +2348,10 @@ class ValuesClauseSegment(ansi.ValuesClauseSegment):
             ),
         ),
         # LIMIT/ORDER are unreserved in sparksql.
-        AnyNumberOf(
-            Ref("AliasExpressionSegment"),
-            min_times=0,
-            max_times=1,
+        Ref(
+            "AliasExpressionSegment",
             exclude=OneOf("LIMIT", "ORDER"),
+            optional=True,
         ),
         Ref("OrderByClauseSegment", optional=True),
         Ref("LimitClauseSegment", optional=True),
@@ -2418,8 +2417,8 @@ class FromExpressionElementSegment(ansi.FromExpressionElementSegment):
     match_grammar = Sequence(
         Ref("PreTableFunctionKeywordsGrammar", optional=True),
         OptionallyBracketed(Ref("TableExpressionSegment")),
-        OneOf(
-            Ref("AliasExpressionSegment"),
+        Ref(
+            "AliasExpressionSegment",
             exclude=Ref("SamplingExpressionSegment"),
             optional=True,
         ),

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2079,16 +2079,10 @@ class FunctionSegment(BaseSegment):
             Ref("WithinGroupClause", optional=True),
         ),
         Sequence(
-            OneOf(
-                AnyNumberOf(
-                    Ref("FunctionNameSegment"),
-                    max_times=1,
-                    min_times=1,
-                    exclude=OneOf(
-                        Ref("ValuesClauseSegment"),
-                    ),
-                ),
+            Ref(
+                "FunctionNameSegment",
                 exclude=OneOf(
+                    Ref("ValuesClauseSegment"),
                     # List of special functions handled differently
                     Ref("CastFunctionNameSegment"),
                     Ref("ConvertFunctionNameSegment"),

--- a/test/core/parser/grammar_test.py
+++ b/test/core/parser/grammar_test.py
@@ -329,6 +329,17 @@ def test__parser__grammar__ref_eq():
     assert r1 not in check_list
 
 
+def test__parser__grammar_ref_exclude(generate_test_segments, fresh_ansi_dialect):
+    """Test the Ref grammar exclude option."""
+    ni = Ref("NakedIdentifierSegment", exclude=Ref.keyword("ABS"))
+    ts = generate_test_segments(["ABS", "ABSOLUTE"])
+    with RootParseContext(dialect=fresh_ansi_dialect) as ctx:
+        # Asset ABS does not match, due to the exclude
+        assert not ni.match([ts[0]], parse_context=ctx)
+        # Asset ABSOLUTE does match
+        assert ni.match([ts[1]], parse_context=ctx)
+
+
 def test__parser__grammar__oneof__copy():
     """Test grammar copying."""
     bs = StringParser("bar", KeywordSegment)


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
We often want to exclude certain matches from bits of grammar.
Currently that requires wrapping the Grammar in an `AnyOf` or a `OneOf` - even if there is only one of them!
This PR adds the ability to use `exclude` directly on a `Ref()` segment, and also cleans up the grammars that had implemented the workaround.

### Are there any other side effects of this change that we should be aware of?
Shouldn't be.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
