### PR TITLE
L038: Add config to enable linting for trailing commas in `CREATE TABLE`

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -118,6 +118,7 @@ force_enable = False
 [sqlfluff:rules:L038]
 # Trailing commas
 select_clause_trailing_comma = forbid
+create_table_trailing_comma = forbid
 
 [sqlfluff:rules:L040]
 # Null & Boolean Literals

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -74,6 +74,13 @@ STANDARD_CONFIG_INFO_DICT = {
             "Should trailing commas within select clauses be required or forbidden?"
         ),
     },
+    "create_table_trailing_comma": {
+        "validation": ["forbid", "require"],
+        "definition": (
+            "Should trailing commas within create table clauses be required or "
+            "forbidden?"
+        ),
+    },
     "ignore_comment_lines": {
         "validation": [True, False],
         "definition": (

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2554,6 +2554,27 @@ class TypelessStructSegment(BaseSegment):
     match_grammar: Matchable = Nothing()
 
 
+class ColumnListSegment(BaseSegment):
+    """Abstraction for the list of columns in a CREATE TABLE statement.
+
+    Includes the surrounding brackets. Can be useful in rule definitions.
+    """
+
+    type = "column_list_segment"
+    match_grammar: Matchable = Sequence(
+        Bracketed(
+            Delimited(
+                OneOf(
+                    Ref("TableConstraintSegment"),
+                    Ref("ColumnDefinitionSegment"),
+                ),
+                allow_trailing=True,
+            )
+        ),
+        Ref("CommentClauseSegment", optional=True),
+    )
+
+
 class CreateTableStatementSegment(BaseSegment):
     """A `CREATE TABLE` statement."""
 
@@ -2568,18 +2589,7 @@ class CreateTableStatementSegment(BaseSegment):
         Ref("IfNotExistsGrammar", optional=True),
         Ref("TableReferenceSegment"),
         OneOf(
-            # Columns and comment syntax:
-            Sequence(
-                Bracketed(
-                    Delimited(
-                        OneOf(
-                            Ref("TableConstraintSegment"),
-                            Ref("ColumnDefinitionSegment"),
-                        ),
-                    )
-                ),
-                Ref("CommentClauseSegment", optional=True),
-            ),
+            Ref("ColumnListSegment"),
             # Create AS syntax:
             Sequence(
                 "AS",

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1047,20 +1047,7 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
         "TABLE",
         Ref("IfNotExistsGrammar", optional=True),
         Ref("TableReferenceSegment"),
-        # Column list
-        Sequence(
-            Bracketed(
-                Delimited(
-                    OneOf(
-                        Ref("TableConstraintSegment"),
-                        Ref("ColumnDefinitionSegment"),
-                    ),
-                    allow_trailing=True,
-                )
-            ),
-            Ref("CommentClauseSegment", optional=True),
-            optional=True,
-        ),
+        Ref("ColumnListSegment", optional=True),
         Ref("PartitionBySegment", optional=True),
         Ref("ClusterBySegment", optional=True),
         Ref("OptionsSegment", optional=True),

--- a/src/sqlfluff/rules/L038.py
+++ b/src/sqlfluff/rules/L038.py
@@ -87,7 +87,7 @@ class Rule_L038(BaseRule):
             bracketed_target = column_list_target.children(sp.is_type("bracketed"))
             column_list_definitions_target = bracketed_target.children()
             # ... and do not consider the closing bracket
-            last_content: BaseSegment = column_list_definitions_target.last(
+            last_content = column_list_definitions_target.last(
                 sp.and_(sp.is_code(), sp.not_(sp.is_type("end_bracket")))
             )[0]
 

--- a/test/fixtures/dialects/ansi/create_table_a_c1_c2.yml
+++ b/test/fixtures/dialects/ansi/create_table_a_c1_c2.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 67ff62ba0b2f1d9bccac8583abf2016c64fad312b6bd39ab434f81a3f7954b87
+_hash: aa772641c7e7ca331c50ebd420867cee7dfb7e7e40610ff6a90095f537733a78
 file:
   statement:
     create_table_statement:
@@ -11,15 +11,16 @@ file:
     - keyword: table
     - table_reference:
         identifier: table1
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: c1
-          data_type:
-            data_type_identifier: SMALLINT
-      - comma: ','
-      - column_definition:
-          identifier: c2
-          data_type:
-            data_type_identifier: DATE
-      - end_bracket: )
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: c1
+            data_type:
+              data_type_identifier: SMALLINT
+        - comma: ','
+        - column_definition:
+            identifier: c2
+            data_type:
+              data_type_identifier: DATE
+        - end_bracket: )

--- a/test/fixtures/dialects/ansi/create_table_a_column_constraints.yml
+++ b/test/fixtures/dialects/ansi/create_table_a_column_constraints.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3df412d5cf7df13a1fff015dd84b29d94ef20b4c0c4718ef28be1d4564b0a7fd
+_hash: f5c6cff66481f4adef9f2439077ae9cf42e4db8ff319a971a481d0dcd9dc995e
 file:
   statement:
     create_table_statement:
@@ -11,187 +11,188 @@ file:
     - keyword: table
     - table_reference:
         identifier: table1
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: c1
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-      - comma: ','
-      - column_definition:
-        - identifier: c2
-        - data_type:
-            data_type_identifier: INT
-        - column_constraint_segment:
-            keyword: 'NULL'
-        - column_constraint_segment:
-            keyword: DEFAULT
-            literal: '1'
-      - comma: ','
-      - column_definition:
-          identifier: c3
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: PRIMARY
-          - keyword: KEY
-      - comma: ','
-      - column_definition:
-          identifier: c4
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-            keyword: UNIQUE
-      - comma: ','
-      - column_definition:
-          identifier: c5
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-            keyword: REFERENCES
-            table_reference:
-              identifier: table2
-      - comma: ','
-      - column_definition:
-          identifier: c6
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-            keyword: REFERENCES
-            table_reference:
-              identifier: table2
-            bracketed:
-              start_bracket: (
-              column_reference:
-                identifier: c6_other
-              end_bracket: )
-      - comma: ','
-      - column_definition:
-          identifier: c6
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: REFERENCES
-          - table_reference:
-              identifier: table2
-          - bracketed:
-              start_bracket: (
-              column_reference:
-                identifier: c6_other
-              end_bracket: )
-          - keyword: MATCH
-          - keyword: FULL
-      - comma: ','
-      - column_definition:
-          identifier: c6
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: REFERENCES
-          - table_reference:
-              identifier: table2
-          - bracketed:
-              start_bracket: (
-              column_reference:
-                identifier: c6_other
-              end_bracket: )
-          - keyword: MATCH
-          - keyword: PARTIAL
-      - comma: ','
-      - column_definition:
-          identifier: c6
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: REFERENCES
-          - table_reference:
-              identifier: table2
-          - bracketed:
-              start_bracket: (
-              column_reference:
-                identifier: c6_other
-              end_bracket: )
-          - keyword: MATCH
-          - keyword: SIMPLE
-      - comma: ','
-      - column_definition:
-          identifier: c6
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: REFERENCES
-          - table_reference:
-              identifier: table2
-          - bracketed:
-              start_bracket: (
-              column_reference:
-                identifier: c6_other
-              end_bracket: )
-          - keyword: 'ON'
-          - keyword: DELETE
-          - keyword: 'NO'
-          - keyword: ACTION
-      - comma: ','
-      - column_definition:
-          identifier: c6
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: REFERENCES
-          - table_reference:
-              identifier: table2
-          - bracketed:
-              start_bracket: (
-              column_reference:
-                identifier: c6_other
-              end_bracket: )
-          - keyword: 'ON'
-          - keyword: UPDATE
-          - keyword: SET
-          - keyword: 'NULL'
-      - comma: ','
-      - column_definition:
-          identifier: c6
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: REFERENCES
-          - table_reference:
-              identifier: table2
-          - bracketed:
-              start_bracket: (
-              column_reference:
-                identifier: c6_other
-              end_bracket: )
-          - keyword: 'ON'
-          - keyword: DELETE
-          - keyword: RESTRICT
-          - keyword: 'ON'
-          - keyword: UPDATE
-          - keyword: CASCADE
-      - comma: ','
-      - column_definition:
-        - identifier: c7
-        - data_type:
-            data_type_identifier: INT
-        - column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-        - column_constraint_segment:
-            keyword: DEFAULT
-            literal: '1'
-        - column_constraint_segment:
-            keyword: UNIQUE
-        - column_constraint_segment:
-            keyword: REFERENCES
-            table_reference:
-              identifier: table3
-            bracketed:
-              start_bracket: (
-              column_reference:
-                identifier: c7_other
-              end_bracket: )
-      - end_bracket: )
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: c1
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+          - identifier: c2
+          - data_type:
+              data_type_identifier: INT
+          - column_constraint_segment:
+              keyword: 'NULL'
+          - column_constraint_segment:
+              keyword: DEFAULT
+              literal: '1'
+        - comma: ','
+        - column_definition:
+            identifier: c3
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: PRIMARY
+            - keyword: KEY
+        - comma: ','
+        - column_definition:
+            identifier: c4
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+              keyword: UNIQUE
+        - comma: ','
+        - column_definition:
+            identifier: c5
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+              keyword: REFERENCES
+              table_reference:
+                identifier: table2
+        - comma: ','
+        - column_definition:
+            identifier: c6
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+              keyword: REFERENCES
+              table_reference:
+                identifier: table2
+              bracketed:
+                start_bracket: (
+                column_reference:
+                  identifier: c6_other
+                end_bracket: )
+        - comma: ','
+        - column_definition:
+            identifier: c6
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: REFERENCES
+            - table_reference:
+                identifier: table2
+            - bracketed:
+                start_bracket: (
+                column_reference:
+                  identifier: c6_other
+                end_bracket: )
+            - keyword: MATCH
+            - keyword: FULL
+        - comma: ','
+        - column_definition:
+            identifier: c6
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: REFERENCES
+            - table_reference:
+                identifier: table2
+            - bracketed:
+                start_bracket: (
+                column_reference:
+                  identifier: c6_other
+                end_bracket: )
+            - keyword: MATCH
+            - keyword: PARTIAL
+        - comma: ','
+        - column_definition:
+            identifier: c6
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: REFERENCES
+            - table_reference:
+                identifier: table2
+            - bracketed:
+                start_bracket: (
+                column_reference:
+                  identifier: c6_other
+                end_bracket: )
+            - keyword: MATCH
+            - keyword: SIMPLE
+        - comma: ','
+        - column_definition:
+            identifier: c6
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: REFERENCES
+            - table_reference:
+                identifier: table2
+            - bracketed:
+                start_bracket: (
+                column_reference:
+                  identifier: c6_other
+                end_bracket: )
+            - keyword: 'ON'
+            - keyword: DELETE
+            - keyword: 'NO'
+            - keyword: ACTION
+        - comma: ','
+        - column_definition:
+            identifier: c6
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: REFERENCES
+            - table_reference:
+                identifier: table2
+            - bracketed:
+                start_bracket: (
+                column_reference:
+                  identifier: c6_other
+                end_bracket: )
+            - keyword: 'ON'
+            - keyword: UPDATE
+            - keyword: SET
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            identifier: c6
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: REFERENCES
+            - table_reference:
+                identifier: table2
+            - bracketed:
+                start_bracket: (
+                column_reference:
+                  identifier: c6_other
+                end_bracket: )
+            - keyword: 'ON'
+            - keyword: DELETE
+            - keyword: RESTRICT
+            - keyword: 'ON'
+            - keyword: UPDATE
+            - keyword: CASCADE
+        - comma: ','
+        - column_definition:
+          - identifier: c7
+          - data_type:
+              data_type_identifier: INT
+          - column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          - column_constraint_segment:
+              keyword: DEFAULT
+              literal: '1'
+          - column_constraint_segment:
+              keyword: UNIQUE
+          - column_constraint_segment:
+              keyword: REFERENCES
+              table_reference:
+                identifier: table3
+              bracketed:
+                start_bracket: (
+                column_reference:
+                  identifier: c7_other
+                end_bracket: )
+        - end_bracket: )

--- a/test/fixtures/dialects/ansi/create_table_a_pk_unique_fk_constraints.yml
+++ b/test/fixtures/dialects/ansi/create_table_a_pk_unique_fk_constraints.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 455bcf8b86cd9e0b64027e1dfa1c8ec48437f853e6ffd2f4d0fcc4deacec35dc
+_hash: a2733f096d7c7a1ad454a2df90b414e1ca3fdfc5af4d17d7068109b93eedd5c5
 file:
   statement:
     create_table_statement:
@@ -11,64 +11,65 @@ file:
     - keyword: table
     - table_reference:
         identifier: table1
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: c1
-          data_type:
-            data_type_identifier: INT
-      - comma: ','
-      - column_definition:
-          identifier: c2
-          data_type:
-            data_type_identifier: INT
-      - comma: ','
-      - column_definition:
-          identifier: c3
-          data_type:
-            data_type_identifier: INT
-      - comma: ','
-      - table_constraint:
-        - keyword: PRIMARY
-        - keyword: KEY
-        - bracketed:
-            start_bracket: (
-            expression:
-              column_reference:
-                identifier: c1
-            end_bracket: )
-      - comma: ','
-      - table_constraint:
-          keyword: UNIQUE
-          bracketed:
-          - start_bracket: (
-          - column_reference:
-              identifier: c2
-          - comma: ','
-          - column_reference:
-              identifier: c3
-          - end_bracket: )
-      - comma: ','
-      - table_constraint:
-        - keyword: FOREIGN
-        - keyword: KEY
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-              identifier: c2
-          - comma: ','
-          - column_reference:
-              identifier: c3
-          - end_bracket: )
-        - keyword: REFERENCES
-        - table_reference:
-            identifier: table2
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-              identifier: c2_
-          - comma: ','
-          - column_reference:
-              identifier: c3_
-          - end_bracket: )
-      - end_bracket: )
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: c1
+            data_type:
+              data_type_identifier: INT
+        - comma: ','
+        - column_definition:
+            identifier: c2
+            data_type:
+              data_type_identifier: INT
+        - comma: ','
+        - column_definition:
+            identifier: c3
+            data_type:
+              data_type_identifier: INT
+        - comma: ','
+        - table_constraint:
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: c1
+              end_bracket: )
+        - comma: ','
+        - table_constraint:
+            keyword: UNIQUE
+            bracketed:
+            - start_bracket: (
+            - column_reference:
+                identifier: c2
+            - comma: ','
+            - column_reference:
+                identifier: c3
+            - end_bracket: )
+        - comma: ','
+        - table_constraint:
+          - keyword: FOREIGN
+          - keyword: KEY
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+                identifier: c2
+            - comma: ','
+            - column_reference:
+                identifier: c3
+            - end_bracket: )
+          - keyword: REFERENCES
+          - table_reference:
+              identifier: table2
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+                identifier: c2_
+            - comma: ','
+            - column_reference:
+                identifier: c3_
+            - end_bracket: )
+        - end_bracket: )

