### PR TITLE
Disable L059 by default for Postgres

### DIFF
--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -27,7 +27,7 @@ class Rule_L059(BaseRule):
     unnecessary, except for reserved keywords and special characters in identifiers.
 
     .. note::
-       This rule is disabled by default for Postgres abd Snowflake because the allow
+       This rule is disabled by default for Postgres and Snowflake because they allow
        quotes as part of the column name. In other words, ``date`` and ``"date"`` are
        two different columns.
 

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -27,9 +27,9 @@ class Rule_L059(BaseRule):
     unnecessary, except for reserved keywords and special characters in identifiers.
 
     .. note::
-       This rule is disabled by default for Snowflake because it allows quotes as
-       part of the column name. In other words, ``date`` and ``"date"`` are two
-       different columns.
+       This rule is disabled by default for Postgres abd Snowflake because the allow
+       quotes as part of the column name. In other words, ``date`` and ``"date"`` are
+       two different columns.
 
        It can be enabled with the ``force_enable = True`` flag.
 
@@ -86,7 +86,7 @@ class Rule_L059(BaseRule):
         "ignore_words_regex",
         "force_enable",
     ]
-    _dialects_allowing_quotes_in_column_names = ["snowflake"]
+    _dialects_allowing_quotes_in_column_names = ["postgres", "snowflake"]
 
     # Ignore "password_auth" type to allow quotes around passwords within
     # `CREATE USER` statements in Exasol dialect.

--- a/test/fixtures/rules/std_rule_cases/L059.yml
+++ b/test/fixtures/rules/std_rule_cases/L059.yml
@@ -357,3 +357,26 @@ test_fail_quoted_column_snowflake_force_enable:
     rules:
       L059:
         force_enable: true
+
+test_pass_quoted_column_postgres:
+  # The rule is disabled by default in Postgres.
+  pass_str: |
+    SELECT d."date"
+    FROM d
+  configs:
+    core:
+      dialect: postgres
+
+test_fail_quoted_column_postgres_force_enable:
+  fail_str: |
+    SELECT d."date"
+    FROM d
+  fix_str: |
+    SELECT d.date
+    FROM d
+  configs:
+    core:
+      dialect: postgres
+    rules:
+      L059:
+        force_enable: true


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3485 

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
