### PR TITLE
Redshift: syntax for array unnesting with index

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2248,7 +2248,10 @@ class TableExpressionSegment(ansi.TableExpressionSegment):
     """
 
     match_grammar = ansi.TableExpressionSegment.match_grammar.copy(
-        insert=[Ref("ObjectUnpivotSegment", optional=True)],
+        insert=[
+            Ref("ObjectUnpivotSegment", optional=True),
+            Ref("ArrayUnnestSegment", optional=True),
+        ],
         before=Ref("TableReferenceSegment"),
     )
 
@@ -2262,6 +2265,22 @@ class ObjectUnpivotSegment(BaseSegment):
     type = "object_unpivoting"
     match_grammar: Matchable = Sequence(
         "UNPIVOT",
+        Ref("ObjectReferenceSegment"),
+        "AS",
+        Ref("SingleIdentifierGrammar"),
+        "AT",
+        Ref("SingleIdentifierGrammar"),
+    )
+
+
+class ArrayUnnestSegment(BaseSegment):
+    """Array unnesting.
+
+    https://docs.aws.amazon.com/redshift/latest/dg/query-super.html
+    """
+
+    type = "array_unnesting"
+    match_grammar: Matchable = Sequence(
         Ref("ObjectReferenceSegment"),
         "AS",
         Ref("SingleIdentifierGrammar"),

--- a/test/fixtures/dialects/redshift/redshift_array_unnest.sql
+++ b/test/fixtures/dialects/redshift/redshift_array_unnest.sql
@@ -1,0 +1,23 @@
+WITH example_data AS (
+    SELECT
+        10 AS shop_id
+        , json_parse('[1, 2]') AS inventory
+    UNION ALL
+    SELECT
+        20 AS shop_id
+        , json_parse('[3, 4, 5]') AS inventory
+    UNION ALL
+    SELECT
+        30 AS shop_id
+        , json_parse('[6, 7, 8, 9]') AS inventory
+)
+
+SELECT
+    shop_id
+    , value
+    , index
+FROM example_data ed, ed.inventory AS value AT index;
+
+SELECT c_name, orders.o_orderkey AS orderkey, index AS orderkey_index
+FROM customer_orders_lineitem c, c.c_orders AS orders AT index
+ORDER BY orderkey_index;

--- a/test/fixtures/dialects/redshift/redshift_array_unnest.yml
+++ b/test/fixtures/dialects/redshift/redshift_array_unnest.yml
@@ -1,0 +1,174 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: b7f5d79f534ffa1f6d1714056692ab53e0ef871331e039467eef411283da0ba4
+file:
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        identifier: example_data
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          set_expression:
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  literal: '10'
+                  alias_expression:
+                    keyword: AS
+                    identifier: shop_id
+              - comma: ','
+              - select_clause_element:
+                  function:
+                    function_name:
+                      function_name_identifier: json_parse
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        literal: "'[1, 2]'"
+                      end_bracket: )
+                  alias_expression:
+                    keyword: AS
+                    identifier: inventory
+          - set_operator:
+            - keyword: UNION
+            - keyword: ALL
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  literal: '20'
+                  alias_expression:
+                    keyword: AS
+                    identifier: shop_id
+              - comma: ','
+              - select_clause_element:
+                  function:
+                    function_name:
+                      function_name_identifier: json_parse
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        literal: "'[3, 4, 5]'"
+                      end_bracket: )
+                  alias_expression:
+                    keyword: AS
+                    identifier: inventory
+          - set_operator:
+            - keyword: UNION
+            - keyword: ALL
+          - select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  literal: '30'
+                  alias_expression:
+                    keyword: AS
+                    identifier: shop_id
+              - comma: ','
+              - select_clause_element:
+                  function:
+                    function_name:
+                      function_name_identifier: json_parse
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        literal: "'[6, 7, 8, 9]'"
+                      end_bracket: )
+                  alias_expression:
+                    keyword: AS
+                    identifier: inventory
+          end_bracket: )
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              identifier: shop_id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              identifier: value
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              identifier: index
+        from_clause:
+        - keyword: FROM
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: example_data
+              alias_expression:
+                identifier: ed
+        - comma: ','
+        - from_expression:
+            from_expression_element:
+              table_expression:
+                array_unnesting:
+                - object_reference:
+                  - identifier: ed
+                  - dot: .
+                  - identifier: inventory
+                - keyword: AS
+                - identifier: value
+                - keyword: AT
+                - identifier: index
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            identifier: c_name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - identifier: orders
+          - dot: .
+          - identifier: o_orderkey
+          alias_expression:
+            keyword: AS
+            identifier: orderkey
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            identifier: index
+          alias_expression:
+            keyword: AS
+            identifier: orderkey_index
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: customer_orders_lineitem
+            alias_expression:
+              identifier: c
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              array_unnesting:
+              - object_reference:
+                - identifier: c
+                - dot: .
+                - identifier: c_orders
+              - keyword: AS
+              - identifier: orders
+              - keyword: AT
+              - identifier: index
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          identifier: orderkey_index
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Redshift: support array unnesting with index syntax

```sql
SELECT index, value
FROM mytable m, m.superarray AS value AT index
```

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
