### PR TITLE
Oracle: extend support for `ALTER TABLE`

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -7,6 +7,7 @@ from sqlfluff.core.parser import (
     AnyNumberOf,
     BaseFileSegment,
     BaseSegment,
+    Bracketed,
     CodeSegment,
     CommentSegment,
     Delimited,
@@ -133,7 +134,18 @@ class AlterTableColumnClausesSegment(BaseSegment):
     match_grammar = OneOf(
         # @TODO: add_column_clause
         # @TODO: modify_column_clause
-        # @TODO: drop_column_clause
+        # drop_column_clause
+        # @TODO: extend drop_column_clause
+        Sequence(
+            "DROP",
+            OneOf(
+                Sequence(
+                    "COLUMN",
+                    Ref("ColumnReferenceSegment")
+                ),
+                Bracketed(Delimited(Ref("ColumnReferenceSegment")))
+            ),
+        ),
         # @TODO: add_period_clause
         # @TODO: drop_period_clause
         # rename_column_clause

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -133,7 +133,7 @@ class AlterTableColumnClausesSegment(BaseSegment):
             "DROP",
             OneOf(
                 Sequence("COLUMN", Ref("ColumnReferenceSegment")),
-                Bracketed(Delimited(Ref("ColumnReferenceSegment")))
+                Bracketed(Delimited(Ref("ColumnReferenceSegment"))),
             ),
         ),
         # @TODO: add_period_clause

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -50,6 +50,106 @@ oracle_dialect.add(
 )
 
 
+
+class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
+    """An `ALTER TABLE` statement.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/ALTER-TABLE.html
+    If possible, please keep the order below the same as Oracle's doc:
+    """
+
+    match_grammar: Matchable = Sequence(
+        "ALTER",
+        "TABLE",
+        Ref("TableReferenceSegment"),
+        OneOf(
+            # @TODO all stuff inside this "Delimited" is not validated for Oracle
+            Delimited(
+                OneOf(
+                    # Table options
+                    Sequence(
+                        Ref("ParameterNameSegment"),
+                        Ref("EqualsSegment", optional=True),
+                        OneOf(Ref("LiteralGrammar"), Ref("NakedIdentifierSegment")),
+                    ),
+                    # Add things
+                    Sequence(
+                        OneOf("ADD", "MODIFY"),
+                        Ref.keyword("COLUMN", optional=True),
+                        Ref("ColumnDefinitionSegment"),
+                        OneOf(
+                            Sequence(
+                                OneOf("FIRST", "AFTER"), Ref("ColumnReferenceSegment")
+                            ),
+                            # Bracketed Version of the same
+                            Ref("BracketedColumnReferenceListGrammar"),
+                            optional=True,
+                        ),
+                    ),
+                ),
+            ),
+            Ref("AlterTablePropertiesSegment"),
+            Ref("AlterTableColumnClausesSegment"),
+        ),
+    )
+
+
+
+class AlterTablePropertiesSegment(BaseSegment):
+    """ALTER TABLE `alter_table_properties` per defined in Oracle's grammar.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/ALTER-TABLE.html
+
+    If possible, please match the order of this sequence with what's defined in
+    Oracle's alter_table_properties grammar.
+    """
+
+    type = "alter_table_properties"
+
+    # TODO: There are many more alter_table_properties to implement
+    match_grammar = OneOf(
+        # Rename
+        Sequence(
+            "RENAME",
+            "TO",
+            Ref("TableReferenceSegment"),
+        ),
+    )
+
+
+
+class AlterTableColumnClausesSegment(BaseSegment):
+    """ALTER TABLE `column_clauses` per defined in Oracle's grammar.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/ALTER-TABLE.html
+
+    If possible, please match the order of this sequence with what's defined in
+    Oracle's column_clauses grammar.
+    """
+
+    type = "alter_table_column_clauses"
+
+    match_grammar = OneOf(
+        # @TODO: add_column_clause
+        # @TODO: modify_column_clause
+        # @TODO: drop_column_clause
+        # @TODO: add_period_clause
+        # @TODO: drop_period_clause
+        # rename_column_clause
+        Sequence(
+            "RENAME",
+            "COLUMN",
+            Ref("ColumnReferenceSegment"),
+            "TO",
+            Ref("ColumnReferenceSegment"),
+        )
+        # @TODO: modify_collection_retrieval
+        # @TODO: modify_LOB_storage_clause
+        # @TODO: alter_varray_col_properties
+    )
+
+
+
 class ExecuteFileSegment(BaseSegment):
     """A reference to an indextype."""
 

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -132,10 +132,7 @@ class AlterTableColumnClausesSegment(BaseSegment):
         Sequence(
             "DROP",
             OneOf(
-                Sequence(
-                    "COLUMN",
-                    Ref("ColumnReferenceSegment")
-                ),
+                Sequence("COLUMN", Ref("ColumnReferenceSegment")),
                 Bracketed(Delimited(Ref("ColumnReferenceSegment")))
             ),
         ),

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -90,6 +90,7 @@ class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
             ),
             Ref("AlterTablePropertiesSegment"),
             Ref("AlterTableColumnClausesSegment"),
