### PR TITLE
Allow escaping single quotes in single-quoted literal with ''

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -33,6 +33,7 @@ from sqlfluff.core.parser import (
     Indent,
     KeywordSegment,
     Matchable,
+    MultiStringParser,
     NamedParser,
     NewlineSegment,
     Nothing,
@@ -48,7 +49,6 @@ from sqlfluff.core.parser import (
     StringParser,
     SymbolSegment,
     WhitespaceSegment,
-    MultiStringParser,
 )
 from sqlfluff.core.parser.segments.base import BracketedSegment
 from sqlfluff.dialects.dialect_ansi_keywords import (
@@ -85,7 +85,7 @@ ansi_dialect.set_lexer_matchers(
                 WhitespaceSegment,
             ),
         ),
-        RegexLexer("single_quote", r"'([^'\\]|\\.)*'", CodeSegment),
+        RegexLexer("single_quote", r"'([^'\\]|\\.|'')*'", CodeSegment),
         RegexLexer("double_quote", r'"([^"\\]|\\.)*"', CodeSegment),
         RegexLexer("back_quote", r"`[^`]*`", CodeSegment),
         # See https://www.geeksforgeeks.org/postgresql-dollar-quoted-string-constants/

--- a/test/fixtures/dialects/ansi/escaped_quotes.sql
+++ b/test/fixtures/dialects/ansi/escaped_quotes.sql
@@ -1,1 +1,3 @@
-select case when "Spec\"s 23" like 'Spec\'s%' then 'boop' end as field
+select case when "Spec\"s 23" like 'Spec\'s%' then 'boop' end as field;
+
+select 'This shouldn''t fail' as success;

--- a/test/fixtures/dialects/ansi/escaped_quotes.yml
+++ b/test/fixtures/dialects/ansi/escaped_quotes.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d7e3b651df33f7ec8605e1ee45a739bf7d31f858570ccd2190e86b550168ee38
+_hash: 0bf4be7b356668afd6b9b4091cc17316ccc1fcdf2757cbad937427c3a77989c6
 file:
-  statement:
+- statement:
     select_statement:
       select_clause:
         keyword: select
@@ -27,3 +27,14 @@ file:
           alias_expression:
             keyword: as
             identifier: field
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          literal: "'This shouldn''t fail'"
+          alias_expression:
+            keyword: as
+            identifier: success
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Allows escaping single quotes inside single-quoted literals with `''`.

This used to fail, but now it works:

```
$ echo "SELECT 'This doesn''t parse!' AS mycolumn" | sqlfluff lint --dialect ansi -
All Finished 📜 🎉!
```

Fixes #3675

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
