### PR TITLE
Postgres: Parse index with column sort

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1009,6 +1009,7 @@ ansi_dialect.add(
             ),
         ),
         Sequence(OneOf("IGNORE", "RESPECT"), "NULLS"),
+        Ref("IndexColumnDefinitionSegment"),
     ),
     PostFunctionGrammar=OneOf(
         # Optional OVER suffix for window functions.

--- a/test/fixtures/dialects/postgres/postgres_create_index.sql
+++ b/test/fixtures/dialects/postgres/postgres_create_index.sql
@@ -20,3 +20,5 @@ CREATE INDEX pointloc
     ON points USING gist (box(location,location));
 
 CREATE INDEX CONCURRENTLY sales_quantity_index ON sales_table (quantity);
+
+CREATE INDEX super_idx ON super_table USING BTREE (super_column DESC);

--- a/test/fixtures/dialects/postgres/postgres_create_index.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_index.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4140e61b55beec0689cfe104cdc27723bd067ed2e5e199e2f54548a0acc3a721
+_hash: e62ea5caf64bfb7a80de1613c0950ae34219e4938e3b5ab51e4b0b6f2381580e
 file:
 - statement:
     create_index_statement:
@@ -242,4 +242,24 @@ file:
         column_reference:
           identifier: quantity
         end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_index_statement:
+    - keyword: CREATE
+    - keyword: INDEX
+    - index_reference:
+        identifier: super_idx
+    - keyword: 'ON'
+    - table_reference:
+        identifier: super_table
+    - keyword: USING
+    - function:
+        function_name:
+          function_name_identifier: BTREE
+        bracketed:
+          start_bracket: (
+          index_column_definition:
+            identifier: super_column
+            keyword: DESC
+          end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Closes https://github.com/sqlfluff/sqlfluff/issues/3368

### Are there any other side effects of this change that we should be aware of?
Maybe it should be Postgres-only instead.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
