### PR TITLE
Use UUIDs for matching

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -25,6 +25,7 @@ from typing import (
     TYPE_CHECKING,
 )
 import logging
+from uuid import UUID, uuid4
 
 from tqdm import tqdm
 
@@ -237,6 +238,7 @@ class BaseSegment:
         segments,
         pos_marker: Optional[PositionMarker] = None,
         name: Optional[str] = None,
+        uuid: Optional[UUID] = None,
     ):
         # A cache variable for expandable
         self._is_expandable: Optional[bool] = None
@@ -272,6 +274,8 @@ class BaseSegment:
                 )
 
         self.pos_marker = pos_marker
+        # Tracker for matching when things start moving.
+        self.uuid = uuid or uuid4()
 
         self._recalculate_caches()
 
@@ -1211,9 +1215,9 @@ class BaseSegment:
                 else:
                     seg = todo_buffer.pop(0)
 
-                    # Look for identity not just equality.
+                    # Look for uuid match.
                     # This handles potential positioning ambiguity.
-                    anchor_info: Optional[AnchorEditInfo] = fixes.pop(id(seg), None)
+                    anchor_info: Optional[AnchorEditInfo] = fixes.pop(seg.uuid, None)
                     if anchor_info is not None:
                         seg_fixes = anchor_info.fixes
                         if (
@@ -1225,7 +1229,7 @@ class BaseSegment:
                             seg_fixes.reverse()
 
                         for f in anchor_info.fixes:
-                            assert f.anchor is seg
+                            assert f.anchor.uuid == seg.uuid
                             fixes_applied.append(f)
                             linter_logger.debug(
                                 "Matched fix against segment: %s -> %s", f, seg
@@ -1350,9 +1354,9 @@ class BaseSegment:
         """Group and count fixes by anchor, return dictionary."""
         anchor_info = defaultdict(AnchorEditInfo)  # type: ignore
         for fix in fixes:
-            # :TRICKY: Use segment id() as the dictionary key since
+            # :TRICKY: Use segment uuid as the dictionary key since
             # different segments may compare as equal.
-            anchor_id = id(fix.anchor)
+            anchor_id = fix.anchor.uuid
             anchor_info[anchor_id].add(fix)
         return dict(anchor_info)
 

--- a/src/sqlfluff/core/parser/segments/meta.py
+++ b/src/sqlfluff/core/parser/segments/meta.py
@@ -135,6 +135,8 @@ class TemplateSegment(MetaSegment):
 
         Used mostly by fixes.
 
+        NOTE: This *doesn't* copy the uuid. The edited segment is a new segment.
+
         """
         if raw:
             raise ValueError(

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -5,6 +5,7 @@ any children, and the output of the lexer.
 """
 
 from typing import List, Optional, Tuple
+from uuid import UUID, uuid4
 
 from sqlfluff.core.parser.segments.base import BaseSegment, SourceFix
 from sqlfluff.core.parser.markers import PositionMarker
@@ -30,6 +31,7 @@ class RawSegment(BaseSegment):
         trim_start: Optional[Tuple[str, ...]] = None,
         trim_chars: Optional[Tuple[str, ...]] = None,
         source_fixes: Optional[List[SourceFix]] = None,
+        uuid: Optional[UUID] = None,
     ):
         """Initialise raw segment.
 
@@ -56,6 +58,8 @@ class RawSegment(BaseSegment):
         self._is_expandable = None
         # Keep track of any source fixes
         self._source_fixes = source_fixes
+        # UUID for matching
+        self.uuid = uuid or uuid4()
 
     def __repr__(self):
         return "<{}: ({}) {!r}>".format(
@@ -187,6 +191,8 @@ class RawSegment(BaseSegment):
 
         Used mostly by fixes.
 
+        NOTE: This *doesn't* copy the uuid. The edited segment is a new segment.
+
         """
         return self.__class__(
             raw=raw or self.raw,
@@ -292,6 +298,8 @@ class KeywordSegment(CodeSegment):
             A copy of this object with new contents.
 
         Used mostly by fixes.
+
+        NOTE: This *doesn't* copy the uuid. The edited segment is a new segment.
 
         """
         return self.__class__(


### PR DESCRIPTION
This partly sets some of the groundwork for more immutable segments in future, but really I think this solves the test fails I'm getting on #3658.

Replace `id()` matching with explicit `uuid` so that we can control where to match and where not.