### PR TITLE
Postgres: Support `COLLATE` in more clauses

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -211,6 +211,7 @@ postgres_dialect.add(
 
 postgres_dialect.replace(
     LikeGrammar=OneOf("LIKE", "ILIKE", Sequence("SIMILAR", "TO")),
+    StringBinaryOperatorGrammar=OneOf(Ref("ConcatSegment"), "COLLATE"),
     ComparisonOperatorGrammar=OneOf(
         Ref("EqualsSegment"),
         Ref("GreaterThanSegment"),

--- a/test/fixtures/dialects/postgres/postgres_select.sql
+++ b/test/fixtures/dialects/postgres/postgres_select.sql
@@ -49,3 +49,13 @@ SELECT
     t.col2
 FROM schema1.table1
 CROSS JOIN LATERAL somefunc(tb.columnb) as t(col1 text, col2 bool);
+
+SELECT a COLLATE "de_DE" < b FROM test1;
+
+SELECT a < ('foo' COLLATE "fr_FR") FROM test1;
+
+SELECT a < b COLLATE "de_DE" FROM test1;
+
+SELECT a COLLATE "de_DE" < b FROM test1;
+
+SELECT * FROM test1 ORDER BY a || b COLLATE "fr_FR";

--- a/test/fixtures/dialects/postgres/postgres_select.yml
+++ b/test/fixtures/dialects/postgres/postgres_select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 32923ee3d80fb8d18d067f7e061beb76a9e1bacfbc3ebfee12339d59b6f40548
+_hash: 572e9cff030f960fecb75a5b65fa334eafee69090a608803d23fd9851874312f
 file:
 - statement:
     select_statement:
@@ -443,4 +443,129 @@ file:
                 - data_type:
                     keyword: bool
                 - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - column_reference:
+              identifier: a
+          - keyword: COLLATE
+          - column_reference:
+              identifier: '"de_DE"'
+          - comparison_operator:
+              raw_comparison_operator: <
+          - column_reference:
+              identifier: b
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: test1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            column_reference:
+              identifier: a
+            comparison_operator:
+              raw_comparison_operator: <
+            bracketed:
+              start_bracket: (
+              expression:
+                literal: "'foo'"
+                keyword: COLLATE
+                column_reference:
+                  identifier: '"fr_FR"'
+              end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: test1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - column_reference:
+              identifier: a
+          - comparison_operator:
+              raw_comparison_operator: <
+          - column_reference:
+              identifier: b
+          - keyword: COLLATE
+          - column_reference:
+              identifier: '"de_DE"'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: test1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - column_reference:
+              identifier: a
+          - keyword: COLLATE
+          - column_reference:
+              identifier: '"de_DE"'
+          - comparison_operator:
+              raw_comparison_operator: <
+          - column_reference:
+              identifier: b
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: test1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: test1
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - expression:
+        - column_reference:
+            identifier: a
+        - binary_operator:
+          - pipe: '|'
+          - pipe: '|'
+        - column_reference:
+            identifier: b
+        - keyword: COLLATE
+        - column_reference:
+            identifier: '"fr_FR"'
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3094

### Are there any other side effects of this change that we should be aware of?
Nope.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
