### PR TITLE
Make if exists work with union

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1734,7 +1734,7 @@ ansi_dialect.add(
     # Expression_C_Grammar
     # https://www.cockroachlabs.com/docs/v20.2/sql-grammar.htm#c_expr
     Expression_C_Grammar=OneOf(
-        Sequence("EXISTS", Bracketed(Ref("SelectStatementSegment"))),
+        Sequence("EXISTS", Bracketed(Ref("SelectableGrammar"))),
         # should be first priority, otherwise EXISTS() would be matched as a function
         Sequence(
             OneOf(

--- a/test/fixtures/dialects/tsql/if_else.sql
+++ b/test/fixtures/dialects/tsql/if_else.sql
@@ -6,3 +6,7 @@ ELSE
     SELECT ProductKey, EnglishDescription, Weight, 'This product is available for shipping or pickup.'
         AS ShippingStatus
     FROM DimProduct WHERE ProductKey = 1
+
+
+if exists (select * from #a union all select * from #b)
+  set @var = 1;

--- a/test/fixtures/dialects/tsql/if_else.yml
+++ b/test/fixtures/dialects/tsql/if_else.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4cf4e475c018f2f5231d6d6024d6bf466380a8fce69d77a9df8d46ac6ddaf8e2
+_hash: 74bad0d28ff18bdd2b6afaa5af6ddbaa8ebce2f71fc9a7368d9e6395cbcc4e93
 file:
   batch:
-    statement:
+  - statement:
       if_then_statement:
       - if_clause:
           keyword: IF
@@ -114,3 +114,54 @@ file:
                 comparison_operator:
                   raw_comparison_operator: '='
                 literal: '1'
+  - statement:
+      if_then_statement:
+        if_clause:
+          keyword: if
+          expression:
+            keyword: exists
+            bracketed:
+              start_bracket: (
+              set_expression:
+              - select_statement:
+                  select_clause:
+                    keyword: select
+                    select_clause_element:
+                      wildcard_expression:
+                        wildcard_identifier:
+                          star: '*'
+                  from_clause:
+                    keyword: from
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            identifier: '#a'
+              - set_operator:
+                - keyword: union
+                - keyword: all
+              - select_statement:
+                  select_clause:
+                    keyword: select
+                    select_clause_element:
+                      wildcard_expression:
+                        wildcard_identifier:
+                          star: '*'
+                  from_clause:
+                    keyword: from
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            identifier: '#b'
+              end_bracket: )
+        statement:
+          set_segment:
+            keyword: set
+            parameter: '@var'
+            assignment_operator:
+              comparison_operator:
+                raw_comparison_operator: '='
+            expression:
+              literal: '1'
+            statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Adds support for `if exists (select * from #a union all select * from #b)`

fixes #3197
### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