--- a/test/fixtures/dialects/ansi/create_table_auto_increment.yml
+++ b/test/fixtures/dialects/ansi/create_table_auto_increment.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d00db67215ded67be9146ba40451692a128228111b64b231de699a74c75bad95
+_hash: b64139884268bb2de85d2260e3575c86d391015df0310e077ff039c4fd4ad20b
 file:
   statement:
     create_table_statement:
@@ -11,12 +11,13 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: a
-    - bracketed:
-        start_bracket: (
-        column_definition:
-          identifier: id
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-            keyword: AUTO_INCREMENT
-        end_bracket: )
+    - column_list_segment:
+        bracketed:
+          start_bracket: (
+          column_definition:
+            identifier: id
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+              keyword: AUTO_INCREMENT
+          end_bracket: )

--- a/test/fixtures/dialects/ansi/create_table_column_comment.yml
+++ b/test/fixtures/dialects/ansi/create_table_column_comment.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8df5a2083015c3372a848debe26df4291ad06b9fe6e5af421517332354b8d8d2
+_hash: f16f56f0bcef22c6ab52a33f43b17bf62d4a47ce229a3ad196d140d0984db587
 file:
   statement:
     create_table_statement:
@@ -11,19 +11,20 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: a
-    - bracketed:
-        start_bracket: (
-        column_definition:
-          identifier: id
-          data_type:
-            data_type_identifier: VARCHAR
-            bracketed:
-              start_bracket: (
-              expression:
-                literal: '100'
-              end_bracket: )
-          column_constraint_segment:
-            comment_clause:
-              keyword: COMMENT
-              literal: "'Column comment'"
-        end_bracket: )
+    - column_list_segment:
+        bracketed:
+          start_bracket: (
+          column_definition:
+            identifier: id
+            data_type:
+              data_type_identifier: VARCHAR
+              bracketed:
+                start_bracket: (
+                expression:
+                  literal: '100'
+                end_bracket: )
+            column_constraint_segment:
+              comment_clause:
+                keyword: COMMENT
+                literal: "'Column comment'"
+          end_bracket: )

--- a/test/fixtures/dialects/ansi/create_table_column_constraint.yml
+++ b/test/fixtures/dialects/ansi/create_table_column_constraint.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: efd2e8cc5e85c8f4c91a68726455bdccedfd0168f56283ac32676317c8e05cdc
+_hash: e21d7ce27dab3c36ee8779625158f4b36c1bd2ce2b6f5fbf6feb3bfe4048abc0
 file:
 - statement:
     create_table_statement:
