### PR TITLE
Improved signed literal parsing

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -375,6 +375,7 @@ ansi_dialect.add(
         Ref("BitwiseLShiftSegment"),
         Ref("BitwiseRShiftSegment"),
     ),
+    SignedSegmentGrammar=OneOf(Ref("PositiveSegment"), Ref("NegativeSegment")),
     StringBinaryOperatorGrammar=OneOf(Ref("ConcatSegment")),
     BooleanBinaryOperatorGrammar=OneOf(
         Ref("AndKeywordSegment"), Ref("OrKeywordSegment")
@@ -930,7 +931,7 @@ class QualifiedNumericLiteralSegment(BaseSegment):
 
     type = "numeric_literal"
     match_grammar: Matchable = Sequence(
-        OneOf(Ref("PlusSegment"), Ref("MinusSegment")),
+        Ref("SignedSegmentGrammar"),
         Ref("NumericLiteralSegment"),
         allow_gaps=False,
     )
@@ -1611,8 +1612,7 @@ ansi_dialect.add(
             Ref("Expression_C_Grammar"),
             Sequence(
                 OneOf(
-                    Ref("PositiveSegment"),
-                    Ref("NegativeSegment"),
+                    Ref("SignedSegmentGrammar"),
                     # Ref('TildeSegment'),
                     "NOT",
                     "PRIOR",
@@ -1690,10 +1690,7 @@ ansi_dialect.add(
         OneOf(
             Ref("Expression_C_Grammar"),
             Sequence(
-                OneOf(
-                    Ref("PositiveSegment"),
-                    Ref("NegativeSegment"),
-                ),
+                Ref("SignedSegmentGrammar"),
                 Ref("Expression_B_Grammar"),
             ),
         ),

--- a/test/fixtures/dialects/ansi/select_f.yml
+++ b/test/fixtures/dialects/ansi/select_f.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 30401ed631b4693384cba4246c8aa34558d3e9dce8761459e71b0f19d81b507c
+_hash: d0de7da882bad017f976206b63be9e53e4d7c34c4edf65ca8dbcbbdffe95bea3
 file:
   statement:
     select_statement:
@@ -25,7 +25,7 @@ file:
                     start_bracket: (
                     expression:
                       numeric_literal:
-                        binary_operator: '-'
+                        sign_indicator: '-'
                         literal: '1'
                     end_bracket: )
               - binary_operator: '*'

--- a/test/fixtures/dialects/ansi/select_numeric_literal_exponential_format.yml
+++ b/test/fixtures/dialects/ansi/select_numeric_literal_exponential_format.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 97680a544e8a22305b99f7a7561ef6d29e061f16f4c5072d9c14f8119f65f523
+_hash: 69b5de97ece69009ad4d99e515c1eabed87fd3b4aacb0bff6f2603a2a3fab082
 file:
   statement:
     select_statement:
@@ -14,7 +14,7 @@ file:
       - comma: ','
       - select_clause_element:
           numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: 12.345e12
       - comma: ','
       - select_clause_element:
@@ -25,7 +25,7 @@ file:
       - comma: ','
       - select_clause_element:
           numeric_literal:
-            binary_operator: +
+            sign_indicator: +
             literal: '6.34'
       - comma: ','
       - select_clause_element:
@@ -36,7 +36,7 @@ file:
       - comma: ','
       - select_clause_element:
           numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: '1'
       - comma: ','
       - select_clause_element:

--- a/test/fixtures/dialects/ansi/select_simple_i.yml
+++ b/test/fixtures/dialects/ansi/select_simple_i.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d13117144eca059754e21c8379a8a86dbf9fb247b572c0b26d7ddc3788679a59
+_hash: da1306224a6a569779f9f0e243d9a2a9dbac32ec510943d4902cfcbdd692ac8b
 file:
   statement:
     select_statement:
@@ -59,7 +59,7 @@ file:
       - comma: ','
       - select_clause_element:
           numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: '786'
           alias_expression:
             keyword: as

--- a/test/fixtures/dialects/bigquery/select_interval_expression.yml
+++ b/test/fixtures/dialects/bigquery/select_interval_expression.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e7268b94073a4651e56b5016dff5f7642b3543dabcb2b12c2747d52e7862017f
+_hash: 69473b426334c6d9e68ca11fba6aaecbce9ad5ed775c3bcadf82c631bd0df349
 file:
   statement:
     select_statement:
@@ -28,7 +28,7 @@ file:
                   keyword: INTERVAL
                   expression:
                     numeric_literal:
-                      binary_operator: '-'
+                      sign_indicator: '-'
                       literal: '1'
                     binary_operator: +
                     literal: '2'

--- a/test/fixtures/dialects/bigquery/select_safe_function.yml
+++ b/test/fixtures/dialects/bigquery/select_safe_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f7907313f6ed80ed70a7803d4289bf65b1776f4753f359835361ed6e6353ce30
+_hash: 6b7cba331bbdc7f1b2f668daf4b17415a803eecd32c34e258599011135a582c4
 file:
   statement:
     select_statement:
@@ -31,7 +31,7 @@ file:
             - comma: ','
             - expression:
                 numeric_literal:
-                  binary_operator: '-'
+                  sign_indicator: '-'
                   literal: '2'
             - end_bracket: )
           alias_expression:
@@ -50,7 +50,7 @@ file:
             - comma: ','
             - expression:
                 numeric_literal:
-                  binary_operator: '-'
+                  sign_indicator: '-'
                   literal: '2'
             - comma: ','
             - expression:

--- a/test/fixtures/dialects/exasol/SelectStatement.yml
+++ b/test/fixtures/dialects/exasol/SelectStatement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5a00a9d8b0608cab322459746faf9918d1197b36e273c3f8b7f833141926bb41
+_hash: b5f7a315c0424c22f5feb115d2cd64c1a7888e365f2f6c381a6b4a583d5fb8bd
 file:
 - statement:
     select_statement:
@@ -1578,7 +1578,7 @@ file:
           select_clause_element:
             expression:
               numeric_literal:
-                binary_operator: '-'
+                sign_indicator: '-'
                 literal: '1'
               binary_operator: '*'
               function:

--- a/test/fixtures/dialects/mysql/interval.yml
+++ b/test/fixtures/dialects/mysql/interval.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 16fde14028919875d259e244f9620226a249cd1f78ee8a5eeaaa97160399107a
+_hash: c97934eaf51f702823f4320a83bbbf734e8951c88f92d3c81e24a16d19ac5273
 file:
 - statement:
     select_statement:
@@ -28,7 +28,7 @@ file:
                   keyword: INTERVAL
                   expression:
                     numeric_literal:
-                      binary_operator: '-'
+                      sign_indicator: '-'
                       literal: '30'
                   date_part: DAY
             - end_bracket: )
@@ -77,7 +77,7 @@ file:
                   keyword: INTERVAL
                   expression:
                     numeric_literal:
-                      binary_operator: '-'
+                      sign_indicator: '-'
                       literal: '30'
                   date_part: DAY
             - end_bracket: )

--- a/test/fixtures/dialects/mysql/values_statement.yml
+++ b/test/fixtures/dialects/mysql/values_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7d3bf6e107b885f4ea371574fcf0b0d3cc3232a45ad44c3bc9d2b75ad18d3c31
+_hash: 61fe61f9ec9fc6536dfa997d315e7487164aed23166472826132415009c5f96d
 file:
 - statement:
     values_clause:
@@ -76,7 +76,7 @@ file:
             keyword: interval
             expression:
               numeric_literal:
-                binary_operator: '-'
+                sign_indicator: '-'
                 literal: '5'
             date_part: day
       - end_bracket: )

--- a/test/fixtures/dialects/postgres/postgres_array.yml
+++ b/test/fixtures/dialects/postgres/postgres_array.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: aa1167d7941c122f0338319a714f752ee649d9c99d2f856dc896f573be65e755
+_hash: 4d356aa40e2cb86273e0b9b49cb717d28ad973e942507997996d6968c2c32cac
 file:
 - statement:
     select_statement:
@@ -563,7 +563,7 @@ file:
           - end_square_bracket: ']'
           - start_square_bracket: '['
           - numeric_literal:
-              binary_operator: '-'
+              sign_indicator: '-'
               literal: '2'
           - end_square_bracket: ']'
           - start_square_bracket: '['
@@ -582,7 +582,7 @@ file:
           - end_square_bracket: ']'
           - start_square_bracket: '['
           - numeric_literal:
-              binary_operator: '-'
+              sign_indicator: '-'
               literal: '1'
           - end_square_bracket: ']'
           - start_square_bracket: '['

--- a/test/fixtures/dialects/postgres/postgres_select.yml
+++ b/test/fixtures/dialects/postgres/postgres_select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 572e9cff030f960fecb75a5b65fa334eafee69090a608803d23fd9851874312f
+_hash: 0c9c1bbf564a625016182ad72f57eeef3f4ec96ef5f3478c242daadebdf3f595
 file:
 - statement:
     select_statement:
@@ -40,7 +40,7 @@ file:
             - comma: ','
             - expression:
                 numeric_literal:
-                  binary_operator: '-'
+                  sign_indicator: '-'
                   literal: '2'
             - comma: ','
             - expression:

--- a/test/fixtures/dialects/snowflake/snowflake_changes_clause.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_changes_clause.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1c770e97f248c856aee0666fea03476805979edf4633b2c8a99204ead13d0a26
+_hash: 3e26e953c76d3057c8870add1b2ae20687a47122872dc58e1cb484b0d6f9c1d5
 file:
 - statement:
     select_statement:
@@ -71,7 +71,7 @@ file:
               parameter_assigner: =>
               expression:
                 numeric_literal:
-                  binary_operator: '-'
+                  sign_indicator: '-'
                   literal: '60'
                 binary_operator: '*'
                 literal: '5'

--- a/test/fixtures/dialects/snowflake/snowflake_create_stream.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_create_stream.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3525c8e1f5a249c92615ebb39a752234e12fce761e08017f621f270b463834c8
+_hash: 627d4051655c8128e310a4c60e0537aafe16ee372f009bd859201b4de4cd76fc
 file:
 - statement:
     create_stream_statement:
@@ -65,7 +65,7 @@ file:
           parameter_assigner: =>
           expression:
             numeric_literal:
-              binary_operator: '-'
+              sign_indicator: '-'
               literal: '60'
             binary_operator: '*'
             literal: '5'

--- a/test/fixtures/dialects/snowflake/snowflake_datetime_intervals.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_datetime_intervals.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9c1d4b73adfbb46d347dc14df9531b505a57c9865e40d79064db04bb9aed82af
+_hash: 9a820a2d3a09e29af2291f5aa6b7e7ed2d3aacbe9d2a3dcd813127d6de864ef2
 file:
 - statement:
     select_statement:
@@ -19,7 +19,7 @@ file:
             - comma: ','
             - expression:
                 numeric_literal:
-                  binary_operator: '-'
+                  sign_indicator: '-'
                   literal: '1'
             - comma: ','
             - expression:

--- a/test/fixtures/dialects/sparksql/numeric_literal.yml
+++ b/test/fixtures/dialects/sparksql/numeric_literal.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5fba4f0d03b1fdc822ee34a5bcd92329068ceba814f0431df751ad0d935b2d83
+_hash: d305549a336d86c4845edee893b67618bf1bcf8d830d74082bdd3ff242902486
 file:
   statement:
     select_statement:
@@ -27,7 +27,7 @@ file:
         - comparison_operator:
             raw_comparison_operator: '>'
         - numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: '2147483648'
         - binary_operator: AND
         - column_reference:
@@ -47,7 +47,7 @@ file:
         - comparison_operator:
             raw_comparison_operator: '>'
         - numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: 32y
         - binary_operator: AND
         - column_reference:
@@ -55,7 +55,7 @@ file:
         - comparison_operator:
             raw_comparison_operator: '>'
         - numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: 32Y
         - binary_operator: AND
         - column_reference:
@@ -81,7 +81,7 @@ file:
         - comparison_operator:
             raw_comparison_operator: '>'
         - numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: '0.1234567'
         - binary_operator: AND
         - column_reference:
@@ -89,7 +89,7 @@ file:
         - comparison_operator:
             raw_comparison_operator: '>'
         - numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: '.1234567'
         - binary_operator: AND
         - column_reference:
@@ -97,7 +97,7 @@ file:
         - comparison_operator:
             raw_comparison_operator: '>'
         - numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: '123.'
         - binary_operator: AND
         - column_reference:
@@ -141,7 +141,7 @@ file:
         - comparison_operator:
             raw_comparison_operator: '>'
         - numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: 5bd
         - binary_operator: AND
         - column_reference:
@@ -149,7 +149,7 @@ file:
         - comparison_operator:
             raw_comparison_operator: '>'
         - numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: 5BD
         - binary_operator: AND
         - column_reference:
@@ -169,7 +169,7 @@ file:
         - comparison_operator:
             raw_comparison_operator: '>'
         - numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: .1234567e+2bd
         - binary_operator: AND
         - column_reference:
@@ -177,7 +177,7 @@ file:
         - comparison_operator:
             raw_comparison_operator: '>'
         - numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: .1234567E+2BD
         - binary_operator: AND
         - column_reference:
@@ -185,7 +185,7 @@ file:
         - comparison_operator:
             raw_comparison_operator: '>'
         - numeric_literal:
-            binary_operator: +
+            sign_indicator: +
             literal: '3.e+3'
         - binary_operator: AND
         - column_reference:
@@ -193,7 +193,7 @@ file:
         - comparison_operator:
             raw_comparison_operator: '>'
         - numeric_literal:
-            binary_operator: +
+            sign_indicator: +
             literal: '3.E+3'
         - binary_operator: AND
         - column_reference:
@@ -201,7 +201,7 @@ file:
         - comparison_operator:
             raw_comparison_operator: '>'
         - numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: 3.E-3D
         - binary_operator: AND
         - column_reference:
@@ -209,5 +209,5 @@ file:
         - comparison_operator:
             raw_comparison_operator: '>'
         - numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: 3.e-3d

--- a/test/fixtures/dialects/sparksql/select_cluster_by.yml
+++ b/test/fixtures/dialects/sparksql/select_cluster_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2b157da3900f150a9a2676248a164bb45924583fde57bb652d3b2fecafc926e8
+_hash: ff198ba535c84b801c569c815830e92738a537853f207ad77facffe3412aa277
 file:
 - statement:
     select_statement:
@@ -121,7 +121,7 @@ file:
                   - comma: ','
                   - expression:
                       numeric_literal:
-                        binary_operator: '-'
+                        sign_indicator: '-'
                         literal: '1'
                   - end_bracket: )
             - comma: ','

