### PR TITLE
T-SQL: Properly parse collation names

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -472,6 +472,7 @@ ansi_dialect.add(
     # non-standard keywords)
     IsNullGrammar=Nothing(),
     NotNullGrammar=Nothing(),
+    CollateGrammar=Nothing(),
     FromClauseTerminatorGrammar=OneOf(
         "WHERE",
         "LIMIT",
@@ -1751,6 +1752,7 @@ ansi_dialect.add(
                 ),
                 Ref("IsNullGrammar"),
                 Ref("NotNullGrammar"),
+                Ref("CollateGrammar"),
                 Sequence(
                     # e.g. NOT EXISTS, but other expressions could be met as
                     # well by inverting the condition with the NOT operator

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -455,9 +455,7 @@ tsql_dialect.replace(
         Ref("PivotUnpivotStatementSegment"),
         min_times=1,
     ),
-    CollateGrammar=Sequence(
-        "COLLATE", OneOf(Ref("CollationSegment"), "database_default")
-    ),
+    CollateGrammar=Sequence("COLLATE", Ref("CollationSegment")),
 )
 
 

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -240,7 +240,6 @@ UNRESERVED_KEYWORDS = [
     "COMPRESSION_DELAY",
     "CURSOR_CLOSE_ON_COMMIT",
     "CYCLE",
-    "database_default",
     "DATA_COMPRESSION",
     "DATASOURCE",
     "DATE",

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -240,6 +240,7 @@ UNRESERVED_KEYWORDS = [
     "COMPRESSION_DELAY",
     "CURSOR_CLOSE_ON_COMMIT",
     "CYCLE",
+    "database_default",
     "DATA_COMPRESSION",
     "DATASOURCE",
     "DATE",

--- a/test/fixtures/dialects/tsql/collate.sql
+++ b/test/fixtures/dialects/tsql/collate.sql
@@ -4,6 +4,11 @@ FROM table1
 INNER JOIN table2
     ON table1.col = table2.col COLLATE Latin1_GENERAL_CS_AS;
 
+SELECT table1.col
+FROM table1
+INNER JOIN table2
+    ON table1.col COLLATE Latin1_GENERAL_CS_AS = table2.col;
+
 -- `COLLATE` in ORDER BY clause
 SELECT col
 FROM my_table
@@ -11,4 +16,7 @@ ORDER BY col COLLATE Latin1_General_CS_AS_KS_WS DESC;
 
 -- `COLLATE` in SELECT
 SELECT col COLLATE Latin1_General_CS_AS_KS_WS
+FROM my_table;
+
+SELECT col COLLATE database_default
 FROM my_table;

--- a/test/fixtures/dialects/tsql/collate.yml
+++ b/test/fixtures/dialects/tsql/collate.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7995c7bec5afac4793c873a918cb0bdce9a534f7996268b9d7b10c2cb41a1555
+_hash: 74f499926398aefa1e0c93f26292651f2787f706091ab6108b6e78744c63dd90
 file:
   batch:
   - statement:
@@ -43,8 +43,46 @@ file:
                   - dot: .
                   - identifier: col
                 - keyword: COLLATE
+                - collation: Latin1_GENERAL_CS_AS
+          statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+            - identifier: table1
+            - dot: .
+            - identifier: col
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: table1
+            join_clause:
+            - keyword: INNER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    identifier: table2
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
                 - column_reference:
-                    identifier: Latin1_GENERAL_CS_AS
+                  - identifier: table1
+                  - dot: .
+                  - identifier: col
+                - keyword: COLLATE
+                - collation: Latin1_GENERAL_CS_AS
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - identifier: table2
+                  - dot: .
+                  - identifier: col
           statement_terminator: ;
   - statement:
       select_statement:
@@ -64,11 +102,10 @@ file:
         - keyword: ORDER
         - keyword: BY
         - expression:
-          - column_reference:
+            column_reference:
               identifier: col
-          - keyword: COLLATE
-          - column_reference:
-              identifier: Latin1_General_CS_AS_KS_WS
+            keyword: COLLATE
+            collation: Latin1_General_CS_AS_KS_WS
         - keyword: DESC
         statement_terminator: ;
   - statement:
@@ -77,11 +114,28 @@ file:
           keyword: SELECT
           select_clause_element:
             expression:
-            - column_reference:
+              column_reference:
                 identifier: col
-            - keyword: COLLATE
-            - column_reference:
-                identifier: Latin1_General_CS_AS_KS_WS
+              keyword: COLLATE
+              collation: Latin1_General_CS_AS_KS_WS
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  identifier: my_table
+          statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            expression:
+              column_reference:
+                identifier: col
+              keyword: COLLATE
+              collation: database_default
         from_clause:
           keyword: FROM
           from_expression:


### PR DESCRIPTION
### Brief summary of the change made

The main branch of SQLFluff currently parses collation names appearing in `COLLATE` expressions as column identifiers. For example, the following SQL ...

```
SELECT table1.col COLLATE Latin1_General_CI_AS
FROM table1;
```

... generates the following errors with dialect `tsql`:

```
L:   1 | P:  27 | L014 | Unquoted identifiers must be consistently lower case.                                                                      
L:   1 | P:  27 | L028 | Unqualified reference 'Latin1_General_CI_AS' found in
                       | single table select.
L:   1 | P:  27 | L028 | Unqualified reference 'Latin1_General_CI_AS' found in
                       | single table select which is inconsistent with previous
                       | references.
```

Instead, we want to parse the collation as dedicated identifier `"collation"`. This PR causes the above SQL query to be linted without errors.

### Are there any other side effects of this change that we should be aware of?

Probably not, but I did modify `Expression_A_Grammar`. Should be checked carefully.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
