### PR TITLE
Simplify lint fixing (prep for source fixes)

### DIFF
--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -27,7 +27,6 @@ from sqlfluff.core.errors import (
     SQLLintError,
     CheckTuple,
 )
-from sqlfluff.core.string_helpers import findall
 from sqlfluff.core.templaters import TemplatedFile
 
 # Classes needed only for type checking
@@ -326,7 +325,7 @@ class LintedFile(NamedTuple):
                 filtered_source_patches.append(patch)
                 dedupe_buffer.append(patch.dedupe_tuple())
             else:
-                NotImplementedError( # pragma: no cover
+                NotImplementedError(  # pragma: no cover
                     "Template tracing logic means that this situation should "
                     "never occur. Please report this as an issue on GitHub "
                     "with a version of your query which triggers this "

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -27,6 +27,7 @@ from sqlfluff.core.errors import (
     SQLLintError,
     CheckTuple,
 )
+from sqlfluff.core.string_helpers import findall
 from sqlfluff.core.templaters import TemplatedFile
 
 # Classes needed only for type checking
@@ -325,12 +326,38 @@ class LintedFile(NamedTuple):
                 filtered_source_patches.append(patch)
                 dedupe_buffer.append(patch.dedupe_tuple())
             else:
-                NotImplementedError(  # pragma: no cover
-                    "Template tracing logic means that this situation should "
-                    "never occur. Please report this as an issue on GitHub "
-                    "with a version of your query which triggers this "
-                    "error"
+                # We've got a situation where the ends of our patch need to be
+                # more carefully mapped. Likely because we're greedily including
+                # a section of source templating with our fix and we need to work
+                # around it gracefully.
+
+                # Identify all the places the string appears in the source content.
+                positions = list(findall(patch.templated_str, patch.source_str))
+                if len(positions) != 1:
+                    linter_logger.debug(
+                        "        - Skipping edit patch on non-unique templated "
+                        "content: %s",
+                        patch,
+                    )
+                    continue
+
+                # We have a single occurrence of the thing we want to patch. This
+                # means we can use its position to place our patch.
+                new_source_slice = slice(
+                    patch.source_slice.start + positions[0],
+                    patch.source_slice.start + positions[0] + len(patch.templated_str),
                 )
+                linter_logger.debug(
+                    "      * Keeping Tricky Case. Positions: %s, New Slice: %s, "
+                    "Patch: %s",
+                    positions,
+                    new_source_slice,
+                    patch,
+                )
+                patch.source_slice = new_source_slice
+                filtered_source_patches.append(patch)
+                dedupe_buffer.append(patch.dedupe_tuple())
+                continue
 
         # Sort the patches before building up the file.
         filtered_source_patches = sorted(

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -334,12 +334,16 @@ class LintedFile(NamedTuple):
                 # Identify all the places the string appears in the source content.
                 positions = list(findall(patch.templated_str, patch.source_str))
                 if len(positions) != 1:
-                    linter_logger.debug(
+                    # NOTE: This section is not covered in tests. While we
+                    # don't have an example of it's use (we should), the 
+                    # code after this relies on there being only one
+                    # instance found - so the safety check remains.
+                    linter_logger.debug(  # pragma: no cover
                         "        - Skipping edit patch on non-unique templated "
                         "content: %s",
                         patch,
                     )
-                    continue
+                    continue  # pragma: no cover
 
                 # We have a single occurrence of the thing we want to patch. This
                 # means we can use its position to place our patch.

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -335,7 +335,7 @@ class LintedFile(NamedTuple):
                 positions = list(findall(patch.templated_str, patch.source_str))
                 if len(positions) != 1:
                     # NOTE: This section is not covered in tests. While we
-                    # don't have an example of it's use (we should), the 
+                    # don't have an example of it's use (we should), the
                     # code after this relies on there being only one
                     # instance found - so the safety check remains.
                     linter_logger.debug(  # pragma: no cover

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -54,7 +54,7 @@ linter_logger = logging.getLogger("sqlfluff.linter")
 
 @dataclass
 class FixPatch:
-    """An edit patch for a templated file."""
+    """An edit patch for a source file."""
 
     templated_slice: slice
     fixed_raw: str
@@ -62,37 +62,35 @@ class FixPatch:
     # than for function. It allows traceability of *why* this patch was
     # generated. It has no significance for processing.
     patch_category: str
-
-    def enrich(self, templated_file: TemplatedFile) -> "EnrichedFixPatch":
-        """Convert patch to source space."""
-        source_slice = templated_file.templated_slice_to_source_slice(
-            self.templated_slice,
-        )
-        return EnrichedFixPatch(
-            source_slice=source_slice,
-            templated_slice=self.templated_slice,
-            patch_category=self.patch_category,
-            fixed_raw=self.fixed_raw,
-            templated_str=templated_file.templated_str[self.templated_slice],
-            source_str=templated_file.source_str[source_slice],
-        )
-
-
-@dataclass
-class EnrichedFixPatch(FixPatch):
-    """An edit patch for a source file."""
-
     source_slice: slice
     templated_str: str
     source_str: str
 
-    def enrich(self, templated_file: TemplatedFile) -> "EnrichedFixPatch":
-        """No-op override of base class function."""
-        return self
-
     def dedupe_tuple(self):
         """Generate a tuple of this fix for deduping."""
         return (self.source_slice, self.fixed_raw)
+    
+    @classmethod
+    def infer_from_template(
+        cls,
+        templated_slice: slice,
+        fixed_raw:str,
+        patch_category:str,
+        templated_file: TemplatedFile,
+    ):
+        # NOTE: There used to be error handling here to catch ValueErrors.
+        # Removed in July 2022 because untestable.
+        source_slice = templated_file.templated_slice_to_source_slice(
+            templated_slice,
+        )
+        return cls(
+            source_slice=source_slice,
+            templated_slice=templated_slice,
+            patch_category=patch_category,
+            fixed_raw=fixed_raw,
+            templated_str=templated_file.templated_str[templated_slice],
+            source_str=templated_file.source_str[source_slice],
+        )
 
 
 @dataclass
@@ -1297,7 +1295,7 @@ class BaseSegment:
 
     def iter_patches(
         self, templated_file: TemplatedFile
-    ) -> Iterator[Union[EnrichedFixPatch, FixPatch]]:
+    ) -> Iterator[FixPatch]:
         """Iterate through the segments generating fix patches.
 
         The patches are generated in TEMPLATED space. This is important
@@ -1326,8 +1324,11 @@ class BaseSegment:
         # If it's all literal, then we don't need to recurse.
         if self.pos_marker.is_literal():
             # Yield the position in the source file and the patch
-            yield FixPatch(
-                self.pos_marker.templated_slice, self.raw, patch_category="literal"
+            yield FixPatch.infer_from_template(
+                self.pos_marker.templated_slice,
+                self.raw,
+                patch_category="literal",
+                templated_file=templated_file
             )
         # Can we go deeper?
         elif not self.segments:
@@ -1367,7 +1368,7 @@ class BaseSegment:
                 if start_diff > 0 or insert_buff:
                     # If we have an insert buffer, then it's an edit, otherwise a
                     # deletion.
-                    yield FixPatch(
+                    yield FixPatch.infer_from_template(
                         slice(
                             segment.pos_marker.templated_slice.start
                             - max(start_diff, 0),
@@ -1375,7 +1376,9 @@ class BaseSegment:
                         ),
                         insert_buff,
                         patch_category="mid_point",
+                        templated_file=templated_file,
                     )
+
                     insert_buff = ""
 
                 # Now we deal with any changes *within* the segment itself.
@@ -1398,11 +1401,12 @@ class BaseSegment:
                     templated_idx,
                     self.pos_marker.templated_slice.stop,
                 )
-                # By returning an EnrichedFixPatch (rather than FixPatch), which
-                # includes a source_slice field, we ensure that fixes adjacent
-                # to source-only slices (e.g. {% endif %}) are placed
-                # appropriately relative to source-only slices.
-                yield EnrichedFixPatch(
+                # We determine the source_slice directly rather than
+                # infering it so that we can be very specific that 
+                # we ensure that fixes adjacent to source-only slices
+                # (e.g. {% endif %}) are placed appropriately relative
+                # to source-only slices.
+                yield FixPatch(
                     source_slice=source_slice,
                     templated_slice=templated_slice,
                     patch_category="end_point",


### PR DESCRIPTION
This is in preparation for allowing source fixes. Lots of deletions 🚀 

Two main changes I'm making here:
1. We used to have `FixPatch` (which only had templated position) and `EnrichedFixPatch` (which had templated and source position). I've combined these into one class because I think we can always go straight to creating the latter. Perhaps confusingly, I've renamed the latter to the former, so now we just have `FixPatch`, but it also has templated position. This involved pushing a little logic upstream but not much.
2. In `.fix_string()` there were a few `if` statements for conditions that haven't been covered with tests and I've tried quite hard to trigger them. I'm relatively sure that the new template tracing logic means that our positioning is now good enough that we don't need them anymore. They were useful when tracing was less precise, in that they handled potential ambiguity in the positioning. Without a test case I think it's going to be challenging to support those code paths, so I've added warning asking people to submit queries if they would ever have been used.

I'm getting closer to actually adding functionality! I promise. It's just involving picking through a load of very old code which I'm going to need to rethink a bit.