### PR TITLE
Allow `numeric_dollar` templater to have curly braces, update `dollar` + `numeric_dollar` templater examples in docs

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -287,7 +287,7 @@ A few common styles are supported:
     WHERE bla = %(my_name)s
 
     -- dollar
-    WHERE bla = $my_name
+    WHERE bla = $my_name or WHERE bla = ${my_name}
 
     -- question_mark
     WHERE bla = ?

--- a/src/sqlfluff/core/templaters/placeholder.py
+++ b/src/sqlfluff/core/templaters/placeholder.py
@@ -37,9 +37,9 @@ KNOWN_STYLES = {
     ),
     # e.g. WHERE bla = ?
     "question_mark": regex.compile(r"(?<![:\w\x5c])\?", regex.UNICODE),
-    # e.g. WHERE bla = $3
+    # e.g. WHERE bla = $3 or WHERE bla = ${3}
     "numeric_dollar": regex.compile(
-        r"(?<![:\w\x5c])\$(?P<param_name>[\d]+)", regex.UNICODE
+        r"(?<![:\w\x5c])\${?(?P<param_name>[\d]+)}?", regex.UNICODE
     ),
     # e.g. WHERE bla = %s
     "percent": regex.compile(r"(?<![:\w\x5c])%s", regex.UNICODE),

--- a/test/core/templaters/placeholder_test.py
+++ b/test/core/templaters/placeholder_test.py
@@ -214,6 +214,25 @@ def test__templater_raw():
             """
             SELECT user_mail, city_id
             FROM users_data
+            WHERE (city_id) IN ${12}
+            AND date > ${90}
+            """,
+            "numeric_dollar",
+            """
+            SELECT user_mail, city_id
+            FROM users_data
+            WHERE (city_id) IN (1, 2, 3, 45)
+            AND date > '2020-10-01'
+            """,
+            {
+                "12": "(1, 2, 3, 45)",
+                "90": "'2020-10-01'",
+            },
+        ),
+        (
+            """
+            SELECT user_mail, city_id
+            FROM users_data
             WHERE (city_id) IN %s
             AND date > %s
             """,
@@ -264,6 +283,7 @@ def test__templater_raw():
         "pyformat",
         "dollar",
         "numeric_dollar",
+        "numeric_dollar_with_braces",
         "percent",
         "ampersand",
     ],

--- a/test/core/templaters/placeholder_test.py
+++ b/test/core/templaters/placeholder_test.py
@@ -233,6 +233,25 @@ def test__templater_raw():
             """
             SELECT user_mail, city_id
             FROM users_data
+            WHERE user_mail = '${12}'
+            AND date > ${90}
+            """,
+            "numeric_dollar",
+            """
+            SELECT user_mail, city_id
+            FROM users_data
+            WHERE user_mail = 'test@example.com'
+            AND date > '2020-10-01'
+            """,
+            {
+                "12": "test@example.com",
+                "90": "'2020-10-01'",
+            },
+        ),
+        (
+            """
+            SELECT user_mail, city_id
+            FROM users_data
             WHERE (city_id) IN %s
             AND date > %s
             """,
@@ -284,6 +303,7 @@ def test__templater_raw():
         "dollar",
         "numeric_dollar",
         "numeric_dollar_with_braces",
+        "numeric_dollar_with_braces_and_string",
         "percent",
         "ampersand",
     ],


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

* Per [the SQLFluff documentation](https://docs.sqlfluff.com/en/stable/configuration.html#placeholder-templating) the `dollar` templater may not include surrounding curly braces `{ }`, while the `numeric_dollar` templater may:

```sql
 -- dollar
 WHERE bla = $my_name

 -- numeric_dollar
 WHERE bla = $3 or WHERE bla = ${3}
```

However, the documentation is not accurate here, as it's actually the other way around: the `dollar` templater may include curly braces, while the `numeric_dollar` templater does not support them.

This PR does the following:
* updates the example of the `dollar` templater in the docs to show usage with curly braces
* updates the `numeric_dollar` templater to allow optional surrounding curly braces

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist

- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