@@ -11,29 +11,30 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: users
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: username
-          data_type:
-            data_type_identifier: TEXT
-      - comma: ','
-      - column_definition:
-          identifier: age
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-            keyword: CHECK
-            bracketed:
-              start_bracket: (
-              expression:
-                column_reference:
-                  identifier: age
-                comparison_operator:
-                  raw_comparison_operator: '>'
-                literal: '18'
-              end_bracket: )
-      - end_bracket: )
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: username
+            data_type:
+              data_type_identifier: TEXT
+        - comma: ','
+        - column_definition:
+            identifier: age
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+              keyword: CHECK
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    identifier: age
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  literal: '18'
+                end_bracket: )
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -41,29 +42,30 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: users
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: username
-          data_type:
-            data_type_identifier: TEXT
-      - comma: ','
-      - column_definition:
-          identifier: age
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-            keyword: CHECK
-            bracketed:
-              start_bracket: (
-              expression:
-              - column_reference:
-                  identifier: age
-              - keyword: IS
-              - keyword: NOT
-              - keyword: 'NULL'
-              end_bracket: )
-      - end_bracket: )
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: username
+            data_type:
+              data_type_identifier: TEXT
+        - comma: ','
+        - column_definition:
+            identifier: age
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+              keyword: CHECK
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                    identifier: age
+                - keyword: IS
+                - keyword: NOT
+                - keyword: 'NULL'
+                end_bracket: )
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -71,75 +73,76 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: Persons
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: ID
-          data_type:
-            data_type_identifier: int
-          column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-      - comma: ','
-      - column_definition:
-          identifier: LastName
-          data_type:
-            data_type_identifier: varchar
-            bracketed:
-              start_bracket: (
-              expression:
-                literal: '255'
-              end_bracket: )
-          column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-      - comma: ','
-      - column_definition:
-          identifier: FirstName
-          data_type:
-            data_type_identifier: varchar
-            bracketed:
-              start_bracket: (
-              expression:
-                literal: '255'
-              end_bracket: )
-      - comma: ','
-      - column_definition:
-          identifier: Age
-          data_type:
-            data_type_identifier: int
-      - comma: ','
-      - column_definition:
-          identifier: City
-          data_type:
-            data_type_identifier: varchar
-            bracketed:
-              start_bracket: (
-              expression:
-                literal: '255'
-              end_bracket: )
-      - comma: ','
-      - column_definition:
-          identifier: CONSTRAINT
-          data_type:
-            data_type_identifier: CHK_Person
-          column_constraint_segment:
-            keyword: CHECK
-            bracketed:
-              start_bracket: (
-              expression:
-              - column_reference:
-                  identifier: Age
-              - comparison_operator:
-                - raw_comparison_operator: '>'
-                - raw_comparison_operator: '='
-              - literal: '18'
-              - binary_operator: AND
-              - column_reference:
-                  identifier: City
-              - comparison_operator:
-                  raw_comparison_operator: '='
-              - literal: "'Sandnes'"
-              end_bracket: )
-      - end_bracket: )
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: ID
+            data_type:
+              data_type_identifier: int
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            identifier: LastName
+            data_type:
+              data_type_identifier: varchar
+              bracketed:
+                start_bracket: (
+                expression:
+                  literal: '255'
+                end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            identifier: FirstName
+            data_type:
+              data_type_identifier: varchar
+              bracketed:
+                start_bracket: (
+                expression:
+                  literal: '255'
+                end_bracket: )
+        - comma: ','
+        - column_definition:
+            identifier: Age
+            data_type:
+              data_type_identifier: int
+        - comma: ','
+        - column_definition:
+            identifier: City
+            data_type:
+              data_type_identifier: varchar
+              bracketed:
+                start_bracket: (
+                expression:
+                  literal: '255'
+                end_bracket: )
+        - comma: ','
+        - column_definition:
+            identifier: CONSTRAINT
+            data_type:
+              data_type_identifier: CHK_Person
+            column_constraint_segment:
+              keyword: CHECK
+              bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                    identifier: Age
+                - comparison_operator:
+                  - raw_comparison_operator: '>'
+                  - raw_comparison_operator: '='
+                - literal: '18'
+                - binary_operator: AND
+                - column_reference:
+                    identifier: City
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - literal: "'Sandnes'"
+                end_bracket: )
+        - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/ansi/create_table_constraint_default.yml
+++ b/test/fixtures/dialects/ansi/create_table_constraint_default.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5edc8237281865faa18cc8d39b37eb227d501b9a1a7dfcb67d1df4a6299b83a7
+_hash: b6db7adebdccc50dc58892ff527b3720d85b17d9ade5dc3f5e475b2ebb8c2214
 file:
 - statement:
     transaction_statement:
@@ -19,19 +19,20 @@ file:
     - keyword: EXISTS
     - table_reference:
         identifier: '"tbl"'
-    - bracketed:
-        start_bracket: (
-        column_definition:
-        - identifier: '"col"'
-        - data_type:
-            keyword: TIMESTAMP
-        - column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-        - column_constraint_segment:
-            keyword: DEFAULT
-            bare_function: CURRENT_TIMESTAMP
-        end_bracket: )
+    - column_list_segment:
+        bracketed:
+          start_bracket: (
+          column_definition:
+          - identifier: '"col"'
+          - data_type:
+              keyword: TIMESTAMP
+          - column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          - column_constraint_segment:
+              keyword: DEFAULT
+              bare_function: CURRENT_TIMESTAMP
+          end_bracket: )
 - statement_terminator: ;
 - statement:
     transaction_statement:

--- a/test/fixtures/dialects/ansi/create_table_constraint_reference_option.yml
+++ b/test/fixtures/dialects/ansi/create_table_constraint_reference_option.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a942d019c6cd1e08d911c8767f9646126e87fd50ffbb0c1077e08bfc34c99fe7
+_hash: 37f1c4f83ef0973540bfe7c53da3ca30748779bf588ddeb2826f7c0a6c0f6a49
 file:
   statement:
     create_table_statement:
@@ -11,107 +11,108 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: b
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: b
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: NOT
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: b
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            identifier: c
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            identifier: d
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              identifier: c_b
+          - keyword: FOREIGN
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: b
+              end_bracket: )
+          - keyword: REFERENCES
+          - table_reference:
+              identifier: a
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: b
+              end_bracket: )
+          - keyword: 'ON'
+          - keyword: DELETE
+          - keyword: RESTRICT
+          - keyword: 'ON'
+          - keyword: UPDATE
+          - keyword: 'NO'
+          - keyword: ACTION
+        - comma: ','
+        - table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              identifier: c_d
+          - keyword: FOREIGN
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: d
+              end_bracket: )
+          - keyword: REFERENCES
+          - table_reference:
+              identifier: a
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: d
+              end_bracket: )
+          - keyword: 'ON'
+          - keyword: UPDATE
+          - keyword: CASCADE
+          - keyword: 'ON'
+          - keyword: DELETE
+          - keyword: SET
           - keyword: 'NULL'
-      - comma: ','
-      - column_definition:
-          identifier: c
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-      - comma: ','
-      - column_definition:
-          identifier: d
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-      - comma: ','
-      - table_constraint:
-        - keyword: CONSTRAINT
-        - object_reference:
-            identifier: c_b
-        - keyword: FOREIGN
-        - keyword: KEY
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: b
-            end_bracket: )
-        - keyword: REFERENCES
-        - table_reference:
-            identifier: a
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: b
-            end_bracket: )
-        - keyword: 'ON'
-        - keyword: DELETE
-        - keyword: RESTRICT
-        - keyword: 'ON'
-        - keyword: UPDATE
-        - keyword: 'NO'
-        - keyword: ACTION
-      - comma: ','
-      - table_constraint:
-        - keyword: CONSTRAINT
-        - object_reference:
-            identifier: c_d
-        - keyword: FOREIGN
-        - keyword: KEY
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: d
-            end_bracket: )
-        - keyword: REFERENCES
-        - table_reference:
-            identifier: a
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: d
-            end_bracket: )
-        - keyword: 'ON'
-        - keyword: UPDATE
-        - keyword: CASCADE
-        - keyword: 'ON'
-        - keyword: DELETE
-        - keyword: SET
-        - keyword: 'NULL'
-      - comma: ','
-      - table_constraint:
-        - keyword: CONSTRAINT
-        - object_reference:
-            identifier: c_c
-        - keyword: FOREIGN
-        - keyword: KEY
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: c
-            end_bracket: )
-        - keyword: REFERENCES
-        - table_reference:
-            identifier: a
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: c
-            end_bracket: )
-        - keyword: 'ON'
-        - keyword: DELETE
-        - keyword: SET
-        - keyword: DEFAULT
-      - end_bracket: )
+        - comma: ','
+        - table_constraint:
+          - keyword: CONSTRAINT
+          - object_reference:
+              identifier: c_c
+          - keyword: FOREIGN
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: c
+              end_bracket: )
+          - keyword: REFERENCES
+          - table_reference:
+              identifier: a
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: c
+              end_bracket: )
+          - keyword: 'ON'
+          - keyword: DELETE
+          - keyword: SET
+          - keyword: DEFAULT
+        - end_bracket: )

--- a/test/fixtures/dialects/ansi/create_table_default_function.yml
+++ b/test/fixtures/dialects/ansi/create_table_default_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 42b7a603a37da0a418b5f20c347d0a80b906d2a373b5e96090192e67631a36c2
+_hash: 46f9f89e9c9e90f892b8943c0a92c6e4f449d52ba80e78d6e0bf66e7e4db3d65
 file:
   statement:
     create_table_statement:
