### PR TITLE
Postgres add `ALTER ROLE`/`ALTER USER` support

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1109,7 +1109,7 @@ class CreateRoleStatementSegment(ansi.CreateRoleStatementSegment):
 
 
 class AlterRoleStatementSegment(BaseSegment):
-    """A `ALTER ROLE` statement.
+    """An `ALTER ROLE` statement.
 
     As per:
     https://www.postgresql.org/docs/current/sql-alterrole.html

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1144,7 +1144,7 @@ class AlterRoleStatementSegment(BaseSegment):
                     "IN",
                     "DATABASE",
                     Ref("ObjectReferenceSegment"),
-                    optional=True
+                    optional=True,
                 ),
                 OneOf(
                     Sequence(

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1108,6 +1108,67 @@ class CreateRoleStatementSegment(ansi.CreateRoleStatementSegment):
     )
 
 
+class AlterRoleStatementSegment(BaseSegment):
+    """A `ALTER ROLE` statement.
+
+    As per:
+    https://www.postgresql.org/docs/current/sql-alterrole.html
+    """
+
+    type = "alter_role_statement"
+
+    match_grammar = Sequence(
+        "ALTER",
+        OneOf("ROLE", "USER"),
+        OneOf(Ref("RoleReferenceSegment"), "ALL"),
+        OneOf(
+            Sequence(
+                Ref.keyword("WITH", optional=True),
+                AnySetOf(
+                    OneOf("SUPERUSER", "NOSUPERUSER"),
+                    OneOf("CREATEDB", "NOCREATEDB"),
+                    OneOf("CREATEROLE", "NOCREATEROLE"),
+                    OneOf("INHERIT", "NOINHERIT"),
+                    OneOf("LOGIN", "NOLOGIN"),
+                    OneOf("REPLICATION", "NOREPLICATION"),
+                    OneOf("BYPASSRLS", "NOBYPASSRLS"),
+                    Sequence("CONNECTION", "LIMIT", Ref("NumericLiteralSegment")),
+                    Sequence("PASSWORD", OneOf(Ref("QuotedLiteralSegment"), "NULL")),
+                    Sequence("VALID", "UNTIL", Ref("QuotedLiteralSegment")),
+                ),
+                optional=True,
+            ),
+            Sequence("RENAME", "TO", Ref("ObjectReferenceSegment"), optional=True),
+            Sequence(
+                Sequence(
+                    "IN",
+                    "DATABASE",
+                    Ref("ObjectReferenceSegment"),
+                    optional=True
+                ),
+                OneOf(
+                    Sequence(
+                        "SET",
+                        Ref("ObjectReferenceSegment"),
+                        OneOf(
+                            Sequence(
+                                OneOf("TO", Ref("EqualsSegment")),
+                                OneOf(Ref("QuotedLiteralSegment"), "DEFAULT"),
+                            ),
+                            Sequence(
+                                "FROM",
+                                "CURRENT",
+                            ),
+                        ),
+                    ),
+                    Sequence("RESET", OneOf(Ref("QuotedLiteralSegment"), "ALL")),
+                ),
+                optional=True,
+            ),
+        ),
+    )
+
+
 class ExplainStatementSegment(ansi.ExplainStatementSegment):
     """An `Explain` statement.
 
@@ -3068,6 +3129,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("DoStatementSegment"),
             Ref("AlterIndexStatementSegment"),
             Ref("ReindexStatementSegment"),
+            Ref("AlterRoleStatementSegment"),
         ],
     )
 

--- a/test/fixtures/dialects/postgres/postgres_alter_role.sql
+++ b/test/fixtures/dialects/postgres/postgres_alter_role.sql
@@ -1,0 +1,18 @@
+ALTER ROLE davide WITH PASSWORD 'hu8jmn3';
+ALTER ROLE davide WITH PASSWORD NULL;
+ALTER ROLE chris VALID UNTIL 'May 4 12:00:00 2015 +1';
+ALTER ROLE fred VALID UNTIL 'infinity';
+ALTER ROLE worker_bee SET maintenance_work_mem = '100000';
+ALTER ROLE fred IN DATABASE devel SET client_min_messages TO DEFAULT;
+ALTER ROLE fred IN DATABASE devel SET client_min_messages FROM CURRENT;
+ALTER ROLE fred IN DATABASE devel RESET ALL;
+ALTER ROLE miriam CREATEROLE CREATEDB;
+ALTER USER davide WITH PASSWORD 'hu8jmn3';
+ALTER USER davide WITH PASSWORD NULL;
+ALTER USER chris VALID UNTIL 'May 4 12:00:00 2015 +1';
+ALTER USER fred VALID UNTIL 'infinity';
+ALTER USER worker_bee SET maintenance_work_mem = '100000';
+ALTER USER fred IN DATABASE devel SET client_min_messages TO DEFAULT;
+ALTER USER fred IN DATABASE devel SET client_min_messages FROM CURRENT;
+ALTER USER fred IN DATABASE devel RESET ALL;
+ALTER USER miriam CREATEROLE CREATEDB;

--- a/test/fixtures/dialects/postgres/postgres_alter_role.yml
+++ b/test/fixtures/dialects/postgres/postgres_alter_role.yml
@@ -1,0 +1,221 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e3763487178dc2a32b3d317afc4aff4ba2bc64022fa4018366e4fbba5fad49b1
+file:
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - role_reference:
+        identifier: davide
+    - keyword: WITH
+    - keyword: PASSWORD
+    - literal: "'hu8jmn3'"
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - role_reference:
+        identifier: davide
+    - keyword: WITH
+    - keyword: PASSWORD
+    - keyword: 'NULL'
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - role_reference:
+        identifier: chris
+    - keyword: VALID
+    - keyword: UNTIL
+    - literal: "'May 4 12:00:00 2015 +1'"
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - role_reference:
+        identifier: fred
+    - keyword: VALID
+    - keyword: UNTIL
+    - literal: "'infinity'"
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - role_reference:
+        identifier: worker_bee
+    - keyword: SET
+    - object_reference:
+        identifier: maintenance_work_mem
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - literal: "'100000'"
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - role_reference:
+        identifier: fred
+    - keyword: IN
+    - keyword: DATABASE
+    - object_reference:
+        identifier: devel
+    - keyword: SET
+    - object_reference:
+        identifier: client_min_messages
+    - keyword: TO
+    - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - role_reference:
+        identifier: fred
+    - keyword: IN
+    - keyword: DATABASE
+    - object_reference:
+        identifier: devel
+    - keyword: SET
+    - object_reference:
+        identifier: client_min_messages
+    - keyword: FROM
+    - keyword: CURRENT
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - role_reference:
+        identifier: fred
+    - keyword: IN
+    - keyword: DATABASE
+    - object_reference:
+        identifier: devel
+    - keyword: RESET
+    - keyword: ALL
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - role_reference:
+        identifier: miriam
+    - keyword: CREATEROLE
+    - keyword: CREATEDB
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: USER
+    - role_reference:
+        identifier: davide
+    - keyword: WITH
+    - keyword: PASSWORD
+    - literal: "'hu8jmn3'"
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: USER
+    - role_reference:
+        identifier: davide
+    - keyword: WITH
+    - keyword: PASSWORD
+    - keyword: 'NULL'
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: USER
+    - role_reference:
+        identifier: chris
+    - keyword: VALID
+    - keyword: UNTIL
+    - literal: "'May 4 12:00:00 2015 +1'"
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: USER
+    - role_reference:
+        identifier: fred
+    - keyword: VALID
+    - keyword: UNTIL
+    - literal: "'infinity'"
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: USER
+    - role_reference:
+        identifier: worker_bee
+    - keyword: SET
+    - object_reference:
+        identifier: maintenance_work_mem
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - literal: "'100000'"
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: USER
+    - role_reference:
+        identifier: fred
+    - keyword: IN
+    - keyword: DATABASE
+    - object_reference:
+        identifier: devel
+    - keyword: SET
+    - object_reference:
+        identifier: client_min_messages
+    - keyword: TO
+    - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: USER
+    - role_reference:
+        identifier: fred
+    - keyword: IN
+    - keyword: DATABASE
+    - object_reference:
+        identifier: devel
+    - keyword: SET
+    - object_reference:
+        identifier: client_min_messages
+    - keyword: FROM
+    - keyword: CURRENT
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: USER
+    - role_reference:
+        identifier: fred
+    - keyword: IN
+    - keyword: DATABASE
+    - object_reference:
+        identifier: devel
+    - keyword: RESET
+    - keyword: ALL
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: USER
+    - role_reference:
+        identifier: miriam
+    - keyword: CREATEROLE
+    - keyword: CREATEDB
+- statement_terminator: ;

--- a/test/fixtures/dialects/redshift/redshift_alter_user.yml
+++ b/test/fixtures/dialects/redshift/redshift_alter_user.yml
@@ -3,38 +3,38 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 914b5822b521637de63bf93b1d5518fd0027e8b943dbacf8c330d2b047eee651
+_hash: f982bd196fa03d9c7773fc03b49d59594fab8edb9b06aec16481ebe4b7e9f62a
 file:
 - statement:
-    alter_user:
+    alter_role_statement:
     - keyword: alter
     - keyword: user
-    - object_reference:
+    - role_reference:
         identifier: admin
     - keyword: createdb
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_role_statement:
     - keyword: alter
     - keyword: user
-    - object_reference:
+    - role_reference:
         identifier: admin
     - keyword: with
     - keyword: createdb
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_role_statement:
     - keyword: alter
     - keyword: user
-    - object_reference:
+    - role_reference:
         identifier: admin
     - keyword: nocreatedb
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_role_statement:
     - keyword: alter
     - keyword: user
-    - object_reference:
+    - role_reference:
         identifier: admin
     - keyword: with
     - keyword: nocreatedb
@@ -137,19 +137,19 @@ file:
     - keyword: unrestricted
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_role_statement:
     - keyword: alter
     - keyword: user
-    - object_reference:
+    - role_reference:
         identifier: iam_superuser
     - keyword: password
     - literal: "'mdA51234567890123456780123456789012'"
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_role_statement:
     - keyword: alter
     - keyword: user
-    - object_reference:
+    - role_reference:
         identifier: iam_superuser
     - keyword: with
     - keyword: password
@@ -175,10 +175,10 @@ file:
     - keyword: DISABLE
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_role_statement:
     - keyword: alter
     - keyword: user
-    - object_reference:
+    - role_reference:
         identifier: admin
     - keyword: password
     - literal: "'adminPass9'"
@@ -187,10 +187,10 @@ file:
     - literal: "'2017-12-31 23:59'"
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_role_statement:
     - keyword: alter
     - keyword: user
-    - object_reference:
+    - role_reference:
         identifier: admin
     - keyword: with
     - keyword: password
@@ -200,10 +200,10 @@ file:
     - literal: "'2017-12-31 23:59'"
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_role_statement:
     - keyword: alter
     - keyword: user
-    - object_reference:
+    - role_reference:
         identifier: admin
     - keyword: rename
     - keyword: to
@@ -223,20 +223,20 @@ file:
         identifier: sysadmin
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_role_statement:
     - keyword: alter
     - keyword: user
-    - object_reference:
+    - role_reference:
         identifier: admin
     - keyword: connection
     - keyword: limit
     - literal: '10'
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_role_statement:
     - keyword: alter
     - keyword: user
-    - object_reference:
+    - role_reference:
         identifier: admin
     - keyword: with
     - keyword: connection
@@ -332,10 +332,10 @@ file:
     - literal: '100'
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_role_statement:
     - keyword: alter
     - keyword: user
-    - object_reference:
+    - role_reference:
         identifier: dbuser
     - keyword: set
     - object_reference:
@@ -359,10 +359,10 @@ file:
     - literal: "'hi'"
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_role_statement:
     - keyword: alter
     - keyword: user
-    - object_reference:
+    - role_reference:
         identifier: dbuser
     - keyword: set
     - object_reference:
@@ -384,10 +384,10 @@ file:
     - keyword: default
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_role_statement:
     - keyword: alter
     - keyword: user
-    - object_reference:
+    - role_reference:
         identifier: dbuser
     - keyword: set
     - object_reference:


### PR DESCRIPTION
### Brief summary of the change made
Creates new class that provides support for both ALTER ROLE and ALTER USER statements following spec in postgres docs.

### Are there any other side effects of this change that we should be aware of?
New functionality so shouldn't affect existing behavior.

### Pull Request checklist
New supporting test cases and fixtures added

fixes #3042 