### PR TITLE
Don't allow fixes to span template blocks

### DIFF
--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -301,12 +301,11 @@ class LintFix:
             file_end_slice=RawFileSlice("", "literal", -1),
         )
 
-    def has_template_conflicts(
-        self, fix_slices: Set[RawFileSlice], templated_file: TemplatedFile
-    ) -> bool:
+    def has_template_conflicts(self, templated_file: TemplatedFile) -> bool:
         """Based on the fix slices, should we discard the fix?"""
         # Given fix slices, check for conflicts.
         check_fn = all if self.edit_type in ("create_before", "create_after") else any
+        fix_slices = self.get_fix_slices(templated_file, within_only=False)
         result = check_fn(fs.slice_type == "templated" for fs in fix_slices)
         if result or not self.source:
             return result
@@ -845,8 +844,7 @@ class BaseRule:
 
         # Check for fixes that touch templated code.
         for fix in lint_result.fixes:
-            fix_slices = fix.get_fix_slices(templated_file, within_only=False)
-            if fix.has_template_conflicts(fix_slices, templated_file):
+            if fix.has_template_conflicts(templated_file):
                 linter_logger.info(
                     "      * Discarding fixes that touch templated code: %s",
                     lint_result.fixes,

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -858,7 +858,10 @@ class BaseRule:
         for fix in lint_result.fixes:
             fix_slices = fix.get_fix_slices(templated_file, within_only=True)
             for fix_slice in fix_slices:
-                if fix_slice.slice_type not in ("block_start", "block_end"):
+                # Ignore fix slices that exist only in the source. For purposes
+                # of this check, it's not meaningful to say that a fix "touched"
+                # one of these.
+                if not fix_slice.is_source_only_slice():
                     block_indices.add(fix_slice.block_idx)
         if len(block_indices) > 1:
             linter_logger.info(

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -858,7 +858,8 @@ class BaseRule:
         for fix in lint_result.fixes:
             fix_slices = fix.get_fix_slices(templated_file, within_only=True)
             for fix_slice in fix_slices:
-                block_indices.add(fix_slice.block_idx)
+                if fix_slice.slice_type not in ("block_start", "block_end"):
+                    block_indices.add(fix_slice.block_idx)
         if len(block_indices) > 1:
             linter_logger.info(
                 "      * Discarding fixes that span multiple template blocks: %s",

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -38,6 +38,10 @@ class RawFileSlice(NamedTuple):
         """Return the a slice object for this slice."""
         return slice(self.source_idx, self.end_source_idx())
 
+    def is_source_only_slice(self):
+        """Based on its slice_type, does it only appear in the *source*?"""
+        return self.slice_type in ("comment", "block_end", "block_start", "block_mid")
+
 
 class TemplatedFileSlice(NamedTuple):
     """A slice referring to a templated file."""
@@ -386,7 +390,7 @@ class TemplatedFile:
         """
         ret_buff = []
         for elem in self.raw_sliced:
-            if elem.slice_type in ("comment", "block_end", "block_start", "block_mid"):
+            if elem.is_source_only_slice():
                 ret_buff.append(elem)
         return ret_buff
 

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -23,10 +23,12 @@ def iter_indices_of_newlines(raw_str: str) -> Iterator[int]:
 class RawFileSlice(NamedTuple):
     """A slice referring to a raw file."""
 
-    raw: str
+    raw: str  # Source string
     slice_type: str
-    source_idx: int
+    source_idx: int  # Offset from beginning of source string
     slice_subtype: Optional[str] = None
+    # Block index, incremented on start or end block tags, e.g. "if", "for"
+    block_idx: int = 0
 
     def end_source_idx(self):
         """Return the closing index of this slice."""

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -309,6 +309,10 @@ class JinjaAnalyzer:
         block_idx = 0
         last_elem_type = None
         for _, elem_type, raw in self.env.lex(self.raw_str):
+            if last_elem_type == "block_end" or elem_type == "block_start":
+                block_idx += 1
+            last_elem_type = elem_type
+
             if elem_type == "data":
                 self.track_literal(raw, block_idx)
                 continue
@@ -317,9 +321,6 @@ class JinjaAnalyzer:
 
             if elem_type.endswith("_begin"):
                 self.handle_left_whitespace_stripping(raw, block_idx)
-            if last_elem_type == "block_end" or elem_type == "block_start":
-                block_idx += 1
-            last_elem_type = elem_type
 
             raw_slice_info: RawSliceInfo = self.make_raw_slice_info(None, None)
             tag_contents = []

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -307,6 +307,7 @@ class JinjaAnalyzer:
 
         # https://jinja.palletsprojects.com/en/2.11.x/api/#jinja2.Environment.lex
         block_idx = 0
+        last_elem_type = None
         for _, elem_type, raw in self.env.lex(self.raw_str):
             if elem_type == "data":
                 self.track_literal(raw, block_idx)
@@ -316,8 +317,9 @@ class JinjaAnalyzer:
 
             if elem_type.endswith("_begin"):
                 self.handle_left_whitespace_stripping(raw, block_idx)
-            if elem_type in ("block_start", "block_end"):
+            if last_elem_type == "block_end" or elem_type == "block_start":
                 block_idx += 1
+            last_elem_type = elem_type
 
             raw_slice_info: RawSliceInfo = self.make_raw_slice_info(None, None)
             tag_contents = []

--- a/test/fixtures/rules/std_rule_cases/L052.yml
+++ b/test/fixtures/rules/std_rule_cases/L052.yml
@@ -470,6 +470,7 @@ test_fail_whitespace_after_simple_select:
     SELECT 1 ;
   fix_str: |
     SELECT 1;
+
 test_fail_whitespace_after_snowflake_set:
   fail_str: |
     SET foo = (SELECT foo FROM foo.foo) ;
@@ -478,3 +479,18 @@ test_fail_whitespace_after_snowflake_set:
   configs:
     core:
       dialect: snowflake
+
+test_fail_templated_fix_crosses_block_boundary:
+  # The rule wants to move the semicolon to the same line as the SELECT, but
+  # the core linter prevents it because it crosses a template block boundary.
+  fail_str: |
+    {% if True %}
+    SELECT 1
+    {% else %}
+    SELECT 2
+    {% endif %}
+    ;
+  configs:
+    rules:
+      L052:
+        require_final_semicolon: true


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3079

A `LintResult` whose fixes span multiple template blocks (where a "block" is where a Jinja `if` or `for` starts or ends) should be discarded. That's because one slice may be executed separately from the other at template rendering time, so a fix touching both may corrupt the code.

This new check is similar in spirit to an older one I removed a few months ago. The old one prevented a fix from touching 3 or more slices. It was more of a "rule of thumb", and there were no tests for it. This check, while similar, is more formal, and I've added a test for it.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
