### PR TITLE
Specifying comma delimited is unnecessary

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -3059,7 +3059,6 @@ class AccessStatementSegment(BaseSegment):
                 Sequence(
                     Delimited(
                         OneOf(_global_permissions, _permissions),
-                        delimiter=Ref("CommaSegment"),
                         terminator="ON",
                     ),
                     "ON",
@@ -3076,7 +3075,6 @@ class AccessStatementSegment(BaseSegment):
             OneOf("GROUP", "USER", "ROLE", "SHARE", optional=True),
             Delimited(
                 OneOf(Ref("RoleReferenceSegment"), Ref("FunctionSegment"), "PUBLIC"),
-                delimiter=Ref("CommaSegment"),
             ),
             OneOf(
                 Sequence("WITH", "GRANT", "OPTION"),
@@ -3103,7 +3101,6 @@ class AccessStatementSegment(BaseSegment):
                 Sequence(
                     Delimited(
                         OneOf(_global_permissions, _permissions),
-                        delimiter=Ref("CommaSegment"),
                         terminator="ON",
                     ),
                     "ON",
@@ -3116,7 +3113,6 @@ class AccessStatementSegment(BaseSegment):
             OneOf("GROUP", "USER", "ROLE", "SHARE", optional=True),
             Delimited(
                 Ref("ObjectReferenceSegment"),
-                delimiter=Ref("CommaSegment"),
             ),
             Ref("DropBehaviorGrammar", optional=True),
         ),
@@ -3275,7 +3271,6 @@ class FunctionParameterListGrammar(BaseSegment):
     match_grammar: Matchable = Bracketed(
         Delimited(
             Ref("FunctionParameterGrammar"),
-            delimiter=Ref("CommaSegment"),
             optional=True,
         ),
     )

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -121,7 +121,6 @@ bigquery_dialect.add(
     DashSegment=StringParser("-", SymbolSegment, name="dash", type="dash"),
     SelectClauseElementListGrammar=Delimited(
         Ref("SelectClauseElementSegment"),
-        delimiter=Ref("CommaSegment"),
         allow_trailing=True,
     ),
     QuestionMarkSegment=StringParser(
@@ -920,7 +919,6 @@ class FunctionDefinitionGrammar(ansi.FunctionDefinitionGrammar):
                                 Ref("EqualsSegment"),
                                 Anything(),
                             ),
-                            delimiter=Ref("CommaSegment"),
                         )
                     ),
                     optional=True,
@@ -961,7 +959,7 @@ class ExceptClauseSegment(BaseSegment):
     match_grammar = Sequence(
         "EXCEPT",
         Bracketed(
-            Delimited(Ref("SingleIdentifierGrammar"), delimiter=Ref("CommaSegment"))
+            Delimited(Ref("SingleIdentifierGrammar"))
         ),
     )
 
@@ -977,7 +975,6 @@ class ReplaceClauseSegment(BaseSegment):
                 # Not *really* a select target element. It behaves exactly
                 # the same way however.
                 Ref("SelectClauseElementSegment"),
-                delimiter=Ref("CommaSegment"),
             )
         ),
     )
@@ -1018,7 +1015,6 @@ class StructTypeSegment(ansi.StructTypeSegment):
                     ),
                     Ref("OptionsSegment", optional=True),
                 ),
-                delimiter=Ref("CommaSegment"),
             ),
             bracket_type="angle",
             bracket_pairs_set="angle_bracket_pairs",
@@ -1846,7 +1842,6 @@ class ProcedureParameterListSegment(BaseSegment):
     match_grammar = Bracketed(
         Delimited(
             Ref("ProcedureParameterGrammar"),
-            delimiter=Ref("CommaSegment"),
             optional=True,
         )
     )

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -958,9 +958,7 @@ class ExceptClauseSegment(BaseSegment):
     type = "select_except_clause"
     match_grammar = Sequence(
         "EXCEPT",
-        Bracketed(
-            Delimited(Ref("SingleIdentifierGrammar"))
-        ),
+        Bracketed(Delimited(Ref("SingleIdentifierGrammar"))),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -1072,7 +1072,6 @@ class ProcedureParameterListGrammar(BaseSegment):
     match_grammar = Bracketed(
         Delimited(
             Ref("ProcedureParameterGrammar"),
-            delimiter=Ref("CommaSegment"),
             optional=True,
         ),
     )

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -709,7 +709,6 @@ class CreateFunctionStatementSegment(ansi.CreateFunctionStatementSegment):
                                     Ref("DatatypeSegment"),
                                 ),
                             ),
