### PR TITLE
Postgres: Support multiple `CONSTRAINTS` in `CREATE DOMAIN`

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -3583,17 +3583,18 @@ class CreateDomainStatementSegment(BaseSegment):
         Ref("DatatypeSegment"),
         Sequence("COLLATE", Ref("ObjectReferenceSegment"), optional=True),
         Sequence("DEFAULT", Ref("ExpressionSegment"), optional=True),
-        Sequence(
+        AnyNumberOf(
             Sequence(
-                "CONSTRAINT",
-                Ref("ObjectReferenceSegment"),
-                optional=True,
+                Sequence(
+                    "CONSTRAINT",
+                    Ref("ObjectReferenceSegment"),
+                    optional=True,
+                ),
+                OneOf(
+                    Sequence(Ref.keyword("NOT", optional=True), "NULL"),
+                    Sequence("CHECK", Ref("ExpressionSegment")),
+                ),
             ),
-            OneOf(
-                Sequence(Ref.keyword("NOT", optional=True), "NULL"),
-                Sequence("CHECK", Ref("ExpressionSegment")),
-            ),
-            optional=True,
         ),
     )
 

--- a/test/fixtures/dialects/postgres/postgres_create_domain.sql
+++ b/test/fixtures/dialects/postgres/postgres_create_domain.sql
@@ -5,3 +5,7 @@ OR VALUE ~ '^\d{5}-\d{4}$'
 );
 
 create domain oname as text;
+
+CREATE DOMAIN mystr AS text
+CONSTRAINT not_empty CHECK (LENGTH(value) > 0)
+CONSTRAINT too_big CHECK (LENGTH(value) <= 50000);

--- a/test/fixtures/dialects/postgres/postgres_create_domain.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_domain.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ca51084f71d69e23ae2b5ae81e93a389717073adbad8bdbe51556d4edd4b183c
+_hash: b97b13b6d58597831556ee1950904e8f2ad5570b185f6efb42b9f1d73129e043
 file:
 - statement:
     create_domain_statement:
@@ -39,4 +39,57 @@ file:
     - keyword: as
     - data_type:
         keyword: text
+- statement_terminator: ;
+- statement:
+    create_domain_statement:
+    - keyword: CREATE
+    - keyword: DOMAIN
+    - object_reference:
+        identifier: mystr
+    - keyword: AS
+    - data_type:
+        keyword: text
+    - keyword: CONSTRAINT
+    - object_reference:
+        identifier: not_empty
+    - keyword: CHECK
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+            function:
+              function_name:
+                function_name_identifier: LENGTH
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    identifier: value
+                end_bracket: )
+            comparison_operator:
+              raw_comparison_operator: '>'
+            literal: '0'
+          end_bracket: )
+    - keyword: CONSTRAINT
+    - object_reference:
+        identifier: too_big
+    - keyword: CHECK
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+            function:
+              function_name:
+                function_name_identifier: LENGTH
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    identifier: value
+                end_bracket: )
+            comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+            literal: '50000'
+          end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3459 

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
