### PR TITLE
When fixing a file, preserve the input file's permissions

### DIFF
--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -515,6 +515,6 @@ class LintedFile(NamedTuple):
             tmp.flush()
             os.fsync(tmp.fileno())
         # Once the temp file is safely written, replace the existing file.
-        shutil.move(tmp.name, output_path)
         if mode is not None:
-            os.chmod(output_path, mode)
+            os.chmod(tmp.name, mode)
+        shutil.move(tmp.name, output_path)

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -492,16 +492,22 @@ class LintedFile(NamedTuple):
         return success
 
     @staticmethod
-    def _safe_create_replace_file(input_path, output_path, write_buff, encoding):
+    def _safe_create_replace_file(
+        input_path: str, output_path: str, write_buff: str, encoding: str
+    ):
         # Write to a temporary file first, so in case of encoding or other
         # issues, we don't delete or corrupt the user's existing file.
 
         # Get file mode (i.e. permissions) on existing file. We'll preserve the
         # same permissions on the output file.
-        status = os.stat(input_path)
         mode = None
-        if stat.S_ISREG(status.st_mode):
-            mode = stat.S_IMODE(status.st_mode)
+        try:
+            status = os.stat(input_path)
+        except FileNotFoundError:
+            pass
+        else:
+            if stat.S_ISREG(status.st_mode):
+                mode = stat.S_IMODE(status.st_mode)
         dirname, basename = os.path.split(output_path)
         with tempfile.NamedTemporaryFile(
             mode="w",

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -8,6 +8,7 @@ post linting.
 import os
 import logging
 import shutil
+import stat
 import tempfile
 from typing import (
     Any,
@@ -487,24 +488,33 @@ class LintedFile(NamedTuple):
             if suffix:
                 root, ext = os.path.splitext(fname)
                 fname = root + suffix + ext
-            self._safe_create_replace_file(fname, write_buff, self.encoding)
+            self._safe_create_replace_file(self.path, fname, write_buff, self.encoding)
         return success
 
     @staticmethod
-    def _safe_create_replace_file(fname, write_buff, encoding):
+    def _safe_create_replace_file(input_path, output_path, write_buff, encoding):
         # Write to a temporary file first, so in case of encoding or other
         # issues, we don't delete or corrupt the user's existing file.
-        dirname, basename = os.path.split(fname)
+
+        # Get file mode (i.e. permissions) on existing file. We'll preserve the
+        # same permissions on the output file.
+        status = os.stat(input_path)
+        mode = None
+        if stat.S_ISREG(status.st_mode):
+            mode = stat.S_IMODE(status.st_mode)
+        dirname, basename = os.path.split(output_path)
         with tempfile.NamedTemporaryFile(
             mode="w",
             encoding=encoding,
             prefix=basename,
             dir=dirname,
-            suffix=os.path.splitext(fname)[1],
+            suffix=os.path.splitext(output_path)[1],
             delete=False,
         ) as tmp:
             tmp.file.write(write_buff)
             tmp.flush()
             os.fsync(tmp.fileno())
         # Once the temp file is safely written, replace the existing file.
-        shutil.move(tmp.name, fname)
+        shutil.move(tmp.name, output_path)
+        if mode is not None:
+            os.chmod(output_path, mode)

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -5,6 +5,7 @@ import json
 import os
 import pathlib
 import shutil
+import stat
 import tempfile
 import textwrap
 from unittest.mock import MagicMock, patch
@@ -476,6 +477,9 @@ def generic_roundtrip_test(
     with open(filepath, mode="w", encoding=input_file_encoding) as dest_file:
         for line in source_file:
             dest_file.write(line)
+    status = os.stat(filepath)
+    assert stat.S_ISREG(status.st_mode)
+    old_mode = stat.S_IMODE(status.st_mode)
     # Check that we first detect the issue
     invoke_assert_code(
         ret_code=65, args=[lint, ["--dialect=ansi", "--rules", rulestring, filepath]]
@@ -499,6 +503,11 @@ def generic_roundtrip_test(
         with open(filepath, mode="rb") as f:
             data = f.read()
         assert chardet.detect(data)["encoding"] == output_file_encoding
+    # Also check the file mode was preserved.
+    status = os.stat(filepath)
+    assert stat.S_ISREG(status.st_mode)
+    new_mode = stat.S_IMODE(status.st_mode)
+    assert new_mode == old_mode
     shutil.rmtree(tempdir_path)
 
 

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -907,7 +907,7 @@ def test_safe_create_replace_file(case, tmp_path):
         p.write_text(case["existing"])
     try:
         linter.LintedFile._safe_create_replace_file(
-            str(p), case["update"], case["encoding"]
+            str(p), str(p), case["update"], case["encoding"]
         )
     except:  # noqa: E722
         pass


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Previously, file permissions were being modified by `sqlfluff fix`. This was a side effect of using `NamedTemporaryFile`, which was setting the file to be readable only by the current user. This change grabs the permissions of the original input file and reapplies them to the output file.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
