### PR TITLE
MySQL: Support `Create User`

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -321,9 +321,13 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
     https://dev.mysql.com/doc/refman/8.0/en/create-user.html
     """
 
+    _string_literal = OneOf(
+        Ref("QuotedLiteralSegment"), Ref("DoubleQuotedLiteralSegment")
+    )
+
     _random_password = Sequence("RANDOM", "PASSWORD")
     _auth_plugin = Ref("ObjectReferenceSegment")
-    _auth_string = Ref("SingleQuotedIdentifierSegment")
+    _auth_string = _string_literal
 
     _initial_auth_option = Sequence(
         "INITIAL",
@@ -366,9 +370,9 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
     _tls_option = OneOf(
         "SSL",
         "X509",
-        Sequence("CIPHER", Ref("SingleQuotedIdentifierSegment")),
-        Sequence("ISSUER", Ref("SingleQuotedIdentifierSegment")),
-        Sequence("SUBJECT", Ref("SingleQuotedIdentifierSegment")),
+        Sequence("CIPHER", _string_literal),
+        Sequence("ISSUER", _string_literal),
+        Sequence("SUBJECT", _string_literal),
     )
 
     _resource_option = Sequence(
@@ -438,7 +442,7 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
         Sequence("ACCOUNT", OneOf("UNLOCK", "LOCK"), optional=True),
         Sequence(
             OneOf("COMMENT", "ATTRIBUTE"),
-            Ref("SingleQuotedIdentifierSegment"),
+            _string_literal,
             optional=True,
         ),
     )

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -102,6 +102,20 @@ mysql_dialect.sets("unreserved_keywords").update(
         "CHANNEL",
         "EXPORT",
         "RANDOM",
+        "FAILED_LOGIN_ATTEMPTS",
+        "PASSWORD_LOCK_TIME",
+        "EXPIRE",
+        "NEVER",
+        "HISTORY",
+        "REUSE",
+        "CIPHER",
+        "ISSUER",
+        "SUBJECT",
+        "MAX_QUERIES_PER_HOUR",
+        "MAX_UPDATES_PER_HOUR",
+        "MAX_CONNECTIONS_PER_HOUR",
+        "MAX_USER_CONNECTIONS",
+        "AUTHENTICATION",
     ]
 )
 mysql_dialect.sets("reserved_keywords").update(

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -435,9 +435,12 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
         ),
         Sequence("WITH", Delimited(_resource_option), optional=True),
         Sequence(_password_option, optional=True),
-        # lock_option
-        # comment
-        # attribute
+        Sequence("ACCOUNT", OneOf("UNLOCK", "LOCK"), optional=True),
+        Sequence(
+            OneOf("COMMENT", "ATTRIBUTE"),
+            Ref("SingleQuotedIdentifierSegment"),
+            optional=True,
+        ),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -381,6 +381,38 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
         Ref("NumericLiteralSegment"),
     )
 
+    _password_option = OneOf(
+        Sequence(
+            "PASSWORD",
+            "EXPIRE",
+            Sequence(
+                OneOf(
+                    "DEFAULT",
+                    "NEVER",
+                    Sequence("INTERVAL", Ref("NumericLiteralSegment"), "DAY"),
+                ),
+                optional=True,
+            ),
+        ),
+        Sequence("PASSWORD", "HISTORY", OneOf("DEFAULT", Ref("NumericLiteralSegment"))),
+        Sequence(
+            "PASSWORD",
+            "REUSE",
+            "INTERVAL",
+            OneOf("DEFAULT", Sequence(Ref("NumericLiteralSegment"), "DAY")),
+        ),
+        Sequence(
+            "PASSWORD",
+            "REQUIRE",
+            "CURRENT",
+            Sequence(OneOf("DEFAULT", "OPTIONAL"), optional=True),
+        ),
+        Sequence("FAILED_LOGIN_ATTEMPTS", Ref("NumericLiteralSegment")),
+        Sequence(
+            "PASSWORD_LOCK_TIME", OneOf(Ref("NumericLiteralSegment"), "UNBOUNDED")
+        ),
+    )
+
     match_grammar = Sequence(
         "CREATE",
         "USER",
@@ -402,6 +434,10 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
             optional=True,
         ),
         Sequence("WITH", Delimited(_resource_option), optional=True),
+        Sequence(_password_option, optional=True),
+        # lock_option
+        # comment
+        # attribute
     )
 
 

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -373,7 +373,12 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
             Sequence(
                 Ref("RoleReferenceSegment"), Delimited(_auth_option, delimiter="AND")
             ),
-            delimiter=Ref("CommaSegment"),
+        ),
+        Sequence(
+            "DEFAULT",
+            "ROLE",
+            Delimited(Ref("RoleReferenceSegment")),
+            optional=True,
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -371,6 +371,16 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
         Sequence("SUBJECT", Ref("SingleQuotedIdentifierSegment")),
     )
 
+    _resource_option = Sequence(
+        OneOf(
+            "MAX_QUERIES_PER_HOUR",
+            "MAX_UPDATES_PER_HOUR",
+            "MAX_CONNECTIONS_PER_HOUR",
+            "MAX_USER_CONNECTIONS",
+        ),
+        Ref("NumericLiteralSegment"),
+    )
+
     match_grammar = Sequence(
         "CREATE",
         "USER",
@@ -391,6 +401,7 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
             OneOf("NONE", Delimited(_tls_option, delimiter="AND")),
             optional=True,
         ),
+        Sequence("WITH", Delimited(_resource_option), optional=True),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -116,6 +116,7 @@ mysql_dialect.sets("unreserved_keywords").update(
         "MAX_CONNECTIONS_PER_HOUR",
         "MAX_USER_CONNECTIONS",
         "AUTHENTICATION",
+        "OPTIONAL",
     ]
 )
 mysql_dialect.sets("reserved_keywords").update(
@@ -347,12 +348,14 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
         "INITIAL",
         "AUTHENTICATION",
         "IDENTIFIED",
-        OneOf(Sequence("BY", OneOf(_random_password, _auth_string))),
-        Sequence(
-            "WITH",
-            _auth_plugin,
-            "AS",
-            _auth_string,
+        OneOf(
+            Sequence("BY", OneOf(_random_password, _auth_string)),
+            Sequence(
+                "WITH",
+                _auth_plugin,
+                "AS",
+                _auth_string,
+            ),
         ),
     )
 
@@ -399,7 +402,7 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
         Ref("NumericLiteralSegment"),
     )
 
-    _password_option = OneOf(
+    _password_option = AnyNumberOf(
         Sequence(
             "PASSWORD",
             "EXPIRE",
@@ -437,7 +440,8 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
         Ref("IfNotExistsGrammar", optional=True),
         Delimited(
             Sequence(
-                Ref("RoleReferenceSegment"), Delimited(_auth_option, delimiter="AND")
+                Ref("RoleReferenceSegment"),
+                Sequence(Delimited(_auth_option, delimiter="AND"), optional=True),
             ),
         ),
         Sequence(
@@ -451,7 +455,7 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
             OneOf("NONE", Delimited(_tls_option, delimiter="AND")),
             optional=True,
         ),
-        Sequence("WITH", Delimited(_resource_option), optional=True),
+        Sequence("WITH", AnyNumberOf(_resource_option), optional=True),
         Sequence(_password_option, optional=True),
         Sequence("ACCOUNT", OneOf("UNLOCK", "LOCK"), optional=True),
         Sequence(

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -352,17 +352,23 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
                     OneOf(
                         Sequence(
                             "BY",
-                            OneOf(
-                                _random_password, Ref("SingleQuotedIdentifierSegment")
-                            ),
+                            OneOf(_random_password, _auth_string),
                         ),
-                        Sequence("AS", Ref("SingleQuotedIdentifierSegment")),
+                        Sequence("AS", _auth_string),
                         _initial_auth_option,
                     ),
                     optional=True,
                 ),
             ),
         ),
+    )
+
+    _tls_option = OneOf(
+        "SSL",
+        "X509",
+        Sequence("CIPHER", Ref("SingleQuotedIdentifierSegment")),
+        Sequence("ISSUER", Ref("SingleQuotedIdentifierSegment")),
+        Sequence("SUBJECT", Ref("SingleQuotedIdentifierSegment")),
     )
 
     match_grammar = Sequence(
@@ -378,6 +384,11 @@ class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
             "DEFAULT",
             "ROLE",
             Delimited(Ref("RoleReferenceSegment")),
+            optional=True,
+        ),
+        Sequence(
+            "REQUIRE",
+            OneOf("NONE", Delimited(_tls_option, delimiter="AND")),
             optional=True,
         ),
     )

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -101,6 +101,7 @@ mysql_dialect.sets("unreserved_keywords").update(
         "USER_RESOURCES",
         "CHANNEL",
         "EXPORT",
+        "RANDOM",
     ]
 )
 mysql_dialect.sets("reserved_keywords").update(
@@ -311,6 +312,43 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
                 ),
             ),
         ],
+    )
+
+
+class CreateUserStatementSegment(ansi.CreateUserStatementSegment):
+    """`CREATE USER` statement.
+
+    https://dev.mysql.com/doc/refman/8.0/en/create-user.html
+    """
+
+    auth_option = Sequence(
+        "IDENTIFIED",
+        OneOf(
+            Sequence(
+                "BY",
+                OneOf(
+                    Sequence("RANDOM", "PASSWORD"),
+                    Ref("SingleQuotedIdentifierSegment"),
+                ),
+            ),
+            Sequence(
+                "WITH",
+                Ref("ObjectReferenceSegment"),
+                Sequence("AS", Ref("SingleQuotedIdentifierSegment"), optional=True),
+            ),
+        ),
+    )
+
+    match_grammar = Sequence(
+        "CREATE",
+        "USER",
+        Ref("IfNotExistsGrammar", optional=True),
+        Delimited(
+            Sequence(
+                Ref("RoleReferenceSegment"), Delimited(auth_option, delimiter="AND")
+            ),
+            delimiter=Ref("CommaSegment"),
+        ),
     )
 
 

--- a/test/fixtures/dialects/mysql/create_user.sql
+++ b/test/fixtures/dialects/mysql/create_user.sql
@@ -1,4 +1,74 @@
+CREATE USER jeffrey;
+CREATE USER IF NOT EXISTS jeffrey;
 CREATE USER 'prj_svc' IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';
 CREATE USER 'jeffrey'@'localhost' IDENTIFIED BY 'password';
+CREATE USER "jeffrey"@"localhost" IDENTIFIED BY "password";
+CREATE USER `jeffrey`@`localhost` IDENTIFIED BY "password";
 CREATE USER 'jeffrey'@'localhost'
   IDENTIFIED BY 'new_password' PASSWORD EXPIRE;
+CREATE USER 'jeffrey'@'localhost'
+  IDENTIFIED WITH caching_sha2_password BY 'new_password'
+  PASSWORD EXPIRE INTERVAL 180 DAY
+  FAILED_LOGIN_ATTEMPTS 3 PASSWORD_LOCK_TIME 2;
+CREATE USER
+  'jeffrey'@'localhost' IDENTIFIED WITH mysql_native_password
+                                   BY 'new_password1',
+  'jeanne'@'localhost' IDENTIFIED WITH caching_sha2_password
+                                  BY 'new_password2'
+  REQUIRE X509 WITH MAX_QUERIES_PER_HOUR 60
+  PASSWORD HISTORY 5
+  ACCOUNT LOCK;
+CREATE USER 'jeffrey'@'localhost'
+  IDENTIFIED WITH mysql_native_password BY 'password';
+CREATE USER 'u1'@'localhost'
+  IDENTIFIED WITH caching_sha2_password
+    BY 'sha2_password'
+  AND IDENTIFIED WITH authentication_ldap_sasl
+    AS 'uid=u1_ldap,ou=People,dc=example,dc=com';
+CREATE USER 'u1'@'localhost'
+  IDENTIFIED WITH caching_sha2_password
+    BY 'sha2_password'
+  AND IDENTIFIED WITH authentication_ldap_sasl
+    AS 'uid=u1_ldap,ou=People,dc=example,dc=com'
+  AND IDENTIFIED WITH authentication_fido;
+CREATE USER user
+  IDENTIFIED WITH authentication_fido
+  INITIAL AUTHENTICATION IDENTIFIED BY RANDOM PASSWORD;
+CREATE USER 'joe'@'10.0.0.1' DEFAULT ROLE administrator, developer;
+CREATE USER 'jeffrey'@'localhost' REQUIRE NONE;
+CREATE USER 'jeffrey'@'localhost' REQUIRE SSL;
+CREATE USER 'jeffrey'@'localhost' REQUIRE X509;
+CREATE USER 'jeffrey'@'localhost'
+  REQUIRE ISSUER '/C=SE/ST=Stockholm/L=Stockholm/
+    O=MySQL/CN=CA/emailAddress=ca@example.com';
+CREATE USER 'jeffrey'@'localhost'
+  REQUIRE SUBJECT '/C=SE/ST=Stockholm/L=Stockholm/
+    O=MySQL demo client certificate/
+    CN=client/emailAddress=client@example.com';
+CREATE USER 'jeffrey'@'localhost'
+  REQUIRE CIPHER 'EDH-RSA-DES-CBC3-SHA';
+CREATE USER 'jeffrey'@'localhost'
+  REQUIRE SUBJECT '/C=SE/ST=Stockholm/L=Stockholm/
+    O=MySQL demo client certificate/
+    CN=client/emailAddress=client@example.com'
+  AND ISSUER '/C=SE/ST=Stockholm/L=Stockholm/
+    O=MySQL/CN=CA/emailAddress=ca@example.com'
+  AND CIPHER 'EDH-RSA-DES-CBC3-SHA';
+CREATE USER 'jeffrey'@'localhost'
+  WITH MAX_QUERIES_PER_HOUR 500 MAX_UPDATES_PER_HOUR 100;
+CREATE USER 'jeffrey'@'localhost' PASSWORD EXPIRE;
+CREATE USER 'jeffrey'@'localhost' PASSWORD EXPIRE DEFAULT;
+CREATE USER 'jeffrey'@'localhost' PASSWORD EXPIRE NEVER;
+CREATE USER 'jeffrey'@'localhost' PASSWORD EXPIRE INTERVAL 180 DAY;
+CREATE USER 'jeffrey'@'localhost' PASSWORD HISTORY DEFAULT;
+CREATE USER 'jeffrey'@'localhost' PASSWORD HISTORY 6;
+CREATE USER 'jeffrey'@'localhost' PASSWORD REUSE INTERVAL DEFAULT;
+CREATE USER 'jeffrey'@'localhost' PASSWORD REUSE INTERVAL 360 DAY;
+CREATE USER 'jeffrey'@'localhost' PASSWORD REQUIRE CURRENT;
+CREATE USER 'jeffrey'@'localhost' PASSWORD REQUIRE CURRENT OPTIONAL;
+CREATE USER 'jeffrey'@'localhost' PASSWORD REQUIRE CURRENT DEFAULT;
+CREATE USER 'jeffrey'@'localhost'
+  FAILED_LOGIN_ATTEMPTS 4 PASSWORD_LOCK_TIME 2;
+CREATE USER 'jon'@'localhost' COMMENT 'Some information about Jon';
+CREATE USER 'jim'@'localhost'
+    ATTRIBUTE '{"fname": "James", "lname": "Scott", "phone": "123-456-7890"}';

--- a/test/fixtures/dialects/mysql/create_user.sql
+++ b/test/fixtures/dialects/mysql/create_user.sql
@@ -1,1 +1,4 @@
 CREATE USER 'prj_svc' IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';
+CREATE USER 'jeffrey'@'localhost' IDENTIFIED BY 'password';
+CREATE USER 'jeffrey'@'localhost'
+  IDENTIFIED BY 'new_password' PASSWORD EXPIRE;

--- a/test/fixtures/dialects/mysql/create_user.sql
+++ b/test/fixtures/dialects/mysql/create_user.sql
@@ -1,0 +1,1 @@
+CREATE USER 'prj_svc' IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';

--- a/test/fixtures/dialects/mysql/create_user.yml
+++ b/test/fixtures/dialects/mysql/create_user.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9ba65c9cd4e4366db172a80c9d6b1f8b92c610739392e73fae528275cf9f69a6
+_hash: ab9a0d05a3e6c44c51fc3a7bb36814acd57122e597c95fdf78d42de95d5aaeae
 file:
-  statement:
+- statement:
     create_user_statement:
     - keyword: CREATE
     - keyword: USER
@@ -17,4 +17,30 @@ file:
         identifier: AWSAuthenticationPlugin
     - keyword: AS
     - literal: "'RDS'"
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: IDENTIFIED
+    - keyword: BY
+    - literal: "'password'"
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: IDENTIFIED
+    - keyword: BY
+    - literal: "'new_password'"
+    - keyword: PASSWORD
+    - keyword: EXPIRE
+- statement_terminator: ;

--- a/test/fixtures/dialects/mysql/create_user.yml
+++ b/test/fixtures/dialects/mysql/create_user.yml
@@ -3,8 +3,25 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ab9a0d05a3e6c44c51fc3a7bb36814acd57122e597c95fdf78d42de95d5aaeae
+_hash: fdff90fd283d2612216ebef91d1f7eb68a4b7bbb2b61d3de12de35a5a540da3b
 file:
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+        identifier: jeffrey
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - role_reference:
+        identifier: jeffrey
+- statement_terminator: ;
 - statement:
     create_user_statement:
     - keyword: CREATE
@@ -35,6 +52,30 @@ file:
     - keyword: CREATE
     - keyword: USER
     - role_reference:
+      - literal: '"jeffrey"'
+      - literal: '@'
+      - literal: '"localhost"'
+    - keyword: IDENTIFIED
+    - keyword: BY
+    - literal: '"password"'
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: '`jeffrey`'
+      - literal: '@'
+      - identifier: '`localhost`'
+    - keyword: IDENTIFIED
+    - keyword: BY
+    - literal: '"password"'
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
       - identifier: "'jeffrey'"
       - literal: '@'
       - identifier: "'localhost'"
@@ -43,4 +84,438 @@ file:
     - literal: "'new_password'"
     - keyword: PASSWORD
     - keyword: EXPIRE
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: IDENTIFIED
+    - keyword: WITH
+    - object_reference:
+        identifier: caching_sha2_password
+    - keyword: BY
+    - literal: "'new_password'"
+    - keyword: PASSWORD
+    - keyword: EXPIRE
+    - keyword: INTERVAL
+    - literal: '180'
+    - keyword: DAY
+    - keyword: FAILED_LOGIN_ATTEMPTS
+    - literal: '3'
+    - keyword: PASSWORD_LOCK_TIME
+    - literal: '2'
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: IDENTIFIED
+    - keyword: WITH
+    - object_reference:
+        identifier: mysql_native_password
+    - keyword: BY
+    - literal: "'new_password1'"
+    - comma: ','
+    - role_reference:
+      - identifier: "'jeanne'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: IDENTIFIED
+    - keyword: WITH
+    - object_reference:
+        identifier: caching_sha2_password
+    - keyword: BY
+    - literal: "'new_password2'"
+    - keyword: REQUIRE
+    - keyword: X509
+    - keyword: WITH
+    - keyword: MAX_QUERIES_PER_HOUR
+    - literal: '60'
+    - keyword: PASSWORD
+    - keyword: HISTORY
+    - literal: '5'
+    - keyword: ACCOUNT
+    - keyword: LOCK
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: IDENTIFIED
+    - keyword: WITH
+    - object_reference:
+        identifier: mysql_native_password
+    - keyword: BY
+    - literal: "'password'"
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'u1'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: IDENTIFIED
+    - keyword: WITH
+    - object_reference:
+        identifier: caching_sha2_password
+    - keyword: BY
+    - literal: "'sha2_password'"
+    - binary_operator: AND
+    - keyword: IDENTIFIED
+    - keyword: WITH
+    - object_reference:
+        identifier: authentication_ldap_sasl
+    - keyword: AS
+    - literal: "'uid=u1_ldap,ou=People,dc=example,dc=com'"
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'u1'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: IDENTIFIED
+    - keyword: WITH
+    - object_reference:
+        identifier: caching_sha2_password
+    - keyword: BY
+    - literal: "'sha2_password'"
+    - binary_operator: AND
+    - keyword: IDENTIFIED
+    - keyword: WITH
+    - object_reference:
+        identifier: authentication_ldap_sasl
+    - keyword: AS
+    - literal: "'uid=u1_ldap,ou=People,dc=example,dc=com'"
+    - binary_operator: AND
+    - keyword: IDENTIFIED
+    - keyword: WITH
+    - object_reference:
+        identifier: authentication_fido
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+        identifier: user
+    - keyword: IDENTIFIED
+    - keyword: WITH
+    - object_reference:
+        identifier: authentication_fido
+    - keyword: INITIAL
+    - keyword: AUTHENTICATION
+    - keyword: IDENTIFIED
+    - keyword: BY
+    - keyword: RANDOM
+    - keyword: PASSWORD
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'joe'"
+      - literal: '@'
+      - identifier: "'10.0.0.1'"
+    - keyword: DEFAULT
+    - keyword: ROLE
+    - role_reference:
+        identifier: administrator
+    - comma: ','
+    - role_reference:
+        identifier: developer
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: REQUIRE
+    - keyword: NONE
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: REQUIRE
+    - keyword: SSL
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: REQUIRE
+    - keyword: X509
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: REQUIRE
+    - keyword: ISSUER
+    - literal: "'/C=SE/ST=Stockholm/L=Stockholm/\n    O=MySQL/CN=CA/emailAddress=ca@example.com'"
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: REQUIRE
+    - keyword: SUBJECT
+    - literal: "'/C=SE/ST=Stockholm/L=Stockholm/\n    O=MySQL demo client certificate/\n\
+        \    CN=client/emailAddress=client@example.com'"
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: REQUIRE
+    - keyword: CIPHER
+    - literal: "'EDH-RSA-DES-CBC3-SHA'"
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: REQUIRE
+    - keyword: SUBJECT
+    - literal: "'/C=SE/ST=Stockholm/L=Stockholm/\n    O=MySQL demo client certificate/\n\
+        \    CN=client/emailAddress=client@example.com'"
+    - binary_operator: AND
+    - keyword: ISSUER
+    - literal: "'/C=SE/ST=Stockholm/L=Stockholm/\n    O=MySQL/CN=CA/emailAddress=ca@example.com'"
+    - binary_operator: AND
+    - keyword: CIPHER
+    - literal: "'EDH-RSA-DES-CBC3-SHA'"
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: WITH
+    - keyword: MAX_QUERIES_PER_HOUR
+    - literal: '500'
+    - keyword: MAX_UPDATES_PER_HOUR
+    - literal: '100'
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: PASSWORD
+    - keyword: EXPIRE
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: PASSWORD
+    - keyword: EXPIRE
+    - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: PASSWORD
+    - keyword: EXPIRE
+    - keyword: NEVER
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: PASSWORD
+    - keyword: EXPIRE
+    - keyword: INTERVAL
+    - literal: '180'
+    - keyword: DAY
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: PASSWORD
+    - keyword: HISTORY
+    - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: PASSWORD
+    - keyword: HISTORY
+    - literal: '6'
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: PASSWORD
+    - keyword: REUSE
+    - keyword: INTERVAL
+    - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: PASSWORD
+    - keyword: REUSE
+    - keyword: INTERVAL
+    - literal: '360'
+    - keyword: DAY
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: PASSWORD
+    - keyword: REQUIRE
+    - keyword: CURRENT
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: PASSWORD
+    - keyword: REQUIRE
+    - keyword: CURRENT
+    - keyword: OPTIONAL
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: PASSWORD
+    - keyword: REQUIRE
+    - keyword: CURRENT
+    - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jeffrey'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: FAILED_LOGIN_ATTEMPTS
+    - literal: '4'
+    - keyword: PASSWORD_LOCK_TIME
+    - literal: '2'
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jon'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: COMMENT
+    - literal: "'Some information about Jon'"
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+      - identifier: "'jim'"
+      - literal: '@'
+      - identifier: "'localhost'"
+    - keyword: ATTRIBUTE
+    - literal: "'{\"fname\": \"James\", \"lname\": \"Scott\", \"phone\": \"123-456-7890\"\
+        }'"
 - statement_terminator: ;

--- a/test/fixtures/dialects/mysql/create_user.yml
+++ b/test/fixtures/dialects/mysql/create_user.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 919554e2c05cb6c42c0e01378e2e3ced4f996562223b35c5e6cdcd8921edffcf
+_hash: 9ba65c9cd4e4366db172a80c9d6b1f8b92c610739392e73fae528275cf9f69a6
 file:
   statement:
     create_user_statement:
@@ -16,5 +16,5 @@ file:
     - object_reference:
         identifier: AWSAuthenticationPlugin
     - keyword: AS
-    - identifier: "'RDS'"
+    - literal: "'RDS'"
   statement_terminator: ;

--- a/test/fixtures/dialects/mysql/create_user.yml
+++ b/test/fixtures/dialects/mysql/create_user.yml
@@ -1,0 +1,20 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 919554e2c05cb6c42c0e01378e2e3ced4f996562223b35c5e6cdcd8921edffcf
+file:
+  statement:
+    create_user_statement:
+    - keyword: CREATE
+    - keyword: USER
+    - role_reference:
+        identifier: "'prj_svc'"
+    - keyword: IDENTIFIED
+    - keyword: WITH
+    - object_reference:
+        identifier: AWSAuthenticationPlugin
+    - keyword: AS
+    - identifier: "'RDS'"
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fleshes out `Create User` per the MySQL doc. Tests various cases, including all samples from [the MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/create-user.html).

Closes #3188


### Are there any other side effects of this change that we should be aware of?
I locally solved for literal strings can be either single or double quoted in MySQL (and stuff like users can also be backticked, as we saw [here](https://github.com/sqlfluff/sqlfluff/pull/3286)), but we should file a separate issue for a more holistic solution.
```python
    _string_literal = OneOf(
        Ref("QuotedLiteralSegment"), Ref("DoubleQuotedLiteralSegment")
    )
```

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
