### PR TITLE
Postgres: treat `GENERATE_SERIES` as a value table function

### DIFF
--- a/src/sqlfluff/core/rules/analysis/select.py
+++ b/src/sqlfluff/core/rules/analysis/select.py
@@ -134,7 +134,7 @@ def _has_value_table_function(table_expr, dialect):
         # Other rules can increase whitespace in the function name, so use strip to
         # remove
         # See: https://github.com/sqlfluff/sqlfluff/issues/1304
-        if function_name.raw.lower().strip() in dialect.sets("value_table_functions"):
+        if function_name.raw.upper().strip() in dialect.sets("value_table_functions"):
             return True
     return False
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -343,7 +343,7 @@ bigquery_dialect.sets("date_part_function_name").update(
 
 # In BigQuery, UNNEST() returns a "value table".
 # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#value_tables
-bigquery_dialect.sets("value_table_functions").update(["unnest"])
+bigquery_dialect.sets("value_table_functions").update(["UNNEST"])
 
 # Bracket pairs (a set of tuples). Note that BigQuery inherits the default
 # "bracket_pairs" set from ANSI. Here, we're adding a different set of bracket

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -188,7 +188,7 @@ postgres_dialect.sets("datetime_units").update(
 postgres_dialect.sets("date_part_function_name").clear()
 
 # In Postgres, UNNEST() returns a "value table", similar to BigQuery
-postgres_dialect.sets("value_table_functions").update(["unnest"])
+postgres_dialect.sets("value_table_functions").update(["UNNEST", "GENERATE_SERIES"])
 
 postgres_dialect.add(
     JsonOperatorSegment=NamedParser(

--- a/test/fixtures/rules/std_rule_cases/L025.yml
+++ b/test/fixtures/rules/std_rule_cases/L025.yml
@@ -43,6 +43,18 @@ test_ignore_postgres_value_table_functions:
     core:
       dialect: postgres
 
+test_ignore_postgres_value_table_functions_generate_series:
+  # L025 fix with https://github.com/sqlfluff/sqlfluff/issues/3462
+  pass_str: |
+    SELECT
+      date_trunc('day', dd):: timestamp with time zone
+    FROM generate_series (
+        '2022-02-01'::timestamp , NOW()::timestamp , '1 day'::interval
+    ) dd ;
+  configs:
+    core:
+      dialect: postgres
+
 test_fail_table_alias_not_referenced_2:
   # Similar to test_1, but with implicit alias.
   fail_str: SELECT * FROM my_tbl foo


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3462 

### Are there any other side effects of this change that we should be aware of?
I uppercased value table values in common with other syntax

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
