### PR TITLE
Exasol: `CREATE/DROP/ALTER USER/ROLE` clean up for consistency

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -3294,6 +3294,21 @@ class CreateTypeStatementSegment(BaseSegment):
     )
 
 
+class CreateUserStatementSegment(BaseSegment):
+    """A `CREATE USER` statement.
+
+    A very simple create user syntax which can be extended
+    by other dialects.
+    """
+
+    type = "create_user_statement"
+    match_grammar: Matchable = Sequence(
+        "CREATE",
+        "USER",
+        Ref("ObjectReferenceSegment"),
+    )
+
+
 class CreateRoleStatementSegment(BaseSegment):
     """A `CREATE ROLE` statement.
 
@@ -3371,6 +3386,7 @@ class StatementSegment(BaseSegment):
         Ref("TransactionStatementSegment"),
         Ref("DropTableStatementSegment"),
         Ref("DropViewStatementSegment"),
+        Ref("CreateUserStatementSegment"),
         Ref("DropUserStatementSegment"),
         Ref("TruncateStatementSegment"),
         Ref("AccessStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -2332,13 +2332,13 @@ class FileOptionSegment(BaseSegment):
 ############################
 # USER
 ############################
-class CreateUserSegment(BaseSegment):
+class CreateUserStatementSegment(BaseSegment):
     """`CREATE USER` statement.
 
     https://docs.exasol.com/sql/create_user.htm
     """
 
-    type = "create_user"
+    type = "create_user_statement"
 
     is_ddl = False
     is_dml = False
@@ -2362,13 +2362,13 @@ class CreateUserSegment(BaseSegment):
     )
 
 
-class AlterUserSegment(BaseSegment):
+class AlterUserStatementSegment(BaseSegment):
     """`ALTER USER` statement.
 
     https://docs.exasol.com/sql/alter_user.htm
     """
 
-    type = "alter_user"
+    type = "alter_user_statement"
 
     is_ddl = False
     is_dml = False
@@ -2556,13 +2556,13 @@ class DropConsumerGroupSegment(BaseSegment):
 ############################
 # ROLE
 ############################
-class CreateRoleSegment(ansi.CreateRoleStatementSegment):
+class CreateRoleStatementSegment(ansi.CreateRoleStatementSegment):
     """`CREATE ROLE` statement.
 
     https://docs.exasol.com/sql/create_role.htm
     """
 
-    type = "create_role"
+    type = "create_role_statement"
 
     is_ddl = False
     is_dml = False
@@ -2579,13 +2579,13 @@ class CreateRoleSegment(ansi.CreateRoleStatementSegment):
     )
 
 
-class AlterRoleSegment(BaseSegment):
+class AlterRoleStatementSegment(BaseSegment):
     """`ALTER ROLE` statement.
 
     Only allowed to alter CONSUMER GROUPs
     """
 
-    type = "alter_role"
+    type = "alter_role_statement"
 
     is_ddl = False
     is_dml = False
@@ -3630,10 +3630,10 @@ class StatementSegment(ansi.StatementSegment):
         # Access Control Language (DCL)
         Ref("AccessStatementSegment"),
         Ref("AlterConnectionSegment"),
-        Ref("AlterUserSegment"),
+        Ref("AlterUserStatementSegment"),
         Ref("CreateConnectionSegment"),
-        Ref("CreateRoleSegment"),
-        Ref("CreateUserSegment"),
+        Ref("CreateRoleStatementSegment"),
+        Ref("CreateUserStatementSegment"),
         Ref("DropRoleStatementSegment"),
         Ref("DropUserStatementSegment"),
         Ref("DropConnectionStatementSegment"),
@@ -3641,7 +3641,7 @@ class StatementSegment(ansi.StatementSegment):
         Ref("CreateConsumerGroupSegment"),
         Ref("AlterConsumerGroupSegment"),
         Ref("DropConsumerGroupSegment"),
-        Ref("AlterRoleSegment"),
+        Ref("AlterRoleStatementSegment"),
         Ref("AlterSessionSegment"),
         Ref("AlterSystemSegment"),
         Ref("OpenSchemaSegment"),

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -2345,10 +2345,7 @@ class CreateUserStatementSegment(BaseSegment):
     is_dql = False
     is_dcl = True
 
-    match_grammar = StartsWith(
-        Sequence("CREATE", "USER"),
-    )
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "CREATE",
         "USER",
         Ref("SingleIdentifierGrammar"),
@@ -2466,13 +2463,11 @@ class UserOpenIDAuthSegment(BaseSegment):
     )
 
 
-class DropUserStatementSegment(BaseSegment):
+class DropUserStatementSegment(ansi.DropUserStatementSegment):
     """A `DROP USER` statement with CASCADE option.
 
     https://docs.exasol.com/sql/drop_user.htm
     """
-
-    type = "drop_user_statement"
 
     is_ddl = False
     is_dml = False
@@ -2562,17 +2557,12 @@ class CreateRoleStatementSegment(ansi.CreateRoleStatementSegment):
     https://docs.exasol.com/sql/create_role.htm
     """
 
