### PR TITLE
Snowflake: `StartsWith()` in `FromExpressionElementSegment` caused performance issues for large queries

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -913,8 +913,7 @@ class FromExpressionElementSegment(ansi.FromExpressionElementSegment):
     """A table expression."""
 
     type = "from_expression_element"
-    match_grammar = StartsWith(
-        Sequence(
+    match_grammar = Sequence(
             Ref("PreTableFunctionKeywordsGrammar", optional=True),
             OptionallyBracketed(Ref("TableExpressionSegment")),
             Ref(
@@ -930,13 +929,6 @@ class FromExpressionElementSegment(ansi.FromExpressionElementSegment):
             Sequence("WITH", "OFFSET", Ref("AliasExpressionSegment"), optional=True),
             Ref("SamplingExpressionSegment", optional=True),
             Ref("PostTableExpressionGrammar", optional=True),
-        ),
-        terminator=OneOf(
-            Ref("JoinClauseSegment"),
-            Ref("JoinLikeClauseGrammar"),
-            Ref("JoinOnConditionSegment"),
-            Ref("CommaSegment"),
-        ),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -914,21 +914,21 @@ class FromExpressionElementSegment(ansi.FromExpressionElementSegment):
 
     type = "from_expression_element"
     match_grammar = Sequence(
-            Ref("PreTableFunctionKeywordsGrammar", optional=True),
-            OptionallyBracketed(Ref("TableExpressionSegment")),
-            Ref(
-                "AliasExpressionSegment",
-                exclude=OneOf(
-                    Ref("SamplingExpressionSegment"),
-                    Ref("ChangesClauseSegment"),
-                    Ref("JoinLikeClauseGrammar"),
-                ),
-                optional=True,
+        Ref("PreTableFunctionKeywordsGrammar", optional=True),
+        OptionallyBracketed(Ref("TableExpressionSegment")),
+        Ref(
+            "AliasExpressionSegment",
+            exclude=OneOf(
+                Ref("SamplingExpressionSegment"),
+                Ref("ChangesClauseSegment"),
+                Ref("JoinLikeClauseGrammar"),
             ),
-            # https://cloud.google.com/bigquery/docs/reference/standard-sql/arrays#flattening_arrays
-            Sequence("WITH", "OFFSET", Ref("AliasExpressionSegment"), optional=True),
-            Ref("SamplingExpressionSegment", optional=True),
-            Ref("PostTableExpressionGrammar", optional=True),
+            optional=True,
+        ),
+        # https://cloud.google.com/bigquery/docs/reference/standard-sql/arrays#flattening_arrays
+        Sequence("WITH", "OFFSET", Ref("AliasExpressionSegment"), optional=True),
+        Ref("SamplingExpressionSegment", optional=True),
+        Ref("PostTableExpressionGrammar", optional=True),
     )
 
 

--- a/test/core/rules/config_test.py
+++ b/test/core/rules/config_test.py
@@ -130,13 +130,10 @@ def test_rule_exception_is_caught_to_validation():
 
 def test_std_rule_import_fail_bad_naming():
     """Check that rule import from file works."""
-    assert (
-        get_rules_from_path(
-            rules_path="test/fixtures/rules/custom/*.py",
-            base_module="test.fixtures.rules.custom",
-        )
-        == [Rule_L000, Rule_S000]
-    )
+    assert get_rules_from_path(
+        rules_path="test/fixtures/rules/custom/*.py",
+        base_module="test.fixtures.rules.custom",
+    ) == [Rule_L000, Rule_S000]
 
     with pytest.raises(AttributeError) as e:
         get_rules_from_path(

--- a/test/core/rules/config_test.py
+++ b/test/core/rules/config_test.py
@@ -130,10 +130,13 @@ def test_rule_exception_is_caught_to_validation():
 
 def test_std_rule_import_fail_bad_naming():
     """Check that rule import from file works."""
-    assert get_rules_from_path(
-        rules_path="test/fixtures/rules/custom/*.py",
-        base_module="test.fixtures.rules.custom",
-    ) == [Rule_L000, Rule_S000]
+    assert (
+        get_rules_from_path(
+            rules_path="test/fixtures/rules/custom/*.py",
+            base_module="test.fixtures.rules.custom",
+        )
+        == [Rule_L000, Rule_S000]
+    )
 
     with pytest.raises(AttributeError) as e:
         get_rules_from_path(


### PR DESCRIPTION

### Brief summary of the change made
StartsWith() is not performant (to be addressed). For now, I've removed this from FromExpressionElementSegment(). This has parity with ANSI, and caused no errors or changes in our suite of Snowflake dialect tests

Fixes #3127

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
