### PR TITLE
Allow no alias for selects in CTEs with a column list

### DIFF
--- a/test/fixtures/rules/std_rule_cases/L013.yml
+++ b/test/fixtures/rules/std_rule_cases/L013.yml
@@ -47,3 +47,33 @@ test_pass_function_emits:
   configs:
     core:
       dialect: exasol
+
+test_fail_cte_no_column_list:
+  fail_str: |
+    WITH cte AS (
+        SELECT
+            col_a,
+            min(col_b)
+        FROM my_table
+        GROUP BY 1
+    )
+
+    SELECT
+        a,
+        b
+    FROM cte
+
+test_pass_cte_column_list:
+  pass_str: |
+    WITH cte(a, b) AS (
+        SELECT
+            col_a,
+            min(col_b)
+        FROM my_table
+        GROUP BY 1
+    )
+
+    SELECT
+        a,
+        b
+    FROM cte


### PR DESCRIPTION
### Brief summary of the change made

In cases where the CTE has a column list, we don't need an alias for columns. This checks if the select has a `common_table_expression` parent and if that parent has a `cte_column_list` child. In that case, it doesn't complain about a missing alias.

Fixes #3558

### Are there any other side effects of this change that we should be aware of?

I'm not 100% positive that this won't lead to false negatives in some weirdly nested situation. Open to feedback there.

Also, I'm not sure if this rule should be checking if the number of items in the `cte_column_list` matches the number of selects. It seems like that is out of scope for this rule (since it probably means that you have a syntax error), but I could be wrong.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