-                            delimiter=Ref("CommaSegment"),
                         )
                     ),
                     optional=True,
@@ -983,7 +982,6 @@ class FunctionDefinitionGrammar(ansi.FunctionDefinitionGrammar):
                                 Ref("ParameterNameSegment"),
                                 Ref("LiteralGrammar"),
                             ),
-                            delimiter=Ref("CommaSegment"),
                         ),
                     ),
                     Sequence("FROM", "CURRENT"),
@@ -1004,7 +1002,7 @@ class FunctionDefinitionGrammar(ansi.FunctionDefinitionGrammar):
         Sequence(
             "WITH",
             Bracketed(
-                Delimited(Ref("ParameterNameSegment"), delimiter=Ref("CommaSegment"))
+                Delimited(Ref("ParameterNameSegment"))
             ),
             optional=True,
         ),
@@ -1090,7 +1088,7 @@ class SelectClauseModifierSegment(ansi.SelectClauseModifierSegment):
             Sequence(
                 "ON",
                 Bracketed(
-                    Delimited(Ref("ExpressionSegment"), delimiter=Ref("CommaSegment"))
+                    Delimited(Ref("ExpressionSegment"))
                 ),
                 optional=True,
             ),
@@ -1445,7 +1443,7 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
                     "INHERITS",
                     Bracketed(
                         Delimited(
-                            Ref("TableReferenceSegment"), delimiter=Ref("CommaSegment")
+                            Ref("TableReferenceSegment")
                         )
                     ),
                     optional=True,
@@ -1463,7 +1461,6 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
                             AnyNumberOf(Ref("ColumnConstraintSegment")),
                         ),
                         Ref("TableConstraintSegment"),
-                        delimiter=Ref("CommaSegment"),
                     ),
                     optional=True,
                 ),
@@ -1481,7 +1478,6 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
                             AnyNumberOf(Ref("ColumnConstraintSegment")),
                         ),
                         Ref("TableConstraintSegment"),
-                        delimiter=Ref("CommaSegment"),
                     ),
                     optional=True,
                 ),
@@ -1513,7 +1509,6 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
                                     Ref("ParameterNameSegment", optional=True),
                                 ),
                             ),
-                            delimiter=Ref("CommaSegment"),
                         )
                     )
                 ),
@@ -1631,7 +1626,7 @@ class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
                 Ref("StarSegment", optional=True),
                 OneOf(
                     Delimited(
-                        Ref("AlterTableActionSegment"), delimiter=Ref("CommaSegment")
+                        Ref("AlterTableActionSegment")
                     ),
                     Sequence(
                         "RENAME",
@@ -1682,7 +1677,7 @@ class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
                     "OWNED",
                     "BY",
                     Delimited(
-                        Ref("ObjectReferenceSegment"), delimiter=Ref("CommaSegment")
+                        Ref("ObjectReferenceSegment")
                     ),
                     optional=True,
                 ),
@@ -1785,7 +1780,6 @@ class AlterTableActionSegment(BaseSegment):
                                 Ref("EqualsSegment"),
                                 Ref("LiteralGrammar"),
                             ),
-                            delimiter=Ref("CommaSegment"),
                         )
                     ),
                 ),
@@ -1793,7 +1787,7 @@ class AlterTableActionSegment(BaseSegment):
                     "RESET",
                     Bracketed(
                         Delimited(
-                            Ref("ParameterNameSegment"), delimiter=Ref("CommaSegment")
+                            Ref("ParameterNameSegment")
                         )
                     ),
                 ),
@@ -1864,14 +1858,13 @@ class AlterTableActionSegment(BaseSegment):
                         Ref("EqualsSegment"),
                         Ref("LiteralGrammar"),
                     ),