--- a/test/fixtures/dialects/sparksql/select_distribute_by.yml
+++ b/test/fixtures/dialects/sparksql/select_distribute_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e8d12a79d10158acab955206a1a3661c18693750e06c8d9c347746283e64cc92
+_hash: 216046fcf1cf2f947ad4df7674d2d4d4662c3fe7f18a2adbca56d03aed7f0ed4
 file:
 - statement:
     select_statement:
@@ -121,7 +121,7 @@ file:
                   - comma: ','
                   - expression:
                       numeric_literal:
-                        binary_operator: '-'
+                        sign_indicator: '-'
                         literal: '1'
                   - end_bracket: )
             - comma: ','

--- a/test/fixtures/dialects/sparksql/select_sort_by.yml
+++ b/test/fixtures/dialects/sparksql/select_sort_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e9f5faadf9cf816b385cd25b192715e3e1d27fd9e7f9d04e25c77a643deff4be
+_hash: 8a14d663c197424f7d68f19434cb111e35a1e0161ec9108422ad2d1e79718663
 file:
 - statement:
     select_statement:
@@ -469,7 +469,7 @@ file:
                   - comma: ','
                   - expression:
                       numeric_literal:
-                        binary_operator: '-'
+                        sign_indicator: '-'
                         literal: '1'
                   - end_bracket: )
             - comma: ','

