### PR TITLE
Allow column-less `INSERT INTO` with bracketed `SELECT` in ANSI and BigQuery

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2300,8 +2300,16 @@ class InsertStatementSegment(BaseSegment):
         Ref.keyword("OVERWRITE", optional=True),
         "INTO",
         Ref("TableReferenceSegment"),
-        Ref("BracketedColumnReferenceListGrammar", optional=True),
-        Ref("SelectableGrammar"),
+        OneOf(
+            # As SelectableGrammar can be bracketed too, the parse gets confused
+            # so we need slightly odd syntax here to allow those to parse (rather
+            # than just add optional=True to BracketedColumnReferenceListGrammar).
+            Ref("SelectableGrammar"),
+            Sequence(
+                Ref("BracketedColumnReferenceListGrammar"),
+                Ref("SelectableGrammar"),
+            ),
+        ),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1256,8 +1256,16 @@ class InsertStatementSegment(ansi.InsertStatementSegment):
         "INSERT",
         Ref.keyword("INTO", optional=True),
         Ref("TableReferenceSegment"),
-        Ref("BracketedColumnReferenceListGrammar", optional=True),
-        Ref("SelectableGrammar"),
+        OneOf(
+            # As SelectableGrammar can be bracketed too, the parse gets confused
+            # so we need slightly odd syntax here to allow those to parse (rather
+            # than just add optional=True to BracketedColumnReferenceListGrammar).
+            Ref("SelectableGrammar"),
+            Sequence(
+                Ref("BracketedColumnReferenceListGrammar"),
+                Ref("SelectableGrammar"),
+            ),
+        ),
     )
 
 

--- a/test/fixtures/dialects/ansi/insert_a.sql
+++ b/test/fixtures/dialects/ansi/insert_a.sql
@@ -1,1 +1,6 @@
 INSERT into tbl_b (col1) values (123);
+
+INSERT INTO tbl_c (
+    SELECT *
+    FROM table1
+);

--- a/test/fixtures/dialects/ansi/insert_a.yml
+++ b/test/fixtures/dialects/ansi/insert_a.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 06ad119eeec7565615837a8c76a3f0fb826f88b8a2ce6ca92cbc5e1bf3259872
+_hash: 578cbbda22bc9a10e02bb4add5fac204809ffbe17635b6eb707960cf8ce38b5a
 file:
-  statement:
+- statement:
     insert_statement:
     - keyword: INSERT
     - keyword: into
@@ -23,4 +23,28 @@ file:
           expression:
             literal: '123'
           end_bracket: )
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        identifier: tbl_c
+    - bracketed:
+        start_bracket: (
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: table1
+        end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/insert.sql
+++ b/test/fixtures/dialects/bigquery/insert.sql
@@ -3,3 +3,8 @@ VALUES ('The Great Gatsby', 'F. Scott Fitzgerald');
 
 INSERT books (title, author)
 VALUES ('The Great Gatsby', 'F. Scott Fitzgerald');
+
+INSERT INTO `project.dataset.table` (
+    SELECT *
+    FROM table1
+);

--- a/test/fixtures/dialects/bigquery/insert.yml
+++ b/test/fixtures/dialects/bigquery/insert.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6c471b062659bfa4cdd16019e38e5c1ac53a16df7333c2f20eb2b63f5c6fb1f5
+_hash: 107b92d6e0fc3978121b3b9bcb3abb21c66fd9106f8dd1afac4dd490903914fd
 file:
 - statement:
     insert_statement:
@@ -53,4 +53,28 @@ file:
         - expression:
             literal: "'F. Scott Fitzgerald'"
         - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        identifier: '`project.dataset.table`'
+    - bracketed:
+        start_bracket: (
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: table1
+        end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
As discussed on Slack

### Are there any other side effects of this change that we should be aware of?
I haven't fixed ALL dialects as some have quite complex `INSERT INTO` grammar.
The original issue was raised for BigQuery.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