@@ -11,18 +11,19 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: a
-    - bracketed:
-        start_bracket: (
-        column_definition:
-          identifier: ts
-          data_type:
-            keyword: TIMESTAMP
-          column_constraint_segment:
-            keyword: DEFAULT
-            function:
-              function_name:
-                function_name_identifier: GETDATE
-              bracketed:
-                start_bracket: (
-                end_bracket: )
-        end_bracket: )
+    - column_list_segment:
+        bracketed:
+          start_bracket: (
+          column_definition:
+            identifier: ts
+            data_type:
+              keyword: TIMESTAMP
+            column_constraint_segment:
+              keyword: DEFAULT
+              function:
+                function_name:
+                  function_name_identifier: GETDATE
+                bracketed:
+                  start_bracket: (
+                  end_bracket: )
+          end_bracket: )

--- a/test/fixtures/dialects/ansi/create_table_double_precision.yml
+++ b/test/fixtures/dialects/ansi/create_table_double_precision.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6d3a0ef214ac96690502bf67cdab220126c5777f65faf4585d91a9868faa7efd
+_hash: 0f0466d6c314e117f4a12710ba7b02231cb24c7203df43c6c1546cf742727014
 file:
   statement:
     create_table_statement:
@@ -11,12 +11,13 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: test
-    - bracketed:
-        start_bracket: (
-        column_definition:
-          identifier: angle
-          data_type:
-          - keyword: double
-          - keyword: precision
-        end_bracket: )
+    - column_list_segment:
+        bracketed:
+          start_bracket: (
+          column_definition:
+            identifier: angle
+            data_type:
+            - keyword: double
+            - keyword: precision
+          end_bracket: )
   statement_terminator: ;

--- a/test/fixtures/dialects/ansi/create_table_table_comment.yml
+++ b/test/fixtures/dialects/ansi/create_table_table_comment.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 005ed9752ff8ba41b938facbadfc5e3ee0d61f696750908402fd1dab518e19ea
+_hash: 4d70f0348540a8b0d98055a6b8850976dcaf4ebf769f2eb56e1fa68cb492fe1a
 file:
   statement:
     create_table_statement:
@@ -11,18 +11,19 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: a
-    - bracketed:
-        start_bracket: (
-        column_definition:
-          identifier: id
-          data_type:
-            data_type_identifier: VARCHAR
-            bracketed:
-              start_bracket: (
-              expression:
-                literal: '100'
-              end_bracket: )
-        end_bracket: )
-    - comment_clause:
-        keyword: COMMENT
-        literal: "'Table comment'"
+    - column_list_segment:
+        bracketed:
+          start_bracket: (
+          column_definition:
+            identifier: id
+            data_type:
+              data_type_identifier: VARCHAR
+              bracketed:
+                start_bracket: (
+                expression:
+                  literal: '100'
+                end_bracket: )
+          end_bracket: )
+        comment_clause:
+          keyword: COMMENT
+          literal: "'Table comment'"

--- a/test/fixtures/dialects/ansi/create_table_varchar.yml
+++ b/test/fixtures/dialects/ansi/create_table_varchar.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: dba4f2cfdbb010bb8bf760e8772505b0b4f3d16e92f112691e28e2cf782ba199
+_hash: 1fd9ad29b0fdb991d6b3583cec96e2222fcaa42c62a6ccbfc40402a08678506e
 file:
   statement:
     create_table_statement:
@@ -11,15 +11,16 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: a
-    - bracketed:
-        start_bracket: (
-        column_definition:
-          identifier: id
-          data_type:
-            data_type_identifier: VARCHAR
-            bracketed:
-              start_bracket: (
-              expression:
-                literal: '100'
-              end_bracket: )
-        end_bracket: )
+    - column_list_segment:
+        bracketed:
+          start_bracket: (
+          column_definition:
+            identifier: id
+            data_type:
+              data_type_identifier: VARCHAR
+              bracketed:
+                start_bracket: (
+                expression:
+                  literal: '100'
+                end_bracket: )
+          end_bracket: )

--- a/test/fixtures/dialects/bigquery/create_table_column_options.yml
+++ b/test/fixtures/dialects/bigquery/create_table_column_options.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a3429a7470b5a9294bf9bb8d383cee02dcccb9235466218d16da77f6df7fabd2
+_hash: d97376a79e9ecaa49a0abd89712eed2768fc2f4b1c6a86afa69fe39bd4987f34
 file:
 - statement:
     create_table_statement:
@@ -11,63 +11,11 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: t_table1
-    - bracketed:
-        start_bracket: (
-        column_definition:
-          identifier: x
-          data_type:
-            data_type_identifier: INT64
-          options_segment:
-            keyword: OPTIONS
-            bracketed:
-              start_bracket: (
-              parameter: description
-              comparison_operator:
-                raw_comparison_operator: '='
-              literal: '"An INTEGER field"'
-              end_bracket: )
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: CREATE
-    - keyword: TABLE
-    - table_reference:
-        identifier: t_table1
-    - bracketed:
-        start_bracket: (
-        column_definition:
-          identifier: x
-          data_type:
-            data_type_identifier: INT64
-          column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-          options_segment:
-            keyword: OPTIONS
-            bracketed:
-              start_bracket: (
-              parameter: description
-              comparison_operator:
-                raw_comparison_operator: '='
-              literal: '"An INTEGER field that is NOT NULL"'
-              end_bracket: )
-        end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: CREATE
-    - keyword: TABLE
-    - table_reference:
-        identifier: t_table1
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: x
-          data_type:
-            keyword: STRUCT
-            start_angle_bracket: <
-            parameter: col1
+    - column_list_segment:
+        bracketed:
+          start_bracket: (
+          column_definition:
+            identifier: x
             data_type:
               data_type_identifier: INT64
             options_segment:
@@ -77,15 +25,48 @@ file:
                 parameter: description
                 comparison_operator:
                   raw_comparison_operator: '='
-                literal: '"An INTEGER field in a STRUCT"'
+                literal: '"An INTEGER field"'
                 end_bracket: )
-            end_angle_bracket: '>'
-      - comma: ','
-      - column_definition:
-          identifier: y
-          data_type:
-            keyword: ARRAY
-            start_angle_bracket: <
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: t_table1
+    - column_list_segment:
+        bracketed:
+          start_bracket: (
+          column_definition:
+            identifier: x
+            data_type:
+              data_type_identifier: INT64
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+            options_segment:
+              keyword: OPTIONS
+              bracketed:
+                start_bracket: (
+                parameter: description
+                comparison_operator:
+                  raw_comparison_operator: '='
+                literal: '"An INTEGER field that is NOT NULL"'
+                end_bracket: )
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: t_table1
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: x
             data_type:
               keyword: STRUCT
               start_angle_bracket: <
@@ -99,9 +80,31 @@ file:
                   parameter: description
                   comparison_operator:
                     raw_comparison_operator: '='
-                  literal: '"An INTEGER field in a REPEATED STRUCT"'
+                  literal: '"An INTEGER field in a STRUCT"'
                   end_bracket: )
               end_angle_bracket: '>'
-            end_angle_bracket: '>'
-      - end_bracket: )
+        - comma: ','
+        - column_definition:
+            identifier: y
+            data_type:
+              keyword: ARRAY
+              start_angle_bracket: <
+              data_type:
+                keyword: STRUCT
+                start_angle_bracket: <
+                parameter: col1
+                data_type:
+                  data_type_identifier: INT64
+                options_segment:
+                  keyword: OPTIONS
+                  bracketed:
+                    start_bracket: (
+                    parameter: description
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    literal: '"An INTEGER field in a REPEATED STRUCT"'
+                    end_bracket: )
+                end_angle_bracket: '>'
+              end_angle_bracket: '>'
+        - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/create_table_columns_partition_options.yml
+++ b/test/fixtures/dialects/bigquery/create_table_columns_partition_options.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cb8482ae65428c5be0ab51a183895c810e4bc48e5436f3a9edc97f310a36f976
+_hash: d22cdaadb2ecd5d21b0c53478e757949601c80d55e8691671722f544422f1232
 file:
   statement:
     create_table_statement:
@@ -11,18 +11,19 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: newtable
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: x
-          data_type:
-            data_type_identifier: TIMESTAMP
-      - comma: ','
-      - column_definition:
-          identifier: y
-          data_type:
-            data_type_identifier: INT64
-      - end_bracket: )
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: x
+            data_type:
+              data_type_identifier: TIMESTAMP
+        - comma: ','
+        - column_definition:
+            identifier: y
+            data_type:
+              data_type_identifier: INT64
+        - end_bracket: )
     - partition_by_segment:
       - keyword: PARTITION
       - keyword: BY

--- a/test/fixtures/dialects/bigquery/create_table_partition_by_as.yml
+++ b/test/fixtures/dialects/bigquery/create_table_partition_by_as.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cfdcfef5a66e9e19c75aeedb5e79a45a7aa5f56f1d8b3ff300c514981b8fec80
+_hash: 22644f22c39b61816a8aa570d62b04890b9fe2a3d12307b29395f30a5d2188a2
 file:
   statement:
     create_table_statement:
@@ -11,18 +11,19 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: newtable
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: x
-          data_type:
-            data_type_identifier: INT64
-      - comma: ','
-      - column_definition:
-          identifier: y
-          data_type:
-            data_type_identifier: INT64
-      - end_bracket: )
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: x
+            data_type:
+              data_type_identifier: INT64
+        - comma: ','
+        - column_definition:
+            identifier: y
+            data_type:
+              data_type_identifier: INT64
+        - end_bracket: )
     - partition_by_segment:
       - keyword: PARTITION
       - keyword: BY