+            Ref("AlterTableConstraintClauses"),
         ),
     )
 
@@ -148,6 +149,27 @@ class AlterTableColumnClausesSegment(BaseSegment):
         # @TODO: alter_varray_col_properties
     )
 
+
+class AlterTableConstraintClauses(BaseSegment):
+    """ALTER TABLE `constraint_clauses` per defined in Oracle's grammar.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/ALTER-TABLE.html
+
+    If possible, please match the order of this sequence with what's defined in
+    Oracle's constraint_clauses grammar.
+    """
+
+    type = "alter_table_constraint_clauses"
+
+    match_grammar = OneOf(
+        Sequence(
+            "ADD",
+            Ref("TableConstraintSegment"),
+        ),
+        # @TODO MODIFY
+        # @TODO RENAME
+        # @TODO DROP
+    )
 
 
 class ExecuteFileSegment(BaseSegment):

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -183,10 +183,7 @@ class AlterTableConstraintClauses(BaseSegment):
                     "UNIQUE",
                     Bracketed(Ref("ColumnReferenceSegment")),
                 ),
-                Sequence(
-                    "CONSTRAINT",
-                    Ref("ObjectReferenceSegment")
-                )
+                Sequence("CONSTRAINT", Ref("ObjectReferenceSegment")),
             ),
             Ref.keyword("CASCADE", optional=True),
             Sequence(
@@ -195,10 +192,10 @@ class AlterTableConstraintClauses(BaseSegment):
                     "DROP",
                 ),
                 "INDEX",
-                optional=True
+                optional=True,
             ),
             Ref.keyword("ONLINE", optional=True),
-        )
+        ),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -73,20 +73,6 @@ class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
                         Ref("EqualsSegment", optional=True),
                         OneOf(Ref("LiteralGrammar"), Ref("NakedIdentifierSegment")),
                     ),
-                    # Add things
-                    Sequence(
-                        OneOf("ADD", "MODIFY"),
-                        Ref.keyword("COLUMN", optional=True),
-                        Ref("ColumnDefinitionSegment"),
-                        OneOf(
-                            Sequence(
-                                OneOf("FIRST", "AFTER"), Ref("ColumnReferenceSegment")
-                            ),
-                            # Bracketed Version of the same
-                            Ref("BracketedColumnReferenceListGrammar"),
-                            optional=True,
-                        ),
-                    ),
                 ),
             ),
             Ref("AlterTablePropertiesSegment"),
@@ -132,8 +118,18 @@ class AlterTableColumnClausesSegment(BaseSegment):
     type = "alter_table_column_clauses"
 
     match_grammar = OneOf(
-        # @TODO: add_column_clause
-        # @TODO: modify_column_clause
+        # add_column_clause
+        # modify_column_clause
+        Sequence(
+            OneOf(
+                "ADD",
+                "MODIFY",
+            ),
+            OneOf(
+                Ref("ColumnDefinitionSegment"),
+                Bracketed(Delimited(Ref("ColumnDefinitionSegment"))),
+            ),
+        ),
         # drop_column_clause
         # @TODO: extend drop_column_clause
         Sequence(

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -51,7 +51,6 @@ oracle_dialect.add(
 )
 
 
-
 class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
     """An `ALTER TABLE` statement.
 
@@ -82,7 +81,6 @@ class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
     )
 
 
-
 class AlterTablePropertiesSegment(BaseSegment):
     """ALTER TABLE `alter_table_properties` per defined in Oracle's grammar.
 
@@ -103,7 +101,6 @@ class AlterTablePropertiesSegment(BaseSegment):
             Ref("TableReferenceSegment"),
         ),
     )
