### PR TITLE
Bug: L058 (flatten nested `CASE`) triggers incorrectly (the `ELSE` contains additional code)

### DIFF
--- a/src/sqlfluff/rules/L058.py
+++ b/src/sqlfluff/rules/L058.py
@@ -53,6 +53,9 @@ class Rule_L058(BaseRule):
             )
             expression_children = case1_else_expressions.children()
             case2 = expression_children.select(sp.is_type("case_expression"))
+            # The len() checks below are for safety, to ensure the CASE inside
+            # the ELSE is not part of a larger expression. In that case, it's
+            # not safe to simplify in this way -- we'd be deleting other code.
             if (
                 not case1_last_when
                 or len(case1_else_expressions) > 1

--- a/src/sqlfluff/rules/L058.py
+++ b/src/sqlfluff/rules/L058.py
@@ -48,10 +48,17 @@ class Rule_L058(BaseRule):
             case1_children = segment.children()
             case1_last_when = case1_children.last(sp.is_type("when_clause"))
             case1_else_clause = case1_children.select(sp.is_type("else_clause"))
-            case2 = case1_else_clause.children(sp.is_type("expression")).children(
-                sp.is_type("case_expression")
+            case1_else_expressions = case1_else_clause.children(
+                sp.is_type("expression")
             )
-            if not case1_last_when or not case2:
+            expression_children = case1_else_expressions.children()
+            case2 = expression_children.select(sp.is_type("case_expression"))
+            if (
+                not case1_last_when
+                or len(case1_else_expressions) > 1
+                or len(expression_children) > 1
+                or not case2
+            ):
                 return LintResult()
 
             # Delete stuff between the last "WHEN" clause and the "ELSE" clause.

--- a/test/fixtures/rules/std_rule_cases/L058.yml
+++ b/test/fixtures/rules/std_rule_cases/L058.yml
@@ -14,6 +14,22 @@ test_pass_1:
         END AS sound
     FROM mytable
 
+test_pass_2:
+  # Issue 3110. The nested CASE is part of a larger expression. Cannot flatten.
+  pass_str: |
+    SELECT CASE 'b'
+            WHEN 'a' THEN
+                TRUE
+            ELSE
+                '2022-01-01'::date > CURRENT_DATE + CASE 'b'
+                    WHEN 'b' THEN
+                        8
+                    WHEN 'c' THEN
+                        9
+                END
+                AND (c > 10)
+        END AS test
+
 test_fail_1:
   # Simple case.
   fail_str: |


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3110

Changes L058 to verify there's no other code alongside the nested `CASE`.
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
