### PR TITLE
ANSI (and other dialects): Add `DROP FUNCTION` support

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -3233,6 +3233,19 @@ class FunctionParameterListGrammar(BaseSegment):
     )
 
 
+class DropFunctionStatementSegment(BaseSegment):
+    """A `DROP FUNCTION` statement."""
+
+    type = "drop_function_statement"
+
+    match_grammar = Sequence(
+        "DROP",
+        "FUNCTION",
+        Ref("IfExistsGrammar", optional=True),
+        Ref("FunctionNameSegment"),
+    )
+
+
 class CreateModelStatementSegment(BaseSegment):
     """A BigQuery `CREATE MODEL` statement."""
 
@@ -3407,6 +3420,7 @@ class StatementSegment(BaseSegment):
         Ref("DeleteStatementSegment"),
         Ref("UpdateStatementSegment"),
         Ref("CreateFunctionStatementSegment"),
+        Ref("DropFunctionStatementSegment"),
         Ref("CreateModelStatementSegment"),
         Ref("DropModelStatementSegment"),
         Ref("DescribeStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -676,7 +676,6 @@ class StatementSegment(ansi.StatementSegment):
             Ref("ResignalSegment"),
             Ref("CursorOpenCloseSegment"),
             Ref("CursorFetchSegment"),
-            Ref("DropFunctionStatementSegment"),
             Ref("DropProcedureStatementSegment"),
             Ref("AlterTableStatementSegment"),
             Ref("RenameTableStatementSegment"),
@@ -1582,7 +1581,7 @@ class DropFunctionStatementSegment(BaseSegment):
     https://dev.mysql.com/doc/refman/8.0/en/drop-function-loadable.html
     """
 
-    type = "drop_function_ statement"
+    type = "drop_function_statement"
 
     # DROP FUNCTION [IF EXISTS] function_name
     match_grammar = Sequence(

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -3109,7 +3109,6 @@ class StatementSegment(ansi.StatementSegment):
             Ref("CreateTableAsStatementSegment"),
             Ref("AlterTriggerStatementSegment"),
             Ref("SetStatementSegment"),
-            Ref("DropFunctionStatementSegment"),
             Ref("CreatePolicyStatementSegment"),
             Ref("DropPolicyStatementSegment"),
             Ref("CreateMaterializedViewStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -2211,7 +2211,6 @@ class StatementSegment(ansi.StatementSegment):
             Ref("AlterTableStatementSegment"),
             Ref("AlterViewStatementSegment"),
             Ref("CreateHiveFormatTableStatementSegment"),
-            Ref("DropFunctionStatementSegment"),
             Ref("MsckRepairTableStatementSegment"),
             Ref("UseDatabaseStatementSegment"),
             # Auxiliary Statements

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -436,7 +436,6 @@ class StatementSegment(ansi.StatementSegment):
             Ref("DropStatisticsStatementSegment"),
             Ref("DropProcedureStatementSegment"),
             Ref("UpdateStatisticsStatementSegment"),
-            Ref("DropFunctionStatementSegment"),
             Ref("BeginEndSegment"),
             Ref("TryCatchSegment"),
             Ref("MergeStatementSegment"),

--- a/test/fixtures/dialects/ansi/create_function.sql
+++ b/test/fixtures/dialects/ansi/create_function.sql
@@ -1,3 +1,5 @@
 CREATE FUNCTION add(integer, integer) RETURNS integer
     AS 'select $1 + $2;'
     LANGUAGE SQL;
+
+DROP FUNCTION add;

--- a/test/fixtures/dialects/ansi/create_function.yml
+++ b/test/fixtures/dialects/ansi/create_function.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5b6c9ff7a75b871ac5c2a29f7a6c326d82a750b1bad28df58a87fd6594468eae
+_hash: 60e795338c620c492f635127c15ac55b03ff4e3a9801ee947bd3f7d0fe600b72
 file:
-  statement:
+- statement:
     create_function_statement:
     - keyword: CREATE
     - keyword: FUNCTION
@@ -28,4 +28,11 @@ file:
       - literal: "'select $1 + $2;'"
       - keyword: LANGUAGE
       - identifier: SQL
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    drop_function_statement:
+    - keyword: DROP
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: add
+- statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/create_function_no_args.sql
+++ b/test/fixtures/dialects/bigquery/create_function_no_args.sql
@@ -1,3 +1,5 @@
 CREATE FUNCTION add() RETURNS integer
     AS 'select $1 + $2;'
     LANGUAGE SQL;
+
+DROP FUNCTION myproject.mydataset.addfunc;

--- a/test/fixtures/dialects/bigquery/create_function_no_args.yml
+++ b/test/fixtures/dialects/bigquery/create_function_no_args.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5f38dd8cdd79212ed38bc07ea1f6052263adc7f3bcaa80af5bebb1ab9d93429c
+_hash: 468e128aa402dfdbe11c73ddbd6af9bc0909006170bbf158c23373386d150d12
 file:
-  statement:
+- statement:
     create_function_statement:
     - keyword: CREATE
     - keyword: FUNCTION
@@ -23,4 +23,15 @@ file:
       - udf_body: "'select $1 + $2;'"
       - keyword: LANGUAGE
       - identifier: SQL
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    drop_function_statement:
+    - keyword: DROP
+    - keyword: FUNCTION
+    - function_name:
+      - identifier: myproject
+      - dot: .
+      - identifier: mydataset
+      - dot: .
+      - function_name_identifier: addfunc
+- statement_terminator: ;

--- a/test/fixtures/dialects/mysql/drop_function.yml
+++ b/test/fixtures/dialects/mysql/drop_function.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0564ec090cf82d370de7ecdffb92aa0bfaf1593bdefdbca166b7fa331e7ff2c7
+_hash: 1d978a137af07bb853b1ef0737267fa48523b13d448cd1e4e6aa7b19a5971dce
 file:
   statement:
-    drop_function_ statement:
+    drop_function_statement:
     - keyword: DROP
     - keyword: FUNCTION
     - keyword: IF


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3078

### Are there any other side effects of this change that we should be aware of?
I added this to ANSI (the `CREATE FUNCTION` was already in there), meaning could remove some off the inserts in other dialects (I left the class in those dialects as mostly different to ANSI).
Also fixed a typo in MySQL implementation.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