-                    delimiter=Ref("CommaSegment"),
                 )
             ),
         ),
         Sequence(
             "RESET",
             Bracketed(
-                Delimited(Ref("ParameterNameSegment"), delimiter=Ref("CommaSegment"))
+                Delimited(Ref("ParameterNameSegment"))
             ),
         ),
         Sequence(
@@ -2454,7 +2447,7 @@ class PartitionBoundSpecSegment(BaseSegment):
         Sequence(
             "IN",
             Bracketed(
-                Delimited(Ref("ExpressionSegment"), delimiter=Ref("CommaSegment"))
+                Delimited(Ref("ExpressionSegment"))
             ),
         ),
         Sequence(
@@ -2462,14 +2455,12 @@ class PartitionBoundSpecSegment(BaseSegment):
             Bracketed(
                 Delimited(
                     OneOf(Ref("ExpressionSegment"), "MINVALUE", "MAXVALUE"),
-                    delimiter=Ref("CommaSegment"),
                 )
             ),
             "TO",
             Bracketed(
                 Delimited(
                     OneOf(Ref("ExpressionSegment"), "MINVALUE", "MAXVALUE"),
-                    delimiter=Ref("CommaSegment"),
                 )
             ),
         ),
@@ -2595,7 +2586,6 @@ class IndexParametersSegment(BaseSegment):
                         Ref("EqualsSegment"),
                         Ref("LiteralGrammar"),
                     ),
-                    delimiter=Ref("CommaSegment"),
                 )
             ),
             optional=True,
@@ -2953,7 +2943,6 @@ class CreateIndexStatementSegment(ansi.CreateIndexStatementSegment):
                                                 Ref("QuotedIdentifierSegment"),
                                             ),
                                         ),
-                                        delimiter=Ref("CommaSegment"),
                                     ),
                                 ),
                             ),
@@ -2963,7 +2952,6 @@ class CreateIndexStatementSegment(ansi.CreateIndexStatementSegment):
                             ),
                         ),
                     ),
-                    delimiter=Ref("CommaSegment"),
                 )
             ),
         ),
@@ -2972,7 +2960,7 @@ class CreateIndexStatementSegment(ansi.CreateIndexStatementSegment):
                 "INCLUDE",
                 Bracketed(
                     Delimited(
-                        Ref("ColumnReferenceSegment"), delimiter=Ref("CommaSegment")
+                        Ref("ColumnReferenceSegment")
                     )
                 ),
             ),
@@ -2985,7 +2973,6 @@ class CreateIndexStatementSegment(ansi.CreateIndexStatementSegment):
                             Ref("EqualsSegment"),
                             Ref("LiteralGrammar"),
                         ),
-                        delimiter=Ref("CommaSegment"),
                     )
                 ),
             ),

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1001,9 +1001,7 @@ class FunctionDefinitionGrammar(ansi.FunctionDefinitionGrammar):
         ),
         Sequence(
             "WITH",
-            Bracketed(
-                Delimited(Ref("ParameterNameSegment"))
-            ),
+            Bracketed(Delimited(Ref("ParameterNameSegment"))),
             optional=True,
         ),
     )
@@ -1087,9 +1085,7 @@ class SelectClauseModifierSegment(ansi.SelectClauseModifierSegment):
             "DISTINCT",
             Sequence(
                 "ON",
-                Bracketed(
-                    Delimited(Ref("ExpressionSegment"))
-                ),
+                Bracketed(Delimited(Ref("ExpressionSegment"))),
                 optional=True,
             ),
         ),
@@ -1441,11 +1437,7 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
                 ),
                 Sequence(
                     "INHERITS",
-                    Bracketed(
-                        Delimited(
-                            Ref("TableReferenceSegment")
-                        )
-                    ),
+                    Bracketed(Delimited(Ref("TableReferenceSegment"))),
                     optional=True,
                 ),
             ),
