### PR TITLE
SparkSQL: Support for Delta `UPDATE` statement syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -2548,3 +2548,29 @@ class MergeInsertClauseSegment(ansi.MergeInsertClauseSegment):
             ),
         ),
     )
+
+
+class UpdateStatementSegment(ansi.UpdateStatementSegment):
+    """An `Update` statement.
+
+    Enhancing from ANSI dialect to be SparkSQL & Delta Lake specific.
+
+    https://docs.delta.io/latest/delta-update.html#update-a-table
+    """
+
+    match_grammar: Matchable = Sequence(
+        "UPDATE",
+        OneOf(
+            Ref("FileReferenceSegment"),
+            Ref("TableReferenceSegment"),
+        ),
+        # SET is not a resevered word in all dialects (e.g. RedShift)
+        # So specifically exclude as an allowed implict alias to avoid parsing errors
+        Ref(
+            "AliasExpressionSegment",
+            exclude=Ref.keyword("SET"),
+            optional=True,
+        ),
+        Ref("SetClauseListSegment"),
+        Ref("WhereClauseSegment"),
+    )

--- a/test/fixtures/dialects/sparksql/delta_update_table.sql
+++ b/test/fixtures/dialects/sparksql/delta_update_table.sql
@@ -1,0 +1,26 @@
+UPDATE events SET event_type = 'click' WHERE event_type = 'clck';
+
+UPDATE DELTA.`/data/events/` SET event_type = 'click' WHERE event_type = 'clck';
+
+UPDATE all_events
+SET session_time = 0, ignored = true
+WHERE session_time < (
+    SELECT min(session_time)
+    FROM good_events
+);
+
+UPDATE orders AS t1
+SET order_status = 'returned'
+WHERE EXISTS (
+    SELECT returned_orders.oid
+    FROM returned_orders
+    WHERE t1.oid = returned_orders.oid
+);
+
+UPDATE events
+SET category = 'undefined'
+WHERE category NOT IN (
+    SELECT category
+    FROM events2
+    WHERE date > '2001-01-01'
+);

--- a/test/fixtures/dialects/sparksql/delta_update_table.yml
+++ b/test/fixtures/dialects/sparksql/delta_update_table.yml
@@ -1,0 +1,202 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 5f9ad7bf7b49d556f00496d6ec41b3142cdef9d5ca22fb863c788a65b03389fb
+file:
+- statement:
+    update_statement:
+      keyword: UPDATE
+      table_reference:
+        identifier: events
+      set_clause_list:
+        keyword: SET
+        set_clause:
+          column_reference:
+            identifier: event_type
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: "'click'"
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            identifier: event_type
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: "'clck'"
+- statement_terminator: ;
+- statement:
+    update_statement:
+      keyword: UPDATE
+      file_reference:
+        keyword: DELTA
+        dot: .
+        identifier: '`/data/events/`'
+      set_clause_list:
+        keyword: SET
+        set_clause:
+          column_reference:
+            identifier: event_type
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: "'click'"
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            identifier: event_type
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: "'clck'"
+- statement_terminator: ;
+- statement:
+    update_statement:
+      keyword: UPDATE
+      table_reference:
+        identifier: all_events
+      set_clause_list:
+      - keyword: SET
+      - set_clause:
+          column_reference:
+            identifier: session_time
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: '0'
+      - comma: ','
+      - set_clause:
+          column_reference:
+            identifier: ignored
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: 'true'
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            identifier: session_time
+          comparison_operator:
+            raw_comparison_operator: <
+          bracketed:
+            start_bracket: (
+            expression:
+              select_statement:
+                select_clause:
+                  keyword: SELECT
+                  select_clause_element:
+                    function:
+                      function_name:
+                        function_name_identifier: min
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            identifier: session_time
+                        end_bracket: )
+                from_clause:
+                  keyword: FROM
+                  from_expression:
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                          identifier: good_events
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    update_statement:
+      keyword: UPDATE
+      table_reference:
+        identifier: orders
+      alias_expression:
+        keyword: AS
+        identifier: t1
+      set_clause_list:
+        keyword: SET
+        set_clause:
+          column_reference:
+            identifier: order_status
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: "'returned'"
+      where_clause:
+        keyword: WHERE
+        expression:
+          keyword: EXISTS
+          bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  column_reference:
+                  - identifier: returned_orders
+                  - dot: .
+                  - identifier: oid
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: returned_orders
+              where_clause:
+                keyword: WHERE
+                expression:
+                - column_reference:
+                  - identifier: t1
+                  - dot: .
+                  - identifier: oid
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - identifier: returned_orders
+                  - dot: .
+                  - identifier: oid
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    update_statement:
+      keyword: UPDATE
+      table_reference:
+        identifier: events
+      set_clause_list:
+        keyword: SET
+        set_clause:
+          column_reference:
+            identifier: category
+          comparison_operator:
+            raw_comparison_operator: '='
+          literal: "'undefined'"
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            identifier: category
+        - keyword: NOT
+        - keyword: IN
+        - bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  column_reference:
+                    identifier: category
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: events2
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    identifier: date
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  literal: "'2001-01-01'"
+            end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
- redefine `UpdateStatementSegment` from ANSI dialect
- added test cases for `UPDATE` syntax

### Are there any other side effects of this change that we should be aware of?
N/A

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
