### PR TITLE
SQLite: add parsing of INSERT statement

### DIFF
--- a/test/fixtures/dialects/sqlite/insert.sql
+++ b/test/fixtures/dialects/sqlite/insert.sql
@@ -1,0 +1,25 @@
+INSERT INTO t1 VALUES (1, 2, 3), (4, 5, 6);
+
+INSERT INTO t1 (a, b, c) VALUES (1, 2, 3), (4, 5, 6);
+
+INSERT OR ABORT INTO t1 (a, b, c) VALUES (1, 2, 3), (4, 5, 6);
+
+INSERT OR FAIL INTO t1 (a, b, c) VALUES (1, 2, 3), (4, 5, 6);
+
+INSERT OR IGNORE INTO t1 (a, b, c) VALUES (1, 2, 3), (4, 5, 6);
+
+INSERT OR REPLACE INTO t1 (a, b, c) VALUES (1, 2, 3), (4, 5, 6);
+
+REPLACE INTO t1 (a, b, c) VALUES (1, 2, 3), (4, 5, 6);
+
+INSERT OR ROLLBACK INTO t1 (a, b, c) VALUES (1, 2, 3), (4, 5, 6);
+
+INSERT INTO t1
+SELECT * FROM (SELECT
+    c,
+    c + d AS e
+    FROM t2) AS dt;
+
+INSERT INTO t1 DEFAULT VALUES;
+
+INSERT INTO t1 (a, b, c) DEFAULT VALUES;

--- a/test/fixtures/dialects/sqlite/insert.yml
+++ b/test/fixtures/dialects/sqlite/insert.yml
@@ -1,0 +1,428 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 5f028ef635cbb9c766ad3b82ae3dffb38d47f1bb204455cd04172af9cfd4d0cc
+file:
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - comma: ','
+        - expression:
+            numeric_literal: '3'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '4'
+        - comma: ','
+        - expression:
+            numeric_literal: '5'
+        - comma: ','
+        - expression:
+            numeric_literal: '6'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - comma: ','
+      - column_reference:
+          naked_identifier: c
+      - end_bracket: )
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - comma: ','
+        - expression:
+            numeric_literal: '3'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '4'
+        - comma: ','
+        - expression:
+            numeric_literal: '5'
+        - comma: ','
+        - expression:
+            numeric_literal: '6'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OR
+    - keyword: ABORT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - comma: ','
+      - column_reference:
+          naked_identifier: c
+      - end_bracket: )
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - comma: ','
+        - expression:
+            numeric_literal: '3'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '4'
+        - comma: ','
+        - expression:
+            numeric_literal: '5'
+        - comma: ','
+        - expression:
+            numeric_literal: '6'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OR
+    - keyword: FAIL
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - comma: ','
+      - column_reference:
+          naked_identifier: c
+      - end_bracket: )
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - comma: ','
+        - expression:
+            numeric_literal: '3'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '4'
+        - comma: ','
+        - expression:
+            numeric_literal: '5'
+        - comma: ','
+        - expression:
+            numeric_literal: '6'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OR
+    - keyword: IGNORE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - comma: ','
+      - column_reference:
+          naked_identifier: c
+      - end_bracket: )
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - comma: ','
+        - expression:
+            numeric_literal: '3'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '4'
+        - comma: ','
+        - expression:
+            numeric_literal: '5'
+        - comma: ','
+        - expression:
+            numeric_literal: '6'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - comma: ','
+      - column_reference:
+          naked_identifier: c
+      - end_bracket: )
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - comma: ','
+        - expression:
+            numeric_literal: '3'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '4'
+        - comma: ','
+        - expression:
+            numeric_literal: '5'
+        - comma: ','
+        - expression:
+            numeric_literal: '6'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: REPLACE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - comma: ','
+      - column_reference:
+          naked_identifier: c
+      - end_bracket: )
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - comma: ','
+        - expression:
+            numeric_literal: '3'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '4'
+        - comma: ','
+        - expression:
+            numeric_literal: '5'
+        - comma: ','
+        - expression:
+            numeric_literal: '6'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OR
+    - keyword: ROLLBACK
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - comma: ','
+      - column_reference:
+          naked_identifier: c
+      - end_bracket: )
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - comma: ','
+        - expression:
+            numeric_literal: '3'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '4'
+        - comma: ','
+        - expression:
+            numeric_literal: '5'
+        - comma: ','
+        - expression:
+            numeric_literal: '6'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                    - keyword: SELECT
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: c
+                    - comma: ','
+                    - select_clause_element:
+                        expression:
+                        - column_reference:
+                            naked_identifier: c
+                        - binary_operator: +
+                        - column_reference:
+                            naked_identifier: d
+                        alias_expression:
+                          keyword: AS
+                          naked_identifier: e
+                    from_clause:
+                      keyword: FROM
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                              naked_identifier: t2
+                  end_bracket: )
+              alias_expression:
+                keyword: AS
+                naked_identifier: dt
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - keyword: DEFAULT
+    - keyword: VALUES
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - comma: ','
+      - column_reference:
+          naked_identifier: c
+      - end_bracket: )
+    - keyword: DEFAULT
+    - keyword: VALUES
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Implementing most of the SQLite [INSERT](https://www.sqlite.org/lang_insert.html) statement parsing. This change aims to cover most common use cases at first.

For reference these parts are known to be missing:
* upsert & return clauses at the end of the statement
* the AS table alias (which is relevant for upsert only)
* the leading WITH ... case 

All of which could be part of future work.

Fixes #3733 

### Are there any other side effects of this change that we should be aware of?

Not that I can think of.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