--- a/test/fixtures/dialects/teradata/select_stmt.yml
+++ b/test/fixtures/dialects/teradata/select_stmt.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bd17e7438ba701410abf847c3dd1fe1bc242b72f974edc5e624d4600166c290a
+_hash: dfcc9bfeb2ebaa2ad71f970a1ef40d4bb0832bea56bfae3d7fb90fb8320b4849
 file:
 - statement:
     select_statement:
@@ -23,7 +23,7 @@ file:
             - comma: ','
             - expression:
                 numeric_literal:
-                  binary_operator: '-'
+                  sign_indicator: '-'
                   literal: '12'
             - end_bracket: )
           alias_expression:

--- a/test/fixtures/dialects/tsql/create_table_constraints.yml
+++ b/test/fixtures/dialects/tsql/create_table_constraints.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c4f10916b18ae988374b4b4fb5d6cba228846d3bd241d0368add84e4c1453201
+_hash: a796718d04f9ad17b20dff0919bdd408d031e1e73c03c1a4a3129084fa55778b
 file:
 - batch:
     statement:
@@ -78,7 +78,7 @@ file:
                 bracketed:
                   start_bracket: (
                   numeric_literal:
-                    binary_operator: '-'
+                    sign_indicator: '-'
                     literal: '1'
                   end_bracket: )
                 end_bracket: )
