### PR TITLE
Improve error on missing keywords

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -263,9 +263,19 @@ class Dialect:
                     )
                 )
         else:  # pragma: no cover
+            if name.endswith("KeywordSegment"):
+                keyword_tip = (
+                    " Perhaps specify the keyword? "
+                    "https://github.com/sqlfluff/sqlfluff/wiki/Contributing-Dialect-Changes#keywords"  # noqa E501
+                )
+            else:
+                keyword_tip = ""
             raise RuntimeError(
-                "Grammar refers to {!r} which was not found in the {} dialect".format(
-                    name, self.name
+                (
+                    "Grammar refers to "
+                    "{!r} which was not found in the {} dialect.{}".format(
+                        name, self.name, keyword_tip
+                    )
                 )
             )
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Mention the [relevant documentation](https://github.com/sqlfluff/sqlfluff/wiki/Contributing-Dialect-Changes#keywords) in the error if you have not specified a keyword. Could help new developers like me:
```
RuntimeError: Grammar refers to 'EngineKeywordSegment' which was not found in the mysql dialect. Perhaps specify the keyword? https://github.com/sqlfluff/sqlfluff/wiki/Contributing-Dialect-Changes#keywords
```


### Are there any other side effects of this change that we should be aware of?
Could lead to more verbose error logs, but hopefully it's helpful?

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
