### PR TITLE
SOQL: Disable L026 rule

### DIFF
--- a/src/sqlfluff/rules/L026.py
+++ b/src/sqlfluff/rules/L026.py
@@ -60,13 +60,14 @@ class Rule_L026(BaseRule):
 
     groups = ("all", "core")
     config_keywords = ["force_enable"]
+    _dialects_disabled_by_default = ["bigquery", "hive", "redshift", "soql", "sparksql"]
 
     def _eval(self, context: RuleContext) -> EvalResultType:
         # Config type hints
         self.force_enable: bool
 
         if (
-            context.dialect.name in ["bigquery", "hive", "redshift", "soql", "sparksql"]
+            context.dialect.name in self._dialects_disabled_by_default
             and not self.force_enable
         ):
             return LintResult()

--- a/src/sqlfluff/rules/L026.py
+++ b/src/sqlfluff/rules/L026.py
@@ -66,7 +66,7 @@ class Rule_L026(BaseRule):
         self.force_enable: bool
 
         if (
-            context.dialect.name in ["bigquery", "hive", "redshift", "sparksql"]
+            context.dialect.name in ["bigquery", "hive", "redshift", "soql", "sparksql"]
             and not self.force_enable
         ):
             return LintResult()

--- a/src/sqlfluff/rules/L026.py
+++ b/src/sqlfluff/rules/L026.py
@@ -33,8 +33,8 @@ class Rule_L026(BaseRule):
 
     .. note::
        This rule is disabled by default for BigQuery, Hive, Redshift, SOQL, and SparkSQL
-       due to the use of structs and lateral views which trigger false positives.
-       It can be enabled with the ``force_enable = True`` flag.
+       due to the support of things like structs and lateral views which trigger false
+       positives. It can be enabled with the ``force_enable = True`` flag.
 
     **Anti-pattern**
 

--- a/src/sqlfluff/rules/L026.py
+++ b/src/sqlfluff/rules/L026.py
@@ -32,7 +32,7 @@ class Rule_L026(BaseRule):
     """References cannot reference objects not present in ``FROM`` clause.
 
     .. note::
-       This rule is disabled by default for BigQuery, Hive, Redshift, and SparkSQL
+       This rule is disabled by default for BigQuery, Hive, Redshift, SOQL, and SparkSQL
        due to the use of structs and lateral views which trigger false positives.
        It can be enabled with the ``force_enable = True`` flag.
 

--- a/test/dialects/soql_test.py
+++ b/test/dialects/soql_test.py
@@ -2,17 +2,24 @@
 import pytest
 
 from sqlfluff.core import FluffConfig, Linter
+from sqlfluff.core.errors import SQLParseError
 
 
 @pytest.mark.parametrize(
     "raw",
     [
-        "ALTER TABLE foo DROP COLUMN bar",
-        "CREATE USER my_user",
-        "TRUNCATE TABLE foo",
-        "EXPLAIN SELECT Id FROM Contact",
-        "DROP TABLE foo",
-        "DROP USER my_user",
+        """ALTER TABLE foo DROP COLUMN bar
+        """,
+        """CREATE USER my_user
+        """,
+        """TRUNCATE TABLE foo
+        """,
+        """EXPLAIN SELECT Id FROM Contact
+        """,
+        """DROP TABLE foo
+        """,
+        """DROP USER my_user
+        """,
     ],
 )
 def test_non_selects_unparseable(raw: str) -> None:
@@ -20,4 +27,16 @@ def test_non_selects_unparseable(raw: str) -> None:
     cfg = FluffConfig(configs={"core": {"dialect": "soql"}})
     lnt = Linter(config=cfg)
     result = lnt.lint_string(raw)
-    assert result.num_violations() > 0
+    assert len(result.violations) == 1
+    assert isinstance(result.violations[0], SQLParseError)
+
+
+def test_ignore_unreferenced_object() -> None:
+    """SOQL often has an implicit relationship between objects."""
+    cfg = FluffConfig(configs={"core": {"dialect": "soql"}})
+    lnt = Linter(config=cfg)
+    result = lnt.lint_string(
+        """SELECT Account.Name FROM Contact
+    """
+    )
+    assert result.num_violations() == 0

--- a/test/dialects/soql_test.py
+++ b/test/dialects/soql_test.py
@@ -29,14 +29,3 @@ def test_non_selects_unparseable(raw: str) -> None:
     result = lnt.lint_string(raw)
     assert len(result.violations) == 1
     assert isinstance(result.violations[0], SQLParseError)
-
-
-def test_ignore_unreferenced_object() -> None:
-    """SOQL often has an implicit relationship between objects."""
-    cfg = FluffConfig(configs={"core": {"dialect": "soql"}})
-    lnt = Linter(config=cfg)
-    result = lnt.lint_string(
-        """SELECT Account.Name FROM Contact
-    """
-    )
-    assert result.num_violations() == 0

--- a/test/fixtures/rules/std_rule_cases/L026.yml
+++ b/test/fixtures/rules/std_rule_cases/L026.yml
@@ -258,3 +258,10 @@ test_parenthesized_join_clauses_do_not_flag:
   configs:
     core:
       dialect: tsql
+
+test_soql_ignore_rule:
+  pass_str: |
+    SELECT Account.Name FROM Contact
+  configs:
+    core:
+      dialect: soql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Closes https://github.com/sqlfluff/sqlfluff/issues/3322

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
