### PR TITLE
Indent procedure parameters

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1818,7 +1818,9 @@ class CreateProcedureStatementSegment(BaseSegment):
         Sequence("OR", "ALTER", optional=True),
         OneOf("PROCEDURE", "PROC"),
         Ref("ObjectReferenceSegment"),
+        Indent,
         Ref("ProcedureParameterListGrammar", optional=True),
+        Dedent,
         "AS",
         Ref("ProcedureDefinitionGrammar"),
     )

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -970,3 +970,27 @@ test_fail_hanging_indents_fix_mixed_indents:
     rules:
       L003:
         hanging_indents: False
+
+test_pass_indented_procedure_parameters:
+  pass_str: |
+    CREATE OR ALTER PROCEDURE some_procedure
+        @param1 int
+    AS SELECT * FROM dbo
+  configs:
+    core:
+      dialect: tsql
+
+test_fail_unindented_procedure_parameters:
+  fail_str: |
+    CREATE OR ALTER PROCEDURE someOtherProcedure
+    @param1 nvarchar(100),
+    @param2 nvarchar(20)
+    AS SELECT * FROM dbo
+  fix_str: |
+    CREATE OR ALTER PROCEDURE someOtherProcedure
+        @param1 nvarchar(100),
+        @param2 nvarchar(20)
+    AS SELECT * FROM dbo
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Procedure parameters are now indented, like function parameters.

Fixes #3200
### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
