### PR TITLE
Postgres: Optional select clause elements and better `ON CONFLICT` support

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1030,7 +1030,7 @@ class IntoClauseSegment(BaseSegment):
 class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
     """Overrides ANSI Statement, to allow for SELECT INTO statements."""
 
-    match_grammar = ansi.UnorderedSelectStatementSegment.match_grammar
+    match_grammar = ansi.UnorderedSelectStatementSegment.match_grammar.copy()
     match_grammar.terminator = match_grammar.terminator.copy(  # type: ignore
         insert=[
             Sequence("ON", "CONFLICT"),
@@ -1047,7 +1047,7 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
 class SelectStatementSegment(ansi.SelectStatementSegment):
     """Overrides ANSI as the parse grammar copy needs to be reapplied."""
 
-    match_grammar = ansi.SelectStatementSegment.match_grammar
+    match_grammar = ansi.SelectStatementSegment.match_grammar.copy()
     match_grammar.terminator = match_grammar.terminator.copy(  # type: ignore
         insert=[
             Sequence("ON", "CONFLICT"),

--- a/test/fixtures/dialects/postgres/postgres_insert.sql
+++ b/test/fixtures/dialects/postgres/postgres_insert.sql
@@ -49,3 +49,13 @@ ON CONFLICT (bar) WHERE is_active DO NOTHING;
 
 INSERT INTO foo (bar, baz) VALUES (1, 'var')
 ON CONFLICT (bar) DO UPDATE SET (baz) = (SELECT baz FROM foobar WHERE bar = 1);
+
+INSERT INTO megatable (megacolumn)
+SELECT * FROM (
+    VALUES ( 'megavalue' )
+) AS tmp (megacolumn)
+WHERE NOT EXISTS (
+SELECT FROM megatable AS mt
+    WHERE mt.megacolumn = tmp.megacolumn
+)
+ON CONFLICT DO NOTHING;

--- a/test/fixtures/dialects/postgres/postgres_insert.yml
+++ b/test/fixtures/dialects/postgres/postgres_insert.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 35976c6f45c6ee2a737cdfbfa6abed174e60583b3ac944771f04d773c5ed64bc
+_hash: 3844ba7a79bb56ca8928f9801fdae250c223753c4207f4f03935e208fab02984
 file:
 - statement:
     insert_statement:
@@ -679,4 +679,85 @@ file:
                     raw_comparison_operator: '='
                   literal: '1'
           end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        identifier: megatable
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          identifier: megacolumn
+        end_bracket: )
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              bracketed:
+                start_bracket: (
+                table_expression:
+                  values_clause:
+                    keyword: VALUES
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        literal: "'megavalue'"
+                      end_bracket: )
+                end_bracket: )
+              alias_expression:
+                keyword: AS
+                identifier: tmp
+                bracketed:
+                  start_bracket: (
+                  identifier_list:
+                    identifier: megacolumn
+                  end_bracket: )
+        where_clause:
+          keyword: WHERE
+          expression:
+          - keyword: NOT
+          - keyword: EXISTS
+          - bracketed:
+              start_bracket: (
+              select_statement:
+                select_clause:
+                  keyword: SELECT
+                from_clause:
+                  keyword: FROM
+                  from_expression:
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                          identifier: megatable
+                      alias_expression:
+                        keyword: AS
+                        identifier: mt
+                where_clause:
+                  keyword: WHERE
+                  expression:
+                  - column_reference:
+                    - identifier: mt
+                    - dot: .
+                    - identifier: megacolumn
+                  - comparison_operator:
+                      raw_comparison_operator: '='
+                  - column_reference:
+                    - identifier: tmp
+                    - dot: .
+                    - identifier: megacolumn
+              end_bracket: )
+    - keyword: 'ON'
+    - keyword: CONFLICT
+    - conflict_action:
+      - keyword: DO
+      - keyword: NOTHING
 - statement_terminator: ;

--- a/test/fixtures/dialects/postgres/postgres_select.sql
+++ b/test/fixtures/dialects/postgres/postgres_select.sql
@@ -59,3 +59,5 @@ SELECT a < b COLLATE "de_DE" FROM test1;
 SELECT a COLLATE "de_DE" < b FROM test1;
 
 SELECT * FROM test1 ORDER BY a || b COLLATE "fr_FR";
+
+SELECT FROM test1;

--- a/test/fixtures/dialects/postgres/postgres_select.yml
+++ b/test/fixtures/dialects/postgres/postgres_select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2ac14552506be39c7f8cb304071dd62b0f075b16dc4632cc94609fe8bbaac8bc
+_hash: 1d894d48a1b845df3f02e80075d0c81d2f78aaa187fd8e9188110bcaa1233139
 file:
 - statement:
     select_statement:
@@ -574,4 +574,16 @@ file:
         - keyword: COLLATE
         - column_reference:
             identifier: '"fr_FR"'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: test1
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3365 

### Are there any other side effects of this change that we should be aware of?
I'm hoping not!

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
