### PR TITLE
BigQuery: Fix parsing parameterized data types

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -200,7 +200,10 @@ bigquery_dialect.replace(
     SimpleArrayTypeGrammar=Sequence(
         "ARRAY",
         Bracketed(
-            Ref("DatatypeSegment"),
+            Sequence(
+                Ref("DatatypeSegment"),
+                Bracketed(Anything(), optional=True),  # For types like STRING(10)
+            ),
             bracket_type="angle",
             bracket_pairs_set="angle_bracket_pairs",
         ),
@@ -979,10 +982,18 @@ class StructTypeSegment(ansi.StructTypeSegment):
                         # ParameterNames can look like Datatypes so can't use
                         # Optional=True here and instead do a OneOf in order
                         # with DataType only first, followed by both.
-                        Ref("DatatypeSegment"),
+                        Sequence(
+                            Ref("DatatypeSegment"),
+                            Bracketed(
+                                Anything(), optional=True
+                            ),  # For types like STRING(10)
+                        ),
                         Sequence(
                             Ref("ParameterNameSegment"),
                             Ref("DatatypeSegment"),
+                            Bracketed(
+                                Anything(), optional=True
+                            ),  # For types like STRING(10)
                         ),
                     ),
                     Ref("OptionsSegment", optional=True),
@@ -1265,10 +1276,14 @@ class DeclareStatementSegment(BaseSegment):
         "DECLARE",
         Delimited(Ref("SingleIdentifierFullGrammar")),
         OneOf(
-            Ref("DatatypeSegment"),
+            Sequence(
+                Ref("DatatypeSegment"),
+                Bracketed(Anything(), optional=True),  # For types like STRING(10)
+            ),
             Ref("DefaultDeclareOptionsGrammar"),
             Sequence(
                 Ref("DatatypeSegment"),
+                Bracketed(Anything(), optional=True),  # For types like STRING(10)
                 Ref("DefaultDeclareOptionsGrammar"),
             ),
         ),

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -202,7 +202,7 @@ bigquery_dialect.replace(
         Bracketed(
             Sequence(
                 Ref("DatatypeSegment"),
-                Bracketed(Anything(), optional=True),  # For types like STRING(10)
+                Bracketed(Delimited(Ref("NumericLiteralSegment")), optional=True),
             ),
             bracket_type="angle",
             bracket_pairs_set="angle_bracket_pairs",
@@ -985,15 +985,15 @@ class StructTypeSegment(ansi.StructTypeSegment):
                         Sequence(
                             Ref("DatatypeSegment"),
                             Bracketed(
-                                Anything(), optional=True
-                            ),  # For types like STRING(10)
+                                Delimited(Ref("NumericLiteralSegment")), optional=True
+                            ),
                         ),
                         Sequence(
                             Ref("ParameterNameSegment"),
                             Ref("DatatypeSegment"),
                             Bracketed(
-                                Anything(), optional=True
-                            ),  # For types like STRING(10)
+                                Delimited(Ref("NumericLiteralSegment")), optional=True
+                            ),
                         ),
                     ),
                     Ref("OptionsSegment", optional=True),
@@ -1278,12 +1278,12 @@ class DeclareStatementSegment(BaseSegment):
         OneOf(
             Sequence(
                 Ref("DatatypeSegment"),
-                Bracketed(Anything(), optional=True),  # For types like STRING(10)
+                Bracketed(Delimited(Ref("NumericLiteralSegment")), optional=True),
             ),
             Ref("DefaultDeclareOptionsGrammar"),
             Sequence(
                 Ref("DatatypeSegment"),
-                Bracketed(Anything(), optional=True),  # For types like STRING(10)
+                Bracketed(Delimited(Ref("NumericLiteralSegment")), optional=True),
                 Ref("DefaultDeclareOptionsGrammar"),
             ),
         ),
