### PR TITLE
Fix class vars in plugin rules

### DIFF
--- a/plugins/sqlfluff-plugin-example/src/example/rules.py
+++ b/plugins/sqlfluff-plugin-example/src/example/rules.py
@@ -68,6 +68,7 @@ class Rule_Example_L001(BaseRule):
         ORDER BY bar
     """
 
+    groups = ("all",)
     config_keywords = ["forbidden_columns"]
 
     def __init__(self, *args, **kwargs):

--- a/test/core/plugin_test.py
+++ b/test/core/plugin_test.py
@@ -29,3 +29,16 @@ def test__plugin_default_config_read():
     fluff_config = FluffConfig(overrides={"dialect": "ansi"})
     # The plugin import order is non-deterministic
     assert "forbidden_columns" in fluff_config._configs["rules"]["Example_L001"]
+
+
+def test__plugin_class_vars_exist():
+    """Test that class variables are created for custom rules."""
+    plugin_manager = get_plugin_manager()
+    custom_rule = [
+        rule
+        for rules in plugin_manager.hook.get_rules()
+        for rule in rules
+        if rule.__name__ == "Rule_Example_L001"
+    ].pop()
+    assert custom_rule.config_keywords
+    assert custom_rule.groups


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This is related to the work in #3142 

It seems like the class variables in the rules (which is how we're going to categorize rules) do not carry over to the example plugin rule for some strange reason 🔮 

I've spent a decent amount of time debugging this and am now kicking it over to the larger group with a failing test case.

An interesting note: the reason this wasn't caught before is because `config_keywords` must get created differently (possibly through the default config for this rule). I tried modifying the value of the `config_keywords` class variable for this custom rule and it didn't actually change anything.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
