### PR TITLE
TSQL: Support opening, closing, deallocating and fetching cursors

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3832,7 +3832,7 @@ class CreateTypeStatementSegment(BaseSegment):
 
 
 class OpenCursorStatementSegment(BaseSegment):
-    """An `OPEN` cursor statement
+    """An `OPEN` cursor statement.
 
     https://docs.microsoft.com/en-us/sql/t-sql/language-elements/open-transact-sql?view=sql-server-ver15
     """
@@ -3844,7 +3844,7 @@ class OpenCursorStatementSegment(BaseSegment):
 
 
 class CloseCursorStatementSegment(BaseSegment):
-    """A `CLOSE` cursor statement
+    """A `CLOSE` cursor statement.
 
     https://docs.microsoft.com/en-us/sql/t-sql/language-elements/close-transact-sql?view=sql-server-ver15
     """
@@ -3857,7 +3857,7 @@ class CloseCursorStatementSegment(BaseSegment):
 
 
 class DeallocateCursorStatementSegment(BaseSegment):
-    """A `DEALLOCATE` cursor statement
+    """A `DEALLOCATE` cursor statement.
 
     https://docs.microsoft.com/en-us/sql/t-sql/language-elements/deallocate-transact-sql?view=sql-server-ver15
     """
@@ -3870,7 +3870,7 @@ class DeallocateCursorStatementSegment(BaseSegment):
 
 
 class FetchCursorStatementSegment(BaseSegment):
-    """A `FETCH` cursor statement
+    """A `FETCH` cursor statement.
 
     https://docs.microsoft.com/en-us/sql/t-sql/language-elements/fetch-transact-sql?view=sql-server-ver15
     """

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -470,6 +470,9 @@ class StatementSegment(ansi.StatementSegment):
             Ref("BreakStatement"),
             Ref("ContinueStatement"),
             Ref("WaitForStatementSegment"),
+            Ref("OpenCursorStatementSegment"),
+            Ref("CloseCursorStatementSegment"),
+            Ref("DeallocateCursorStatementSegment"),
         ],
         remove=[
             Ref("CreateModelStatementSegment"),
@@ -3824,4 +3827,42 @@ class CreateTypeStatementSegment(BaseSegment):
                 ),
             ),
         ),
+    )
+
+
+class OpenCursorStatementSegment(BaseSegment):
+    """An `OPEN` cursor statement
+
+    https://docs.microsoft.com/en-us/sql/t-sql/language-elements/open-transact-sql?view=sql-server-ver15
+    """
+
+    type = "open_cursor_statement"
+    match_grammar: Matchable = Sequence(
+        "OPEN", Sequence(Sequence("GLOBAL", optional=True), Ref("ParameterNameSegment"))
+    )
+
+
+class CloseCursorStatementSegment(BaseSegment):
+    """A `CLOSE` cursor statement
+
+    https://docs.microsoft.com/en-us/sql/t-sql/language-elements/close-transact-sql?view=sql-server-ver15
+    """
+
+    type = "close_cursor_statement"
+    match_grammar: Matchable = Sequence(
+        "CLOSE",
+        Sequence(Sequence("GLOBAL", optional=True), Ref("ParameterNameSegment")),
+    )
+
+
+class DeallocateCursorStatementSegment(BaseSegment):
+    """A `DEALLOCATE` cursor statement
+
+    https://docs.microsoft.com/en-us/sql/t-sql/language-elements/deallocate-transact-sql?view=sql-server-ver15
+    """
+
+    type = "deallocate_cursor_statement"
+    match_grammar: Matchable = Sequence(
+        "DEALLOCATE",
+        Sequence(Sequence("GLOBAL", optional=True), Ref("ParameterNameSegment")),
     )

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -473,6 +473,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("OpenCursorStatementSegment"),
             Ref("CloseCursorStatementSegment"),
             Ref("DeallocateCursorStatementSegment"),
