### PR TITLE
Postgres: Support `DROP EXTENSION`

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2677,25 +2677,6 @@ class DropDatabaseStatementSegment(BaseSegment):
     )
 
 
-class CreateExtensionStatementSegment(BaseSegment):
-    """A `CREATE EXTENSION` statement.
-
-    https://www.postgresql.org/docs/9.1/sql-createextension.html
-    """
-
-    type = "create_extension_statement"
-    match_grammar: Matchable = Sequence(
-        "CREATE",
-        "EXTENSION",
-        Ref("IfNotExistsGrammar", optional=True),
-        Ref("ExtensionReferenceSegment"),
-        Ref.keyword("WITH", optional=True),
-        Sequence("SCHEMA", Ref("SchemaReferenceSegment"), optional=True),
-        Sequence("VERSION", Ref("VersionIdentifierSegment"), optional=True),
-        Sequence("FROM", Ref("VersionIdentifierSegment"), optional=True),
-    )
-
-
 class CreateIndexStatementSegment(BaseSegment):
     """A `CREATE INDEX` statement."""
 
@@ -3400,7 +3381,6 @@ class StatementSegment(BaseSegment):
         Ref("DropTypeStatementSegment"),
         Ref("CreateDatabaseStatementSegment"),
         Ref("DropDatabaseStatementSegment"),
-        Ref("CreateExtensionStatementSegment"),
         Ref("CreateIndexStatementSegment"),
         Ref("DropIndexStatementSegment"),
         Ref("CreateViewStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -495,7 +495,6 @@ class StatementSegment(ansi.StatementSegment):
             Ref("TransactionStatementSegment"),
             Ref("CreateSchemaStatementSegment"),
             Ref("SetSchemaStatementSegment"),
-            Ref("CreateExtensionStatementSegment"),
             Ref("CreateModelStatementSegment"),
             Ref("DropModelStatementSegment"),
         ],

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1,26 +1,27 @@
 """The PostgreSQL dialect."""
 
 from sqlfluff.core.parser import (
-    OneOf,
     AnyNumberOf,
-    Ref,
-    Sequence,
-    Bracketed,
-    OptionallyBracketed,
     Anything,
     BaseSegment,
+    Bracketed,
+    CodeSegment,
+    CommentSegment,
+    Dedent,
     Delimited,
+    Indent,
+    Matchable,
+    NamedParser,
+    NewlineSegment,
+    OneOf,
+    OptionallyBracketed,
+    Ref,
     RegexLexer,
     RegexParser,
-    CodeSegment,
-    NamedParser,
+    SegmentGenerator,
+    Sequence,
     SymbolSegment,
     StartsWith,
-    CommentSegment,
-    Indent,
-    Dedent,
-    SegmentGenerator,
-    NewlineSegment,
 )
 
 from sqlfluff.core.dialects import load_raw_dialect
@@ -1742,6 +1743,41 @@ class AlterTableActionSegment(BaseSegment):
     )
 
 
+class CreateExtensionStatementSegment(BaseSegment):
+    """A `CREATE EXTENSION` statement.
+
+    https://www.postgresql.org/docs/9.1/sql-createextension.html
+    """
+
+    type = "create_extension_statement"
+    match_grammar: Matchable = Sequence(
+        "CREATE",
+        "EXTENSION",
+        Ref("IfNotExistsGrammar", optional=True),
+        Ref("ExtensionReferenceSegment"),
+        Ref.keyword("WITH", optional=True),
+        Sequence("SCHEMA", Ref("SchemaReferenceSegment"), optional=True),
+        Sequence("VERSION", Ref("VersionIdentifierSegment"), optional=True),
+        Sequence("FROM", Ref("VersionIdentifierSegment"), optional=True),
+    )
+
+
+class DropExtensionStatementSegment(BaseSegment):
+    """A `DROP EXTENSION` statement.
+
+    https://www.postgresql.org/docs/14/sql-dropextension.html
+    """
+
+    type = "drop_extension_statement"
+    match_grammar: Matchable = Sequence(
+        "DROP",
+        "EXTENSION",
+        Ref("IfNotExistsGrammar", optional=True),
+        Ref("ExtensionReferenceSegment"),
+        OneOf("CASCADE", "RESTRICT", optional=True),
+    )
+
+
 class CreateMaterializedViewStatementSegment(BaseSegment):
     """A `CREATE MATERIALIZED VIEW` statement.
 
@@ -3133,6 +3169,8 @@ class StatementSegment(ansi.StatementSegment):
             Ref("AlterIndexStatementSegment"),
             Ref("ReindexStatementSegment"),
             Ref("AlterRoleStatementSegment"),
+            Ref("CreateExtensionStatementSegment"),
+            Ref("DropExtensionStatementSegment"),
         ],
     )
 

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -828,7 +828,6 @@ class StatementSegment(ansi.StatementSegment):
         ],
         remove=[
             Ref("CreateTypeStatementSegment"),
-            Ref("CreateExtensionStatementSegment"),
             Ref("CreateIndexStatementSegment"),
             Ref("DropIndexStatementSegment"),
         ],

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -2239,7 +2239,6 @@ class StatementSegment(ansi.StatementSegment):
             Ref("TransactionStatementSegment"),
             Ref("CreateSchemaStatementSegment"),
             Ref("SetSchemaStatementSegment"),
-            Ref("CreateExtensionStatementSegment"),
             Ref("CreateModelStatementSegment"),
             Ref("DropModelStatementSegment"),
         ],

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -451,7 +451,6 @@ class StatementSegment(ansi.StatementSegment):
             Ref("WaitForStatementSegment"),
         ],
         remove=[
-            Ref("CreateExtensionStatementSegment"),
             Ref("CreateModelStatementSegment"),
             Ref("DropModelStatementSegment"),
             Ref("DescribeStatementSegment"),

--- a/test/fixtures/dialects/postgres/postgres_create_extension.sql
+++ b/test/fixtures/dialects/postgres/postgres_create_extension.sql
@@ -1,4 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS amazing_extension
     with schema schema1
     VERSION 2.0
-    FROM 1.0
+    FROM 1.0;
+
+DROP EXTENSION amazing_extension;

--- a/test/fixtures/dialects/postgres/postgres_create_extension.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_extension.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 790fb83cc2ebcbee4dd258f4c2d8b6cb63cd40a28bda0842a221e00aa0431097
+_hash: 5e8bc80269bd8ba7b0b8e30c11af61ee0581352db8c9273d40534c0ba364f759
 file:
-  statement:
+- statement:
     create_extension_statement:
     - keyword: CREATE
     - keyword: EXTENSION
@@ -22,3 +22,11 @@ file:
     - identifier: '2.0'
     - keyword: FROM
     - identifier: '1.0'
+- statement_terminator: ;
+- statement:
+    drop_extension_statement:
+    - keyword: DROP
+    - keyword: EXTENSION
+    - extension_reference:
+        identifier: amazing_extension
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3081

### Are there any other side effects of this change that we should be aware of?
I moved the `CREATE EXTENSION` from ANSI to Postgres, as seems to be Postgres specific.
Also dropped it from TSQL as wasn't needed there.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