--- a/test/fixtures/dialects/bigquery/create_table_partition_by_cluster_by_as.yml
+++ b/test/fixtures/dialects/bigquery/create_table_partition_by_cluster_by_as.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 628ae2abfe1c0da63bf3f63acf4a0536183ec1d2a8614fc1275ac278806b9e4a
+_hash: 3f6ea5e1fd2b3f420df6c405e4c4dc8083b2647dcfae543ef1cdad5444cf239e
 file:
   statement:
     create_table_statement:
@@ -11,18 +11,19 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: newtable
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: x
-          data_type:
-            data_type_identifier: INT64
-      - comma: ','
-      - column_definition:
-          identifier: y
-          data_type:
-            data_type_identifier: INT64
-      - end_bracket: )
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: x
+            data_type:
+              data_type_identifier: INT64
+        - comma: ','
+        - column_definition:
+            identifier: y
+            data_type:
+              data_type_identifier: INT64
+        - end_bracket: )
     - partition_by_segment:
       - keyword: PARTITION
       - keyword: BY

--- a/test/fixtures/dialects/bigquery/create_table_trailing_comma.sql
+++ b/test/fixtures/dialects/bigquery/create_table_trailing_comma.sql
@@ -8,3 +8,10 @@ CREATE TABLE t_table (
     col1 STRING,
     x INT64 NOT NULL OPTIONS(description="An INTEGER field that is NOT NULL"),
 );
+
+-- Even more complex example with optional statement after column list
+CREATE TABLE t_table (
+    col1 STRING,
+    x INT64 NOT NULL OPTIONS(description="An INTEGER field that is NOT NULL"),
+)
+PARTITION BY x;

--- a/test/fixtures/dialects/bigquery/create_table_trailing_comma.yml
+++ b/test/fixtures/dialects/bigquery/create_table_trailing_comma.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c9bb3144ff80289d82f0717754a2bb9fa552a8fa37324a3e54f188055049eb94
+_hash: fba05b44b40f553e9fc759ee98826311e144cdb365376a873c60a0d27aa421b3
 file:
 - statement:
     create_table_statement:
@@ -11,14 +11,15 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: t_table
-    - bracketed:
-        start_bracket: (
-        column_definition:
-          identifier: col1
-          data_type:
-            data_type_identifier: STRING
-        comma: ','
-        end_bracket: )
+    - column_list_segment:
+        bracketed:
+          start_bracket: (
+          column_definition:
+            identifier: col1
+            data_type:
+              data_type_identifier: STRING
+          comma: ','
+          end_bracket: )
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -26,29 +27,69 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: t_table
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: col1
-          data_type:
-            data_type_identifier: STRING
-      - comma: ','
-      - column_definition:
-          identifier: x
-          data_type:
-            data_type_identifier: INT64
-          column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-          options_segment:
-            keyword: OPTIONS
-            bracketed:
-              start_bracket: (
-              parameter: description
-              comparison_operator:
-                raw_comparison_operator: '='
-              literal: '"An INTEGER field that is NOT NULL"'
-              end_bracket: )
-      - comma: ','
-      - end_bracket: )
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: col1
+            data_type:
+              data_type_identifier: STRING
+        - comma: ','
+        - column_definition:
+            identifier: x
+            data_type:
+              data_type_identifier: INT64
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+            options_segment:
+              keyword: OPTIONS
+              bracketed:
+                start_bracket: (
+                parameter: description
+                comparison_operator:
+                  raw_comparison_operator: '='
+                literal: '"An INTEGER field that is NOT NULL"'
+                end_bracket: )
+        - comma: ','
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: t_table
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: col1
+            data_type:
+              data_type_identifier: STRING
+        - comma: ','
+        - column_definition:
+            identifier: x
+            data_type:
+              data_type_identifier: INT64
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+            options_segment:
+              keyword: OPTIONS
+              bracketed:
+                start_bracket: (
+                parameter: description
+                comparison_operator:
+                  raw_comparison_operator: '='
+                literal: '"An INTEGER field that is NOT NULL"'
+                end_bracket: )
+        - comma: ','
+        - end_bracket: )
+    - partition_by_segment:
+      - keyword: PARTITION
+      - keyword: BY
+      - expression:
+          column_reference:
+            identifier: x
 - statement_terminator: ;

--- a/test/fixtures/dialects/mysql/create_table.yml
+++ b/test/fixtures/dialects/mysql/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 71febe91f1d57338e1ff1d3ada75652ea5064ebdc3d6c10d20a6598ad5a0584f
+_hash: cffb9ba5985da5f1f334f8ebddadaec8ef0b20b58573027ddc71f1cc5f0251d0
 file:
   statement:
     create_table_statement:
@@ -11,45 +11,46 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: '`foo`'
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: b
-          data_type:
-            data_type_identifier: VARCHAR
-            bracketed:
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: b
+            data_type:
+              data_type_identifier: VARCHAR
+              bracketed:
+                start_bracket: (
+                expression:
+                  literal: '255'
+                end_bracket: )
+              keyword: BINARY
+        - comma: ','
+        - column_definition:
+          - identifier: '`id`'
+          - data_type:
+              data_type_identifier: int
+              bracketed:
+                start_bracket: (
+                expression:
+                  literal: '11'
+                end_bracket: )
+          - column_constraint_segment:
+              keyword: unsigned
+          - column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          - column_constraint_segment:
+              keyword: AUTO_INCREMENT
+        - comma: ','
+        - table_constraint:
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
               start_bracket: (
-              expression:
-                literal: '255'
+              column_reference:
+                identifier: '`id`'
               end_bracket: )
-            keyword: BINARY
-      - comma: ','
-      - column_definition:
-        - identifier: '`id`'
-        - data_type:
-            data_type_identifier: int
-            bracketed:
-              start_bracket: (
-              expression:
-                literal: '11'
-              end_bracket: )
-        - column_constraint_segment:
-            keyword: unsigned
-        - column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-        - column_constraint_segment:
-            keyword: AUTO_INCREMENT
-      - comma: ','
-      - table_constraint:
-        - keyword: PRIMARY
-        - keyword: KEY
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: '`id`'
-            end_bracket: )
-      - end_bracket: )
+        - end_bracket: )
     - parameter: ENGINE
     - comparison_operator:
         raw_comparison_operator: '='

--- a/test/fixtures/dialects/mysql/create_table_constraint_unique.yml
+++ b/test/fixtures/dialects/mysql/create_table_constraint_unique.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2a461692811ad1b011d37d3a66002a6b1993994fea82550bf86b35ed37834118
+_hash: ea32bd4b8643f738c909451b6451ba5a582e33f91a94b2ce7c7b7bd9551970dc
 file:
   statement:
     create_table_statement:
@@ -11,74 +11,75 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: a
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: a
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-      - comma: ','
-      - table_constraint:
-          keyword: UNIQUE
-          bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: a
-            end_bracket: )
-      - comma: ','
-      - table_constraint:
-          keyword: UNIQUE
-          object_reference:
-            identifier: idx_c
-          bracketed:
-            start_bracket: (
-            expression:
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: a
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - table_constraint:
+            keyword: UNIQUE
+            bracketed:
+              start_bracket: (
               column_reference:
                 identifier: a
-            end_bracket: )
-      - comma: ','
-      - table_constraint:
-        - keyword: UNIQUE
-        - keyword: KEY
-        - bracketed:
-            start_bracket: (
-            expression:
+              end_bracket: )
+        - comma: ','
+        - table_constraint:
+            keyword: UNIQUE
+            object_reference:
+              identifier: idx_c
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: a
+              end_bracket: )
+        - comma: ','
+        - table_constraint:
+          - keyword: UNIQUE
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: a
+              end_bracket: )
+        - comma: ','
+        - table_constraint:
+          - keyword: UNIQUE
+          - keyword: KEY
+          - object_reference:
+              identifier: idx_a
+          - bracketed:
+              start_bracket: (
               column_reference:
                 identifier: a
-            end_bracket: )
-      - comma: ','
-      - table_constraint:
-        - keyword: UNIQUE
-        - keyword: KEY
-        - object_reference:
-            identifier: idx_a
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: a
-            end_bracket: )
-      - comma: ','
-      - table_constraint:
-        - keyword: UNIQUE
-        - keyword: INDEX
-        - bracketed:
-            start_bracket: (
-            expression:
+              end_bracket: )
+        - comma: ','
+        - table_constraint:
+          - keyword: UNIQUE
+          - keyword: INDEX
+          - bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: a
+              end_bracket: )
+        - comma: ','
+        - table_constraint:
+          - keyword: UNIQUE
+          - keyword: INDEX
+          - object_reference:
+              identifier: idx_b
+          - bracketed:
+              start_bracket: (
               column_reference:
                 identifier: a
-            end_bracket: )
-      - comma: ','
-      - table_constraint:
-        - keyword: UNIQUE
-        - keyword: INDEX
-        - object_reference:
-            identifier: idx_b
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: a
-            end_bracket: )
-      - end_bracket: )
+              end_bracket: )
+        - end_bracket: )

