### PR TITLE
Fix bug where undefined Jinja variable in macro file crashes linter

### DIFF
--- a/test/fixtures/linter/autofix/ansi/macro_file_jinja_include_undefined_variable/.sqlfluff
+++ b/test/fixtures/linter/autofix/ansi/macro_file_jinja_include_undefined_variable/.sqlfluff
@@ -1,0 +1,5 @@
+[sqlfluff]
+dialect = ansi
+
+[sqlfluff:templater:jinja]
+load_macros_from_path = test/fixtures/linter/autofix/ansi/macro_file_jinja_include_undefined_variable/macros

--- a/test/fixtures/linter/autofix/ansi/macro_file_jinja_include_undefined_variable/after.sql
+++ b/test/fixtures/linter/autofix/ansi/macro_file_jinja_include_undefined_variable/after.sql
@@ -1,0 +1,2 @@
+SELECT id
+FROM records

--- a/test/fixtures/linter/autofix/ansi/macro_file_jinja_include_undefined_variable/before.sql
+++ b/test/fixtures/linter/autofix/ansi/macro_file_jinja_include_undefined_variable/before.sql
@@ -1,0 +1,3 @@
+SELECT
+id
+FROM records

--- a/test/fixtures/linter/autofix/ansi/macro_file_jinja_include_undefined_variable/macros/utils.sql
+++ b/test/fixtures/linter/autofix/ansi/macro_file_jinja_include_undefined_variable/macros/utils.sql
@@ -1,0 +1,1 @@
+{% include sql_file %}

--- a/test/fixtures/linter/autofix/ansi/macro_file_jinja_include_undefined_variable/test-config.yml
+++ b/test/fixtures/linter/autofix/ansi/macro_file_jinja_include_undefined_variable/test-config.yml
@@ -1,0 +1,3 @@
+test-config:
+  rules:
+    - L036


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3738 
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