-    type = "create_role_statement"
-
     is_ddl = False
     is_dml = False
     is_dql = False
     is_dcl = True
 
-    match_grammar = StartsWith(
-        Sequence("CREATE", "ROLE"),
-    )
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "CREATE",
         "ROLE",
         Ref("SingleIdentifierGrammar"),
@@ -2613,8 +2603,6 @@ class DropRoleStatementSegment(ansi.DropRoleStatementSegment):
 
     https://docs.exasol.com/sql/drop_role.htm
     """
-
-    type = "drop_role_statement"
 
     is_ddl = False
     is_dml = False

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -2332,13 +2332,11 @@ class FileOptionSegment(BaseSegment):
 ############################
 # USER
 ############################
-class CreateUserStatementSegment(BaseSegment):
+class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
     """`CREATE USER` statement.
 
     https://docs.exasol.com/sql/create_user.htm
     """
-
-    type = "create_user_statement"
 
     is_ddl = False
     is_dml = False

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -23,6 +23,7 @@ from sqlfluff.dialects.dialect_redshift_keywords import (
     redshift_unreserved_keywords,
 )
 from sqlfluff.dialects import dialect_postgres as postgres
+from sqlfluff.dialects import dialect_ansi as ansi
 
 postgres_dialect = load_raw_dialect("postgres")
 ansi_dialect = load_raw_dialect("ansi")
@@ -1762,7 +1763,6 @@ class StatementSegment(postgres.StatementSegment):
     parse_grammar = postgres.StatementSegment.parse_grammar.copy(
         insert=[
             Ref("CreateLibraryStatementSegment"),
-            Ref("CreateUserStatementSegment"),
             Ref("CreateGroupStatementSegment"),
             Ref("AlterUserStatementSegment"),
             Ref("AlterGroupStatementSegment"),
@@ -1837,13 +1837,11 @@ class RowFormatDelimitedSegment(BaseSegment):
     )
 
 
-class CreateUserStatementSegment(BaseSegment):
+class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
     """`CREATE USER` statement.
 
     https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_USER.html
     """
-
-    type = "create_user_statement"
 
     match_grammar = Sequence(
         "CREATE",

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -1843,7 +1843,7 @@ class CreateUserStatementSegment(BaseSegment):
     https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_USER.html
     """
 
