### PR TITLE
Improve documentation for custom implemented rules

### DIFF
--- a/docs/source/developingplugins.rst
+++ b/docs/source/developingplugins.rst
@@ -41,7 +41,7 @@ and is meant to categorize rules; you could use the
 letter 'S' to denote rules that enforce security checks
 for example.
 
-An important thing to note when running custom implemented rules: 
+An important thing to note when running custom implemented rules:
 Run ``pip install -e .``, inside the plugin folder so custom rules in linting
 are included.
 

--- a/docs/source/developingplugins.rst
+++ b/docs/source/developingplugins.rst
@@ -41,6 +41,8 @@ and is meant to categorize rules; you could use the
 letter 'S' to denote rules that enforce security checks
 for example.
 
+An important thing to note when running custom implemented rules. Run ``pip install - e`` inside the plugin folder so  custom rules in linting are included.
+
 A plugin Rule code includes the PluginName,
 so a rule "Rule_L000" in core will have code "L000",
 while "Rule_PluginName_L000" will have code "PluginName_L000".

--- a/docs/source/developingplugins.rst
+++ b/docs/source/developingplugins.rst
@@ -41,7 +41,8 @@ and is meant to categorize rules; you could use the
 letter 'S' to denote rules that enforce security checks
 for example.
 
-An important thing to note when running custom implemented rules. Run ``pip install - e`` inside the plugin folder so  custom rules in linting are included.
+An important thing to note when running custom implemented rules: 
+Run ``pip install - e``, inside the plugin folder so  custom rules in linting are included.
 
 A plugin Rule code includes the PluginName,
 so a rule "Rule_L000" in core will have code "L000",

--- a/docs/source/developingplugins.rst
+++ b/docs/source/developingplugins.rst
@@ -42,7 +42,8 @@ letter 'S' to denote rules that enforce security checks
 for example.
 
 An important thing to note when running custom implemented rules: 
-Run ``pip install - e``, inside the plugin folder so  custom rules in linting are included.
+Run ``pip install -e .``, inside the plugin folder so custom rules in linting
+are included.
 
 A plugin Rule code includes the PluginName,
 so a rule "Rule_L000" in core will have code "L000",


### PR DESCRIPTION
### Brief summary of the change made
Previously the documentation did not mention how the _pluggy_ library works. People not familiar with the library will face issues when running custom implemented rules.  Added the documentation that supports how to include custom rules in linting. 
Fixes  #1429

### Are there any other side effects of this change that we should be aware of?
No. 


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
