### PR TITLE
Allow `DEFAULT` expression in Redshift `ALTER TABLE ADD COLUMN` statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -655,6 +655,7 @@ class AlterTableActionSegment(BaseSegment):
             Ref.keyword("COLUMN", optional=True),
             Ref("ColumnReferenceSegment"),
             Ref("DatatypeSegment"),
+            Sequence("DEFAULT", Ref("ExpressionSegment"), optional=True),
             Sequence("COLLATE", Ref("QuotedLiteralSegment"), optional=True),
             AnyNumberOf(Ref("ColumnConstraintSegment")),
         ),

--- a/test/fixtures/dialects/redshift/redshift_alter_table.sql
+++ b/test/fixtures/dialects/redshift/redshift_alter_table.sql
@@ -46,3 +46,12 @@ alter table t2 alter column c0 encode lzo;
 ALTER TABLE the_schema.the_table ADD COLUMN the_timestamp TIMESTAMP;
 
 ALTER TABLE the_schema.the_table ADD COLUMN the_boolean BOOLEAN DEFAULT FALSE;
+
+alter table users
+add column feedback_score int
+default NULL;
+
+alter table users drop column feedback_score;
+
+alter table users
+drop column feedback_score cascade;

--- a/test/fixtures/dialects/redshift/redshift_alter_table.sql
+++ b/test/fixtures/dialects/redshift/redshift_alter_table.sql
@@ -42,3 +42,7 @@ alter table t1 alter sortkey(c0, c1);
 alter table t1 alter encode auto;
 
 alter table t2 alter column c0 encode lzo;
+
+ALTER TABLE the_schema.the_table ADD COLUMN the_timestamp TIMESTAMP;
+
+ALTER TABLE the_schema.the_table ADD COLUMN the_boolean BOOLEAN DEFAULT FALSE;

--- a/test/fixtures/dialects/redshift/redshift_alter_table.yml
+++ b/test/fixtures/dialects/redshift/redshift_alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1d4d0e6da207670465d878eb8f0162e9bb80934e9a36ce22029c38e4f72e8407
+_hash: e6ec7ed245bc31af652d9776b8149d02ec0a4486e19793a77e488ea6e1596957
 file:
 - statement:
     alter_table_statement:
@@ -315,4 +315,82 @@ file:
           identifier: c0
       - keyword: encode
       - keyword: lzo
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - identifier: the_schema
+      - dot: .
+      - identifier: the_table
+    - alter_table_action_segment:
+      - keyword: ADD
+      - keyword: COLUMN
+      - column_reference:
+          identifier: the_timestamp
+      - data_type:
+          datetime_type_identifier:
+            keyword: TIMESTAMP
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - identifier: the_schema
+      - dot: .
+      - identifier: the_table
+    - alter_table_action_segment:
+      - keyword: ADD
+      - keyword: COLUMN
+      - column_reference:
+          identifier: the_boolean
+      - data_type:
+          keyword: BOOLEAN
+      - keyword: DEFAULT
+      - expression:
+          literal: 'FALSE'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: users
+    - alter_table_action_segment:
+      - keyword: add
+      - keyword: column
+      - column_reference:
+          identifier: feedback_score
+      - data_type:
+          keyword: int
+      - keyword: default
+      - expression:
+          literal: 'NULL'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: users
+    - alter_table_action_segment:
+      - keyword: drop
+      - keyword: column
+      - column_reference:
+          identifier: feedback_score
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: alter
+    - keyword: table
+    - table_reference:
+        identifier: users
+    - alter_table_action_segment:
+      - keyword: drop
+      - keyword: column
+      - column_reference:
+          identifier: feedback_score
+      - keyword: cascade
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Added support for default expression in Redshift alter table add column statements. 

Per [the AWS documentation](https://docs.aws.amazon.com/redshift/latest/dg/r_ALTER_TABLE.html) this is supported:

```
ALTER TABLE table_name 
{
ADD table_constraint 
| DROP CONSTRAINT constraint_name [ RESTRICT | CASCADE ] 
| OWNER TO new_owner 
| RENAME TO new_name 
| RENAME COLUMN column_name TO new_name            
| ALTER COLUMN column_name TYPE new_data_type
| ALTER COLUMN column_name ENCODE new_encode_type     
| ALTER COLUMN column_name ENCODE encode_type, 
| ALTER COLUMN column_name ENCODE encode_type, .....;      
| ALTER DISTKEY column_name 
| ALTER DISTSTYLE ALL       
| ALTER DISTSTYLE EVEN
| ALTER DISTSTYLE KEY DISTKEY column_name 
| ALTER DISTSTYLE AUTO             
| ALTER [COMPOUND] SORTKEY ( column_name [,...] ) 
| ALTER SORTKEY AUTO 
| ALTER SORTKEY NONE
| ALTER ENCODE AUTO
| ADD [ COLUMN ] column_name column_type              
  [ DEFAULT default_expr ]                                   <----- this line
  [ ENCODE encoding ]
  [ NOT NULL | NULL ] |
| DROP [ COLUMN ] column_name [ RESTRICT | CASCADE ] }
```

but SQLFluff throws a parse error in this scenario.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?

Not that I am aware of.


### Pull Request checklist

- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
