### PR TITLE
SparkSQL: Support for `CONVERT TO DELTA` command

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -2736,8 +2736,5 @@ class ConvertToDeltaStatementSegment(BaseSegment):
         "DELTA",
         Ref("FileReferenceSegment"),
         Sequence("NO", "STATISTICS", optional=True),
-        Ref(
-            "PartitionSpecGrammar",
-            optional=True,
-        ),
+        Ref("PartitionSpecGrammar", optional=True),
     )

--- a/src/sqlfluff/dialects/dialect_sparksql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_sparksql_keywords.py
@@ -280,6 +280,7 @@ UNRESERVED_KEYWORDS = [
     # Community Contributed Data Sources
     "DELTA",  # https://github.com/delta-io/delta
     "XML",  # https://github.com/databricks/spark-xml
+    "ICEBERG",
     # Delta Lake
     "DETAIL",
     "DRY",

--- a/test/fixtures/dialects/sparksql/delta_convert_to.sql
+++ b/test/fixtures/dialects/sparksql/delta_convert_to.sql
@@ -1,0 +1,13 @@
+-- Convert unpartitioned Parquet table at path '<path-to-table>'
+CONVERT TO DELTA PARQUET.`/data/events/`;
+
+-- Convert partitioned Parquet table at path '<path-to-table>'
+-- and partitioned by integer columns named 'part' and 'part2'
+CONVERT TO DELTA PARQUET.`/data/events/` PARTITIONED BY (part int, part2 int);
+
+-- Convert the Iceberg table in the path <path-to-table>.
+CONVERT TO DELTA ICEBERG.`/data/events/`;
+
+-- Convert the Iceberg table in the path <path-to-table>
+-- without collecting statistics
+CONVERT TO DELTA ICEBERG.`/data/events/` NO STATISTICS;

--- a/test/fixtures/dialects/sparksql/delta_convert_to.yml
+++ b/test/fixtures/dialects/sparksql/delta_convert_to.yml
@@ -1,0 +1,65 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 2c7c05978f82e2fc0f6dbdf7d8f1ae11b70b24c3d2ca90a2288bd6d145ae5a08
+file:
+- statement:
+    convert_to_delta_statement:
+    - keyword: CONVERT
+    - keyword: TO
+    - keyword: DELTA
+    - file_reference:
+        keyword: PARQUET
+        dot: .
+        identifier: '`/data/events/`'
+- statement_terminator: ;
+- statement:
+    convert_to_delta_statement:
+    - keyword: CONVERT
+    - keyword: TO
+    - keyword: DELTA
+    - file_reference:
+        keyword: PARQUET
+        dot: .
+        identifier: '`/data/events/`'
+    - keyword: PARTITIONED
+    - keyword: BY
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          identifier: part
+          data_type:
+            primitive_type:
+              keyword: int
+      - comma: ','
+      - column_definition:
+          identifier: part2
+          data_type:
+            primitive_type:
+              keyword: int
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    convert_to_delta_statement:
+    - keyword: CONVERT
+    - keyword: TO
+    - keyword: DELTA
+    - file_reference:
+        keyword: ICEBERG
+        dot: .
+        identifier: '`/data/events/`'
+- statement_terminator: ;
+- statement:
+    convert_to_delta_statement:
+    - keyword: CONVERT
+    - keyword: TO
+    - keyword: DELTA
+    - file_reference:
+        keyword: ICEBERG
+        dot: .
+        identifier: '`/data/events/`'
+    - keyword: 'NO'
+    - keyword: STATISTICS
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
- update `PartitionSpecGrammar` to allow `ColumnDefinitionSegment` as a valid segment
- add `ICEBERG` non-reserved keyword
- add `ConvertToDeltaStatementSegment` class
- test cases 

### Are there any other side effects of this change that we should be aware of?
N/A

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
