### PR TITLE
Add `deltalake` dialect as an alias for `sparsql` dialect

### DIFF
--- a/docs/source/dialects.rst
+++ b/docs/source/dialects.rst
@@ -79,6 +79,15 @@ The dialect for `Db2`_.
 
 .. _`Db2`: https://www.ibm.com/analytics/db2
 
+.. _deltalake_dialect_ref:
+
+Delta Lake
+----------
+
+The dialect `Delta Lake`_ is an alias for the :ref:`sparksql_dialect_ref`.
+
+.. _`Delta Lake`: https://delta.io/
+
 .. _exasol_dialect_ref:
 
 Exasol

--- a/src/sqlfluff/core/dialects/__init__.py
+++ b/src/sqlfluff/core/dialects/__init__.py
@@ -37,6 +37,7 @@ _dialect_lookup = {
     "tsql": ("dialect_tsql", "tsql_dialect"),
     "sparksql": ("dialect_sparksql", "sparksql_dialect"),
     "databricks": ("dialect_sparksql", "sparksql_dialect"),
+    "deltalake": ("dialect_sparksql", "sparksql_dialect"),
 }
 
 _legacy_dialects = {

--- a/test/cli/autocomplete_test.py
+++ b/test/cli/autocomplete_test.py
@@ -8,7 +8,7 @@ from sqlfluff.cli.autocomplete import dialect_shell_complete
     "incomplete,expected",
     [
         ["an", ["ansi"]],
-        ["d", ["databricks", "db2"]],
+        ["d", ["databricks", "db2", "deltalake"]],
         ["s", ["snowflake", "soql", "sparksql", "sqlite"]],
         ["post", ["postgres"]],
     ],


### PR DESCRIPTION
Brief summary of the change made
This adds a new dialect which is an alias for Spark SQL.

Are there any other side effects of this change that we should be aware of?
n/a

Pull Request checklist
 Please confirm you have completed any of the necessary steps below.

Included test cases to demonstrate any code changes, which may be one or more of the following:

.yml rule test cases in test/fixtures/rules/std_rule_cases.
.sql/.yml parser test cases in test/fixtures/dialects (note YML files can be auto generated with tox -e generate-fixture-yml).
Full autofix test cases in test/fixtures/linter/autofix.
Other.
Added appropriate documentation for the change.

Created GitHub issues for any relevant followup/future enhancements if appropriate.