### PR TITLE
L027: Fix false positives by reverting the PR for issue #2992: Check table aliases exist

### DIFF
--- a/src/sqlfluff/rules/L027.py
+++ b/src/sqlfluff/rules/L027.py
@@ -99,23 +99,6 @@ class Rule_L027(Rule_L020):
                     )
                 )
 
-            all_table_aliases = [t.ref_str for t in table_aliases] + standalone_aliases
-
-            # For qualified references, we want to check that the alias is actually
-            # valid
-            if (
-                this_ref_type == "qualified"
-                and list(r.iter_raw_references())[0].part not in all_table_aliases
-            ):
-                violation_buff.append(
-                    LintResult(
-                        anchor=r,
-                        description=f"Qualified reference {r.raw!r} not found in "
-                        f"available tables/view aliases {all_table_aliases} in select "
-                        "with more than one referenced table/view.",
-                    )
-                )
-
         return violation_buff or None
 
     def _init_ignore_words_list(self):

--- a/test/fixtures/rules/std_rule_cases/L027.yml
+++ b/test/fixtures/rules/std_rule_cases/L027.yml
@@ -221,43 +221,6 @@ test_pass_rowtype_with_join:
     core:
       dialect: hive
 
-test_fail_column_name_not_found_in_table_aliases_bigquery:
-  # qualified reference should actually exists in table aliases
-  fail_str: |
-    SELECT
-        a.bar,
-        b.foo,
-        this_is.some_struct.id
-    FROM
-        a LEFT JOIN b ON TRUE
-  configs:
-    core:
-      dialect: bigquery
-
-test_pass_column_name_is_a_struct_bigquery:
-  # check structs work as expected
-  pass_str: |
-    SELECT
-        a.bar,
-        b.this_is.some_struct.id
-    FROM
-        a LEFT JOIN b ON TRUE
-  configs:
-    core:
-      dialect: bigquery
-
-test_pass_column_name_from_unnest_bigquery:
-  # Check that we allow an table alias come from UNNEST statement
-  pass_str: |
-    SELECT
-        a.bar,
-        e.foo
-    FROM
-        a LEFT JOIN UNEST(a.events) AS e
-  configs:
-    core:
-      dialect: bigquery
-
 test_fail_table_plus_flatten_snowflake_1:
   # FLATTEN() returns a table, thus there are two tables, thus lint failure.
   fail_str: |

--- a/test/fixtures/rules/std_rule_cases/L027.yml
+++ b/test/fixtures/rules/std_rule_cases/L027.yml
@@ -291,3 +291,33 @@ test_pass_ignore_words_regex_bigquery_declare_example:
     rules:
       L027:
         ignore_words_regex: ^_
+
+test_pass_redshift:
+  # This was failing in issue 3380.
+  pass_str:
+    SELECT account.id
+    FROM salesforce_sd.account
+    INNER JOIN salesforce_sd."user" ON salesforce_sd."user".id = account.ownerid
+  configs:
+    core:
+      dialect: redshift
+
+test_pass_tsql:
+  # This was failing in issue 3380.
+  pass_str:
+    select
+        psc.col1
+    from
+        tbl1 as psc
+    where
+        exists
+        (
+            select 1 as data
+            from
+                tbl2 as pr
+            join tbl2 as c on c.cid = pr.cid
+            where
+                c.col1 = 'x'
+                and pr.col2 <= convert(date, getdate())
+                and pr.pid = psc.pid
+        )

--- a/test/fixtures/rules/std_rule_cases/L027.yml
+++ b/test/fixtures/rules/std_rule_cases/L027.yml
@@ -303,7 +303,7 @@ test_pass_redshift:
       dialect: redshift
 
 test_pass_tsql:
-  # This was failing in issue 3380.
+  # This was failing in issue 3342.
   pass_str:
     select
         psc.col1
@@ -321,3 +321,18 @@ test_pass_tsql:
                 and pr.col2 <= convert(date, getdate())
                 and pr.pid = psc.pid
         )
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_ansi:
+  # This was failing in issue 3055.
+  pass_str: |
+    SELECT my_col
+    FROM my_table
+    WHERE EXISTS (
+        SELECT 1
+        FROM other_table
+        INNER JOIN mapping_table ON (mapping_table.other_fk = other_table.id_pk)
+        WHERE mapping_table.kind = my_table.kind
+    )

--- a/test/rules/std_test.py
+++ b/test/rules/std_test.py
@@ -68,7 +68,7 @@ from sqlfluff.testing.rules import assert_rule_raises_violations_in_file
         ),
         ("L016", "block_comment_errors_2.sql", [(1, 85), (2, 86)]),
         # Column references
-        ("L027", "column_references.sql", [(1, 8), (1, 11)]),
+        ("L027", "column_references.sql", [(1, 8)]),
         ("L027", "column_references_bare_function.sql", []),
         ("L026", "column_references.sql", [(1, 11)]),
         ("L025", "column_references.sql", [(2, 11)]),


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3055, #3380, #3342

This PR reverts PR #2998, which introduced a lot of false positives in L027. This means #2992 could be reopened. We can revisit that enhancement if/when there's an implementation that avoids these issues. @dmohns 

It also adds test cases for the 3 user issues reported in relation to this new behavior.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