--- a/test/fixtures/dialects/mysql/create_table_datetime.yml
+++ b/test/fixtures/dialects/mysql/create_table_datetime.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bfdca649a237349a55e8915062675688d0d019bbb510fd6f75b8bf4b736fb80e
+_hash: 55ebf2264938917916c0512fb239082212ded96a028e2236061cbeb6dfd50f10
 file:
   statement:
     create_table_statement:
@@ -11,182 +11,183 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: '`foo`'
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-        - identifier: created_date
-        - keyword: DATETIME
-        - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
-        - column_constraint_segment:
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+          - identifier: created_date
+          - keyword: DATETIME
+          - keyword: DEFAULT
+          - keyword: CURRENT_TIMESTAMP
+          - column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+          - identifier: ts1
+          - keyword: TIMESTAMP
+          - keyword: DEFAULT
+          - keyword: CURRENT_TIMESTAMP
+          - keyword: 'ON'
+          - keyword: UPDATE
+          - keyword: CURRENT_TIMESTAMP
+        - comma: ','
+        - column_definition:
+          - identifier: dt1
+          - keyword: DATETIME
+          - keyword: DEFAULT
+          - keyword: CURRENT_TIMESTAMP
+          - keyword: 'ON'
+          - keyword: UPDATE
+          - keyword: CURRENT_TIMESTAMP
+        - comma: ','
+        - column_definition:
+          - identifier: ts2
+          - keyword: TIMESTAMP
+          - keyword: DEFAULT
+          - keyword: CURRENT_TIMESTAMP
+        - comma: ','
+        - column_definition:
+          - identifier: dt2
+          - keyword: DATETIME
+          - keyword: DEFAULT
+          - keyword: CURRENT_TIMESTAMP
+        - comma: ','
+        - column_definition:
+          - identifier: ts3
+          - keyword: TIMESTAMP
+          - keyword: DEFAULT
+          - literal: '0'
+        - comma: ','
+        - column_definition:
+          - identifier: dt3
+          - keyword: DATETIME
+          - keyword: DEFAULT
+          - literal: '0'
+        - comma: ','
+        - column_definition:
+          - identifier: ts4
+          - keyword: TIMESTAMP
+          - keyword: DEFAULT
+          - literal: '0'
+          - keyword: 'ON'
+          - keyword: UPDATE
+          - keyword: CURRENT_TIMESTAMP
+        - comma: ','
+        - column_definition:
+          - identifier: dt4
+          - keyword: DATETIME
+          - keyword: DEFAULT
+          - literal: '0'
+          - keyword: 'ON'
+          - keyword: UPDATE
+          - keyword: CURRENT_TIMESTAMP
+        - comma: ','
+        - column_definition:
+          - identifier: ts5
+          - keyword: TIMESTAMP
+          - keyword: 'ON'
+          - keyword: UPDATE
+          - keyword: CURRENT_TIMESTAMP
+        - comma: ','
+        - column_definition:
+          - identifier: ts6
+          - keyword: TIMESTAMP
+          - keyword: 'NULL'
+          - keyword: 'ON'
+          - keyword: UPDATE
+          - keyword: CURRENT_TIMESTAMP
+        - comma: ','
+        - column_definition:
+          - identifier: dt5
+          - keyword: DATETIME
+          - keyword: 'ON'
+          - keyword: UPDATE
+          - keyword: CURRENT_TIMESTAMP
+        - comma: ','
+        - column_definition:
+          - identifier: dt6
+          - keyword: DATETIME
           - keyword: NOT
           - keyword: 'NULL'
-      - comma: ','
-      - column_definition:
-        - identifier: ts1
-        - keyword: TIMESTAMP
-        - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
-        - keyword: 'ON'
-        - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
-      - comma: ','
-      - column_definition:
-        - identifier: dt1
-        - keyword: DATETIME
-        - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
-        - keyword: 'ON'
-        - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
-      - comma: ','
-      - column_definition:
-        - identifier: ts2
-        - keyword: TIMESTAMP
-        - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
-      - comma: ','
-      - column_definition:
-        - identifier: dt2
-        - keyword: DATETIME
-        - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
-      - comma: ','
-      - column_definition:
-        - identifier: ts3
-        - keyword: TIMESTAMP
-        - keyword: DEFAULT
-        - literal: '0'
-      - comma: ','
-      - column_definition:
-        - identifier: dt3
-        - keyword: DATETIME
-        - keyword: DEFAULT
-        - literal: '0'
-      - comma: ','
-      - column_definition:
-        - identifier: ts4
-        - keyword: TIMESTAMP
-        - keyword: DEFAULT
-        - literal: '0'
-        - keyword: 'ON'
-        - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
-      - comma: ','
-      - column_definition:
-        - identifier: dt4
-        - keyword: DATETIME
-        - keyword: DEFAULT
-        - literal: '0'
-        - keyword: 'ON'
-        - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
-      - comma: ','
-      - column_definition:
-        - identifier: ts5
-        - keyword: TIMESTAMP
-        - keyword: 'ON'
-        - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
-      - comma: ','
-      - column_definition:
-        - identifier: ts6
-        - keyword: TIMESTAMP
-        - keyword: 'NULL'
-        - keyword: 'ON'
-        - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
-      - comma: ','
-      - column_definition:
-        - identifier: dt5
-        - keyword: DATETIME
-        - keyword: 'ON'
-        - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
-      - comma: ','
-      - column_definition:
-        - identifier: dt6
-        - keyword: DATETIME
-        - keyword: NOT
-        - keyword: 'NULL'
-        - keyword: 'ON'
-        - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
-      - comma: ','
-      - column_definition:
-        - identifier: ts7
-        - keyword: TIMESTAMP
-        - bracketed:
-            start_bracket: (
-            literal: '6'
-            end_bracket: )
-        - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
-        - bracketed:
-            start_bracket: (
-            literal: '6'
-            end_bracket: )
-        - keyword: 'ON'
-        - keyword: UPDATE
-        - keyword: CURRENT_TIMESTAMP
-        - bracketed:
-            start_bracket: (
-            literal: '6'
-            end_bracket: )
-      - comma: ','
-      - column_definition:
-        - identifier: ts8
-        - keyword: TIMESTAMP
-        - keyword: 'NULL'
-        - keyword: DEFAULT
-        - column_constraint_segment:
-            keyword: 'NULL'
-      - comma: ','
-      - column_definition:
-        - identifier: ts9
-        - keyword: TIMESTAMP
-        - keyword: 'NULL'
-        - keyword: DEFAULT
-        - literal: '0'
-      - comma: ','
-      - column_definition:
-        - identifier: ts10
-        - keyword: TIMESTAMP
-        - keyword: 'NULL'
-        - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
-      - comma: ','
-      - column_definition:
-        - identifier: ts11
-        - keyword: TIMESTAMP
-        - keyword: 'NULL'
-        - keyword: DEFAULT
-        - keyword: CURRENT_TIMESTAMP
-        - bracketed:
-            start_bracket: (
-            end_bracket: )
-      - comma: ','
-      - column_definition:
-        - identifier: ts12
-        - keyword: TIMESTAMP
-        - keyword: 'NULL'
-        - keyword: DEFAULT
-        - literal: "'0000-00-00 00:00:00'"
-      - comma: ','
-      - column_definition:
-        - identifier: ts13
-        - keyword: TIMESTAMP
-        - keyword: 'NULL'
-        - keyword: DEFAULT
-        - keyword: NOW
-      - comma: ','
-      - column_definition:
-        - identifier: ts14
-        - keyword: TIMESTAMP
-        - keyword: 'NULL'
-        - keyword: DEFAULT
-        - keyword: NOW
-        - bracketed:
-            start_bracket: (
-            end_bracket: )
-      - end_bracket: )
+          - keyword: 'ON'
+          - keyword: UPDATE
+          - keyword: CURRENT_TIMESTAMP
+        - comma: ','
+        - column_definition:
+          - identifier: ts7
+          - keyword: TIMESTAMP
+          - bracketed:
+              start_bracket: (
+              literal: '6'
+              end_bracket: )
+          - keyword: DEFAULT
+          - keyword: CURRENT_TIMESTAMP
+          - bracketed:
+              start_bracket: (
+              literal: '6'
+              end_bracket: )
+          - keyword: 'ON'
+          - keyword: UPDATE
+          - keyword: CURRENT_TIMESTAMP
+          - bracketed:
+              start_bracket: (
+              literal: '6'
+              end_bracket: )
+        - comma: ','
+        - column_definition:
+          - identifier: ts8
+          - keyword: TIMESTAMP
+          - keyword: 'NULL'
+          - keyword: DEFAULT
+          - column_constraint_segment:
+              keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+          - identifier: ts9
+          - keyword: TIMESTAMP
+          - keyword: 'NULL'
+          - keyword: DEFAULT
+          - literal: '0'
+        - comma: ','
+        - column_definition:
+          - identifier: ts10
+          - keyword: TIMESTAMP
+          - keyword: 'NULL'
+          - keyword: DEFAULT
+          - keyword: CURRENT_TIMESTAMP
+        - comma: ','
+        - column_definition:
+          - identifier: ts11
+          - keyword: TIMESTAMP
+          - keyword: 'NULL'
+          - keyword: DEFAULT
+          - keyword: CURRENT_TIMESTAMP
+          - bracketed:
+              start_bracket: (
+              end_bracket: )
+        - comma: ','
+        - column_definition:
+          - identifier: ts12
+          - keyword: TIMESTAMP
+          - keyword: 'NULL'
+          - keyword: DEFAULT
+          - literal: "'0000-00-00 00:00:00'"
+        - comma: ','
+        - column_definition:
+          - identifier: ts13
+          - keyword: TIMESTAMP
+          - keyword: 'NULL'
+          - keyword: DEFAULT
+          - keyword: NOW
+        - comma: ','
+        - column_definition:
+          - identifier: ts14
+          - keyword: TIMESTAMP
+          - keyword: 'NULL'
+          - keyword: DEFAULT
+          - keyword: NOW
+          - bracketed:
+              start_bracket: (
+              end_bracket: )
+        - end_bracket: )

