### PR TITLE
SparkSQL: Support for Delta syntax to create manifest files through the `GENERATE` command

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -135,6 +135,7 @@ sparksql_dialect.sets("bare_functions").update(
         "CURRENT_DATE",
         "CURRENT_TIMESTAMP",
         "CURRENT_USER",
+        "symlink_format_manifest",
     ]
 )
 
@@ -2237,6 +2238,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("VacuumStatementSegment"),
             Ref("DescribeHistoryStatementSegment"),
             Ref("DescribeDetailStatementSegment"),
+            Ref("GenerateManifestFileStatementSegment"),
         ],
         remove=[
             Ref("TransactionStatementSegment"),
@@ -2679,6 +2681,27 @@ class DescribeDetailStatementSegment(BaseSegment):
     match_grammar: Matchable = Sequence(
         "DESCRIBE",
         "DETAIL",
+        OneOf(
+            Ref("QuotedLiteralSegment"),
+            Ref("FileReferenceSegment"),
+            Ref("TableReferenceSegment"),
+        ),
+    )
+
+
+class GenerateManifestFileStatementSegment(BaseSegment):
+    """A statement to `GENERATE` manifest files for a Delta Table.
+
+    https://docs.delta.io/latest/delta-utility.html#generate-a-manifest-file
+    """
+
+    type = "generate_manifest_file_statement"
+
+    match_grammar: Matchable = Sequence(
+        "GENERATE",
+        Ref("BareFunctionSegment"),
+        "FOR",
+        "TABLE",
         OneOf(
             Ref("QuotedLiteralSegment"),
             Ref("FileReferenceSegment"),

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -2698,7 +2698,11 @@ class GenerateManifestFileStatementSegment(BaseSegment):
 
     match_grammar: Matchable = Sequence(
         "GENERATE",
-        StringParser("symlink_format_manifest", CodeSegment, name="symlink_format_manifest"),
+        StringParser(
+            "symlink_format_manifest",
+            CodeSegment,
+            name="symlink_format_manifest",
+        ),
         "FOR",
         "TABLE",
         OneOf(

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -2698,7 +2698,7 @@ class GenerateManifestFileStatementSegment(BaseSegment):
 
     match_grammar: Matchable = Sequence(
         "GENERATE",
-        "symlink_format_manifest",
+        StringParser("symlink_format_manifest", CodeSegment, name="symlink_format_manifest"),
         "FOR",
         "TABLE",
         OneOf(

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -135,7 +135,6 @@ sparksql_dialect.sets("bare_functions").update(
         "CURRENT_DATE",
         "CURRENT_TIMESTAMP",
         "CURRENT_USER",
-        "symlink_format_manifest",
     ]
 )
 
@@ -2699,7 +2698,7 @@ class GenerateManifestFileStatementSegment(BaseSegment):
 
     match_grammar: Matchable = Sequence(
         "GENERATE",
-        Ref("BareFunctionSegment"),
+        "symlink_format_manifest",
         "FOR",
         "TABLE",
         OneOf(

--- a/src/sqlfluff/dialects/dialect_sparksql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_sparksql_keywords.py
@@ -287,5 +287,4 @@ UNRESERVED_KEYWORDS = [
     "HISTORY",
     "RETAIN",
     "RUN",
-    "symlink_format_manifest",
 ]

--- a/src/sqlfluff/dialects/dialect_sparksql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_sparksql_keywords.py
@@ -283,6 +283,7 @@ UNRESERVED_KEYWORDS = [
     # Delta Lake
     "DETAIL",
     "DRY",
+    "GENERATE",
     "HISTORY",
     "RETAIN",
     "RUN",

--- a/src/sqlfluff/dialects/dialect_sparksql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_sparksql_keywords.py
@@ -287,4 +287,5 @@ UNRESERVED_KEYWORDS = [
     "HISTORY",
     "RETAIN",
     "RUN",
+    "symlink_format_manifest",
 ]

--- a/test/fixtures/dialects/sparksql/delta_generate_manifest.sql
+++ b/test/fixtures/dialects/sparksql/delta_generate_manifest.sql
@@ -1,0 +1,5 @@
+GENERATE symlink_format_manifest FOR TABLE DELTA.`/data/events/`;
+
+GENERATE symlink_format_manifest FOR TABLE '/data/events/';
+
+GENERATE symlink_format_manifest FOR TABLE events;

--- a/test/fixtures/dialects/sparksql/delta_generate_manifest.sql
+++ b/test/fixtures/dialects/sparksql/delta_generate_manifest.sql
@@ -1,5 +1,5 @@
-GENERATE SYMLINK_FORMAT_MANIFEST FOR TABLE DELTA.`/data/events/`;
+GENERATE symlink_format_manifest FOR TABLE DELTA.`/data/events/`;
 
-GENERATE SYMLINK_FORMAT_MANIFEST FOR TABLE '/data/events/';
+GENERATE symlink_format_manifest FOR TABLE '/data/events/';
 
-GENERATE SYMLINK_FORMAT_MANIFEST FOR TABLE events;
+GENERATE symlink_format_manifest FOR TABLE events;

--- a/test/fixtures/dialects/sparksql/delta_generate_manifest.sql
+++ b/test/fixtures/dialects/sparksql/delta_generate_manifest.sql
@@ -1,5 +1,5 @@
-GENERATE symlink_format_manifest FOR TABLE DELTA.`/data/events/`;
+GENERATE SYMLINK_FORMAT_MANIFEST FOR TABLE DELTA.`/data/events/`;
 
-GENERATE symlink_format_manifest FOR TABLE '/data/events/';
+GENERATE SYMLINK_FORMAT_MANIFEST FOR TABLE '/data/events/';
 
-GENERATE symlink_format_manifest FOR TABLE events;
+GENERATE SYMLINK_FORMAT_MANIFEST FOR TABLE events;

--- a/test/fixtures/dialects/sparksql/delta_generate_manifest.yml
+++ b/test/fixtures/dialects/sparksql/delta_generate_manifest.yml
@@ -1,0 +1,35 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 88368f13dfbfb76b725a5ac404392039ae9bf3479a89e4af6057f4b284c3599c
+file:
+- statement:
+    generate_manifest_file_statement:
+    - keyword: GENERATE
+    - bare_function: symlink_format_manifest
+    - keyword: FOR
+    - keyword: TABLE
+    - file_reference:
+        keyword: DELTA
+        dot: .
+        identifier: '`/data/events/`'
+- statement_terminator: ;
+- statement:
+    generate_manifest_file_statement:
+    - keyword: GENERATE
+    - bare_function: symlink_format_manifest
+    - keyword: FOR
+    - keyword: TABLE
+    - literal: "'/data/events/'"
+- statement_terminator: ;
+- statement:
+    generate_manifest_file_statement:
+    - keyword: GENERATE
+    - bare_function: symlink_format_manifest
+    - keyword: FOR
+    - keyword: TABLE
+    - table_reference:
+        identifier: events
+- statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/delta_generate_manifest.yml
+++ b/test/fixtures/dialects/sparksql/delta_generate_manifest.yml
@@ -3,12 +3,12 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 20d46c80d8c8ce76b5e3efaa743be31affdebaec8ab067c8233fdf59e3e60a9a
+_hash: faf4f2753aeae3b1d57875ef7becfd1994517e58f49a9ee3ca54bb8c76db2ff5
 file:
 - statement:
     generate_manifest_file_statement:
     - keyword: GENERATE
-    - keyword: SYMLINK_FORMAT_MANIFEST
+    - raw: symlink_format_manifest
     - keyword: FOR
     - keyword: TABLE
     - file_reference:
@@ -19,7 +19,7 @@ file:
 - statement:
     generate_manifest_file_statement:
     - keyword: GENERATE
-    - keyword: SYMLINK_FORMAT_MANIFEST
+    - raw: symlink_format_manifest
     - keyword: FOR
     - keyword: TABLE
     - literal: "'/data/events/'"
@@ -27,7 +27,7 @@ file:
 - statement:
     generate_manifest_file_statement:
     - keyword: GENERATE
-    - keyword: SYMLINK_FORMAT_MANIFEST
+    - raw: symlink_format_manifest
     - keyword: FOR
     - keyword: TABLE
     - table_reference:

--- a/test/fixtures/dialects/sparksql/delta_generate_manifest.yml
+++ b/test/fixtures/dialects/sparksql/delta_generate_manifest.yml
@@ -3,12 +3,12 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 88368f13dfbfb76b725a5ac404392039ae9bf3479a89e4af6057f4b284c3599c
+_hash: 20d46c80d8c8ce76b5e3efaa743be31affdebaec8ab067c8233fdf59e3e60a9a
 file:
 - statement:
     generate_manifest_file_statement:
     - keyword: GENERATE
-    - bare_function: symlink_format_manifest
+    - keyword: SYMLINK_FORMAT_MANIFEST
     - keyword: FOR
     - keyword: TABLE
     - file_reference:
@@ -19,7 +19,7 @@ file:
 - statement:
     generate_manifest_file_statement:
     - keyword: GENERATE
-    - bare_function: symlink_format_manifest
+    - keyword: SYMLINK_FORMAT_MANIFEST
     - keyword: FOR
     - keyword: TABLE
     - literal: "'/data/events/'"
@@ -27,7 +27,7 @@ file:
 - statement:
     generate_manifest_file_statement:
     - keyword: GENERATE
-    - bare_function: symlink_format_manifest
+    - keyword: SYMLINK_FORMAT_MANIFEST
     - keyword: FOR
     - keyword: TABLE
     - table_reference:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Created `GenerateManifestFilesStatementSegment`, updated `UNRESERVED_KEYWORDS` to include 'symlink_format_manifest' and added test cases

### Are there any other side effects of this change that we should be aware of?
N/A

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
