### PR TITLE
Allow aliases to pass L028

### DIFF
--- a/test/fixtures/rules/std_rule_cases/L028.yml
+++ b/test/fixtures/rules/std_rule_cases/L028.yml
@@ -19,29 +19,13 @@ test_fail_single_table_mixed_qualification_of_references_subquery:
   fail_str: SELECT * FROM (SELECT my_tbl.bar, baz FROM my_tbl)
   fix_str: SELECT * FROM (SELECT my_tbl.bar, my_tbl.baz FROM my_tbl)
 
-test_pass_lateral_table_ref_with_qa:
+test_pass_lateral_table_ref:
   pass_str: |
     SELECT
       tbl.a,
       tbl.b,
       tbl.a + tbl.b AS col_created_right_here,
-      col_created_right_here + 1 AS sub_self_ref -- noqa: disable=L028
-    FROM tbl
-
-test_fail_lateral_table_ref_without_qa_help:
-  fail_str: |
-    SELECT
-      tbl.a,
-      tbl.b,
-      tbl.a + tbl.b AS col_created_right_here,
       col_created_right_here + 1 AS sub_self_ref
-    FROM tbl
-  fix_str: |
-    SELECT
-      tbl.a,
-      tbl.b,
-      tbl.a + tbl.b AS col_created_right_here,
-      tbl.col_created_right_here + 1 AS sub_self_ref
     FROM tbl
 
 test_pass_single_table_consistent_references_1_subquery:
@@ -188,7 +172,6 @@ test_date_functions_are_excluded:
     core:
       dialect: tsql
 
-
 test_select_alias_in_where_clause_1:
   # This should pass for certain dialects
   pass_str: |
@@ -200,7 +183,6 @@ test_select_alias_in_where_clause_1:
   configs:
     core:
       dialect: redshift
-
 
 test_select_alias_in_where_clause_2:
   # This should pass for certain dialects
@@ -214,40 +196,29 @@ test_select_alias_in_where_clause_2:
     core:
       dialect: snowflake
 
+test_pass_group_by_alias:
+  pass_str: |
+    select
+        t.col1 + 1 as alias_col1,
+        count(1)
+    from table1 as t
+    group by alias_col1
 
-test_select_alias_in_where_clause_3:
-  # This should fail for ansi
-  fail_str: |
+test_pass_order_by_alias:
+  pass_str: |
     select
-        t.col0,
-        t.col1 + 1 as alias_col1
+        t.col1 + 1 as alias_col1,
+        count(1)
     from table1 as t
-    where alias_col1 > 5
-  fix_str: |
-    select
-        t.col0,
-        t.col1 + 1 as alias_col1
-    from table1 as t
-    where t.alias_col1 > 5
+    order by alias_col1
 
-test_select_alias_in_where_clause_4:
-  # This should fail for ansi
-  fail_str: |
+test_pass_having:
+  pass_str: |
     select
         t.col0,
         t.col1 + 1 as alias_col1
     from table1 as t
-    where alias_col1 > 5
-  fix_str: |
-    select
-        t.col0,
-        t.col1 + 1 as alias_col1
-    from table1 as t
-    where t.alias_col1 > 5
-  configs:
-    rules:
-      L028:
-        single_table_references: qualified
+    having alias_col1 > 5
 
 test_fail_select_alias_in_where_clause_5:
   # This should fail for ansi (and be fixable)
@@ -267,7 +238,6 @@ test_fail_select_alias_in_where_clause_5:
     rules:
       L028:
         single_table_references: unqualified
-
 
 test_pass_tsql_parameter:
   # This should pass for certain dialects

--- a/test/fixtures/rules/std_rule_cases/L028.yml
+++ b/test/fixtures/rules/std_rule_cases/L028.yml
@@ -207,8 +207,8 @@ test_pass_group_by_alias:
 test_pass_order_by_alias:
   pass_str: |
     select
-        t.col1 + 1 as alias_col1,
-        count(1)
+        t.col0,
+        t.col1 + 1 as alias_col1
     from table1 as t
     order by alias_col1
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3053 

### Are there any other side effects of this change that we should be aware of?
This allows aliases throughout the query, including in places they maybe shouldn't be allowed like the `WHERE` clause. Some dilalects used to allow this only for those dialects, but forbid it from others. Now we're generalising this, that restriction is no longer in places for the others. I think that's fine though, and the intention of L028 is not to catch this type of syntax error. We can make another rule to check for that if we really want it.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
