### PR TITLE
Postgres: Fix Drop Extension syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1802,7 +1802,7 @@ class DropExtensionStatementSegment(BaseSegment):
     match_grammar: Matchable = Sequence(
         "DROP",
         "EXTENSION",
-        Ref("IfNotExistsGrammar", optional=True),
+        Ref("IfExistsGrammar", optional=True),
         Ref("ExtensionReferenceSegment"),
         OneOf("CASCADE", "RESTRICT", optional=True),
     )

--- a/test/fixtures/dialects/postgres/postgres_create_extension.sql
+++ b/test/fixtures/dialects/postgres/postgres_create_extension.sql
@@ -1,6 +1,14 @@
+CREATE EXTENSION amazing_extension
+    with schema schema1
+    VERSION 2.0
+    FROM 1.0;
+
 CREATE EXTENSION IF NOT EXISTS amazing_extension
     with schema schema1
     VERSION 2.0
     FROM 1.0;
 
+
 DROP EXTENSION amazing_extension;
+
+DROP EXTENSION IF EXISTS amazing_extension;

--- a/test/fixtures/dialects/postgres/postgres_create_extension.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_extension.yml
@@ -3,8 +3,23 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5e8bc80269bd8ba7b0b8e30c11af61ee0581352db8c9273d40534c0ba364f759
+_hash: f79e354a953d0122ec1715d27a9804e868ab65d4e1a95e14f5a33cbb8b07528c
 file:
+- statement:
+    create_extension_statement:
+    - keyword: CREATE
+    - keyword: EXTENSION
+    - extension_reference:
+        identifier: amazing_extension
+    - keyword: with
+    - keyword: schema
+    - schema_reference:
+        identifier: schema1
+    - keyword: VERSION
+    - identifier: '2.0'
+    - keyword: FROM
+    - identifier: '1.0'
+- statement_terminator: ;
 - statement:
     create_extension_statement:
     - keyword: CREATE
@@ -27,6 +42,15 @@ file:
     drop_extension_statement:
     - keyword: DROP
     - keyword: EXTENSION
+    - extension_reference:
+        identifier: amazing_extension
+- statement_terminator: ;
+- statement:
+    drop_extension_statement:
+    - keyword: DROP
+    - keyword: EXTENSION
+    - keyword: IF
+    - keyword: EXISTS
     - extension_reference:
         identifier: amazing_extension
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Follow up to #3083 as noted in https://github.com/sqlfluff/sqlfluff/issues/3081#issuecomment-1111858000

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
