### PR TITLE
Small grammar cleanup in team rollout docs

### DIFF
--- a/docs/source/teamrollout.rst
+++ b/docs/source/teamrollout.rst
@@ -3,12 +3,12 @@
 Rolling out SQLFluff with a new team
 ====================================
 
-Rolling out SQLFluff (like rolling out any other linter or style
-guide) is not just about just the *technical* rollout, but also
-how you introduce to the tool to the team and organisation around
+Rolling out SQLFluff, like rolling out any other linter or style
+guide, is not just about the *technical* rollout, but also
+how you introduce the tool to the team and organisation around
 you.
 
-   *The effect of SQLFluff should be to change your behaviours not*
+   *The effect of SQLFluff should be to change your behaviours, not*
    *just your SQL*.
 
 With that in mind, it's worth reminding ourselves what we're trying
@@ -25,7 +25,7 @@ might be:
    found in open source projects is easy to read and *looks familiar*
    then you're more likely to use it. This means more reusable code
    across the industry.
-#. **Productive discussions  around style**. By defining your
+#. **Productive discussions around style**. By defining your
    organisation's style guide in code, it means you can version
    control it, discuss changes and ultimately give a concrete output
    to discussions over style.
@@ -37,7 +37,7 @@ Consider which of these success measures is most important and most
 desirable for your team. *Write that down*.
 
 The following steps are a guide, which you should adapt to your
-organisation, and in particular it's level of data maturity.
+organisation, and in particular its level of data maturity.
 
 1. Assess the situation
 -----------------------
@@ -48,12 +48,12 @@ This step is done by you, or a small group of people who *already*
 * Run ``sqlfluff lint`` on your project with the stock configuration
   to find out how things work *out of the box*.
 * Set up your :ref:`config` so that things run and that you can get
-  a readout of of the errors which you would want the team to see and
+  a readout of the errors which you would want the team to see and
   *not the ones you don't*. Great tools for this are to use
   :ref:`sqlfluffignore`, ``--exclude-rules`` or ``--ignore`` in the
   CLI (see :ref:`cliref`).
-* Identify which areas of your project are the worst and which the
-  tidiest are. In particular, any areas which are particularly good
+* Identify which areas of your project are the worst and which are the
+  tidiest. In particular, any areas which are particularly tidy
   already will be particularly useful in the next phase.
 
 2. Make a plan
@@ -67,24 +67,24 @@ There are three sensible rollout phases:
 
 In each of these phases you have three levers to play with:
 
-#. Areas of the project.
+#. Areas of the project in which to apply rules.
 #. Depth of rules enforced (this might also include whether
-   to ignore parsing errors or not too).
+   to ignore parsing errors or not).
 #. Whether to just lint changes (:ref:`diff-quality`),
-   or whether to lint all the existing code as well.
+   or to lint all the existing code as well.
 
 Work out a sensible roadmap of how hard you want to go in
 each phase. Be clear who is responsible for changes at each
 phase. An example plan might look like this:
 
-#. **Pre CI/CD** we get the cleanest area of a project
-   to a stage that it fully passes the rules we eventually.
+#. **Pre CI/CD** we get the tidiest area of a project
+   to a stage that it fully passes the rules we eventually want to enforce.
    The core project team will do this. Liberal use of
    ``sqlfluff fix`` can be a lifesaver in this phase.
 #. **Soft CI/CD** is applied to the whole project, team
-   members are encouraged to write tidy SQL, but not *required*.
+   members are encouraged to write tidy SQL, but not *required* to.
 #. **Hard CI/CD** is applied to the tidy areas of the project
-   and to also to any changes to the whole project. Anyone
+   and also to any changes to the whole project. Anyone
    making changes is *required* to write SQL which passes check.
 #. **Hard CI/CD** is applied to the whole project on not just
    changes, with only a few particularly problematic files
@@ -122,8 +122,8 @@ norms and rituals around how you change the rules. In particular:
   or whether some are creating unnecessary stress?
 
 It's normal for your usage of tools like SQLFluff to change and
-evolve over time, what's important is to know this in advance
-and welcome it when it happens, and make sure you're always driving
+evolve over time. It's important to expect this change in advance,
+and welcome it when it happens. Always make sure you're driving
 toward the success measures you decided up front, rather than
 just resisting the change.
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Was reading through [docs](https://docs.sqlfluff.com/en/stable/teamrollout.html) and came across a couple of changes to be made in the grammar.  This just looks at that one file.

### Are there any other side effects of this change that we should be aware of?

Shouldn't be any code impacts since I'm just touching the docs

### Pull Request checklist
- [na] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

(Not-applicable, since I'm just touching docs)