### PR TITLE
Add short versions of several cli options

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -205,6 +205,7 @@ def core_options(f: Callable) -> Callable:
     # that supports it
     if shell_completion_enabled:
         f = click.option(
+            "-d",
             "--dialect",
             default=None,
             help="The dialect of SQL to lint",
@@ -212,11 +213,13 @@ def core_options(f: Callable) -> Callable:
         )(f)
     else:  # pragma: no cover
         f = click.option(
+            "-d",
             "--dialect",
             default=None,
             help="The dialect of SQL to lint",
         )(f)
     f = click.option(
+        "-t",
         "--templater",
         default=None,
         help="The templater to use (default=jinja)",
@@ -230,6 +233,7 @@ def core_options(f: Callable) -> Callable:
         ),
     )(f)
     f = click.option(
+        "-r",
         "--rules",
         default=None,
         help=(
@@ -241,6 +245,7 @@ def core_options(f: Callable) -> Callable:
         ),
     )(f)
     f = click.option(
+        "-e",
         "--exclude-rules",
         default=None,
         help=(
@@ -284,6 +289,7 @@ def core_options(f: Callable) -> Callable:
         ),
     )(f)
     f = click.option(
+        "-i",
         "--ignore",
         default=None,
         help=(
@@ -673,7 +679,10 @@ def do_fixes(lnt, result, formatter=None, **kwargs):
     ),
 )
 @click.option(
-    "--fixed-suffix", default=None, help="An optional suffix to add to fixed files."
+    "-x",
+    "--fixed-suffix",
+    default=None,
+    help="An optional suffix to add to fixed files.",
 )
 @click.option(
     "-p",

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -289,7 +289,8 @@ def test__cli__command_lint_stdin(command):
                 "L051",
             ],
         ),
-        # Test basic linting with specific logger
+        # Test basic linting with specific logger.
+        # Also test short rule exclusion.
         (
             lint,
             [
@@ -298,7 +299,7 @@ def test__cli__command_lint_stdin(command):
                 "-vvv",
                 "--logger",
                 "parser",
-                "--exclude-rules",
+                "-e",
                 "L051",
             ],
         ),
@@ -311,7 +312,7 @@ def test__cli__command_lint_stdin(command):
                 "-n",
                 "test/fixtures/cli/passing_b.sql",
                 "-vvvvvvvvvvv",
-                "--exclude-rules",
+                "-e",
                 "L051",
             ],
         ),
@@ -658,7 +659,8 @@ def test__cli__command__fix(rule, fname):
             FROM my_schema.my_table
             where processdate {{ condition }}
             """,
-            ["--force", "--fixed-suffix", "FIXED", "--rules", "L010"],
+            # Test the short versions of the options.
+            ["--force", "-x", "FIXED", "-r", "L010"],
             None,
             1,
         ),
@@ -671,7 +673,8 @@ def test__cli__command__fix(rule, fname):
             FROM my_schema.my_table
             where processdate ! 3  -- noqa: PRS
             """,
-            ["--force", "--fixed-suffix", "FIXED", "--rules", "L010"],
+            # Test the short versions of the options.
+            ["--force", "-x", "FIXED", "-r", "L010"],
             None,
             1,
         ),
@@ -780,7 +783,9 @@ def test__cli__fix_error_handling_behavior(sql, fix_args, fixed, exit_code, tmpd
                 fix_args
                 + [
                     "-f",
-                    "--dialect=ansi",
+                    # Use the short dialect option
+                    "-d",
+                    "ansi",
                 ]
             )
         assert exit_code == e.value.code


### PR DESCRIPTION
This adds short options for many cli commands. I'm having to type too much during testing 😄 .

- `-d` for dialect
- `-t` for templater
- `-r` for rules
- `-e` for excluding rules
- `-i` for ignoring
- `-x` for fixed suffix

I've updated some of the pre existing tests to cover these cases.