### PR TITLE
Highlight `PRS` errors in red

### DIFF
--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -56,7 +56,7 @@ def split_string_on_spaces(s: str, line_length: int = 100) -> List[str]:
 
 def format_violation(violation: SQLBaseError, max_line_length: int = 90) -> str:
     """Format a violation."""
-    if not isinstance(violation, SQLBaseError):
+    if not isinstance(violation, SQLBaseError): # pragma: no cover
         raise ValueError(f"Unexpected violation format: {violation}")
     
     desc: str = violation.desc()

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -56,18 +56,12 @@ def split_string_on_spaces(s: str, line_length: int = 100) -> List[str]:
 
 def format_violation(violation: SQLBaseError, max_line_length: int = 90) -> str:
     """Format a violation."""
-    if isinstance(violation, SQLBaseError):
-        desc = violation.desc()
-        if violation.line_no is not None:
-            line_elem = f"{violation.line_no:4d}"
-        else:
-            line_elem = "   -"  # pragma: no cover
-        if violation.line_pos is not None:
-            pos_elem = f"{violation.line_pos:4d}"
-        else:
-            pos_elem = "   -"  # pragma: no cover
-    else:  # pragma: no cover
+    if not isinstance(violation, SQLBaseError):
         raise ValueError(f"Unexpected violation format: {violation}")
+    
+    desc: str = violation.desc()
+    line_elem = "   -"  if violation.line_no is None else f"{violation.line_no:4d}"
+    pos_elem = "   -"  if violation.line_pos is None else f"{violation.line_pos:4d}"
 
     if violation.ignore:
         desc = "IGNORE: " + desc  # pragma: no cover
@@ -75,12 +69,16 @@ def format_violation(violation: SQLBaseError, max_line_length: int = 90) -> str:
     split_desc = split_string_on_spaces(desc, line_length=max_line_length - 25)
 
     out_buff = ""
+    # Grey out the violation if we're ignoring it.
+    section_color: Color = Color.lightgrey if violation.ignore else Color.blue
     for idx, line in enumerate(split_desc):
         if idx == 0:
+            rule_code = violation.rule_code().rjust(4)
+            if "PRS" in rule_code:
+                section_color = Color.red
             out_buff += colorize(
-                f"L:{line_elem} | P:{pos_elem} | {violation.rule_code().rjust(4)} | ",
-                # Grey out the violation if we're ignoring it.
-                Color.lightgrey if violation.ignore else Color.blue,
+                f"L:{line_elem} | P:{pos_elem} | {rule_code} | ",
+                section_color,
             )
         else:
             out_buff += (
@@ -88,7 +86,7 @@ def format_violation(violation: SQLBaseError, max_line_length: int = 90) -> str:
                 + (" " * 23)
                 + colorize(
                     "| ",
-                    Color.lightgrey if violation.ignore else Color.blue,
+                    section_color,
                 )
             )
         out_buff += line

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -56,12 +56,12 @@ def split_string_on_spaces(s: str, line_length: int = 100) -> List[str]:
 
 def format_violation(violation: SQLBaseError, max_line_length: int = 90) -> str:
     """Format a violation."""
-    if not isinstance(violation, SQLBaseError): # pragma: no cover
+    if not isinstance(violation, SQLBaseError):  # pragma: no cover
         raise ValueError(f"Unexpected violation format: {violation}")
-    
+
     desc: str = violation.desc()
-    line_elem = "   -"  if violation.line_no is None else f"{violation.line_no:4d}"
-    pos_elem = "   -"  if violation.line_pos is None else f"{violation.line_pos:4d}"
+    line_elem = "   -" if violation.line_no is None else f"{violation.line_no:4d}"
+    pos_elem = "   -" if violation.line_pos is None else f"{violation.line_pos:4d}"
 
     if violation.ignore:
         desc = "IGNORE: " + desc  # pragma: no cover

--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -43,7 +43,7 @@ class SQLBaseError(ValueError):
         """
         if hasattr(self, "rule"):
             return getattr(self, "rule").code
-        
+
         return self._code or "????"
 
     def desc(self) -> str:
@@ -57,8 +57,8 @@ class SQLBaseError(ValueError):
         if hasattr(self, "description") and getattr(self, "description", None):
             # This can only override if it's present AND
             # if it's non-null.
-            return getattr(self, "description", None)
-        
+            return getattr(self, "description")
+
         if hasattr(self, "rule"):
             return getattr(self, "rule").description
 
@@ -68,8 +68,8 @@ class SQLBaseError(ValueError):
 
         if len(self.args) == 1:
             return self.args[0]
-        
-        return self.__class__.__name__
+
+        return self.__class__.__name__  # pragma: no cover
 
     def get_info_dict(self):
         """Return a dict of properties.

