### PR TITLE
TSQL: Fix `for xml path` identifier

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3918,13 +3918,9 @@ class ForXmlSegment(BaseSegment):
         "FOR",
         "XML",
         OneOf(
-            Sequence(
-                "RAW", Bracketed(Ref("SingleQuotedIdentifierSegment"), optional=True)
-            ),
-            Ref.keyword("AUTO"),
-            Ref.keyword("EXPLICIT"),
-            Sequence(
-                "PATH", Bracketed(Ref("SingleQuotedIdentifierSegment"), optional=True)
-            ),
+            Sequence("RAW", Bracketed(Ref("QuotedLiteralSegment"), optional=True)),
+            "AUTO",
+            "EXPLICIT",
+            Sequence("PATH", Bracketed(Ref("QuotedLiteralSegment"), optional=True)),
         ),
     )

--- a/test/fixtures/dialects/tsql/xml.yml
+++ b/test/fixtures/dialects/tsql/xml.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a2f8ee0b740c5e3392e7c6bf43d70e87cad4b69a86981a12b59e5c3351cc0c07
+_hash: 87f2457cf4ab2d51acb4b6e20f7a9cb456cc7166fabd050bfc4b6a1a6f3437b6
 file:
   batch:
   - statement:
@@ -144,6 +144,6 @@ file:
         - keyword: PATH
         - bracketed:
             start_bracket: (
-            identifier: "'root'"
+            literal: "'root'"
             end_bracket: )
   - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This fixes wrong parsing of `for xml path ('something')` statements in T-SQL.

Fixes #3219

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
