### PR TITLE
Add groups each rule is in to Rules documentation

### DIFF
--- a/docs/source/rules.rst
+++ b/docs/source/rules.rst
@@ -10,7 +10,7 @@ each specific rule should be really streamlined and only contain the logic
 for the rule itself, with all the other mechanics abstracted away.
 
 Core Rules
-__________
+----------
 
 Certain rules belong to the :code:`core` rule group. In order for
 a rule to be designated as :code:`core`, it must meet the following

--- a/plugins/sqlfluff-plugin-example/src/example/rules.py
+++ b/plugins/sqlfluff-plugin-example/src/example/rules.py
@@ -7,8 +7,9 @@ from sqlfluff.core.rules.base import (
     RuleContext,
 )
 from sqlfluff.core.rules.doc_decorators import (
-    document_fix_compatible,
     document_configuration,
+    document_fix_compatible,
+    document_groups,
 )
 from typing import List
 import os.path
@@ -42,6 +43,7 @@ def get_configs_info() -> dict:
 # to be displayed in the sqlfluff docs
 @document_fix_compatible
 @document_configuration
+@document_groups
 class Rule_Example_L001(BaseRule):
     """ORDER BY on these columns is forbidden!
 
@@ -68,8 +70,8 @@ class Rule_Example_L001(BaseRule):
         ORDER BY bar
     """
 
-    config_keywords = ["forbidden_columns"]
     groups = ("all",)
+    config_keywords = ["forbidden_columns"]
 
     def __init__(self, *args, **kwargs):
         """Overwrite __init__ to set config."""

--- a/plugins/sqlfluff-plugin-example/src/example/rules.py
+++ b/plugins/sqlfluff-plugin-example/src/example/rules.py
@@ -41,9 +41,9 @@ def get_configs_info() -> dict:
 
 # These two decorators allow plugins
 # to be displayed in the sqlfluff docs
+@document_groups
 @document_fix_compatible
 @document_configuration
-@document_groups
 class Rule_Example_L001(BaseRule):
     """ORDER BY on these columns is forbidden!
 

--- a/src/sqlfluff/core/rules/doc_decorators.py
+++ b/src/sqlfluff/core/rules/doc_decorators.py
@@ -5,7 +5,6 @@ from sqlfluff.core.rules.base import rules_logger  # noqa
 import re
 
 
-CORE_RULE = "    This rule is a Core SQLFluff rule."
 FIX_COMPATIBLE = "    This rule is ``sqlfluff fix`` compatible."
 
 
@@ -23,7 +22,7 @@ def document_fix_compatible(cls):
     return cls
 
 
-def is_fix_compatible(cls) -> bool:  # pragma: no cover TODO?
+def is_fix_compatible(cls) -> bool:
     """Return whether the rule is documented as fixable."""
     return FIX_COMPATIBLE in cls.__doc__
 
@@ -46,7 +45,7 @@ def document_groups(cls):
     return cls
 
 
-def is_documenting_groups(cls) -> bool:  # pragma: no cover TODO?
+def is_documenting_groups(cls) -> bool:
     """Return whether the rule groups are documented."""
     return "\n    **Groups**: " in cls.__doc__
 

--- a/src/sqlfluff/core/rules/doc_decorators.py
+++ b/src/sqlfluff/core/rules/doc_decorators.py
@@ -5,6 +5,7 @@ from sqlfluff.core.rules.base import rules_logger  # noqa
 import re
 
 
+CORE_RULE = "    This rule is a Core SQLFluff rule."
 FIX_COMPATIBLE = "    This rule is ``sqlfluff fix`` compatible."
 
 
@@ -25,6 +26,27 @@ def document_fix_compatible(cls):
 def is_fix_compatible(cls) -> bool:  # pragma: no cover TODO?
     """Return whether the rule is documented as fixable."""
     return FIX_COMPATIBLE in cls.__doc__
+
+
+def document_groups(cls):
+    """Mark the rule as fixable in the documentation."""
+    # Match `**Anti-pattern**`, `.. note::` and `**Configuration**`,
+    # then insert fix_compatible before the first occurrences.
+    # We match `**Configuration**` here to make it work in all order of doc decorators
+    pattern = re.compile(
+        "(\\s{4}\\*\\*Anti-pattern\\*\\*|\\s{4}\\.\\. note::|"
+        "\\s{4}\\*\\*Configuration\\*\\*)",
+        flags=re.MULTILINE,
+    )
+
+    groups_docs = "\n    **Groups**: " + ", ".join(cls.groups) + "\n"
+    cls.__doc__ = pattern.sub(f"\n\n{groups_docs}\n\n\\1", cls.__doc__, count=1)
+    return cls
+
+
+def is_documenting_groups(cls) -> bool:  # pragma: no cover TODO?
+    """Return whether the rule groups are documented."""
+    return "\n    **Groups**: " in cls.__doc__
 
 
 def document_configuration(cls, ruleset="std"):

--- a/src/sqlfluff/core/rules/doc_decorators.py
+++ b/src/sqlfluff/core/rules/doc_decorators.py
@@ -31,15 +31,17 @@ def is_fix_compatible(cls) -> bool:  # pragma: no cover TODO?
 def document_groups(cls):
     """Mark the rule as fixable in the documentation."""
     # Match `**Anti-pattern**`, `.. note::` and `**Configuration**`,
-    # then insert fix_compatible before the first occurrences.
+    # then insert group documentation    before the first occurrences.
     # We match `**Configuration**` here to make it work in all order of doc decorators
     pattern = re.compile(
         "(\\s{4}\\*\\*Anti-pattern\\*\\*|\\s{4}\\.\\. note::|"
-        "\\s{4}\\*\\*Configuration\\*\\*)",
+        "\\s\\s{4}\\*\\*Configuration\\*\\*)",
         flags=re.MULTILINE,
     )
 
-    groups_docs = "\n    **Groups**: " + ", ".join(cls.groups) + "\n"
+    groups_docs = (
+        "\n    **Groups**: ``" + "``, ``".join(getattr(cls, "groups")) + "``\n"
+    )
     cls.__doc__ = pattern.sub(f"\n\n{groups_docs}\n\n\\1", cls.__doc__, count=1)
     return cls
 

--- a/src/sqlfluff/rules/L001.py
+++ b/src/sqlfluff/rules/L001.py
@@ -7,8 +7,8 @@ from sqlfluff.core.rules.doc_decorators import (
 )
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L001(BaseRule):
     """Unnecessary trailing whitespace.
 

--- a/src/sqlfluff/rules/L001.py
+++ b/src/sqlfluff/rules/L001.py
@@ -1,10 +1,14 @@
 """Implementation of Rule L001."""
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.functional import segment_predicates as sp
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import (
+    document_fix_compatible,
+    document_groups,
+)
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L001(BaseRule):
     """Unnecessary trailing whitespace.
 

--- a/src/sqlfluff/rules/L002.py
+++ b/src/sqlfluff/rules/L002.py
@@ -10,8 +10,8 @@ from sqlfluff.core.rules.doc_decorators import (
 
 
 @document_configuration
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L002(BaseRule):
     """Mixed Tabs and Spaces in single whitespace.
 

--- a/src/sqlfluff/rules/L002.py
+++ b/src/sqlfluff/rules/L002.py
@@ -9,9 +9,9 @@ from sqlfluff.core.rules.doc_decorators import (
 )
 
 
-@document_configuration
 @document_groups
 @document_fix_compatible
+@document_configuration
 class Rule_L002(BaseRule):
     """Mixed Tabs and Spaces in single whitespace.
 

--- a/src/sqlfluff/rules/L002.py
+++ b/src/sqlfluff/rules/L002.py
@@ -5,11 +5,13 @@ from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
+    document_groups,
 )
 
 
 @document_configuration
 @document_fix_compatible
+@document_groups
 class Rule_L002(BaseRule):
     """Mixed Tabs and Spaces in single whitespace.
 

