### PR TITLE
L028, L032: Fix bug where fixes were copying templated table names

### DIFF
--- a/src/sqlfluff/rules/L028.py
+++ b/src/sqlfluff/rules/L028.py
@@ -154,7 +154,6 @@ def _check_references(
     col_alias_names: List[str] = [c.alias_identifier_name for c in col_aliases]
     table_ref_str: str = table_aliases[0].ref_str
     table_ref_str_source = table_aliases[0].segment
-    assert table_ref_str_source
     # Check all the references that we have.
     seen_ref_types: Set[str] = set()
     for ref in references:
@@ -204,7 +203,7 @@ def _validate_one_reference(
     this_ref_type: str,
     standalone_aliases: List[str],
     table_ref_str: str,
-    table_ref_str_source: BaseSegment,
+    table_ref_str_source: Optional[BaseSegment],
     col_alias_names: List[str],
     seen_ref_types: Set[str],
     fixable: bool,
@@ -257,7 +256,7 @@ def _validate_one_reference(
             fixes = [
                 LintFix.create_before(
                     ref.segments[0] if len(ref.segments) else ref,
-                    source=[table_ref_str_source],
+                    source=[table_ref_str_source] if table_ref_str_source else None,
                     edit_segments=[
                         CodeSegment(
                             raw=table_ref_str,

--- a/src/sqlfluff/rules/L028.py
+++ b/src/sqlfluff/rules/L028.py
@@ -153,6 +153,8 @@ def _check_references(
     # A buffer to keep any violations.
     col_alias_names: List[str] = [c.alias_identifier_name for c in col_aliases]
     table_ref_str: str = table_aliases[0].ref_str
+    table_ref_str_source = table_aliases[0].segment
+    assert table_ref_str_source
     # Check all the references that we have.
     seen_ref_types: Set[str] = set()
     for ref in references:
@@ -168,6 +170,7 @@ def _check_references(
             this_ref_type,
             standalone_aliases,
             table_ref_str,
+            table_ref_str_source,
             col_alias_names,
             seen_ref_types,
             fixable,
@@ -201,6 +204,7 @@ def _validate_one_reference(
     this_ref_type: str,
     standalone_aliases: List[str],
     table_ref_str: str,
+    table_ref_str_source: BaseSegment,
     col_alias_names: List[str],
     seen_ref_types: Set[str],
     fixable: bool,
@@ -253,6 +257,7 @@ def _validate_one_reference(
             fixes = [
                 LintFix.create_before(
                     ref.segments[0] if len(ref.segments) else ref,
+                    source=[table_ref_str_source],
                     edit_segments=[
                         CodeSegment(
                             raw=table_ref_str,

--- a/src/sqlfluff/rules/L032.py
+++ b/src/sqlfluff/rules/L032.py
@@ -117,9 +117,12 @@ class Rule_L032(BaseRule):
             _extract_cols_from_using(segment, using_anchor),
         )
 
+        assert table_a.segment
+        assert table_b.segment
         fixes = [
             LintFix.create_before(
                 anchor_segment=insert_after_anchor,
+                source=[table_a.segment, table_b.segment],
                 edit_segments=edit_segments,
             ),
             *[LintFix.delete(seg) for seg in to_delete],

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -1139,8 +1139,9 @@ FROM {{ j }}{{ self.table_name() }}
             ],
         ),
         (
-            """{% call statement('variables', fetch_result=true) %}select 1 as test{% endcall %}
-""",
+            "{% call statement('variables', fetch_result=true) %}"
+            "select 1 as test"
+            "{% endcall %}\n",
             dict(
                 statement=_statement,
                 load_result=_load_result,

--- a/test/fixtures/rules/std_rule_cases/L028.yml
+++ b/test/fixtures/rules/std_rule_cases/L028.yml
@@ -303,3 +303,10 @@ passes_tql_table_variable:
     rules:
       L028:
         single_table_references: qualified
+
+fail_but_dont_fix_templated_table_name:
+  fail_str: |
+    SELECT
+        a,
+        {{ "foo" }}.b
+    FROM {{ "foo" }}

--- a/test/fixtures/rules/std_rule_cases/L028.yml
+++ b/test/fixtures/rules/std_rule_cases/L028.yml
@@ -293,7 +293,6 @@ test_pass_snowflake_flatten_function:
     core:
       dialect: snowflake
 
-
 passes_tql_table_variable:
   # Issue 3243
   pass_str: select a, b from @tablevar
@@ -304,9 +303,20 @@ passes_tql_table_variable:
       L028:
         single_table_references: qualified
 
-fail_but_dont_fix_templated_table_name:
+fail_but_dont_fix_templated_table_name_consistent:
   fail_str: |
     SELECT
         a,
         {{ "foo" }}.b
     FROM {{ "foo" }}
+
+fail_but_dont_fix_templated_table_name_qualified:
+  fail_str: |
+    SELECT
+        a,
+        {{ "foo" }}.b
+    FROM {{ "foo" }}
+  configs:
+    rules:
+      L028:
+        single_table_references: qualified

--- a/test/fixtures/rules/std_rule_cases/L032.yml
+++ b/test/fixtures/rules/std_rule_cases/L032.yml
@@ -56,3 +56,12 @@ test_fail_parent_child_positioning:
   fix_str: |
     select * from c1 join c2 ON c1.ID = c2.ID
     join (select * from c3 join c4 ON c3.ID = c4.ID) as c5 on c1.ID = c5.ID
+
+fail_but_dont_fix_templated_table_names:
+  fail_str: |
+    SELECT
+        {{ "table_a" }}.field_1,
+        table_b.field_2
+    FROM
+        {{ "table_a" }}
+    INNER JOIN table_b USING (id)


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes an issue raised on Slack where rules L028 and L032 autofix copy table names from one place in the code to another without setting the `source` field on `LintFix`. If those table names were templated, the fix would "untemplate" them at the fix destination.

With this PR, those lint issues will still be flagged, but no automatic fix will be applied.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