--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -34,7 +34,7 @@ class SQLBaseError(ValueError):
         """Should this error be considered fixable?"""
         return False
 
-    def rule_code(self):
+    def rule_code(self) -> str:
         """Fetch the code of the rule which cause this error.
 
         NB: This only returns a real code for some subclasses of
@@ -42,11 +42,11 @@ class SQLBaseError(ValueError):
         returns a placeholder value which can be used instead.
         """
         if hasattr(self, "rule"):
-            return self.rule.code
-        else:
-            return self._code or "????"
+            return getattr(self, "rule").code
+        
+        return self._code or "????"
 
-    def desc(self):
+    def desc(self) -> str:
         """Fetch a description of this violation.
 
         NB: For violations which don't directly implement a rule
@@ -54,20 +54,22 @@ class SQLBaseError(ValueError):
         caused the violation. Optionally some errors may have their
         description set directly.
         """
-        if hasattr(self, "description") and self.description:
+        if hasattr(self, "description") and getattr(self, "description", None):
             # This can only override if it's present AND
             # if it's non-null.
-            return self.description
-        elif hasattr(self, "rule"):
-            return self.rule.description
-        else:
-            # Return the first element - probably a string message
-            if len(self.args) > 1:  # pragma: no cover TODO?
-                return self.args
-            elif len(self.args) == 1:
-                return self.args[0]
-            else:  # pragma: no cover TODO?
-                return self.__class__.__name__
+            return getattr(self, "description", None)
+        
+        if hasattr(self, "rule"):
+            return getattr(self, "rule").description
+
+        # Return the first element - probably a string message
+        if len(self.args) > 1 and isinstance(self.args, str):  # pragma: no cover TODO?
+            return self.args
+
+        if len(self.args) == 1:
+            return self.args[0]
+        
+        return self.__class__.__name__
 
     def get_info_dict(self):
         """Return a dict of properties.

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -201,12 +201,13 @@ class JinjaTemplater(PythonTemplater):
         for elem in tree.iter_child_nodes():
             yield from cls._crawl_tree(elem, variable_names, raw)
         # Then assess self
-        if isinstance(tree, jinja2.nodes.Name) and tree.name in variable_names:
-            line_no = tree.lineno
+        if isinstance(tree, jinja2.nodes.Name) and tree.name in variable_names: # type: ignore
+            line_no: int = tree.lineno # type: ignore
+            tree_name: str = tree.name # type: ignore
             line = raw.split("\n")[line_no - 1]
-            pos = line.index(tree.name) + 1
+            pos = line.index(tree_name) + 1
             yield SQLTemplaterError(
-                f"Undefined jinja template variable: {tree.name!r}",
+                f"Undefined jinja template variable: {tree_name!r}",
                 line_no=line_no,
                 line_pos=pos,
             )

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -381,7 +381,6 @@ class JinjaTemplater(PythonTemplater):
         try:
             # NB: Passing no context. Everything is loaded when the template is loaded.
             out_str = template.render()
-            assert out_str, "TypeGuard"
             # Slice the file once rendered.
             raw_sliced, sliced_file, out_str = self.slice_file(
                 in_str,

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -201,9 +201,12 @@ class JinjaTemplater(PythonTemplater):
         for elem in tree.iter_child_nodes():
             yield from cls._crawl_tree(elem, variable_names, raw)
         # Then assess self
-        if isinstance(tree, jinja2.nodes.Name) and tree.name in variable_names: # type: ignore
-            line_no: int = tree.lineno # type: ignore
-            tree_name: str = tree.name # type: ignore
+        if (
+            isinstance(tree, jinja2.nodes.Name)
+            and tree.name in variable_names  # type: ignore
+        ):
+            line_no: int = tree.lineno  # type: ignore
+            tree_name: str = tree.name  # type: ignore
             line = raw.split("\n")[line_no - 1]
             pos = line.index(tree_name) + 1
             yield SQLTemplaterError(

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -251,7 +251,10 @@ class JinjaAnalyzer:
                     f"{self.env.block_end_string}"
                 )
             except TemplateSyntaxError as e:
-                if "Unexpected end of template" in e.message:
+                if (
+                    isinstance(e.message, str)
+                    and "Unexpected end of template" in e.message
+                ):
                     # It was opening a block, thus we're inside a set or macro.
                     self.inside_set_or_macro = True
                 else:


### PR DESCRIPTION
In large outputs PRS errors are almost impossible to see with the human eye. In addition they tend to be the only thing you care about if they exist. This PR just changes the color printed to be RED if the violation is a PRS error

### Are there any other side effects of this change that we should be aware of?
No Side Effects