### PR TITLE
Postgres: Fix `UNNEST` for L025

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -185,6 +185,9 @@ postgres_dialect.sets("datetime_units").update(
 # It quotes dateparts. So don't need this.
 postgres_dialect.sets("date_part_function_name").clear()
 
+# In Postgres, UNNEST() returns a "value table", similar to BigQuery
+postgres_dialect.sets("value_table_functions").update(["unnest"])
+
 postgres_dialect.add(
     JsonOperatorSegment=NamedParser(
         "json_operator", SymbolSegment, name="json_operator", type="binary_operator"

--- a/test/fixtures/rules/std_rule_cases/L025.yml
+++ b/test/fixtures/rules/std_rule_cases/L025.yml
@@ -21,7 +21,7 @@ test_pass_unaliased_table_referenced:
   # L025 fix with https://github.com/sqlfluff/sqlfluff/issues/449
   pass_str: select ps.*, pandgs.blah from ps join pandgs using(moo)
 
-test_ignore_value_table_functions:
+test_ignore_bigquery_value_table_functions:
   # L025 fix with https://github.com/sqlfluff/sqlfluff/issues/356
   pass_str: |
     select *
@@ -30,6 +30,19 @@ test_ignore_value_table_functions:
   configs:
     core:
       dialect: bigquery
+
+test_ignore_postgres_value_table_functions:
+  # L025 fix with https://github.com/sqlfluff/sqlfluff/issues/3051
+  pass_str: |
+    SELECT json_build_object(
+        'name', 'ticket_status',
+        'type', 'enum',
+        'values', json_agg(status_name)
+    )
+    FROM unnest(enum_range(NULL::my_enum)) AS status_name;
+  configs:
+    core:
+      dialect: postgres
 
 test_fail_table_alias_not_referenced_2:
   # Similar to test_1, but with implicit alias.


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3051 

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
