### PR TITLE
SOQL: Disallow non-`SELECT` statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_soql.py
+++ b/src/sqlfluff/dialects/dialect_soql.py
@@ -3,6 +3,8 @@
 https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm
 """
 
+from sqlfluff.dialects import dialect_ansi as ansi
+from sqlfluff.core.parser import Ref
 from sqlfluff.core.dialects import load_raw_dialect
 
 ansi_dialect = load_raw_dialect("ansi")
@@ -42,3 +44,13 @@ date_literals = [
 soql_dialect.sets("reserved_keywords").update(date_literals)
 
 soql_dialect.sets("bare_functions").update(date_literals)
+
+
+class StatementSegment(ansi.StatementSegment):
+    """SOQL seems to only support SELECT statements.
+
+    https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm
+    """
+
+    match_grammar = Ref("SelectableGrammar")
+    parse_grammar = Ref("SelectableGrammar")

--- a/test/dialects/soql_test.py
+++ b/test/dialects/soql_test.py
@@ -1,0 +1,23 @@
+"""Tests specific to the postgres dialect."""
+import pytest
+
+from sqlfluff.core import FluffConfig, Linter
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "ALTER TABLE foo DROP COLUMN bar",
+        "CREATE USER my_user",
+        "TRUNCATE TABLE foo",
+        "EXPLAIN SELECT Id FROM Contact",
+        "DROP TABLE foo",
+        "DROP USER my_user",
+    ],
+)
+def test_non_selects_unparseable(raw: str) -> None:
+    """Test that non-SELECT commands are not parseable."""
+    cfg = FluffConfig(configs={"core": {"dialect": "soql"}})
+    lnt = Linter(config=cfg)
+    result = lnt.lint_string(raw)
+    assert result.num_violations() > 0


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Closes #3325


### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
