### PR TITLE
GitHub Actions: Update existing PR on new runs

### DIFF
--- a/.github/workflows/create-release-pull-request.yaml
+++ b/.github/workflows/create-release-pull-request.yaml
@@ -44,7 +44,6 @@ jobs:
         with:
           delete-branch: true
           branch: prep-${{ github.event.inputs.newVersionNumber }}
-          branch-suffix: short-commit-hash
           commit-message: "Bump to version ${{ github.event.inputs.newVersionNumber }}"
           title: Prep version ${{ github.event.inputs.newVersionNumber }}
           body: |


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
OK, this was easier than I thought. I ran the action two times and the second time force-pushes the new release note to the PR: https://github.com/greg-finley/sqlfluff/pull/30

Closes https://github.com/sqlfluff/sqlfluff/issues/3361

### Are there any other side effects of this change that we should be aware of?
It will overwrite any manual changes on the branch if the GitHub Action is run again. Typically one person would be doing the release end-to-end, so maybe the risk is low.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
