### PR TITLE
Snowflake: CREATE STAGE grammar enhancement for file formats

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -3239,13 +3239,19 @@ class FileFormatSegment(BaseSegment):
     type = "file_format_segment"
 
     match_grammar = OneOf(
-        OneOf(Ref("NakedIdentifierSegment"), Ref("QuotedLiteralSegment")),
+        OneOf(
+            Ref("QuotedLiteralSegment"),
+            Ref("ObjectReferenceSegment"),
+        ),
         Bracketed(
             OneOf(
                 Sequence(
                     "FORMAT_NAME",
                     Ref("EqualsSegment"),
-                    OneOf(Ref("NakedIdentifierSegment"), Ref("QuotedLiteralSegment")),
+                    OneOf(
+                        Ref("NakedIdentifierSegment"),
+                        Ref("QuotedLiteralSegment"),
+                    ),
                 ),
                 OneOf(
                     Ref("CsvFileFormatTypeParameters"),

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -3237,7 +3237,6 @@ class FileFormatSegment(BaseSegment):
     """
 
     type = "file_format_segment"
-
     match_grammar = OneOf(
         OneOf(
             Ref("QuotedLiteralSegment"),
@@ -3249,8 +3248,8 @@ class FileFormatSegment(BaseSegment):
                     "FORMAT_NAME",
                     Ref("EqualsSegment"),
                     OneOf(
-                        Ref("NakedIdentifierSegment"),
                         Ref("QuotedLiteralSegment"),
+                        Ref("ObjectReferenceSegment"),
                     ),
                 ),
                 OneOf(

--- a/test/fixtures/dialects/snowflake/snowflake_copy_into_table.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_copy_into_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3150d1dc3a437d07ab6d4bc5662136f03132fd5950f9586d3a287a02090a5f82
+_hash: 18c9c93f5c44a112826e7e45181dea96073e7bef8deb59b75a6a94834fd1dedc
 file:
 - statement:
     copy_into_statement:
@@ -102,7 +102,8 @@ file:
           keyword: format_name
           comparison_operator:
             raw_comparison_operator: '='
-          identifier: myformat
+          object_reference:
+            identifier: myformat
           end_bracket: )
     - keyword: pattern
     - comparison_operator:

--- a/test/fixtures/dialects/snowflake/snowflake_create_stage.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_create_stage.sql
@@ -66,3 +66,8 @@ CREATE OR REPLACE STAGE foo.bar
     STORAGE_INTEGRATION = foo
     FILE_FORMAT = foo.bar.baz
 ;
+CREATE OR REPLACE STAGE foo.bar
+  URL = 's3://foobar'
+  STORAGE_INTEGRATION = foo
+  FILE_FORMAT = (FORMAT_NAME = foo.bar.baz)
+;

--- a/test/fixtures/dialects/snowflake/snowflake_create_stage.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_create_stage.sql
@@ -61,3 +61,8 @@ CREATE STAGE mystage
     AUTO_REFRESH = true
     NOTIFICATION_INTEGRATION = 'MY_NOTIFICATION_INT'
   );
+CREATE OR REPLACE STAGE foo.bar
+    URL = 's3://foobar'
+    STORAGE_INTEGRATION = foo
+    FILE_FORMAT = foo.bar.baz
+;

--- a/test/fixtures/dialects/snowflake/snowflake_create_stage.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_create_stage.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 59d5da5e33f8aaadada01d04892fc436cba32428b1013572f7d90250c22185e4
+_hash: 5b31b8e1575ad443be3088446877cbc8d145ad6e98121d69a96abd8a840466b6
 file:
 - statement:
     create_stage_statement:
@@ -71,7 +71,8 @@ file:
     - comparison_operator:
         raw_comparison_operator: '='
     - file_format_segment:
-        identifier: my_csv_format
+        object_reference:
+          identifier: my_csv_format
 - statement_terminator: ;
 - statement:
     create_stage_statement:
@@ -93,7 +94,8 @@ file:
     - comparison_operator:
         raw_comparison_operator: '='
     - file_format_segment:
-        identifier: myformat
+        object_reference:
+          identifier: myformat
 - statement_terminator: ;
 - statement:
     create_stage_statement:
@@ -389,7 +391,8 @@ file:
     - comparison_operator:
         raw_comparison_operator: '='
     - file_format_segment:
-        identifier: my_csv_format
+        object_reference:
+          identifier: my_csv_format
 - statement_terminator: ;
 - statement:
     create_stage_statement:
@@ -425,4 +428,35 @@ file:
           raw_comparison_operator: '='
       - literal: "'MY_NOTIFICATION_INT'"
       - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_stage_statement:
+    - keyword: CREATE
+    - binary_operator: OR
+    - keyword: REPLACE
+    - keyword: STAGE
+    - object_reference:
+      - identifier: foo
+      - dot: .
+      - identifier: bar
+    - keyword: URL
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bucket_path: "'s3://foobar'"
+    - stage_parameters:
+        keyword: STORAGE_INTEGRATION
+        comparison_operator:
+          raw_comparison_operator: '='
+        object_reference:
+          identifier: foo
+    - keyword: FILE_FORMAT
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - file_format_segment:
+        object_reference:
+        - identifier: foo
+        - dot: .
+        - identifier: bar
+        - dot: .
+        - identifier: baz
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/snowflake_create_stage.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_create_stage.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5b31b8e1575ad443be3088446877cbc8d145ad6e98121d69a96abd8a840466b6
+_hash: 75105144639fd5ada6fe171bc270a949d3c8c3569b1a7f46f13d901ca9f6efd6
 file:
 - statement:
     create_stage_statement:
@@ -459,4 +459,41 @@ file:
         - identifier: bar
         - dot: .
         - identifier: baz
+- statement_terminator: ;
+- statement:
+    create_stage_statement:
+    - keyword: CREATE
+    - binary_operator: OR
+    - keyword: REPLACE
+    - keyword: STAGE
+    - object_reference:
+      - identifier: foo
+      - dot: .
+      - identifier: bar
+    - keyword: URL
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bucket_path: "'s3://foobar'"
+    - stage_parameters:
+        keyword: STORAGE_INTEGRATION
+        comparison_operator:
+          raw_comparison_operator: '='
+        object_reference:
+          identifier: foo
+    - keyword: FILE_FORMAT
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - file_format_segment:
+        bracketed:
+          start_bracket: (
+          keyword: FORMAT_NAME
+          comparison_operator:
+            raw_comparison_operator: '='
+          object_reference:
+          - identifier: foo
+          - dot: .
+          - identifier: bar
+          - dot: .
+          - identifier: baz
+          end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

The following should parse:

```
CREATE OR REPLACE STAGE foo.bar
  URL = 's3://foobar'
  STORAGE_INTEGRATION = foo
  FILE_FORMAT = foo.bar.baz
;
```

`FILE_FORMAT` can be object (e.g. `database.schema.object`) but at the moment can only handle naked identifiers (fails to parse the `.`s in the above).

---

Enhanced the `FileFormatSegment` class in Snowflake to handle objects.


### Are there any other side effects of this change that we should be aware of?

None that I'm aware of.


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
