### PR TITLE
Enhance L062 to ignore blocked words in comments

### DIFF
--- a/src/sqlfluff/rules/L062.py
+++ b/src/sqlfluff/rules/L062.py
@@ -65,6 +65,9 @@ class Rule_L062(BaseRule):
         if not self.blocked_words and not self.blocked_regex:
             return None
 
+        if context.segment.type == "comment":
+            return None
+
         # Get the ignore list configuration and cache it
         try:
             blocked_words_list = self.blocked_words_list

--- a/test/fixtures/rules/std_rule_cases/L062.yml
+++ b/test/fixtures/rules/std_rule_cases/L062.yml
@@ -133,3 +133,79 @@ test_fail_bigquery3:
     rules:
       L062:
         blocked_regex: (2022_06_01|2022_05_01)
+
+test_pass_comment_word1:
+  pass_str: |
+    SELECT *
+    FROM table1
+    -- TABLESAMPLE SYSTEM (.05 PERCENT)
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L062:
+        blocked_words: TABLESAMPLE
+
+test_pass_comment_word2:
+  pass_str: |
+    SELECT *
+    FROM table1
+    # TABLESAMPLE SYSTEM (.05 PERCENT)
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L062:
+        blocked_words: TABLESAMPLE
+
+test_pass_comment_word3:
+  pass_str: |
+    SELECT *
+    FROM table1
+    /*
+    TABLESAMPLE SYSTEM (.05 PERCENT)
+    */
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L062:
+        blocked_words: TABLESAMPLE
+
+test_pass_comment_regex1:
+  pass_str: |
+    SELECT *
+    FROM table1
+    -- TABLESAMPLE SYSTEM (.05 PERCENT)
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L062:
+        blocked_regex: (TABLESAMPLE)
+
+test_pass_comment_regex2:
+  pass_str: |
+    SELECT *
+    FROM table1
+    # TABLESAMPLE SYSTEM (.05 PERCENT)
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L062:
+        blocked_regex: (TABLESAMPLE)
+
+test_pass_comment_regex3:
+  pass_str: |
+    SELECT *
+    FROM table1
+    /*
+    TABLESAMPLE SYSTEM (.05 PERCENT)
+    */
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      L062:
+        blocked_regex: (TABLESAMPLE)


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
We shouldn't really block words in comments IMHO and since I wrote this rule, guess I should fix it 😉

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