--- a/src/sqlfluff/rules/L003.py
+++ b/src/sqlfluff/rules/L003.py
@@ -8,8 +8,9 @@ from sqlfluff.core.parser.segments import BaseSegment
 from sqlfluff.core.rules.functional import rsp, sp, Segments
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
-    document_fix_compatible,
     document_configuration,
+    document_fix_compatible,
+    document_groups,
 )
 from sqlfluff.core.templaters import TemplatedFile
 from sqlfluff.core.templaters.base import RawFileSlice
@@ -160,6 +161,7 @@ class _Memory:
 
 @document_fix_compatible
 @document_configuration
+@document_groups
 class Rule_L003(BaseRule):
     """Indentation not consistent with previous lines.
 

--- a/src/sqlfluff/rules/L003.py
+++ b/src/sqlfluff/rules/L003.py
@@ -159,9 +159,9 @@ class _Memory:
         return self.hanging_lines.union(self.problem_lines)
 
 
+@document_groups
 @document_fix_compatible
 @document_configuration
-@document_groups
 class Rule_L003(BaseRule):
     """Indentation not consistent with previous lines.
 

--- a/src/sqlfluff/rules/L004.py
+++ b/src/sqlfluff/rules/L004.py
@@ -8,9 +8,9 @@ from sqlfluff.core.rules.doc_decorators import (
 )
 
 
+@document_groups
 @document_fix_compatible
 @document_configuration
-@document_groups
 class Rule_L004(BaseRule):
     """Incorrect indentation type.
 

--- a/src/sqlfluff/rules/L004.py
+++ b/src/sqlfluff/rules/L004.py
@@ -2,13 +2,15 @@
 from sqlfluff.core.parser import WhitespaceSegment
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
-    document_fix_compatible,
     document_configuration,
+    document_fix_compatible,
+    document_groups,
 )
 
 
 @document_fix_compatible
 @document_configuration
+@document_groups
 class Rule_L004(BaseRule):
     """Incorrect indentation type.
 

--- a/src/sqlfluff/rules/L005.py
+++ b/src/sqlfluff/rules/L005.py
@@ -6,8 +6,8 @@ from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L005(BaseRule):
     """Commas should not have whitespace directly before them.
 

--- a/src/sqlfluff/rules/L005.py
+++ b/src/sqlfluff/rules/L005.py
@@ -3,10 +3,11 @@ from typing import Optional
 
 from sqlfluff.core.parser import RawSegment
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L005(BaseRule):
     """Commas should not have whitespace directly before them.
 

--- a/src/sqlfluff/rules/L006.py
+++ b/src/sqlfluff/rules/L006.py
@@ -15,8 +15,8 @@ from sqlfluff.core.rules.base import (
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L006(BaseRule):
     """Operators should be surrounded by a single whitespace.
 

--- a/src/sqlfluff/rules/L006.py
+++ b/src/sqlfluff/rules/L006.py
@@ -12,10 +12,11 @@ from sqlfluff.core.rules.base import (
     RuleContext,
     EvalResultType,
 )
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L006(BaseRule):
     """Operators should be surrounded by a single whitespace.
 

--- a/src/sqlfluff/rules/L007.py
+++ b/src/sqlfluff/rules/L007.py
@@ -8,6 +8,7 @@ import sqlfluff.core.rules.functional.segment_predicates as sp
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
+    document_groups,
 )
 from sqlfluff.core.rules.functional.segments import Segments
 
@@ -17,6 +18,7 @@ before_description = "Operators near newlines should be before, not after the ne
 
 @document_fix_compatible
 @document_configuration
+@document_groups
 class Rule_L007(BaseRule):
     """Operators should follow a standard for being before/after newlines.
 

--- a/src/sqlfluff/rules/L007.py
+++ b/src/sqlfluff/rules/L007.py
@@ -16,9 +16,9 @@ after_description = "Operators near newlines should be after, not before the new
 before_description = "Operators near newlines should be before, not after the newline"
 
 
+@document_groups
 @document_fix_compatible
 @document_configuration
-@document_groups
 class Rule_L007(BaseRule):
     """Operators should follow a standard for being before/after newlines.
 

--- a/src/sqlfluff/rules/L008.py
+++ b/src/sqlfluff/rules/L008.py
@@ -10,8 +10,8 @@ import sqlfluff.core.rules.functional.segment_predicates as sp
 from sqlfluff.core.parser.segments.base import BaseSegment
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L008(BaseRule):
     """Commas should be followed by a single whitespace unless followed by a comment.
 

--- a/src/sqlfluff/rules/L008.py
+++ b/src/sqlfluff/rules/L008.py
@@ -4,13 +4,14 @@ from typing import Optional, Tuple
 from sqlfluff.core.parser import WhitespaceSegment
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
 from sqlfluff.core.parser.segments.base import BaseSegment
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L008(BaseRule):
     """Commas should be followed by a single whitespace unless followed by a comment.
 

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple
 
 from sqlfluff.core.parser import BaseSegment, NewlineSegment
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.core.rules.functional import Segments, sp, tsp
 
 
@@ -31,6 +31,7 @@ def get_last_segment(segment: Segments) -> Tuple[List[BaseSegment], Segments]:
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L009(BaseRule):
     """Files must end with a single trailing newline.
 

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -30,8 +30,8 @@ def get_last_segment(segment: Segments) -> Tuple[List[BaseSegment], Segments]:
             return parent_stack, segment
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L009(BaseRule):
     """Files must end with a single trailing newline.
 

--- a/src/sqlfluff/rules/L010.py
+++ b/src/sqlfluff/rules/L010.py
@@ -6,13 +6,15 @@ from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.config_info import get_config_info
 from sqlfluff.core.rules.doc_decorators import (
-    document_fix_compatible,
     document_configuration,
+    document_fix_compatible,
+    document_groups,
 )
 
 
 @document_fix_compatible
 @document_configuration
+@document_groups
 class Rule_L010(BaseRule):
     """Inconsistent capitalisation of keywords.
 

--- a/src/sqlfluff/rules/L010.py
+++ b/src/sqlfluff/rules/L010.py
@@ -12,9 +12,9 @@ from sqlfluff.core.rules.doc_decorators import (
 )
 
 
+@document_groups
 @document_fix_compatible
 @document_configuration
-@document_groups
 class Rule_L010(BaseRule):
     """Inconsistent capitalisation of keywords.
 

--- a/src/sqlfluff/rules/L011.py
+++ b/src/sqlfluff/rules/L011.py
@@ -8,13 +8,15 @@ from sqlfluff.core.parser import (
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
-    document_fix_compatible,
     document_configuration,
+    document_fix_compatible,
+    document_groups,
 )
 
 
 @document_fix_compatible
 @document_configuration
+@document_groups
 class Rule_L011(BaseRule):
     """Implicit/explicit aliasing of table.
 

--- a/src/sqlfluff/rules/L011.py
+++ b/src/sqlfluff/rules/L011.py
@@ -14,9 +14,9 @@ from sqlfluff.core.rules.doc_decorators import (
 )
 
 
+@document_groups
 @document_fix_compatible
 @document_configuration
-@document_groups
 class Rule_L011(BaseRule):
     """Implicit/explicit aliasing of table.
 

--- a/src/sqlfluff/rules/L012.py
+++ b/src/sqlfluff/rules/L012.py
@@ -2,11 +2,12 @@
 from typing import Optional
 
 from sqlfluff.rules.L011 import Rule_L011
-from sqlfluff.core.rules.doc_decorators import document_configuration
+from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 from sqlfluff.core.rules.base import LintResult, RuleContext
 
 
 @document_configuration