@@ -1625,9 +1617,7 @@ class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
                 Ref("TableReferenceSegment"),
                 Ref("StarSegment", optional=True),
                 OneOf(
-                    Delimited(
-                        Ref("AlterTableActionSegment")
-                    ),
+                    Delimited(Ref("AlterTableActionSegment")),
                     Sequence(
                         "RENAME",
                         Ref.keyword("COLUMN", optional=True),
@@ -1676,9 +1666,7 @@ class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
                 Sequence(
                     "OWNED",
                     "BY",
-                    Delimited(
-                        Ref("ObjectReferenceSegment")
-                    ),
+                    Delimited(Ref("ObjectReferenceSegment")),
                     optional=True,
                 ),
                 "SET",
@@ -1785,11 +1773,7 @@ class AlterTableActionSegment(BaseSegment):
                 ),
                 Sequence(
                     "RESET",
-                    Bracketed(
-                        Delimited(
-                            Ref("ParameterNameSegment")
-                        )
-                    ),
+                    Bracketed(Delimited(Ref("ParameterNameSegment"))),
                 ),
                 Sequence(
                     "SET", "STORAGE", OneOf("PLAIN", "EXTERNAL", "EXTENDED", "MAIN")
@@ -1863,9 +1847,7 @@ class AlterTableActionSegment(BaseSegment):
         ),
         Sequence(
             "RESET",
-            Bracketed(
-                Delimited(Ref("ParameterNameSegment"))
-            ),
+            Bracketed(Delimited(Ref("ParameterNameSegment"))),
         ),
         Sequence(
             Ref.keyword("NO", optional=True), "INHERIT", Ref("TableReferenceSegment")
@@ -2446,9 +2428,7 @@ class PartitionBoundSpecSegment(BaseSegment):
     match_grammar = OneOf(
         Sequence(
             "IN",
-            Bracketed(
-                Delimited(Ref("ExpressionSegment"))
-            ),
+            Bracketed(Delimited(Ref("ExpressionSegment"))),
         ),
         Sequence(
             "FROM",
@@ -2958,11 +2938,7 @@ class CreateIndexStatementSegment(ansi.CreateIndexStatementSegment):
         AnyNumberOf(
             Sequence(
                 "INCLUDE",
-                Bracketed(
-                    Delimited(
-                        Ref("ColumnReferenceSegment")
-                    )
-                ),
+                Bracketed(Delimited(Ref("ColumnReferenceSegment"))),
             ),
             Sequence(
                 "WITH",

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1040,14 +1040,13 @@ class SetAssignmentStatementSegment(BaseSegment):
             "SET",
             Bracketed(
                 Delimited(
-                    Ref("LocalVariableNameSegment"), delimiter=Ref("CommaSegment")
+                    Ref("LocalVariableNameSegment")
                 )
             ),
             Ref("EqualsSegment"),
             Bracketed(
                 Delimited(
                     Ref("ExpressionSegment"),
-                    delimiter=Ref("CommaSegment"),
                 ),
             ),
         ),
@@ -1299,7 +1298,7 @@ class FromPivotExpressionSegment(BaseSegment):
             "FOR",
             Ref("SingleIdentifierGrammar"),
             "IN",
-            Bracketed(Delimited(Ref("LiteralGrammar"), delimiter=Ref("CommaSegment"))),
+            Bracketed(Delimited(Ref("LiteralGrammar"))),
         ),
     )
 
@@ -1316,7 +1315,7 @@ class FromUnpivotExpressionSegment(BaseSegment):
             Ref("SingleIdentifierGrammar"),
             "IN",
             Bracketed(
-                Delimited(Ref("SingleIdentifierGrammar"), delimiter=Ref("CommaSegment"))
+                Delimited(Ref("SingleIdentifierGrammar"))
             ),
         ),
     )
@@ -4510,7 +4509,7 @@ class AlterSessionUnsetClauseSegment(BaseSegment):
 
     match_grammar = Sequence(
         "UNSET",
-        Delimited(Ref("ParameterNameSegment"), delimiter=Ref("CommaSegment")),
+        Delimited(Ref("ParameterNameSegment")),
     )
 
 
@@ -4627,7 +4626,6 @@ class AlterTaskSetClauseSegment(BaseSegment):
                     Ref("NumericLiteralSegment"),
                 ),
             ),
-            delimiter=Ref("CommaSegment"),
         ),
     )
 
