### PR TITLE
BigQuery: Better support hyphened projects

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1201,7 +1201,7 @@ class ColumnReferenceSegment(ObjectReferenceSegment):
         return super().extract_possible_multipart_references(levels)
 
 
-class HyphenatedTableReferenceSegment(ObjectReferenceSegment):
+class TableReferenceSegment(ObjectReferenceSegment):
     """A reference to an object that may contain embedded hyphens."""
 
     type = "table_reference"
@@ -1256,16 +1256,6 @@ class HyphenatedTableReferenceSegment(ObjectReferenceSegment):
                 segments = list(elems)
                 parts = [seg.raw_trimmed() for seg in segments]
                 yield self.ObjectReferencePart("".join(parts), segments)
-
-
-class TableExpressionSegment(ansi.TableExpressionSegment):
-    """Main table expression e.g. within a FROM clause, with hyphen support."""
-
-    match_grammar = ansi.TableExpressionSegment.match_grammar.copy(
-        insert=[
-            Ref("HyphenatedTableReferenceSegment"),
-        ]
-    )
 
 
 class DeclareStatementSegment(BaseSegment):

--- a/test/fixtures/dialects/bigquery/create_table_hyphen_project.sql
+++ b/test/fixtures/dialects/bigquery/create_table_hyphen_project.sql
@@ -1,0 +1,5 @@
+CREATE OR REPLACE TABLE project-name.dataset_name.table_name
+(
+    x INT64 OPTIONS(description="An INTEGER field")
+)
+PARTITION BY DATE(import_ts);

--- a/test/fixtures/dialects/bigquery/create_table_hyphen_project.yml
+++ b/test/fixtures/dialects/bigquery/create_table_hyphen_project.yml
@@ -1,0 +1,51 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: a22a54dc6f042164d8e11093f1b059871536cc95d0fd3732658f462972bab493
+file:
+  statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: TABLE
+    - table_reference:
+      - identifier: project
+      - dash: '-'
+      - identifier: name
+      - dot: .
+      - identifier: dataset_name
+      - dot: .
+      - identifier: table_name
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          identifier: x
+          data_type:
+            data_type_identifier: INT64
+          options_segment:
+            keyword: OPTIONS
+            bracketed:
+              start_bracket: (
+              parameter: description
+              comparison_operator:
+                raw_comparison_operator: '='
+              literal: '"An INTEGER field"'
+              end_bracket: )
+        end_bracket: )
+    - partition_by_segment:
+      - keyword: PARTITION
+      - keyword: BY
+      - expression:
+          function:
+            function_name:
+              function_name_identifier: DATE
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  identifier: import_ts
+              end_bracket: )
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Closes https://github.com/sqlfluff/sqlfluff/issues/3609

I think this refactor covers BigQuery better without any regression. It doesn't seem like `HyphenatedTableReferenceSegment` needs to be its own thing.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
