### PR TITLE
Add config for optionally indenting contents of `ON` blocks

### DIFF
--- a/docs/source/indentation.rst
+++ b/docs/source/indentation.rst
@@ -207,6 +207,20 @@ being indented, in which case above SQL would become:
    JOIN another_table
    USING(a)
 
+There is also a similar :code:`indented_on_contents` config (defaulted to
+:code:`True`) which can be set to :code:`False` to align any :code:`AND` subsections
+of an :code:`ON` block with each other. If set to :code:`False` the SQL would become:
+
+.. code-block:: sql
+
+   SELECT
+      a,
+      b,
+   FROM my_table
+   JOIN another_table
+      ON condition1
+      AND condition2
+
 There is also a similar :code:`indented_ctes` config (defaulted to
 :code:`False`) which can be set to :code:`True` to enforce CTEs to be
 indented within the :code:`WITH` clause:

--- a/docs/source/indentation.rst
+++ b/docs/source/indentation.rst
@@ -167,6 +167,18 @@ however this is one element which is configurable.
 By setting values in the :code:`sqlfluff:indentation` section of your config
 file you can control how this is parsed.
 
+For example, the default indentation would be as follows:
+
+.. code-block:: sql
+
+   SELECT
+      a,
+      b
+   FROM my_table
+   JOIN another_table
+      ON condition1
+         AND condition2
+
 By setting your config file to:
 
 .. code-block:: cfg
@@ -179,47 +191,55 @@ Then the expected indentation will be:
 .. code-block:: sql
 
    SELECT
-      a, b, c
+      a,
+      b
    FROM my_table
       JOIN another_table
-         USING(a)
-
-However if no value for :code:`indented_joins` is set, or if it is set to
-:code:`False` then then following indentation will be expected:
-
-.. code-block:: sql
-
-   SELECT
-      a, b, c
-   FROM my_table
-   JOIN another_table
-      USING(a)
+         ON condition1
+            AND condition2
 
 There is a similar :code:`indented_using_on` config (defaulted to :code:`True`)
-which can be set to :code:`False` to prevent the :code:`using` clause from
-being indented, in which case above SQL would become:
-
-.. code-block:: sql
-
-   SELECT
-      a, b, c
-   FROM my_table
-   JOIN another_table
-   USING(a)
-
-There is also a similar :code:`indented_on_contents` config (defaulted to
-:code:`True`) which can be set to :code:`False` to align any :code:`AND` subsections
-of an :code:`ON` block with each other. If set to :code:`False` the SQL would become:
+which can be set to :code:`False` to prevent the :code:`USING` or :code:`ON`
+clause from being indented, in which case the original SQL would become:
 
 .. code-block:: sql
 
    SELECT
       a,
-      b,
+      b
+   FROM my_table
+   JOIN another_table
+   ON condition1
+      AND condition2
+
+There is also a similar :code:`indented_on_contents` config (defaulted to
+:code:`True`) which can be set to :code:`False` to align any :code:`AND`
+subsections of an :code:`ON` block with each other. If set to :code:`False`
+the original SQL would become:
+
+.. code-block:: sql
+
+   SELECT
+      a,
+      b
    FROM my_table
    JOIN another_table
       ON condition1
       AND condition2
+
+These can also be combined, so if :code:`indented_using_on` config is set to
+:code:`False`, and :code:`indented_on_contents` is also set to :code:`False`
+then the SQL would become:
+
+.. code-block:: sql
+
+   SELECT
+      a,
+      b
+   FROM my_table
+   JOIN another_table
+   ON condition1
+   AND condition2
 
 There is also a similar :code:`indented_ctes` config (defaulted to
 :code:`False`) which can be set to :code:`True` to enforce CTEs to be