@@ -4646,7 +4644,7 @@ class AlterTaskUnsetClauseSegment(BaseSegment):
 
     match_grammar = Sequence(
         "UNSET",
-        Delimited(Ref("ParameterNameSegment"), delimiter=Ref("CommaSegment")),
+        Delimited(Ref("ParameterNameSegment")),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1038,11 +1038,7 @@ class SetAssignmentStatementSegment(BaseSegment):
         ),
         Sequence(
             "SET",
-            Bracketed(
-                Delimited(
-                    Ref("LocalVariableNameSegment")
-                )
-            ),
+            Bracketed(Delimited(Ref("LocalVariableNameSegment"))),
             Ref("EqualsSegment"),
             Bracketed(
                 Delimited(
@@ -1314,9 +1310,7 @@ class FromUnpivotExpressionSegment(BaseSegment):
             "FOR",
             Ref("SingleIdentifierGrammar"),
             "IN",
-            Bracketed(
-                Delimited(Ref("SingleIdentifierGrammar"))
-            ),
+            Bracketed(Delimited(Ref("SingleIdentifierGrammar"))),
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -226,11 +226,7 @@ class TdCollectStatisticsStatementSegment(BaseSegment):
                     "INDEX",
                     Ref("IndexReferenceSegment", optional=True),
                     Ref.keyword("ALL", optional=True),
-                    Bracketed(
-                        Delimited(
-                            Ref("ColumnReferenceSegment")
-                        )
-                    ),
+                    Bracketed(Delimited(Ref("ColumnReferenceSegment"))),
                     Ref("TdOrderByStatClauseSegment", optional=True),
                 ),
                 # UNIQUE INDEX index_name
@@ -428,9 +424,7 @@ class TdColumnConstraintSegment(BaseSegment):
             Sequence(  # COMPRESS [(1.,3.) | 3. | NULL],
                 "COMPRESS",
                 OneOf(
-                    Bracketed(
-                        Delimited(Ref("LiteralGrammar"))
-                    ),
+                    Bracketed(Delimited(Ref("LiteralGrammar"))),
                     Ref("LiteralGrammar"),
                     "NULL",
                     optional=True,
@@ -571,9 +565,7 @@ class TdTableConstraints(BaseSegment):
                 Ref("ObjectReferenceSegment"),  # Index name
                 Ref.keyword("ALL", optional=True),
                 Bracketed(  # Columns making up  constraint
-                    Delimited(
-                        Ref("ColumnReferenceSegment")
-                    ),
+                    Delimited(Ref("ColumnReferenceSegment")),
                 ),
             ),
         )

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -228,7 +228,7 @@ class TdCollectStatisticsStatementSegment(BaseSegment):
                     Ref.keyword("ALL", optional=True),
                     Bracketed(
                         Delimited(
-                            Ref("ColumnReferenceSegment"), delimiter=Ref("CommaSegment")
+                            Ref("ColumnReferenceSegment")
                         )
                     ),
                     Ref("TdOrderByStatClauseSegment", optional=True),
@@ -249,7 +249,6 @@ class TdCollectStatisticsStatementSegment(BaseSegment):
                                 Ref.keyword("PARTITION"),
                                 # TODO: expression
                             ),
-                            delimiter=Ref("CommaSegment"),
                         ),
                     ),
                     Sequence(
@@ -259,7 +258,6 @@ class TdCollectStatisticsStatementSegment(BaseSegment):
                     ),
                 ),
             ),
-            delimiter=Ref("CommaSegment"),
             optional=True,
         ),
         "ON",
@@ -343,7 +341,7 @@ class DatatypeSegment(ansi.DatatypeSegment):
         Ref("DatatypeIdentifierSegment"),
         Bracketed(
             OneOf(
-                Delimited(Ref("ExpressionSegment"), delimiter=Ref("CommaSegment")),
+                Delimited(Ref("ExpressionSegment")),
                 # The brackets might be empty for some cases...
                 optional=True,
             ),
@@ -431,7 +429,7 @@ class TdColumnConstraintSegment(BaseSegment):
                 "COMPRESS",
                 OneOf(
                     Bracketed(
-                        Delimited(Ref("LiteralGrammar"), delimiter=Ref("CommaSegment"))
+                        Delimited(Ref("LiteralGrammar"))
                     ),
                     Ref("LiteralGrammar"),
                     "NULL",
@@ -525,7 +523,6 @@ class TdTablePartitioningLevel(BaseSegment):
                     Ref("FunctionNameSegment"),
                     Bracketed(Anything(optional=True)),
                 ),
-                delimiter=Ref("CommaSegment"),
             ),
         ),
     )