-
 
 
 class AlterTableColumnClausesSegment(BaseSegment):

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -181,6 +181,34 @@ class AlterTableConstraintClauses(BaseSegment):
         # @TODO MODIFY
         # @TODO RENAME
         # @TODO DROP
+        # drop_constraint_clause
+        Sequence(
+            "DROP",
+            OneOf(
+                Sequence(
+                    "PRIMARY",
+                    "KEY",
+                ),
+                Sequence(
+                    "UNIQUE",
+                    Bracketed(Ref("ColumnReferenceSegment")),
+                ),
+                Sequence(
+                    "CONSTRAINT",
+                    Ref("ObjectReferenceSegment")
+                )
+            ),
+            Ref.keyword("CASCADE", optional=True),
+            Sequence(
+                OneOf(
+                    "KEEP",
+                    "DROP",
+                ),
+                "INDEX",
+                optional=True
+            ),
+            Ref.keyword("ONLINE", optional=True),
+        )
     )
 
 

--- a/test/fixtures/dialects/oracle/alter_table.sql
+++ b/test/fixtures/dialects/oracle/alter_table.sql
@@ -12,3 +12,6 @@ DROP (column_name_one, column_name_two);
 ALTER TABLE table_name
 ADD CONSTRAINT constraint_name
 FOREIGN KEY (column_name) REFERENCES other_table_name (other_column_name);
+
+-- drop_constraint_clause
+ALTER TABLE table_name DROP CONSTRAINT constraint_name;

--- a/test/fixtures/dialects/oracle/alter_table.sql
+++ b/test/fixtures/dialects/oracle/alter_table.sql
@@ -1,2 +1,7 @@
 -- AlterTableColumnClausesSegment
 ALTER TABLE table_name RENAME COLUMN old_column_name TO new_column_name;
+
+-- AlterTableConstraintClauses
+ALTER TABLE table_name
+ADD CONSTRAINT constraint_name
+FOREIGN KEY (column_name) REFERENCES other_table_name (other_column_name);

--- a/test/fixtures/dialects/oracle/alter_table.sql
+++ b/test/fixtures/dialects/oracle/alter_table.sql
@@ -1,0 +1,2 @@
+-- AlterTableColumnClausesSegment
+ALTER TABLE table_name RENAME COLUMN old_column_name TO new_column_name;

--- a/test/fixtures/dialects/oracle/alter_table.sql
+++ b/test/fixtures/dialects/oracle/alter_table.sql
@@ -1,6 +1,13 @@
 -- AlterTableColumnClausesSegment
 ALTER TABLE table_name RENAME COLUMN old_column_name TO new_column_name;
 
+-- drop_column_clause
+ALTER TABLE table_name
+DROP COLUMN column_name;
+
+ALTER TABLE table_name
+DROP (column_name_one, column_name_two);
+
 -- AlterTableConstraintClauses
 ALTER TABLE table_name
 ADD CONSTRAINT constraint_name

--- a/test/fixtures/dialects/oracle/alter_table.sql
+++ b/test/fixtures/dialects/oracle/alter_table.sql
@@ -1,6 +1,14 @@
 -- AlterTableColumnClausesSegment
 ALTER TABLE table_name RENAME COLUMN old_column_name TO new_column_name;
 
+-- add_column_clause
+ALTER TABLE table_name
+ADD (column_name NUMBER(18));
+
+-- modify_column_clauses
+ALTER TABLE table_name
+MODIFY column_name NUMBER(18);
+
 -- drop_column_clause
 ALTER TABLE table_name
 DROP COLUMN column_name;

--- a/test/fixtures/dialects/oracle/alter_table.yml
+++ b/test/fixtures/dialects/oracle/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b3fdb4c72ecca196f9d60a3c203ab73c135f4e8af342969e01784f270eff0e1f
+_hash: 3e7fe40ebaff29fe1db679e34e429696efe86015a25ed5632106ee642d574880
 file:
 - statement:
     alter_table_statement:
@@ -19,6 +19,45 @@ file:
       - keyword: TO
       - column_reference:
           identifier: new_column_name
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_name
+    - alter_table_column_clauses:
+        keyword: ADD
+        bracketed:
+          start_bracket: (
+          column_definition:
+            identifier: column_name
+            data_type:
+              data_type_identifier: NUMBER
+              bracketed:
+                start_bracket: (
+                expression:
+                  literal: '18'
+                end_bracket: )
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_name
+    - alter_table_column_clauses:
+        keyword: MODIFY
+        column_definition:
+          identifier: column_name
+          data_type:
+            data_type_identifier: NUMBER
+            bracketed:
+              start_bracket: (
+              expression:
+                literal: '18'
+              end_bracket: )
 - statement_terminator: ;
 - statement:
     alter_table_statement:

--- a/test/fixtures/dialects/oracle/alter_table.yml
+++ b/test/fixtures/dialects/oracle/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0c0148ace10d816dd173eaa2b279c13325ead198ba699200dffbba81ae7dbf3d
+_hash: b3fdb4c72ecca196f9d60a3c203ab73c135f4e8af342969e01784f270eff0e1f
 file:
 - statement:
     alter_table_statement:
@@ -14,9 +14,11 @@ file:
     - alter_table_column_clauses:
       - keyword: RENAME
       - keyword: COLUMN
-      - identifier: old_column_name
+      - column_reference:
+          identifier: old_column_name
       - keyword: TO
-      - identifier: new_column_name
+      - column_reference:
+          identifier: new_column_name
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -74,4 +76,16 @@ file:
             column_reference:
               identifier: other_column_name
             end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_name
+    - alter_table_constraint_clauses:
+      - keyword: DROP
+      - keyword: CONSTRAINT
+      - object_reference:
+          identifier: constraint_name
 - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/alter_table.yml
+++ b/test/fixtures/dialects/oracle/alter_table.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4783bc85f651f0a64f3f0a37a131ee362ae764b66db2f8e61b45fb58136f24ba
+_hash: 4565a193ee449be52c161818c5ce20c9677f158df248a08c05695b6fe337a58f
 file:
-  statement:
+- statement:
     alter_table_statement:
     - keyword: ALTER
     - keyword: TABLE
@@ -17,4 +17,32 @@ file:
       - identifier: old_column_name
       - keyword: TO
       - identifier: new_column_name
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_name
+    - alter_table_constraint_clauses:
+        keyword: ADD
+        table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            identifier: constraint_name
+        - keyword: FOREIGN
+        - keyword: KEY
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              identifier: column_name
+            end_bracket: )
+        - keyword: REFERENCES
+        - table_reference:
+            identifier: other_table_name
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              identifier: other_column_name
+            end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/oracle/alter_table.yml
+++ b/test/fixtures/dialects/oracle/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4565a193ee449be52c161818c5ce20c9677f158df248a08c05695b6fe337a58f
+_hash: 0c0148ace10d816dd173eaa2b279c13325ead198ba699200dffbba81ae7dbf3d
 file:
 - statement:
     alter_table_statement:
@@ -17,6 +17,35 @@ file:
       - identifier: old_column_name
       - keyword: TO
       - identifier: new_column_name
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_name
+    - alter_table_column_clauses:
+      - keyword: DROP
+      - keyword: COLUMN
+      - column_reference:
+          identifier: column_name
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_name
+    - alter_table_column_clauses:
+        keyword: DROP
+        bracketed:
+        - start_bracket: (
+        - column_reference:
+            identifier: column_name_one
+        - comma: ','
+        - column_reference:
+            identifier: column_name_two
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     alter_table_statement:

--- a/test/fixtures/dialects/oracle/alter_table.yml
+++ b/test/fixtures/dialects/oracle/alter_table.yml
@@ -1,0 +1,20 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 4783bc85f651f0a64f3f0a37a131ee362ae764b66db2f8e61b45fb58136f24ba
+file:
+  statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        identifier: table_name
+    - alter_table_column_clauses:
+      - keyword: RENAME
+      - keyword: COLUMN
+      - identifier: old_column_name
+      - keyword: TO
+      - identifier: new_column_name
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
