### PR TITLE
Allow optional `AS` in `MERGE` statements using `SELECT`

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2358,7 +2358,7 @@ class MergeStatementSegment(BaseSegment):
                 Bracketed(
                     Ref("SelectableGrammar"),
                 ),
-                Ref("AliasExpressionSegment"),
+                Ref("AliasExpressionSegment", optional=True),
             ),
         ),
         Dedent,

--- a/test/fixtures/dialects/bigquery/merge_into.sql
+++ b/test/fixtures/dialects/bigquery/merge_into.sql
@@ -78,3 +78,10 @@ USING dataset.newarrivals s
 ON t.product = s.product
 WHEN NOT MATCHED BY SOURCE THEN
     UPDATE SET quantity = t.quantity + s.quantity;
+
+-- Merge using Select without alias
+MERGE dataset.NewArrivals
+USING (SELECT * FROM dataset.NewArrivals WHERE warehouse <> 'warehouse #2')
+ON FALSE
+WHEN MATCHED THEN
+  DELETE

--- a/test/fixtures/dialects/bigquery/merge_into.yml
+++ b/test/fixtures/dialects/bigquery/merge_into.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: be29d8eac88d4901f217f6c10a4a05d5d0ef6900f788d32cb5ce9789bca03892
+_hash: a3da3d358eeaf5a5c0f9c7e2f4dbee4a0e0384f5381c798a8ccd721dbe895c70
 file:
 - statement:
     merge_statement:
@@ -767,3 +767,50 @@ file:
                   - dot: .
                   - identifier: quantity
 - statement_terminator: ;
+- statement:
+    merge_statement:
+    - keyword: MERGE
+    - table_reference:
+      - identifier: dataset
+      - dot: .
+      - identifier: NewArrivals
+    - keyword: USING
+    - bracketed:
+        start_bracket: (
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                  - identifier: dataset
+                  - dot: .
+                  - identifier: NewArrivals
+          where_clause:
+            keyword: WHERE
+            expression:
+              column_reference:
+                identifier: warehouse
+              comparison_operator:
+              - raw_comparison_operator: <
+              - raw_comparison_operator: '>'
+              literal: "'warehouse #2'"
+        end_bracket: )
+    - join_on_condition:
+        keyword: 'ON'
+        expression:
+          literal: 'FALSE'
+    - merge_match:
+        merge_when_matched_clause:
+        - keyword: WHEN
+        - keyword: MATCHED
+        - keyword: THEN
+        - merge_delete_clause:
+            keyword: DELETE


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3270 

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
