### PR TITLE
T-SQL: Fix `PIVOT` placement

### DIFF
--- a/src/sqlfluff/core/rules/analysis/select.py
+++ b/src/sqlfluff/core/rules/analysis/select.py
@@ -145,7 +145,7 @@ def _get_pivot_table_columns(segment, dialect):
         # we don't have it, assume the clause does not have a pivot table
         return []  # pragma: no cover
 
-    fc = segment.get_child("from_pivot_expression")
+    fc = segment.recursive_crawl("from_pivot_expression")
     if not fc:
         # If there's no pivot clause then just abort.
         return []

--- a/src/sqlfluff/core/rules/analysis/select.py
+++ b/src/sqlfluff/core/rules/analysis/select.py
@@ -145,19 +145,6 @@ def _get_pivot_table_columns(segment, dialect):
         # we don't have it, assume the clause does not have a pivot table
         return []  # pragma: no cover
 
-    # If there's no pivot clause then just abort.
-    fc = segment.get_child("from_pivot_expression")
-    if not fc:
-        fc = segment.get_child("from_expression")
-
-        if not fc:
-            return []
-
-        fc = fc.get_child("from_pivot_expression")
-
-        if not fc:
-            return []
-
     pivot_table_column_aliases = []
 
     for pivot_table_column_alias in segment.recursive_crawl("pivot_column_reference"):

--- a/src/sqlfluff/core/rules/analysis/select.py
+++ b/src/sqlfluff/core/rules/analysis/select.py
@@ -145,6 +145,11 @@ def _get_pivot_table_columns(segment, dialect):
         # we don't have it, assume the clause does not have a pivot table
         return []  # pragma: no cover
 
+    fc = segment.recursive_crawl("from_pivot_expression")
+    if not fc:
+        # If there's no pivot clause then just abort.
+        return []  # pragma: no cover
+
     pivot_table_column_aliases = []
 
     for pivot_table_column_alias in segment.recursive_crawl("pivot_column_reference"):

--- a/src/sqlfluff/core/rules/analysis/select.py
+++ b/src/sqlfluff/core/rules/analysis/select.py
@@ -145,10 +145,18 @@ def _get_pivot_table_columns(segment, dialect):
         # we don't have it, assume the clause does not have a pivot table
         return []  # pragma: no cover
 
-    fc = segment.recursive_crawl("from_pivot_expression")
+    # If there's no pivot clause then just abort.
+    fc = segment.get_child("from_pivot_expression")
     if not fc:
-        # If there's no pivot clause then just abort.
-        return []
+        fc = segment.get_child("from_expression")
+
+        if not fc:
+            return []
+
+        fc = fc.get_child("from_pivot_expression")
+
+        if not fc:
+            return []
 
     pivot_table_column_aliases = []
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -24,6 +24,7 @@ from sqlfluff.core.parser import (
     CommentSegment,
     SegmentGenerator,
     Conditional,
+    AnySetOf,
 )
 
 from sqlfluff.core.dialects import load_raw_dialect
@@ -345,8 +346,6 @@ tsql_dialect.replace(
         Sequence("GROUP", "BY"),
         Sequence("ORDER", "BY"),
         "HAVING",
-        "PIVOT",
-        "UNPIVOT",
         Ref("SetOperatorSegment"),
         Ref("WithNoSchemaBindingClauseSegment"),
         Ref("DelimiterGrammar"),
@@ -444,6 +443,12 @@ tsql_dialect.replace(
     ),
     TrimParametersGrammar=Nothing(),
     TemporaryGrammar=Nothing(),
+    JoinLikeClauseGrammar=Sequence(
+        AnySetOf(
+            Ref("PivotUnpivotStatementSegment"),
+            min_times=1,
+        ),
+    ),
 )
 
 
@@ -635,7 +640,6 @@ class UnorderedSelectStatementSegment(BaseSegment):
         Dedent,
         Ref("IntoTableSegment", optional=True),
         Ref("FromClauseSegment", optional=True),