@@ -239,7 +259,7 @@ indented within the :code:`WITH` clause:
    SELECT 1 FROM some_cte
 
 Note that using :code:`indented_ctes` may clash with `Rule L018`_ (`"WITH
-clause closing bracket should be aligned with WITH keyword."``), so if using
+clause closing bracket should be aligned with WITH keyword."`), so if using
 this option you will likely want to disable that rule.
 
 By default, *SQLFluff* aims to follow the indentation most common approach

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -40,7 +40,7 @@ fix_even_unparsable = False
 indented_joins = False
 indented_ctes = False
 indented_using_on = True
-intented_on_contents = True
+indented_on_contents = True
 template_blocks_indent = True
 
 [sqlfluff:templater]

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -40,6 +40,7 @@ fix_even_unparsable = False
 indented_joins = False
 indented_ctes = False
 indented_using_on = True
+intented_on_contents = True
 template_blocks_indent = True
 
 [sqlfluff:templater]

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1518,7 +1518,7 @@ class JoinOnConditionSegment(BaseSegment):
         "ON",
         Conditional(Indent, indented_on_contents=True),
         OptionallyBracketed(Ref("ExpressionSegment")),
-        Conditional(Dedent, indented_on_contents=True)
+        Conditional(Dedent, indented_on_contents=True),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1516,9 +1516,9 @@ class JoinOnConditionSegment(BaseSegment):
     type = "join_on_condition"
     match_grammar: Matchable = Sequence(
         "ON",
-        Indent,
+        Conditional(Indent, indented_on_contents=True),
         OptionallyBracketed(Ref("ExpressionSegment")),
-        Dedent,
+        Conditional(Dedent, indented_on_contents=True)
     )
 
 

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -219,6 +219,20 @@ test_pass_indented_using_on_merge_statment_false:
     indentation:
       indented_using_on: false
 
+test_pass_indented_on_contents_false:
+  # Test indented_on_contents when false (non-default)
+  pass_str: |
+    SELECT
+        r.a,
+        s.b
+    FROM r
+    JOIN s
+        ON r.a = s.a
+        AND true
+  configs:
+    indentation:
+      indented_on_contents: false
+
 test_pass_indented_from_with_comment:
   pass_str: |
     SELECT *

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -219,6 +219,31 @@ test_pass_indented_using_on_merge_statment_false:
     indentation:
       indented_using_on: false
 
+test_pass_indented_on_contents_default:
+  # Test indented_on_contents when default (true)
+  pass_str: |
+    SELECT
+        r.a,
+        s.b
+    FROM r
+    JOIN s
+        ON r.a = s.a
+            AND true
+
+test_pass_indented_on_contents_true:
+  # Test indented_on_contents when true (default)
+  pass_str: |
+    SELECT
+        r.a,
+        s.b
+    FROM r
+    JOIN s
+        ON r.a = s.a
+            AND true
+  configs:
+    indentation:
+      indented_on_contents: true
+
 test_pass_indented_on_contents_false:
   # Test indented_on_contents when false (non-default)
   pass_str: |
@@ -228,6 +253,41 @@ test_pass_indented_on_contents_false:
     FROM r
     JOIN s
         ON r.a = s.a
+        AND true
+  configs:
+    indentation:
+      indented_on_contents: false
+test_fail_indented_on_contents_default_fix:
+# Default config for indented_on_contents is true
+  fail_str: |
+    SELECT *
+    FROM t1
+    JOIN t2
+        ON true
+    AND true
+  fix_str: |
+    SELECT *
+    FROM t1
+    JOIN t2
+        ON true
+            AND true
+
+test_fail_indented_on_contents_false_fix:
+  fail_str: |
+    SELECT
+        t1.a,
+        t2.b
+    FROM t1
+    JOIN t2
+        ON true
+    AND true
+  fix_str: |
+    SELECT
+        t1.a,
+        t2.b
+    FROM t1
+    JOIN t2
+        ON true
         AND true
   configs:
     indentation:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #3469
See [discussion in slack](https://sqlfluff.slack.com/archives/C01GX4L213J/p1654102498025949)

- Adds another config option for whether to indent the contents of an ON statement.
- Add tests for this rule

### Are there any other side effects of this change that we should be aware of?

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
