### PR TITLE
Redshift: support expressions in array accessors

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2273,6 +2273,25 @@ class ObjectUnpivotSegment(BaseSegment):
     )
 
 
+class ArrayAccessorSegment(ansi.ArrayAccessorSegment):
+    """Array element accessor.
+
+    Redshift allows multiple levels of array access, like Postgres,
+    but it
+    * doesn't allow ranges like `myarray[1:2]`
+    * does allow function or column expressions `myarray[idx]`
+    """
+
+    match_grammar = Sequence(
+        AnyNumberOf(
+            Bracketed(
+                OneOf(Ref("NumericLiteralSegment"), Ref("ExpressionSegment")),
+                bracket_type="square",
+            )
+        )
+    )
+
+
 class ArrayUnnestSegment(BaseSegment):
     """Array unnesting.
 

--- a/test/fixtures/dialects/redshift/redshift_array_unnest.sql
+++ b/test/fixtures/dialects/redshift/redshift_array_unnest.sql
@@ -21,3 +21,10 @@ FROM example_data ed, ed.inventory AS value AT index;
 SELECT c_name, orders.o_orderkey AS orderkey, index AS orderkey_index
 FROM customer_orders_lineitem c, c.c_orders AS orders AT index
 ORDER BY orderkey_index;
+
+-- can extract the correlated values from multiple arrays using the index variable
+SELECT
+    value_a::BIGINT,
+    array_b[idx]::VARCHAR AS value_b,
+    array_c[MOD(idx, 3) + 1]::FLOAT8 AS value_c
+FROM mytable t, t.array_a AS value_a AT idx;

--- a/test/fixtures/dialects/redshift/redshift_array_unnest.yml
+++ b/test/fixtures/dialects/redshift/redshift_array_unnest.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b7f5d79f534ffa1f6d1714056692ab53e0ef871331e039467eef411283da0ba4
+_hash: fc389399c1b0cf7ccbac61f827b87fefa5253555592adea9ddada7f914944f2e
 file:
 - statement:
     with_compound_statement:
@@ -171,4 +171,87 @@ file:
       - keyword: BY
       - column_reference:
           identifier: orderkey_index
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+            column_reference:
+              identifier: value_a
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: BIGINT
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              identifier: array_b
+            array_accessor:
+              start_square_bracket: '['
+              expression:
+                column_reference:
+                  identifier: idx
+              end_square_bracket: ']'
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: VARCHAR
+          alias_expression:
+            keyword: AS
+            identifier: value_b
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              identifier: array_c
+            array_accessor:
+              start_square_bracket: '['
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: MOD
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        identifier: idx
+                  - comma: ','
+                  - expression:
+                      literal: '3'
+                  - end_bracket: )
+                binary_operator: +
+                literal: '1'
+              end_square_bracket: ']'
+            cast_expression:
+              casting_operator: '::'
+              data_type:
+                keyword: FLOAT8
+          alias_expression:
+            keyword: AS
+            identifier: value_c
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                identifier: mytable
+            alias_expression:
+              identifier: t
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              array_unnesting:
+              - object_reference:
+                - identifier: t
+                - dot: .
+                - identifier: array_a
+              - keyword: AS
+              - identifier: value_a
+              - keyword: AT
+              - identifier: idx
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Redshift currently uses the Postgres syntax for accessing array elements, but this appears to not be wholly correct.

* Postgres supports (but Redshift does not) range expressions like `myarray[1:3]`
* Redshift supports (I'm not certain whether Postgres does) expressions in the array index:

```sql
SELECT
   value_a,
   t.array_b[idx] AS value_b,
   t.array_c[MOD(idx, 2)] AS value_c
FROM mytable t, t.array_a AS value_a AT idx
```

This adds a dedicated `ArrayAccessorSegment` for Redshift and a corresponding test.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
