### PR TITLE
T-SQL - `ALTER TABLE` - add support for `WITH CHECK ADD CONSTRAINT` and `CHECK CONSTRAINT`

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2186,11 +2186,19 @@ class AlterTableStatementSegment(BaseSegment):
                     Ref("ColumnReferenceSegment"),
                 ),
                 Sequence(
+                    Sequence(
+                        "WITH",
+                        "CHECK",
+                        optional=True,
+                    ),
                     "ADD",
                     Ref("TableConstraintSegment"),
                 ),
                 Sequence(
-                    "DROP",
+                    OneOf(
+                        "CHECK",
+                        "DROP",
+                    ),
                     "CONSTRAINT",
                     Ref("ObjectReferenceSegment"),
                 ),

--- a/test/fixtures/dialects/tsql/alter_table.sql
+++ b/test/fixtures/dialects/tsql/alter_table.sql
@@ -40,3 +40,12 @@ GO
 
 ALTER TABLE Production.TransactionHistoryArchive
 DROP CONSTRAINT PK_TransactionHistoryArchive_TransactionID
+
+ALTER TABLE [Production].[ProductCostHistory]
+WITH CHECK ADD CONSTRAINT [FK_ProductCostHistory_Product_ProductID] FOREIGN KEY([ProductID])
+REFERENCES [Production].[Product] ([ProductID])
+GO
+
+ALTER TABLE [Production].[ProductCostHistory]
+CHECK CONSTRAINT [FK_ProductCostHistory_Product_ProductID]
+GO

--- a/test/fixtures/dialects/tsql/alter_table.yml
+++ b/test/fixtures/dialects/tsql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 45076fc4f279fd8cfa91c9fc06e55fcea7b8aa0aaa1ac27a5ba73f4ac3c79bfd
+_hash: f764e68ea672dbbfd2b726a0c582ba7615524a549eaedb43255b0c6974edad3f
 file:
 - batch:
     statement:
@@ -293,7 +293,7 @@ file:
 - go_statement:
     keyword: GO
 - batch:
-    statement:
+  - statement:
       alter_table_statement:
       - keyword: ALTER
       - keyword: TABLE
@@ -305,3 +305,53 @@ file:
       - keyword: CONSTRAINT
       - object_reference:
           identifier: PK_TransactionHistoryArchive_TransactionID
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+        - identifier: '[Production]'
+        - dot: .
+        - identifier: '[ProductCostHistory]'
+      - keyword: WITH
+      - keyword: CHECK
+      - keyword: ADD
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            identifier: '[FK_ProductCostHistory_Product_ProductID]'
+        - keyword: FOREIGN
+        - keyword: KEY
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              identifier: '[ProductID]'
+            end_bracket: )
+        - references_constraint_grammar:
+            keyword: REFERENCES
+            table_reference:
+            - identifier: '[Production]'
+            - dot: .
+            - identifier: '[Product]'
+            bracketed:
+              start_bracket: (
+              column_reference:
+                identifier: '[ProductID]'
+              end_bracket: )
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+        - identifier: '[Production]'
+        - dot: .
+        - identifier: '[ProductCostHistory]'
+      - keyword: CHECK
+      - keyword: CONSTRAINT
+      - object_reference:
+          identifier: '[FK_ProductCostHistory_Product_ProductID]'
+- go_statement:
+    keyword: GO


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

TSQL - ALTER TABLE statements - adds support for:
- WITH CHECK ADD CONSTRAINT
- CHECK CONSTRAINT

Added corresponding tests.

Fixes #3131 


### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
