### PR TITLE
Swap to skip file if not found

### DIFF
--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -388,7 +388,7 @@ class DbtTemplater(JinjaTemplater):
                 raise SQLTemplaterSkipFile(
                     f"Skipped file {fname} because it is {skip_reason}"
                 )
-            raise RuntimeError(
+            raise SQLTemplaterSkipFile(
                 "File %s was not found in dbt project" % fname
             )  # pragma: no cover
         return results[0]


### PR DESCRIPTION
While testing 1.0.0 I found this quality of life bug.

While using the dbt templater, if you're not careful with the path specification you could accidentally specify files explicitly in your dependencies which aren't actually rendered (as I found out in https://github.com/brooklyn-data/dbt_artifacts/issues/125). I don't think it's a _bug_ but it does currently result in a fatal `RuntimeError` if sqlfluff tries to lint a file which isn't found.

I think this is the wrong behaviour and while we should still warn the user, the linting of the rest of the project should continue. Hence changing the error to `SQLTemplaterSkipFile` instead of `RuntimeError`.