@@ -1387,7 +1387,7 @@ class ColumnDefinitionSegment(ansi.ColumnDefinitionSegment):
     match_grammar: Matchable = Sequence(
         Ref("SingleIdentifierGrammar"),  # Column name
         Ref("DatatypeSegment"),  # Column type
-        Bracketed(Anything(), optional=True),  # For types like STRING(10)
+        Bracketed(Delimited(Ref("NumericLiteralSegment")), optional=True),
         AnyNumberOf(
             Ref("ColumnConstraintSegment", optional=True),
         ),

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1387,7 +1387,7 @@ class ColumnDefinitionSegment(ansi.ColumnDefinitionSegment):
     match_grammar: Matchable = Sequence(
         Ref("SingleIdentifierGrammar"),  # Column name
         Ref("DatatypeSegment"),  # Column type
-        Bracketed(Anything(), optional=True),  # For types like VARCHAR(100)
+        Bracketed(Anything(), optional=True),  # For types like STRING(10)
         AnyNumberOf(
             Ref("ColumnConstraintSegment", optional=True),
         ),

--- a/test/fixtures/dialects/bigquery/declare_variable.sql
+++ b/test/fixtures/dialects/bigquery/declare_variable.sql
@@ -3,6 +3,7 @@ declare var2, var3 string;
 declare var4 default 'value';
 declare var5 int64 default 1 + 2;
 declare var6 string(10);
+declare var7 numeric(5, 2);
 declare arr1 array<string>;
 declare arr2 default ['one', 'two'];
 declare arr3 default [];

--- a/test/fixtures/dialects/bigquery/declare_variable.sql
+++ b/test/fixtures/dialects/bigquery/declare_variable.sql
@@ -2,14 +2,17 @@ declare var1 int64;
 declare var2, var3 string;
 declare var4 default 'value';
 declare var5 int64 default 1 + 2;
+declare var6 string(10);
 declare arr1 array<string>;
 declare arr2 default ['one', 'two'];
 declare arr3 default [];
 declare arr4 array<string> default ['one', 'two'];
+declare arr5 array<string(10)>;
 declare str1 struct<f1 string, f2 string>;
 declare str2 struct<f1 string, f2 string> default struct('one', 'two');
 declare str3 default struct('one', 'two');
 declare str4 struct<f1 string, f2 string> default ('one', 'two');
+declare str5 struct<f1 string(10), f2 string(10)>;
 -- Defining variables in quoted names
 declare `var1` string;
 declare `var1` string default 'value';

--- a/test/fixtures/dialects/bigquery/declare_variable.yml
+++ b/test/fixtures/dialects/bigquery/declare_variable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e7c3d1f233e5041e5097f81128665af7895b563ccfcf6e247911f714db0b0c04
+_hash: 3b17e71de9db77f87edb67886d67c0b9f59f8697db4a00a860db090a6f2c797e
 file:
 - statement:
     declare_segment:
@@ -39,6 +39,17 @@ file:
       - numeric_literal: '1'
       - binary_operator: +
       - numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    declare_segment:
+      keyword: declare
+      naked_identifier: var6
+      data_type:
+        data_type_identifier: string
+      bracketed:
+        start_bracket: (
+        raw: '10'
+        end_bracket: )
 - statement_terminator: ;
 - statement:
     declare_segment:
@@ -89,6 +100,21 @@ file:
       - comma: ','
       - quoted_literal: "'two'"
       - end_square_bracket: ']'
+- statement_terminator: ;
+- statement:
+    declare_segment:
+      keyword: declare
+      naked_identifier: arr5
+      data_type:
+        keyword: array
+        start_angle_bracket: <
+        data_type:
+          data_type_identifier: string
+        bracketed:
+          start_bracket: (
+          raw: '10'
+          end_bracket: )
+        end_angle_bracket: '>'
 - statement_terminator: ;
 - statement:
     declare_segment:
@@ -173,6 +199,31 @@ file:
         - comma: ','
         - quoted_literal: "'two'"
         - end_bracket: )
+- statement_terminator: ;
+- statement:
+    declare_segment:
+      keyword: declare
+      naked_identifier: str5
+      data_type:
+        struct_type:
+        - keyword: struct
+        - start_angle_bracket: <
+        - parameter: f1
+        - data_type:
+            data_type_identifier: string
+        - bracketed:
+            start_bracket: (
+            raw: '10'
+            end_bracket: )
+        - comma: ','
+        - parameter: f2
+        - data_type:
+            data_type_identifier: string
+        - bracketed:
+            start_bracket: (
+            raw: '10'
+            end_bracket: )
+        - end_angle_bracket: '>'
 - statement_terminator: ;
 - statement:
     declare_segment:

--- a/test/fixtures/dialects/bigquery/declare_variable.yml
+++ b/test/fixtures/dialects/bigquery/declare_variable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3f8dd62bbc3aa635110e8d2a40c829daf27d53b2a9cde8bcc410f08249d4619d
+_hash: a7344a57c0e59ce697ccfabc4e78ada5ea7a5f53123ec3a8839bca556863d42d
 file:
 - statement:
     declare_segment:
@@ -46,10 +46,10 @@ file:
       naked_identifier: var6
       data_type:
         data_type_identifier: string
-      bracketed:
-        start_bracket: (
-        numeric_literal: '10'
-        end_bracket: )
+        bracketed:
+          start_bracket: (
+          numeric_literal: '10'
+          end_bracket: )
 - statement_terminator: ;
 - statement:
     declare_segment:
@@ -57,12 +57,12 @@ file:
       naked_identifier: var7
       data_type:
         data_type_identifier: numeric
-      bracketed:
-      - start_bracket: (
-      - numeric_literal: '5'
-      - comma: ','
-      - numeric_literal: '2'
-      - end_bracket: )
+        bracketed:
+        - start_bracket: (
+        - numeric_literal: '5'
+        - comma: ','
+        - numeric_literal: '2'
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     declare_segment:
@@ -123,10 +123,10 @@ file:
         start_angle_bracket: <
         data_type:
           data_type_identifier: string
-        bracketed:
-          start_bracket: (
-          numeric_literal: '10'
-          end_bracket: )
+          bracketed:
+            start_bracket: (
+            numeric_literal: '10'
+            end_bracket: )
         end_angle_bracket: '>'
 - statement_terminator: ;
 - statement:
@@ -224,18 +224,18 @@ file:
         - parameter: f1
         - data_type:
             data_type_identifier: string
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '10'
-            end_bracket: )
+            bracketed:
+              start_bracket: (
+              numeric_literal: '10'
+              end_bracket: )
         - comma: ','
         - parameter: f2
         - data_type:
             data_type_identifier: string
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '10'
-            end_bracket: )
+            bracketed:
+              start_bracket: (
+              numeric_literal: '10'
+              end_bracket: )
         - end_angle_bracket: '>'
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/bigquery/declare_variable.yml
+++ b/test/fixtures/dialects/bigquery/declare_variable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3b17e71de9db77f87edb67886d67c0b9f59f8697db4a00a860db090a6f2c797e
+_hash: 3f8dd62bbc3aa635110e8d2a40c829daf27d53b2a9cde8bcc410f08249d4619d
 file:
 - statement:
     declare_segment:
@@ -48,8 +48,21 @@ file:
         data_type_identifier: string
       bracketed:
         start_bracket: (
-        raw: '10'
+        numeric_literal: '10'
         end_bracket: )
+- statement_terminator: ;
+- statement:
+    declare_segment:
+      keyword: declare
+      naked_identifier: var7
+      data_type:
+        data_type_identifier: numeric
+      bracketed:
+      - start_bracket: (
+      - numeric_literal: '5'
+      - comma: ','
+      - numeric_literal: '2'
+      - end_bracket: )
 - statement_terminator: ;
 - statement:
     declare_segment:
@@ -112,7 +125,7 @@ file:
           data_type_identifier: string
         bracketed:
           start_bracket: (
-          raw: '10'
+          numeric_literal: '10'
           end_bracket: )
         end_angle_bracket: '>'
 - statement_terminator: ;
@@ -213,7 +226,7 @@ file:
             data_type_identifier: string
         - bracketed:
             start_bracket: (
-            raw: '10'
+            numeric_literal: '10'
             end_bracket: )
         - comma: ','
         - parameter: f2
@@ -221,7 +234,7 @@ file:
             data_type_identifier: string
         - bracketed:
             start_bracket: (
-            raw: '10'
+            numeric_literal: '10'
             end_bracket: )
         - end_angle_bracket: '>'
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Support parameterized data types (https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types?hl=en#parameterized_data_types)

Fixes #3663

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