-        Ref("PivotUnpivotStatementSegment", optional=True),
         Ref("WhereClauseSegment", optional=True),
         Ref("GroupByClauseSegment", optional=True),
         Ref("HavingClauseSegment", optional=True),

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -443,11 +443,9 @@ tsql_dialect.replace(
     ),
     TrimParametersGrammar=Nothing(),
     TemporaryGrammar=Nothing(),
-    JoinLikeClauseGrammar=Sequence(
-        AnySetOf(
-            Ref("PivotUnpivotStatementSegment"),
-            min_times=1,
-        ),
+    JoinLikeClauseGrammar=AnySetOf(
+        Ref("PivotUnpivotStatementSegment"),
+        min_times=1,
     ),
 )
 

--- a/test/fixtures/dialects/tsql/create_view_with_pivot.yml
+++ b/test/fixtures/dialects/tsql/create_view_with_pivot.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4f394efeb23b6f838b5fd9f7278f98b49696440e7372e563c1c8810ed73771ae
+_hash: 062a9499ecf3ee7c0a9a36e4af3365a760e611fa9120ad19ee29c3502357287d
 file:
   batch:
     statement:
@@ -75,42 +75,42 @@ file:
                 alias_expression:
                   keyword: AS
                   identifier: SourceTable
-          from_pivot_expression:
-          - keyword: PIVOT
-          - bracketed:
-            - start_bracket: (
-            - function:
-                function_name:
-                  function_name_identifier: AVG
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    column_reference:
-                      identifier: StandardCost
-                  end_bracket: )
-            - keyword: FOR
-            - column_reference:
-                identifier: DaysToManufacture
-            - keyword: IN
-            - bracketed:
-              - start_bracket: (
-              - pivot_column_reference:
-                  identifier: '[0]'
-              - comma: ','
-              - pivot_column_reference:
-                  identifier: '[1]'
-              - comma: ','
-              - pivot_column_reference:
-                  identifier: '[2]'
-              - comma: ','
-              - pivot_column_reference:
-                  identifier: '[3]'
-              - comma: ','
-              - pivot_column_reference:
-                  identifier: '[4]'
-              - end_bracket: )
-            - end_bracket: )
-          - keyword: AS
-          - table_reference:
-              identifier: PivotTable
-          statement_terminator: ;
+              from_pivot_expression:
+              - keyword: PIVOT
+              - bracketed:
+                - start_bracket: (
+                - function:
+                    function_name:
+                      function_name_identifier: AVG
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          identifier: StandardCost
+                      end_bracket: )
+                - keyword: FOR
+                - column_reference:
+                    identifier: DaysToManufacture
+                - keyword: IN
+                - bracketed:
+                  - start_bracket: (
+                  - pivot_column_reference:
+                      identifier: '[0]'
+                  - comma: ','
+                  - pivot_column_reference:
+                      identifier: '[1]'
+                  - comma: ','
+                  - pivot_column_reference:
+                      identifier: '[2]'
+                  - comma: ','
+                  - pivot_column_reference:
+                      identifier: '[3]'
+                  - comma: ','
+                  - pivot_column_reference:
+                      identifier: '[4]'
+                  - end_bracket: )
+                - end_bracket: )
+              - keyword: AS
+              - table_reference:
+                  identifier: PivotTable
+            statement_terminator: ;

--- a/test/fixtures/dialects/tsql/create_view_with_unpivot.yml
+++ b/test/fixtures/dialects/tsql/create_view_with_unpivot.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 484b70bfb2806f0ad9abded5077f111aeb6484ed8c1c40b9ac6d99aaadb8fce9
+_hash: 351b171bee2ef80feb0a318a2e621e5b4400bb830bb9d1e88e8d0be6dd83d86d
 file:
   batch:
     statement:
@@ -70,35 +70,35 @@ file:
                     end_bracket: )
                 alias_expression:
                   identifier: p
