### PR TITLE
Fix `load_macros_from_path` to actually support multiple paths

### DIFF
--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -67,12 +67,12 @@ class JinjaTemplater(PythonTemplater):
     @classmethod
     def _extract_macros_from_path(cls, path: List[str], env: Environment, ctx: Dict):
         """Take a path and extract macros from it."""
+        macro_ctx = {}
         for path_entry in path:
             # Does it exist? It should as this check was done on config load.
             if not os.path.exists(path_entry):
                 raise ValueError(f"Path does not exist: {path_entry}")
 
-            macro_ctx = {}
             if os.path.isfile(path_entry):
                 # It's a file. Extract macros from it.
                 with open(path_entry) as opened_file:

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -593,6 +593,8 @@ def assert_structure(yaml_loader, path, code_only=True, include_meta=False):
         # Test more dbt configurations
         ("jinja_o_config_override_dbt_builtins/override_dbt_builtins", True, False),
         ("jinja_p_disable_dbt_builtins/disable_dbt_builtins", True, False),
+        # Load all the macros
+        ("jinja_q_multiple_path_macros/jinja", True, False),
     ],
 )
 def test__templater_full(subpath, code_only, include_meta, yaml_loader, caplog):

--- a/test/fixtures/templater/jinja_q_multiple_path_macros/.sqlfluff
+++ b/test/fixtures/templater/jinja_q_multiple_path_macros/.sqlfluff
@@ -1,0 +1,2 @@
+[sqlfluff:templater:jinja]
+load_macros_from_path=macros,more_macros,even_more_macros

--- a/test/fixtures/templater/jinja_q_multiple_path_macros/even_more_macros/ultimate_foo.sql
+++ b/test/fixtures/templater/jinja_q_multiple_path_macros/even_more_macros/ultimate_foo.sql
@@ -1,0 +1,1 @@
+{%- macro foo3() -%}103{%- endmacro -%}

--- a/test/fixtures/templater/jinja_q_multiple_path_macros/jinja.sql
+++ b/test/fixtures/templater/jinja_q_multiple_path_macros/jinja.sql
@@ -1,0 +1,5 @@
+select
+    {{ foo1() }},
+    {{ foo2() }},
+    {{ foo3() }}
+from my_table

--- a/test/fixtures/templater/jinja_q_multiple_path_macros/jinja.yml
+++ b/test/fixtures/templater/jinja_q_multiple_path_macros/jinja.yml
@@ -1,0 +1,20 @@
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: select
+      - select_clause_element:
+          literal: '101'
+      - comma: ','
+      - select_clause_element:
+          literal: '102'
+      - comma: ','
+      - select_clause_element:
+          literal: '103'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: my_table

--- a/test/fixtures/templater/jinja_q_multiple_path_macros/macros/foo.sql
+++ b/test/fixtures/templater/jinja_q_multiple_path_macros/macros/foo.sql
@@ -1,0 +1,1 @@
+{%- macro foo1() -%}101{%- endmacro -%}

--- a/test/fixtures/templater/jinja_q_multiple_path_macros/more_macros/other_foo.sql
+++ b/test/fixtures/templater/jinja_q_multiple_path_macros/more_macros/other_foo.sql
@@ -1,0 +1,1 @@
+{%- macro foo2() -%}102{%- endmacro -%}


### PR DESCRIPTION
The definition of `macro_ctx` inside the `for` loop basically kills the feature of "comma-separated list of `.sql` or folders" (see [docs](https://docs.sqlfluff.com/en/stable/configuration.html))

If a folder has multiple entries, only the last one will prevail because the `macro_ctx = {}` is being executed on each iteration.

Also, the `return` value of the function is a variable defined in an inner scope!

### Are there any other side effects of this change that we should be aware of?
Since the _extraction_ of macros is accumulative (updating the same dictionary) I suggest updating the docs to explicitly say the last path takes precedence.

⚠️ Not sure how to test this. I couldn't find any test related to the code that I'm changing.
Should I create a bunch of directories with files defining dummy macros and prove it works?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
