### PR TITLE
Add large file check

### DIFF
--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -25,7 +25,7 @@ from jinja2_simple_tags import StandaloneTag
 from sqlfluff.core.cached_property import cached_property
 from sqlfluff.core.errors import SQLTemplaterError, SQLTemplaterSkipFile
 
-from sqlfluff.core.templaters.base import TemplatedFile
+from sqlfluff.core.templaters.base import TemplatedFile, large_file_check
 
 from sqlfluff.core.templaters.jinja import JinjaTemplater
 
@@ -308,6 +308,7 @@ class DbtTemplater(JinjaTemplater):
             if fname not in already_yielded:
                 yield fname
 
+    @large_file_check
     def process(self, *, fname, in_str=None, config=None, formatter=None):
         """Compile a dbt model and return the compiled SQL.
 
@@ -318,8 +319,6 @@ class DbtTemplater(JinjaTemplater):
                 templating operation. Only necessary for some templaters.
             formatter (:obj:`CallbackFormatter`): Optional object for output.
         """
-        self.large_file_check(in_str, fname, config)
-
         # Stash the formatter if provided to use in cached methods.
         self.formatter = formatter
         self.sqlfluff_config = config

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -318,6 +318,8 @@ class DbtTemplater(JinjaTemplater):
                 templating operation. Only necessary for some templaters.
             formatter (:obj:`CallbackFormatter`): Optional object for output.
         """
+        self.large_file_check(in_str, fname, config)
+
         # Stash the formatter if provided to use in cached methods.
         self.formatter = formatter
         self.sqlfluff_config = config

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -34,6 +34,11 @@ sql_file_exts = .sql,.sql.j2,.dml,.ddl
 # Allow fix to run on files, even if they contain parsing errors
 # Note altering this is NOT RECOMMENDED as can corrupt SQL
 fix_even_unparsable = False
+# Very large files can make the parser effectively hang.
+# This limit skips files over a certain character length
+# and warns the user what has happened.
+# Set this to 0 to disable.
+large_file_skip_char_limit = 20000
 
 [sqlfluff:indentation]
 # See https://docs.sqlfluff.com/en/stable/indentation.html

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -22,6 +22,7 @@ from sqlfluff.core.templaters.base import (
     RawFileSlice,
     TemplatedFile,
     TemplatedFileSlice,
+    large_file_check,
 )
 from sqlfluff.core.templaters.python import PythonTemplater
 from sqlfluff.core.templaters.slicers.tracer import JinjaAnalyzer
@@ -307,6 +308,7 @@ class JinjaTemplater(PythonTemplater):
 
         return env, live_context, make_template
 
+    @large_file_check
     def process(
         self, *, in_str: str, fname: str, config=None, formatter=None
     ) -> Tuple[Optional[TemplatedFile], list]:
@@ -329,8 +331,6 @@ class JinjaTemplater(PythonTemplater):
             formatter (:obj:`CallbackFormatter`): Optional object for output.
 
         """
-        self.large_file_check(in_str, fname, config)
-
         if not config:  # pragma: no cover
             raise ValueError(
                 "For the jinja templater, the `process()` method requires a config "

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -329,6 +329,8 @@ class JinjaTemplater(PythonTemplater):
             formatter (:obj:`CallbackFormatter`): Optional object for output.
 
         """
+        self.large_file_check(in_str, fname, config)
+
         if not config:  # pragma: no cover
             raise ValueError(
                 "For the jinja templater, the `process()` method requires a config "

--- a/src/sqlfluff/core/templaters/placeholder.py
+++ b/src/sqlfluff/core/templaters/placeholder.py
@@ -11,9 +11,9 @@ from sqlfluff.core.templaters.base import (
     RawFileSlice,
     TemplatedFile,
     TemplatedFileSlice,
+    large_file_check,
+    RawTemplater,
 )
-
-from sqlfluff.core.templaters.base import RawTemplater
 
 # Instantiate the templater logger
 templater_logger = logging.getLogger("sqlfluff.templater")
@@ -110,6 +110,7 @@ class PlaceholderTemplater(RawTemplater):
 
         return live_context
 
+    @large_file_check
     def process(
         self, *, in_str: str, fname: str, config=None, formatter=None
     ) -> Tuple[Optional[TemplatedFile], list]:
@@ -132,8 +133,6 @@ class PlaceholderTemplater(RawTemplater):
             formatter (:obj:`CallbackFormatter`): Optional object for output.
 
         """
-        self.large_file_check(in_str, fname, config)
-
         context = self.get_context(config)
         template_slices = []
         raw_slices = []

--- a/src/sqlfluff/core/templaters/placeholder.py
+++ b/src/sqlfluff/core/templaters/placeholder.py
@@ -132,6 +132,8 @@ class PlaceholderTemplater(RawTemplater):
             formatter (:obj:`CallbackFormatter`): Optional object for output.
 
         """
+        self.large_file_check(in_str, fname, config)
+
         context = self.get_context(config)
         template_slices = []
         raw_slices = []

--- a/src/sqlfluff/core/templaters/python.py
+++ b/src/sqlfluff/core/templaters/python.py
@@ -219,6 +219,7 @@ class PythonTemplater(RawTemplater):
             formatter (:obj:`CallbackFormatter`): Optional object for output.
 
         """
+        self.large_file_check(in_str, fname, config)
         live_context = self.get_context(fname=fname, config=config)
         try:
             new_str = in_str.format(**live_context)

--- a/src/sqlfluff/core/templaters/python.py
+++ b/src/sqlfluff/core/templaters/python.py
@@ -13,6 +13,7 @@ from sqlfluff.core.templaters.base import (
     templater_logger,
     RawFileSlice,
     TemplatedFileSlice,
+    large_file_check,
 )
 
 
@@ -197,6 +198,7 @@ class PythonTemplater(RawTemplater):
             live_context[k] = self.infer_type(live_context[k])
         return live_context
 
+    @large_file_check
     def process(
         self, *, in_str: str, fname: str, config=None, formatter=None
     ) -> Tuple[Optional[TemplatedFile], list]:
@@ -219,7 +221,6 @@ class PythonTemplater(RawTemplater):
             formatter (:obj:`CallbackFormatter`): Optional object for output.
 
         """
-        self.large_file_check(in_str, fname, config)
         live_context = self.get_context(fname=fname, config=config)
         try:
             new_str = in_str.format(**live_context)


### PR DESCRIPTION
This addresses #3537. I've gone for a character limit rather than a line limit because it's a) easier and b) probably more indicative of parsing complexity.

Setting the detail at 20k chars puts it around the size I'd expect from a 1k line file, and comfortably above most of the manually written sql in the tails.com repo.

I've implemented as a decorator to make it as reusable as possible, but if we define new templaters it will need to be imported and added directly rather than bundled "by default" in a shim. Doing the latter might be tidier but we don't otherwise currently have a shim around `.process()` with each templater defining their own and that being called directly - so it felt like too much additional change to add it for just this.