### PR TITLE
Postgres: Add `DOMAIN` support

### DIFF
--- a/test/fixtures/dialects/postgres/postgres_alter_domain.sql
+++ b/test/fixtures/dialects/postgres/postgres_alter_domain.sql
@@ -1,0 +1,13 @@
+ALTER DOMAIN zipcode SET NOT NULL;
+
+ALTER DOMAIN zipcode DROP NOT NULL;
+
+ALTER DOMAIN zipcode ADD CONSTRAINT zipchk CHECK (char_length(VALUE) = 5);
+
+ALTER DOMAIN zipcode DROP CONSTRAINT zipchk;
+
+ALTER DOMAIN zipcode RENAME CONSTRAINT zipchk TO zip_check;
+
+ALTER DOMAIN zipcode SET SCHEMA customers;
+
+alter domain oname add constraint "test" check (length(value) <  512);

--- a/test/fixtures/dialects/postgres/postgres_alter_domain.yml
+++ b/test/fixtures/dialects/postgres/postgres_alter_domain.yml
@@ -1,0 +1,121 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9c4fcc99db32bb75485502d6ca6c6f7fc2bfea986023d0b3c04df28e3c3619d1
+file:
+- statement:
+    alter_domain_statement:
+    - keyword: ALTER
+    - keyword: DOMAIN
+    - object_reference:
+        identifier: zipcode
+    - keyword: SET
+    - keyword: NOT
+    - keyword: 'NULL'
+- statement_terminator: ;
+- statement:
+    alter_domain_statement:
+    - keyword: ALTER
+    - keyword: DOMAIN
+    - object_reference:
+        identifier: zipcode
+    - keyword: DROP
+    - keyword: NOT
+    - keyword: 'NULL'
+- statement_terminator: ;
+- statement:
+    alter_domain_statement:
+    - keyword: ALTER
+    - keyword: DOMAIN
+    - object_reference:
+        identifier: zipcode
+    - keyword: ADD
+    - keyword: CONSTRAINT
+    - object_reference:
+        identifier: zipchk
+    - keyword: CHECK
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+            function:
+              function_name:
+                function_name_identifier: char_length
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    identifier: VALUE
+                end_bracket: )
+            comparison_operator:
+              raw_comparison_operator: '='
+            literal: '5'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_domain_statement:
+    - keyword: ALTER
+    - keyword: DOMAIN
+    - object_reference:
+        identifier: zipcode
+    - keyword: DROP
+    - keyword: CONSTRAINT
+    - object_reference:
+        identifier: zipchk
+- statement_terminator: ;
+- statement:
+    alter_domain_statement:
+    - keyword: ALTER
+    - keyword: DOMAIN
+    - object_reference:
+        identifier: zipcode
+    - keyword: RENAME
+    - keyword: CONSTRAINT
+    - object_reference:
+        identifier: zipchk
+    - keyword: TO
+    - object_reference:
+        identifier: zip_check
+- statement_terminator: ;
+- statement:
+    alter_domain_statement:
+    - keyword: ALTER
+    - keyword: DOMAIN
+    - object_reference:
+        identifier: zipcode
+    - keyword: SET
+    - keyword: SCHEMA
+    - object_reference:
+        identifier: customers
+- statement_terminator: ;
+- statement:
+    alter_domain_statement:
+    - keyword: alter
+    - keyword: domain
+    - object_reference:
+        identifier: oname
+    - keyword: add
+    - keyword: constraint
+    - object_reference:
+        identifier: '"test"'
+    - keyword: check
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+            function:
+              function_name:
+                function_name_identifier: length
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    identifier: value
+                end_bracket: )
+            comparison_operator:
+              raw_comparison_operator: <
+            literal: '512'
+          end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/postgres/postgres_create_domain.sql
+++ b/test/fixtures/dialects/postgres/postgres_create_domain.sql
@@ -1,0 +1,7 @@
+CREATE DOMAIN us_postal_code AS TEXT
+CHECK(
+   VALUE ~ '^\d{5}$'
+OR VALUE ~ '^\d{5}-\d{4}$'
+);
+
+create domain oname as text;

--- a/test/fixtures/dialects/postgres/postgres_create_domain.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_domain.yml
@@ -1,0 +1,42 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: ca51084f71d69e23ae2b5ae81e93a389717073adbad8bdbe51556d4edd4b183c
+file:
+- statement:
+    create_domain_statement:
+    - keyword: CREATE
+    - keyword: DOMAIN
+    - object_reference:
+        identifier: us_postal_code
+    - keyword: AS
+    - data_type:
+        keyword: TEXT
+    - keyword: CHECK
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              identifier: VALUE
+          - comparison_operator: '~'
+          - literal: "'^\\d{5}$'"
+          - binary_operator: OR
+          - column_reference:
+              identifier: VALUE
+          - comparison_operator: '~'
+          - literal: "'^\\d{5}-\\d{4}$'"
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_domain_statement:
+    - keyword: create
+    - keyword: domain
+    - object_reference:
+        identifier: oname
+    - keyword: as
+    - data_type:
+        keyword: text
+- statement_terminator: ;

--- a/test/fixtures/dialects/postgres/postgres_drop_domain.sql
+++ b/test/fixtures/dialects/postgres/postgres_drop_domain.sql
@@ -1,0 +1,1 @@
+DROP DOMAIN box;

--- a/test/fixtures/dialects/postgres/postgres_drop_domain.yml
+++ b/test/fixtures/dialects/postgres/postgres_drop_domain.yml
@@ -1,0 +1,14 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: c5ba329dbdeab07fec1da271050a1eb101ebc1886c9dc2f6edb66f74534773b6
+file:
+  statement:
+    drop_domain_statement:
+    - keyword: DROP
+    - keyword: DOMAIN
+    - object_reference:
+        identifier: box
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3256 

### Are there any other side effects of this change that we should be aware of?
Only added test cases in docs in case I got any wrong, but these are not comprehensive.

Also cleaned a pointless `match_grammar` in the DropTrigger statement that I noticed at same time.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
