### PR TITLE
Snowflake: Support `ALTER EXTERNAL TABLE`

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -845,6 +845,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("CopyIntoTableStatementSegment"),
             Ref("AlterWarehouseStatementSegment"),
             Ref("CreateExternalTableSegment"),
+            Ref("AlterExternalTableStatementSegment"),
             Ref("CreateSchemaStatementSegment"),
             Ref("AlterSchemaStatementSegment"),
             Ref("CreateFunctionStatementSegment"),
@@ -1653,6 +1654,58 @@ class AlterWarehouseStatementSegment(BaseSegment):
                     Delimited(Ref("NakedIdentifierSegment")),
                     Sequence("TAG", Delimited(Ref("NakedIdentifierSegment"))),
                 ),
+            ),
+        ),
+    )
+
+
+class AlterExternalTableStatementSegment(BaseSegment):
+    """An `ALTER EXTERNAL TABLE` statement.
+
+    https://docs.snowflake.com/en/sql-reference/sql/alter-external-table.html
+    """
+
+    type = "alter_external_table_statement"
+
+    match_grammar = Sequence(
+        "ALTER",
+        "EXTERNAL",
+        "TABLE",
+        Ref("IfExistsGrammar", optional=True),
+        Ref("TableReferenceSegment"),
+        OneOf(
+            Sequence("REFRESH", Ref("QuotedLiteralSegment", optional=True)),
+            Sequence(
+                OneOf("ADD", "REMOVE"),
+                "FILES",
+                Bracketed(Delimited(Ref("QuotedLiteralSegment"))),
+            ),
+            Sequence(
+                "SET",
+                Sequence(
+                    "AUTO_REFRESH",
+                    Ref("EqualsSegment"),
+                    Ref("BooleanLiteralGrammar"),
+                    optional=True,
+                ),
+                Ref("TagEqualsSegment", optional=True),
+            ),
+            Sequence("UNSET", Ref("TagEqualsSegment")),
+            Sequence("DROP", "PARTITION", "LOCATION", Ref("QuotedLiteralSegment")),
+            Sequence(
+                "ADD",
+                "PARTITION",
+                Bracketed(
+                    Delimited(
+                        Sequence(
+                            Ref("ColumnReferenceSegment"),
+                            Ref("EqualsSegment"),
+                            Ref("QuotedLiteralSegment"),
+                        ),
+                    ),
+                ),
+                "LOCATION",
+                Ref("QuotedLiteralSegment"),
             ),
         ),
     )

--- a/test/fixtures/dialects/snowflake/snowflake_alter_external_table.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_external_table.sql
@@ -1,0 +1,9 @@
+alter external table foo refresh;
+alter external table foo refresh '2018/08/05/';
+alter external table foo add files ('foo/bar.json.gz', 'bar/foo.json.gz');
+alter external table foo remove files ('foo/bar.json.gz', 'bar/foo.json.gz');
+alter external table foo add partition(foo='baz', bar='bar', baz='foo') location '2022/01';
+alter external table foo drop partition location '2022/01';
+alter external table if exists foo set auto_refresh = true;
+alter external table if exists foo set tag foo = 'foo', bar = 'bar';
+alter external table foo unset tag foo = 'foo';

--- a/test/fixtures/dialects/snowflake/snowflake_alter_external_table.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_external_table.yml
@@ -1,0 +1,154 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 41b982e8244800218b342abf1bd594c54c0eba76fa46920a9b6874d2b31f0804
+file:
+- statement:
+    alter_external_table_statement:
+    - keyword: alter
+    - keyword: external
+    - keyword: table
+    - table_reference:
+        identifier: foo
+    - keyword: refresh
+- statement_terminator: ;
+- statement:
+    alter_external_table_statement:
+    - keyword: alter
+    - keyword: external
+    - keyword: table
+    - table_reference:
+        identifier: foo
+    - keyword: refresh
+    - literal: "'2018/08/05/'"
+- statement_terminator: ;
+- statement:
+    alter_external_table_statement:
+    - keyword: alter
+    - keyword: external
+    - keyword: table
+    - table_reference:
+        identifier: foo
+    - keyword: add
+    - keyword: files
+    - bracketed:
+      - start_bracket: (
+      - literal: "'foo/bar.json.gz'"
+      - comma: ','
+      - literal: "'bar/foo.json.gz'"
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_external_table_statement:
+    - keyword: alter
+    - keyword: external
+    - keyword: table
+    - table_reference:
+        identifier: foo
+    - keyword: remove
+    - keyword: files
+    - bracketed:
+      - start_bracket: (
+      - literal: "'foo/bar.json.gz'"
+      - comma: ','
+      - literal: "'bar/foo.json.gz'"
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_external_table_statement:
+    - keyword: alter
+    - keyword: external
+    - keyword: table
+    - table_reference:
+        identifier: foo
+    - keyword: add
+    - keyword: partition
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          identifier: foo
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - literal: "'baz'"
+      - comma: ','
+      - column_reference:
+          identifier: bar
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - literal: "'bar'"
+      - comma: ','
+      - column_reference:
+          identifier: baz
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - literal: "'foo'"
+      - end_bracket: )
+    - keyword: location
+    - literal: "'2022/01'"
+- statement_terminator: ;
+- statement:
+    alter_external_table_statement:
+    - keyword: alter
+    - keyword: external
+    - keyword: table
+    - table_reference:
+        identifier: foo
+    - keyword: drop
+    - keyword: partition
+    - keyword: location
+    - literal: "'2022/01'"
+- statement_terminator: ;
+- statement:
+    alter_external_table_statement:
+    - keyword: alter
+    - keyword: external
+    - keyword: table
+    - keyword: if
+    - keyword: exists
+    - table_reference:
+        identifier: foo
+    - keyword: set
+    - keyword: auto_refresh
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - literal: 'true'
+- statement_terminator: ;
+- statement:
+    alter_external_table_statement:
+    - keyword: alter
+    - keyword: external
+    - keyword: table
+    - keyword: if
+    - keyword: exists
+    - table_reference:
+        identifier: foo
+    - keyword: set
+    - tag_equals:
+      - keyword: tag
+      - identifier: foo
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - literal: "'foo'"
+      - comma: ','
+      - identifier: bar
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - literal: "'bar'"
+- statement_terminator: ;
+- statement:
+    alter_external_table_statement:
+    - keyword: alter
+    - keyword: external
+    - keyword: table
+    - table_reference:
+        identifier: foo
+    - keyword: unset
+    - tag_equals:
+        keyword: tag
+        identifier: foo
+        comparison_operator:
+          raw_comparison_operator: '='
+        literal: "'foo'"
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Adds support for ALTER EXTERNAL TABLE in Snowflake.

https://docs.snowflake.com/en/sql-reference/sql/alter-external-table.html


### Are there any other side effects of this change that we should be aware of?

None that I'm aware of!

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
