### PR TITLE
T-SQL: Support `NVARCHAR(MAX)`

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1235,8 +1235,8 @@ class DatatypeSegment(BaseSegment):
         ),
         Bracketed(
             OneOf(
-                Delimited(Ref("ExpressionSegment")),
                 "MAX",
+                Delimited(Ref("ExpressionSegment")),
                 # The brackets might be empty for some cases...
                 optional=True,
             ),

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1236,6 +1236,7 @@ class DatatypeSegment(BaseSegment):
         Bracketed(
             OneOf(
                 Delimited(Ref("ExpressionSegment")),
+                "MAX",
                 # The brackets might be empty for some cases...
                 optional=True,
             ),

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -291,6 +291,7 @@ UNRESERVED_KEYWORDS = [
     "MAX_GRANT_PERCENT",
     "MASKED",
     "MATCHED",
+    "MAX",
     "MAXDOP",
     "MAXRECURSION",
     "MAXVALUE",

--- a/test/fixtures/dialects/tsql/cast_variable.sql
+++ b/test/fixtures/dialects/tsql/cast_variable.sql
@@ -4,3 +4,4 @@ select enc.personid as personid,
 				 cast('1900-01-01' as datetime2(7)) as DataRefreshDate
 from encounter enc;
 
+ declare @sample nvarchar(max) = cast(100 as nvarchar(max))

--- a/test/fixtures/dialects/tsql/cast_variable.yml
+++ b/test/fixtures/dialects/tsql/cast_variable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 03a0841edd11332238c135bbe9bd530deaeec17853cf68f61f28fc9495987d19
+_hash: a06fff489bcd0afcba91e01cec2588ea9fecac3fd32477bb2e2cef2e1902140d
 file:
   batch:
   - statement:
@@ -88,3 +88,35 @@ file:
               alias_expression:
                 identifier: enc
           statement_terminator: ;
+  - statement:
+      declare_segment:
+        keyword: declare
+        parameter: '@sample'
+        data_type:
+          data_type_identifier: nvarchar
+          bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                identifier: max
+            end_bracket: )
+        comparison_operator:
+          raw_comparison_operator: '='
+        expression:
+          function:
+            function_name:
+              keyword: cast
+            bracketed:
+              start_bracket: (
+              expression:
+                literal: '100'
+              keyword: as
+              data_type:
+                data_type_identifier: nvarchar
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      identifier: max
+                  end_bracket: )
+              end_bracket: )

--- a/test/fixtures/dialects/tsql/cast_variable.yml
+++ b/test/fixtures/dialects/tsql/cast_variable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a06fff489bcd0afcba91e01cec2588ea9fecac3fd32477bb2e2cef2e1902140d
+_hash: 477864755d8e0946c51abd12e90d9c7120af83d169bfb9b5e3e572033348697b
 file:
   batch:
   - statement:
@@ -96,9 +96,7 @@ file:
           data_type_identifier: nvarchar
           bracketed:
             start_bracket: (
-            expression:
-              column_reference:
-                identifier: max
+            keyword: max
             end_bracket: )
         comparison_operator:
           raw_comparison_operator: '='
@@ -115,8 +113,6 @@ file:
                 data_type_identifier: nvarchar
                 bracketed:
                   start_bracket: (
-                  expression:
-                    column_reference:
-                      identifier: max
+                  keyword: max
                   end_bracket: )
               end_bracket: )


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Support `nvarchar(max)` and similar phrasings.

fixes #2710, #3116
### Are there any other side effects of this change that we should be aware of?
I don't think so

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
