### PR TITLE
BUGFIX: dbt templater now needs 1.2.0 or later

### DIFF
--- a/plugins/sqlfluff-templater-dbt/setup.cfg
+++ b/plugins/sqlfluff-templater-dbt/setup.cfg
@@ -60,7 +60,7 @@ keywords =
 packages = find:
 python_requires = >=3.7
 install_requires =
-    sqlfluff>=0.7.0
+    sqlfluff>=1.2.0
     dbt-core>=0.20.0
     jinja2-simple-tags>=0.3.1
     markupsafe<=2.0.1


### PR DESCRIPTION
newest dbt templater also needs newest sqlfluff. This should probably go out as a hotfix.