### PR TITLE
Fix bug handling Jinja set with multiple vars, e.g.: {% set a, b = 1, 2 %}

### DIFF
--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -10,6 +10,7 @@ from typing import Callable, cast, Dict, List, NamedTuple, Optional
 
 from jinja2 import Environment
 from jinja2.environment import Template
+from jinja2.exceptions import TemplateSyntaxError
 
 from sqlfluff.core.templaters.base import (
     RawFileSlice,
@@ -240,10 +241,21 @@ class JinjaAnalyzer:
             # as other code inside these regions require special handling.
             # (Generally speaking, JinjaTracer ignores the contents of these
             # blocks, treating them like opaque templated regions.)
-            filtered_trimmed_parts = [p for p in trimmed_parts if not p.isspace()]
-            if len(filtered_trimmed_parts) < 3 or filtered_trimmed_parts[2] != "=":
-                # Entering a set/macro block.
-                self.inside_set_or_macro = True
+            try:
+                # Entering a set/macro block. Build a source string consisting
+                # of just this one Jinja command and see if it parses. If so,
+                # it's a standalone command. OTOH, if it fails with "Unexpected
+                # end of template", it was the opening command for a block.
+                self.env.from_string(
+                    f"{self.env.block_start_string} {' '.join(trimmed_parts)} "
+                    f"{self.env.block_end_string}"
+                )
+            except TemplateSyntaxError as e:
+                if "Unexpected end of template" in e.message:
+                    # It was opening a block, thus we're inside a set or macro.
+                    self.inside_set_or_macro = True
+                else:
+                    raise  # pragma: no cover
         elif block_type == "block_end" and (trimmed_parts[0] in ("endmacro", "endset")):
             # Exiting a set/macro block.
             self.inside_set_or_macro = False

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -335,6 +335,58 @@ FROM
                 "\n",
             ],
         ),
+        RawTemplatedTestCase(
+            "set_multiple_variables_and_define_macro",
+            """{% macro echo(text) %}
+{{text}}
+{% endmacro %}
+
+{% set a, b = 1, 2 %}
+
+SELECT
+    {{ echo(a) }},
+    {{ echo(b) }}""",
+            "\n\n\n\nSELECT\n    \n1\n,\n    \n2\n",
+            [
+                "{% macro echo(text) %}",
+                "\n",
+                "{{text}}",
+                "\n",
+                "{% endmacro %}",
+                "\n\n",
+                "{% set a, b = 1, 2 %}",
+                "\n\nSELECT\n    ",
+                "{{ echo(a) }}",
+                ",\n    ",
+                "{{ echo(b) }}",
+            ],
+            [
+                "",
+                "",
+                "",
+                "",
+                "",
+                "\n\n",
+                "",
+                "\n\nSELECT\n    ",
+                "\n1\n",
+                ",\n    ",
+                "\n2\n",
+            ],
+            [
+                "{% macro echo(text) %}",
+                "\n",
+                "{{text}}",
+                "\n",
+                "{% endmacro %}",
+                "\n\n",
+                "{% set a, b = 1, 2 %}",
+                "\n\nSELECT\n    ",
+                "{{ echo(a) }}",
+                ",\n    ",
+                "{{ echo(b) }}",
+            ],
+        ),
     ],
     ids=lambda case: case.name,
 )


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3049 

Updates JinjaAnalyzer to use Jinja's own parser to understand `{% set %}` commands
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
