### PR TITLE
Snowflake: allow bracketless `VALUES` in `FROM` clauses

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -2920,7 +2920,7 @@ class TableExpressionSegment(ansi.TableExpressionSegment):
         Ref("TableReferenceSegment"),
         # Nested Selects
         Bracketed(Ref("SelectableGrammar")),
-        # Values clause?
+        Ref("ValuesClauseSegment"),
         Ref("StagePath"),
     )
 

--- a/test/fixtures/dialects/snowflake/snowflake_col_position.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_col_position.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d7a5bd084ff5ccf03e2711171e8aa5f25e4b1cdcb92d3cc95ed7ad416af627a2
+_hash: 96ceeb5e867c924794c291945a2a581e7019d2731d8e769fc9fed894e7f6e5d8
 file:
   statement:
     select_statement:
@@ -26,9 +26,9 @@ file:
         keyword: from
         from_expression:
           from_expression_element:
-            table_expression:
-              bracketed:
-                start_bracket: (
+            bracketed:
+              start_bracket: (
+              table_expression:
                 values_clause:
                 - keyword: values
                 - bracketed:
@@ -57,4 +57,4 @@ file:
                   - expression:
                       literal: '1'
                   - end_bracket: )
-                end_bracket: )
+              end_bracket: )

--- a/test/fixtures/dialects/snowflake/snowflake_select_values.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_select_values.sql
@@ -1,0 +1,3 @@
+select * from (values (1, 'one'), (2, 'two'), (3, 'three'));
+
+select * from values (1, 'one'), (2, 'two'), (3, 'three');

--- a/test/fixtures/dialects/snowflake/snowflake_select_values.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_select_values.yml
@@ -1,0 +1,94 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 338e58d5380acf9d2ce36f87dda8cd0947c4cf3197286dbdcb3324b2130405c4
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: values
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '1'
+                  - comma: ','
+                  - expression:
+                      literal: "'one'"
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '2'
+                  - comma: ','
+                  - expression:
+                      literal: "'two'"
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      literal: '3'
+                  - comma: ','
+                  - expression:
+                      literal: "'three'"
+                  - end_bracket: )
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              values_clause:
+              - keyword: values
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                    literal: '1'
+                - comma: ','
+                - expression:
+                    literal: "'one'"
+                - end_bracket: )
+              - comma: ','
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                    literal: '2'
+                - comma: ','
+                - expression:
+                    literal: "'two'"
+                - end_bracket: )
+              - comma: ','
+              - bracketed:
+                - start_bracket: (
+                - expression:
+                    literal: '3'
+                - comma: ','
+                - expression:
+                    literal: "'three'"
+                - end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/snowflake_within_group.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_within_group.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1be53192fbb96166328a0d4a26d908d45548942fd42c9faa3ad932395b352ea5
+_hash: e055abed63064d701205d01aa7a1db53a595627a3816220fc5ae3ecad163c78b
 file:
 - statement:
     with_compound_statement:
@@ -33,9 +33,9 @@ file:
               keyword: from
               from_expression:
                 from_expression_element:
-                  table_expression:
-                    bracketed:
-                      start_bracket: (
+                  bracketed:
+                    start_bracket: (
+                    table_expression:
                       values_clause:
                       - keyword: values
                       - bracketed:
@@ -91,7 +91,7 @@ file:
                         - expression:
                             literal: "'red'"
                         - end_bracket: )
-                      end_bracket: )
+                    end_bracket: )
           end_bracket: )
       select_statement:
         select_clause:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3103 

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
