### PR TITLE
SparkSQL: Add Delta Syntax for `DESCRIBE HISTORY` statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -1943,6 +1943,7 @@ class DescribeStatementSegment(BaseSegment):
                     Ref("StatementSegment"),
                 ),
             ),
+            exclude=Ref.keyword("HISTORY"),
         ),
     )
 
@@ -2231,6 +2232,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("DistributeByClauseSegment"),
             # Delta Lake
             Ref("VacuumStatementSegment"),
+            Ref("DescribeHistoryStatementSegment"),
         ],
         remove=[
             Ref("TransactionStatementSegment"),
@@ -2639,4 +2641,24 @@ class VacuumStatementSegment(BaseSegment):
             ),
             optional=True,
         ),
+    )
+
+
+class DescribeHistoryStatementSegment(BaseSegment):
+    """A `DESCRIBE HISTORY` statement segment.
+
+    https://docs.delta.io/latest/delta-utility.html#retrieve-delta-table-history
+    """
+
+    type = "describe_history_statement"
+
+    match_grammar: Matchable = Sequence(
+        "DESCRIBE",
+        "HISTORY",
+        OneOf(
+            Ref("QuotedLiteralSegment"),
+            Ref("FileReferenceSegment"),
+            Ref("TableReferenceSegment"),
+        ),
+        Ref("LimitClauseSegment", optional=True),
     )

--- a/src/sqlfluff/dialects/dialect_sparksql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_sparksql_keywords.py
@@ -282,6 +282,7 @@ UNRESERVED_KEYWORDS = [
     "XML",  # https://github.com/databricks/spark-xml
     # Delta Lake
     "DRY",
+    "HISTORY",
     "RETAIN",
     "RUN",
 ]

--- a/test/fixtures/dialects/sparksql/delta_describe_history.sql
+++ b/test/fixtures/dialects/sparksql/delta_describe_history.sql
@@ -1,0 +1,9 @@
+-- get the full history of the table
+DESCRIBE HISTORY '/data/events/';
+
+DESCRIBE HISTORY DELTA.`/data/events/`;
+
+-- get the last operation only
+DESCRIBE HISTORY '/data/events/' LIMIT 1;
+
+DESCRIBE HISTORY EVENTSTABLE;

--- a/test/fixtures/dialects/sparksql/delta_describe_history.yml
+++ b/test/fixtures/dialects/sparksql/delta_describe_history.yml
@@ -1,0 +1,38 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: db4407a651c3b398e9151fea9ef2d46140cafa39e18452d43f49cf56ad5c19ae
+file:
+- statement:
+    describe_history_statement:
+    - keyword: DESCRIBE
+    - keyword: HISTORY
+    - literal: "'/data/events/'"
+- statement_terminator: ;
+- statement:
+    describe_history_statement:
+    - keyword: DESCRIBE
+    - keyword: HISTORY
+    - file_reference:
+        keyword: DELTA
+        dot: .
+        identifier: '`/data/events/`'
+- statement_terminator: ;
+- statement:
+    describe_history_statement:
+    - keyword: DESCRIBE
+    - keyword: HISTORY
+    - literal: "'/data/events/'"
+    - limit_clause:
+        keyword: LIMIT
+        literal: '1'
+- statement_terminator: ;
+- statement:
+    describe_history_statement:
+    - keyword: DESCRIBE
+    - keyword: HISTORY
+    - table_reference:
+        identifier: EVENTSTABLE
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Adds `DescribeHistoryStatementSegment` and test cases in `DescribeHistoryStatementSegment`

### Are there any other side effects of this change that we should be aware of?
- purposefully separated from `DescribeStatementSegment` since it's not a native spark command.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