-    type = "create_user"
+    type = "create_user_statement"
 
     match_grammar = Sequence(
         "CREATE",
@@ -1917,7 +1917,7 @@ class AlterUserStatementSegment(BaseSegment):
     https://docs.aws.amazon.com/redshift/latest/dg/r_ALTER_USER.html
     """
 
-    type = "alter_user"
+    type = "alter_user_statement"
 
     match_grammar = Sequence(
         "ALTER",

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -773,7 +773,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("CreateCloneStatementSegment"),
             Ref("CreateProcedureStatementSegment"),
             Ref("ShowStatementSegment"),
-            Ref("AlterUserSegment"),
+            Ref("AlterUserStatementSegment"),
             Ref("AlterSessionStatementSegment"),
             Ref("AlterTaskStatementSegment"),
             Ref("SetAssignmentStatementSegment"),
@@ -3401,7 +3401,7 @@ class ShowStatementSegment(BaseSegment):
     )
 
 
-class AlterUserSegment(BaseSegment):
+class AlterUserStatementSegment(BaseSegment):
     """`ALTER USER` statement.
 
     https://docs.snowflake.com/en/sql-reference/sql/alter-user.html
@@ -3410,7 +3410,7 @@ class AlterUserSegment(BaseSegment):
     https://docs.snowflake.com/en/sql-reference/parameters.html
     """
 
-    type = "alter_user"
+    type = "alter_user_statement"
 
     match_grammar = StartsWith(
         Sequence("ALTER", "USER"),

--- a/test/fixtures/dialects/ansi/create_user.sql
+++ b/test/fixtures/dialects/ansi/create_user.sql
@@ -1,0 +1,1 @@
+CREATE USER foo_user

--- a/test/fixtures/dialects/ansi/create_user.yml
+++ b/test/fixtures/dialects/ansi/create_user.yml
@@ -1,0 +1,13 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 1c6b528e2eedf348621c703e720fc4636646aac9f58d5db53299d08ea43cceb9
+file:
+  statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - object_reference:
+        identifier: foo_user

--- a/test/fixtures/dialects/exasol/AlterRole.yml
+++ b/test/fixtures/dialects/exasol/AlterRole.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b02409a52edf2ba89b628bf79ab8396480d6f7520f19822fc19d133e8763f045
+_hash: 13796427e55a28e3cecd41043e9386f69878289bc37e2338a6b81ce2da55308b
 file:
 - statement:
-    alter_role:
+    alter_role_statement:
     - keyword: ALTER
     - keyword: ROLE
     - identifier: role1
@@ -17,7 +17,7 @@ file:
     - identifier: CEO
 - statement_terminator: ;
 - statement:
-    alter_role:
+    alter_role_statement:
     - keyword: ALTER
     - keyword: ROLE
     - identifier: role2
@@ -28,7 +28,7 @@ file:
     - keyword: 'NULL'
 - statement_terminator: ;
 - statement:
-    alter_role:
+    alter_role_statement:
     - keyword: ALTER
     - keyword: ROLE
     - identifier: '"TABLE"'

--- a/test/fixtures/dialects/exasol/AlterUser.yml
+++ b/test/fixtures/dialects/exasol/AlterUser.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1f3cf9cfc7ce37a8561888aa40b051445962db12465583b07db1b53f2376e831
+_hash: 58f0f47b74fde009b07b503fe4bcaccd06662393493edcae607f79d81a63f28e
 file:
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - identifier: user_1
@@ -18,7 +18,7 @@ file:
     - identifier: '"h12_xhz"'
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - identifier: user_1
@@ -28,7 +28,7 @@ file:
         identifier: '"h12_xhz"'
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - identifier: user_2
@@ -40,7 +40,7 @@ file:
       - literal: "'cn=user_2,dc=authorization,dc=exasol,dc=com'"
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - identifier: user_3
@@ -50,7 +50,7 @@ file:
     - literal: "'42 days'"
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - identifier: user_4
@@ -58,7 +58,7 @@ file:
     - keyword: EXPIRE
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - identifier: user_5
@@ -68,7 +68,7 @@ file:
     - keyword: ATTEMPTS
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - identifier: userx
@@ -79,7 +79,7 @@ file:
     - identifier: CEO
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - identifier: userx
@@ -90,7 +90,7 @@ file:
     - keyword: 'NULL'
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - identifier: '"ADMIN"'
@@ -101,7 +101,7 @@ file:
     - identifier: '"TABLE"'
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - identifier: '[admin]'
@@ -112,7 +112,7 @@ file:
     - identifier: '"DAY"'
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - identifier: '"ADMIN"'
@@ -123,7 +123,7 @@ file:
     - identifier: '[day]'
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - identifier: oidctestuser

--- a/test/fixtures/dialects/exasol/CreateRole.yml
+++ b/test/fixtures/dialects/exasol/CreateRole.yml
@@ -3,22 +3,22 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8e5577eba21ac24749827a383ba21f3e6335bd49685220f621cbcac58d4d5db1
+_hash: 68a3edadff83ba6b7b85a880b8d34c4974d63b5f837e41c706365b04f666611f
 file:
 - statement:
-    create_role:
+    create_role_statement:
     - keyword: CREATE
     - keyword: ROLE
     - identifier: test_role
 - statement_terminator: ;
 - statement:
-    create_role:
+    create_role_statement:
     - keyword: CREATE
     - keyword: ROLE
     - identifier: '"test_role"'
 - statement_terminator: ;
 - statement:
-    create_role:
+    create_role_statement:
     - keyword: CREATE
     - keyword: ROLE
     - identifier: '[admin]'

--- a/test/fixtures/dialects/exasol/CreateUser.yml
+++ b/test/fixtures/dialects/exasol/CreateUser.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a5fa8725372d16c8ad86f0be4c520f3054bffa4d0058196dab60feddcfebc9f8
+_hash: e7dfd2812835391d1f97ca7c196dd923c26a2f7989e36cf8632bdb1a8522e41f
 file:
 - statement:
-    create_user:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - identifier: user_1
@@ -16,7 +16,7 @@ file:
         identifier: '"h12_xhz"'
 - statement_terminator: ;
 - statement:
-    create_user:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - identifier: user_2
@@ -28,7 +28,7 @@ file:
       - literal: "'cn=user_2,dc=authorization,dc=exasol,dc=com'"
 - statement_terminator: ;
 - statement:
-    create_user:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - identifier: user_3
@@ -40,7 +40,7 @@ file:
       - literal: "'<user>@<realm>'"
 - statement_terminator: ;
 - statement:
-    create_user:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - identifier: oidctestuser

--- a/test/fixtures/dialects/postgres/postgres_create_role.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_role.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 84332bcf9169f5c9c43a1747fbfc64555ba2e38828ae20bdae00167b101185b7
+_hash: 5ba67ae516de43f28161a2962848830299bb533cd41d2e4e625d03c2e6ca3668
 file:
 - statement:
     create_role_statement:
@@ -21,7 +21,7 @@ file:
         identifier: foo_group
 - statement_terminator: ;
 - statement:
-    create_role_statement:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:

--- a/test/fixtures/dialects/redshift/redshift_alter_user.yml
+++ b/test/fixtures/dialects/redshift/redshift_alter_user.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f982bd196fa03d9c7773fc03b49d59594fab8edb9b06aec16481ebe4b7e9f62a
+_hash: 28ef26b5f980694569c84486afda1739b41b1e127ac75bb0a9e54d733c8c4cff
 file:
 - statement:
     alter_role_statement:
@@ -40,7 +40,7 @@ file:
     - keyword: nocreatedb
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -50,7 +50,7 @@ file:
         identifier: var
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -61,7 +61,7 @@ file:
         identifier: var
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -69,7 +69,7 @@ file:
     - keyword: createuser
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -78,7 +78,7 @@ file:
     - keyword: createuser
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -86,7 +86,7 @@ file:
     - keyword: nocreateuser
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -95,7 +95,7 @@ file:
     - keyword: nocreateuser
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -105,7 +105,7 @@ file:
     - keyword: restricted
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -116,7 +116,7 @@ file:
     - keyword: restricted
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -126,7 +126,7 @@ file:
     - keyword: unrestricted
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -156,7 +156,7 @@ file:
     - literal: "'mdA51234567890123456780123456789012'"
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -165,7 +165,7 @@ file:
     - keyword: DISABLE
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -211,7 +211,7 @@ file:
         identifier: sysadmin
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -244,7 +244,7 @@ file:
     - literal: '10'
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -254,7 +254,7 @@ file:
     - keyword: unlimited
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -265,7 +265,7 @@ file:
     - keyword: unlimited
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -275,7 +275,7 @@ file:
     - literal: '300'
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -286,7 +286,7 @@ file:
     - literal: '300'
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -296,7 +296,7 @@ file:
     - keyword: timeout
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -307,7 +307,7 @@ file:
     - keyword: timeout
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -319,7 +319,7 @@ file:
     - literal: '100'
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -345,7 +345,7 @@ file:
     - literal: "'hi'"
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -371,7 +371,7 @@ file:
     - keyword: default
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -397,7 +397,7 @@ file:
     - keyword: default
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -411,7 +411,7 @@ file:
     - keyword: default
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:
@@ -421,7 +421,7 @@ file:
         identifier: var
 - statement_terminator: ;
 - statement:
-    alter_user:
+    alter_user_statement:
     - keyword: alter
     - keyword: user
     - object_reference:

--- a/test/fixtures/dialects/redshift/redshift_create_user.yml
+++ b/test/fixtures/dialects/redshift/redshift_create_user.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f29e4b091d6c216b3ce74e10a1b7dd79f3461b55b852cd61b7436829b9a26738
+_hash: 34ae3480c4706854f8d10be8b0e2c118962d35a996e0fdd197b101a50492b8b2
 file:
 - statement:
-    create_role_statement:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:
@@ -15,7 +15,7 @@ file:
     - literal: "'md5153c434b4b77c89e6b94f12c5393af5b'"
 - statement_terminator: ;
 - statement:
-    create_role_statement:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:
@@ -54,7 +54,7 @@ file:
     - keyword: DISABLE
 - statement_terminator: ;
 - statement:
-    create_role_statement:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:
@@ -64,7 +64,7 @@ file:
     - keyword: CREATEDB
 - statement_terminator: ;
 - statement:
-    create_role_statement:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:
@@ -118,7 +118,7 @@ file:
     - keyword: UNRESTRICTED
 - statement_terminator: ;
 - statement:
-    create_role_statement:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:
@@ -127,7 +127,7 @@ file:
     - literal: "'md5153c434b4b77c89e6b94f12c5393af5b'"
     - keyword: IN
     - keyword: GROUP
-    - role_reference:
+    - object_reference:
         identifier: group_1
 - statement_terminator: ;
 - statement:
@@ -147,7 +147,7 @@ file:
         identifier: group_2
 - statement_terminator: ;
 - statement:
-    create_role_statement:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:
@@ -159,7 +159,7 @@ file:
     - literal: "'2017-06-10'"
 - statement_terminator: ;
 - statement:
-    create_role_statement:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:

--- a/test/fixtures/dialects/redshift/redshift_create_user.yml
+++ b/test/fixtures/dialects/redshift/redshift_create_user.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f95f8af7e410a87c0e438444fa05fed29615de14f3864026f651118628733bd0
+_hash: f29e4b091d6c216b3ce74e10a1b7dd79f3461b55b852cd61b7436829b9a26738
 file:
 - statement:
     create_role_statement:
@@ -25,7 +25,7 @@ file:
     - literal: "'sha256|Mypassword1'"
 - statement_terminator: ;
 - statement:
-    create_user:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:
@@ -34,7 +34,7 @@ file:
     - keyword: DISABLE
 - statement_terminator: ;
 - statement:
-    create_user:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:
@@ -44,7 +44,7 @@ file:
     - keyword: DISABLE
 - statement_terminator: ;
 - statement:
-    create_user:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:
@@ -74,7 +74,7 @@ file:
     - keyword: NOCREATEDB
 - statement_terminator: ;
 - statement:
-    create_user:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:
@@ -84,7 +84,7 @@ file:
     - keyword: CREATEUSER
 - statement_terminator: ;
 - statement:
-    create_user:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:
@@ -94,7 +94,7 @@ file:
     - keyword: NOCREATEUSER
 - statement_terminator: ;
 - statement:
-    create_user:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:
@@ -106,7 +106,7 @@ file:
     - keyword: RESTRICTED
 - statement_terminator: ;
 - statement:
-    create_user:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:
@@ -131,7 +131,7 @@ file:
         identifier: group_1
 - statement_terminator: ;
 - statement:
-    create_user:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:
@@ -171,7 +171,7 @@ file:
     - literal: '30'
 - statement_terminator: ;
 - statement:
-    create_user:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:
@@ -183,7 +183,7 @@ file:
     - keyword: UNLIMITED
 - statement_terminator: ;
 - statement:
-    create_user:
+    create_user_statement:
     - keyword: CREATE
     - keyword: USER
     - object_reference:

--- a/test/fixtures/dialects/snowflake/snowflake_alter_user_abort_query.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_user_abort_query.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a2132d18e5f8c4a0107083768cc9448707c823fafa457a1b30c490a839f82762
+_hash: 15aad0d6bb2655e9d6ecbe351f9a6883a552d5ba792431655c99b39b5237f7a6
 file:
   statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - keyword: IF

--- a/test/fixtures/dialects/snowflake/snowflake_alter_user_delegate_auth.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_user_delegate_auth.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d0032d44859e038759b8b8f350ad6c63e473b0fd64d1f95339b8e4a48f4ebdc0
+_hash: 676e0a224ecc3cfcdb64ee852d9bd1d3b262d580aa8dc2ed4a2aea717acc09d8
 file:
   statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - object_reference:

--- a/test/fixtures/dialects/snowflake/snowflake_alter_user_delegate_auth_role.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_user_delegate_auth_role.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9981e95226dc621c718b797a33a2e2c81b87e6c7c848c2d67a39db7fdffd0241
+_hash: cab8332b1d742cab593103c230098e87fa5746feb05b116e04da1b6a7a2b3784
 file:
   statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - object_reference:

--- a/test/fixtures/dialects/snowflake/snowflake_alter_user_remove_delegate_auth.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_user_remove_delegate_auth.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cbd710bc6e64bc8ae417442f503734bd45639a9b2d599ebfaadd95a8b5a5b8b4
+_hash: a6a8adad54978c93f3317c8e4d93a76945b4ae6a0011046aa4ee0904050606db
 file:
   statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - object_reference:

--- a/test/fixtures/dialects/snowflake/snowflake_alter_user_rename.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_user_rename.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2bb31886b05b97cf868ea9e281cb5314fbd2de949eb1f4f75fa03579be397157
+_hash: 14798202a5d20f8f936999bda24cc07b604e70b34961aa487cbd7297a476d61d
 file:
   statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - keyword: IF

--- a/test/fixtures/dialects/snowflake/snowflake_alter_user_reset_password.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_user_reset_password.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 04ce17ea4cdf6e654ee5c9708763373d118e1721a4d2b30c99af0f503e8dc90d
+_hash: 11d0f66969014559a75ed10942f75506500b00c101342eeeba53b754706d4f7c
 file:
   statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - object_reference:

--- a/test/fixtures/dialects/snowflake/snowflake_alter_user_set_values.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_user_set_values.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 01fe74924c4bc776fed57cd0a68c88f8f407c8d9fc28f55c1feb345431dfd4b6
+_hash: 15fc2c9ef63793244885686aba4c43cf9ca2b7ac90b1a6cbfaed34756c2179ea
 file:
   statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - object_reference:

--- a/test/fixtures/dialects/snowflake/snowflake_alter_user_unset_values.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_user_unset_values.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bc8989dfb0db168c69070858f414bcc5fade88b926bc82b06db1ab965e235528
+_hash: 35ab7ce8df3ef7476fff938c2b5e36005685e89d789f744fd859e90d33bbbc86
 file:
   statement:
-    alter_user:
+    alter_user_statement:
     - keyword: ALTER
     - keyword: USER
     - object_reference:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Noticed while reviewing #3043 that these statements were inconsistent with other dialects.

### Are there any other side effects of this change that we should be aware of?
Shouldn't be

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