--- a/test/fixtures/dialects/mysql/create_table_primary_foreign_keys.yml
+++ b/test/fixtures/dialects/mysql/create_table_primary_foreign_keys.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 07e39498149b03b49c1e841d2d8cb9e6b756c751ca37624e08aa0f0f9c696241
+_hash: 2732416a89fd13a63dce437879474c07fbf44ab3019d5b454f2e737f64b59924
 file:
 - statement:
     create_table_statement:
@@ -11,25 +11,26 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: parent
-    - bracketed:
-        start_bracket: (
-        column_definition:
-          identifier: id
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-        comma: ','
-        table_constraint:
-        - keyword: PRIMARY
-        - keyword: KEY
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: id
-            end_bracket: )
-        end_bracket: )
+    - column_list_segment:
+        bracketed:
+          start_bracket: (
+          column_definition:
+            identifier: id
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          comma: ','
+          table_constraint:
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: id
+              end_bracket: )
+          end_bracket: )
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -37,49 +38,50 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: child
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: id
-          data_type:
-            data_type_identifier: INT
-      - comma: ','
-      - column_definition:
-          identifier: parent_id
-          data_type:
-            data_type_identifier: INT
-      - comma: ','
-      - column_definition:
-          identifier: INDEX
-          data_type:
-            data_type_identifier: par_ind
-            bracketed:
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: id
+            data_type:
+              data_type_identifier: INT
+        - comma: ','
+        - column_definition:
+            identifier: parent_id
+            data_type:
+              data_type_identifier: INT
+        - comma: ','
+        - column_definition:
+            identifier: INDEX
+            data_type:
+              data_type_identifier: par_ind
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    identifier: parent_id
+                end_bracket: )
+        - comma: ','
+        - table_constraint:
+          - keyword: FOREIGN
+          - keyword: KEY
+          - bracketed:
               start_bracket: (
-              expression:
-                column_reference:
-                  identifier: parent_id
+              column_reference:
+                identifier: parent_id
               end_bracket: )
-      - comma: ','
-      - table_constraint:
-        - keyword: FOREIGN
-        - keyword: KEY
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: parent_id
-            end_bracket: )
-        - keyword: REFERENCES
-        - column_reference:
-            identifier: parent
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: id
-            end_bracket: )
-        - keyword: 'ON'
-        - keyword: DELETE
-        - keyword: CASCADE
-      - end_bracket: )
+          - keyword: REFERENCES
+          - column_reference:
+              identifier: parent
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: id
+              end_bracket: )
+          - keyword: 'ON'
+          - keyword: DELETE
+          - keyword: CASCADE
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -87,41 +89,42 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: product
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: category
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-      - comma: ','
-      - column_definition:
-          identifier: id
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-      - comma: ','
-      - column_definition:
-          identifier: price
-          data_type:
-            data_type_identifier: DECIMAL
-      - comma: ','
-      - table_constraint:
-        - keyword: PRIMARY
-        - keyword: KEY
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-              identifier: category
-          - comma: ','
-          - column_reference:
-              identifier: id
-          - end_bracket: )
-      - end_bracket: )
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: category
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            identifier: id
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            identifier: price
+            data_type:
+              data_type_identifier: DECIMAL
+        - comma: ','
+        - table_constraint:
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+                identifier: category
+            - comma: ','
+            - column_reference:
+                identifier: id
+            - end_bracket: )
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -129,25 +132,26 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: customer
-    - bracketed:
-        start_bracket: (
-        column_definition:
-          identifier: id
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-        comma: ','
-        table_constraint:
-        - keyword: PRIMARY
-        - keyword: KEY
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: id
-            end_bracket: )
-        end_bracket: )
+    - column_list_segment:
+        bracketed:
+          start_bracket: (
+          column_definition:
+            identifier: id
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          comma: ','
+          table_constraint:
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: id
+              end_bracket: )
+          end_bracket: )
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -155,88 +159,89 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: product_order
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: product_category
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-      - comma: ','
-      - column_definition:
-          identifier: product_id
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-      - comma: ','
-      - column_definition:
-          identifier: customer_id
-          data_type:
-            data_type_identifier: INT
-          column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-      - comma: ','
-      - table_constraint:
-        - keyword: PRIMARY
-        - keyword: KEY
-        - bracketed:
-            start_bracket: (
-            expression:
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: product_category
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            identifier: product_id
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            identifier: customer_id
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - table_constraint:
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: 'no'
+              end_bracket: )
+        - comma: ','
+        - table_constraint:
+          - keyword: FOREIGN
+          - keyword: KEY
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+                identifier: product_category
+            - comma: ','
+            - column_reference:
+                identifier: product_id
+            - end_bracket: )
+          - keyword: REFERENCES
+          - column_reference:
+              identifier: product
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+                identifier: category
+            - comma: ','
+            - column_reference:
+                identifier: id
+            - end_bracket: )
+          - keyword: 'ON'
+          - keyword: UPDATE
+          - keyword: CASCADE
+          - keyword: 'ON'
+          - keyword: DELETE
+          - keyword: RESTRICT
+        - comma: ','
+        - table_constraint:
+          - keyword: FOREIGN
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
               column_reference:
-                identifier: 'no'
-            end_bracket: )
-      - comma: ','
-      - table_constraint:
-        - keyword: FOREIGN
-        - keyword: KEY
-        - bracketed:
-          - start_bracket: (
+                identifier: customer_id
+              end_bracket: )
+          - keyword: REFERENCES
           - column_reference:
-              identifier: product_category
-          - comma: ','
-          - column_reference:
-              identifier: product_id
-          - end_bracket: )
-        - keyword: REFERENCES
-        - column_reference:
-            identifier: product
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-              identifier: category
-          - comma: ','
-          - column_reference:
-              identifier: id
-          - end_bracket: )
-        - keyword: 'ON'
-        - keyword: UPDATE
-        - keyword: CASCADE
-        - keyword: 'ON'
-        - keyword: DELETE
-        - keyword: RESTRICT
-      - comma: ','
-      - table_constraint:
-        - keyword: FOREIGN
-        - keyword: KEY
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: customer_id
-            end_bracket: )
-        - keyword: REFERENCES
-        - column_reference:
-            identifier: customer
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: id
-            end_bracket: )
-      - end_bracket: )
+              identifier: customer
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: id
+              end_bracket: )
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -244,79 +249,80 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: source_tag_assoc
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-        - identifier: source_id
-        - data_type:
-            data_type_identifier: INT
-        - column_constraint_segment:
-            keyword: UNSIGNED
-        - column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-      - comma: ','
-      - column_definition:
-        - identifier: tag_id
-        - data_type:
-            data_type_identifier: INT
-        - column_constraint_segment:
-            keyword: UNSIGNED
-        - column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-      - comma: ','
-      - table_constraint:
-        - keyword: PRIMARY
-        - keyword: KEY
-        - bracketed:
-          - start_bracket: (
-          - column_reference:
-              identifier: source_id
-          - comma: ','
-          - column_reference:
-              identifier: tag_id
-          - end_bracket: )
-      - comma: ','
-      - table_constraint:
-        - keyword: FOREIGN
-        - keyword: KEY
-        - bracketed:
-            start_bracket: (
-            expression:
-              column_reference:
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+          - identifier: source_id
+          - data_type:
+              data_type_identifier: INT
+          - column_constraint_segment:
+              keyword: UNSIGNED
+          - column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+          - identifier: tag_id
+          - data_type:
+              data_type_identifier: INT
+          - column_constraint_segment:
+              keyword: UNSIGNED
+          - column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - table_constraint:
+          - keyword: PRIMARY
+          - keyword: KEY
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
                 identifier: source_id
-            end_bracket: )
-        - keyword: REFERENCES
-        - column_reference:
-            identifier: source
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: id
-            end_bracket: )
-        - keyword: 'ON'
-        - keyword: DELETE
-        - keyword: CASCADE
-      - comma: ','
-      - table_constraint:
-        - keyword: FOREIGN
-        - keyword: KEY
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: tag_id
-            end_bracket: )
-        - keyword: REFERENCES
-        - column_reference:
-            identifier: source_tag
-        - bracketed:
-            start_bracket: (
-            column_reference:
-              identifier: id
-            end_bracket: )
-        - keyword: 'ON'
-        - keyword: DELETE
-        - keyword: CASCADE
-      - end_bracket: )
+            - comma: ','
+            - column_reference:
+                identifier: tag_id
+            - end_bracket: )
+        - comma: ','
+        - table_constraint:
+          - keyword: FOREIGN
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: source_id
+              end_bracket: )
+          - keyword: REFERENCES
+          - column_reference:
+              identifier: source
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: id
+              end_bracket: )
+          - keyword: 'ON'
+          - keyword: DELETE
+          - keyword: CASCADE
+        - comma: ','
+        - table_constraint:
+          - keyword: FOREIGN
+          - keyword: KEY
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: tag_id
+              end_bracket: )
+          - keyword: REFERENCES
+          - column_reference:
+              identifier: source_tag
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: id
+              end_bracket: )
+          - keyword: 'ON'
+          - keyword: DELETE
+          - keyword: CASCADE
+        - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/mysql/create_table_unique_key.yml
+++ b/test/fixtures/dialects/mysql/create_table_unique_key.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 97353e89d8d6843ce1335967262bd1e7f1a8c26ec6494b643102c602331162f5
+_hash: df6eb4f2ec90f6920831755810ecd0f34b3f5d977c64c3e2255ca75bd3164905
 file:
   statement:
     create_table_statement:
