### PR TITLE
Snowflake: `ALTER MATERIALIZED VIEW` statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -843,6 +843,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("CommentStatementSegment"),
             Ref("CallStatementSegment"),
             Ref("AlterViewStatementSegment"),
+            Ref("AlterMaterializedViewStatementSegment"),
             Ref("RemoveStatementSegment"),
         ],
         remove=[
@@ -2769,6 +2770,39 @@ class AlterViewStatementSegment(BaseSegment):
                             Delimited(Ref("NakedIdentifierSegment")),
                         ),
                     ),
+                ),
+            ),
+        ),
+    )
+
+
+class AlterMaterializedViewStatementSegment(BaseSegment):
+    """An `ALTER MATERIALIZED VIEW` statement, specifically for Snowflake's dialect.
+
+    https://docs.snowflake.com/en/sql-reference/sql/alter-materialized-view.html
+    """
+
+    type = "alter_materialized_view_statement"
+
+    match_grammar = Sequence(
+        "ALTER",
+        "MATERIALIZED",
+        "VIEW",
+        Ref("TableReferenceSegment"),
+        OneOf(
+            Sequence("RENAME", "TO", Ref("TableReferenceSegment")),
+            Sequence("CLUSTER", "BY", Delimited(Ref("ExpressionSegment"))),
+            Sequence("DROP", "CLUSTERING", "KEY"),
+            Sequence("SUSPEND", "RECLUSTER"),
+            Sequence("RESUME", "RECLUSTER"),
+            "SUSPEND",
+            "RESUME",
+            Sequence(
+                OneOf("SET", "UNSET"),
+                OneOf(
+                    Ref.keyword("SECURE"),
+                    Ref("CommentEqualsClauseSegment"),
+                    Ref("TagEqualsSegment"),
                 ),
             ),
         ),

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -2800,7 +2800,7 @@ class AlterMaterializedViewStatementSegment(BaseSegment):
             Sequence(
                 OneOf("SET", "UNSET"),
                 OneOf(
-                    Ref.keyword("SECURE"),
+                    "SECURE",
                     Ref("CommentEqualsClauseSegment"),
                     Ref("TagEqualsSegment"),
                 ),

--- a/test/fixtures/dialects/snowflake/snowflake_alter_materialized_view.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_materialized_view.sql
@@ -1,0 +1,11 @@
+alter materialized view table1_mv rename to my_mv;
+alter materialized view my_mv cluster by(i);
+alter materialized view my_mv suspend recluster;
+alter materialized view my_mv resume recluster;
+alter materialized view my_mv suspend;
+alter materialized view my_mv resume;
+alter materialized view my_mv drop clustering key;
+alter materialized view mv1 set secure;
+alter materialized view mv1 set comment = 'Sample view';
+alter materialized view mv1 set tag my_tag = 'my tag';
+alter materialized view mv1 unset tag my_tag = 'not my tag anymore';

--- a/test/fixtures/dialects/snowflake/snowflake_alter_materialized_view.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_materialized_view.yml
@@ -1,0 +1,139 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 26e98484e7efd942e9865e0639c293dc32afc4d77f9a002887ef51070757ef97
+file:
+- statement:
+    alter_materialized_view_statement:
+    - keyword: alter
+    - keyword: materialized
+    - keyword: view
+    - table_reference:
+        identifier: table1_mv
+    - keyword: rename
+    - keyword: to
+    - table_reference:
+        identifier: my_mv
+- statement_terminator: ;
+- statement:
+    alter_materialized_view_statement:
+    - keyword: alter
+    - keyword: materialized
+    - keyword: view
+    - table_reference:
+        identifier: my_mv
+    - keyword: cluster
+    - keyword: by
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+            column_reference:
+              identifier: i
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_materialized_view_statement:
+    - keyword: alter
+    - keyword: materialized
+    - keyword: view
+    - table_reference:
+        identifier: my_mv
+    - keyword: suspend
+    - keyword: recluster
+- statement_terminator: ;
+- statement:
+    alter_materialized_view_statement:
+    - keyword: alter
+    - keyword: materialized
+    - keyword: view
+    - table_reference:
+        identifier: my_mv
+    - keyword: resume
+    - keyword: recluster
+- statement_terminator: ;
+- statement:
+    alter_materialized_view_statement:
+    - keyword: alter
+    - keyword: materialized
+    - keyword: view
+    - table_reference:
+        identifier: my_mv
+    - keyword: suspend
+- statement_terminator: ;
+- statement:
+    alter_materialized_view_statement:
+    - keyword: alter
+    - keyword: materialized
+    - keyword: view
+    - table_reference:
+        identifier: my_mv
+    - keyword: resume
+- statement_terminator: ;
+- statement:
+    alter_materialized_view_statement:
+    - keyword: alter
+    - keyword: materialized
+    - keyword: view
+    - table_reference:
+        identifier: my_mv
+    - keyword: drop
+    - keyword: clustering
+    - keyword: key
+- statement_terminator: ;
+- statement:
+    alter_materialized_view_statement:
+    - keyword: alter
+    - keyword: materialized
+    - keyword: view
+    - table_reference:
+        identifier: mv1
+    - keyword: set
+    - keyword: secure
+- statement_terminator: ;
+- statement:
+    alter_materialized_view_statement:
+    - keyword: alter
+    - keyword: materialized
+    - keyword: view
+    - table_reference:
+        identifier: mv1
+    - keyword: set
+    - comment_equals_clause:
+        keyword: comment
+        comparison_operator:
+          raw_comparison_operator: '='
+        literal: "'Sample view'"
+- statement_terminator: ;
+- statement:
+    alter_materialized_view_statement:
+    - keyword: alter
+    - keyword: materialized
+    - keyword: view
+    - table_reference:
+        identifier: mv1
+    - keyword: set
+    - tag_equals:
+        keyword: tag
+        identifier: my_tag
+        comparison_operator:
+          raw_comparison_operator: '='
+        literal: "'my tag'"
+- statement_terminator: ;
+- statement:
+    alter_materialized_view_statement:
+    - keyword: alter
+    - keyword: materialized
+    - keyword: view
+    - table_reference:
+        identifier: mv1
+    - keyword: unset
+    - tag_equals:
+        keyword: tag
+        identifier: my_tag
+        comparison_operator:
+          raw_comparison_operator: '='
+        literal: "'not my tag anymore'"
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

Resolves https://github.com/sqlfluff/sqlfluff/issues/3201

Adds alter materialized view statement for Snowflake dialect.

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?

None that I'm aware of.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
