### PR TITLE
T-SQL: Fix parsing of CREATE VIEW statements with column name syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3,39 +3,36 @@
 https://docs.microsoft.com/en-us/sql/t-sql/language-elements/language-elements-transact-sql
 """
 
+from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
+    AnyNumberOf,
+    AnySetOf,
+    BaseFileSegment,
     BaseSegment,
-    Sequence,
-    OneOf,
     Bracketed,
-    Ref,
-    Nothing,
-    RegexLexer,
     CodeSegment,
-    RegexParser,
+    CommentSegment,
+    Conditional,
+    Dedent,
     Delimited,
+    Indent,
     Matchable,
     NamedParser,
+    Nothing,
+    OneOf,
     OptionallyBracketed,
-    Dedent,
-    BaseFileSegment,
-    Indent,
-    AnyNumberOf,
-    CommentSegment,
+    Ref,
+    RegexLexer,
+    RegexParser,
     SegmentGenerator,
-    Conditional,
-    AnySetOf,
+    Sequence,
 )
-
-from sqlfluff.core.dialects import load_raw_dialect
-
+from sqlfluff.core.parser.segments.raw import NewlineSegment, WhitespaceSegment
+from sqlfluff.dialects import dialect_ansi as ansi
 from sqlfluff.dialects.dialect_tsql_keywords import (
     RESERVED_KEYWORDS,
     UNRESERVED_KEYWORDS,
 )
-
-from sqlfluff.core.parser.segments.raw import NewlineSegment, WhitespaceSegment
-from sqlfluff.dialects import dialect_ansi as ansi
 
 ansi_dialect = load_raw_dialect("ansi")
 tsql_dialect = ansi_dialect.copy_as("tsql")
@@ -1867,6 +1864,12 @@ class CreateViewStatementSegment(BaseSegment):
         Sequence("OR", "ALTER", optional=True),
         "VIEW",
         Ref("ObjectReferenceSegment"),
+        Bracketed(
+            Delimited(
+                Ref("IndexColumnDefinitionSegment"),
+            ),
+            optional=True,
+        ),
         Sequence(
             "WITH",
             Delimited("ENCRYPTION", "SCHEMABINDING", "VIEW_METADATA"),

--- a/test/fixtures/dialects/tsql/create_view_with_columns.sql
+++ b/test/fixtures/dialects/tsql/create_view_with_columns.sql
@@ -1,0 +1,9 @@
+CREATE VIEW my_view (
+    col1,
+    col2
+)
+AS
+SELECT
+    col1,
+    col2
+FROM source_table;

--- a/test/fixtures/dialects/tsql/create_view_with_columns.yml
+++ b/test/fixtures/dialects/tsql/create_view_with_columns.yml
@@ -1,0 +1,41 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 745134e648385cd3998d82f5ac863b5fafab194c53ab95bf9ff86c44e56cad34
+file:
+  batch:
+    statement:
+      create_view_statement:
+      - keyword: CREATE
+      - keyword: VIEW
+      - object_reference:
+          identifier: my_view
+      - bracketed:
+        - start_bracket: (
+        - index_column_definition:
+            identifier: col1
+        - comma: ','
+        - index_column_definition:
+            identifier: col2
+        - end_bracket: )
+      - keyword: AS
+      - select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                identifier: col1
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                identifier: col2
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: source_table
+            statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Resolves #3667 

### Are there any other side effects of this change that we should be aware of?

n/a

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.