### PR TITLE
Struct type should be a segment

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2621,6 +2621,7 @@ class TypelessArraySegment(BaseSegment):
 
 class StructTypeSegment(BaseSegment):
     """Expression to construct a STRUCT datatype.
+
     (Used in BigQuery for example)
     """
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -527,7 +527,6 @@ ansi_dialect.add(
     ),
     # This is a placeholder for other dialects.
     SimpleArrayTypeGrammar=Nothing(),
-    StructTypeGrammar=Nothing(),
     BaseExpressionElementGrammar=OneOf(
         Ref("LiteralGrammar"),
         Ref("BareFunctionSegment"),
@@ -1809,7 +1808,7 @@ ansi_dialect.add(
                 Ref("SimpleArrayTypeGrammar", optional=True), Ref("ArrayLiteralSegment")
             ),
             Sequence(
-                Ref("StructTypeGrammar"),
+                Ref("StructTypeSegment"),
                 Bracketed(Delimited(Ref("ExpressionSegment"))),
             ),
             Sequence(
@@ -2617,6 +2616,15 @@ class TypelessArraySegment(BaseSegment):
     """
 
     type = "typeless_array"
+    match_grammar: Matchable = Nothing()
+
+
+class StructTypeSegment(BaseSegment):
+    """Expression to construct a STRUCT datatype.
+    (Used in BigQuery for example)
+    """
+
+    type = "struct_type"
     match_grammar: Matchable = Nothing()
 
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -20,7 +20,6 @@ from sqlfluff.core.parser import (
     Delimited,
     GreedyUntil,
     Indent,
-    KeywordSegment,
     Matchable,
     NamedParser,
     Nothing,

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -110,7 +110,6 @@ bigquery_dialect.add(
         type="udf_body",
         trim_chars=("'",),
     ),
-    StructKeywordSegment=StringParser("struct", KeywordSegment, name="struct"),
     StartAngleBracketSegment=StringParser(
         "<", SymbolSegment, name="start_angle_bracket", type="start_angle_bracket"
     ),
@@ -222,30 +221,6 @@ bigquery_dialect.replace(
         "ARRAY",
         Bracketed(
             Ref("DatatypeSegment"),
-            bracket_type="angle",
-            bracket_pairs_set="angle_bracket_pairs",
-        ),
-    ),
-    StructTypeGrammar=Sequence(
-        "STRUCT",
-        Bracketed(
-            Delimited(  # Comma-separated list of field names/types
-                Sequence(
-                    OneOf(
-                        # ParameterNames can look like Datatypes so can't use
-                        # Optional=True here and instead do a OneOf in order
-                        # with DataType only first, followed by both.
-                        Ref("DatatypeSegment"),
-                        Sequence(
-                            Ref("ParameterNameSegment"),
-                            Ref("DatatypeSegment"),
-                        ),
-                    ),
-                    Ref("OptionsSegment", optional=True),
-                ),
-                delimiter=Ref("CommaSegment"),
-                bracket_pairs_set="angle_bracket_pairs",
-            ),
             bracket_type="angle",
             bracket_pairs_set="angle_bracket_pairs",
         ),
@@ -1020,7 +995,7 @@ class DatatypeSegment(ansi.DatatypeSegment):
         Ref("DatatypeIdentifierSegment"),  # Simple type
         Sequence("ANY", "TYPE"),  # SQL UDFs can specify this "type"
         Ref("SimpleArrayTypeGrammar"),
-        Ref("StructTypeGrammar"),
+        Ref("StructTypeSegment"),
     )
 
 
@@ -1036,6 +1011,35 @@ class FunctionParameterListGrammar(ansi.FunctionParameterListGrammar):
             bracket_pairs_set="angle_bracket_pairs",
             optional=True,
         )
+    )
+
+
+class StructTypeSegment(ansi.StructTypeSegment):
+    """Expression to construct a STRUCT datatype."""
+
+    match_grammar = Sequence(
+        "STRUCT",
+        Bracketed(
+            Delimited(  # Comma-separated list of field names/types
+                Sequence(
+                    OneOf(
+                        # ParameterNames can look like Datatypes so can't use
+                        # Optional=True here and instead do a OneOf in order
+                        # with DataType only first, followed by both.
+                        Ref("DatatypeSegment"),
+                        Sequence(
+                            Ref("ParameterNameSegment"),
+                            Ref("DatatypeSegment"),
+                        ),
+                    ),
+                    Ref("OptionsSegment", optional=True),
+                ),
+                delimiter=Ref("CommaSegment"),
+                bracket_pairs_set="angle_bracket_pairs",
+            ),
+            bracket_type="angle",
+            bracket_pairs_set="angle_bracket_pairs",
+        ),
     )
 
 

--- a/test/fixtures/dialects/bigquery/create_js_function_complex_types.yml
+++ b/test/fixtures/dialects/bigquery/create_js_function_complex_types.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9a4002c192cc575fc3c37ea8a2f3031b12a1f0bce3cd043e226baeb257369c75
+_hash: 44a25147c624bc6ec0fb769642e6f634cd69b4f741b60eb5e6f490b3f0c36cf8
 file:
   statement:
     create_function_statement:
@@ -29,40 +29,17 @@ file:
         - comma: ','
         - parameter: foo3
         - data_type:
-            keyword: STRUCT
-            start_angle_bracket: <
-            parameter: x
-            data_type:
-              data_type_identifier: INT64
-            end_angle_bracket: '>'
+            struct_type:
+              keyword: STRUCT
+              start_angle_bracket: <
+              parameter: x
+              data_type:
+                data_type_identifier: INT64
+              end_angle_bracket: '>'
         - comma: ','
         - parameter: foo4
         - data_type:
-          - keyword: STRUCT
-          - start_angle_bracket: <
-          - parameter: x
-          - data_type:
-              data_type_identifier: INT64
-          - comma: ','
-          - parameter: y
-          - data_type:
-              data_type_identifier: INT64
-          - end_angle_bracket: '>'
-        - comma: ','
-        - parameter: foo5
-        - data_type:
-          - keyword: STRUCT
-          - start_angle_bracket: <
-          - parameter: a
-          - data_type:
-              keyword: ARRAY
-              start_angle_bracket: <
-              data_type:
-                data_type_identifier: FLOAT
-              end_angle_bracket: '>'
-          - comma: ','
-          - parameter: b
-          - data_type:
+            struct_type:
             - keyword: STRUCT
             - start_angle_bracket: <
             - parameter: x
@@ -73,20 +50,48 @@ file:
             - data_type:
                 data_type_identifier: INT64
             - end_angle_bracket: '>'
-          - end_angle_bracket: '>'
+        - comma: ','
+        - parameter: foo5
+        - data_type:
+            struct_type:
+            - keyword: STRUCT
+            - start_angle_bracket: <
+            - parameter: a
+            - data_type:
+                keyword: ARRAY
+                start_angle_bracket: <
+                data_type:
+                  data_type_identifier: FLOAT
+                end_angle_bracket: '>'
+            - comma: ','
+            - parameter: b
+            - data_type:
+                struct_type:
+                - keyword: STRUCT
+                - start_angle_bracket: <
+                - parameter: x
+                - data_type:
+                    data_type_identifier: INT64
+                - comma: ','
+                - parameter: y
+                - data_type:
+                    data_type_identifier: INT64
+                - end_angle_bracket: '>'
+            - end_angle_bracket: '>'
         - end_bracket: )
     - keyword: RETURNS
     - data_type:
-        keyword: STRUCT
-        start_angle_bracket: <
-        parameter: product_id
-        data_type:
-          keyword: ARRAY
+        struct_type:
+          keyword: STRUCT
           start_angle_bracket: <
+          parameter: product_id
           data_type:
-            data_type_identifier: INT64
+            keyword: ARRAY
+            start_angle_bracket: <
+            data_type:
+              data_type_identifier: INT64
+            end_angle_bracket: '>'
           end_angle_bracket: '>'
-        end_angle_bracket: '>'
     - function_definition:
       - keyword: LANGUAGE
       - identifier: js

--- a/test/fixtures/dialects/bigquery/create_js_function_options_library_array.yml
+++ b/test/fixtures/dialects/bigquery/create_js_function_options_library_array.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a221d1b3f2908c42beb320cd33ddde7125bf7d266bd62af9a1be4851a5bc26cb
+_hash: b613e699b3e23ee3a13b0d5e9f00dc250259fe7daedf605d1cdb7a94182ea457
 file:
   statement:
     create_function_statement:
@@ -24,16 +24,17 @@ file:
         keyword: ARRAY
         start_angle_bracket: <
         data_type:
-        - keyword: STRUCT
-        - start_angle_bracket: <
-        - parameter: product_id
-        - data_type:
-            data_type_identifier: INT64
-        - comma: ','
-        - parameter: rating
-        - data_type:
-            data_type_identifier: FLOAT64
-        - end_angle_bracket: '>'
+          struct_type:
+          - keyword: STRUCT
+          - start_angle_bracket: <
+          - parameter: product_id
+          - data_type:
+              data_type_identifier: INT64
+          - comma: ','
+          - parameter: rating
+          - data_type:
+              data_type_identifier: FLOAT64
+          - end_angle_bracket: '>'
         end_angle_bracket: '>'
     - function_definition:
       - keyword: LANGUAGE

--- a/test/fixtures/dialects/bigquery/create_js_function_quoted_name.yml
+++ b/test/fixtures/dialects/bigquery/create_js_function_quoted_name.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0503a97309838cde4c159f0972033bbc9dddb759b09d9fb261be93b5b85e6390
+_hash: dc0225c84256f1aa5962b2af42c1f31662da304ed2c08b624ab7628baa09cdb3
 file:
   statement:
     create_function_statement:
@@ -21,16 +21,17 @@ file:
           end_bracket: )
     - keyword: RETURNS
     - data_type:
-        keyword: STRUCT
-        start_angle_bracket: <
-        parameter: '`$=`'
-        data_type:
-          keyword: ARRAY
+        struct_type:
+          keyword: STRUCT
           start_angle_bracket: <
+          parameter: '`$=`'
           data_type:
-            data_type_identifier: INT64
+            keyword: ARRAY
+            start_angle_bracket: <
+            data_type:
+              data_type_identifier: INT64
+            end_angle_bracket: '>'
           end_angle_bracket: '>'
-        end_angle_bracket: '>'
     - function_definition:
       - keyword: LANGUAGE
       - identifier: js

--- a/test/fixtures/dialects/bigquery/create_js_function_underscore_name.yml
+++ b/test/fixtures/dialects/bigquery/create_js_function_underscore_name.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2c9f7d222f4d8289331226a2f3bc7003e9fadd0d81201ab37b206de3f658d386
+_hash: 0ff3cc7bef9ff3257f10cc93c5d5e7ef177f5c2fbe46ccc4d936a668cebe775d
 file:
   statement:
     create_function_statement:
@@ -21,16 +21,17 @@ file:
           end_bracket: )
     - keyword: RETURNS
     - data_type:
-        keyword: STRUCT
-        start_angle_bracket: <
-        parameter: _product_id
-        data_type:
-          keyword: ARRAY
+        struct_type:
+          keyword: STRUCT
           start_angle_bracket: <
+          parameter: _product_id
           data_type:
-            data_type_identifier: INT64
+            keyword: ARRAY
+            start_angle_bracket: <
+            data_type:
+              data_type_identifier: INT64
+            end_angle_bracket: '>'
           end_angle_bracket: '>'
-        end_angle_bracket: '>'
     - function_definition:
       - keyword: LANGUAGE
       - identifier: js

--- a/test/fixtures/dialects/bigquery/create_table_column_options.yml
+++ b/test/fixtures/dialects/bigquery/create_table_column_options.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a3429a7470b5a9294bf9bb8d383cee02dcccb9235466218d16da77f6df7fabd2
+_hash: 768b525b3be45bf3ab6d64f2267f3d857065f250cf7ebae18fba2fbeb0df4a88
 file:
 - statement:
     create_table_statement:
@@ -65,28 +65,7 @@ file:
       - column_definition:
           identifier: x
           data_type:
-            keyword: STRUCT
-            start_angle_bracket: <
-            parameter: col1
-            data_type:
-              data_type_identifier: INT64
-            options_segment:
-              keyword: OPTIONS
-              bracketed:
-                start_bracket: (
-                parameter: description
-                comparison_operator:
-                  raw_comparison_operator: '='
-                literal: '"An INTEGER field in a STRUCT"'
-                end_bracket: )
-            end_angle_bracket: '>'
-      - comma: ','
-      - column_definition:
-          identifier: y
-          data_type:
-            keyword: ARRAY
-            start_angle_bracket: <
-            data_type:
+            struct_type:
               keyword: STRUCT
               start_angle_bracket: <
               parameter: col1
@@ -99,9 +78,32 @@ file:
                   parameter: description
                   comparison_operator:
                     raw_comparison_operator: '='
-                  literal: '"An INTEGER field in a REPEATED STRUCT"'
+                  literal: '"An INTEGER field in a STRUCT"'
                   end_bracket: )
               end_angle_bracket: '>'
+      - comma: ','
+      - column_definition:
+          identifier: y
+          data_type:
+            keyword: ARRAY
+            start_angle_bracket: <
+            data_type:
+              struct_type:
+                keyword: STRUCT
+                start_angle_bracket: <
+                parameter: col1
+                data_type:
+                  data_type_identifier: INT64
+                options_segment:
+                  keyword: OPTIONS
+                  bracketed:
+                    start_bracket: (
+                    parameter: description
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    literal: '"An INTEGER field in a REPEATED STRUCT"'
+                    end_bracket: )
+                end_angle_bracket: '>'
             end_angle_bracket: '>'
       - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/declare_variable.yml
+++ b/test/fixtures/dialects/bigquery/declare_variable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 314dd609dfc7087e8874e235ab1c8d78bfbec61c644eba51fa7caad598e574ea
+_hash: af396f44cfc07a0f471d2e1a006727d4a664c4cb2022f470778e2ebfc39ea6ef
 file:
 - statement:
     declare_segment:
@@ -99,32 +99,34 @@ file:
       keyword: declare
       identifier: str1
       data_type:
-      - keyword: struct
-      - start_angle_bracket: <
-      - parameter: f1
-      - data_type:
-          data_type_identifier: string
-      - comma: ','
-      - parameter: f2
-      - data_type:
-          data_type_identifier: string
-      - end_angle_bracket: '>'
+        struct_type:
+        - keyword: struct
+        - start_angle_bracket: <
+        - parameter: f1
+        - data_type:
+            data_type_identifier: string
+        - comma: ','
+        - parameter: f2
+        - data_type:
+            data_type_identifier: string
+        - end_angle_bracket: '>'
 - statement_terminator: ;
 - statement:
     declare_segment:
     - keyword: declare
     - identifier: str2
     - data_type:
-      - keyword: struct
-      - start_angle_bracket: <
-      - parameter: f1
-      - data_type:
-          data_type_identifier: string
-      - comma: ','
-      - parameter: f2
-      - data_type:
-          data_type_identifier: string
-      - end_angle_bracket: '>'
+        struct_type:
+        - keyword: struct
+        - start_angle_bracket: <
+        - parameter: f1
+        - data_type:
+            data_type_identifier: string
+        - comma: ','
+        - parameter: f2
+        - data_type:
+            data_type_identifier: string
+        - end_angle_bracket: '>'
     - keyword: default
     - expression:
         typeless_struct:
@@ -156,16 +158,17 @@ file:
     - keyword: declare
     - identifier: str4
     - data_type:
-      - keyword: struct
-      - start_angle_bracket: <
-      - parameter: f1
-      - data_type:
-          data_type_identifier: string
-      - comma: ','
-      - parameter: f2
-      - data_type:
-          data_type_identifier: string
-      - end_angle_bracket: '>'
+        struct_type:
+        - keyword: struct
+        - start_angle_bracket: <
+        - parameter: f1
+        - data_type:
+            data_type_identifier: string
+        - comma: ','
+        - parameter: f2
+        - data_type:
+            data_type_identifier: string
+        - end_angle_bracket: '>'
     - keyword: default
     - tuple:
         bracketed:

--- a/test/fixtures/dialects/bigquery/select_struct.yml
+++ b/test/fixtures/dialects/bigquery/select_struct.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9642639bf3a0eeef7fb18431020e1743ba73186dfed99f1b779ac00bfdde453e
+_hash: b806dad47d25e6923e1edd4d3213a4ded87822525b6968f2feaea493e3226f04
 file:
 - statement:
     select_statement:
@@ -161,16 +161,17 @@ file:
                     keyword: ARRAY
                     start_angle_bracket: <
                     data_type:
-                    - keyword: STRUCT
-                    - start_angle_bracket: <
-                    - parameter: col_1
-                    - data_type:
-                        data_type_identifier: STRING
-                    - comma: ','
-                    - parameter: col_2
-                    - data_type:
-                        data_type_identifier: STRING
-                    - end_angle_bracket: '>'
+                      struct_type:
+                      - keyword: STRUCT
+                      - start_angle_bracket: <
+                      - parameter: col_1
+                      - data_type:
+                          data_type_identifier: STRING
+                      - comma: ','
+                      - parameter: col_2
+                      - data_type:
+                          data_type_identifier: STRING
+                      - end_angle_bracket: '>'
                     end_angle_bracket: '>'
                     array_literal:
                     - start_square_bracket: '['
@@ -198,11 +199,12 @@ file:
       - keyword: SELECT
       - select_clause_element:
           expression:
-            keyword: STRUCT
-            start_angle_bracket: <
-            data_type:
-              data_type_identifier: int64
-            end_angle_bracket: '>'
+            struct_type:
+              keyword: STRUCT
+              start_angle_bracket: <
+              data_type:
+                data_type_identifier: int64
+              end_angle_bracket: '>'
             bracketed:
               start_bracket: (
               expression:
@@ -211,11 +213,12 @@ file:
       - comma: ','
       - select_clause_element:
           expression:
-            keyword: STRUCT
-            start_angle_bracket: <
-            data_type:
-              data_type_identifier: date
-            end_angle_bracket: '>'
+            struct_type:
+              keyword: STRUCT
+              start_angle_bracket: <
+              data_type:
+                data_type_identifier: date
+              end_angle_bracket: '>'
             bracketed:
               start_bracket: (
               expression:
@@ -224,17 +227,18 @@ file:
       - comma: ','
       - select_clause_element:
           expression:
-          - keyword: STRUCT
-          - start_angle_bracket: <
-          - parameter: x
-          - data_type:
-              data_type_identifier: int64
-          - comma: ','
-          - parameter: y
-          - data_type:
-              data_type_identifier: string
-          - end_angle_bracket: '>'
-          - bracketed:
+            struct_type:
+            - keyword: STRUCT
+            - start_angle_bracket: <
+            - parameter: x
+            - data_type:
+                data_type_identifier: int64
+            - comma: ','
+            - parameter: y
+            - data_type:
+                data_type_identifier: string
+            - end_angle_bracket: '>'
+            bracketed:
             - start_bracket: (
             - expression:
                 literal: '1'
@@ -248,11 +252,12 @@ file:
       - comma: ','
       - select_clause_element:
           expression:
-            keyword: STRUCT
-            start_angle_bracket: <
-            data_type:
-              data_type_identifier: int64
-            end_angle_bracket: '>'
+            struct_type:
+              keyword: STRUCT
+              start_angle_bracket: <
+              data_type:
+                data_type_identifier: int64
+              end_angle_bracket: '>'
             bracketed:
               start_bracket: (
               expression:


### PR DESCRIPTION
Was initially part of #3428 but to required as part of new fix #3590.

I think this still makes sense - the other Struct-like things (e.g. `TypelessStructSegment`) are segments and `StructTypeGrammar` was the odd one out. This swaps `StructTypeGrammar` to instead be `StructTypeSegment`.

This also removes the unnecessary and unreferenced definition of `StructKeywordSegment`.