### PR TITLE
T-SQL: Allow `COLLATE` clause in `JOIN` conditions

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3,39 +3,36 @@
 https://docs.microsoft.com/en-us/sql/t-sql/language-elements/language-elements-transact-sql
 """
 
+from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
+    AnyNumberOf,
+    AnySetOf,
+    BaseFileSegment,
     BaseSegment,
-    Sequence,
-    OneOf,
     Bracketed,
-    Ref,
-    Nothing,
-    RegexLexer,
     CodeSegment,
-    RegexParser,
+    CommentSegment,
+    Conditional,
+    Dedent,
     Delimited,
+    Indent,
     Matchable,
     NamedParser,
+    Nothing,
+    OneOf,
     OptionallyBracketed,
-    Dedent,
-    BaseFileSegment,
-    Indent,
-    AnyNumberOf,
-    CommentSegment,
+    Ref,
+    RegexLexer,
+    RegexParser,
     SegmentGenerator,
-    Conditional,
-    AnySetOf,
+    Sequence,
 )
-
-from sqlfluff.core.dialects import load_raw_dialect
-
+from sqlfluff.core.parser.segments.raw import NewlineSegment, WhitespaceSegment
+from sqlfluff.dialects import dialect_ansi as ansi
 from sqlfluff.dialects.dialect_tsql_keywords import (
     RESERVED_KEYWORDS,
     UNRESERVED_KEYWORDS,
 )
-
-from sqlfluff.core.parser.segments.raw import NewlineSegment, WhitespaceSegment
-from sqlfluff.dialects import dialect_ansi as ansi
 
 ansi_dialect = load_raw_dialect("ansi")
 tsql_dialect = ansi_dialect.copy_as("tsql")
@@ -436,6 +433,7 @@ tsql_dialect.replace(
         Ref("PivotUnpivotStatementSegment"),
         min_times=1,
     ),
+    StringBinaryOperatorGrammar=OneOf(Ref("ConcatSegment"), "COLLATE"),
 )
 
 

--- a/test/fixtures/dialects/tsql/collate.sql
+++ b/test/fixtures/dialects/tsql/collate.sql
@@ -1,0 +1,14 @@
+-- `COLLATE` in JOIN condition
+SELECT table1.col
+FROM table1
+INNER JOIN table2
+    ON table1.col = table2.col COLLATE Latin1_GENERAL_CS_AS;
+
+-- `COLLATE` in ORDER BY clause
+SELECT col
+FROM my_table
+ORDER BY col COLLATE Latin1_General_CS_AS_KS_WS DESC;
+
+-- `COLLATE` in SELECT
+SELECT col COLLATE Latin1_General_CS_AS_KS_WS
+FROM my_table;

--- a/test/fixtures/dialects/tsql/collate.yml
+++ b/test/fixtures/dialects/tsql/collate.yml
@@ -1,0 +1,92 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 7995c7bec5afac4793c873a918cb0bdce9a534f7996268b9d7b10c2cb41a1555
+file:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+            - identifier: table1
+            - dot: .
+            - identifier: col
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: table1
+            join_clause:
+            - keyword: INNER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: table2
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - identifier: table1
+                  - dot: .
+                  - identifier: col
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - identifier: table2
+                  - dot: .
+                  - identifier: col
+                - keyword: COLLATE
+                - column_reference:
+                    identifier: Latin1_GENERAL_CS_AS
+          statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              identifier: col
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: my_table
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - expression:
+          - column_reference:
+              identifier: col
+          - keyword: COLLATE
+          - column_reference:
+              identifier: Latin1_General_CS_AS_KS_WS
+        - keyword: DESC
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+            - column_reference:
+                identifier: col
+            - keyword: COLLATE
+            - column_reference:
+                identifier: Latin1_General_CS_AS_KS_WS
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: my_table
+          statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Resolves #3671 


### Are there any other side effects of this change that we should be aware of?

n/a

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
