### PR TITLE
Fix critical parse error logged after L003 fix

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1199,9 +1199,9 @@ class BaseSegment:
 
             before = []
             after = []
-            if fixes_applied and not r.can_start_end_non_code:
+            if not r.can_start_end_non_code:
                 idx_non_code = self._find_start_or_end_non_code(seg_buffer)
-                # Did the fixes leave misplaced segments?
+                # Are there misplaced segments from a fix?
                 if idx_non_code is not None:
                     # Yes. Fix the misplaced segments: Do not include them
                     # in the new segment's children. Instead, return them to the

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -1007,3 +1007,22 @@ test_fail_unindented_procedure_parameters:
   configs:
     core:
       dialect: tsql
+
+
+test_tsql_bubble_up_newline_after_fix:
+  # Tests issue 3303, where an L003 fix leaves a newline as the final child
+  # segment that has to be "bubbled up" two levels to avoid violating the
+  # _is_code_or_meta() check in core/parser/segments/base.py.
+  fail_str: |
+    create procedure name as
+    begin
+    drop table if exists #something
+      end
+  fix_str: |
+    create procedure name as
+    begin
+        drop table if exists #something
+    end
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3303. These kinds of issues were supposed to be addressed by PR #3232 (aka the 🍺 🍻 review PR 😉 ), which was first included in 0.13.1. There was a slight bug in that logic which prevented it from always completing its job.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?
It should be pretty safe. This code is only activated when it detects an impending post-fix parse issue, and this is just a minor tweak to the existing code.


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
