### PR TITLE
Exclude .coverage.py from linting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -133,7 +133,7 @@ commands =
 # D107: Don't require docstrings on __init__
 # D105: Don't require docstrings on magic methods
 ignore = W503, D107, D105, D418
-exclude = .git,__pycache__,env,.tox,build,.venv,venv
+exclude = .git,__pycache__,env,.tox,build,.venv,venv,.coverage.py
 max-line-length = 88
 extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #3563 
Because of the .coverage.py file, the linting raised this kind of error:
```
ValueError: source code string cannot contain null bytes
ERROR: InvocationError for command /home/zidder/pythonTricks/sqlfluff/.tox/linting/bin/flake8 (exited with code 1)
```

Now this error is gone, because the `.coverage.py` is not linted anymore.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
