### PR TITLE
Postgres: correct `RETURNS TABLE` column type

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -682,7 +682,8 @@ class CreateFunctionStatementSegment(ansi.CreateFunctionStatementSegment):
                             OneOf(
                                 Ref("DatatypeSegment"),
                                 Sequence(
-                                    Ref("ParameterNameSegment"), Ref("DatatypeSegment")
+                                    Ref("ColumnReferenceSegment"),
+                                    Ref("DatatypeSegment"),
                                 ),
                             ),
                             delimiter=Ref("CommaSegment"),

--- a/test/fixtures/dialects/postgres/postgres_create_function.sql
+++ b/test/fixtures/dialects/postgres/postgres_create_function.sql
@@ -64,6 +64,11 @@ CREATE FUNCTION dup(int) RETURNS TABLE(f1 int, f2 text)
     AS $$ SELECT $1, CAST($1 AS text) || ' is text' $$
     LANGUAGE SQL;
 
+CREATE FUNCTION dup(int) RETURNS TABLE("f1" int, "f2" text)
+    AS $$ SELECT $1, CAST($1 AS text) || ' is text' $$
+    LANGUAGE SQL;
+
+
 SELECT * FROM dup(42);
 
 CREATE FUNCTION check_password(uname TEXT, pass TEXT)

--- a/test/fixtures/dialects/postgres/postgres_create_function.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3ece8a979e6e2414a9dfd307ab67b326790a3b13bd881c7aeefd569dc5ae8a90
+_hash: 6dd4491aff1ef376638cb3cc10ca2b974c08e581a8cf6a693ba8d248f3fab435
 file:
 - statement:
     create_function_statement:
@@ -392,11 +392,46 @@ file:
     - keyword: TABLE
     - bracketed:
       - start_bracket: (
-      - parameter: f1
+      - column_reference:
+          identifier: f1
       - data_type:
           keyword: int
       - comma: ','
-      - parameter: f2
+      - column_reference:
+          identifier: f2
+      - data_type:
+          keyword: text
+      - end_bracket: )
+    - function_definition:
+        keyword: AS
+        literal: "$$ SELECT $1, CAST($1 AS text) || ' is text' $$"
+        language_clause:
+          keyword: LANGUAGE
+          identifier: SQL
+- statement_terminator: ;
+- statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: dup
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          data_type:
+            keyword: int
+          end_bracket: )
+    - keyword: RETURNS
+    - keyword: TABLE
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          identifier: '"f1"'
+      - data_type:
+          keyword: int
+      - comma: ','
+      - column_reference:
+          identifier: '"f2"'
       - data_type:
           keyword: text
       - end_bracket: )


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3377 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
