### PR TITLE
Fix L022 false positive when the CTE definition has a column list

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2233,6 +2233,15 @@ ansi_dialect.add(
 )
 
 
+class CTEColumnList(BaseSegment):
+    """Bracketed column list portion of a CTE definition."""
+
+    type = "cte_column_list"
+    match_grammar = Bracketed(
+        Ref("SingleIdentifierListSegment"),
+    )
+
+
 class CTEDefinitionSegment(BaseSegment):
     """A CTE Definition from a WITH statement.
 
@@ -2242,10 +2251,7 @@ class CTEDefinitionSegment(BaseSegment):
     type = "common_table_expression"
     match_grammar: Matchable = Sequence(
         Ref("SingleIdentifierGrammar"),
-        Bracketed(
-            Ref("SingleIdentifierListSegment"),
-            optional=True,
-        ),
+        Ref("CTEColumnList", optional=True),
         "AS",
         Bracketed(
             # Ephemeral here to subdivide the query.

--- a/src/sqlfluff/rules/L022.py
+++ b/src/sqlfluff/rules/L022.py
@@ -63,21 +63,7 @@ class Rule_L022(BaseRule):
             )
             for idx, seg in enumerate(expanded_segments):
                 if seg.is_type("bracketed"):
-                    # Check if the preceding keyword is AS, otherwise it's a column name
-                    # definition in the CTE.
-                    preceding_keyword = next(
-                        (
-                            s
-                            for s in expanded_segments[:idx][::-1]
-                            if s.is_type("keyword")
-                        ),
-                        None,
-                    )
-                    if (
-                        preceding_keyword is not None
-                        and preceding_keyword.raw.upper() == "AS"
-                    ):
-                        bracket_indices.append(idx)
+                    bracket_indices.append(idx)
 
             # Work through each point and deal with it individually
             for bracket_idx in bracket_indices:

--- a/test/fixtures/dialects/ansi/select_with_recursive.yml
+++ b/test/fixtures/dialects/ansi/select_with_recursive.yml
@@ -3,21 +3,22 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bd4359f11fbb418769bf1d0fa5d56a403132c0e00d35845b8685cbd36dfe3999
+_hash: 8921c4f8390d9ea672e57260f95f01b095e7af459434a18fbc786ed6e837fe88
 file:
   statement:
     with_compound_statement:
     - keyword: WITH
     - keyword: RECURSIVE
     - common_table_expression:
-      - identifier: cte
-      - bracketed:
-          start_bracket: (
-          identifier_list:
-            identifier: a
-          end_bracket: )
-      - keyword: AS
-      - bracketed:
+        identifier: cte
+        cte_column_list:
+          bracketed:
+            start_bracket: (
+            identifier_list:
+              identifier: a
+            end_bracket: )
+        keyword: AS
+        bracketed:
           start_bracket: (
           set_expression:
           - select_statement:

--- a/test/fixtures/dialects/sparksql/common_table_expressions.yml
+++ b/test/fixtures/dialects/sparksql/common_table_expressions.yml
@@ -3,22 +3,23 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7068b60485f3d9f4e1b8e0e14224226b5cfdc8a06e457c8a33522b65ab1c1306
+_hash: 55552c8e7d241533be286e380f9752bab773d4a2c5dce274d14b02adcec867f6
 file:
 - statement:
     with_compound_statement:
       keyword: WITH
       common_table_expression:
-      - identifier: t
-      - bracketed:
-          start_bracket: (
-          identifier_list:
-          - identifier: x
-          - comma: ','
-          - identifier: y
-          end_bracket: )
-      - keyword: AS
-      - bracketed:
+        identifier: t
+        cte_column_list:
+          bracketed:
+            start_bracket: (
+            identifier_list:
+            - identifier: x
+            - comma: ','
+            - identifier: y
+            end_bracket: )
+        keyword: AS
+        bracketed:
           start_bracket: (
           select_statement:
             select_clause:
@@ -133,14 +134,15 @@ file:
                 with_compound_statement:
                   keyword: WITH
                   common_table_expression:
-                  - identifier: t
-                  - bracketed:
-                      start_bracket: (
-                      identifier_list:
-                        identifier: c
-                      end_bracket: )
-                  - keyword: AS
-                  - bracketed:
+                    identifier: t
+                    cte_column_list:
+                      bracketed:
+                        start_bracket: (
+                        identifier_list:
+                          identifier: c
+                        end_bracket: )
+                    keyword: AS
+                    bracketed:
                       start_bracket: (
                       select_statement:
                         select_clause:
@@ -211,20 +213,21 @@ file:
     - with_compound_statement:
         keyword: WITH
         common_table_expression:
-        - identifier: t
-        - bracketed:
-            start_bracket: (
-            identifier_list:
-            - identifier: a
-            - comma: ','
-            - identifier: b
-            - comma: ','
-            - identifier: c
-            - comma: ','
-            - identifier: d
-            end_bracket: )
-        - keyword: AS
-        - bracketed:
+          identifier: t
+          cte_column_list:
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - identifier: a
+              - comma: ','
+              - identifier: b
+              - comma: ','
+              - identifier: c
+              - comma: ','
+              - identifier: d
+              end_bracket: )
+          keyword: AS
+          bracketed:
             start_bracket: (
             select_statement:
               select_clause:

--- a/test/fixtures/dialects/tsql/create_view_with_cte.yml
+++ b/test/fixtures/dialects/tsql/create_view_with_cte.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f7e48a8c432b2a3fbeee5237aade3bdd5455870722f1acddbf76a2057482fb06
+_hash: aef1f1330486fb6e3e2894376a415dde571773e64ccf08efb884bcb5c2bc6406
 file:
   batch:
     statement:
@@ -16,18 +16,19 @@ file:
       - with_compound_statement:
           keyword: WITH
           common_table_expression:
-          - identifier: cte
-          - bracketed:
-              start_bracket: (
-              identifier_list:
-              - identifier: EmployeeID
-              - comma: ','
-              - identifier: ManagerID
-              - comma: ','
-              - identifier: Title
-              end_bracket: )
-          - keyword: AS
-          - bracketed:
+            identifier: cte
+            cte_column_list:
+              bracketed:
+                start_bracket: (
+                identifier_list:
+                - identifier: EmployeeID
+                - comma: ','
+                - identifier: ManagerID
+                - comma: ','
+                - identifier: Title
+                end_bracket: )
+            keyword: AS
+            bracketed:
               start_bracket: (
               set_expression:
               - select_statement:

--- a/test/fixtures/dialects/tsql/cte_s.yml
+++ b/test/fixtures/dialects/tsql/cte_s.yml
@@ -3,23 +3,24 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 71c37fda083d9cb57258a02461686c2d84ec45670d26eaadcb91c9850a113ed3
+_hash: f1fe1f3849303d271a43b34e746a174e8bf3d6e2c0f82fb8adf021cfbf57f49b
 file:
   batch:
     statement:
       with_compound_statement:
         keyword: WITH
         common_table_expression:
-        - identifier: Sales_CTE
-        - bracketed:
-            start_bracket: (
-            identifier_list:
-            - identifier: SalesPersonID
-            - comma: ','
-            - identifier: NumberOfOrders
-            end_bracket: )
-        - keyword: AS
-        - bracketed:
+          identifier: Sales_CTE
+          cte_column_list:
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - identifier: SalesPersonID
+              - comma: ','
+              - identifier: NumberOfOrders
+              end_bracket: )
+          keyword: AS
+          bracketed:
             start_bracket: (
             select_statement:
               select_clause:

--- a/test/fixtures/dialects/tsql/hints.yml
+++ b/test/fixtures/dialects/tsql/hints.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5bcf24968b7d9978c558f165b2a84e3ea46a42f03558600cdad2930890852042
+_hash: 092aaf4a7e6c31549fd74a735ccf589b578804e1b977005cab253642467eac69
 file:
 - batch:
     statement:
@@ -155,18 +155,19 @@ file:
       with_compound_statement:
         keyword: WITH
         common_table_expression:
-        - identifier: cte
-        - bracketed:
-            start_bracket: (
-            identifier_list:
-            - identifier: CustomerID
-            - comma: ','
-            - identifier: PersonID
-            - comma: ','
-            - identifier: StoreID
-            end_bracket: )
-        - keyword: AS
-        - bracketed:
+          identifier: cte
+          cte_column_list:
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - identifier: CustomerID
+              - comma: ','
+              - identifier: PersonID
+              - comma: ','
+              - identifier: StoreID
+              end_bracket: )
+          keyword: AS
+          bracketed:
             start_bracket: (
             set_expression:
             - select_statement:

--- a/test/fixtures/rules/std_rule_cases/L022.yml
+++ b/test/fixtures/rules/std_rule_cases/L022.yml
@@ -184,3 +184,64 @@ test_pass_column_name_definition:
     )
 
     select n from t limit 100;
+
+test_pass_column_name_definition_multiple:
+  # Issue #3474
+  pass_str: |
+    WITH
+    cte_1 AS (
+        SELECT 1 AS var
+    ),
+
+    cte_2 (var) AS (
+        SELECT 2
+    )
+
+    SELECT
+        cte_1.var,
+        cte_2.var
+    FROM cte_1, cte_2;
+
+test_fail_column_name_definition_newline:
+  fail_str: |
+    WITH
+    cte_1 (var) AS
+    (
+        SELECT 2
+    )
+    SELECT
+        cte_1.var,
+        cte_2.var
+    FROM cte_1, cte_2;
+  fix_str: |
+    WITH
+    cte_1 (var) AS
+    (
+        SELECT 2
+    )
+
+    SELECT
+        cte_1.var,
+        cte_2.var
+    FROM cte_1, cte_2;
+
+test_fail_column_name_definition_comment:
+  fail_str: |
+    WITH
+    cte_1 (var) AS /* random comment */ (
+        SELECT 2
+    )
+    SELECT
+        cte_1.var,
+        cte_2.var
+    FROM cte_1, cte_2;
+  fix_str: |
+    WITH
+    cte_1 (var) AS /* random comment */ (
+        SELECT 2
+    )
+
+    SELECT
+        cte_1.var,
+        cte_2.var
+    FROM cte_1, cte_2;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3474
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?

Changes the parse structure for CTEs with column lists (unusual within the SQLFluff test cases).

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
