### PR TITLE
Add handling for redshift convert function data type argument

### DIFF
--- a/test/fixtures/dialects/redshift/redshift_cast_conversion.yml
+++ b/test/fixtures/dialects/redshift/redshift_cast_conversion.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d88e5f09aebf827225e0e8212e0629860009f8d5ac1bdb6f8df8abbd37bcbda4
+_hash: 29b2bd2f7511b32a80bbd5d7ef8cfdc99ef123a566c1f35099f3d97b439675da
 file:
 - statement:
     select_statement:
@@ -37,17 +37,16 @@ file:
         select_clause_element:
           function:
             function_name:
-              function_name_identifier: convert
+              keyword: convert
             bracketed:
-            - start_bracket: (
-            - expression:
-                column_reference:
-                  identifier: integer
-            - comma: ','
-            - expression:
+              start_bracket: (
+              data_type:
+                keyword: integer
+              comma: ','
+              expression:
                 column_reference:
                   identifier: col1
-            - end_bracket: )
+              end_bracket: )
       from_clause:
         keyword: from
         from_expression:
@@ -109,17 +108,17 @@ file:
         select_clause_element:
           function:
             function_name:
-              function_name_identifier: convert
+              keyword: convert
             bracketed:
-            - start_bracket: (
-            - expression:
-                column_reference:
-                  identifier: timestamptz
-            - comma: ','
-            - expression:
+              start_bracket: (
+              data_type:
+                datetime_type_identifier:
+                  keyword: timestamptz
+              comma: ','
+              expression:
                 column_reference:
                   identifier: col1
-            - end_bracket: )
+              end_bracket: )
       from_clause:
         keyword: from
         from_expression:
@@ -187,26 +186,22 @@ file:
         select_clause_element:
           function:
             function_name:
-              function_name_identifier: convert
+              keyword: convert
             bracketed:
-            - start_bracket: (
-            - expression:
-                function:
-                  function_name:
-                    function_name_identifier: decimal
-                  bracketed:
-                  - start_bracket: (
-                  - expression:
-                      literal: '38'
-                  - comma: ','
-                  - expression:
-                      literal: '2'
-                  - end_bracket: )
-            - comma: ','
-            - expression:
+              start_bracket: (
+              data_type:
+                keyword: decimal
+                bracketed:
+                - start_bracket: (
+                - literal: '38'
+                - comma: ','
+                - literal: '2'
+                - end_bracket: )
+              comma: ','
+              expression:
                 column_reference:
                   identifier: col1
-            - end_bracket: )
+              end_bracket: )
       from_clause:
         keyword: from
         from_expression:
@@ -273,17 +268,16 @@ file:
         select_clause_element:
           function:
             function_name:
-              function_name_identifier: convert
+              keyword: convert
             bracketed:
-            - start_bracket: (
-            - expression:
-                column_reference:
-                  identifier: interval
-            - comma: ','
-            - expression:
+              start_bracket: (
+              data_type:
+                keyword: interval
+              comma: ','
+              expression:
                 column_reference:
                   identifier: col1
-            - end_bracket: )
+              end_bracket: )
       from_clause:
         keyword: from
         from_expression:

--- a/test/fixtures/rules/std_rule_cases/L027.yml
+++ b/test/fixtures/rules/std_rule_cases/L027.yml
@@ -336,3 +336,16 @@ test_pass_ansi:
         INNER JOIN mapping_table ON (mapping_table.other_fk = other_table.id_pk)
         WHERE mapping_table.kind = my_table.kind
     )
+
+test_pass_redshift_convert:
+  # This was failing in issue 3651.
+  pass_str: |
+    SELECT
+        sellers.name,
+        CONVERT(integer, sales.pricepaid) AS price
+    FROM sales
+    LEFT JOIN sellers ON sales.sellerid = sellers.sellerid
+    WHERE sales.salesid = 100
+  configs:
+    core:
+      dialect: redshift


### PR DESCRIPTION
### Brief summary of the change made

Fixes issue #3651.

Previously, the first argument to the `convert` redshift function was interpreted as a column reference rather than a data type. This could cause rule L027 to fail since the data type wasn't qualified with a table name even though that doesn't make sense. This adds explicit handling for `convert` to eliminate that issue.

### Are there any other side effects of this change that we should be aware of?

Not that I'm aware of.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
