### PR TITLE
Redshift: Correct `ALTER TABLE` syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -2421,7 +2421,7 @@ class TableConstraintUsingIndexSegment(BaseSegment):
             "CONSTRAINT", Ref("ObjectReferenceSegment"), optional=True
         ),
         Sequence(
-            OneOf("UNIQUE", Sequence("PRIMARY", "KEY")),
+            OneOf("UNIQUE", Ref("PrimaryKeyGrammar")),
             "USING",
             "INDEX",
             Ref("IndexReferenceSegment"),

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -551,6 +551,121 @@ class ColumnConstraintSegment(BaseSegment):
     )
 
 
+class AlterTableActionSegment(BaseSegment):
+    """Alter Table Action Segment.
+
+    https://docs.aws.amazon.com/redshift/latest/dg/r_ALTER_TABLE.html
+    """
+
+    type = "alter_table_action_segment"
+
+    match_grammar = OneOf(
+        Sequence(
+            "ADD",
+            Ref("TableConstraintSegment"),
+            Sequence("NOT", "VALID", optional=True),
+        ),
+        Sequence("VALIDATE", "CONSTRAINT", Ref("ParameterNameSegment")),
+        Sequence(
+            "DROP",
+            "CONSTRAINT",
+            Ref("ParameterNameSegment"),
+            Ref("DropBehaviorGrammar", optional=True),
+        ),
+        Sequence(
+            "OWNER",
+            "TO",
+            OneOf(
+                OneOf(Ref("ParameterNameSegment"), Ref("QuotedIdentifierSegment")),
+            ),
+        ),
+        Sequence(
+            "RENAME",
+            "TO",
+            OneOf(
+                OneOf(Ref("ParameterNameSegment"), Ref("QuotedIdentifierSegment")),
+            ),
+        ),
+        Sequence(
+            "RENAME",
+            "COLUMN",
+            "TO",
+            OneOf(
+                Ref("ColumnReferenceSegment"),
+            ),
+        ),
+        Sequence(
+            "ALTER",
+            Ref.keyword("COLUMN", optional=True),
+            Ref("ColumnReferenceSegment"),
+            OneOf(
+                Sequence(
+                    "TYPE",
+                    Ref("DatatypeSegment"),
+                ),
+                Sequence(
+                    "ENCODE",
+                    Delimited(
+                        Ref("ColumnEncodingGrammar"),
+                    ),
+                ),
+            ),
+        ),
+        Sequence(
+            "ALTER",
+            "DISTKEY",
+            Ref("ColumnReferenceSegment"),
+        ),
+        Sequence(
+            "ALTER",
+            "DISTSTYLE",
+            OneOf(
+                "ALL",
+                "EVEN",
+                Sequence("KEY", "DISTKEY", Ref("ColumnReferenceSegment")),
+                "AUTO",
+            ),
+        ),
+        Sequence(
+            "ALTER",
+            Ref.keyword("COMPOUND", optional=True),
+            "SORTKEY",
+            Bracketed(
+                Delimited(
+                    Ref("ColumnReferenceSegment"),
+                ),
+            ),
+        ),
+        Sequence(
+            "ALTER",
+            "SORTKEY",
+            OneOf(
+                "AUTO",
+                "NONE",
+            ),
+        ),
+        Sequence(
+            "ALTER",
+            "ENCODE",
+            "AUTO",
+        ),
+        Sequence(
+            "ADD",
+            Ref.keyword("COLUMN", optional=True),
+            Ref("ColumnReferenceSegment"),
+            Ref("DatatypeSegment"),
+            Sequence("COLLATE", Ref("QuotedLiteralSegment"), optional=True),
+            AnyNumberOf(Ref("ColumnConstraintSegment")),
+        ),
+        Sequence(
+            "DROP",
+            Ref.keyword("COLUMN", optional=True),
+            Ref("ColumnReferenceSegment"),
+            Ref("DropBehaviorGrammar", optional=True),
+        ),
+    )
+
+
 class TableAttributeSegment(BaseSegment):
     """Redshift specific table attributes.
 

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -542,7 +542,7 @@ class ColumnConstraintSegment(BaseSegment):
 
     match_grammar = AnySetOf(
         OneOf(Sequence("NOT", "NULL"), "NULL"),
-        OneOf("UNIQUE", Sequence("PRIMARY", "KEY")),
+        OneOf("UNIQUE", Ref("PrimaryKeyGrammar")),
         Sequence(
             "REFERENCES",
             Ref("TableReferenceSegment"),
@@ -585,20 +585,25 @@ class TableConstraintSegment(BaseSegment):
 
     type = "table_constraint"
 
-    match_grammar = AnySetOf(
-        Sequence("UNIQUE", Bracketed(Delimited(Ref("ColumnReferenceSegment")))),
-        Sequence(
-            "PRIMARY",
-            "KEY",
-            Bracketed(Delimited(Ref("ColumnReferenceSegment"))),
+    match_grammar = Sequence(
+        Sequence(  # [ CONSTRAINT <Constraint name> ]
+            "CONSTRAINT", Ref("ObjectReferenceSegment"), optional=True
         ),
-        Sequence(
-            "FOREIGN",
-            "KEY",
-            Bracketed(Delimited(Ref("ColumnReferenceSegment"))),
-            "REFERENCES",
-            Ref("TableReferenceSegment"),
-            Sequence(Bracketed(Ref("ColumnReferenceSegment"))),
+        OneOf(
+            Sequence("UNIQUE", Bracketed(Delimited(Ref("ColumnReferenceSegment")))),
+            Sequence(
+                "PRIMARY",
+                "KEY",
+                Bracketed(Delimited(Ref("ColumnReferenceSegment"))),
+            ),
+            Sequence(
+                "FOREIGN",
+                "KEY",
+                Bracketed(Delimited(Ref("ColumnReferenceSegment"))),
+                "REFERENCES",
+                Ref("TableReferenceSegment"),
+                Sequence(Bracketed(Ref("ColumnReferenceSegment"))),
+            ),
         ),
     )
 

--- a/test/fixtures/dialects/redshift/redshift_alter_table.sql
+++ b/test/fixtures/dialects/redshift/redshift_alter_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE example_table
+    ADD CONSTRAINT example_name PRIMARY KEY (example_sk);

--- a/test/fixtures/dialects/redshift/redshift_alter_table.sql
+++ b/test/fixtures/dialects/redshift/redshift_alter_table.sql
@@ -1,2 +1,44 @@
 ALTER TABLE example_table
     ADD CONSTRAINT example_name PRIMARY KEY (example_sk);
+
+alter table users
+rename to users_bkup;
+
+alter table venue
+owner to dwuser;
+
+alter table vdate owner to vuser;
+
+alter table venue
+rename column venueseats to venuesize;
+
+alter table category
+drop constraint category_pkey;
+
+alter table event alter column eventname type varchar(300);
+
+create table t1(c0 int encode lzo, c1 bigint encode zstd, c2 varchar(16) encode lzo, c3 varchar(32) encode zstd);
+
+alter table t1 alter column c0 encode az64;
+
+alter table t1 alter column c1 encode az64;
+
+alter table t1 alter column c2 encode bytedict;
+
+alter table t1 alter column c3 encode runlength;
+
+alter table inventory alter diststyle key distkey inv_warehouse_sk;
+
+alter table inventory alter distkey inv_item_sk;
+
+alter table inventory alter diststyle all;
+
+alter table t1 alter sortkey(c0, c1);
+
+alter table t1 alter sortkey none;
+
+alter table t1 alter sortkey(c0, c1);
+
+alter table t1 alter encode auto;
+
+alter table t2 alter column c0 encode lzo;

--- a/test/fixtures/dialects/redshift/redshift_alter_table.yml
+++ b/test/fixtures/dialects/redshift/redshift_alter_table.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a74e5cff8634acec967a7093e90c7805a63902888ff4e805a912d1c267f8a6ea
+_hash: 1d4d0e6da207670465d878eb8f0162e9bb80934e9a36ce22029c38e4f72e8407
 file:
-  statement:
+- statement:
     alter_table_statement:
     - keyword: ALTER
     - keyword: TABLE
@@ -24,4 +24,295 @@ file:
             column_reference:
               identifier: example_sk
             end_bracket: )
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: users
+    - alter_table_action_segment:
+      - keyword: rename
+      - keyword: to
+      - parameter: users_bkup
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: venue
+    - alter_table_action_segment:
+      - keyword: owner
+      - keyword: to
+      - parameter: dwuser
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: vdate
+    - alter_table_action_segment:
+      - keyword: owner
+      - keyword: to
+      - parameter: vuser
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: venue
+    - keyword: rename
+    - keyword: column
+    - column_reference:
+        identifier: venueseats
+    - keyword: to
+    - column_reference:
+        identifier: venuesize
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: category
+    - alter_table_action_segment:
+      - keyword: drop
+      - keyword: constraint
+      - parameter: category_pkey
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: event
+    - alter_table_action_segment:
+      - keyword: alter
+      - keyword: column
+      - column_reference:
+          identifier: eventname
+      - keyword: type
+      - data_type:
+          keyword: varchar
+          bracketed:
+            start_bracket: (
+            literal: '300'
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: create
+    - keyword: table
+    - table_reference:
+        identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          identifier: c0
+      - data_type:
+          keyword: int
+      - column_attribute_segment:
+        - keyword: encode
+        - keyword: lzo
+      - comma: ','
+      - column_reference:
+          identifier: c1
+      - data_type:
+          keyword: bigint
+      - column_attribute_segment:
+        - keyword: encode
+        - keyword: zstd
+      - comma: ','
+      - column_reference:
+          identifier: c2
+      - data_type:
+          keyword: varchar
+          bracketed:
+            start_bracket: (
+            literal: '16'
+            end_bracket: )
+      - column_attribute_segment:
+        - keyword: encode
+        - keyword: lzo
+      - comma: ','
+      - column_reference:
+          identifier: c3
+      - data_type:
+          keyword: varchar
+          bracketed:
+            start_bracket: (
+            literal: '32'
+            end_bracket: )
+      - column_attribute_segment:
+        - keyword: encode
+        - keyword: zstd
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: t1
+    - alter_table_action_segment:
+      - keyword: alter
+      - keyword: column
+      - column_reference:
+          identifier: c0
+      - keyword: encode
+      - keyword: az64
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: t1
+    - alter_table_action_segment:
+      - keyword: alter
+      - keyword: column
+      - column_reference:
+          identifier: c1
+      - keyword: encode
+      - keyword: az64
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: t1
+    - alter_table_action_segment:
+      - keyword: alter
+      - keyword: column
+      - column_reference:
+          identifier: c2
+      - keyword: encode
+      - keyword: bytedict
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: t1
+    - alter_table_action_segment:
+      - keyword: alter
+      - keyword: column
+      - column_reference:
+          identifier: c3
+      - keyword: encode
+      - keyword: runlength
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: inventory
+    - alter_table_action_segment:
+      - keyword: alter
+      - keyword: diststyle
+      - keyword: key
+      - keyword: distkey
+      - column_reference:
+          identifier: inv_warehouse_sk
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: inventory
+    - alter_table_action_segment:
+      - keyword: alter
+      - keyword: distkey
+      - column_reference:
+          identifier: inv_item_sk
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: inventory
+    - alter_table_action_segment:
+      - keyword: alter
+      - keyword: diststyle
+      - keyword: all
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: t1
+    - alter_table_action_segment:
+      - keyword: alter
+      - keyword: sortkey
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            identifier: c0
+        - comma: ','
+        - column_reference:
+            identifier: c1
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: t1
+    - alter_table_action_segment:
+      - keyword: alter
+      - keyword: sortkey
+      - keyword: none
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: t1
+    - alter_table_action_segment:
+      - keyword: alter
+      - keyword: sortkey
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            identifier: c0
+        - comma: ','
+        - column_reference:
+            identifier: c1
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: t1
+    - alter_table_action_segment:
+      - keyword: alter
+      - keyword: encode
+      - keyword: auto
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: t2
+    - alter_table_action_segment:
+      - keyword: alter
+      - keyword: column
+      - column_reference:
+          identifier: c0
+      - keyword: encode
+      - keyword: lzo
+- statement_terminator: ;

--- a/test/fixtures/dialects/redshift/redshift_alter_table.yml
+++ b/test/fixtures/dialects/redshift/redshift_alter_table.yml
@@ -1,0 +1,27 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: a74e5cff8634acec967a7093e90c7805a63902888ff4e805a912d1c267f8a6ea
+file:
+  statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: example_table
+    - alter_table_action_segment:
+        keyword: ADD
+        table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            identifier: example_name
+        - keyword: PRIMARY
+        - keyword: KEY
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              identifier: example_sk
+            end_bracket: )
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3391 

### Are there any other side effects of this change that we should be aware of?
Also fixed some PrimaryKeyGrammar references

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
