### PR TITLE
L042: Address corner cases where fix corrupts the SQL

### DIFF
--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -120,7 +120,6 @@ class Rule_L042(BaseRule):
         if not nested_subqueries:
             return None
         # If there are offending elements calculate fixes
-
         return _calculate_fixes(
             dialect=context.dialect,
             root_select=segment,

--- a/test/fixtures/rules/std_rule_cases/L042.yml
+++ b/test/fixtures/rules/std_rule_cases/L042.yml
@@ -406,3 +406,19 @@ issue_3622_no_space_after_from:
     rules:
       L042:
         forbid_subquery_in: both
+
+issue_3617_parentheses_around_ctas_select:
+  fail_str: |
+    CREATE TABLE t
+    AS
+    (SELECT
+        Col1
+    FROM
+    (
+        SELECT 'x' AS COl1
+    ) x
+    )
+  configs:
+    rules:
+      L042:
+        forbid_subquery_in: both

--- a/test/fixtures/rules/std_rule_cases/L042.yml
+++ b/test/fixtures/rules/std_rule_cases/L042.yml
@@ -383,3 +383,26 @@ issue_3623_internal_error_multiple_templated_files:
     rules:
       L042:
         forbid_subquery_in: both
+
+issue_3622_no_space_after_from:
+  fail_str: |
+    CREATE TABLE t
+    AS
+    SELECT
+        col1
+    FROM(
+        SELECT 'x' AS col1
+    ) x
+  fix_str: |
+    CREATE TABLE t
+    AS
+    WITH x AS (
+        SELECT 'x' AS col1
+    )
+    SELECT
+        col1
+    FROM x
+  configs:
+    rules:
+      L042:
+        forbid_subquery_in: both


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3622, #3617
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