-          from_pivot_expression:
-          - keyword: UNPIVOT
-          - bracketed:
-            - start_bracket: (
-            - column_reference:
-                identifier: Orders
-            - keyword: FOR
-            - column_reference:
-                identifier: Employee
-            - keyword: IN
-            - bracketed:
-              - start_bracket: (
-              - pivot_column_reference:
-                  identifier: Emp1
-              - comma: ','
-              - pivot_column_reference:
-                  identifier: Emp2
-              - comma: ','
-              - pivot_column_reference:
-                  identifier: Emp3
-              - comma: ','
-              - pivot_column_reference:
-                  identifier: Emp4
-              - comma: ','
-              - pivot_column_reference:
-                  identifier: Emp5
-              - end_bracket: )
-            - end_bracket: )
-          - keyword: AS
-          - table_reference:
-              identifier: unpvt
-          statement_terminator: ;
+              from_pivot_expression:
+              - keyword: UNPIVOT
+              - bracketed:
+                - start_bracket: (
+                - column_reference:
+                    identifier: Orders
+                - keyword: FOR
+                - column_reference:
+                    identifier: Employee
+                - keyword: IN
+                - bracketed:
+                  - start_bracket: (
+                  - pivot_column_reference:
+                      identifier: Emp1
+                  - comma: ','
+                  - pivot_column_reference:
+                      identifier: Emp2
+                  - comma: ','
+                  - pivot_column_reference:
+                      identifier: Emp3
+                  - comma: ','
+                  - pivot_column_reference:
+                      identifier: Emp4
+                  - comma: ','
+                  - pivot_column_reference:
+                      identifier: Emp5
+                  - end_bracket: )
+                - end_bracket: )
+              - keyword: AS
+              - table_reference:
+                  identifier: unpvt
+            statement_terminator: ;

--- a/test/fixtures/dialects/tsql/select_pivot.sql
+++ b/test/fixtures/dialects/tsql/select_pivot.sql
@@ -9,3 +9,15 @@ from
     table1 as t1
 pivot
     (max(value) for rn in ([1], [2], [3]) ) pvt;
+GO
+
+SELECT
+       unpvt.Program
+     , dd.[Month Number] AS Month
+FROM p
+UNPIVOT (
+	MonthValue FOR MonthColumn IN (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec)
+	) AS unpvt
+INNER JOIN d
+	ON [Month Name] = unpvt.MonthColumn;
+GO

--- a/test/fixtures/dialects/tsql/select_pivot.yml
+++ b/test/fixtures/dialects/tsql/select_pivot.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8d3d73e16dbaad8f56f91700adb49ee982e3eba0db666149af8a2fa5d50afd2f
+_hash: fcf65900ed1781c40878c7941fd88a08a9369907eedf46a3a3dde6ee980f7243
 file:
-  batch:
+- batch:
   - statement:
       select_statement:
         select_clause:
@@ -31,39 +31,39 @@ file:
               alias_expression:
                 keyword: as
                 identifier: t1
-        from_pivot_expression:
-        - keyword: pivot
-        - bracketed:
-          - start_bracket: (
-          - function:
-              function_name:
-                function_name_identifier: max
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    identifier: value
-                end_bracket: )
-          - keyword: for
-          - column_reference:
-              identifier: rn
-          - keyword: in
-          - bracketed:
-            - start_bracket: (
-            - pivot_column_reference:
-                identifier: '[1]'
-            - comma: ','
-            - pivot_column_reference:
-                identifier: '[2]'
-            - comma: ','
-            - pivot_column_reference:
-                identifier: '[3]'
-            - end_bracket: )
-          - end_bracket: )
-        - keyword: as
-        - table_reference:
-            identifier: pvt
-        statement_terminator: ;
+            from_pivot_expression:
+            - keyword: pivot
+            - bracketed:
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: max
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: value
+                    end_bracket: )
+              - keyword: for
+              - column_reference:
+                  identifier: rn
+              - keyword: in
+              - bracketed:
+                - start_bracket: (
+                - pivot_column_reference:
+                    identifier: '[1]'
+                - comma: ','
+                - pivot_column_reference:
+                    identifier: '[2]'
+                - comma: ','
+                - pivot_column_reference:
+                    identifier: '[3]'
+                - end_bracket: )
+              - end_bracket: )
+            - keyword: as
+            - table_reference:
+                identifier: pvt
+          statement_terminator: ;
   - statement:
       select_statement:
         select_clause:
@@ -89,35 +89,136 @@ file:
               alias_expression:
                 keyword: as
                 identifier: t1
