### PR TITLE
TSQL: Support names for transactions

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2501,9 +2501,9 @@ class TransactionStatementSegment(BaseSegment):
 
     type = "transaction_statement"
     match_grammar = OneOf(
-        # [ BEGIN | SAVE ] [ TRANSACTION | TRAN ] [ <Transaction Name> | <Transaction Name Variable> ]
+        # [ BEGIN | SAVE ] [ TRANSACTION | TRAN ] [ <Name> | <Variable> ]
         # COMMIT [ TRANSACTION | TRAN | WORK ]
-        # ROLLBACK [ TRANSACTION | TRAN | WORK ] [ <Transaction Name> | <Transaction Name Variable> ]
+        # ROLLBACK [ TRANSACTION | TRAN | WORK ] [ <Name> | <Variable> ]
         # https://docs.microsoft.com/en-us/sql/t-sql/language-elements/begin-transaction-transact-sql?view=sql-server-ver15
         Sequence(
             "BEGIN",

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2501,9 +2501,9 @@ class TransactionStatementSegment(BaseSegment):
 
     type = "transaction_statement"
     match_grammar = OneOf(
-        # [ BEGIN | SAVE ] [ TRANSACTION | TRAN ]
+        # [ BEGIN | SAVE ] [ TRANSACTION | TRAN ] [ <Transaction Name> | <Transaction Name Variable> ]
         # COMMIT [ TRANSACTION | TRAN | WORK ]
-        # ROLLBACK [ TRANSACTION | TRAN | WORK ]
+        # ROLLBACK [ TRANSACTION | TRAN | WORK ] [ <Transaction Name> | <Transaction Name Variable> ]
         # https://docs.microsoft.com/en-us/sql/t-sql/language-elements/begin-transaction-transact-sql?view=sql-server-ver15
         Sequence(
             "BEGIN",
@@ -2515,11 +2515,28 @@ class TransactionStatementSegment(BaseSegment):
         ),
         Sequence(
             OneOf("COMMIT", "ROLLBACK"),
-            OneOf(Ref("TransactionGrammar"), "WORK", optional=True),
+            Ref("TransactionGrammar", optional=True),
+            OneOf(
+                Ref("SingleIdentifierGrammar"),
+                Ref("VariableIdentifierSegment"),
+                optional=True,
+            ),
             Ref("DelimiterGrammar", optional=True),
         ),
         Sequence(
-            "SAVE", Ref("TransactionGrammar"), Ref("DelimiterGrammar", optional=True)
+            OneOf("COMMIT", "ROLLBACK"),
+            Sequence("WORK", optional=True),
+            Ref("DelimiterGrammar", optional=True),
+        ),
+        Sequence(
+            "SAVE",
+            Ref("TransactionGrammar"),
+            OneOf(
+                Ref("SingleIdentifierGrammar"),
+                Ref("VariableIdentifierSegment"),
+                optional=True,
+            ),
+            Ref("DelimiterGrammar", optional=True),
         ),
     )
 

--- a/test/fixtures/dialects/tsql/transaction.sql
+++ b/test/fixtures/dialects/tsql/transaction.sql
@@ -10,3 +10,8 @@ ROLLBACK TRAN;
 
 BEGIN TRAN;
 SAVE TRANSACTION;
+
+BEGIN TRAN namey;
+ROLLBACK namey;
+SAVE TRAN @variable;
+COMMIT @variable;

--- a/test/fixtures/dialects/tsql/transaction.yml
+++ b/test/fixtures/dialects/tsql/transaction.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 58b28c183be9e0c849a3cfcb288fd9c284186f343a5cf8b9c2d936b09a72f0f5
+_hash: 5c3cd942189d32e628456ae60bb5bee873e8622bd3d09c52f5beb66551fa57b5
 file:
   batch:
   - statement:
@@ -77,3 +77,25 @@ file:
       - keyword: SAVE
       - keyword: TRANSACTION
       - statement_terminator: ;
+  - statement:
+      transaction_statement:
+      - keyword: BEGIN
+      - keyword: TRAN
+      - identifier: namey
+      - statement_terminator: ;
+  - statement:
+      transaction_statement:
+        keyword: ROLLBACK
+        identifier: namey
+        statement_terminator: ;
+  - statement:
+      transaction_statement:
+      - keyword: SAVE
+      - keyword: TRAN
+      - parameter: '@variable'
+      - statement_terminator: ;
+  - statement:
+      transaction_statement:
+        keyword: COMMIT
+        parameter: '@variable'
+        statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
This adds support for specifying a transaction for `save`, `rollback`, `commit` and `begin` (cf https://docs.microsoft.com/en-us/sql/t-sql/language-elements/begin-transaction-transact-sql?view=sql-server-ver15)

fixes #3122

### Are there any other side effects of this change that we should be aware of?
I don't think so

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
