### PR TITLE
L062: add `blocked_regex` support

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -182,6 +182,7 @@ force_enable = False
 [sqlfluff:rules:L062]
 # Comma separated list of blocked words that should not be used
 blocked_words = None
+blocked_regex = None
 
 [sqlfluff:rules:L063]
 # Data Types

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -177,6 +177,11 @@ STANDARD_CONFIG_INFO_DICT = {
             "in statements."
         ),
     },
+    "blocked_regex": {
+        "definition": (
+            "Optional, regex of blocked pattern which should not be used in statements."
+        ),
+    },
     "preferred_quoted_literal_style": {
         "validation": ["consistent", "single_quotes", "double_quotes"],
         "definition": (

--- a/src/sqlfluff/rules/L062.py
+++ b/src/sqlfluff/rules/L062.py
@@ -1,5 +1,6 @@
 """Implementation of Rule L062."""
 
+import regex
 from typing import Optional
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
@@ -49,14 +50,16 @@ class Rule_L062(BaseRule):
     groups = ("all",)
     config_keywords = [
         "blocked_words",
+        "blocked_regex",
     ]
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         # Config type hints
         self.blocked_words: Optional[str]
+        self.blocked_regex: Optional[str]
 
         # Exit early if no block list set
-        if not self.blocked_words:
+        if not self.blocked_words and not self.blocked_regex:
             return None
 
         # Get the ignore list configuration and cache it
@@ -77,6 +80,12 @@ class Rule_L062(BaseRule):
             return LintResult(
                 anchor=context.segment,
                 description=f"Use of blocked word '{context.segment.raw}'.",
+            )
+
+        if self.blocked_regex and regex.search(self.blocked_regex, context.segment.raw):
+            return LintResult(
+                anchor=context.segment,
+                description=f"Use of blocked regex '{context.segment.raw}'.",
             )
 
         return None

--- a/test/fixtures/rules/std_rule_cases/L062.yml
+++ b/test/fixtures/rules/std_rule_cases/L062.yml
@@ -89,3 +89,47 @@ test_pass_bool:
     rules:
       L062:
         blocked_words: bool
+
+test_pass_bigquery:
+  pass_str: |
+    SELECT *
+    FROM `owner.schema.table_2022_07_01_desktop`
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L062:
+        blocked_regex: ^.*(2022_06_01|2022_05_01).*$
+
+test_fail_bigquery:
+  fail_str: |
+    SELECT *
+    FROM `owner.schema.table_2022_06_01_desktop`
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L062:
+        blocked_regex: ^.*(2022_06_01|2022_05_01).*$
+
+test_fail_bigquery2:
+  fail_str: |
+    SELECT *
+    FROM `owner.schema.table_2022_06_01_desktop`
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L062:
+        blocked_regex: .*(2022_06_01|2022_05_01).*
+
+test_fail_bigquery3:
+  fail_str: |
+    SELECT *
+    FROM `owner.schema.table_2022_06_01_desktop`
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L062:
+        blocked_regex: (2022_06_01|2022_05_01)


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Adds the ability to use `blocked_regex` as well as `blocked_words` for rule L062 to allow blocking certain bits of SQL (e.g. old schema's that should not be used).

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