@@ -554,7 +551,6 @@ class TdTableConstraints(BaseSegment):
                         Bracketed(
                             Delimited(
                                 Ref("SingleIdentifierGrammar"),
-                                delimiter=Ref("CommaSegment"),
                             )
                         ),
                         Ref("SingleIdentifierGrammar"),
@@ -576,7 +572,7 @@ class TdTableConstraints(BaseSegment):
                 Ref.keyword("ALL", optional=True),
                 Bracketed(  # Columns making up  constraint
                     Delimited(
-                        Ref("ColumnReferenceSegment"), delimiter=Ref("CommaSegment")
+                        Ref("ColumnReferenceSegment")
                     ),
                 ),
             ),
@@ -608,7 +604,6 @@ class CreateTableStatementSegment(BaseSegment):
                             Ref("ColumnDefinitionSegment"),
                             Ref("TableConstraintSegment"),
                         ),
-                        delimiter=Ref("CommaSegment"),
                     )
                 ),
                 Ref("CommentClauseSegment", optional=True),
@@ -660,7 +655,6 @@ class FromUpdateClauseSegment(BaseSegment):
         Delimited(
             # Optional old school delimited joins
             Ref("FromExpressionElementSegment"),
-            delimiter=Ref("CommaSegment"),
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -923,7 +923,6 @@ class RelationalIndexOptionsSegment(BaseSegment):
                                                         "BLOCKERS",
                                                     ),
                                                 ),
-                                                delimiter=Ref("CommaSegment"),
                                             ),
                                         ),
                                     ),
@@ -956,7 +955,6 @@ class RelationalIndexOptionsSegment(BaseSegment):
                     ),
                     min_times=1,
                 ),
-                delimiter=Ref("CommaSegment"),
             ),
         ),
     )
@@ -3893,7 +3891,6 @@ class AccessStatementSegment(BaseSegment):
                 Sequence(
                     Delimited(
                         OneOf(_global_permissions, _permissions),
-                        delimiter=Ref("CommaSegment"),
                         terminator="ON",
                     ),
                 ),
@@ -3909,7 +3906,6 @@ class AccessStatementSegment(BaseSegment):
             "TO",
             Delimited(
                 OneOf(Ref("RoleReferenceSegment"), Ref("FunctionSegment")),
-                delimiter=Ref("CommaSegment"),
             ),
             OneOf(
                 Sequence("WITH", "GRANT", "OPTION"),
@@ -3926,7 +3922,6 @@ class AccessStatementSegment(BaseSegment):
             OneOf(
                 Delimited(
                     OneOf(_global_permissions, _permissions),
-                    delimiter=Ref("CommaSegment"),
                     terminator="ON",
                 ),
                 Sequence("ALL", Ref.keyword("PRIVILEGES", optional=True)),
@@ -3941,7 +3936,6 @@ class AccessStatementSegment(BaseSegment):
             OneOf("TO"),
             Delimited(
                 Ref("RoleReferenceSegment"),
-                delimiter=Ref("CommaSegment"),
             ),
             Sequence(
                 Ref.keyword("CASCADE", optional=True),
@@ -3955,7 +3949,6 @@ class AccessStatementSegment(BaseSegment):
             OneOf(
                 Delimited(
                     OneOf(_global_permissions, _permissions),
-                    delimiter=Ref("CommaSegment"),
                     terminator="ON",
                 ),
                 Sequence("ALL", Ref.keyword("PRIVILEGES", optional=True)),
@@ -3970,7 +3963,6 @@ class AccessStatementSegment(BaseSegment):
             OneOf("TO", "FROM"),
             Delimited(
                 Ref("RoleReferenceSegment"),
-                delimiter=Ref("CommaSegment"),
             ),
             Sequence(
                 Ref.keyword("CASCADE", optional=True),


### PR DESCRIPTION
This is a clearup job.

On the `Delimited` grammar, specifying a comma as the delimiter is unnecessary, it's the default. Removing explicit references to commas results in smaller codebase and also less repetition.