### PR TITLE
Proof of concept: Release via Python util script

### DIFF
--- a/.github/workflows/create-release-pull-request.yaml
+++ b/.github/workflows/create-release-pull-request.yaml
@@ -12,12 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          pip install requests click pyyaml
 
       - name: Replace version
         run: |
-          sed -i -e '/version =/ s/= .*/= ${{ github.event.inputs.newVersionNumber }}/' ./plugins/sqlfluff-templater-dbt/setup.cfg
-          sed -i -e '/version =/ s/= .*/= ${{ github.event.inputs.newVersionNumber }}/' ./setup.cfg
-          sed -i -e '/stable_version =/ s/= .*/= ${{ github.event.inputs.newVersionNumber }}/' ./setup.cfg
+          python util.py replace-version --new_version_num=${{ github.event.inputs.newVersionNumber }}
 
       - name: Start Changelog entry
         run: |

--- a/util.py
+++ b/util.py
@@ -121,5 +121,21 @@ def benchmark(cmd, runs, from_file):
         click.echo("Run {:>5}: {}".format(f"#{run_no}", all_results[run_no]))
 
 
+@cli.command()
+@click.option("--new_version_num")
+def replace_version(new_version_num):
+    """Change version number in the cfg files."""
+    for filename in ["setup.cfg", "plugins/sqlfluff-templater-dbt/setup.cfg"]:
+        input_file = open(filename, "r").readlines()
+        write_file = open(filename, "w")
+        for line in input_file:
+            for key in ["stable_version", "version"]:
+                if line.startswith(key):
+                    line = f"{key} = {new_version_num}\n"
+                    break
+            write_file.write(line)
+        write_file.close()
+
+
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
As discussed with @tunetheweb , maybe we can do the release tasks via a Python script instead of shell commands. It should be more interoperable than shell commands, allowing the functions to be developed/run locally much more easily. After this change, [bot PRs still look ok](https://github.com/greg-finley/sqlfluff/pull/31/files).

Next step would be make an (idempotent!) `def start_changelog_entry` to replace the shell version, but I wanted to ensure this was headed the right direction first.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
