### PR TITLE
ANSI: Allow `indented_using_on` in `MERGE` statements `ON`

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2335,7 +2335,9 @@ class MergeStatementSegment(BaseSegment):
             ),
         ),
         Dedent,
+        Conditional(Indent, indented_using_on=True),
         Ref("JoinOnConditionSegment"),
+        Conditional(Dedent, indented_using_on=True),
         Ref("MergeMatchSegment"),
     )
 

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -192,6 +192,33 @@ test_fail_indented_joins_using_on_false:
       indented_joins: false
       indented_using_on: false
 
+test_fail_indented_using_on_merge_statment_default:
+  # indented_using_on also covers MERGE INTO statements
+  fail_str: |
+    MERGE INTO t
+    USING u
+    ON t.a = u.b
+    WHEN MATCHED THEN
+        UPDATE SET a = 1
+  fix_str: |
+    MERGE INTO t
+    USING u
+        ON t.a = u.b
+    WHEN MATCHED THEN
+        UPDATE SET a = 1
+
+test_pass_indented_using_on_merge_statment_false:
+  # indented_using_on also covers MERGE INTO statements
+  pass_str: |
+    MERGE INTO t
+    USING u
+    ON t.a = u.b
+    WHEN MATCHED THEN
+        UPDATE SET a = 1
+  configs:
+    indentation:
+      indented_using_on: false
+
 test_pass_indented_from_with_comment:
   pass_str: |
     SELECT *


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fixes #3091

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
