### PR TITLE
Fix parsing of Compound Statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2239,8 +2239,7 @@ class WithCompoundStatementSegment(BaseSegment):
 
     type = "with_compound_statement"
     # match grammar
-    match_grammar: Matchable = StartsWith("WITH")
-    parse_grammar: Optional[Matchable] = Sequence(
+    match_grammar: Matchable = Sequence(
         "WITH",
         Ref.keyword("RECURSIVE", optional=True),
         Conditional(Indent, indented_ctes=True),

--- a/test/fixtures/dialects/postgres/postgres_cte_in_materialized_view.sql
+++ b/test/fixtures/dialects/postgres/postgres_cte_in_materialized_view.sql
@@ -1,0 +1,27 @@
+CREATE MATERIALIZED VIEW public.mv_sales
+TABLESPACE pg_default
+AS
+
+WITH regional_sales AS (
+    SELECT
+        region,
+        SUM(amount) AS total_sales
+    FROM orders
+    GROUP BY region
+),
+
+top_regions AS (
+    SELECT region
+    FROM regional_sales
+    WHERE total_sales > (SELECT SUM(total_sales) / 10 FROM regional_sales)
+)
+
+SELECT
+    region,
+    product,
+    SUM(quantity) AS product_units,
+    SUM(amount) AS product_sales
+FROM orders
+WHERE region IN (SELECT region FROM top_regions)
+GROUP BY region, product
+WITH DATA;

--- a/test/fixtures/dialects/postgres/postgres_cte_in_materialized_view.yml
+++ b/test/fixtures/dialects/postgres/postgres_cte_in_materialized_view.yml
@@ -1,0 +1,193 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 8872d775a7d7f9eaa325e30a68ee62a5be37c88705c4538de81cdf7cd1f5bfb2
+file:
+  statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+      - identifier: public
+      - dot: .
+      - identifier: mv_sales
+    - keyword: TABLESPACE
+    - tablespace_reference:
+        identifier: pg_default
+    - keyword: AS
+    - with_compound_statement:
+      - keyword: WITH
+      - common_table_expression:
+          identifier: regional_sales
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    identifier: region
+              - comma: ','
+              - select_clause_element:
+                  function:
+                    function_name:
+                      function_name_identifier: SUM
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          identifier: amount
+                      end_bracket: )
+                  alias_expression:
+                    keyword: AS
+                    identifier: total_sales
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: orders
+              groupby_clause:
+              - keyword: GROUP
+              - keyword: BY
+              - column_reference:
+                  identifier: region
+            end_bracket: )
+      - comma: ','
+      - common_table_expression:
+          identifier: top_regions
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            select_statement:
+              select_clause:
+                keyword: SELECT
+                select_clause_element:
+                  column_reference:
+                    identifier: region
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        identifier: regional_sales
+              where_clause:
+                keyword: WHERE
+                expression:
+                  column_reference:
+                    identifier: total_sales
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      select_statement:
+                        select_clause:
+                          keyword: SELECT
+                          select_clause_element:
+                            expression:
+                              function:
+                                function_name:
+                                  function_name_identifier: SUM
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                    column_reference:
+                                      identifier: total_sales
+                                  end_bracket: )
+                              binary_operator: /
+                              literal: '10'
+                        from_clause:
+                          keyword: FROM
+                          from_expression:
+                            from_expression_element:
+                              table_expression:
+                                table_reference:
+                                  identifier: regional_sales
+                    end_bracket: )
+            end_bracket: )
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                identifier: region
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: product
+          - comma: ','
+          - select_clause_element:
+              function:
+                function_name:
+                  function_name_identifier: SUM
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      identifier: quantity
+                  end_bracket: )
+              alias_expression:
+                keyword: AS
+                identifier: product_units
+          - comma: ','
+          - select_clause_element:
+              function:
+                function_name:
+                  function_name_identifier: SUM
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      identifier: amount
+                  end_bracket: )
+              alias_expression:
+                keyword: AS
+                identifier: product_sales
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: orders
+          where_clause:
+            keyword: WHERE
+            expression:
+              column_reference:
+                identifier: region
+              keyword: IN
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      column_reference:
+                        identifier: region
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            identifier: top_regions
+                end_bracket: )
+          groupby_clause:
+          - keyword: GROUP
+          - keyword: BY
+          - column_reference:
+              identifier: region
+          - comma: ','
+          - column_reference:
+              identifier: product
+    - with_data_clause:
+      - keyword: WITH
+      - keyword: DATA
+  statement_terminator: ;


### PR DESCRIPTION
Extra WITH statements could be associated with the compound statement.
Fixed by replacing match_grammar StartsWith and parse_grammar optional
Sequnce with a match_grammar Sequence.


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3092 


### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
