### PR TITLE
SparkSQL: Add support for Delta `VACUUM` statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -2608,3 +2608,29 @@ class IntervalExpressionSegment(ansi.IntervalExpressionSegment):
             Ref("QuotedLiteralSegment"),
         ),
     )
+
+class VacuumStatementSegment(BaseSegment):
+    """ A `VACUUM` statement segment.
+
+    https://docs.delta.io/latest/delta-utility.html#remove-files-no-longer-referenced-by-a-delta-table
+    """
+
+    match_grammar: Matchable = Sequence(
+        "VACUUM",
+        OneOf(
+            Ref("FileReferenceSegment"),
+            Ref("TableReferenceSegment"),
+        ),
+        OneOf(
+            Sequence(
+                "RETAIN",
+                Ref("NumericLiteralSegment"),
+                "HOURS",
+            ),
+            Sequence(
+                "DRY",
+                "RUN",
+            ),
+            optional = True,
+        ),
+    )

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -2609,8 +2609,9 @@ class IntervalExpressionSegment(ansi.IntervalExpressionSegment):
         ),
     )
 
+
 class VacuumStatementSegment(BaseSegment):
-    """ A `VACUUM` statement segment.
+    """A `VACUUM` statement segment.
 
     https://docs.delta.io/latest/delta-utility.html#remove-files-no-longer-referenced-by-a-delta-table
     """
@@ -2631,6 +2632,6 @@ class VacuumStatementSegment(BaseSegment):
                 "DRY",
                 "RUN",
             ),
-            optional = True,
+            optional=True,
         ),
     )

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -327,6 +327,24 @@ sparksql_dialect.add(
         ),
         allow_gaps=False,
     ),
+    RetainKeywordSegment=StringParser(
+        "RETAIN",
+        KeywordSegment,
+        name="retain",
+        type="retain_keyword",
+    ),
+    DryKeywordSegment=StringParser(
+        "DRY",
+        KeywordSegment,
+        name="dry",
+        type="dry_keyword",
+    ),
+    RunKeywordSegment=StringParser(
+        "RUN",
+        KeywordSegment,
+        name="run",
+        type="run_keyword",
+    ),
     # Add relevant Hive Grammar
     CommentGrammar=hive_dialect.get_grammar("CommentGrammar"),
     LocationGrammar=hive_dialect.get_grammar("LocationGrammar"),
@@ -2229,6 +2247,8 @@ class StatementSegment(ansi.StatementSegment):
             # Data Retrieval Statements
             Ref("ClusterByClauseSegment"),
             Ref("DistributeByClauseSegment"),
+            # Delta Lake
+            Ref("VacuumStatementSegment"),
         ],
         remove=[
             Ref("TransactionStatementSegment"),
@@ -2616,9 +2636,12 @@ class VacuumStatementSegment(BaseSegment):
     https://docs.delta.io/latest/delta-utility.html#remove-files-no-longer-referenced-by-a-delta-table
     """
 