@@ -11,14 +11,15 @@ file:
     - keyword: table
     - table_reference:
         identifier: a
-    - bracketed:
-        start_bracket: (
-        column_definition:
-          identifier: b
-          data_type:
-            data_type_identifier: int
-          column_constraint_segment:
-          - keyword: unique
-          - keyword: key
-        end_bracket: )
+    - column_list_segment:
+        bracketed:
+          start_bracket: (
+          column_definition:
+            identifier: b
+            data_type:
+              data_type_identifier: int
+            column_constraint_segment:
+            - keyword: unique
+            - keyword: key
+          end_bracket: )
   statement_terminator: ;

--- a/test/fixtures/dialects/sqlite/create_table_constraint_default.yml
+++ b/test/fixtures/dialects/sqlite/create_table_constraint_default.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5edc8237281865faa18cc8d39b37eb227d501b9a1a7dfcb67d1df4a6299b83a7
+_hash: b6db7adebdccc50dc58892ff527b3720d85b17d9ade5dc3f5e475b2ebb8c2214
 file:
 - statement:
     transaction_statement:
@@ -19,19 +19,20 @@ file:
     - keyword: EXISTS
     - table_reference:
         identifier: '"tbl"'
-    - bracketed:
-        start_bracket: (
-        column_definition:
-        - identifier: '"col"'
-        - data_type:
-            keyword: TIMESTAMP
-        - column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-        - column_constraint_segment:
-            keyword: DEFAULT
-            bare_function: CURRENT_TIMESTAMP
-        end_bracket: )
+    - column_list_segment:
+        bracketed:
+          start_bracket: (
+          column_definition:
+          - identifier: '"col"'
+          - data_type:
+              keyword: TIMESTAMP
+          - column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          - column_constraint_segment:
+              keyword: DEFAULT
+              bare_function: CURRENT_TIMESTAMP
+          end_bracket: )
 - statement_terminator: ;
 - statement:
     transaction_statement:

--- a/test/fixtures/dialects/sqlite/create_table_constraint_regexp.yml
+++ b/test/fixtures/dialects/sqlite/create_table_constraint_regexp.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 116902a9e93751b07acc409d5e2e373b5367604f1695a267341664309152b6e2
+_hash: 926e6d77ca117737e3904335066bc6af69d152f926754a8b5f91289a36b0432a
 file:
   statement:
     create_table_statement:
@@ -11,26 +11,27 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: colors
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: css_name
-          data_type:
-            data_type_identifier: TEXT
-      - comma: ','
-      - column_definition:
-          identifier: rgb
-          data_type:
-            data_type_identifier: TEXT
-          column_constraint_segment:
-            keyword: CHECK
-            bracketed:
-              start_bracket: (
-              expression:
-                column_reference:
-                  identifier: rgb
-                keyword: REGEXP
-                literal: "'^#[0-9A-F]{6}$'"
-              end_bracket: )
-      - end_bracket: )
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: css_name
+            data_type:
+              data_type_identifier: TEXT
+        - comma: ','
+        - column_definition:
+            identifier: rgb
+            data_type:
+              data_type_identifier: TEXT
+            column_constraint_segment:
+              keyword: CHECK
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    identifier: rgb
+                  keyword: REGEXP
+                  literal: "'^#[0-9A-F]{6}$'"
+                end_bracket: )
+        - end_bracket: )
   statement_terminator: ;

--- a/test/fixtures/dialects/sqlite/create_table_without_rowid.yml
+++ b/test/fixtures/dialects/sqlite/create_table_without_rowid.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 94b516f95cfe6c0efc44f7d1859aa9fea9f1028c3203c4977c303064d198db54
+_hash: ffdab172332843eda05eeea9e3b625020eb5d9ec4509ac8c9ee535c4b45556f7
 file:
 - statement:
     create_table_statement:
@@ -11,19 +11,20 @@ file:
     - keyword: TABLE
     - table_reference:
         identifier: foo
-    - bracketed:
-        start_bracket: (
-        column_definition:
-        - identifier: id
-        - data_type:
-            data_type_identifier: INTEGER
-        - column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
-        - column_constraint_segment:
-          - keyword: PRIMARY
-          - keyword: KEY
-        end_bracket: )
+    - column_list_segment:
+        bracketed:
+          start_bracket: (
+          column_definition:
+          - identifier: id
+          - data_type:
+              data_type_identifier: INTEGER
+          - column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          - column_constraint_segment:
+            - keyword: PRIMARY
+            - keyword: KEY
+          end_bracket: )
     - table_end_clause_segment:
       - keyword: WITHOUT
       - keyword: ROWID
@@ -37,21 +38,22 @@ file:
     - keyword: EXISTS
     - table_reference:
         identifier: wordcount
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          identifier: word
-          data_type:
-            data_type_identifier: TEXT
-          column_constraint_segment:
-          - keyword: PRIMARY
-          - keyword: KEY
-      - comma: ','
-      - column_definition:
-          identifier: cnt
-          data_type:
-            data_type_identifier: INTEGER
-      - end_bracket: )
+    - column_list_segment:
+        bracketed:
+        - start_bracket: (
+        - column_definition:
+            identifier: word
+            data_type:
+              data_type_identifier: TEXT
+            column_constraint_segment:
+            - keyword: PRIMARY
+            - keyword: KEY
+        - comma: ','
+        - column_definition:
+            identifier: cnt
+            data_type:
+              data_type_identifier: INTEGER
+        - end_bracket: )
     - table_end_clause_segment:
       - keyword: WITHOUT
       - keyword: ROWID

--- a/test/fixtures/rules/std_rule_cases/L038.yml
+++ b/test/fixtures/rules/std_rule_cases/L038.yml
@@ -1,13 +1,13 @@
 rule: L038
 
-test_require_pass:
+test_select_clause_trailing_comma_require_pass:
   pass_str: SELECT a, b, FROM foo
   configs:
     rules:
       L038:
         select_clause_trailing_comma: require
 
-test_require_fail:
+test_select_clause_trailing_comma_require_fail:
   fail_str: SELECT a, b FROM foo
   fix_str: SELECT a, b, FROM foo
   configs:
@@ -15,18 +15,47 @@ test_require_fail:
       L038:
         select_clause_trailing_comma: require
 
-
-test_forbid_pass:
+test_select_clause_trailing_comma_forbid_pass:
   pass_str: SELECT a, b FROM foo
   configs:
     rules:
       L038:
         select_clause_trailing_comma: forbid
 
-test_forbid_fail:
+test_select_clause_trailing_comma_forbid_fail:
   fail_str: SELECT a, b, FROM foo
   fix_str: SELECT a, b FROM foo
   configs:
     rules:
       L038:
         select_clause_trailing_comma: forbid
+
+test_create_table_trailing_comma_require_pass:
+  pass_str: CREATE TABLE t_table (a STRING, b STRING,)
+  configs:
+    rules:
+      L038:
+        create_table_trailing_comma: require
+
+test_create_table_trailing_comma_require_fail:
+  fail_str: CREATE TABLE t_table (a STRING, b STRING)
+  fix_str: CREATE TABLE t_table (a STRING, b STRING,)
+  configs:
+    rules:
+      L038:
+        create_table_trailing_comma: require
+
+test_create_table_trailing_comma_forbid_pass:
+  pass_str: CREATE TABLE t_table (a STRING, b STRING)
+  configs:
+    rules:
+      L038:
+        create_table_trailing_comma: forbid
+
+test_create_table_trailing_comma_forbid_fail:
+  fail_str: CREATE TABLE t_table (a STRING, b STRING,)
+  fix_str: CREATE TABLE t_table (a STRING, b STRING)
+  configs:
+    rules:
+      L038:
+        create_table_trailing_comma: forbid


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Follow up to #3011

Trying to make L038 also cover `CREATE TABLE` statements. Achieved by adding an abstraction level to `CREATE TABLE` statements. Not sure, how much I like it, as it seems to be very specific to L038. Open for comments.

If we want to go that route, we probably should check `CreateTableStatementSegment` of other dialects. For demonstration purposes I only added to `bigquery` dialect.

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
