### PR TITLE
Enhance `apply_fixes()` to automatically fix violations of `can_start_end_non_code`

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -592,7 +592,7 @@ class Linter:
                             # This is the happy path. We have fixes, now we want to
                             # apply them.
                             last_fixes = fixes
-                            new_tree = tree.apply_fixes(
+                            new_tree, _, _ = tree.apply_fixes(
                                 config.get("dialect_obj"), crawler.code, anchor_info
                             )
                             # Check for infinite loops

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -592,7 +592,7 @@ class Linter:
                             # This is the happy path. We have fixes, now we want to
                             # apply them.
                             last_fixes = fixes
-                            new_tree, _ = tree.apply_fixes(
+                            new_tree = tree.apply_fixes(
                                 config.get("dialect_obj"), crawler.code, anchor_info
                             )
                             # Check for infinite loops

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1090,7 +1090,7 @@ class BaseSegment:
         """If segment's first/last child is non-code, return index."""
         if segments:
             for idx in [0, -1]:
-                if not cls._is_code_or_meta(segments[idx]):  # pragma: no cover
+                if not cls._is_code_or_meta(segments[idx]):
                     return idx
         return None
 
@@ -1202,6 +1202,7 @@ class BaseSegment:
             if fixes_applied and not r.can_start_end_non_code:
                 idx_non_code = self._find_start_or_end_non_code(seg_buffer)
                 if idx_non_code is not None:
+                    save_seg_buffer = list(seg_buffer)
                     # If there are non-code segments at the beginning or end,
                     # pull them out and bubble them up the tree.
                     for seg in seg_buffer:
@@ -1216,7 +1217,16 @@ class BaseSegment:
                         else:
                             break
                     after.reverse()
-                    seg_buffer = seg_buffer[: -len(after)]
+                    seg_buffer = seg_buffer[: len(seg_buffer) - len(after)]
+                    assert before + seg_buffer + after == save_seg_buffer
+                    linter_logger.debug(
+                        "After applying fixes, segment %s violated "
+                        "'can_start_end_non_code=False' constraint. Autofixing, "
+                        "before=%s, after=%s",
+                        self,
+                        before,
+                        after,
+                    )
             r = r.__class__(
                 # Realign the segments within
                 segments=self._position_segments(

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1000,7 +1000,7 @@ class BaseSegment:
             else:
                 pre_nc = ()
                 post_nc = ()
-                idx_non_code = self.find_start_or_end_non_code()
+                idx_non_code = self._find_start_or_end_non_code()
                 if idx_non_code is not None:  # pragma: no cover
                     raise ValueError(
                         f"Segment {self} {'starts' if idx_non_code == 0 else 'ends'} "
@@ -1081,14 +1081,16 @@ class BaseSegment:
 
         return self
 
-    def find_start_or_end_non_code(self) -> Optional[int]:
+    @staticmethod
+    def _is_code_or_meta(segment: "BaseSegment") -> bool:
+        return segment.is_code or segment.is_meta
+
+    def _find_start_or_end_non_code(self) -> Optional[int]:
         """If segment's first/last child is non-code, return index."""
         segments = self.segments
         if segments:
             for idx in [0, -1]:
-                if (not segments[idx].is_code) and (
-                    not segments[idx].is_meta
-                ):  # pragma: no cover
+                if not self._is_code_or_meta(segments[idx]):  # pragma: no cover
                     return idx
         return None
 

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1090,7 +1090,7 @@ class BaseSegment:
 
         return self
 
-    def apply_fixes(self, dialect, rule_code, fixes):
+    def apply_fixes(self, dialect, rule_code: str, fixes: Dict) -> "BaseSegment":
         """Apply an iterable of fixes to this segment.
 
         Used in applying fixes if we're fixing linting errors.
@@ -1180,7 +1180,7 @@ class BaseSegment:
             seg_queue = seg_buffer
             seg_buffer = []
             for seg in seg_queue:
-                s, fixes = seg.apply_fixes(dialect, rule_code, fixes)
+                s = seg.apply_fixes(dialect, rule_code, fixes)
                 seg_buffer.append(s)
 
             # Reform into a new segment
@@ -1195,10 +1195,10 @@ class BaseSegment:
             )
             if fixes_applied:
                 self._validate_segment_after_fixes(rule_code, dialect, fixes_applied, r)
-            # Return the new segment with any unused fixes.
-            return r, fixes
+            # Return the new segment.
+            return r
         else:
-            return self, fixes
+            return self
 
     @classmethod
     def compute_anchor_edit_info(cls, fixes) -> Dict[int, AnchorEditInfo]:

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1000,21 +1000,12 @@ class BaseSegment:
             else:
                 pre_nc = ()
                 post_nc = ()
-                if (not segments[0].is_code) and (
-                    not segments[0].is_meta
-                ):  # pragma: no cover
+                idx_non_code = self.find_start_or_end_non_code()
+                if idx_non_code is not None:  # pragma: no cover
                     raise ValueError(
-                        "Segment {} starts with non code segment: {!r}.\n{!r}".format(
-                            self, segments[0].raw, segments
-                        )
-                    )
-                if (not segments[-1].is_code) and (
-                    not segments[-1].is_meta
-                ):  # pragma: no cover
-                    raise ValueError(
-                        "Segment {} ends with non code segment: {!r}.\n{!r}".format(
-                            self, segments[-1].raw, segments
-                        )
+                        f"Segment {self} {'starts' if idx_non_code == 0 else 'ends'} "
+                        f"with non code segment: "
+                        f"{segments[idx_non_code].raw!r}.\n{segments!r}"
                     )
 
             # NOTE: No match_depth kwarg, because this is the start of the matching.
@@ -1089,6 +1080,17 @@ class BaseSegment:
                 )
 
         return self
+
+    def find_start_or_end_non_code(self) -> Optional[int]:
+        """If segment's first/last child is non-code, return index."""
+        segments = self.segments
+        if segments:
+            for idx in [0, -1]:
+                if (not segments[idx].is_code) and (
+                    not segments[idx].is_meta
+                ):  # pragma: no cover
+                    return idx
+        return None
 
     def apply_fixes(self, dialect, rule_code: str, fixes: Dict) -> "BaseSegment":
         """Apply an iterable of fixes to this segment.

--- a/src/sqlfluff/rules/L036.py
+++ b/src/sqlfluff/rules/L036.py
@@ -391,30 +391,6 @@ class Rule_L036(BaseRule):
                 ),
             ]
 
-            between_newline_and_select_target = select_children.select(
-                start_seg=select_children[select_targets_info.first_new_line_idx],
-                stop_seg=select_children[select_targets_info.first_select_target_idx],
-            )
-            # If there are additional newlines (blank lines) between the first
-            # newline and the first SELECT column, delete those. This avoids
-            # introducing parse errors with the fix. (For more context, see the
-            # area of code reporting "ends with non code segment" in
-            # BaseSegment.parse(). If we see still see issues with this, we may
-            # need to look for a more sophisticated, robust solution, e.g.
-            # moving these segments "up" the parse tree, similar to the logic in
-            # BaseRule._adjust_anchors_for_fixes().
-            if between_newline_and_select_target.all(sp.is_type("newline")):
-                deletes_and_replaces = IdentitySet(
-                    fix.anchor
-                    for fix in fixes
-                    if fix.edit_type in ("delete", "replace")
-                )
-                fixes += [
-                    LintFix.delete(seg)
-                    for seg in between_newline_and_select_target
-                    if seg not in deletes_and_replaces
-                ]
-
             return LintResult(
                 anchor=select_clause.get(),
                 fixes=fixes,

--- a/test/fixtures/linter/autofix/snowflake/003_previously_parse_tree_damaging/after.sql
+++ b/test/fixtures/linter/autofix/snowflake/003_previously_parse_tree_damaging/after.sql
@@ -1,2 +1,3 @@
 set cutoff = (select foo
+
 );


### PR DESCRIPTION



<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
About a month ago, I reworked the core linter to re-parse areas of the tree affected by fixes. This detects misbehaving rules so they can be fixed. One downside is that there's one kind of parse error that can be difficult to avoid: Generally, a segment's first and last children must be code or meta (for example, whitespace is not allowed).

This PR changes `BaseSegment.apply_fixes()` to automatically detect and fix these issues. It's a pretty simple and safe change, and I think it'll save future debugging and frustration for rule developers.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