+    type = "vacuum_statement"
+
     match_grammar: Matchable = Sequence(
         "VACUUM",
         OneOf(
+            Ref("QuotedLiteralSegment"),
             Ref("FileReferenceSegment"),
             Ref("TableReferenceSegment"),
         ),
@@ -2626,7 +2649,7 @@ class VacuumStatementSegment(BaseSegment):
             Sequence(
                 "RETAIN",
                 Ref("NumericLiteralSegment"),
-                "HOURS",
+                Ref("DatetimeUnitSegment"),
             ),
             Sequence(
                 "DRY",

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -327,24 +327,6 @@ sparksql_dialect.add(
         ),
         allow_gaps=False,
     ),
-    RetainKeywordSegment=StringParser(
-        "RETAIN",
-        KeywordSegment,
-        name="retain",
-        type="retain_keyword",
-    ),
-    DryKeywordSegment=StringParser(
-        "DRY",
-        KeywordSegment,
-        name="dry",
-        type="dry_keyword",
-    ),
-    RunKeywordSegment=StringParser(
-        "RUN",
-        KeywordSegment,
-        name="run",
-        type="run_keyword",
-    ),
     # Add relevant Hive Grammar
     CommentGrammar=hive_dialect.get_grammar("CommentGrammar"),
     LocationGrammar=hive_dialect.get_grammar("LocationGrammar"),

--- a/src/sqlfluff/dialects/dialect_sparksql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_sparksql_keywords.py
@@ -280,4 +280,8 @@ UNRESERVED_KEYWORDS = [
     # Community Contributed Data Sources
     "DELTA",  # https://github.com/delta-io/delta
     "XML",  # https://github.com/databricks/spark-xml
+    # Delta Lake
+    "DRY",
+    "RETAIN",
+    "RUN",
 ]

--- a/test/core/rules/config_test.py
+++ b/test/core/rules/config_test.py
@@ -163,13 +163,10 @@ def test_rule_must_belong_to_all_group():
 
 def test_std_rule_import_fail_bad_naming():
     """Check that rule import from file works."""
-    assert (
-        get_rules_from_path(
-            rules_path="test/fixtures/rules/custom/*.py",
-            base_module="test.fixtures.rules.custom",
-        )
-        == [Rule_L000, Rule_S000]
-    )
+    assert get_rules_from_path(
+        rules_path="test/fixtures/rules/custom/*.py",
+        base_module="test.fixtures.rules.custom",
+    ) == [Rule_L000, Rule_S000]
 
     with pytest.raises(AttributeError) as e:
         get_rules_from_path(

--- a/test/core/rules/config_test.py
+++ b/test/core/rules/config_test.py
@@ -163,10 +163,13 @@ def test_rule_must_belong_to_all_group():
 
 def test_std_rule_import_fail_bad_naming():
     """Check that rule import from file works."""
-    assert get_rules_from_path(
-        rules_path="test/fixtures/rules/custom/*.py",
-        base_module="test.fixtures.rules.custom",
-    ) == [Rule_L000, Rule_S000]
+    assert (
+        get_rules_from_path(
+            rules_path="test/fixtures/rules/custom/*.py",
+            base_module="test.fixtures.rules.custom",
+        )
+        == [Rule_L000, Rule_S000]
+    )
 
     with pytest.raises(AttributeError) as e:
         get_rules_from_path(

--- a/test/fixtures/dialects/sparksql/delta_vacuum.sql
+++ b/test/fixtures/dialects/sparksql/delta_vacuum.sql
@@ -1,0 +1,12 @@
+-- vacuum files not required by versions older than the default retention period
+VACUUM eventsTable;
+
+-- vacuum files in path-based table
+VACUUM '/data/events';
+VACUUM delta.`/data/events/`;
+
+-- vacuum files not required by versions more than 100 hours old
+VACUUM delta.`/data/events/` RETAIN 100 HOURS;
+
+-- do dry run to get the list of files to be deleted
+VACUUM eventsTable DRY RUN;

--- a/test/fixtures/dialects/sparksql/delta_vacuum.sql
+++ b/test/fixtures/dialects/sparksql/delta_vacuum.sql
@@ -1,12 +1,12 @@
 -- vacuum files not required by versions older than the default retention period
-VACUUM eventsTable;
+VACUUM EVENTSTABLE;
 
 -- vacuum files in path-based table
 VACUUM '/data/events';
-VACUUM delta.`/data/events/`;
+VACUUM DELTA.`/data/events/`;
 
 -- vacuum files not required by versions more than 100 hours old
-VACUUM delta.`/data/events/` RETAIN 100 HOURS;
+VACUUM DELTA.`/data/events/` RETAIN 100 HOURS;
 
 -- do dry run to get the list of files to be deleted
-VACUUM eventsTable DRY RUN;
+VACUUM EVENTSTABLE DRY RUN;

--- a/test/fixtures/dialects/sparksql/delta_vacuum.yml
+++ b/test/fixtures/dialects/sparksql/delta_vacuum.yml
@@ -1,0 +1,45 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: abd15bc2fa99af4e3b81678c2f399db5afc4417420c9e11a575ebdcd2426de23
+file:
+- statement:
+    vacuum_statement:
+      keyword: VACUUM
+      table_reference:
+        identifier: EVENTSTABLE
+- statement_terminator: ;
+- statement:
+    vacuum_statement:
+      keyword: VACUUM
+      literal: "'/data/events'"
+- statement_terminator: ;
+- statement:
+    vacuum_statement:
+      keyword: VACUUM
+      file_reference:
+        keyword: DELTA
+        dot: .
+        identifier: '`/data/events/`'
+- statement_terminator: ;
+- statement:
+    vacuum_statement:
+      keyword: VACUUM
+      file_reference:
+        keyword: DELTA
+        dot: .
+        identifier: '`/data/events/`'
+      retain_keyword: RETAIN
+      literal: '100'
+      date_part: HOURS
+- statement_terminator: ;
+- statement:
+    vacuum_statement:
+      keyword: VACUUM
+      table_reference:
+        identifier: EVENTSTABLE
+      dry_keyword: DRY
+      run_keyword: RUN
+- statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/delta_vacuum.yml
+++ b/test/fixtures/dialects/sparksql/delta_vacuum.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: abd15bc2fa99af4e3b81678c2f399db5afc4417420c9e11a575ebdcd2426de23
+_hash: c28f1106be5c6dfd0b714e0fd8748e93648dd6f84c1eae0eea3ba18275ee5ab9
 file:
 - statement:
     vacuum_statement:
@@ -26,20 +26,20 @@ file:
 - statement_terminator: ;
 - statement:
     vacuum_statement:
-      keyword: VACUUM
-      file_reference:
+    - keyword: VACUUM
+    - file_reference:
         keyword: DELTA
         dot: .
         identifier: '`/data/events/`'
-      retain_keyword: RETAIN
-      literal: '100'
-      date_part: HOURS
+    - keyword: RETAIN
+    - literal: '100'
+    - date_part: HOURS
 - statement_terminator: ;
 - statement:
     vacuum_statement:
-      keyword: VACUUM
-      table_reference:
+    - keyword: VACUUM
+    - table_reference:
         identifier: EVENTSTABLE
-      dry_keyword: DRY
-      run_keyword: RUN
+    - keyword: DRY
+    - keyword: RUN
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Implement `VacuumStatementSegment` and required keywordSegments to support Delta Lake's `VACUUM` statement and add test cases for the same.

### Are there any other side effects of this change that we should be aware of?
N/A

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
