### PR TITLE
Hive: Support back quoted identifier and literal

### DIFF
--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -135,6 +135,12 @@ hive_dialect.add(
             )
         ),
     ),
+    BackQuotedIdentifierSegment=NamedParser(
+        "back_quote",
+        CodeSegment,
+        name="quoted_identifier",
+        type="identifier",
+    ),
 )
 
 # https://cwiki.apache.org/confluence/display/hive/languagemanual+joins
@@ -158,13 +164,10 @@ hive_dialect.replace(
     ),
     SimpleArrayTypeGrammar=Ref.keyword("ARRAY"),
     TrimParametersGrammar=Nothing(),
-    SingleQuotedIdentifierSegment=OneOf(
-        NamedParser(
-            "single_quote", CodeSegment, name="quoted_identifier", type="identifier"
-        ),
-        NamedParser(
-            "back_quote", CodeSegment, name="quoted_identifier", type="identifier"
-        ),
+    SingleIdentifierGrammar=ansi_dialect.get_grammar("SingleIdentifierGrammar").copy(
+        insert=[
+            Ref("BackQuotedIdentifierSegment"),
+        ]
     ),
 )
 

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -143,6 +143,7 @@ hive_dialect.replace(
     QuotedLiteralSegment=OneOf(
         NamedParser("single_quote", CodeSegment, name="quoted_literal", type="literal"),
         NamedParser("double_quote", CodeSegment, name="quoted_literal", type="literal"),
+        NamedParser("back_quote", CodeSegment, name="quoted_literal", type="literal"),
     ),
     LiteralGrammar=OneOf(
         Ref("QuotedLiteralSegment"),
@@ -157,6 +158,14 @@ hive_dialect.replace(
     ),
     SimpleArrayTypeGrammar=Ref.keyword("ARRAY"),
     TrimParametersGrammar=Nothing(),
+    SingleQuotedIdentifierSegment=OneOf(
+        NamedParser(
+            "single_quote", CodeSegment, name="quoted_identifier", type="identifier"
+        ),
+        NamedParser(
+            "back_quote", CodeSegment, name="quoted_identifier", type="identifier"
+        ),
+    ),
 )
 
 

--- a/test/fixtures/dialects/hive/quoted_literal.sql
+++ b/test/fixtures/dialects/hive/quoted_literal.sql
@@ -1,4 +1,4 @@
-SELECT result
+SELECT result, `timestamp` as `timestamp`
 FROM student
 WHERE
     name = "John Smith"

--- a/test/fixtures/dialects/hive/quoted_literal.yml
+++ b/test/fixtures/dialects/hive/quoted_literal.yml
@@ -3,15 +3,21 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 84c2ac0f762ed2cf2d0c9dc3d3282219c7a34a05c30dc8aa77f0c985a59f9cae
+_hash: 8126a9cf587f21c619e47d0b431a8c89ce39e492e8609c7e97654e78e24aba73
 file:
   statement:
     select_statement:
       select_clause:
-        keyword: SELECT
-        select_clause_element:
+      - keyword: SELECT
+      - select_clause_element:
           column_reference:
             identifier: result
+      - comma: ','
+      - select_clause_element:
+          literal: '`timestamp`'
+          alias_expression:
+            keyword: as
+            identifier: '`timestamp`'
       from_clause:
         keyword: FROM
         from_expression:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #3138
Support back quoted identifier and literal in hive dialect 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
