### PR TITLE
Add ClickHouse as a dialect

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Although SQL is reasonably consistent in its implementations, there are several 
 
 - ANSI SQL - this is the base version and on occasion may not strictly follow the ANSI/ISO SQL definition
 - [BigQuery](https://cloud.google.com/bigquery/)
+- [ClickHouse](https://clickhouse.com/)
 - [Databricks](https://databricks.com/) (note: currently this is just an alias for the `sparksql` dialect).
 - [Db2](https://www.ibm.com/analytics/db2)
 - [Exasol](https://www.exasol.com/)

--- a/docs/source/dialects.rst
+++ b/docs/source/dialects.rst
@@ -61,6 +61,15 @@ The dialect for `Google BigQuery`_.
 
 .. _`Google BigQuery`: https://cloud.google.com/bigquery/
 
+.. _clickhouse_dialect_ref:
+
+ClickHouse
+----------
+
+The dialect for `CickHouse`_.
+
+.. _`CickHouse`: https://clickhouse.com/
+
 .. _databricks_dialect_ref:
 
 Databricks

--- a/plugins/sqlfluff-templater-dbt/setup.cfg
+++ b/plugins/sqlfluff-templater-dbt/setup.cfg
@@ -41,6 +41,7 @@ keywords =
     linter
     formatter
     bigquery
+    clickhouse
     db2
     exasol
     hive

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ keywords =
     linter
     formatter
     bigquery
+    clickhouse
     db2
     exasol
     hive

--- a/src/sqlfluff/core/dialects/__init__.py
+++ b/src/sqlfluff/core/dialects/__init__.py
@@ -23,6 +23,7 @@ from sqlfluff.core.errors import SQLFluffUserError
 _dialect_lookup = {
     "ansi": ("dialect_ansi", "ansi_dialect"),
     "bigquery": ("dialect_bigquery", "bigquery_dialect"),
+    "clickhouse": ("dialect_clickhouse", "clickhouse_dialect"),
     "db2": ("dialect_db2", "db2_dialect"),
     "exasol": ("dialect_exasol", "exasol_dialect"),
     "hive": ("dialect_hive", "hive_dialect"),

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -1,0 +1,47 @@
+"""The clickhouse dialect.
+
+https://clickhouse.com/
+"""
+
+from sqlfluff.core.parser import (
+    Bracketed,
+    Matchable,
+    OneOf,
+    Ref,
+    Sequence,
+)
+
+from sqlfluff.core.dialects import load_raw_dialect
+from sqlfluff.dialects import dialect_ansi as ansi
+
+ansi_dialect = load_raw_dialect("ansi")
+
+clickhouse_dialect = ansi_dialect.copy_as("clickhouse")
+
+
+class CTEDefinitionSegment(ansi.CTEDefinitionSegment):
+    """A CTE Definition from a WITH statement.
+
+    https://clickhouse.com/docs/en/sql-reference/statements/select/with/
+    """
+
+    type = "common_table_expression"
+    match_grammar: Matchable = OneOf(
+        Sequence(
+            Ref("SingleIdentifierGrammar"),
+            Bracketed(
+                Ref("SingleIdentifierListSegment"),
+                optional=True,
+            ),
+            "AS",
+            Bracketed(
+                # Ephemeral here to subdivide the query.
+                Ref("SelectableGrammar", ephemeral_name="SelectableGrammar")
+            ),
+        ),
+        Sequence(
+            Ref("ExpressionSegment"),
+            "AS",
+            Ref("SingleIdentifierGrammar"),
+        ),
+    )

--- a/test/fixtures/dialects/clickhouse/.sqlfluff
+++ b/test/fixtures/dialects/clickhouse/.sqlfluff
@@ -1,0 +1,2 @@
+[sqlfluff]
+dialect = clickhouse

--- a/test/fixtures/dialects/clickhouse/cte.sql
+++ b/test/fixtures/dialects/clickhouse/cte.sql
@@ -1,0 +1,43 @@
+with (
+    select 1 as p
+) as test_param
+
+select
+    toString(1) as Test_string,
+    toDateTime64('2022-05-25', 3) as Test_dateTime64,
+    ifNull(null, 'TestNull') as testIf,
+    JSONExtractString('{"abc": "hello"}', 'abc') as testJSON,
+    test_param as param;
+
+WITH '2019-08-01 15:23:00' as ts_upper_bound
+SELECT *
+FROM hits
+WHERE
+    EventDate = toDate(ts_upper_bound) AND
+    EventTime <= ts_upper_bound;
+
+WITH sum(bytes) as s
+SELECT
+    formatReadableSize(s),
+    table
+FROM system.parts
+GROUP BY table
+ORDER BY s;
+
+/* this example would return TOP 10 of most huge tables */
+WITH
+    (
+        SELECT sum(bytes)
+        FROM system.parts
+        WHERE active
+    ) AS total_disk_usage
+SELECT
+    (sum(bytes) / total_disk_usage) * 100 AS table_disk_usage,
+    table
+FROM system.parts
+GROUP BY table
+ORDER BY table_disk_usage DESC
+LIMIT 10;
+
+WITH test1 AS (SELECT i + 1, j + 1 FROM test1)
+SELECT * FROM test1;

--- a/test/fixtures/dialects/clickhouse/cte.yml
+++ b/test/fixtures/dialects/clickhouse/cte.yml
@@ -1,0 +1,336 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: f90ae55bc8af8b2e181e6066e356c3144e423b0be2a7e0974790b69a910aefb3
+file:
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        expression:
+          bracketed:
+            start_bracket: (
+            expression:
+              select_statement:
+                select_clause:
+                  keyword: select
+                  select_clause_element:
+                    literal: '1'
+                    alias_expression:
+                      keyword: as
+                      identifier: p
+            end_bracket: )
+        keyword: as
+        identifier: test_param
+      select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: toString
+              bracketed:
+                start_bracket: (
+                expression:
+                  literal: '1'
+                end_bracket: )
+            alias_expression:
+              keyword: as
+              identifier: Test_string
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: toDateTime64
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  literal: "'2022-05-25'"
+              - comma: ','
+              - expression:
+                  literal: '3'
+              - end_bracket: )
+            alias_expression:
+              keyword: as
+              identifier: Test_dateTime64
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: ifNull
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  literal: 'null'
+              - comma: ','
+              - expression:
+                  literal: "'TestNull'"
+              - end_bracket: )
+            alias_expression:
+              keyword: as
+              identifier: testIf
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSONExtractString
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  literal: "'{\"abc\": \"hello\"}'"
+              - comma: ','
+              - expression:
+                  literal: "'abc'"
+              - end_bracket: )
+            alias_expression:
+              keyword: as
+              identifier: testJSON
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              identifier: test_param
+            alias_expression:
+              keyword: as
+              identifier: param
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        expression:
+          literal: "'2019-08-01 15:23:00'"
+        keyword: as
+        identifier: ts_upper_bound
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: hits
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+              identifier: EventDate
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - function:
+              function_name:
+                function_name_identifier: toDate
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    identifier: ts_upper_bound
+                end_bracket: )
+          - binary_operator: AND
+          - column_reference:
+              identifier: EventTime
+          - comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+          - column_reference:
+              identifier: ts_upper_bound
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        expression:
+          function:
+            function_name:
+              function_name_identifier: sum
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: bytes
+              end_bracket: )
+        keyword: as
+        identifier: s
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: formatReadableSize
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    identifier: s
+                end_bracket: )
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              identifier: table
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - identifier: system
+                - dot: .
+                - identifier: parts
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            identifier: table
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            identifier: s
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        expression:
+          bracketed:
+            start_bracket: (
+            expression:
+              select_statement:
+                select_clause:
+                  keyword: SELECT
+                  select_clause_element:
+                    function:
+                      function_name:
+                        function_name_identifier: sum
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            identifier: bytes
+                        end_bracket: )
+                from_clause:
+                  keyword: FROM
+                  from_expression:
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                        - identifier: system
+                        - dot: .
+                        - identifier: parts
+                where_clause:
+                  keyword: WHERE
+                  expression:
+                    column_reference:
+                      identifier: active
+            end_bracket: )
+        keyword: AS
+        identifier: total_disk_usage
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: sum
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          identifier: bytes
+                      end_bracket: )
+                  binary_operator: /
+                  column_reference:
+                    identifier: total_disk_usage
+                end_bracket: )
+              binary_operator: '*'
+              literal: '100'
+            alias_expression:
+              keyword: AS
+              identifier: table_disk_usage
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              identifier: table
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - identifier: system
+                - dot: .
+                - identifier: parts
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            identifier: table
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            identifier: table_disk_usage
+        - keyword: DESC
+        limit_clause:
+          keyword: LIMIT
+          literal: '10'
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        identifier: test1
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                expression:
+                  column_reference:
+                    identifier: i
+                  binary_operator: +
+                  literal: '1'
+            - comma: ','
+            - select_clause_element:
+                expression:
+                  column_reference:
+                    identifier: j
+                  binary_operator: +
+                  literal: '1'
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      identifier: test1
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: test1
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3437 byt adding `clickhouse` as a dialect

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