-        from_pivot_expression:
-          keyword: pivot
-          bracketed:
-          - start_bracket: (
-          - function:
-              function_name:
-                function_name_identifier: max
+            from_pivot_expression:
+              keyword: pivot
               bracketed:
-                start_bracket: (
+              - start_bracket: (
+              - function:
+                  function_name:
+                    function_name_identifier: max
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        identifier: value
+                    end_bracket: )
+              - keyword: for
+              - column_reference:
+                  identifier: rn
+              - keyword: in
+              - bracketed:
+                - start_bracket: (
+                - pivot_column_reference:
+                    identifier: '[1]'
+                - comma: ','
+                - pivot_column_reference:
+                    identifier: '[2]'
+                - comma: ','
+                - pivot_column_reference:
+                    identifier: '[3]'
+                - end_bracket: )
+              - end_bracket: )
+              table_reference:
+                identifier: pvt
+          statement_terminator: ;
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - identifier: unpvt
+            - dot: .
+            - identifier: Program
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - identifier: dd
+            - dot: .
+            - identifier: '[Month Number]'
+            alias_expression:
+              keyword: AS
+              identifier: Month
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: p
+            from_pivot_expression:
+            - keyword: UNPIVOT
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                  identifier: MonthValue
+              - keyword: FOR
+              - column_reference:
+                  identifier: MonthColumn
+              - keyword: IN
+              - bracketed:
+                - start_bracket: (
+                - pivot_column_reference:
+                    identifier: Jan
+                - comma: ','
+                - pivot_column_reference:
+                    identifier: Feb
+                - comma: ','
+                - pivot_column_reference:
+                    identifier: Mar
+                - comma: ','
+                - pivot_column_reference:
+                    identifier: Apr
+                - comma: ','
+                - pivot_column_reference:
+                    identifier: May
+                - comma: ','
+                - pivot_column_reference:
+                    identifier: Jun
+                - comma: ','
+                - pivot_column_reference:
+                    identifier: Jul
+                - comma: ','
+                - pivot_column_reference:
+                    identifier: Aug
+                - comma: ','
+                - pivot_column_reference:
+                    identifier: Sep
+                - comma: ','
+                - pivot_column_reference:
+                    identifier: Oct
+                - comma: ','
+                - pivot_column_reference:
+                    identifier: Nov
+                - comma: ','
+                - pivot_column_reference:
+                    identifier: Dec
+                - end_bracket: )
+              - end_bracket: )
+            - keyword: AS
+            - table_reference:
+                identifier: unpvt
+            join_clause:
+            - keyword: INNER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: d
+            - join_on_condition:
+                keyword: 'ON'
                 expression:
-                  column_reference:
-                    identifier: value
-                end_bracket: )
-          - keyword: for
-          - column_reference:
-              identifier: rn
-          - keyword: in
-          - bracketed:
-            - start_bracket: (
-            - pivot_column_reference:
-                identifier: '[1]'
-            - comma: ','
-            - pivot_column_reference:
-                identifier: '[2]'
-            - comma: ','
-            - pivot_column_reference:
-                identifier: '[3]'
-            - end_bracket: )
-          - end_bracket: )
-          table_reference:
-            identifier: pvt
-        statement_terminator: ;
+                - column_reference:
+                    identifier: '[Month Name]'
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - identifier: unpvt
+                  - dot: .
+                  - identifier: MonthColumn
+          statement_terminator: ;
+- go_statement:
+    keyword: GO


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #2890 

TSQL allows for PIVOTs/UNPIVOTs to be interspersed with JOINs within a FROM clause, but the SQLFluff TSQL dialect only allows PIVOTs/UNPIVOTs as terminators to a FROM clause.  This code change will bring SQLFluff TSQL into harmony with TSQL.

As part of this change it is possible for from_pivot_expression segments to be grandchildren of a from_clause segment instead of direct children.  This PR updates the _get_pivot_table_columns function within select.py to handle this scenario.

### Are there any other side effects of this change that we should be aware of?
This PR adds a no cover hint to select.py on a return call that flags as uncovered as a result of this change.  This mimics the return call immediately above it.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
