### PR TITLE
T-SQL: Parse `DATEPART` date type as date type instead of column name

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3,39 +3,36 @@
 https://docs.microsoft.com/en-us/sql/t-sql/language-elements/language-elements-transact-sql
 """
 
+from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
+    AnyNumberOf,
+    AnySetOf,
+    BaseFileSegment,
     BaseSegment,
-    Sequence,
-    OneOf,
     Bracketed,
-    Ref,
-    Nothing,
-    RegexLexer,
     CodeSegment,
-    RegexParser,
+    CommentSegment,
+    Conditional,
+    Dedent,
     Delimited,
+    Indent,
     Matchable,
     NamedParser,
+    Nothing,
+    OneOf,
     OptionallyBracketed,
-    Dedent,
-    BaseFileSegment,
-    Indent,
-    AnyNumberOf,
-    CommentSegment,
+    Ref,
+    RegexLexer,
+    RegexParser,
     SegmentGenerator,
-    Conditional,
-    AnySetOf,
+    Sequence,
 )
-
-from sqlfluff.core.dialects import load_raw_dialect
-
+from sqlfluff.core.parser.segments.raw import NewlineSegment, WhitespaceSegment
+from sqlfluff.dialects import dialect_ansi as ansi
 from sqlfluff.dialects.dialect_tsql_keywords import (
     RESERVED_KEYWORDS,
     UNRESERVED_KEYWORDS,
 )
-
-from sqlfluff.core.parser.segments.raw import NewlineSegment, WhitespaceSegment
-from sqlfluff.dialects import dialect_ansi as ansi
 
 ansi_dialect = load_raw_dialect("ansi")
 tsql_dialect = ansi_dialect.copy_as("tsql")
@@ -89,7 +86,7 @@ tsql_dialect.sets("datetime_units").update(
 
 tsql_dialect.sets("date_part_function_name").clear()
 tsql_dialect.sets("date_part_function_name").update(
-    ["DATEADD", "DATEDIFF", "DATEDIFF_BIG", "DATENAME"]
+    ["DATEADD", "DATEDIFF", "DATEDIFF_BIG", "DATENAME", "DATEPART"]
 )
 
 tsql_dialect.insert_lexer_matchers(

--- a/test/fixtures/dialects/tsql/create_function.yml
+++ b/test/fixtures/dialects/tsql/create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f78dbf5872c29abdcfe06775bc5c22755fad8596b185c6de7b73b032c9a3a5e2
+_hash: fb5668d4692a023cbc141d281e70e350027273f62325d15d8d755a7f1c10321b
 file:
 - batch:
     statement:
@@ -54,14 +54,12 @@ file:
                       function_name:
                         function_name_identifier: DATEPART
                       bracketed:
-                      - start_bracket: (
-                      - expression:
-                          column_reference:
-                            identifier: wk
-                      - comma: ','
-                      - expression:
+                        start_bracket: (
+                        date_part: wk
+                        comma: ','
+                        expression:
                           parameter: '@DATE'
-                      - end_bracket: )
+                        end_bracket: )
                   - binary_operator: +
                   - literal: '1'
                   - binary_operator: '-'
@@ -69,12 +67,10 @@ file:
                       function_name:
                         function_name_identifier: DATEPART
                       bracketed:
-                      - start_bracket: (
-                      - expression:
-                          column_reference:
-                            identifier: wk
-                      - comma: ','
-                      - expression:
+                        start_bracket: (
+                        date_part: wk
+                        comma: ','
+                        expression:
                           function:
                             function_name:
                               keyword: CAST
@@ -85,14 +81,12 @@ file:
                                   function_name:
                                     function_name_identifier: DATEPART
                                   bracketed:
-                                  - start_bracket: (
-                                  - expression:
-                                      column_reference:
-                                        identifier: yy
-                                  - comma: ','
-                                  - expression:
+                                    start_bracket: (
+                                    date_part: yy
+                                    comma: ','
+                                    expression:
                                       parameter: '@DATE'
-                                  - end_bracket: )
+                                    end_bracket: )
                               keyword: as
                               data_type:
                                 data_type_identifier: CHAR
@@ -104,7 +98,7 @@ file:
                               end_bracket: )
                           binary_operator: +
                           literal: "'0104'"
-                      - end_bracket: )
+                        end_bracket: )
                   statement_terminator: ;
             - statement:
                 if_then_statement:
@@ -145,14 +139,12 @@ file:
                                       function_name:
                                         function_name_identifier: DATEPART
                                       bracketed:
-                                      - start_bracket: (
-                                      - expression:
-                                          column_reference:
-                                            identifier: yy
-                                      - comma: ','
-                                      - expression:
+                                        start_bracket: (
+                                        date_part: yy
+                                        comma: ','
+                                        expression:
                                           parameter: '@DATE'
-                                      - end_bracket: )
+                                        end_bracket: )
                                     binary_operator: '-'
                                     literal: '1'
                                   keyword: AS
@@ -179,14 +171,12 @@ file:
                                       function_name:
                                         function_name_identifier: DATEPART
                                       bracketed:
-                                      - start_bracket: (
-                                      - expression:
-                                          column_reference:
-                                            identifier: DAY
-                                      - comma: ','
-                                      - expression:
+                                        start_bracket: (
+                                        date_part: DAY
+                                        comma: ','
+                                        expression:
                                           parameter: '@DATE'
-                                      - end_bracket: )
+                                        end_bracket: )
                                   keyword: AS
                                   data_type:
                                     data_type_identifier: CHAR
@@ -215,14 +205,12 @@ file:
                                 function_name:
                                   function_name_identifier: DATEPART
                                 bracketed:
-                                - start_bracket: (
-                                - expression:
-                                    column_reference:
-                                      identifier: mm
-                                - comma: ','
-                                - expression:
+                                  start_bracket: (
+                                  date_part: mm
+                                  comma: ','
+                                  expression:
                                     parameter: '@DATE'
-                                - end_bracket: )
+                                  end_bracket: )
                               comparison_operator:
                                 raw_comparison_operator: '='
                               literal: '12'
@@ -238,27 +226,23 @@ file:
                                     function_name:
                                       function_name_identifier: DATEPART
                                     bracketed:
-                                    - start_bracket: (
-                                    - expression:
-                                        column_reference:
-                                          identifier: dd
-                                    - comma: ','
-                                    - expression:
+                                      start_bracket: (
+                                      date_part: dd
+                                      comma: ','
+                                      expression:
                                         parameter: '@DATE'
-                                    - end_bracket: )
+                                      end_bracket: )
                                 - binary_operator: '-'
                                 - function:
                                     function_name:
                                       function_name_identifier: DATEPART
                                     bracketed:
-                                    - start_bracket: (
-                                    - expression:
-                                        column_reference:
-                                          identifier: dw
-                                    - comma: ','
-                                    - expression:
+                                      start_bracket: (
+                                      date_part: dw
+                                      comma: ','
+                                      expression:
                                         parameter: '@DATE'
-                                    - end_bracket: )
+                                      end_bracket: )
                                 end_bracket: )
                               comparison_operator:
                               - raw_comparison_operator: '>'

--- a/test/fixtures/dialects/tsql/datepart.sql
+++ b/test/fixtures/dialects/tsql/datepart.sql
@@ -1,0 +1,2 @@
+SELECT DATEPART(DW, my_table.date) AS dayofweek
+FROM my_table;

--- a/test/fixtures/dialects/tsql/datepart.yml
+++ b/test/fixtures/dialects/tsql/datepart.yml
@@ -1,0 +1,37 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 6178c02c375d73445a741139a586236270723a4390dbdd51c1f7b58d1a9b9f6c
+file:
+  batch:
+    statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: DATEPART
+              bracketed:
+                start_bracket: (
+                date_part: DW
+                comma: ','
+                expression:
+                  column_reference:
+                  - identifier: my_table
+                  - dot: .
+                  - identifier: date
+                end_bracket: )
+            alias_expression:
+              keyword: AS
+              identifier: dayofweek
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: my_table
+          statement_terminator: ;

--- a/test/fixtures/dialects/tsql/select_date_functions.yml
+++ b/test/fixtures/dialects/tsql/select_date_functions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 301d40a2421d58284616bf1d1ce005637ac62374ecedb67f8c5fe08547a0eff8
+_hash: 6a04c3b0a3cf43d6c427104da2692dfd66c82ddd26bffb08a25c4b22a546ebbe
 file:
   batch:
     statement:
@@ -44,9 +44,7 @@ file:
                 function_name_identifier: DATEPART
               bracketed:
               - start_bracket: (
-              - expression:
-                  column_reference:
-                    identifier: day
+              - date_part: day
               - comma: ','
               - expression:
                   column_reference:


### PR DESCRIPTION
### Brief summary of the change made

Resolves #3630.

### Are there any other side effects of this change that we should be aware of?

n/a

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