+@document_groups
 class Rule_L012(Rule_L011):
     """Implicit/explicit aliasing of columns.
 

--- a/src/sqlfluff/rules/L012.py
+++ b/src/sqlfluff/rules/L012.py
@@ -6,8 +6,8 @@ from sqlfluff.core.rules.doc_decorators import document_configuration, document_
 from sqlfluff.core.rules.base import LintResult, RuleContext
 
 
-@document_configuration
 @document_groups
+@document_configuration
 class Rule_L012(Rule_L011):
     """Implicit/explicit aliasing of columns.
 

--- a/src/sqlfluff/rules/L013.py
+++ b/src/sqlfluff/rules/L013.py
@@ -7,8 +7,8 @@ import sqlfluff.core.rules.functional.segment_predicates as sp
 from sqlfluff.core.rules.functional.segments import Segments
 
 
-@document_configuration
 @document_groups
+@document_configuration
 class Rule_L013(BaseRule):
     """Column expression without alias. Use explicit `AS` clause.
 

--- a/src/sqlfluff/rules/L013.py
+++ b/src/sqlfluff/rules/L013.py
@@ -2,12 +2,13 @@
 from typing import Optional
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_configuration
+from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 import sqlfluff.core.rules.functional.segment_predicates as sp
 from sqlfluff.core.rules.functional.segments import Segments
 
 
 @document_configuration
+@document_groups
 class Rule_L013(BaseRule):
     """Column expression without alias. Use explicit `AS` clause.
 

