### PR TITLE
T-SQL: Allow optional brakets with EXECUTE

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3189,7 +3189,7 @@ class ExecuteScriptSegment(BaseSegment):
     match_grammar = Sequence(
         OneOf("EXEC", "EXECUTE"),
         Sequence(Ref("ParameterNameSegment"), Ref("EqualsSegment"), optional=True),
-        Ref("ObjectReferenceSegment"),
+        OptionallyBracketed(Ref("ObjectReferenceSegment")),
         Indent,
         Sequence(
             Sequence(Ref("ParameterNameSegment"), Ref("EqualsSegment"), optional=True),

--- a/test/fixtures/dialects/tsql/execute.sql
+++ b/test/fixtures/dialects/tsql/execute.sql
@@ -29,3 +29,7 @@ EXEC @pRes = dbo.ProcTestDefaults;
 EXEC @pRes = dbo.ProcTestDefaults @p1 = DEFAULT;
 EXECUTE @pRes = dbo.ProcTestDefaults;
 EXECUTE @pRes = dbo.ProcTestDefaults @p1 = DEFAULT;
+
+-- Executing statement from a variable
+DECLARE @statement nvarchar(max) = 'SELECT 1'
+EXEC (@statement)

--- a/test/fixtures/dialects/tsql/execute.yml
+++ b/test/fixtures/dialects/tsql/execute.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ecd09ca267687792ef1da9fc9a73ebe0614cbef1628958f5b0055a198f4125bd
+_hash: c85b1f08a944af4f2694e1038c620b8ff71eb111bfd371e2b0bf172170b79be9
 file:
   batch:
   - statement:
@@ -200,3 +200,25 @@ file:
           raw_comparison_operator: '='
       - keyword: DEFAULT
       - statement_terminator: ;
+  - statement:
+      declare_segment:
+        keyword: DECLARE
+        parameter: '@statement'
+        data_type:
+          data_type_identifier: nvarchar
+          bracketed:
+            start_bracket: (
+            keyword: max
+            end_bracket: )
+        comparison_operator:
+          raw_comparison_operator: '='
+        expression:
+          literal: "'SELECT 1'"
+  - statement:
+      execute_script_statement:
+        keyword: EXEC
+        bracketed:
+          start_bracket: (
+          object_reference:
+            parameter: '@statement'
+          end_bracket: )


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Allow optional brackets around variables with EXECUTE statements.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `[x] .sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