+            Ref("FetchCursorStatementSegment"),
         ],
         remove=[
             Ref("CreateModelStatementSegment"),
@@ -3865,4 +3866,21 @@ class DeallocateCursorStatementSegment(BaseSegment):
     match_grammar: Matchable = Sequence(
         "DEALLOCATE",
         Sequence(Sequence("GLOBAL", optional=True), Ref("ParameterNameSegment")),
+    )
+
+
+class FetchCursorStatementSegment(BaseSegment):
+    """A `FETCH` cursor statement
+
+    https://docs.microsoft.com/en-us/sql/t-sql/language-elements/fetch-transact-sql?view=sql-server-ver15
+    """
+
+    type = "fetch_cursor_statement"
+    match_grammar: Matchable = Sequence(
+        "FETCH",
+        OneOf("NEXT", "PRIOR", "FIRST", "LAST", optional=True),
+        "FROM",
+        Sequence("GLOBAL", optional=True),
+        Ref("ParameterNameSegment"),
+        Sequence("INTO", Ref("ParameterNameSegment"), optional=True),
     )

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3839,7 +3839,8 @@ class OpenCursorStatementSegment(BaseSegment):
 
     type = "open_cursor_statement"
     match_grammar: Matchable = Sequence(
-        "OPEN", Sequence(Sequence("GLOBAL", optional=True), Ref("ParameterNameSegment"))
+        "OPEN",
+        Sequence(Ref.keyword("GLOBAL", optional=True), Ref("ParameterNameSegment")),
     )
 
 
@@ -3852,7 +3853,7 @@ class CloseCursorStatementSegment(BaseSegment):
     type = "close_cursor_statement"
     match_grammar: Matchable = Sequence(
         "CLOSE",
-        Sequence(Sequence("GLOBAL", optional=True), Ref("ParameterNameSegment")),
+        Sequence(Ref.keyword("GLOBAL", optional=True), Ref("ParameterNameSegment")),
     )
 
 
@@ -3865,7 +3866,7 @@ class DeallocateCursorStatementSegment(BaseSegment):
     type = "deallocate_cursor_statement"
     match_grammar: Matchable = Sequence(
         "DEALLOCATE",
-        Sequence(Sequence("GLOBAL", optional=True), Ref("ParameterNameSegment")),
+        Sequence(Ref.keyword("GLOBAL", optional=True), Ref("ParameterNameSegment")),
     )
 
 
@@ -3880,7 +3881,7 @@ class FetchCursorStatementSegment(BaseSegment):
         "FETCH",
         OneOf("NEXT", "PRIOR", "FIRST", "LAST", optional=True),
         "FROM",
-        Sequence("GLOBAL", optional=True),
+        Ref.keyword("GLOBAL", optional=True),
         Ref("ParameterNameSegment"),
         Sequence("INTO", Ref("ParameterNameSegment"), optional=True),
     )

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -262,6 +262,7 @@ UNRESERVED_KEYWORDS = [
     "FILESTREAM_ON",
     "FILTER",
     "FIPS_FLAGGER",
+    "FIRST",
     "FMTONLY",
     "FOLLOWING",
     "FORCE",
@@ -294,6 +295,7 @@ UNRESERVED_KEYWORDS = [
     # but could break TSQL parsing to add there
     "LABEL",
     "LANGUAGE",
+    "LAST",
     "LEVEL",
     "LOAD",  # listed as reserved but functionally unreserved
     "LOCATION",

--- a/test/fixtures/dialects/tsql/cursor.sql
+++ b/test/fixtures/dialects/tsql/cursor.sql
@@ -3,6 +3,9 @@ SELECT column_a, column_b FROM some_table WHERE column_a IS NOT NULL ORDER BY co
 
 OPEN @pointy;
 
+FETCH FIRST FROM @pointy into @result;
+FETCH NEXT FROM GLOBAL @pointy;
+
 CLOSE GLOBAL @pointy;
 
 DEALLOCATE @pointy;

--- a/test/fixtures/dialects/tsql/cursor.sql
+++ b/test/fixtures/dialects/tsql/cursor.sql
@@ -1,2 +1,8 @@
 DECLARE @pointy CURSOR LOCAL FORWARD_ONLY READ_ONLY FOR
 SELECT column_a, column_b FROM some_table WHERE column_a IS NOT NULL ORDER BY column_b
+
+OPEN @pointy;
+
+CLOSE GLOBAL @pointy;
+
+DEALLOCATE @pointy;

--- a/test/fixtures/dialects/tsql/cursor.yml
+++ b/test/fixtures/dialects/tsql/cursor.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b98e87cc09a631c60893db0a5e68fb29b1746361f7ae20791fa502c7f3cad13b
+_hash: d91bd3512ff360ad02a3c06c3af9bc9a56a8862ab45f6c07e2285498baca142d
 file:
   batch:
   - statement:
@@ -49,6 +49,23 @@ file:
       open_cursor_statement:
         keyword: OPEN
         parameter: '@pointy'
+  - statement_terminator: ;
+  - statement:
+      fetch_cursor_statement:
+      - keyword: FETCH
+      - keyword: FIRST
+      - keyword: FROM
+      - parameter: '@pointy'
+      - keyword: into
+      - parameter: '@result'
+  - statement_terminator: ;
+  - statement:
+      fetch_cursor_statement:
+      - keyword: FETCH
+      - keyword: NEXT
+      - keyword: FROM
+      - keyword: GLOBAL
+      - parameter: '@pointy'
   - statement_terminator: ;
   - statement:
       close_cursor_statement:

--- a/test/fixtures/dialects/tsql/cursor.yml
+++ b/test/fixtures/dialects/tsql/cursor.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f5fa6b2480befb67471130be93f9f80a689fa782b9e3e41ce0b2545fbcd9d6f7
+_hash: b98e87cc09a631c60893db0a5e68fb29b1746361f7ae20791fa502c7f3cad13b
 file:
   batch:
-    statement:
+  - statement:
       declare_segment:
       - keyword: DECLARE
       - parameter: '@pointy'
@@ -45,3 +45,19 @@ file:
           - keyword: BY
           - column_reference:
               identifier: column_b
+  - statement:
+      open_cursor_statement:
+        keyword: OPEN
+        parameter: '@pointy'
+  - statement_terminator: ;
+  - statement:
+      close_cursor_statement:
+      - keyword: CLOSE
+      - keyword: GLOBAL
+      - parameter: '@pointy'
+  - statement_terminator: ;
+  - statement:
+      deallocate_cursor_statement:
+        keyword: DEALLOCATE
+        parameter: '@pointy'
+  - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Adds support for `OPEN`, `CLOSE`, `DEALLOCATE` and `FETCH` cursors

Fixes #2696
### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
