### PR TITLE
Redshift: Add `TOP X` to select clause modifiers

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2258,3 +2258,11 @@ class CallStatementSegment(BaseSegment):
         "CALL",
         Ref("FunctionSegment"),
     )
+
+
+class SelectClauseModifierSegment(postgres.SelectClauseModifierSegment):
+    """Things that come after SELECT but before the columns."""
+
+    match_grammar = postgres.SelectClauseModifierSegment.match_grammar.copy(
+        insert=[Sequence("TOP", Ref("NumericLiteralSegment"))],
+    )

--- a/test/fixtures/dialects/redshift/select_top.sql
+++ b/test/fixtures/dialects/redshift/select_top.sql
@@ -1,0 +1,1 @@
+SELECT TOP 10 example_value_col FROM example_schema.some_table ORDER BY example_value_col;

--- a/test/fixtures/dialects/redshift/select_top.yml
+++ b/test/fixtures/dialects/redshift/select_top.yml
@@ -1,0 +1,32 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 894b302c1b6551a0d3ce2623548d2284bce4dc09e1b2b5cc3cd7bc3ec737b7e4
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_modifier:
+          keyword: TOP
+          literal: '10'
+        select_clause_element:
+          column_reference:
+            identifier: example_value_col
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - identifier: example_schema
+              - dot: .
+              - identifier: some_table
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          identifier: example_value_col
+  statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Adds grammar support for `SELECT TOP N` to redshift dialect. See the [redshift select syntax](https://docs.aws.amazon.com/redshift/latest/dg/r_SELECT_synopsis.html#r_SELECT_synopsis-synopsis) and [top-specific examples](https://docs.aws.amazon.com/redshift/latest/dg/r_Examples_with_TOP.html).

Fixes #3531

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
