### PR TITLE
T-SQL keyword functions should be treated as keywords

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1931,7 +1931,6 @@ class ReservedKeywordFunctionNameSegment(BaseSegment):
     type = "function_name"
     match_grammar = OneOf(
         "COALESCE",
-        "CONVERT",
         "CURRENT_TIMESTAMP",
         "CURRENT_USER",
         "LEFT",

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -278,22 +278,7 @@ tsql_dialect.replace(
             CodeSegment,
             name="function_name_identifier",
             type="function_name_identifier",
-            anti_template=r"^("
-            + r"|".join(
-                dialect.sets("reserved_keywords")
-                - {
-                    "COALESCE",
-                    "CONVERT",
-                    "CURRENT_TIMESTAMP",
-                    "CURRENT_USER",
-                    "LEFT",
-                    "NULLIF",
-                    "RIGHT",
-                    "SESSION_USER",
-                    "SYSTEM_USER",
-                }
-            )
-            + r")$",
+            anti_template=r"^(" + r"|".join(dialect.sets("reserved_keywords")) + r")$",
         )
     ),
     # Override ANSI IsClauseGrammar to remove TSQL non-keyword NAN
@@ -1936,6 +1921,27 @@ class RankFunctionNameSegment(BaseSegment):
     match_grammar = OneOf("DENSE_RANK", "NTILE", "RANK", "ROW_NUMBER")
 
 
