### PR TITLE
Fix incorrect L022 with postgres dialect with CTE argument list

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -4063,10 +4063,7 @@ class CTEDefinitionSegment(ansi.CTEDefinitionSegment):
 
     match_grammar = Sequence(
         Ref("SingleIdentifierGrammar"),
-        Bracketed(
-            Ref("SingleIdentifierListSegment"),
-            optional=True,
-        ),
+        Ref("CTEColumnList", optional=True),
         "AS",
         Sequence("NOT", "MATERIALIZED", optional=True),
         Bracketed(

--- a/test/fixtures/dialects/postgres/postgres_delete.yml
+++ b/test/fixtures/dialects/postgres/postgres_delete.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 18eae966c89e42a090d0cd0e3b7e0a92443577fcf599a5f0325205305564c68f
+_hash: d0f59d3f0579e2e10bd302b8b724640193848f0acdc1df90ce5ff0fa0d900d2e
 file:
 - statement:
     delete_statement:
@@ -495,14 +495,15 @@ file:
     - keyword: WITH
     - keyword: RECURSIVE
     - common_table_expression:
-      - identifier: t
-      - bracketed:
-          start_bracket: (
-          identifier_list:
-            identifier: n
-          end_bracket: )
-      - keyword: AS
-      - bracketed:
+        identifier: t
+        cte_column_list:
+          bracketed:
+            start_bracket: (
+            identifier_list:
+              identifier: n
+            end_bracket: )
+        keyword: AS
+        bracketed:
           start_bracket: (
           set_expression:
             values_clause:

--- a/test/fixtures/dialects/postgres/postgres_values_in_subquery.yml
+++ b/test/fixtures/dialects/postgres/postgres_values_in_subquery.yml
@@ -3,22 +3,23 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cfb0b25673569ea5fca5640575508daa191b21b282d81cbad46654f4f2a3b362
+_hash: 189323503508de52b90fb3989bcf5e547eb2c4c78692d0dd1480f91ff594224f
 file:
 - statement:
     with_compound_statement:
       keyword: WITH
       common_table_expression:
-      - identifier: t
-      - bracketed:
-          start_bracket: (
-          identifier_list:
-          - identifier: col_1
-          - comma: ','
-          - identifier: col_2
-          end_bracket: )
-      - keyword: AS
-      - bracketed:
+        identifier: t
+        cte_column_list:
+          bracketed:
+            start_bracket: (
+            identifier_list:
+            - identifier: col_1
+            - comma: ','
+            - identifier: col_2
+            end_bracket: )
+        keyword: AS
+        bracketed:
           start_bracket: (
           values_clause:
             keyword: VALUES

--- a/test/fixtures/dialects/postgres/postgres_with.yml
+++ b/test/fixtures/dialects/postgres/postgres_with.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9186a2b9abd8dddb08b72c4faee9e10c8c91b2f86a4d3e005a00470a92269f25
+_hash: ebab9cc65a808ee6ab1f3cb71aaac622a02a3eeacf58faf74a89de490da96660
 file:
 - statement:
     with_compound_statement:
@@ -86,15 +86,16 @@ file:
     - keyword: RECURSIVE
     - common_table_expression:
       - identifier: search_tree
-      - bracketed:
-          start_bracket: (
-          identifier_list:
-          - identifier: id
-          - comma: ','
-          - identifier: link
-          - comma: ','
-          - identifier: data
-          end_bracket: )
+      - cte_column_list:
+          bracketed:
+            start_bracket: (
+            identifier_list:
+            - identifier: id
+            - comma: ','
+            - identifier: link
+            - comma: ','
+            - identifier: data
+            end_bracket: )
       - keyword: AS
       - bracketed:
           start_bracket: (
@@ -217,15 +218,16 @@ file:
     - keyword: RECURSIVE
     - common_table_expression:
       - identifier: search_tree
-      - bracketed:
-          start_bracket: (
-          identifier_list:
-          - identifier: id
-          - comma: ','
-          - identifier: link
-          - comma: ','
-          - identifier: data
-          end_bracket: )
+      - cte_column_list:
+          bracketed:
+            start_bracket: (
+            identifier_list:
+            - identifier: id
+            - comma: ','
+            - identifier: link
+            - comma: ','
+            - identifier: data
+            end_bracket: )
       - keyword: AS
       - bracketed:
           start_bracket: (
@@ -348,17 +350,18 @@ file:
     - keyword: RECURSIVE
     - common_table_expression:
       - identifier: search_graph
-      - bracketed:
-          start_bracket: (
-          identifier_list:
-          - identifier: id
-          - comma: ','
-          - identifier: link
-          - comma: ','
-          - identifier: data
-          - comma: ','
-          - identifier: depth
-          end_bracket: )
+      - cte_column_list:
+          bracketed:
+            start_bracket: (
+            identifier_list:
+            - identifier: id
+            - comma: ','
+            - identifier: link
+            - comma: ','
+            - identifier: data
+            - comma: ','
+            - identifier: depth
+            end_bracket: )
       - keyword: AS
       - bracketed:
           start_bracket: (

--- a/test/fixtures/rules/std_rule_cases/L022.yml
+++ b/test/fixtures/rules/std_rule_cases/L022.yml
@@ -245,3 +245,22 @@ test_fail_column_name_definition_comment:
         cte_1.var,
         cte_2.var
     FROM cte_1, cte_2;
+
+test_pass_recursive_with_argument_list:
+  pass_str: |
+    WITH RECURSIVE my_cte (n) AS (
+        select 1
+    )
+
+    select * from my_cte
+
+test_pass_recursive_with_argument_list_postgres:
+  pass_str: |
+    WITH RECURSIVE my_cte (n) AS (
+        select 1
+    )
+
+    select * from my_cte
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
### Brief summary of the change made

This fixes #3569 where rule L022 wants to put a new line after the closing parenthesis of the CTE argument list. It seems like the postgres dialect needed to be updated to match the ansi one as part of #3490 .


### Are there any other side effects of this change that we should be aware of?

Not to my knowledge.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
