### PR TITLE
Fix Bracketed Struct issue

### DIFF
--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -268,6 +268,11 @@ class Bracketed(Sequence):
 
         # Are we dealing with a pre-existing BracketSegment?
         if seg_buff[0].is_type("bracketed"):
+            # Check it's of the right kind of bracket
+            if not start_bracket.match(seg_buff[0].start_bracket, parse_context):
+                # Doesn't match - return no match
+                return MatchResult.from_unmatched(segments)
+
             seg: BracketedSegment = cast(BracketedSegment, seg_buff[0])
             content_segs = seg.segments[len(seg.start_bracket) : -len(seg.end_bracket)]
             bracket_segment = seg

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1057,22 +1057,6 @@ class TypelessStructSegment(ansi.TypelessStructSegment):
         ),
     )
 
-    # Workaround: https://github.com/sqlfluff/sqlfluff/issues/3277
-    # There is a weird issue where sometimes typeless structs are parsed as typed
-    # structs and trigger false-positives of L063 when `parse_grammar` is not set.
-    # Follow the linked issue for progress on this issue.
-    parse_grammar = Sequence(
-        "STRUCT",
-        Bracketed(
-            Delimited(
-                Sequence(
-                    Ref("BaseExpressionElementGrammar"),
-                    Ref("AliasExpressionSegment", optional=True),
-                ),
-            ),
-        ),
-    )
-
 
 class TypelessArraySegment(ansi.TypelessArraySegment):
     """Expression to construct a ARRAY from a subquery.


### PR DESCRIPTION
This addresses #3277.

As @tunetheweb pointed out in the other PR (#3428 - that while immutability helps with the issue, it wasn't the root cause). This PR addresses the root cause.

There are a few routines which check whether a segment has already matched a given set of segments. I.e. if a `SelectStatement` encounters a `SelectStatement` it doesn't need to reparse it - it knows it's already a `SelectStatement`. This allows shortcuts and better performance from not reparsing sections.

The root cause for this is that when checking bracketed sections, all we check is that it's a bracketed section (and not the _type_ of brackets). I.e. a pre-existing bracketed section using `()` would recognise a separate bracketed section using (`<>`). Given the issue we're facing is two segment definitions which only differ in their bracket use (and the content is equivalent) - this solves that problem.