### PR TITLE
Add a skip and better logging for fatal dbt issues

### DIFF
--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -471,7 +471,7 @@ class DbtTemplater(JinjaTemplater):
                     "Please report this error on github at "
                     "https://github.com/sqlfluff/sqlfluff/issues, including "
                     "both the raw and compiled sql for the model affected.",
-                    fname
+                    fname,
                 )
                 # Additional error logging in case we get a fatal dbt error.
                 raise SQLTemplaterSkipFile(  # pragma: no cover

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -464,6 +464,12 @@ class DbtTemplater(JinjaTemplater):
                     node=node,
                     manifest=self.dbt_manifest,
                 )
+            except Exception as err:
+                # Additional error logging in case we get a fatal dbt error.
+                raise SQLTemplaterSkipFile(  # pragma: no cover
+                    f"Skipped file {fname} because dbt raised a fatal "
+                    f"exception during compilation: {err!s}"
+                )
             finally:
                 # Undo the monkeypatch.
                 Environment.from_string = old_from_string

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -465,11 +465,19 @@ class DbtTemplater(JinjaTemplater):
                     manifest=self.dbt_manifest,
                 )
             except Exception as err:
+                templater_logger.exception(
+                    "Fatal dbt compilation error on %s. This occurs most often "
+                    "during incorrect sorting of ephemeral models before linting. "
+                    "Please report this error on github at "
+                    "https://github.com/sqlfluff/sqlfluff/issues, including "
+                    "both the raw and compiled sql for the model affected.",
+                    fname
+                )
                 # Additional error logging in case we get a fatal dbt error.
                 raise SQLTemplaterSkipFile(  # pragma: no cover
                     f"Skipped file {fname} because dbt raised a fatal "
                     f"exception during compilation: {err!s}"
-                )
+                ) from err
             finally:
                 # Undo the monkeypatch.
                 Environment.from_string = old_from_string


### PR DESCRIPTION
This is a draft PR to assist with debugging #3587.

We *may* actually want to consider this a permanent fixture (or a variation of it), to allow dbt projects to a) better understand failing files and b) still lint the rest of the project.

In short, if a `dbt_compiler.compile_node()` raises any exception - we skip the file and output to the user a stringified version of the dbt error _and a reference to the file which caused it_ for later debugging.