@@ -95,7 +95,7 @@ file:
               bracketed:
                 start_bracket: (
                 numeric_literal:
-                  binary_operator: '-'
+                  sign_indicator: '-'
                   literal: '1'
                 end_bracket: )
           - column_constraint_segment:
@@ -109,7 +109,7 @@ file:
           - column_constraint_segment:
               keyword: default
               numeric_literal:
-                binary_operator: '-'
+                sign_indicator: '-'
                 literal: '1'
           - column_constraint_segment:
             - keyword: not

--- a/test/fixtures/dialects/tsql/functions_a.yml
+++ b/test/fixtures/dialects/tsql/functions_a.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 46eeedeef9a1e84458eb58a4d365b4704e5e09effc6f6acff829e2548e01a50a
+_hash: 414d0bd70fbb79c4499b50c67a799b5eb2ebbe965251ae0f48dd5a574e799a29
 file:
 - batch:
     statement:
@@ -88,7 +88,7 @@ file:
               - comma: ','
               - expression:
                   numeric_literal:
-                    binary_operator: '-'
+                    sign_indicator: '-'
                     literal: '1'
               - comma: ','
               - expression:

--- a/test/fixtures/dialects/tsql/raiserror.yml
+++ b/test/fixtures/dialects/tsql/raiserror.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7f2a6825244f19753b04754321ca24fd602b2509cb647cd1f3f23884d2bddc69
+_hash: 55a7be6a253a7a592fa0a0f18511cf58e29f9c320c62019877210a92a0f2d5a4
 file:
   batch:
   - statement:
