### PR TITLE
Prevent Date Constructors from being changed to double quotes by L064

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -393,8 +393,13 @@ ansi_dialect.add(
     ),
     # hookpoint for other dialects
     # e.g. EXASOL str to date cast with DATE '2021-01-01'
+    # Give it a different type as needs to be single quotes and
+    # should not be changed by rules (e.g. rule L064)
     DateTimeLiteralGrammar=Sequence(
-        OneOf("DATE", "TIME", "TIMESTAMP", "INTERVAL"), Ref("QuotedLiteralSegment")
+        OneOf("DATE", "TIME", "TIMESTAMP", "INTERVAL"),
+        NamedParser(
+            "single_quote", CodeSegment, name="date_constructor_literal", type="literal"
+        ),
     ),
     # Hookpoint for other dialects
     # e.g. INTO is optional in BIGQUERY

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -282,7 +282,10 @@ exasol_dialect.replace(
         Ref("CommentClauseSegment"),
     ),
     DateTimeLiteralGrammar=Sequence(
-        OneOf("DATE", "TIMESTAMP"), Ref("QuotedLiteralSegment")
+        OneOf("DATE", "TIMESTAMP"),
+        NamedParser(
+            "single_quote", CodeSegment, name="date_constructor_literal", type="literal"
+        ),
     ),
     CharCharacterSetGrammar=OneOf(
         "UTF8",

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -176,7 +176,12 @@ mysql_dialect.replace(
             optional=True,
         ),
         OneOf(
-            Ref("QuotedLiteralSegment"),
+            NamedParser(
+                "single_quote",
+                CodeSegment,
+                name="date_constructor_literal",
+                type="literal",
+            ),
             Ref("NumericLiteralSegment"),
         ),
     ),

--- a/test/fixtures/rules/std_rule_cases/L064.yml
+++ b/test/fixtures/rules/std_rule_cases/L064.yml
@@ -241,3 +241,21 @@ test_pass_dollar_quoted_strings_are_ignored:
       L064:
         force_enable: True
         preferred_quoted_literal_style: single_quotes
+
+test_pass_date_constructor_strings_are_ignored_1:
+  # Test that we dont interfere with date constructor strings
+  pass_str: |
+    SELECT
+        "quoted string",
+        DATE'some string'
+
+test_pass_date_constructor_strings_are_ignored_2:
+  # Test that we dont interfere with date constructor strings
+  pass_str: |
+    SELECT
+        DATE'some string'
+  configs:
+    rules:
+      L064:
+        force_enable: True
+        preferred_quoted_literal_style: double_quotes


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3186

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
