### PR TITLE
L016: ignore_comment_clauses not working for postgres dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -2790,7 +2790,7 @@ class CommentOnStatementSegment(BaseSegment):
     https://www.postgresql.org/docs/13/sql-comment.html
     """
 
-    type = "comment_on_statement"
+    type = "comment_clause"
 
     match_grammar = Sequence(
         "COMMENT",

--- a/test/fixtures/dialects/postgres/postgres_comment_on.yml
+++ b/test/fixtures/dialects/postgres/postgres_comment_on.yml
@@ -3,10 +3,10 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7c90e4bdbadff9a7fecebca8a640802da706cc7761e116f2cc81ab9e85e30697
+_hash: fdff956652dd6475e54f12211a109f8fc8e876642cb680fe64950fc79c3b20e3
 file:
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: TABLE
@@ -16,7 +16,7 @@ file:
     - literal: "'This is my table.'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: TABLE
@@ -26,7 +26,7 @@ file:
     - keyword: 'NULL'
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: ACCESS
@@ -37,7 +37,7 @@ file:
     - literal: "'GIN index access method'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: AGGREGATE
@@ -52,7 +52,7 @@ file:
     - literal: "'Computes sample variance'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: CAST
@@ -68,7 +68,7 @@ file:
     - literal: "'Allow casts from text to int4'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: COLLATION
@@ -78,7 +78,7 @@ file:
     - literal: "'Canadian French'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: COLUMN
@@ -90,7 +90,7 @@ file:
     - literal: "'Employee ID number'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: CONVERSION
@@ -100,7 +100,7 @@ file:
     - literal: "'Conversion to UTF8'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: CONSTRAINT
@@ -113,7 +113,7 @@ file:
     - literal: "'Constrains column col'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: CONSTRAINT
@@ -127,7 +127,7 @@ file:
     - literal: "'Constrains col of domain'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: DATABASE
@@ -137,7 +137,7 @@ file:
     - literal: "'Development Database'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: DOMAIN
@@ -147,7 +147,7 @@ file:
     - literal: "'Email Address Domain'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: EVENT
@@ -158,7 +158,7 @@ file:
     - literal: "'Aborts all DDL commands'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: EXTENSION
@@ -168,7 +168,7 @@ file:
     - literal: "'implements the hstore data type'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: FOREIGN
@@ -180,7 +180,7 @@ file:
     - literal: "'my foreign data wrapper'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: FOREIGN
@@ -191,7 +191,7 @@ file:
     - literal: "'Employee Information in other database'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: FUNCTION
@@ -208,7 +208,7 @@ file:
     - literal: "'Returns Roman Numeral'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: INDEX
@@ -218,7 +218,7 @@ file:
     - literal: "'Enforces uniqueness on employee ID'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: LANGUAGE
@@ -228,7 +228,7 @@ file:
     - literal: "'Python support for stored procedures'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: MATERIALIZED
@@ -239,7 +239,7 @@ file:
     - literal: "'Summary of order history'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: POLICY
@@ -252,7 +252,7 @@ file:
     - literal: "'Filter rows by users'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: PROCEDURE
@@ -268,7 +268,7 @@ file:
     - literal: "'Runs a report'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: PUBLICATION
@@ -278,7 +278,7 @@ file:
     - literal: "'Publishes all operations on all tables'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: ROLE
@@ -288,7 +288,7 @@ file:
     - literal: "'Administration group for finance tables'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: ROUTINE
@@ -304,7 +304,7 @@ file:
     - literal: "'Runs a routine (which is a function or procedure)'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: RULE
@@ -317,7 +317,7 @@ file:
     - literal: "'Logs updates of employee records'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: SCHEMA
@@ -327,7 +327,7 @@ file:
     - literal: "'Departmental data'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: SEQUENCE
@@ -337,7 +337,7 @@ file:
     - literal: "'Used to generate primary keys'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: SERVER
@@ -347,7 +347,7 @@ file:
     - literal: "'my foreign server'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: STATISTICS
@@ -357,7 +357,7 @@ file:
     - literal: "'Improves planner row estimations'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: SUBSCRIPTION
@@ -367,7 +367,7 @@ file:
     - literal: "'Subscription for all operations on all tables'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: TABLE
@@ -379,7 +379,7 @@ file:
     - literal: "'Employee Information'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: TABLESPACE
@@ -389,7 +389,7 @@ file:
     - literal: "'Tablespace for indexes'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: TEXT
@@ -401,7 +401,7 @@ file:
     - literal: "'Special word filtering'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: TEXT
@@ -413,7 +413,7 @@ file:
     - literal: "'Snowball stemmer for Swedish language'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: TEXT
@@ -425,7 +425,7 @@ file:
     - literal: "'Splits text into words'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: TEXT
@@ -437,7 +437,7 @@ file:
     - literal: "'Snowball stemmer'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: TRIGGER
@@ -450,7 +450,7 @@ file:
     - literal: "'Used for RI'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: TYPE
@@ -460,7 +460,7 @@ file:
     - literal: "'Complex number data type'"
 - statement_terminator: ;
 - statement:
-    comment_on_statement:
+    comment_clause:
     - keyword: COMMENT
     - keyword: 'ON'
     - keyword: VIEW

--- a/test/fixtures/rules/std_rule_cases/L016.yml
+++ b/test/fixtures/rules/std_rule_cases/L016.yml
@@ -299,3 +299,18 @@ test_pass_ignore_comment_clauses_snowflake:
     rules:
       L016:
         ignore_comment_clauses: True
+
+test_pass_ignore_comment_clauses_postgres:
+  pass_str: |
+    CREATE TABLE IF NOT EXISTS foo
+    ( id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+      name TEXT NOT NULL
+    );
+
+    COMMENT ON TABLE foo IS 'Windows Phone 8, however, was never able to overcome a long string of disappointments for Microsoft. ';
+  configs:
+    core:
+      dialect: postgres
+    rules:
+      L016:
+        ignore_comment_clauses: True


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3480 
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