@@ -14,11 +14,11 @@ file:
         - literal: '15600'
         - comma: ','
         - numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: '1'
         - comma: ','
         - numeric_literal:
-            binary_operator: '-'
+            sign_indicator: '-'
             literal: '1'
         - comma: ','
         - literal: "'mysp_CreateCustomer'"

--- a/test/fixtures/dialects/tsql/select_date_functions.yml
+++ b/test/fixtures/dialects/tsql/select_date_functions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 818d4638dcf988381d63e7393545018cb6d77a369501e6e6421bbf727aef2a0c
+_hash: 301d40a2421d58284616bf1d1ce005637ac62374ecedb67f8c5fe08547a0eff8
 file:
   batch:
     statement:
@@ -269,7 +269,7 @@ file:
               - comma: ','
               - expression:
                   numeric_literal:
-                    binary_operator: '-'
+                    sign_indicator: '-'
                     literal: '2147483647'
               - comma: ','
               - expression:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
As identified while reviewing #3102 , the current definition of signed literals could be improved upon by using `PositiveSegment` and `NegativeSegment` instead of `PlusSegment` and `MinusSegment` (which are `binary_operators`).

This would prevent rules flagging incorrectly. Currently we get away with it as the rules check for three segments, but that might not always be the same.

I've also set up a `SignedSegmentGrammar` for ease of use elsewhere.

### Are there any other side effects of this change that we should be aware of?
Nope.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
