### PR TITLE
Fix L025 false positive for tsql VALUES clause

### DIFF
--- a/src/sqlfluff/rules/L025.py
+++ b/src/sqlfluff/rules/L025.py
@@ -113,14 +113,18 @@ class Rule_L025(BaseRule):
         # is actually *required* in order for SQL Server to parse it.
         for segment in from_expression_element.iter_segments(expanding=("bracketed",)):
             if segment.is_type("table_expression"):
-                # Found a table expression.
-                #  Does it have a VALUES clause?
+                # Found a table expression. Does it have a VALUES clause?
                 if not segment.get_child("values_clause"):
-                    # No VALUES clause.
+                    # No VALUES clause, thus the alias is definitely not required.
                     return False
-                # Is this a dialect that requires VALUE clauses to be aliased?
-                if dialect_name in cls._dialects_requiring_alias_for_table_expression:
-                    return True
+                else:
+                    # Is this a dialect that requires VALUE clauses to be aliased?
+                    return (
+                        dialect_name
+                        in cls._dialects_requiring_alias_for_table_expression
+                    )
+
+        # Didn't find a table expression, so the alias is not required.
         return False
 
     @classmethod

--- a/src/sqlfluff/rules/L025.py
+++ b/src/sqlfluff/rules/L025.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import cast, List, Set
 
 from sqlfluff.core.dialects.base import Dialect
+from sqlfluff.core.parser.segments import BaseSegment
 from sqlfluff.core.rules.analysis.select import get_select_statement_info
 from sqlfluff.core.rules.analysis.select_crawler import (
     Query as SelectCrawlerQuery,
@@ -62,6 +63,10 @@ class Rule_L025(BaseRule):
     """
 
     groups = ("all", "core")
+    _dialects_requiring_alias_for_table_expression = [
+        "snowflake",
+        "tsql",
+    ]
 
     def _eval(self, context: RuleContext) -> EvalResultType:
         violations: List[LintResult] = []
@@ -81,18 +86,42 @@ class Rule_L025(BaseRule):
             alias: AliasInfo
             for alias in query.aliases:
 
-                # Skip alias for values clauses
-                if alias.from_expression_element:
-                    table_expression = alias.from_expression_element.get_child(
-                        "table_expression"
-                    )
-                    if table_expression and table_expression.get_child("values_clause"):
-                        continue
+                # Skip alias if it's required (some dialects require aliases for
+                # VALUES clauses).
+                if alias.from_expression_element and self.is_alias_required(
+                    alias.from_expression_element, context.dialect.name
+                ):
+                    continue
 
                 if alias.aliased and alias.ref_str not in query.tbl_refs:
                     # Unused alias. Report and fix.
                     violations.append(self._report_unused_alias(alias))
         return violations or None
+
+    @classmethod
+    def is_alias_required(
+        cls, from_expression_element: BaseSegment, dialect_name: str
+    ) -> bool:
+        """Given an alias, is it REQUIRED to be present?
+
+        Aliases are required in SOME, but not all dialects when there's a VALUES
+        clause.
+        """
+        # Look for a table_expression (i.e. VALUES clause) as a descendant of
+        # the FROM expression, potentially nested inside brackets. The reason we
+        # allow nesting in brackets is that in some dialects (e.g. TSQL), this
+        # is actually *required* in order for SQL Server to parse it.
+        for segment in from_expression_element.iter_segments(expanding=("bracketed",)):
+            if segment.is_type("table_expression"):
+                # Found a table expression.
+                #  Does it have a VALUES clause?
+                if not segment.get_child("values_clause"):
+                    # No VALUES clause.
+                    return False
+                # Is this a dialect that requires VALUE clauses to be aliased?
+                if dialect_name in cls._dialects_requiring_alias_for_table_expression:
+                    return True
+        return False
 
     @classmethod
     def _analyze_table_aliases(cls, query: L025Query, dialect: Dialect):

--- a/src/sqlfluff/rules/L025.py
+++ b/src/sqlfluff/rules/L025.py
@@ -63,7 +63,7 @@ class Rule_L025(BaseRule):
     """
 
     groups = ("all", "core")
-    _dialects_requiring_alias_for_table_expression = [
+    _dialects_requiring_alias_for_values_clause = [
         "snowflake",
         "tsql",
     ]
@@ -120,8 +120,7 @@ class Rule_L025(BaseRule):
                 else:
                     # Is this a dialect that requires VALUE clauses to be aliased?
                     return (
-                        dialect_name
-                        in cls._dialects_requiring_alias_for_table_expression
+                        dialect_name in cls._dialects_requiring_alias_for_values_clause
                     )
 
         # Didn't find a table expression, so the alias is not required.

--- a/src/sqlfluff/rules/L025.py
+++ b/src/sqlfluff/rules/L025.py
@@ -123,8 +123,8 @@ class Rule_L025(BaseRule):
                         dialect_name in cls._dialects_requiring_alias_for_values_clause
                     )
 
-        # Didn't find a table expression, so the alias is not required.
-        return False
+        # This should never happen. Return False just to be safe.
+        return False  # pragma: no cover
 
     @classmethod
     def _analyze_table_aliases(cls, query: L025Query, dialect: Dialect):

--- a/test/fixtures/rules/std_rule_cases/L025.yml
+++ b/test/fixtures/rules/std_rule_cases/L025.yml
@@ -228,6 +228,34 @@ test_fail_sparksql_values_clause:
     core:
       dialect: sparksql
 
+test_pass_snowflake_values:
+  # Tests a fix for issue 3301.
+  pass_str: |
+    SELECT
+      thing_1
+      , thing_2
+    FROM VALUES
+      ( 'foo', 'bar')
+      , ( 'foo', 'bar')
+      my_table_alias(thing_1, thing_2)
+  configs:
+    core:
+      dialect: snowflake
+
+test_pass_tsql_values_clause_in_parentheses:
+  # Tests a fix for issue 3522. In tsql, the parentheses surrouding "values" are
+  # required (otherwise syntax error). SQLFluff was incorrectly complaining that
+  # the alias 't' was unused.
+  pass_str: |
+    SELECT *
+    FROM (VALUES
+        ('a1', 'b1'),
+        ('a2', 'b2'),
+        ('a3', 'b3')) t(a,b)
+  configs:
+    core:
+      dialect: tsql
+
 test_pass_join_on_expression_in_parentheses:
   pass_str: |
     SELECT table1.c1
@@ -284,16 +312,3 @@ test_fail_snowflake_flatten_function:
   configs:
     core:
       dialect: snowflake
-
-
-test_pass_snowflake_values:
-  # Tests a fix for issue 3301.
-  pass_str: |
-    SELECT
-      thing_1
-      , thing_2
-    FROM VALUES
-      ( 'foo', 'bar')
-      , ( 'foo', 'bar')
-      my_table_alias(thing_1, thing_2)
-    ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3522 

For context, see recent, related PR #3358.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
