### PR TITLE
Postgres: Allow `CREATE FUNCTION` to use Expressions in default values

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -352,7 +352,9 @@ postgres_dialect.replace(
             Sequence(Ref("ParameterNameSegment"), Ref("DatatypeSegment")),
         ),
         Sequence(
-            OneOf("DEFAULT", Ref("EqualsSegment")), Ref("LiteralGrammar"), optional=True
+            OneOf("DEFAULT", Ref("EqualsSegment")),
+            Ref("ExpressionSegment"),
+            optional=True,
         ),
     ),
     FrameClauseUnitGrammar=OneOf("RANGE", "ROWS", "GROUPS"),

--- a/test/fixtures/dialects/postgres/postgres_create_function.sql
+++ b/test/fixtures/dialects/postgres/postgres_create_function.sql
@@ -125,3 +125,23 @@ CREATE FUNCTION _add(integer, integer) RETURNS integer
 CREATE FUNCTION _$add(integer, integer) RETURNS integer
     AS 'select $1 + $2;'
     LANGUAGE SQL;
+
+create function test2(
+  x date = current_date
+)
+returns date
+as $$
+  begin
+    return x;
+  end;
+$$;
+
+create function test3(
+  x date default current_date
+)
+returns date
+as $$
+  begin
+    return x;
+  end;
+$$;

--- a/test/fixtures/dialects/postgres/postgres_create_function.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6dd4491aff1ef376638cb3cc10ca2b974c08e581a8cf6a693ba8d248f3fab435
+_hash: 260221447c164df9e45d25f8cbcfd2ebd6668e05fb24c12d50a73b672be56f59
 file:
 - statement:
     create_function_statement:
@@ -697,4 +697,55 @@ file:
         language_clause:
           keyword: LANGUAGE
           identifier: SQL
+- statement_terminator: ;
+- statement:
+    create_function_statement:
+    - keyword: create
+    - keyword: function
+    - function_name:
+        function_name_identifier: test2
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          parameter: x
+          data_type:
+            datetime_type_identifier:
+              keyword: date
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            bare_function: current_date
+          end_bracket: )
+    - keyword: returns
+    - data_type:
+        datetime_type_identifier:
+          keyword: date
+    - function_definition:
+        keyword: as
+        literal: "$$\n  begin\n    return x;\n  end;\n$$"
+- statement_terminator: ;
+- statement:
+    create_function_statement:
+    - keyword: create
+    - keyword: function
+    - function_name:
+        function_name_identifier: test3
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          parameter: x
+          data_type:
+            datetime_type_identifier:
+              keyword: date
+          keyword: default
+          expression:
+            bare_function: current_date
+          end_bracket: )
+    - keyword: returns
+    - data_type:
+        datetime_type_identifier:
+          keyword: date
+    - function_definition:
+        keyword: as
+        literal: "$$\n  begin\n    return x;\n  end;\n$$"
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3400 

### Are there any other side effects of this change that we should be aware of?
Shouldn't be

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
