### PR TITLE
L025 should not remove aliases from derived queries

### DIFF
--- a/test/fixtures/rules/std_rule_cases/L025.yml
+++ b/test/fixtures/rules/std_rule_cases/L025.yml
@@ -65,10 +65,6 @@ test_fail_table_alias_not_referenced_2_subquery:
   fail_str: SELECT * FROM (SELECT * FROM my_tbl foo)
   fix_str: SELECT * FROM (SELECT * FROM my_tbl)
 
-test_fail_subquery_alias_not_referenced:
-  fail_str: select * from (select 1 as a) subquery
-  fix_str: select * from (select 1 as a)
-
 test_pass_bigquery_unaliased_table_with_hyphens:
   # Test non-quoted table name containing hyphens: https://github.com/sqlfluff/sqlfluff/issues/895
   # This is more of a smoke test to exercise the
@@ -312,3 +308,9 @@ test_fail_snowflake_flatten_function:
   configs:
     core:
       dialect: snowflake
+
+test_pass_derived_query_requires_alias:
+  pass_str: |
+    SELECT * FROM (
+        SELECT 1
+    )  as a

--- a/test/fixtures/rules/std_rule_cases/L025.yml
+++ b/test/fixtures/rules/std_rule_cases/L025.yml
@@ -65,6 +65,9 @@ test_fail_table_alias_not_referenced_2_subquery:
   fail_str: SELECT * FROM (SELECT * FROM my_tbl foo)
   fix_str: SELECT * FROM (SELECT * FROM my_tbl)
 
+test_pass_subquery_alias_not_referenced:
+  pass_str: select * from (select 1 as a) subquery
+
 test_pass_bigquery_unaliased_table_with_hyphens:
   # Test non-quoted table name containing hyphens: https://github.com/sqlfluff/sqlfluff/issues/895
   # This is more of a smoke test to exercise the


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3545 
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
