### PR TITLE
Parser misbehaves if no parse grammar

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -983,7 +983,7 @@ class BaseSegment:
             return self
 
         # Check the Parse Grammar
-        parse_grammar = parse_grammar or self.parse_grammar
+        parse_grammar = parse_grammar or self.parse_grammar or self.match_grammar
         if parse_grammar is None:
             # No parse grammar, go straight to expansion
             parse_context.logger.debug(

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -984,7 +984,7 @@ class BaseSegment:
 
         # Check the Parse Grammar
         parse_grammar = (
-            parse_grammar or self.parse_grammar or getattr(self, "match_grammar")
+            parse_grammar or self.parse_grammar or getattr(self, "match_grammar", None)
         )
         if parse_grammar is None:
             # No parse grammar, go straight to expansion

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -983,7 +983,9 @@ class BaseSegment:
             return self
 
         # Check the Parse Grammar
-        parse_grammar = parse_grammar or self.parse_grammar or self.match_grammar
+        parse_grammar = (
+            parse_grammar or self.parse_grammar or getattr(self, "match_grammar")
+        )
         if parse_grammar is None:
             # No parse grammar, go straight to expansion
             parse_context.logger.debug(


### PR DESCRIPTION
### Created this PR for discussion. Not working yet, and would love suggestions how to make it work.

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Makes progress on #3277 

**NOTE**: This change causes parse errors, e.g. the file `test/fixtures/linter/autofix/ansi/004_indentation/before.sql`. In that file, I identified 4 segments encountered by the parse that have `match_grammar` but no `parse_grammar`:
* `WithCompoundStatementSegment`
* `CTEDefinitionSegment`
* `FromExpressionSegment`
* `JoinClauseSegment`

Interestingly, it looks like the file basically parsed successfully, because the parse error occurs after the last code in the file -- the message is `Found unparsable section: ''`.
```
[L: 33, P:  5]      |                            from_expression_element:
[L: 33, P:  5]      |                                table_expression:
[L: 33, P:  5]      |                                    table_reference:
[L: 33, P:  5]      |                                        identifier:           'gdpr_safe_users'
[L: 33, P: 20]      |                            newline:                          '\n'
[L: 34, P:  1]      |                            keyword:                          'USING'
[L: 34, P:  6]      |                            [META] indent:
[L: 34, P:  6]      |                            [META] indent:
[L: 34, P:  6]      |                            newline:                          '\n'
[L: 35, P:  1]      |                            whitespace:                       '    '
[L: 35, P:  5]      |                            bracketed:
[L: 35, P:  5]      |                                start_bracket:                '('
[L: 35, P:  6]      |                                [META] indent:
[L: 35, P:  6]      |                                identifier:                   'user_id'
[L: 35, P: 13]      |                                [META] dedent:
[L: 35, P: 13]      |                                end_bracket:                  ')'
[L: 35, P: 14]      |                            [META] dedent:
[L: 35, P: 14]      |                            [META] dedent:
[L: 35, P: 14]      |                            unparsable:                       !! Expected: 'Nothing...'
[L: 35, P: 14]      |                                [META] dedent:
[L: 35, P: 14]      |                                [META] dedent:
[L: 35, P: 14]      |    newline:                                                  '\n'

==== parsing violations ====
L:  35 | P:  14 |  PRS | Line 35, Position 14: Found unparsable section: ''
```

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
