### PR TITLE
Handle redshift temporary tables with # at the beginning of name

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -3,27 +3,31 @@
 This is based on postgres dialect, since it was initially based off of Postgres 8.
 We should monitor in future and see if it should be rebased off of ANSI
 """
+from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
-    OneOf,
     AnyNumberOf,
     AnySetOf,
     Anything,
-    Ref,
-    Sequence,
-    Bracketed,
     BaseSegment,
+    Bracketed,
+    CodeSegment,
     Delimited,
     Matchable,
     Nothing,
+    OneOf,
     OptionallyBracketed,
+    Ref,
+    RegexLexer,
+    RegexParser,
+    SegmentGenerator,
+    Sequence,
 )
-from sqlfluff.core.dialects import load_raw_dialect
+from sqlfluff.dialects import dialect_ansi as ansi
+from sqlfluff.dialects import dialect_postgres as postgres
 from sqlfluff.dialects.dialect_redshift_keywords import (
     redshift_reserved_keywords,
     redshift_unreserved_keywords,
 )
-from sqlfluff.dialects import dialect_postgres as postgres
-from sqlfluff.dialects import dialect_ansi as ansi
 
 postgres_dialect = load_raw_dialect("postgres")
 ansi_dialect = load_raw_dialect("ansi")
@@ -160,6 +164,18 @@ redshift_dialect.replace(
         ),
         Ref("AliasExpressionSegment", optional=True),
     ),
+    NakedIdentifierSegment=SegmentGenerator(
+        lambda dialect: RegexParser(
+            # Optionally begins with # for temporary tables. Otherwise
+            # must only contain digits, letters, underscore, and $ but
+            # can’t be all digits.
+            r"#?([A-Z_]+|[0-9]+[A-Z_$])[A-Z0-9_$]*",
+            CodeSegment,
+            name="naked_identifier",
+            type="identifier",
+            anti_template=r"^(" + r"|".join(dialect.sets("reserved_keywords")) + r")$",
+        )
+    ),
     ColumnReferenceSegment=Delimited(
         Sequence(
             ansi.ColumnReferenceSegment,
@@ -181,6 +197,13 @@ redshift_dialect.replace(
         ),
         allow_gaps=False,
     ),
+)
+
+redshift_dialect.patch_lexer_matchers(
+    [
+        # add optional leading # to code for temporary tables
+        RegexLexer("code", r"#?[0-9a-zA-Z_]+[0-9a-zA-Z_$]*", CodeSegment),
+    ]
 )
 
 

--- a/src/sqlfluff/rules/L057.py
+++ b/src/sqlfluff/rules/L057.py
@@ -1,6 +1,7 @@
 """Implementation of Rule L057."""
-import regex
 from typing import Optional
+
+import regex
 
 from sqlfluff.core.rules.base import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
@@ -163,6 +164,15 @@ class Rule_L057(BaseRule):
 
         # We always allow underscores so strip them out
         identifier = identifier.replace("_", "")
+
+        # redshift allows a # at the beginning of temporary table names
+        if (
+            context.dialect.name == "redshift"
+            and identifier[0] == "#"
+            and context.parent_stack
+            and context.parent_stack[-1].name == "TableReferenceSegment"
+        ):
+            identifier = identifier[1:]
 
         # Set the identified minus the allowed characters
         if self.additional_allowed_characters:

--- a/test/fixtures/dialects/redshift/redshift_temporary_tables.sql
+++ b/test/fixtures/dialects/redshift/redshift_temporary_tables.sql
@@ -1,0 +1,10 @@
+CREATE TEMPORARY TABLE #temp_table AS
+SELECT name FROM other_table;
+
+CREATE TABLE #other_temp_table (id int);
+
+COPY #temp_table FROM 's3://mybucket/path'
+CREDENTIALS 'aws_access_key_id=SECRET;aws_secret_access_key=ALSO_SECRET'
+GZIP;
+
+SELECT * FROM #temp_table;

--- a/test/fixtures/dialects/redshift/redshift_temporary_tables.yml
+++ b/test/fixtures/dialects/redshift/redshift_temporary_tables.yml
@@ -1,0 +1,71 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: a98eb8d20432c7fae26baedd7eb35ac463854a7add4abbe93f2389728c22f014
+file:
+- statement:
+    create_table_as_statement:
+    - keyword: CREATE
+    - keyword: TEMPORARY
+    - keyword: TABLE
+    - object_reference:
+        identifier: '#temp_table'
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              identifier: name
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: other_table
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        identifier: '#other_temp_table'
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          identifier: id
+        data_type:
+          keyword: int
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - table_reference:
+        identifier: '#temp_table'
+    - keyword: FROM
+    - literal: "'s3://mybucket/path'"
+    - authorization_segment:
+        keyword: CREDENTIALS
+        literal: "'aws_access_key_id=SECRET;aws_secret_access_key=ALSO_SECRET'"
+    - keyword: GZIP
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: '#temp_table'
+- statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/L057.yml
+++ b/test/fixtures/rules/std_rule_cases/L057.yml
@@ -407,3 +407,22 @@ test_fail_special_chars_show_tblproperties:
   configs:
     core:
       dialect: sparksql
+
+test_pass_special_chars_redshift_hash_table:
+  pass_str: |
+    CREATE TABLE #example (
+        id INT
+    );
+  configs:
+    core:
+      dialect: redshift
+
+test_fail_special_chars_redshift_hash_column:
+  fail_str: |
+    CREATE TABLE example
+    (
+        "#example" INT
+    )
+  configs:
+    core:
+      dialect: redshift


### PR DESCRIPTION
### Brief summary of the change made

See [redshift docs](https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html) about these temporary table names. This adds the ability to parse them and makes sure that rule L057 doesn't complain about them.

Fixes #3612

### Are there any other side effects of this change that we should be aware of?

It's possible that this will no longer cause parse errors for `#` randomly at the beginning of some other identifier.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
