### PR TITLE
Add current_timestamp to Redshift as a bare function

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -45,7 +45,9 @@ redshift_dialect.sets("reserved_keywords").update(
 )
 
 redshift_dialect.sets("bare_functions").clear()
-redshift_dialect.sets("bare_functions").update(["current_date", "sysdate"])
+redshift_dialect.sets("bare_functions").update(
+    ["current_date", "sysdate", "current_timestamp"]
+)
 
 redshift_dialect.sets("date_part_function_name").update(
     ["DATEADD", "DATEDIFF", "EXTRACT", "DATE_PART"]

--- a/test/fixtures/dialects/redshift/select_datetime_functions.sql
+++ b/test/fixtures/dialects/redshift/select_datetime_functions.sql
@@ -1,8 +1,8 @@
 SELECT current_date;
 
-SELECT current_timestamp;
-
 SELECT sysdate;
+
+SELECT current_timestamp;
 
 SELECT TRUNC(sysdate);
 

--- a/test/fixtures/dialects/redshift/select_datetime_functions.sql
+++ b/test/fixtures/dialects/redshift/select_datetime_functions.sql
@@ -1,5 +1,7 @@
 SELECT current_date;
 
+SELECT current_timestamp;
+
 SELECT sysdate;
 
 SELECT TRUNC(sysdate);

--- a/test/fixtures/dialects/redshift/select_datetime_functions.yml
+++ b/test/fixtures/dialects/redshift/select_datetime_functions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6516297807ea02447c003c12cfdba79eb76ffd1aafcd4f953bb361f79a5acd8d
+_hash: e2fb45ad50ee67a3ad026619a49cf9ac3890391165e70da50840e88a8c5c1c1f
 file:
 - statement:
     select_statement:
@@ -11,6 +11,13 @@ file:
         keyword: SELECT
         select_clause_element:
           bare_function: current_date
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          bare_function: current_timestamp
 - statement_terminator: ;
 - statement:
     select_statement:

--- a/test/fixtures/dialects/redshift/select_datetime_functions.yml
+++ b/test/fixtures/dialects/redshift/select_datetime_functions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e2fb45ad50ee67a3ad026619a49cf9ac3890391165e70da50840e88a8c5c1c1f
+_hash: 0edddefa88485c2eef616da694d0bdf265eac65a122823622dc8b26f3a003e96
 file:
 - statement:
     select_statement:
@@ -17,14 +17,14 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          bare_function: current_timestamp
+          bare_function: sysdate
 - statement_terminator: ;
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          bare_function: sysdate
+          bare_function: current_timestamp
 - statement_terminator: ;
 - statement:
     select_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This PR is to allow current_timestamp without parenthesis in Redshift. 
Fixes #3573

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