--- a/src/sqlfluff/rules/L014.py
+++ b/src/sqlfluff/rules/L014.py
@@ -32,8 +32,8 @@ def identifiers_policy_applicable(
 
 
 @document_configuration
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L014(Rule_L010):
     """Inconsistent capitalisation of unquoted identifiers.
 

--- a/src/sqlfluff/rules/L014.py
+++ b/src/sqlfluff/rules/L014.py
@@ -7,6 +7,7 @@ from sqlfluff.core.rules.base import LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
+    document_groups,
 )
 from sqlfluff.rules.L010 import Rule_L010
 
@@ -32,6 +33,7 @@ def identifiers_policy_applicable(
 
 @document_configuration
 @document_fix_compatible
+@document_groups
 class Rule_L014(Rule_L010):
     """Inconsistent capitalisation of unquoted identifiers.
 

--- a/src/sqlfluff/rules/L014.py
+++ b/src/sqlfluff/rules/L014.py
@@ -31,9 +31,9 @@ def identifiers_policy_applicable(
     return False
 
 
-@document_configuration
 @document_groups
 @document_fix_compatible
+@document_configuration
 class Rule_L014(Rule_L010):
     """Inconsistent capitalisation of unquoted identifiers.
 

--- a/src/sqlfluff/rules/L015.py
+++ b/src/sqlfluff/rules/L015.py
@@ -8,8 +8,8 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L015(BaseRule):
     """``DISTINCT`` used with parentheses.
 

--- a/src/sqlfluff/rules/L015.py
+++ b/src/sqlfluff/rules/L015.py
@@ -4,11 +4,12 @@ from typing import Optional
 from sqlfluff.core.parser import WhitespaceSegment
 
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L015(BaseRule):
     """``DISTINCT`` used with parentheses.
 

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -12,14 +12,16 @@ from sqlfluff.core.parser import (
 from sqlfluff.core.rules.base import LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.functional import sp
 from sqlfluff.core.rules.doc_decorators import (
-    document_fix_compatible,
     document_configuration,
+    document_fix_compatible,
+    document_groups,
 )
 from sqlfluff.rules.L003 import Rule_L003
 
 
 @document_fix_compatible
 @document_configuration
+@document_groups
 class Rule_L016(Rule_L003):
     """Line is too long."""
 

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -19,9 +19,9 @@ from sqlfluff.core.rules.doc_decorators import (
 from sqlfluff.rules.L003 import Rule_L003
 
 
+@document_groups
 @document_fix_compatible
 @document_configuration
-@document_groups
 class Rule_L016(Rule_L003):
     """Line is too long."""
 

--- a/src/sqlfluff/rules/L017.py
+++ b/src/sqlfluff/rules/L017.py
@@ -5,8 +5,8 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L017(BaseRule):
     """Function name not immediately followed by parenthesis.
 

--- a/src/sqlfluff/rules/L017.py
+++ b/src/sqlfluff/rules/L017.py
@@ -1,11 +1,12 @@
 """Implementation of Rule L017."""
 
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L017(BaseRule):
     """Function name not immediately followed by parenthesis.
 

--- a/src/sqlfluff/rules/L018.py
+++ b/src/sqlfluff/rules/L018.py
@@ -11,14 +11,16 @@ from sqlfluff.core.parser import (
 
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
-    document_fix_compatible,
     document_configuration,
+    document_fix_compatible,
+    document_groups,
 )
 from sqlfluff.core.rules.functional import sp
 
 
 @document_fix_compatible
 @document_configuration
+@document_groups
 class Rule_L018(BaseRule):
     """``WITH`` clause closing bracket should be aligned with ``WITH`` keyword.
 

--- a/src/sqlfluff/rules/L018.py
+++ b/src/sqlfluff/rules/L018.py
@@ -18,9 +18,9 @@ from sqlfluff.core.rules.doc_decorators import (
 from sqlfluff.core.rules.functional import sp
 
 
+@document_groups
 @document_fix_compatible
 @document_configuration
-@document_groups
 class Rule_L018(BaseRule):
     """``WITH`` clause closing bracket should be aligned with ``WITH`` keyword.
 

--- a/src/sqlfluff/rules/L019.py
+++ b/src/sqlfluff/rules/L019.py
@@ -5,13 +5,15 @@ from typing import Any, Dict, Optional, Tuple
 from sqlfluff.core.parser import RawSegment, WhitespaceSegment
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
-    document_fix_compatible,
     document_configuration,
+    document_fix_compatible,
+    document_groups,
 )
 
 
 @document_fix_compatible
 @document_configuration
+@document_groups
 class Rule_L019(BaseRule):
     """Leading/Trailing comma enforcement.
 

--- a/src/sqlfluff/rules/L019.py
+++ b/src/sqlfluff/rules/L019.py
@@ -11,9 +11,9 @@ from sqlfluff.core.rules.doc_decorators import (
 )
 
 
+@document_groups
 @document_fix_compatible
 @document_configuration
-@document_groups
 class Rule_L019(BaseRule):
     """Leading/Trailing comma enforcement.
 

--- a/src/sqlfluff/rules/L020.py
+++ b/src/sqlfluff/rules/L020.py
@@ -7,8 +7,10 @@ from sqlfluff.core.dialects.common import AliasInfo, ColumnAliasInfo
 from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext, EvalResultType
 from sqlfluff.core.rules.analysis.select import get_select_statement_info
+from sqlfluff.core.rules.doc_decorators import document_groups
 
 
+@document_groups
 class Rule_L020(BaseRule):
     """Table aliases should be unique within each clause.
 

--- a/src/sqlfluff/rules/L021.py
+++ b/src/sqlfluff/rules/L021.py
@@ -3,8 +3,10 @@ from typing import Optional
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
 import sqlfluff.core.rules.functional.segment_predicates as sp
+from sqlfluff.core.rules.doc_decorators import document_groups
 
 
+@document_groups
 class Rule_L021(BaseRule):
     """Ambiguous use of ``DISTINCT`` in a ``SELECT`` statement with ``GROUP BY``.
 

--- a/src/sqlfluff/rules/L022.py
+++ b/src/sqlfluff/rules/L022.py
@@ -11,9 +11,9 @@ from sqlfluff.core.rules.doc_decorators import (
 )
 
 
+@document_groups
 @document_fix_compatible
 @document_configuration
-@document_groups
 class Rule_L022(BaseRule):
     """Blank line expected but not found after CTE closing bracket.
 

--- a/src/sqlfluff/rules/L022.py
+++ b/src/sqlfluff/rules/L022.py
@@ -5,13 +5,15 @@ from sqlfluff.core.parser import NewlineSegment
 
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
-    document_fix_compatible,
     document_configuration,
+    document_fix_compatible,
+    document_groups,
 )
 
 
 @document_fix_compatible
 @document_configuration
+@document_groups
 class Rule_L022(BaseRule):
     """Blank line expected but not found after CTE closing bracket.
 

--- a/src/sqlfluff/rules/L023.py
+++ b/src/sqlfluff/rules/L023.py
@@ -8,8 +8,8 @@ from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L023(BaseRule):
     """Single whitespace expected after ``AS`` in ``WITH`` clause.
 

--- a/src/sqlfluff/rules/L023.py
+++ b/src/sqlfluff/rules/L023.py
@@ -5,10 +5,11 @@ from typing import Optional, List
 from sqlfluff.core.parser import BaseSegment, WhitespaceSegment
 
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L023(BaseRule):
     """Single whitespace expected after ``AS`` in ``WITH`` clause.
 

--- a/src/sqlfluff/rules/L024.py
+++ b/src/sqlfluff/rules/L024.py
@@ -5,8 +5,8 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document
 from sqlfluff.rules.L023 import Rule_L023
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L024(Rule_L023):
     """Single whitespace expected after ``USING`` in ``JOIN`` clause.
 

--- a/src/sqlfluff/rules/L024.py
+++ b/src/sqlfluff/rules/L024.py
@@ -1,11 +1,12 @@
 """Implementation of Rule L024."""
 
 
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.rules.L023 import Rule_L023
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L024(Rule_L023):
     """Single whitespace expected after ``USING`` in ``JOIN`` clause.
 

--- a/src/sqlfluff/rules/L025.py
+++ b/src/sqlfluff/rules/L025.py
@@ -29,8 +29,8 @@ class L025Query(SelectCrawlerQuery):
     tbl_refs: Set[str] = field(default_factory=set)
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L025(BaseRule):
     """Tables should not be aliased if that alias is not used.
 

--- a/src/sqlfluff/rules/L025.py
+++ b/src/sqlfluff/rules/L025.py
@@ -16,7 +16,7 @@ from sqlfluff.core.rules.base import (
     RuleContext,
     EvalResultType,
 )
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.core.rules.functional import Segments, sp
 from sqlfluff.core.dialects.common import AliasInfo
 
@@ -30,6 +30,7 @@ class L025Query(SelectCrawlerQuery):
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L025(BaseRule):
     """Tables should not be aliased if that alias is not used.
 

--- a/src/sqlfluff/rules/L026.py
+++ b/src/sqlfluff/rules/L026.py
@@ -14,7 +14,7 @@ from sqlfluff.core.rules.base import (
     RuleContext,
     EvalResultType,
 )
-from sqlfluff.core.rules.doc_decorators import document_configuration
+from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 from sqlfluff.core.rules.functional import sp
 from sqlfluff.core.rules.reference import object_ref_matches_table
 
@@ -27,6 +27,7 @@ class L026Query(SelectCrawlerQuery):
 
 
 @document_configuration
+@document_groups
 class Rule_L026(BaseRule):
     """References cannot reference objects not present in ``FROM`` clause.
 

--- a/src/sqlfluff/rules/L026.py
+++ b/src/sqlfluff/rules/L026.py
@@ -26,8 +26,8 @@ class L026Query(SelectCrawlerQuery):
     aliases: List[AliasInfo] = field(default_factory=list)
 
 
-@document_configuration
 @document_groups
+@document_configuration
 class Rule_L026(BaseRule):
     """References cannot reference objects not present in ``FROM`` clause.
 

--- a/src/sqlfluff/rules/L027.py
+++ b/src/sqlfluff/rules/L027.py
@@ -2,8 +2,10 @@
 
 from sqlfluff.core.rules.base import LintResult
 from sqlfluff.rules.L020 import Rule_L020
+from sqlfluff.core.rules.doc_decorators import document_groups
 
 
+@document_groups
 class Rule_L027(Rule_L020):
     """References should be qualified if select has more than one referenced table/view.
 

--- a/src/sqlfluff/rules/L028.py
+++ b/src/sqlfluff/rules/L028.py
@@ -22,8 +22,8 @@ from sqlfluff.core.rules.doc_decorators import (
 
 
 @document_configuration
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L028(BaseRule):
     """References should be consistent in statements with a single table.
 

--- a/src/sqlfluff/rules/L028.py
+++ b/src/sqlfluff/rules/L028.py
@@ -17,11 +17,13 @@ from sqlfluff.core.rules.functional import sp
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
+    document_groups,
 )
 
 
 @document_configuration
 @document_fix_compatible
+@document_groups
 class Rule_L028(BaseRule):
     """References should be consistent in statements with a single table.
 

--- a/src/sqlfluff/rules/L028.py
+++ b/src/sqlfluff/rules/L028.py
@@ -21,9 +21,9 @@ from sqlfluff.core.rules.doc_decorators import (
 )
 
 
-@document_configuration
 @document_groups
 @document_fix_compatible
+@document_configuration
 class Rule_L028(BaseRule):
     """References should be consistent in statements with a single table.
 

--- a/src/sqlfluff/rules/L029.py
+++ b/src/sqlfluff/rules/L029.py
@@ -3,11 +3,12 @@ import regex
 from typing import Optional, Tuple, List
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_configuration
+from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 from sqlfluff.rules.L014 import identifiers_policy_applicable
 
 
 @document_configuration
+@document_groups
 class Rule_L029(BaseRule):
     """Keywords should not be used as identifiers.
 

--- a/src/sqlfluff/rules/L029.py
+++ b/src/sqlfluff/rules/L029.py
@@ -7,8 +7,8 @@ from sqlfluff.core.rules.doc_decorators import document_configuration, document_
 from sqlfluff.rules.L014 import identifiers_policy_applicable
 
 
-@document_configuration
 @document_groups
+@document_configuration
 class Rule_L029(BaseRule):
     """Keywords should not be used as identifiers.
 

--- a/src/sqlfluff/rules/L030.py
+++ b/src/sqlfluff/rules/L030.py
@@ -5,12 +5,14 @@ from typing import List, Tuple
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
+    document_groups,
 )
 from sqlfluff.rules.L010 import Rule_L010
 
 
 @document_configuration
 @document_fix_compatible
+@document_groups
 class Rule_L030(Rule_L010):
     """Inconsistent capitalisation of function names.
 

--- a/src/sqlfluff/rules/L030.py
+++ b/src/sqlfluff/rules/L030.py
@@ -11,8 +11,8 @@ from sqlfluff.rules.L010 import Rule_L010
 
 
 @document_configuration
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L030(Rule_L010):
     """Inconsistent capitalisation of function names.
 

--- a/src/sqlfluff/rules/L030.py
+++ b/src/sqlfluff/rules/L030.py
@@ -10,9 +10,9 @@ from sqlfluff.core.rules.doc_decorators import (
 from sqlfluff.rules.L010 import Rule_L010
 
 
-@document_configuration
 @document_groups
 @document_fix_compatible
+@document_configuration
 class Rule_L030(Rule_L010):
     """Inconsistent capitalisation of function names.
 

--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -8,6 +8,7 @@ from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
+    document_groups,
 )
 
 import sqlfluff.core.rules.functional.segment_predicates as sp
@@ -24,6 +25,7 @@ class TableAliasInfo(NamedTuple):
 
 @document_fix_compatible
 @document_configuration
+@document_groups
 class Rule_L031(BaseRule):
     """Avoid table aliases in from clauses and join conditions.
 

--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -23,9 +23,9 @@ class TableAliasInfo(NamedTuple):
     alias_identifier_ref: BaseSegment
 
 
+@document_groups
 @document_fix_compatible
 @document_configuration
-@document_groups
 class Rule_L031(BaseRule):
     """Avoid table aliases in from clauses and join conditions.
 

--- a/src/sqlfluff/rules/L032.py
+++ b/src/sqlfluff/rules/L032.py
@@ -15,8 +15,8 @@ from sqlfluff.core.rules.analysis.select import get_select_statement_info
 from sqlfluff.dialects.dialect_ansi import ColumnReferenceSegment
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L032(BaseRule):
     """Prefer specifying join keys instead of using ``USING``.
 

--- a/src/sqlfluff/rules/L032.py
+++ b/src/sqlfluff/rules/L032.py
@@ -8,7 +8,7 @@ from sqlfluff.core.parser.segments.raw import (
     WhitespaceSegment,
 )
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 import sqlfluff.core.rules.functional.segment_predicates as sp
 from sqlfluff.core.rules.functional.segments import Segments
 from sqlfluff.core.rules.analysis.select import get_select_statement_info
@@ -16,6 +16,7 @@ from sqlfluff.dialects.dialect_ansi import ColumnReferenceSegment
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L032(BaseRule):
     """Prefer specifying join keys instead of using ``USING``.
 

--- a/src/sqlfluff/rules/L033.py
+++ b/src/sqlfluff/rules/L033.py
@@ -5,8 +5,10 @@ from sqlfluff.core.parser import (
 )
 
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
+from sqlfluff.core.rules.doc_decorators import document_groups
 
 
+@document_groups
 class Rule_L033(BaseRule):
     """``UNION [DISTINCT|ALL]`` is preferred over just ``UNION``.
 

--- a/src/sqlfluff/rules/L034.py
+++ b/src/sqlfluff/rules/L034.py
@@ -6,8 +6,8 @@ from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L034(BaseRule):
     """Select wildcards then simple targets before calculations and aggregates.
 

--- a/src/sqlfluff/rules/L034.py
+++ b/src/sqlfluff/rules/L034.py
@@ -3,10 +3,11 @@ from typing import List, Optional
 
 from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L034(BaseRule):
     """Select wildcards then simple targets before calculations and aggregates.
 

--- a/src/sqlfluff/rules/L035.py
+++ b/src/sqlfluff/rules/L035.py
@@ -2,11 +2,12 @@
 from typing import Optional
 
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L035(BaseRule):
     """Do not specify ``else null`` in a case when statement (redundant).
 

--- a/src/sqlfluff/rules/L035.py
+++ b/src/sqlfluff/rules/L035.py
@@ -6,8 +6,8 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L035(BaseRule):
     """Do not specify ``else null`` in a case when statement (redundant).
 

--- a/src/sqlfluff/rules/L036.py
+++ b/src/sqlfluff/rules/L036.py
@@ -7,7 +7,7 @@ from sqlfluff.core.parser import WhitespaceSegment
 from sqlfluff.core.parser import BaseSegment, NewlineSegment
 from sqlfluff.core.parser.segments.base import IdentitySet
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.core.rules.functional import Segments
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
@@ -26,6 +26,7 @@ class SelectTargetsInfo(NamedTuple):
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L036(BaseRule):
     """Select targets should be on a new line unless there is only one select target.
 

--- a/src/sqlfluff/rules/L036.py
+++ b/src/sqlfluff/rules/L036.py
@@ -25,8 +25,8 @@ class SelectTargetsInfo(NamedTuple):
     pre_from_whitespace: List[BaseSegment]
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L036(BaseRule):
     """Select targets should be on a new line unless there is only one select target.
 

--- a/src/sqlfluff/rules/L037.py
+++ b/src/sqlfluff/rules/L037.py
@@ -6,7 +6,7 @@ from sqlfluff.core.parser import WhitespaceSegment, KeywordSegment
 
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.parser import BaseSegment
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
 class OrderByColumnInfo(NamedTuple):
@@ -17,6 +17,7 @@ class OrderByColumnInfo(NamedTuple):
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L037(BaseRule):
     """Ambiguous ordering directions for columns in order by clause.
 

--- a/src/sqlfluff/rules/L037.py
+++ b/src/sqlfluff/rules/L037.py
@@ -16,8 +16,8 @@ class OrderByColumnInfo(NamedTuple):
     order: Optional[str]  # One of 'ASC'/'DESC'/None
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L037(BaseRule):
     """Ambiguous ordering directions for columns in order by clause.
 

--- a/src/sqlfluff/rules/L038.py
+++ b/src/sqlfluff/rules/L038.py
@@ -12,9 +12,9 @@ from sqlfluff.core.rules.doc_decorators import (
 )
 
 
-@document_configuration
 @document_groups
 @document_fix_compatible
+@document_configuration
 class Rule_L038(BaseRule):
     """Trailing commas within select clause.
 

--- a/src/sqlfluff/rules/L038.py
+++ b/src/sqlfluff/rules/L038.py
@@ -13,8 +13,8 @@ from sqlfluff.core.rules.doc_decorators import (
 
 
 @document_configuration
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L038(BaseRule):
     """Trailing commas within select clause.
 

--- a/src/sqlfluff/rules/L038.py
+++ b/src/sqlfluff/rules/L038.py
@@ -6,13 +6,15 @@ from sqlfluff.core.parser import BaseSegment, SymbolSegment
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 import sqlfluff.core.rules.functional.segment_predicates as sp
 from sqlfluff.core.rules.doc_decorators import (
-    document_fix_compatible,
     document_configuration,
+    document_fix_compatible,
+    document_groups,
 )
 
 
 @document_configuration
 @document_fix_compatible
+@document_groups
 class Rule_L038(BaseRule):
     """Trailing commas within select clause.
 

--- a/src/sqlfluff/rules/L039.py
+++ b/src/sqlfluff/rules/L039.py
@@ -8,8 +8,8 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document
 from sqlfluff.core.rules.functional import sp
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L039(BaseRule):
     """Unnecessary whitespace found.
 

--- a/src/sqlfluff/rules/L039.py
+++ b/src/sqlfluff/rules/L039.py
@@ -4,11 +4,12 @@ from typing import List, Optional
 from sqlfluff.core.parser import WhitespaceSegment
 from sqlfluff.core.parser.segments.base import IdentitySet
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.core.rules.functional import sp
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L039(BaseRule):
     """Unnecessary whitespace found.
 

--- a/src/sqlfluff/rules/L040.py
+++ b/src/sqlfluff/rules/L040.py
@@ -5,12 +5,14 @@ from typing import Tuple, List
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
+    document_groups,
 )
 from sqlfluff.rules.L010 import Rule_L010
 
 
 @document_configuration
 @document_fix_compatible
+@document_groups
 class Rule_L040(Rule_L010):
     """Inconsistent capitalisation of boolean/null literal.
 

--- a/src/sqlfluff/rules/L040.py
+++ b/src/sqlfluff/rules/L040.py
@@ -11,8 +11,8 @@ from sqlfluff.rules.L010 import Rule_L010
 
 
 @document_configuration
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L040(Rule_L010):
     """Inconsistent capitalisation of boolean/null literal.
 

--- a/src/sqlfluff/rules/L040.py
+++ b/src/sqlfluff/rules/L040.py
@@ -10,9 +10,9 @@ from sqlfluff.core.rules.doc_decorators import (
 from sqlfluff.rules.L010 import Rule_L010
 
 
-@document_configuration
 @document_groups
 @document_fix_compatible
+@document_configuration
 class Rule_L040(Rule_L010):
     """Inconsistent capitalisation of boolean/null literal.
 

--- a/src/sqlfluff/rules/L041.py
+++ b/src/sqlfluff/rules/L041.py
@@ -8,8 +8,8 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document
 from sqlfluff.core.rules.functional import sp
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L041(BaseRule):
     """``SELECT`` modifiers (e.g. ``DISTINCT``) must be on the same line as ``SELECT``.
 

--- a/src/sqlfluff/rules/L041.py
+++ b/src/sqlfluff/rules/L041.py
@@ -4,11 +4,12 @@ from typing import Optional
 from sqlfluff.core.parser import NewlineSegment, WhitespaceSegment
 
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.core.rules.functional import sp
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L041(BaseRule):
     """``SELECT`` modifiers (e.g. ``DISTINCT``) must be on the same line as ``SELECT``.
 

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -18,6 +18,7 @@ from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
+    document_groups,
 )
 from sqlfluff.core.rules.functional.segment_predicates import is_name, is_type
 from sqlfluff.core.rules.functional.segments import Segments
@@ -38,6 +39,7 @@ class _NestedSubQuerySummary(NamedTuple):
 
 @document_fix_compatible
 @document_configuration
+@document_groups
 class Rule_L042(BaseRule):
     """Join/From clauses should not contain subqueries. Use CTEs instead.
 

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -37,9 +37,9 @@ class _NestedSubQuerySummary(NamedTuple):
     subquery: BaseSegment
 
 
+@document_groups
 @document_fix_compatible
 @document_configuration
-@document_groups
 class Rule_L042(BaseRule):
     """Join/From clauses should not contain subqueries. Use CTEs instead.
 

--- a/src/sqlfluff/rules/L043.py
+++ b/src/sqlfluff/rules/L043.py
@@ -13,8 +13,8 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document
 from sqlfluff.core.rules.functional import Segments, sp
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L043(BaseRule):
     """Unnecessary ``CASE`` statement.
 

--- a/src/sqlfluff/rules/L043.py
+++ b/src/sqlfluff/rules/L043.py
@@ -9,11 +9,12 @@ from sqlfluff.core.parser import (
 from sqlfluff.core.parser.segments.base import BaseSegment
 
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.core.rules.functional import Segments, sp
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L043(BaseRule):
     """Unnecessary ``CASE`` statement.
 

--- a/src/sqlfluff/rules/L044.py
+++ b/src/sqlfluff/rules/L044.py
@@ -4,6 +4,7 @@ from typing import Optional
 from sqlfluff.core.rules.analysis.select_crawler import Query, SelectCrawler
 from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.doc_decorators import document_groups
 from sqlfluff.core.rules.functional import sp
 
 
@@ -14,6 +15,7 @@ class RuleFailure(Exception):
         self.anchor: BaseSegment = anchor
 
 
+@document_groups
 class Rule_L044(BaseRule):
     """Query produces an unknown number of result columns.
 

--- a/src/sqlfluff/rules/L045.py
+++ b/src/sqlfluff/rules/L045.py
@@ -1,8 +1,10 @@
 """Implementation of Rule L045."""
 from sqlfluff.core.rules.base import BaseRule, EvalResultType, LintResult, RuleContext
 from sqlfluff.core.rules.analysis.select_crawler import Query, SelectCrawler
+from sqlfluff.core.rules.doc_decorators import document_groups
 
 
+@document_groups
 class Rule_L045(BaseRule):
     """Query defines a CTE (common-table expression) but does not use it.
 

--- a/src/sqlfluff/rules/L046.py
+++ b/src/sqlfluff/rules/L046.py
@@ -3,8 +3,10 @@ from typing import Tuple
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.functional import rsp
+from sqlfluff.core.rules.doc_decorators import document_groups
 
 
+@document_groups
 class Rule_L046(BaseRule):
     """Jinja tags should have a single whitespace on either side.
 

--- a/src/sqlfluff/rules/L047.py
+++ b/src/sqlfluff/rules/L047.py
@@ -5,12 +5,14 @@ from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
+    document_groups,
 )
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
 
 @document_configuration
 @document_fix_compatible
+@document_groups
 class Rule_L047(BaseRule):
     """Use consistent syntax to express "count number of rows".
 

--- a/src/sqlfluff/rules/L047.py
+++ b/src/sqlfluff/rules/L047.py
@@ -11,8 +11,8 @@ import sqlfluff.core.rules.functional.segment_predicates as sp
 
 
 @document_configuration
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L047(BaseRule):
     """Use consistent syntax to express "count number of rows".
 

--- a/src/sqlfluff/rules/L047.py
+++ b/src/sqlfluff/rules/L047.py
@@ -10,9 +10,9 @@ from sqlfluff.core.rules.doc_decorators import (
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
 
-@document_configuration
 @document_groups
 @document_fix_compatible
+@document_configuration
 class Rule_L047(BaseRule):
     """Use consistent syntax to express "count number of rows".
 

--- a/src/sqlfluff/rules/L048.py
+++ b/src/sqlfluff/rules/L048.py
@@ -3,12 +3,13 @@
 from typing import Tuple, List
 
 from sqlfluff.core.parser import BaseSegment
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 from sqlfluff.rules.L006 import Rule_L006
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L048(Rule_L006):
     """Quoted literals should be surrounded by a single whitespace.
 

--- a/src/sqlfluff/rules/L048.py
+++ b/src/sqlfluff/rules/L048.py
@@ -8,8 +8,8 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document
 from sqlfluff.rules.L006 import Rule_L006
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L048(Rule_L006):
     """Quoted literals should be surrounded by a single whitespace.
 

--- a/src/sqlfluff/rules/L049.py
+++ b/src/sqlfluff/rules/L049.py
@@ -11,8 +11,8 @@ import sqlfluff.core.rules.functional.segment_predicates as sp
 CorrectionListType = List[Union[WhitespaceSegment, KeywordSegment]]
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L049(Rule_L006):
     """Comparisons with NULL should use "IS" or "IS NOT".
 

--- a/src/sqlfluff/rules/L049.py
+++ b/src/sqlfluff/rules/L049.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 
 from sqlfluff.core.parser import KeywordSegment, WhitespaceSegment
 from sqlfluff.core.rules.base import LintResult, LintFix, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.rules.L006 import Rule_L006
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
@@ -12,6 +12,7 @@ CorrectionListType = List[Union[WhitespaceSegment, KeywordSegment]]
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L049(Rule_L006):
     """Comparisons with NULL should use "IS" or "IS NOT".
 

--- a/src/sqlfluff/rules/L050.py
+++ b/src/sqlfluff/rules/L050.py
@@ -8,8 +8,8 @@ import sqlfluff.core.rules.functional.raw_file_slice_predicates as rsp
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L050(BaseRule):
     """Files must not begin with newlines or whitespace.
 

--- a/src/sqlfluff/rules/L050.py
+++ b/src/sqlfluff/rules/L050.py
@@ -5,10 +5,11 @@ from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.functional import Segments
 import sqlfluff.core.rules.functional.segment_predicates as sp
 import sqlfluff.core.rules.functional.raw_file_slice_predicates as rsp
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L050(BaseRule):
     """Files must not begin with newlines or whitespace.
 

--- a/src/sqlfluff/rules/L051.py
+++ b/src/sqlfluff/rules/L051.py
@@ -4,13 +4,15 @@ from sqlfluff.core.parser.segments.raw import KeywordSegment, WhitespaceSegment
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
-    document_fix_compatible,
     document_configuration,
+    document_fix_compatible,
+    document_groups,
 )
 
 
 @document_fix_compatible
 @document_configuration
+@document_groups
 class Rule_L051(BaseRule):
     """Join clauses should be fully qualified.
 

--- a/src/sqlfluff/rules/L051.py
+++ b/src/sqlfluff/rules/L051.py
@@ -10,9 +10,9 @@ from sqlfluff.core.rules.doc_decorators import (
 )
 
 
+@document_groups
 @document_fix_compatible
 @document_configuration
-@document_groups
 class Rule_L051(BaseRule):
     """Join clauses should be fully qualified.
 

--- a/src/sqlfluff/rules/L052.py
+++ b/src/sqlfluff/rules/L052.py
@@ -23,9 +23,9 @@ class SegmentMoveContext(NamedTuple):
     whitespace_deletions: Segments
 
 
-@document_configuration
 @document_groups
 @document_fix_compatible
+@document_configuration
 class Rule_L052(BaseRule):
     """Statements must end with a semi-colon.
 

--- a/src/sqlfluff/rules/L052.py
+++ b/src/sqlfluff/rules/L052.py
@@ -24,8 +24,8 @@ class SegmentMoveContext(NamedTuple):
 
 
 @document_configuration
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L052(BaseRule):
     """Statements must end with a semi-colon.
 

--- a/src/sqlfluff/rules/L052.py
+++ b/src/sqlfluff/rules/L052.py
@@ -9,6 +9,7 @@ from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
+    document_groups,
 )
 from sqlfluff.core.rules.functional import Segments, sp
 
@@ -24,6 +25,7 @@ class SegmentMoveContext(NamedTuple):
 
 @document_configuration
 @document_fix_compatible
+@document_groups
 class Rule_L052(BaseRule):
     """Statements must end with a semi-colon.
 

--- a/src/sqlfluff/rules/L053.py
+++ b/src/sqlfluff/rules/L053.py
@@ -7,8 +7,8 @@ from sqlfluff.core.rules.functional import Segments, sp
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L053(BaseRule):
     """Top-level statements should not be wrapped in brackets.
 

--- a/src/sqlfluff/rules/L053.py
+++ b/src/sqlfluff/rules/L053.py
@@ -4,10 +4,11 @@ from typing import Optional
 from sqlfluff.core.parser.segments.base import IdentitySet
 from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.functional import Segments, sp
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L053(BaseRule):
     """Top-level statements should not be wrapped in brackets.
 

--- a/src/sqlfluff/rules/L054.py
+++ b/src/sqlfluff/rules/L054.py
@@ -6,8 +6,8 @@ from sqlfluff.core.rules.doc_decorators import document_configuration, document_
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
 
-@document_configuration
 @document_groups
+@document_configuration
 class Rule_L054(BaseRule):
     """Inconsistent column references in ``GROUP BY/ORDER BY`` clauses.
 

--- a/src/sqlfluff/rules/L054.py
+++ b/src/sqlfluff/rules/L054.py
@@ -2,13 +2,12 @@
 from typing import Optional, List
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-)
+from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
 
 @document_configuration
+@document_groups
 class Rule_L054(BaseRule):
     """Inconsistent column references in ``GROUP BY/ORDER BY`` clauses.
 

--- a/src/sqlfluff/rules/L055.py
+++ b/src/sqlfluff/rules/L055.py
@@ -2,8 +2,10 @@
 from typing import Optional
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.doc_decorators import document_groups
 
 
+@document_groups
 class Rule_L055(BaseRule):
     """Use ``LEFT JOIN`` instead of ``RIGHT JOIN``.
 

--- a/src/sqlfluff/rules/L056.py
+++ b/src/sqlfluff/rules/L056.py
@@ -2,8 +2,10 @@
 from typing import Optional
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.doc_decorators import document_groups
 
 
+@document_groups
 class Rule_L056(BaseRule):
     r"""``SP_`` prefix should not be used for user-defined stored procedures in T-SQL.
 

--- a/src/sqlfluff/rules/L057.py
+++ b/src/sqlfluff/rules/L057.py
@@ -7,8 +7,8 @@ from sqlfluff.core.rules.doc_decorators import document_configuration, document_
 from sqlfluff.rules.L014 import identifiers_policy_applicable
 
 
-@document_configuration
 @document_groups
+@document_configuration
 class Rule_L057(BaseRule):
     """Do not use special characters in identifiers.
 

--- a/src/sqlfluff/rules/L057.py
+++ b/src/sqlfluff/rules/L057.py
@@ -3,13 +3,12 @@ import regex
 from typing import Optional
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-)
+from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 from sqlfluff.rules.L014 import identifiers_policy_applicable
 
 
 @document_configuration
+@document_groups
 class Rule_L057(BaseRule):
     """Do not use special characters in identifiers.
 

--- a/src/sqlfluff/rules/L058.py
+++ b/src/sqlfluff/rules/L058.py
@@ -6,8 +6,8 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document
 from sqlfluff.core.rules.functional import sp
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L058(BaseRule):
     """Nested ``CASE`` statement in ``ELSE`` clause could be flattened.
 

--- a/src/sqlfluff/rules/L058.py
+++ b/src/sqlfluff/rules/L058.py
@@ -2,11 +2,12 @@
 
 from sqlfluff.core.parser import NewlineSegment, WhitespaceSegment
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.core.rules.functional import sp
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L058(BaseRule):
     """Nested ``CASE`` statement in ``ELSE`` clause could be flattened.
 

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -9,12 +9,14 @@ from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
+    document_groups,
 )
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
 
 @document_configuration
 @document_fix_compatible
+@document_groups
 class Rule_L059(BaseRule):
     """Unnecessary quoted identifier.
 

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -15,8 +15,8 @@ import sqlfluff.core.rules.functional.segment_predicates as sp
 
 
 @document_configuration
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L059(BaseRule):
     """Unnecessary quoted identifier.
 

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -14,9 +14,9 @@ from sqlfluff.core.rules.doc_decorators import (
 import sqlfluff.core.rules.functional.segment_predicates as sp
 
 
-@document_configuration
 @document_groups
 @document_fix_compatible
+@document_configuration
 class Rule_L059(BaseRule):
     """Unnecessary quoted identifier.
 

--- a/src/sqlfluff/rules/L060.py
+++ b/src/sqlfluff/rules/L060.py
@@ -4,10 +4,11 @@ from typing import Optional
 
 from sqlfluff.core.parser.segments.raw import CodeSegment
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L060(BaseRule):
     """Use ``COALESCE`` instead of ``IFNULL`` or ``NVL``.
 

--- a/src/sqlfluff/rules/L060.py
+++ b/src/sqlfluff/rules/L060.py
@@ -7,8 +7,8 @@ from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L060(BaseRule):
     """Use ``COALESCE`` instead of ``IFNULL`` or ``NVL``.
 

--- a/src/sqlfluff/rules/L061.py
+++ b/src/sqlfluff/rules/L061.py
@@ -8,8 +8,8 @@ from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document
 from sqlfluff.core.rules.functional import sp
 
 
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L061(BaseRule):
     """Use ``!=`` instead of ``<>`` for "not equal to" comparisons.
 

--- a/src/sqlfluff/rules/L061.py
+++ b/src/sqlfluff/rules/L061.py
@@ -4,11 +4,12 @@ from typing import Optional
 
 from sqlfluff.core.parser.segments.raw import CodeSegment
 from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible
+from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.core.rules.functional import sp
 
 
 @document_fix_compatible
+@document_groups
 class Rule_L061(BaseRule):
     """Use ``!=`` instead of ``<>`` for "not equal to" comparisons.
 

--- a/src/sqlfluff/rules/L062.py
+++ b/src/sqlfluff/rules/L062.py
@@ -6,8 +6,8 @@ from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 
 
-@document_configuration
 @document_groups
+@document_configuration
 class Rule_L062(BaseRule):
     """Block a list of configurable words from being used.
 

--- a/src/sqlfluff/rules/L062.py
+++ b/src/sqlfluff/rules/L062.py
@@ -3,10 +3,11 @@
 from typing import Optional
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_configuration
+from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 
 
 @document_configuration
+@document_groups
 class Rule_L062(BaseRule):
     """Block a list of configurable words from being used.
 

--- a/src/sqlfluff/rules/L063.py
+++ b/src/sqlfluff/rules/L063.py
@@ -10,9 +10,9 @@ from sqlfluff.core.rules.doc_decorators import (
 from sqlfluff.rules.L010 import Rule_L010
 
 
-@document_configuration
 @document_groups
 @document_fix_compatible
+@document_configuration
 class Rule_L063(Rule_L010):
     """Inconsistent capitalisation of datatypes.
 

--- a/src/sqlfluff/rules/L063.py
+++ b/src/sqlfluff/rules/L063.py
@@ -11,8 +11,8 @@ from sqlfluff.rules.L010 import Rule_L010
 
 
 @document_configuration
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L063(Rule_L010):
     """Inconsistent capitalisation of datatypes.
 

--- a/src/sqlfluff/rules/L063.py
+++ b/src/sqlfluff/rules/L063.py
@@ -5,12 +5,14 @@ from typing import Tuple, List
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
+    document_groups,
 )
 from sqlfluff.rules.L010 import Rule_L010
 
 
 @document_configuration
 @document_fix_compatible
+@document_groups
 class Rule_L063(Rule_L010):
     """Inconsistent capitalisation of datatypes.
 

--- a/src/sqlfluff/rules/L064.py
+++ b/src/sqlfluff/rules/L064.py
@@ -9,11 +9,13 @@ from sqlfluff.core.rules.base import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
+    document_groups,
 )
 
 
 @document_configuration
 @document_fix_compatible
+@document_groups
 class Rule_L064(BaseRule):
     r"""Consistent usage of preferred quotes for quoted literals.
 

--- a/src/sqlfluff/rules/L064.py
+++ b/src/sqlfluff/rules/L064.py
@@ -13,9 +13,9 @@ from sqlfluff.core.rules.doc_decorators import (
 )
 
 
-@document_configuration
 @document_groups
 @document_fix_compatible
+@document_configuration
 class Rule_L064(BaseRule):
     r"""Consistent usage of preferred quotes for quoted literals.
 

--- a/src/sqlfluff/rules/L064.py
+++ b/src/sqlfluff/rules/L064.py
@@ -14,8 +14,8 @@ from sqlfluff.core.rules.doc_decorators import (
 
 
 @document_configuration
-@document_fix_compatible
 @document_groups
+@document_fix_compatible
 class Rule_L064(BaseRule):
     r"""Consistent usage of preferred quotes for quoted literals.
 

--- a/test/core/rules/config_test.py
+++ b/test/core/rules/config_test.py
@@ -6,6 +6,7 @@ from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix
 from sqlfluff.core.rules import get_ruleset
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
+    document_fix_compatible,
     document_groups,
 )
 from sqlfluff.core.config import FluffConfig
@@ -27,7 +28,7 @@ class Rule_T042(BaseRule):
 
 
 @document_groups
-@document_configuration
+@document_fix_compatible
 class Rule_T001(BaseRule):
     """A deliberately malicious rule.
 

--- a/test/core/rules/config_test.py
+++ b/test/core/rules/config_test.py
@@ -6,7 +6,6 @@ from sqlfluff.core.rules.base import BaseRule, LintResult, LintFix
 from sqlfluff.core.rules import get_ruleset
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
-    document_fix_compatible,
     document_groups,
 )
 from sqlfluff.core.config import FluffConfig
@@ -27,8 +26,8 @@ class Rule_T042(BaseRule):
         pass
 
 
-@document_fix_compatible
 @document_groups
+@document_configuration
 class Rule_T001(BaseRule):
     """A deliberately malicious rule.
 

--- a/test/core/rules/config_test.py
+++ b/test/core/rules/config_test.py
@@ -7,6 +7,7 @@ from sqlfluff.core.rules import get_ruleset
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
+    document_groups,
 )
 from sqlfluff.core.config import FluffConfig
 from sqlfluff.core.parser import WhitespaceSegment
@@ -27,6 +28,7 @@ class Rule_T042(BaseRule):
 
 
 @document_fix_compatible
+@document_groups
 class Rule_T001(BaseRule):
     """A deliberately malicious rule.
 

--- a/test/core/rules/docstring_test.py
+++ b/test/core/rules/docstring_test.py
@@ -3,7 +3,7 @@ import pytest
 
 from sqlfluff import lint
 from sqlfluff.core.plugin.host import get_plugin_manager
-from sqlfluff.core.rules.doc_decorators import is_configurable
+from sqlfluff.core.rules.doc_decorators import is_configurable, is_documenting_groups
 
 KEYWORD_ANTI = "    **Anti-pattern**"
 KEYWORD_BEST = "    **Best practice**"
@@ -51,6 +51,16 @@ def test_config_decorator():
                     f"Rule {rule.__name__} has config but is not decorated with "
                     "@document_configuration to display that config."
                 )
+
+
+def test_groups_decorator():
+    """Test rules with groups have the @document_groups decorator."""
+    for plugin_rules in get_plugin_manager().hook.get_rules():
+        for rule in plugin_rules:
+            if hasattr(rule, "groups"):
+                assert is_documenting_groups(
+                    rule
+                ), f'Rule {rule.__name__} does not specify "@document_groups".'
 
 
 def test_backtick_replace():

--- a/test/fixtures/rules/custom/L000.py
+++ b/test/fixtures/rules/custom/L000.py
@@ -1,6 +1,8 @@
 """Test std rule import."""
+from sqlfluff.core.rules.doc_decorators import document_groups
 
 
+@document_groups
 class Rule_L000:
     """Test std rule import."""
 

--- a/test/rules/yaml_test_cases_test.py
+++ b/test/rules/yaml_test_cases_test.py
@@ -7,7 +7,7 @@ from sqlfluff.testing.rules import (
     rules__test_helper,
     get_rule_from_set,
 )
-from sqlfluff.core.rules.doc_decorators import is_fix_compatible
+from sqlfluff.core.rules.doc_decorators import is_fix_compatible, is_documenting_groups
 from sqlfluff.core.config import FluffConfig
 
 ids, test_cases = load_test_cases(
@@ -27,6 +27,9 @@ def test__rule_test_case(test_case, caplog):
                 rule
             ), f"Rule {test_case.rule} returned fixes but does not specify "
             '"@document_fix_compatible".'
+            assert is_documenting_groups(
+                rule
+            ), f'Rule {test_case.rule} does not specify "@document_groups".'
 
 
 def test__rule_test_global_config():

--- a/test/rules/yaml_test_cases_test.py
+++ b/test/rules/yaml_test_cases_test.py
@@ -7,7 +7,7 @@ from sqlfluff.testing.rules import (
     rules__test_helper,
     get_rule_from_set,
 )
-from sqlfluff.core.rules.doc_decorators import is_fix_compatible, is_documenting_groups
+from sqlfluff.core.rules.doc_decorators import is_fix_compatible
 from sqlfluff.core.config import FluffConfig
 
 ids, test_cases = load_test_cases(
@@ -27,9 +27,6 @@ def test__rule_test_case(test_case, caplog):
                 rule
             ), f"Rule {test_case.rule} returned fixes but does not specify "
             '"@document_fix_compatible".'
-            assert is_documenting_groups(
-                rule
-            ), f'Rule {test_case.rule} does not specify "@document_groups".'
 
 
 def test__rule_test_global_config():


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
I noticed that we don't actually document the rules in each group. This adds that.

<img width="540" alt="image" src="https://user-images.githubusercontent.com/10931297/167154589-02c7bc97-66b1-43f6-a1ec-f3e4675a7776.png">

### Are there any other side effects of this change that we should be aware of?
Shouldn't be

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
