### PR TITLE
Fix bug where the `fix_even_unparsable` setting was not being respected in `.sqlfluff`

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -751,7 +751,7 @@ def fix(
             )
             click.echo(
                 colorize(
-                    "Use --fix-even-unparsable' to attempt to fix the SQL anyway.",
+                    "Use --FIX-EVEN-UNPARSABLE' to attempt to fix the SQL anyway.",
                     Color.red,
                 ),
                 err=True,

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -674,6 +674,7 @@ def do_fixes(lnt, result, formatter=None, **kwargs):
 @click.option(
     "--FIX-EVEN-UNPARSABLE",
     is_flag=True,
+    default=None,
     help=(
         "Enables fixing of files that have templating or parse errors. "
         "Note that the similar-sounding '--ignore' or 'noqa' features merely "

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -716,6 +716,10 @@ def test_cli_fix_even_unparsable(
         assert method == "config-file"
         with open(str(tmpdir / ".sqlfluff"), "w") as f:
             print(f"[sqlfluff]\nfix_even_unparsable = {fix_even_unparsable}", file=f)
+    # TRICKY: Switch current directory to the one with the SQL file. Otherwise,
+    # the setting doesn't work. That's because SQLFluff reads it in
+    # sqlfluff.cli.commands.fix(), prior to reading any file-specific settings
+    # (down in sqlfluff.core.linter.Linter._load_raw_file_and_config()).
     monkeypatch.chdir(str(tmpdir))
     invoke_assert_code(
         ret_code=0 if fix_even_unparsable else 1,

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -700,14 +700,22 @@ def test_cli_fix_even_unparsable(
     method: str, fix_even_unparsable: bool, monkeypatch, tmpdir
 ):
     """Test the fix_even_unparsable option works from cmd line and config."""
-    sql_path = "test/fixtures/cli/fix_even_unparsable.sql"
-    shutil.copy(sql_path, tmpdir)
+    sql_filename = "fix_even_unparsable.sql"
+    sql_path = str(tmpdir / sql_filename)
+    with open(sql_path, "w") as f:
+        print(
+            """SELECT my_col
+FROM my_schema.my_table
+where processdate ! 3
+""",
+            file=f,
+        )
     options = [
         "--dialect",
         "ansi",
         "-f",
         "--fixed-suffix=FIXED",
-        str(tmpdir / "fix_even_unparsable.sql"),
+        sql_path,
     ]
     if method == "command-line":
         if fix_even_unparsable:
@@ -734,7 +742,10 @@ def test_cli_fix_even_unparsable(
             fixed_sql = f.read()
             assert (
                 fixed_sql
-                == "SELECT my_col\nFROM my_schema.my_table\nWHERE processdate ! 3\n"
+                == """SELECT my_col
+FROM my_schema.my_table
+WHERE processdate ! 3
+"""
             )
     else:
         assert not os.path.isfile(fixed_path)

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -687,6 +687,55 @@ def test__cli__fix_error_handling_behavior(sql, fix_args, fixed, exit_code, tmpd
             assert not fixed_path.is_file()
 
 
+@pytest.mark.parametrize(
+    "method,fix_even_unparsable",
+    [
+        ("command-line", False),
+        ("command-line", True),
+        ("config-file", False),
+        ("config-file", True),
+    ],
+)
+def test_cli_fix_even_unparsable(
+    method: str, fix_even_unparsable: bool, monkeypatch, tmpdir
+):
+    """Test the fix_even_unparsable option works from cmd line and config."""
+    sql_path = "test/fixtures/cli/fix_even_unparsable.sql"
+    shutil.copy(sql_path, tmpdir)
+    options = [
+        "--dialect",
+        "ansi",
+        "-f",
+        "--fixed-suffix=FIXED",
+        str(tmpdir / "fix_even_unparsable.sql"),
+    ]
+    if method == "command-line":
+        if fix_even_unparsable:
+            options.append("--FIX-EVEN-UNPARSABLE")
+    else:
+        assert method == "config-file"
+        with open(str(tmpdir / ".sqlfluff"), "w") as f:
+            print(f"[sqlfluff]\nfix_even_unparsable = {fix_even_unparsable}", file=f)
+    monkeypatch.chdir(str(tmpdir))
+    invoke_assert_code(
+        ret_code=0 if fix_even_unparsable else 1,
+        args=[
+            fix,
+            options,
+        ],
+    )
+    fixed_path = str(tmpdir / "fix_even_unparsableFIXED.sql")
+    if fix_even_unparsable:
+        with open(fixed_path, "r") as f:
+            fixed_sql = f.read()
+            assert (
+                fixed_sql
+                == "SELECT my_col\nFROM my_schema.my_table\nWHERE processdate ! 3\n"
+            )
+    else:
+        assert not os.path.isfile(fixed_path)
+
+
 _old_eval = BaseRule._eval
 _fix_counter = 0
 

--- a/test/fixtures/cli/fix_even_unparsable.sql
+++ b/test/fixtures/cli/fix_even_unparsable.sql
@@ -1,3 +1,0 @@
-SELECT my_col
-FROM my_schema.my_table
-where processdate ! 3

--- a/test/fixtures/cli/fix_even_unparsable.sql
+++ b/test/fixtures/cli/fix_even_unparsable.sql
@@ -1,0 +1,3 @@
+SELECT my_col
+FROM my_schema.my_table
+where processdate ! 3


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3214 
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
