### PR TITLE
L028: In tsql dialect, table variables cannot be used to qualify references

### DIFF
--- a/src/sqlfluff/rules/L028.py
+++ b/src/sqlfluff/rules/L028.py
@@ -217,6 +217,11 @@ def _validate_one_reference(
     if ref.raw in standalone_aliases:
         return None
 
+    # Oddball case: tsql table variables can't be used to qualify references.
+    # This appears here as an empty string for table_ref_str.
+    if not table_ref_str:
+        return None
+
     # Certain dialects allow use of SELECT alias in WHERE clauses
     if ref.raw in col_alias_names:
         return None

--- a/test/fixtures/rules/std_rule_cases/L028.yml
+++ b/test/fixtures/rules/std_rule_cases/L028.yml
@@ -292,3 +292,14 @@ test_pass_snowflake_flatten_function:
   configs:
     core:
       dialect: snowflake
+
+
+passes_tql_table_variable:
+  # Issue 3243
+  pass_str: select a, b from @tablevar
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      L028:
+        single_table_references: qualified


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3243 
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
