### PR TITLE
Bug fix: Handle "lint" human-format file output correctly

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -29,9 +29,10 @@ from sqlfluff.cli.formatters import (
     colorize,
     format_dialect_warning,
     format_dialects,
-    CallbackFormatter,
+    OutputStreamFormatter,
 )
 from sqlfluff.cli.helpers import cli_table, get_package_version
+from sqlfluff.cli.outputstream import make_output_stream, OutputStream
 
 # Import from sqlfluff core.
 from sqlfluff.core import (
@@ -332,28 +333,9 @@ def get_config(
         sys.exit(66)
 
 
-def _callback_handler(cfg: FluffConfig) -> Callable:
-    """Returns function which will be bound as a callback for printing passed message.
-
-    Called in `get_linter_and_formatter`.
-    """
-
-    def _echo_with_tqdm_lock(message: str) -> None:
-        """Makes sure that message printing (echoing) will be not in conflict with tqdm.
-
-        It may happen that progressbar conflicts with extra printing. Nothing very
-        serious happens then, except that there is printed (not removed) progressbar
-        line. The `external_write_mode` allows to disable tqdm for writing time.
-        """
-        with tqdm.external_write_mode():
-            click.echo(message=message, color=cfg.get("color"))
-
-    return _echo_with_tqdm_lock
-
-
 def get_linter_and_formatter(
-    cfg: FluffConfig, silent: bool = False
-) -> Tuple[Linter, CallbackFormatter]:
+    cfg: FluffConfig, output_stream: Optional[OutputStream] = None
+) -> Tuple[Linter, OutputStreamFormatter]:
     """Get a linter object given a config."""
     try:
         # We're just making sure it exists at this stage.
@@ -364,20 +346,12 @@ def get_linter_and_formatter(
     except KeyError:  # pragma: no cover
         click.echo(f"Error: Unknown dialect '{cfg.get('dialect')}'")
         sys.exit(66)
-
-    if not silent:
-        # Instantiate the linter and return it (with an output function)
-        formatter = CallbackFormatter(
-            callback=_callback_handler(cfg=cfg),
-            verbosity=cfg.get("verbose"),
-            output_line_length=cfg.get("output_line_length"),
-        )
-        return Linter(config=cfg, formatter=formatter), formatter
-    else:
-        # Instantiate the linter and return. NB: No formatter
-        # in the Linter and a black formatter otherwise.
-        formatter = CallbackFormatter(callback=lambda m: None, verbosity=0)
-        return Linter(config=cfg), formatter
+    formatter = OutputStreamFormatter(
+        output_stream=output_stream or make_output_stream(cfg),
+        verbosity=cfg.get("verbose"),
+        output_line_length=cfg.get("output_line_length"),
+    )
+    return Linter(config=cfg, formatter=formatter), formatter
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -521,7 +495,8 @@ def lint(
     )
     non_human_output = (format != FormatType.human.value) or (write_output is not None)
     file_output = None
-    lnt, formatter = get_linter_and_formatter(config, silent=non_human_output)
+    output_stream = make_output_stream(config, format, write_output)
+    lnt, formatter = get_linter_and_formatter(config, output_stream)
 
     verbose = config.get("verbose")
     progress_bar_configuration.disable_progress_bar = disable_progress_bar
@@ -709,7 +684,8 @@ def fix(
         extra_config_path, ignore_local_config, require_dialect=False, **kwargs
     )
     fix_even_unparsable = config.get("fix_even_unparsable")
-    lnt, formatter = get_linter_and_formatter(config, silent=fixing_stdin)
+    output_stream = make_output_stream(config)
+    lnt, formatter = get_linter_and_formatter(config, output_stream)
 
     verbose = config.get("verbose")
     progress_bar_configuration.disable_progress_bar = disable_progress_bar
@@ -950,7 +926,8 @@ def parse(
     # We don't want anything else to be logged if we want json or yaml output
     # unless we're writing to a file.
     non_human_output = (format != FormatType.human.value) or (write_output is not None)
-    lnt, formatter = get_linter_and_formatter(c, silent=non_human_output)
+    output_stream = make_output_stream(c, format, write_output)
+    lnt, formatter = get_linter_and_formatter(c, output_stream)
     verbose = c.get("verbose")
     recurse = c.get("recurse")
 
@@ -996,7 +973,7 @@ def parse(
         # iterative print for human readout
         if format == FormatType.human.value:
             violations_count = _print_out_violations_and_timing(
-                bench, code_only, total_time, verbose, parsed_strings
+                output_stream, bench, code_only, total_time, verbose, parsed_strings
             )
         else:
             parsed_strings_dict = [
@@ -1048,6 +1025,7 @@ def parse(
 
 
 def _print_out_violations_and_timing(
+    output_stream: OutputStream,
     bench: bool,
     code_only: bool,
     total_time: float,
@@ -1062,30 +1040,30 @@ def _print_out_violations_and_timing(
         timing.add(parsed_string.time_dict)
 
         if parsed_string.tree:
-            click.echo(parsed_string.tree.stringify(code_only=code_only))
+            output_stream(parsed_string.tree.stringify(code_only=code_only))
         else:
             # TODO: Make this prettier
-            click.echo("...Failed to Parse...")  # pragma: no cover
+            output_stream("...Failed to Parse...")  # pragma: no cover
 
         violations_count += len(parsed_string.violations)
         if parsed_string.violations:
-            click.echo("==== parsing violations ====")  # pragma: no cover
+            output_stream("==== parsing violations ====")  # pragma: no cover
         for v in parsed_string.violations:
-            click.echo(format_violation(v))  # pragma: no cover
+            output_stream(format_violation(v))  # pragma: no cover
         if parsed_string.violations and parsed_string.config.get("dialect") == "ansi":
-            click.echo(format_dialect_warning())  # pragma: no cover
+            output_stream(format_dialect_warning())  # pragma: no cover
 
         if verbose >= 2:
-            click.echo("==== timings ====")
-            click.echo(cli_table(parsed_string.time_dict.items()))
+            output_stream("==== timings ====")
+            output_stream(cli_table(parsed_string.time_dict.items()))
 
     if verbose >= 2 or bench:
-        click.echo("==== overall timings ====")
-        click.echo(cli_table([("Clock time", total_time)]))
+        output_stream("==== overall timings ====")
+        output_stream(cli_table([("Clock time", total_time)]))
         timing_summary = timing.summary()
         for step in timing_summary:
-            click.echo(f"=== {step} ===")
-            click.echo(cli_table(timing_summary[step].items()))
+            output_stream(f"=== {step} ===")
+            output_stream(cli_table(timing_summary[step].items()))
 
     return violations_count
 

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -685,7 +685,9 @@ def fix(
         extra_config_path, ignore_local_config, require_dialect=False, **kwargs
     )
     fix_even_unparsable = config.get("fix_even_unparsable")
-    output_stream = make_output_stream(config, None, os.devnull)
+    output_stream = make_output_stream(
+        config, None, os.devnull if fixing_stdin else None
+    )
     lnt, formatter = get_linter_and_formatter(config, output_stream)
 
     verbose = config.get("verbose")

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -553,8 +553,7 @@ def lint(
                         "start_column": violation["line_pos"],
                         "end_column": violation["line_pos"],
                         "title": "SQLFluff",
-                        "message": f"{violation['code']}: "
-                        f"{violation['description']}",
+                        "message": f"{violation['code']}: {violation['description']}",
                         "annotation_level": annotation_level,
                     }
                 )

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -684,8 +684,7 @@ def fix(
         extra_config_path, ignore_local_config, require_dialect=False, **kwargs
     )
     fix_even_unparsable = config.get("fix_even_unparsable")
-    output_stream = make_output_stream(config)
-    lnt, formatter = get_linter_and_formatter(config, output_stream)
+    lnt, formatter = get_linter_and_formatter(config)
 
     verbose = config.get("verbose")
     progress_bar_configuration.disable_progress_bar = disable_progress_bar

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -502,80 +502,84 @@ def lint(
     verbose = config.get("verbose")
     progress_bar_configuration.disable_progress_bar = disable_progress_bar
 
-    formatter.dispatch_config(lnt)
+    with output_stream:
+        formatter.dispatch_config(lnt)
 
-    # Set up logging.
-    set_logging_level(verbosity=verbose, logger=logger, stderr_output=non_human_output)
-    # add stdin if specified via lone '-'
-    if ("-",) == paths:
-        result = lnt.lint_string_wrapped(sys.stdin.read(), fname="stdin")
-    else:
-        # Output the results as we go
-        if verbose >= 1:
-            click.echo(format_linting_result_header())
-        try:
-            result = lnt.lint_paths(
-                paths,
-                ignore_non_existent_files=False,
-                ignore_files=not disregard_sqlfluffignores,
-                processes=processes,
-            )
-        except OSError:
-            click.echo(
-                colorize(
-                    f"The path(s) '{paths}' could not be accessed. Check it/they "
-                    "exist(s).",
-                    Color.red,
+        # Set up logging.
+        set_logging_level(
+            verbosity=verbose, logger=logger, stderr_output=non_human_output
+        )
+        # add stdin if specified via lone '-'
+        if ("-",) == paths:
+            result = lnt.lint_string_wrapped(sys.stdin.read(), fname="stdin")
+        else:
+            # Output the results as we go
+            if verbose >= 1:
+                click.echo(format_linting_result_header())
+            try:
+                result = lnt.lint_paths(
+                    paths,
+                    ignore_non_existent_files=False,
+                    ignore_files=not disregard_sqlfluffignores,
+                    processes=processes,
                 )
-            )
-            sys.exit(1)
-        # Output the final stats
-        if verbose >= 1:
-            click.echo(format_linting_stats(result, verbose=verbose))
-
-    if format == FormatType.json.value:
-        file_output = json.dumps(result.as_records())
-    elif format == FormatType.yaml.value:
-        file_output = yaml.dump(result.as_records(), sort_keys=False)
-    elif format == FormatType.github_annotation.value:
-        github_result = []
-        for record in result.as_records():
-            filepath = record["filepath"]
-            for violation in record["violations"]:
-                # NOTE: The output format is designed for this GitHub action:
-                # https://github.com/yuzutech/annotations-action
-                # It is similar, but not identical, to the native GitHub format:
-                # https://docs.github.com/en/rest/reference/checks#annotations-items
-                github_result.append(
-                    {
-                        "file": filepath,
-                        "line": violation["line_no"],
-                        "start_column": violation["line_pos"],
-                        "end_column": violation["line_pos"],
-                        "title": "SQLFluff",
-                        "message": f"{violation['code']}: {violation['description']}",
-                        "annotation_level": annotation_level,
-                    }
+            except OSError:
+                click.echo(
+                    colorize(
+                        f"The path(s) '{paths}' could not be accessed. Check it/they "
+                        "exist(s).",
+                        Color.red,
+                    )
                 )
-        file_output = json.dumps(github_result)
+                sys.exit(1)
+            # Output the final stats
+            if verbose >= 1:
+                click.echo(format_linting_stats(result, verbose=verbose))
 
-    if file_output:
-        dump_file_payload(write_output, cast(str, file_output))
+        if format == FormatType.json.value:
+            file_output = json.dumps(result.as_records())
+        elif format == FormatType.yaml.value:
+            file_output = yaml.dump(result.as_records(), sort_keys=False)
+        elif format == FormatType.github_annotation.value:
+            github_result = []
+            for record in result.as_records():
+                filepath = record["filepath"]
+                for violation in record["violations"]:
+                    # NOTE: The output format is designed for this GitHub action:
+                    # https://github.com/yuzutech/annotations-action
+                    # It is similar, but not identical, to the native GitHub format:
+                    # https://docs.github.com/en/rest/reference/checks#annotations-items
+                    github_result.append(
+                        {
+                            "file": filepath,
+                            "line": violation["line_no"],
+                            "start_column": violation["line_pos"],
+                            "end_column": violation["line_pos"],
+                            "title": "SQLFluff",
+                            "message": f"{violation['code']}: "
+                            f"{violation['description']}",
+                            "annotation_level": annotation_level,
+                        }
+                    )
+            file_output = json.dumps(github_result)
 
-    if bench:
-        click.echo("==== overall timings ====")
-        click.echo(cli_table([("Clock time", result.total_time)]))
-        timing_summary = result.timing_summary()
-        for step in timing_summary:
-            click.echo(f"=== {step} ===")
-            click.echo(cli_table(timing_summary[step].items()))
+        if file_output:
+            dump_file_payload(write_output, cast(str, file_output))
 
-    if not nofail:
-        if not non_human_output:
-            _completion_message(config)
-        sys.exit(result.stats()["exit code"])
-    else:
-        sys.exit(0)
+        if bench:
+            click.echo("==== overall timings ====")
+            click.echo(cli_table([("Clock time", result.total_time)]))
+            timing_summary = result.timing_summary()
+            for step in timing_summary:
+                click.echo(f"=== {step} ===")
+                click.echo(cli_table(timing_summary[step].items()))
+
+        if not nofail:
+            if not non_human_output:
+                _completion_message(config)
+            sys.exit(result.stats()["exit code"])
+        else:
+            sys.exit(0)
 
 
 def _handle_files_with_tmp_or_prs_errors(lint_result: LintingResult) -> int:

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -1,6 +1,7 @@
 """Contains the CLI."""
 
 from itertools import chain
+import os
 import sys
 import json
 import logging
@@ -684,7 +685,8 @@ def fix(
         extra_config_path, ignore_local_config, require_dialect=False, **kwargs
     )
     fix_even_unparsable = config.get("fix_even_unparsable")
-    lnt, formatter = get_linter_and_formatter(config)
+    output_stream = make_output_stream(config, None, os.devnull)
+    lnt, formatter = get_linter_and_formatter(config, output_stream)
 
     verbose = config.get("verbose")
     progress_bar_configuration.disable_progress_bar = disable_progress_bar

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -2,7 +2,7 @@
 
 
 from io import StringIO
-from typing import Callable, List, Union
+from typing import List, Union
 
 from sqlfluff.cli.helpers import (
     colorize,
@@ -12,6 +12,7 @@ from sqlfluff.cli.helpers import (
     get_python_implementation,
     pad_line,
 )
+from sqlfluff.cli.outputstream import OutputStream
 from sqlfluff.core import SQLBaseError, FluffConfig, Linter
 from sqlfluff.core.enums import Color
 from sqlfluff.core.linter import LintedFile
@@ -199,8 +200,8 @@ def format_dialect_warning():  # pragma: no cover
     )
 
 
-class CallbackFormatter:
-    """Formatter which uses a callback to output information.
+class OutputStreamFormatter:
+    """Formatter which writes to an OutputStream.
 
     On instantiation, this formatter accepts a function to
     dispatch messages. Each public method accepts an object
@@ -212,23 +213,20 @@ class CallbackFormatter:
 
 
     Args:
-        callback (:obj:`callable`): A callable which can be
-            be called with a string to be output.
-        verbosity (:obj:`int`): An integer specifying how
-            verbose the output should be.
-        filter_empty (:obj:`bool`): If True, empty messages
-            will not be dispatched.
-
+        output_stream: Output is sent here
+        verbosity: Specifies how verbose output should be
+        filter_empty: If True, empty messages will not be dispatched
+        output_line_length: Maximum line length
     """
 
     def __init__(
         self,
-        callback: Callable,
+        output_stream: OutputStream,
         verbosity: int = 0,
         filter_empty: bool = True,
         output_line_length: int = 80,
     ):
-        self._callback = callback
+        self._output_stream = output_stream
         self._verbosity = verbosity
         self._filter_empty = filter_empty
         self.output_line_length = output_line_length
@@ -240,7 +238,7 @@ class CallbackFormatter:
         """
         # The strip here is to filter out any empty messages
         if (not self._filter_empty) or s.strip(" \n\t"):
-            self._callback(s)
+            self._output_stream(s)
 
     def _format_config(self, linter: Linter) -> str:
         """Format the config of a `Linter`."""

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -238,7 +238,7 @@ class OutputStreamFormatter:
         """
         # The strip here is to filter out any empty messages
         if (not self._filter_empty) or s.strip(" \n\t"):
-            self._output_stream(s)
+            self._output_stream.write(s)
 
     def _format_config(self, linter: Linter) -> str:
         """Format the config of a `Linter`."""

--- a/src/sqlfluff/cli/outputstream.py
+++ b/src/sqlfluff/cli/outputstream.py
@@ -18,7 +18,7 @@ class OutputStream(abc.ABC):
 
     def write(self, message: str) -> None:
         """Write message to output."""
-        pass
+        raise NotImplementedError  # pragma: no cover
 
     def close(self):
         """Close output stream."""

--- a/src/sqlfluff/cli/outputstream.py
+++ b/src/sqlfluff/cli/outputstream.py
@@ -1,0 +1,75 @@
+"""Classes for managing linter output, used with CallbackFormatter."""
+import abc
+import os
+from typing import Any, Optional
+
+import click
+from tqdm import tqdm
+
+from sqlfluff.core import FluffConfig
+from sqlfluff.core.enums import FormatType
+
+
+class OutputStream(abc.ABC):
+    """Base class for linter output stream."""
+
+    def __init__(self, config: FluffConfig, context: Any = None):
+        self.config = config
+        self.context = context
+
+    def __call__(self, message: str) -> None:
+        """Write message to output."""
+        pass
+
+    def __enter__(self):
+        if self.context:
+            self.context.__enter__()
+
+    def __exit__(self, type, value, traceback):
+        if self.context:
+            self.context.__exit__()
+
+
+class TqdmOutput(OutputStream):
+    """Outputs to stdout, coordinates to avoid conflict with tqdm.
+
+    It may happen that progressbar conflicts with extra printing. Nothing very
+    serious happens then, except that there is printed (not removed) progressbar
+    line. The `external_write_mode` allows to disable tqdm for writing time.
+    """
+
+    def __init__(self, config: FluffConfig):
+        super().__init__(config, context=tqdm.external_write_mode())
+
+    def __call__(self, message: str) -> None:
+        """Write message to stdout."""
+        click.echo(message=message, color=self.config.get("color"))
+
+
+class FileOutput(OutputStream):
+    """Outputs to a specified file."""
+
+    def __init__(self, config: FluffConfig, output_path: str):
+        super().__init__(config, context=open(output_path, "w"))
+
+    def __call__(self, message: str) -> None:
+        """Write message to output_path."""
+        print(message, file=self.context)
+
+
+def make_output_stream(
+    config: FluffConfig,
+    format: Optional[str] = None,
+    output_path: Optional[str] = None,
+) -> OutputStream:
+    """Create and return appropriate OutputStream instance."""
+    if format is None or format == FormatType.human.value:
+        if not output_path:
+            # Human-format output to stdout.
+            return TqdmOutput(config)
+        else:
+            # Human-format output to a file.
+            return FileOutput(config, output_path)
+    else:
+        # Discard output
+        return FileOutput(config, os.devnull)

--- a/src/sqlfluff/cli/outputstream.py
+++ b/src/sqlfluff/cli/outputstream.py
@@ -67,9 +67,5 @@ def make_output_stream(
         if not output_path:
             # Human-format output to stdout.
             return TqdmOutput(config)
-        else:
-            # Human-format output to a file.
-            return FileOutput(config, output_path)
-    else:
-        # Discard output
-        return FileOutput(config, os.devnull)
+    # Human-format output to a file (discard if output_path is None)..
+    return FileOutput(config, output_path or os.devnull)

--- a/src/sqlfluff/cli/outputstream.py
+++ b/src/sqlfluff/cli/outputstream.py
@@ -72,5 +72,5 @@ def make_output_stream(
             # Human-format output to a file.
             return FileOutput(config, output_path)
     else:
-        # Discard output
+        # Discard human output as not required
         return FileOutput(config, os.devnull)

--- a/src/sqlfluff/cli/outputstream.py
+++ b/src/sqlfluff/cli/outputstream.py
@@ -1,4 +1,4 @@
-"""Classes for managing linter output, used with CallbackFormatter."""
+"""Classes for managing linter output, used with OutputStreamFormatter."""
 import abc
 import os
 from typing import Any, Optional

--- a/src/sqlfluff/cli/outputstream.py
+++ b/src/sqlfluff/cli/outputstream.py
@@ -67,5 +67,9 @@ def make_output_stream(
         if not output_path:
             # Human-format output to stdout.
             return TqdmOutput(config)
-    # Human-format output to a file (discard if output_path is None)..
-    return FileOutput(config, output_path or os.devnull)
+        else:
+            # Human-format output to a file.
+            return FileOutput(config, output_path)
+    else:
+        # Discard output
+        return FileOutput(config, os.devnull)

--- a/src/sqlfluff/cli/outputstream.py
+++ b/src/sqlfluff/cli/outputstream.py
@@ -27,7 +27,7 @@ class OutputStream(abc.ABC):
 
     def __exit__(self, type, value, traceback):
         if self.context:
-            self.context.__exit__()
+            self.context.__exit__(type, value, traceback)
 
 
 class TqdmOutput(OutputStream):

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -967,10 +967,10 @@ def test__cli__command_fail_nice_not_found(command):
     assert "could not be accessed" in result.output
 
 
-@pytest.mark.parametrize("serialize", ["yaml", "json", "github-annotation"])
+@pytest.mark.parametrize("serialize", ["human", "yaml", "json", "github-annotation"])
 @pytest.mark.parametrize("write_file", [None, "outfile"])
 def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_path):
-    """Check the general format of JSON output for multiple files.
+    """Test the output output formats for multiple files.
 
     This tests runs both stdout checking and file checking.
     """
@@ -985,9 +985,11 @@ def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_
     )
 
     if write_file:
-        target_file = os.path.join(
-            tmp_path, write_file + (".yaml" if serialize == "yaml" else ".json")
-        )
+        ext = {
+            "human": ".txt",
+            "yaml": ".yaml",
+        }
+        target_file = os.path.join(tmp_path, write_file + ext.get(serialize, ".json"))
         cmd_args += ("--write-output", target_file)
 
     # note the file is in here twice. two files = two payloads.
@@ -1002,7 +1004,9 @@ def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_
     else:
         result_payload = result.output
 
-    if serialize == "json":
+    if serialize == "human":
+        assert len(result_payload.split("\n")) == 29 if write_file else 30
+    elif serialize == "json":
         result = json.loads(result_payload)
         assert len(result) == 2
     elif serialize == "yaml":

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -11,7 +11,8 @@ from sqlfluff.core import Linter, FluffConfig
 from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.linter import runner
 from sqlfluff.core.errors import SQLLexError, SQLBaseError, SQLLintError, SQLParseError
-from sqlfluff.cli.formatters import CallbackFormatter
+from sqlfluff.cli.formatters import OutputStreamFormatter
+from sqlfluff.cli.outputstream import make_output_stream
 from sqlfluff.core.linter import LintingResult, NoQaDirective
 import sqlfluff.core.linter as linter
 from sqlfluff.core.parser import GreedyUntil, Ref
@@ -256,8 +257,10 @@ def test__linter__linting_parallel_thread(force_error, monkeypatch):
 
         monkeypatch.setattr(runner.MultiProcessRunner, "_create_pool", _create_pool)
 
+    config = FluffConfig(overrides={"dialect": "ansi"})
+    output_stream = make_output_stream(config, None, os.devnull)
     lntr = Linter(
-        formatter=CallbackFormatter(callback=lambda m: None, verbosity=0),
+        formatter=OutputStreamFormatter(output_stream, verbosity=0),
         dialect="ansi",
     )
     result = lntr.lint_paths(


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3080 

The `sqlfluff lint` command was not writing any output to the output file if `--write-output` was used with the default output format (human format). This PR refactors output formatting from output **destination** by creating a new base class for output, `OutputStream`.

It's a bigger PR than I expected, but I felt like there was some tech debt in this area that was worth addressing -- the combination of output formats, output locations, and the existence of the progress bar had created a "house of cards": broken, hard to understand because it coupled output format & location. It was going to be hard  to fix without addressing this.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?
This PR involves fairly low-level changes to how command-line output is written and interleaved with tqdm (progress bar) output. It's possible it could break some output that was previously working. **Manual testing of this change would be helpful.**

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
