### PR TITLE
Support for MySQL system variables

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -95,6 +95,7 @@ mysql_dialect.replace(
     LiteralGrammar=ansi_dialect.get_grammar("LiteralGrammar").copy(
         insert=[
             Ref("DoubleQuotedLiteralSegment"),
+            Ref("SystemVariableSegment"),
         ]
     ),
     FromClauseTerminatorGrammar=ansi_dialect.get_grammar(
@@ -207,6 +208,12 @@ mysql_dialect.add(
         name="at_sign_literal",
         type="literal",
         trim_chars=("@",),
+    ),
+    SystemVariableSegment=RegexParser(
+        r"@@(session|global)\.[A-Za-z0-9_]+",
+        CodeSegment,
+        name="system_variable",
+        type="system_variable",
     ),
 )
 
@@ -710,7 +717,7 @@ mysql_dialect.insert_lexer_matchers(
     [
         RegexLexer(
             "at_sign",
-            r"[@][a-zA-Z0-9_]*",
+            r"@@?[a-zA-Z0-9_.]*",
             CodeSegment,
         ),
     ],

--- a/test/fixtures/dialects/mysql/system_variables.sql
+++ b/test/fixtures/dialects/mysql/system_variables.sql
@@ -1,0 +1,5 @@
+SELECT @@global.time_zone;
+SELECT @@session.time_zone;
+SELECT @@global.version;
+SELECT @@session.rand_seed1;
+SELECT CONVERT_TZ(NOW(), @@global.time_zone, '+00:00')

--- a/test/fixtures/dialects/mysql/system_variables.yml
+++ b/test/fixtures/dialects/mysql/system_variables.yml
@@ -1,0 +1,59 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 7ee845cc79c4b19c5a15b765bf58282520be92649f543a90c3badb1900de89e4
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          system_variable: '@@global.time_zone'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          system_variable: '@@session.time_zone'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          system_variable: '@@global.version'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          system_variable: '@@session.rand_seed1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CONVERT_TZ
+            bracketed:
+            - start_bracket: (
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: NOW
+                  bracketed:
+                    start_bracket: (
+                    end_bracket: )
+            - comma: ','
+            - expression:
+                system_variable: '@@global.time_zone'
+            - comma: ','
+            - expression:
+                literal: "'+00:00'"
+            - end_bracket: )


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3574 
MySQL system variables `@@global.xxx` and `@@session.xxx` are now recognized by the parser.

### Are there any other side effects of this change that we should be aware of?
None that I can think of.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
