### PR TITLE
Allow linter to apply fixes spanning more than 2 slices

### DIFF
--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -343,12 +343,6 @@ class LintedFile(NamedTuple):
                 linter_logger.info(
                     "      - Skipping patch over templated section: %s", enriched_patch
                 )
-            # If we span more than two slices then we should just skip it. Too Hard.
-            elif len(local_raw_slices) > 2:  # pragma: no cover
-                linter_logger.info(
-                    "      - Skipping patch over more than two raw slices: %s",
-                    enriched_patch,
-                )
             # If it's an insertion (i.e. the string in the pre-fix template is '') then
             # we won't be able to place it, so skip.
             elif not enriched_patch.templated_str:  # pragma: no cover TODO?

--- a/test/fixtures/rules/std_rule_cases/L001.yml
+++ b/test/fixtures/rules/std_rule_cases/L001.yml
@@ -17,3 +17,7 @@ test_pass_trailing_whitespace_before_template_code:
         {{ elem }},
         {% endfor %}
         0
+
+test_fail_trailing_whitespace_and_whitespace_control:
+  fail_str: "{%- set temp = 'temp' -%}\n\nSELECT\n    1, \n    2,\n"
+  fix_str: "{%- set temp = 'temp' -%}\n\nSELECT\n    1,\n    2,\n"


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3489
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
