### PR TITLE
Fix bug in patch generation for segments made of templated + literal fixes

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1268,6 +1268,7 @@ class BaseSegment:
             # This segment isn't a literal, but has changed, we need to go deeper.
 
             # Iterate through the child segments
+            source_idx = self.pos_marker.source_slice.start
             templated_idx = self.pos_marker.templated_slice.start
             insert_buff = ""
             for seg_idx, segment in enumerate(self.segments):
@@ -1311,15 +1312,19 @@ class BaseSegment:
 
                 # Once we've dealt with any patches from the segment, update
                 # our position markers.
+                source_idx = segment.pos_marker.source_slice.stop
                 templated_idx = segment.pos_marker.templated_slice.stop
 
             # After the loop, we check whether there's a trailing deletion
             # or insert. Also valid if we still have an insertion buffer here.
             end_diff = self.pos_marker.templated_slice.stop - templated_idx
             if end_diff or insert_buff:
-                source_slice = segment.pos_marker.source_slice
+                source_slice = slice(
+                    source_idx,
+                    self.pos_marker.source_slice.stop,
+                )
                 templated_slice = slice(
-                    self.pos_marker.templated_slice.stop - end_diff,
+                    templated_idx,
                     self.pos_marker.templated_slice.stop,
                 )
                 # By returning an EnrichedFixPatch (rather than FixPatch), which

--- a/test/fixtures/rules/std_rule_cases/L030.yml
+++ b/test/fixtures/rules/std_rule_cases/L030.yml
@@ -60,3 +60,8 @@ test_pass_ignore_templated_code:
     SELECT
         {{ "greatest(a, b)" }},
         GREATEST(i, j)
+
+test_fail_func_name_templated_literal_mix:
+  # Issue 3022. This was actually a bug in BaseSegment.iter_patches().
+  fail_str: SELECT RO(), {{ "t" }}.func()
+  fix_str: SELECT RO(), {{ "t" }}.FUNC()


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3022 

I think I introduced this bug when fixing an earlier issue adding missing newlines to the end of a file (PR #2862). In that PR, I updated `BaseSegment.iter_patches()` to return an `EnrichedFixPatch`, which specifies the location of the change in both source and templated space. The bug was, if the modified segment is a mix of templated and literal code, the source slice was incorrect. which caused code **replacement** (delete + insert) to be misapplied as just an insertion, i.e. leaving the old, bad code in place, followed by the new, corrected code.
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