+class ReservedKeywordFunctionNameSegment(BaseSegment):
+    """Reserved keywords that are also functions.
+
+    Need to be able to specify this as type function_name
+    so that linting rules identify it properly
+    """
+
+    type = "function_name"
+    match_grammar = OneOf(
+        "COALESCE",
+        "CONVERT",
+        "CURRENT_TIMESTAMP",
+        "CURRENT_USER",
+        "LEFT",
+        "NULLIF",
+        "RIGHT",
+        "SESSION_USER",
+        "SYSTEM_USER",
+    )
+
+
 class WithinGroupFunctionNameSegment(BaseSegment):
     """WITHIN GROUP function name segment.
 
@@ -2125,17 +2131,20 @@ class FunctionSegment(BaseSegment):
             Ref("WithinGroupClause", optional=True),
         ),
         Sequence(
-            Ref(
-                "FunctionNameSegment",
-                exclude=OneOf(
-                    Ref("ValuesClauseSegment"),
-                    # List of special functions handled differently
-                    Ref("CastFunctionNameSegment"),
-                    Ref("ConvertFunctionNameSegment"),
-                    Ref("DatePartFunctionNameSegment"),
-                    Ref("WithinGroupFunctionNameSegment"),
-                    Ref("RankFunctionNameSegment"),
+            OneOf(
+                Ref(
+                    "FunctionNameSegment",
+                    exclude=OneOf(
+                        Ref("ValuesClauseSegment"),
+                        # List of special functions handled differently
+                        Ref("CastFunctionNameSegment"),
+                        Ref("ConvertFunctionNameSegment"),
+                        Ref("DatePartFunctionNameSegment"),
+                        Ref("WithinGroupFunctionNameSegment"),
+                        Ref("RankFunctionNameSegment"),
+                    ),
                 ),
+                Ref("ReservedKeywordFunctionNameSegment"),
             ),
             Bracketed(
                 Ref(

--- a/test/fixtures/dialects/tsql/functions_a.yml
+++ b/test/fixtures/dialects/tsql/functions_a.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a3a6930d6681ac484720ab8322991bc463aa8a29ab286671428dc53619fb5001
+_hash: 6f1882c4d59b875099d20209a6218f65916c8012b9c039c4a6ac726bb019c258
 file:
 - batch:
     statement:
@@ -44,13 +44,13 @@ file:
         - select_clause_element:
             function:
               function_name:
-                function_name_identifier: LEFT
+                keyword: LEFT
               bracketed:
               - start_bracket: (
               - expression:
                   function:
                     function_name:
-                      function_name_identifier: RIGHT
+                      keyword: RIGHT
                     bracketed:
                     - start_bracket: (
                     - expression:

--- a/test/fixtures/dialects/tsql/insert_statement.yml
+++ b/test/fixtures/dialects/tsql/insert_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 09086fc0eaf36a2101673087de8442bde4d6f46fa5065c5b18a1f3026f0d5693
+_hash: 394e1703ddf23475cbcb831a44125445412a7675ab0b9345b94febe5047dd187
 file:
 - batch:
     statement:
@@ -126,7 +126,7 @@ file:
                       - expression:
                           function:
                             function_name:
-                              function_name_identifier: LEFT
+                              keyword: LEFT
                             bracketed:
                             - start_bracket: (
                             - expression:
@@ -140,7 +140,7 @@ file:
                       - expression:
                           function:
                             function_name:
-                              function_name_identifier: RIGHT
+                              keyword: RIGHT
                             bracketed:
                             - start_bracket: (
                             - expression:
@@ -184,7 +184,7 @@ file:
                             - expression:
                                 function:
                                   function_name:
-                                    function_name_identifier: LEFT
+                                    keyword: LEFT
                                   bracketed:
                                   - start_bracket: (
                                   - expression:
@@ -198,7 +198,7 @@ file:
                             - expression:
                                 function:
                                   function_name:
-                                    function_name_identifier: RIGHT
+                                    keyword: RIGHT
                                   bracketed:
                                   - start_bracket: (
                                   - expression:

--- a/test/fixtures/dialects/tsql/select.yml
+++ b/test/fixtures/dialects/tsql/select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7ce30980036eafe78e1166b2dc7487b6b3ad1558257fa34dac05a1c3e9595319
+_hash: 82765358fec514857672b3b253c2a28d82038d623688304b7da24b2d10a4814b
 file:
   batch:
     statement:
@@ -628,7 +628,7 @@ file:
                 - keyword: BY
                 - function:
                     function_name:
-                      function_name_identifier: COALESCE
+                      keyword: COALESCE
                     bracketed:
                     - start_bracket: (
                     - expression:
@@ -645,7 +645,7 @@ file:
                 - expression:
                     function:
                       function_name:
-                        function_name_identifier: COALESCE
+                        keyword: COALESCE
                       bracketed:
                       - start_bracket: (
                       - expression:

--- a/test/fixtures/dialects/tsql/stored_procedure_single_statement.yml
+++ b/test/fixtures/dialects/tsql/stored_procedure_single_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0109c17dc0b68524a7932b8ae396a1ebee111662cb9b7ea047a749edce76b426
+_hash: 59d0ba72fdf89e04c01fbd5b3f6065f51b959feb65d79ec15ffed398b28f147c
 file:
   batch:
     create_procedure_statement:
@@ -153,7 +153,7 @@ file:
                           - expression:
                               function:
                                 function_name:
-                                  function_name_identifier: LEFT
+                                  keyword: LEFT
                                 bracketed:
                                 - start_bracket: (
                                 - expression:
@@ -167,7 +167,7 @@ file:
                           - expression:
                               function:
                                 function_name:
-                                  function_name_identifier: RIGHT
+                                  keyword: RIGHT
                                 bracketed:
                                 - start_bracket: (
                                 - expression:
@@ -211,7 +211,7 @@ file:
                                 - expression:
                                     function:
                                       function_name:
-                                        function_name_identifier: LEFT
+                                        keyword: LEFT
                                       bracketed:
                                       - start_bracket: (
                                       - expression:
@@ -225,7 +225,7 @@ file:
                                 - expression:
                                     function:
                                       function_name:
-                                        function_name_identifier: RIGHT
+                                        keyword: RIGHT
                                       bracketed:
                                       - start_bracket: (
                                       - expression:

--- a/test/fixtures/rules/std_rule_cases/L010.yml
+++ b/test/fixtures/rules/std_rule_cases/L010.yml
@@ -195,3 +195,20 @@ test_fail_select_lower:
     rules:
       L010:
         capitalisation_policy: upper
+
+test_fail_select_lower_keyword_functions:
+  # Test for issue #3520
+  fail_str: |
+    SELECT
+    cast(5 AS int) AS test1,
+    coalesce(1, 2) AS test3
+  fix_str: |
+    SELECT
+    CAST(5 AS int) AS test1,
+    COALESCE(1, 2) AS test3
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      L010:
+        capitalisation_policy: upper


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3520 

### Are there any other side effects of this change that we should be aware of?
Nope, this corrects behaviour to be more consistent

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
