### PR TITLE
Add "INTEGER" to PrimitiveTypeSegment for Sparksql

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -639,6 +639,7 @@ class PrimitiveTypeSegment(BaseSegment):
         # "SHORT",
         "SMALLINT",
         "INT",
+        "INTEGER",
         "BIGINT",
         "FLOAT",
         "REAL",

--- a/test/fixtures/dialects/sparksql/parse_integer_type.sql
+++ b/test/fixtures/dialects/sparksql/parse_integer_type.sql
@@ -1,0 +1,3 @@
+SELECT
+    123 AS INTEGER,
+    123 AS INT

--- a/test/fixtures/dialects/sparksql/parse_integer_type.yml
+++ b/test/fixtures/dialects/sparksql/parse_integer_type.yml
@@ -1,0 +1,22 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: a2db9217e6e73facb052f619e3d7531ca70e18fadfc5f129f3340b37a135b033
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          literal: '123'
+          alias_expression:
+            keyword: AS
+            identifier: INTEGER
+      - comma: ','
+      - select_clause_element:
+          literal: '123'
+          alias_expression:
+            keyword: AS
+            identifier: INT


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Add "INTEGER" to PrimitiveTypeSegment for Sparksql
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fix issue [#3554]( https://github.com/sqlfluff/sqlfluff/issues/3554 ) as sparksql also accept the the type `INTEGER`


### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
