### PR TITLE
ReflowSequence 1: Scope + Respacing

### DIFF
--- a/src/sqlfluff/rules/L006.py
+++ b/src/sqlfluff/rules/L006.py
@@ -1,13 +1,12 @@
 """Implementation of Rule L006."""
 
 
-from typing import Tuple, List
+from typing import List
 
 from sqlfluff.core.rules import (
     BaseRule,
     LintResult,
     RuleContext,
-    EvalResultType,
 )
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
@@ -43,17 +42,8 @@ class Rule_L006(BaseRule):
 
     groups = ("all", "core")
     crawl_behaviour = SegmentSeekerCrawler({"binary_operator", "comparison_operator"})
-    # L006 works on operators so requires three operators.
-    # However some rules that inherit from here (e.g. L048) do not.
-    # So allow this to be configurable.
-    _require_three_children: bool = True
 
-    _target_elems: List[Tuple[str, str]] = [
-        ("type", "binary_operator"),
-        ("type", "comparison_operator"),
-    ]
-
-    def _eval(self, context: RuleContext) -> EvalResultType:
+    def _eval(self, context: RuleContext) -> List[LintResult]:
         """Operators should be surrounded by a single whitespace.
 
         Rewritten to assess direct children of a segment to make

--- a/src/sqlfluff/rules/L006.py
+++ b/src/sqlfluff/rules/L006.py
@@ -3,17 +3,15 @@
 
 from typing import Tuple, List
 
-from sqlfluff.core.parser import WhitespaceSegment
-
 from sqlfluff.core.rules import (
     BaseRule,
     LintResult,
-    LintFix,
     RuleContext,
     EvalResultType,
 )
-from sqlfluff.core.rules.crawlers import ParentOfSegmentCrawler
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
+from sqlfluff.utils.reflow.classes import ReflowSequence
 
 
 @document_groups
@@ -44,7 +42,7 @@ class Rule_L006(BaseRule):
     """
 
     groups = ("all", "core")
-    crawl_behaviour = ParentOfSegmentCrawler({"binary_operator", "comparison_operator"})
+    crawl_behaviour = SegmentSeekerCrawler({"binary_operator", "comparison_operator"})
     # L006 works on operators so requires three operators.
     # However some rules that inherit from here (e.g. L048) do not.
     # So allow this to be configurable.
@@ -54,42 +52,6 @@ class Rule_L006(BaseRule):
         ("type", "binary_operator"),
         ("type", "comparison_operator"),
     ]
-
-    @staticmethod
-    def _missing_whitespace(seg, before=True):
-        """Check whether we're missing whitespace given an adjoining segment."""
-        # There is a segment
-        if not seg:
-            return False
-        # And it's not whitespace
-        if seg.is_whitespace:
-            return False
-        # And it's not an opening/closing bracket
-        seg_type = seg.get_type()
-        if seg_type.endswith("_bracket"):
-            if seg_type.startswith("start_" if before else "end_"):
-                return False
-        if seg.is_meta:  # pragma: no cover
-            if before:
-                if seg.source_str.endswith(" ") or seg.source_str.endswith("\n"):
-                    return False
-            else:
-                if seg.source_str.startswith(" ") or seg.source_str.startswith("\n"):
-                    return False
-        return True
-
-    @staticmethod
-    def _find_segment(idx, segments, before=True):
-        """Go back or forward to find the next relevant segment."""
-        step = -1 if before else 1
-        j = idx + step
-        while (j >= 0) if before else (j < len(segments)):
-            # Don't trigger on indents, but placeholders are allowed.
-            if segments[j].is_type("indent"):
-                j += step
-            else:
-                return segments[j]
-        return None
 
     def _eval(self, context: RuleContext) -> EvalResultType:
         """Operators should be surrounded by a single whitespace.
@@ -110,109 +72,46 @@ class Rule_L006(BaseRule):
         # be dealt with by the parent segment. That also means that we need
         # to have at least three children.
 
-        if self._require_three_children and len(context.segment.segments) <= 2:
-            return LintResult()  # pragma: no cover
+        # Operators can be either a single raw segment or multiple, and
+        # a significant number of them are multiple (thanks TSQL). While
+        # we could provide an alternative route for single raws, this is
+        # implemented to separately look before, and after. In the single
+        # raw case - they'll be targetting the same segment, and potentially
+        # waste some processing overhead, but this makes the code simpler.
 
         violations = []
 
-        for idx, sub_seg in enumerate(context.segment.segments):
-            check_before = False
-            check_after = False
-            before_anchor = sub_seg
-            after_anchor = sub_seg
-            # Skip anything which is whitespace
-            if sub_seg.is_whitespace:
-                continue
-            # Skip any non-code elements
-            if not sub_seg.is_code:
-                continue
+        anchors = (
+            # First look for issues before.
+            ("before", context.segment.raw_segments[0]),
+            # Then look for issues after.
+            ("after", context.segment.raw_segments[-1]),
+        )
 
-            # Is it a target in itself?
-            if self.matches_target_tuples(sub_seg, self._target_elems):
-                self.logger.debug(
-                    "Found Target [main] @%s: %r", sub_seg.pos_marker, sub_seg.raw
+        for side, anchor in anchors:
+            raw = context.segment.raw_segments[0]
+            fixes = (
+                ReflowSequence.from_around_target(
+                    raw, context.parent_stack[0], sides=side
                 )
-                check_before = True
-                check_after = True
-            # Is it a compound segment ending or starting with the target?
-            elif sub_seg.segments:
-                # Get first and last raw segments.
-                raw_list = list(sub_seg.get_raw_segments())
-                if len(raw_list) > 1:
-                    leading = raw_list[0]
-                    trailing = raw_list[-1]
-                    if self.matches_target_tuples(leading, self._target_elems):
-                        before_anchor = leading  # pragma: no cover
-                        self.logger.debug(  # pragma: no cover
-                            "Found Target [leading] @%s: %r",
-                            before_anchor.pos_marker,
-                            before_anchor.raw,
-                        )
-                        check_before = True  # pragma: no cover
-                    if self.matches_target_tuples(trailing, self._target_elems):
-                        after_anchor = trailing  # pragma: no cover
-                        self.logger.debug(  # pragma: no cover
-                            "Found Target [trailing] @%s: %r",
-                            after_anchor.pos_marker,
-                            after_anchor.raw,
-                        )
-                        check_after = True  # pragma: no cover
+                .respace()
+                .get_fixes()
+            )
+            # Filter for only creations, because edits are handled as excess
+            # whitespace in a different rule.
+            fixes = [
+                fix
+                for fix in fixes
+                if fix.edit_type in ("create_before", "create_after")
+            ]
 
-            if check_before:
-                prev_seg = self._find_segment(
-                    idx, context.segment.segments, before=True
+            if fixes:
+                violations.append(
+                    LintResult(
+                        context.segment,
+                        fixes=fixes,
+                        description=f"Missing whitespace {side} {raw.raw}",
+                    )
                 )
-                if self._missing_whitespace(prev_seg, before=True):
-                    self.logger.debug(
-                        "Missing Whitespace Before %r. Found %r instead.",
-                        before_anchor.raw,
-                        prev_seg.raw,
-                    )
-                    violations.append(
-                        LintResult(
-                            anchor=before_anchor,
-                            description="Missing whitespace before {}".format(
-                                before_anchor.raw
-                            ),
-                            fixes=[
-                                LintFix.create_before(
-                                    # NB the anchor here is always in the parent and not
-                                    # anchor
-                                    anchor_segment=sub_seg,
-                                    edit_segments=[WhitespaceSegment(raw=" ")],
-                                )
-                            ],
-                        )
-                    )
 
-            if check_after:
-                next_seg = self._find_segment(
-                    idx, context.segment.segments, before=False
-                )
-                if self._missing_whitespace(next_seg, before=False):
-                    self.logger.debug(
-                        "Missing Whitespace After %r. Found %r instead.",
-                        after_anchor.raw,
-                        next_seg.raw,
-                    )
-                    violations.append(
-                        LintResult(
-                            anchor=after_anchor,
-                            description="Missing whitespace after {}".format(
-                                after_anchor.raw
-                            ),
-                            fixes=[
-                                LintFix.create_before(
-                                    # NB the anchor here is always in the parent and not
-                                    # anchor
-                                    anchor_segment=next_seg,
-                                    edit_segments=[WhitespaceSegment(raw=" ")],
-                                )
-                            ],
-                        )
-                    )
-
-        if violations:
-            return violations
-
-        return LintResult()
+        return violations

--- a/src/sqlfluff/rules/L011.py
+++ b/src/sqlfluff/rules/L011.py
@@ -1,9 +1,7 @@
 """Implementation of Rule L011."""
-from multiprocessing.sharedctypes import Value
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 from sqlfluff.core.parser import (
-    WhitespaceSegment,
     KeywordSegment,
 )
 
@@ -66,7 +64,6 @@ class Rule_L011(BaseRule):
         # Config type hints
         self.aliasing: str
         fixes = []
-        raw_segment_pre = context.raw_stack[-1] if context.raw_stack else None
 
         assert context.segment.is_type("alias_expression")
         if self.matches_target_tuples(context.parent_stack[-1], self._target_elems):

--- a/src/sqlfluff/rules/L011.py
+++ b/src/sqlfluff/rules/L011.py
@@ -70,6 +70,7 @@ class Rule_L011(BaseRule):
             if any(e.raw_upper == "AS" for e in context.segment.segments):
                 if self.aliasing == "implicit":
                     if context.segment.segments[0].raw_upper == "AS":
+                        self.logger.debug("Removing AS keyword and respacing.")
                         as_keyword = context.segment.segments[0]
                         # Remove the AS as we're using implicit aliasing
                         fixes.append(LintFix.delete(as_keyword))
@@ -85,6 +86,7 @@ class Rule_L011(BaseRule):
                         return LintResult(anchor=as_keyword, fixes=fixes)
 
             elif self.aliasing != "implicit":
+                self.logger.debug("Inserting AS keyword and respacing.")
                 as_keyword = KeywordSegment("AS")
                 # Add the fix for adding the keyword.
                 # NOTE: It's important that this one comes first because
@@ -100,7 +102,10 @@ class Rule_L011(BaseRule):
                 # NOTE: respace may mutate existing fixes, hence assignment
                 fixes = (
                     ReflowSequence.from_around_target(
-                        context.segment.segments[0], context.parent_stack[0]
+                        context.segment.segments[0],
+                        context.parent_stack[0],
+                        # Only reflow before, otherwise we catch too much.
+                        sides="before",
                     )
                     .insert(
                         as_keyword, target=context.segment.segments[0], pos="before"

--- a/src/sqlfluff/rules/L048.py
+++ b/src/sqlfluff/rules/L048.py
@@ -1,6 +1,6 @@
 """Implementation of Rule L048."""
 
-from typing import Optional, Tuple, List
+from typing import List
 
 from sqlfluff.core.rules.base import BaseRule, LintResult
 from sqlfluff.core.rules.context import RuleContext

--- a/src/sqlfluff/rules/L048.py
+++ b/src/sqlfluff/rules/L048.py
@@ -1,17 +1,17 @@
 """Implementation of Rule L048."""
 
-from typing import Tuple, List
+from typing import Optional, Tuple, List
 
-from sqlfluff.core.parser import BaseSegment
-from sqlfluff.core.rules.crawlers import ParentOfSegmentCrawler
+from sqlfluff.core.rules.base import BaseRule, LintResult
+from sqlfluff.core.rules.context import RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
-
-from sqlfluff.rules.L006 import Rule_L006
+from sqlfluff.utils.reflow.classes import ReflowSequence
 
 
 @document_groups
 @document_fix_compatible
-class Rule_L048(Rule_L006):
+class Rule_L048(BaseRule):
     """Quoted literals should be surrounded by a single whitespace.
 
     **Anti-pattern**
@@ -38,33 +38,50 @@ class Rule_L048(Rule_L006):
     """
 
     groups = ("all", "core")
-    crawl_behaviour = ParentOfSegmentCrawler(
+    crawl_behaviour = SegmentSeekerCrawler(
         {"quoted_literal", "date_constructor_literal"}
     )
-    _require_three_children: bool = False
 
-    _target_elems: List[Tuple[str, str]] = [
-        ("type", "quoted_literal"),
-        ("type", "date_constructor_literal"),
-    ]
+    def _eval(self, context: RuleContext) -> List[LintResult]:
+        """Quoted literals should be surrounded by a single whitespace."""
+        fixes = (
+            ReflowSequence.from_around_target(context.segment, context.parent_stack[0])
+            .respace()
+            .get_fixes()
+        )
 
-    @staticmethod
-    def _missing_whitespace(seg: BaseSegment, before=True) -> bool:
-        """Check whether we're missing whitespace given an adjoining segment.
+        fixes = [
+            fix for fix in fixes if fix.edit_type in ("create_before", "create_after")
+        ]
 
-        This avoids flagging for commas after quoted strings.
-        https://github.com/sqlfluff/sqlfluff/issues/943
-        """
-        simple_res = Rule_L006._missing_whitespace(seg, before=before)
-        if (
-            not before
-            and seg
-            and (
-                seg.is_type("comma", "statement_terminator")
-                or (
-                    seg.is_type("cast_expression") and seg.get_child("casting_operator")
+        violations = []
+
+        for fix in fixes:
+            # Filter for only creations, because edits are handled as excess
+            # whitespace in a different rule.
+            if fix.edit_type not in ("create_before", "create_after"):
+                continue
+            # Is it a creation before
+            if fix.anchor.pos_marker < context.segment.pos_marker or (
+                fix.anchor == context.segment and fix.edit_type == "create_before"
+            ):
+                violations.append(
+                    LintResult(
+                        context.segment,
+                        fixes=[fix],
+                        description=f"Missing whitespace before {context.segment.raw}",
+                    )
                 )
-            )
-        ):
-            return False
-        return simple_res
+            # Is it a creation after
+            if fix.anchor.pos_marker > context.segment.pos_marker or (
+                fix.anchor == context.segment and fix.edit_type == "create_after"
+            ):
+                violations.append(
+                    LintResult(
+                        context.segment,
+                        fixes=[fix],
+                        description=f"Missing whitespace after {context.segment.raw}",
+                    )
+                )
+
+        return violations

--- a/src/sqlfluff/rules/L049.py
+++ b/src/sqlfluff/rules/L049.py
@@ -2,10 +2,11 @@
 from typing import List, Optional, Union
 
 from sqlfluff.core.parser import KeywordSegment, WhitespaceSegment
-from sqlfluff.core.rules import LintResult, LintFix, RuleContext
+from sqlfluff.core.rules import LintResult, RuleContext, BaseRule
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
-from sqlfluff.rules.L006 import Rule_L006
-from sqlfluff.utils.functional import sp, FunctionalContext
+from sqlfluff.utils.functional import sp, Segments
+from sqlfluff.utils.reflow.classes import ReflowSequence
 
 
 CorrectionListType = List[Union[WhitespaceSegment, KeywordSegment]]
@@ -13,7 +14,7 @@ CorrectionListType = List[Union[WhitespaceSegment, KeywordSegment]]
 
 @document_groups
 @document_fix_compatible
-class Rule_L049(Rule_L006):
+class Rule_L049(BaseRule):
     """Comparisons with NULL should use "IS" or "IS NOT".
 
     **Anti-pattern**
@@ -41,79 +42,60 @@ class Rule_L049(Rule_L006):
     """
 
     groups = ("all", "core")
-    # Inherit crawl behaviour from L006
+    crawl_behaviour = SegmentSeekerCrawler({"comparison_operator"})
 
-    def _eval(self, context: RuleContext) -> Optional[List[LintResult]]:
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Relational operators should not be used to check for NULL values."""
         # Context/motivation for this rule:
         # https://news.ycombinator.com/item?id=28772289
         # https://stackoverflow.com/questions/9581745/sql-is-null-and-null
-        if len(context.segment.segments) <= 2:
-            return None  # pragma: no cover
 
         # Allow assignments in SET clauses
-        if context.parent_stack and context.parent_stack[-1].is_type(
+        if context.parent_stack and context.parent_stack[-2].is_type(
             "set_clause_list", "execute_script_statement"
         ):
             return None
 
         # Allow assignments in EXEC clauses
-        if context.segment.is_type("set_clause_list", "execute_script_statement"):
+        if context.parent_stack and context.parent_stack[-1].is_type(
+            "set_clause_list", "execute_script_statement"
+        ):
             return None
 
-        segment = FunctionalContext(context).segment
-        # Iterate through children of this segment looking for equals or "not
-        # equals". Once found, check if the next code segment is a NULL literal.
-
-        children = segment.children()
-        operators = segment.children(sp.raw_is("=", "!=", "<>"))
-        if len(operators) == 0:
+        # We only care about equality operators.
+        if context.segment.raw not in ("=", "!=", "<>"):
             return None
-        self.logger.debug("Operators found: %s", operators)
 
-        results: List[LintResult] = []
-        # We may have many operators
-        for operator in operators:
-            self.logger.debug("Children found: %s", children)
-            after_op_list = children.select(start_seg=operator)
-            # If nothing comes after operator then skip
-            if not after_op_list:
-                continue  # pragma: no cover
-            null_literal = after_op_list.first(sp.is_code())
-            # if the next bit of code isnt a NULL then we are good
-            if not null_literal.all(sp.is_type("null_literal")):
-                continue
+        # We only care if it's followed by a null.
+        siblings = Segments(*context.parent_stack[-1].segments)
+        after_op_list = siblings.select(start_seg=context.segment)
+        next_code = after_op_list.first(sp.is_code())
 
-            sub_seg = null_literal.get()
-            assert sub_seg, "TypeGuard: Segment must exist"
-            self.logger.debug(
-                "Found NULL literal following equals/not equals @%s: %r",
-                sub_seg.pos_marker,
-                sub_seg.raw,
-            )
-            edit = _create_base_is_null_sequence(
-                is_upper=sub_seg.raw[0] == "N",
-                operator_raw=operator.raw,
-            )
-            prev_seg = after_op_list.first().get()
-            next_seg = children.select(stop_seg=operator).last().get()
-            if self._missing_whitespace(prev_seg, before=True):
-                whitespace_segment: CorrectionListType = [WhitespaceSegment()]
-                edit = whitespace_segment + edit
-            if self._missing_whitespace(next_seg, before=False):
-                edit = edit + [WhitespaceSegment()]
-            res = LintResult(
-                anchor=operator,
-                fixes=[
-                    LintFix.replace(
-                        operator,
-                        edit,
-                    )
-                ],
-            )
-            results.append(res)
+        if not next_code.all(sp.is_type("null_literal")):
+            return None
 
-        return results or None
+        sub_seg = next_code.get()
+        assert sub_seg, "TypeGuard: Segment must exist"
+        self.logger.debug(
+            "Found NULL literal following equals/not equals @%s: %r",
+            sub_seg.pos_marker,
+            sub_seg.raw,
+        )
+
+        edit = _create_base_is_null_sequence(
+            is_upper=sub_seg.raw[0] == "N",
+            operator_raw=context.segment.raw,
+        )
+
+        return LintResult(
+            anchor=context.segment,
+            fixes=ReflowSequence.from_around_target(
+                context.segment, context.parent_stack[0]
+            )
+            .replace(context.segment, edit)
+            .respace()
+            .get_fixes(),
+        )
 
 
 def _create_base_is_null_sequence(

--- a/src/sqlfluff/utils/functional/context.py
+++ b/src/sqlfluff/utils/functional/context.py
@@ -39,7 +39,7 @@ class FunctionalContext:
         )
 
     @property
-    def raw_stack(self) -> "Segments":
+    def raw_stack(self) -> "Segments":  # pragma: no cover
         """Returns a Segments object for context.raw_stack."""
         return Segments(
             *self.context.raw_stack, templated_file=self.context.templated_file

--- a/src/sqlfluff/utils/reflow/README.md
+++ b/src/sqlfluff/utils/reflow/README.md
@@ -95,7 +95,7 @@ Some rules add, remove or rearrange segments and need to do so in
 a way which is reflow aware.
 - In general, rules which only _remove_ segments as part of a fix
   should only readdress the _Spacing_ left in the gap. We should
-  not attempt to reflow and attempt to remove any _Line Breaks_
+  not attempt to reflow and not attempt to remove any _Line Breaks_
   which could now be possible due to the remaining shorter lines.
   - This should use the `.respace()` method.
 - For rules which _move_ an element (and not just a movement with

--- a/src/sqlfluff/utils/reflow/README.md
+++ b/src/sqlfluff/utils/reflow/README.md
@@ -1,0 +1,176 @@
+# Reflow Primer
+
+Several SQLFluff rules are concerned with layout and the placement
+of segments with respect to whitespace and newlines. This is reflow.
+
+The benefit of centralising reflow routines is that interdependencies
+can be resolved and duplicate code can be reduced.
+
+The challenge of centralising reflow routines is that separating out
+the functionality to allow rules to _selectively_ apply element of
+that logic without defaulting to a full reflow.
+
+In the interests of separating this out, there are a few distinct
+elements of reflow logic:
+1. _Indentation_. This is the most obvious one we think of. This
+   is concerned _only with the amount of leading whitespace at the_
+   _start of lines_.
+2. _Line Length_. This is concerned only with the total amount of
+   characters on a line (including the amount of leading whitespace).
+3. _Spacing_. This is concerned only with the amount of whitespace
+   between elements on a line.
+4. _Line Breaks_. This is concerned only with where line breaks are
+   introduced within sequences of segments (usually, but not
+   exclusively without reference to changes in indentation). This
+   would (as an example) include the enforcement of trailing or
+   leading commas.
+
+It follows that each of these elements has dependencies on each other:
+1. _Spacing_ will influence the _Line Length_.
+2. Changes in _Indentation_ will influence _Line Length_.
+3. Removal of _Line Breaks_ will influence _Line Length_ and may
+   necessitate changes in _Spacing_.
+4. Addition of _Line Breaks_ must take account of _Indentation_.
+5. Resolving excessing _Line Length_ usually requires changes to
+  _Line Breaks_ and potentially _Indentation_.
+
+## Application in rules
+
+### What is part of reflow and what is not?
+
+In general there are two phases to a reflow related rule:
+1. _Linting_ - working out whether there's an issue.
+2. _Fixing_ - resolving the issue.
+
+The intent is that _Fixing_ should always be in the reflow code.
+_Linting_ may or may not be in the reflow code and could also be
+encoded within the rule itself.
+
+### How to apply in a rule context
+
+When applying reflow in a rule context it makes sense to consider
+how widespread the impact we want to have is:
+- A rule designed around _Spacing_ may act in relative isolation,
+  but may also optionally need to resolve excessive _Line Length_.
+- A rule designed around _Indentation_ may act simply on it's own
+  but may also optionally need to resolve excessive _Line Length_.
+- A rule designed around the placement or presence of _Line Breaks_
+  will probably have to consider _Spacing_ (or at least decide
+  what spacing to impose at least for the moved elements) and if
+  introducing additional _Line Breaks_ it may need to account
+  for _Indentation_.
+- Resolving _Line Length_ will involve introducing additional
+  _Line Breaks_ (assuming that _Spacing_ has already been covered).
+
+As a rule of thumb:
+- If it's a rule about _Spacing_ it should only care about that
+  in full knowledge that it may make lines too long. Unless the
+  user has _also_ enabled long line checking, this is fine.
+- If it's a rule about _Indentation_ we should also not check
+  line length (for the same reasons).
+- If it's a rule about _Line Breaks_ in relation to other segments
+  (e.g. around commas or operators), we should aim to keep the
+  existing _Indentation_ and not reset that or consider any
+  _Line Length_ issues. We **should** consider _Spacing_, but
+  only around the elements moved (e.g. if we're shifting a trailing
+  comma to be a leading one, then we should also correct it's spacing
+  at the same time).
+- If it's a rule about _Line Length_ we will also need to consider
+  _Indentation_ and _Line Breaks_.
+
+### How to apply in a file reflow context
+
+When reflowing a whole file we have a few considerations:
+- Ideally we have all of the compulsory _Line Breaks_ and as few
+  others as possible without going over our maximum _Line Length_,
+  assuming correct _Indentation_ and _Spacing_.
+- If additional _Line Breaks_ are required, we add them at the
+  higher levels in the parse tree first before adding them deeper.
+
+Therefore the order of operations should be:
+1. Coerce the entire file to compulsory _Line Breaks_ **only**.
+   i.e. Strip all non-compulsory ones, add in any missing
+   compulsory ones.
+2. Fix _Spacing_.
+3. Fix _Indentation_.
+4. Evaluate _Line Length_.
+   a. If any lines are found too long. Add the next most appropriate
+      _Line Break_ which shortens the offending line. Once added,
+      re-fix _Indentation_ for the affected lines **only** (we should
+      assume that if all we have done is add _Line Breaks_, i.e.
+      convert `whitespace` to `newline`, that _Spacing_ should have
+      no issues). Repeat step 4.
+   b. If no lines are found too long, then we're good!
+
+## Implications for configuration
+
+To be able to both reflow whole files with knowledge of appropriate
+_Spacing_ and _Line Breaks_, while also being able to lint effectively
+in a rules context - we need to have a common way of defining what
+our intended setup should be. On a very simple level, the understanding
+that commas usually have whitespace after them, but not before, or that
+bracket characters usually have whitespace outside them but not directly
+inside them. On a more complex level, that we might want to configure
+the precedence of operators in evaluating where to insert _Line Breaks_
+in a long arithmetic expression. This naturally includes the
+choice of whether to use trailing or leading commas.
+
+The default configuration is that elements should be surrounded by a
+single whitespace with no particular requirement around newlines.
+
+All other configuration is a deviation from that default. Configuration
+could live in two places:
+1. On the segment definition in the dialect. This is a very helpful
+   central place - and fits with the current location for indentation.
+2. In a config file, either the central one (`.sqlfluff`), or a config
+   file just for this purpose.
+
+Given user requirements to be able to configure at least comma placement
+the config file approach seems the most suitable - as it allows sensible
+inheritance and deviation from a default spacing configuration.
+
+### More specifically...
+
+The configuration section as as `1.3.0` for indentation looks like this:
+
+```ini
+[sqlfluff:indentation]
+# See https://docs.sqlfluff.com/en/stable/indentation.html
+indented_joins = False
+indented_ctes = False
+indented_using_on = True
+indented_on_contents = True
+template_blocks_indent = True
+```
+
+I suggest that we introduce a new `layout` section of the config which has
+roughly the following structure:
+
+```ini
+[sqlfluff:layout:type:comma]
+spacing_before = False
+line_break_relation = after  # default to trailing commas. For leading, specify "before"
+
+[sqlfluff:layout:type:function_name]
+spacing_after = False
+
+[sqlfluff:layout:type:binary_operator]
+line_break_relation = before  # default to operators at the start of lines, and not at the end
+
+[sqlfluff:layout:type:start_bracket]
+spacing_after = False
+
+[sqlfluff:layout:type:end_bracket]
+spacing_before = False
+
+[sqlfluff:layout:type:start_square_bracket]
+spacing_after = False
+
+[sqlfluff:layout:type:end_square_bracket]
+spacing_before = False
+
+...
+```
+
+For now _Indentation_ control will stay where it is, but with _Spacing_ and
+_Line Break_ control in new `layout` sections.

--- a/src/sqlfluff/utils/reflow/README.md
+++ b/src/sqlfluff/utils/reflow/README.md
@@ -18,7 +18,8 @@ elements of reflow logic:
 2. _Line Length_. This is concerned only with the total amount of
    characters on a line (including the amount of leading whitespace).
 3. _Spacing_. This is concerned only with the amount of whitespace
-   between elements on a line.
+   between elements on a line. **NB:** trailing whitespace is in
+   this understanding, a special case of _Spacing_.
 4. _Line Breaks_. This is concerned only with where line breaks are
    introduced within sequences of segments (usually, but not
    exclusively without reference to changes in indentation). This

--- a/src/sqlfluff/utils/reflow/__init__.py
+++ b/src/sqlfluff/utils/reflow/__init__.py
@@ -1,0 +1,1 @@
+"""Reflow utilities for sqlfluff rules."""

--- a/src/sqlfluff/utils/reflow/classes.py
+++ b/src/sqlfluff/utils/reflow/classes.py
@@ -250,32 +250,6 @@ class ReflowPoint(_ReflowElement):
         reflow_logger.debug("New fixes: %s", new_fixes)
         return (fixes or []) + new_fixes
 
-    def trailing_whitespace_fixes(self) -> List[LintFix]:
-        """Fix any trailing whitespace detected.
-
-        Trailing whitespace is unique in that it can be detected
-        solely within the reflow point. It is any whitespace
-        preceeding a newline.
-        """
-        # NOTE: We will need an end_of_file marker to do file ends.
-        reflow_logger.debug("TW: Checking %s", self)
-        if not self.class_types.intersection({"newline", "end_of_file"}):
-            return []
-        fixes = []
-        for idx, seg in enumerate(self.segments):
-            if not (
-                seg.is_type("newline", "end_of_file")
-                and idx > 0
-                and self.segments[idx - 1].is_type("whitespace")
-            ):
-                continue
-            # NOTE: If there's a loop marker in the way, then this
-            # won't trigger. That way we avoid flagging in templated
-            # use cases where it's actually a loop.
-            fixes.append(LintFix("delete", self.segments[idx - 1]))
-            reflow_logger.debug("    !! TW: TRAILING WHITESPACE")
-        return fixes
-
 
 @dataclass
 class ReflowSequence:

--- a/src/sqlfluff/utils/reflow/classes.py
+++ b/src/sqlfluff/utils/reflow/classes.py
@@ -1,0 +1,268 @@
+"""Dataclasses for reflow work."""
+
+
+from itertools import chain
+import logging
+from dataclasses import dataclass
+from typing import List, Sequence, Union, Type
+
+from sqlfluff.core.parser import BaseSegment, RawSegment
+from sqlfluff.core.rules.base import LintFix
+
+
+reflow_logger = logging.getLogger("sqlfluff.utils.reflow")
+
+
+@dataclass
+class _ReflowElement:
+    """Base reflow element class."""
+
+    segments: Sequence[RawSegment]
+    root_segment: BaseSegment
+
+    @property
+    def class_types(self):
+        """The set of contained class types.
+
+        Parallel to BaseSegment.class_types
+        """
+        return set(chain.from_iterable(seg.class_types for seg in self.segments))
+
+
+@dataclass
+class ReflowBlock(_ReflowElement):
+    """Class for keeping track of elements to reflow.
+
+    It holds segments to reflow and also exposes configuration
+    around how they are expected to reflow around others.
+
+    The attributes exposed are designed to be "post configuration"
+    i.e. they should reflect configuration appropriately.
+
+    NOTE: These are the smallest unit of "work" within
+    the reflow methods, and may contain meta segments.
+    """
+
+    # Options for spacing rules are:
+    # - single: the default (one single space)
+    # - close: no whitespace
+    before: str = "single"
+    after: str = "single"
+
+    def __post_init__(self):
+        """Infer spacing behaviour post-init."""
+        # NOTE: This should probably be configured differently in
+        # future, but this works initially. Delegating spacing
+        # configuration to the dialect or an explicit config
+        # are the two most likely options.
+        # TODO: This is not covered in tests yet, it's prep for later.
+        if {"start_bracket"} in self.class_types:
+            self.after = "close"  # pragma: no cover
+        elif {"end_bracket"} in self.class_types:
+            self.before = "close"  # pragma: no cover
+
+
+@dataclass
+class ReflowPoint(_ReflowElement):
+    """Class for keeping track of editable elements in reflow.
+
+    It holds segments which can be changed during a reflow operation
+    such as whitespace and newlines.
+
+    It holds no configuration and is influenced by the blocks either
+    side.
+    """
+
+    def trailing_whitespace_fixes(self) -> List[LintFix]:
+        """Fix any trailing whitespace detected.
+
+        Trailing whitespace is unique in that it can be detected
+        solely within the reflow point. It is any whitespace
+        preceeding a newline.
+        """
+        # NOTE: We will need an end_of_file marker to do file ends.
+        reflow_logger.debug("TW: Checking %s", self)
+        if not self.class_types.intersection({"newline", "end_of_file"}):
+            return []
+        fixes = []
+        for idx, seg in enumerate(self.segments):
+            if not (
+                seg.is_type("newline", "end_of_file")
+                and idx > 0
+                and self.segments[idx - 1].is_type("whitespace")
+            ):
+                continue
+            # NOTE: If there's a loop marker in the way, then this
+            # won't trigger. That way we avoid flagging in templated
+            # use cases where it's actually a loop.
+            fixes.append(LintFix("delete", self.segments[idx - 1]))
+            reflow_logger.debug("    !! TW: TRAILING WHITESPACE")
+        return fixes
+
+
+@dataclass
+class ReflowSequence:
+    """Class for keeping track of elements in a reflow operation.
+
+    It is assumed that there will be alternating blocks and points
+    (even if some points have no segments). This is validated on
+    construction.
+
+    We assume points on each end because this is the case with a file.
+    """
+
+    elements: Sequence[_ReflowElement]
+    root_segment: BaseSegment
+
+    def __post_init__(self):
+        """Validate integrity."""
+        self._validate_reflow_sequence(self.elements, self.root_segment)
+
+    @staticmethod
+    def _validate_reflow_sequence(
+        elements: Sequence[_ReflowElement], root_segment: BaseSegment
+    ):
+        assert elements, "ReflowSequence has empty elements."
+        # Check root segment is shared
+        assert all(
+            elem.root_segment is root_segment for elem in elements
+        ), "ReflowSequence has inconsistent root."
+        # Check first and last
+        try:
+            if isinstance(elements[0], ReflowPoint):
+                # Check odds are all points
+                assert all(
+                    isinstance(elem, ReflowPoint) for elem in elements[::2]
+                ), "Not all odd elements are ReflowPoint"
+                # Check evens are all blocks
+                assert all(
+                    isinstance(elem, ReflowBlock) for elem in elements[1::2]
+                ), "Not all even elements are ReflowBlock"
+            else:
+                # Check odds are all points
+                assert all(
+                    isinstance(elem, ReflowBlock) for elem in elements[::2]
+                ), "Not all odd elements are ReflowBlock"
+                # Check evens are all blocks
+                assert all(
+                    isinstance(elem, ReflowPoint) for elem in elements[1::2]
+                ), "Not all even elements are ReflowPoint"
+        except AssertionError as err:  # pragma: no cover
+            for elem in elements:
+                reflow_logger.error("   - %s", elem)
+            reflow_logger.exception("Assertion check on ReflowSequence failed.")
+            raise err
+
+    @classmethod
+    def from_raw_segments(
+        cls, segments: Sequence[RawSegment], root_segment: BaseSegment
+    ):
+        """Construct a ReflowSequence from a sequence of raw segments.
+
+        Aimed to be the basic constructor, which other more specific
+        ones may fall back to.
+        """
+        elem_buff = []
+        seg_buff: List[RawSegment] = []
+        SeqClass: Union[None, Type[ReflowBlock], Type[ReflowPoint]] = None
+        for seg in segments:
+            NextClass: Union[Type[ReflowBlock], Type[ReflowPoint]] = (
+                ReflowPoint
+                if seg.is_type("whitespace", "newline", "end_of_file", "indent")
+                else ReflowBlock
+            )
+            # NOTE: Can indents be in a reflow block? I assume not.
+            # Placeholders certainly not because they also get indented.
+
+            reflow_logger.debug(
+                "    Evaluating %s. NextClass: %s, SeqClass: %s",
+                seg,
+                NextClass.__name__,
+                SeqClass.__name__ if SeqClass else None,
+            )
+            if (
+                # Extend the buffer if we're the first segment.
+                not SeqClass
+                # Extend the buffer if we're still in a spacing section.
+                or (SeqClass is ReflowPoint and NextClass is ReflowPoint)
+            ):
+                seg_buff.append(seg)
+                SeqClass = NextClass
+                continue
+
+            reflow_logger.debug(
+                "Appending %s with %s elements: %s",
+                SeqClass.__name__,
+                len(seg_buff),
+                seg_buff,
+            )
+            elem_buff.append(SeqClass(segments=seg_buff, root_segment=root_segment))
+            # Then check whether this a second block and whether
+            # we need to add empty point in between.
+            if NextClass is ReflowBlock and SeqClass is ReflowBlock:
+                reflow_logger.debug("Appending Empty ReflowPoint")
+                elem_buff.append(ReflowPoint(segments=[], root_segment=root_segment))
+            seg_buff = [seg]
+            SeqClass = NextClass
+
+        if seg_buff and SeqClass:
+            reflow_logger.debug(
+                "Appending %s with %s elements: %s",
+                SeqClass.__name__,
+                len(seg_buff),
+                seg_buff,
+            )
+            elem_buff.append(SeqClass(segments=seg_buff, root_segment=root_segment))
+
+        return cls(elements=elem_buff, root_segment=root_segment)
+
+    @classmethod
+    def from_root(cls, root_segment: BaseSegment):
+        """Generate a sequence from a root segment."""
+        return cls.from_raw_segments(root_segment.raw_segments, root_segment)
+
+    @classmethod
+    def from_around_target(cls, target_segment: RawSegment, root_segment: BaseSegment):
+        """Generate a sequence around a target.
+
+        To evaluate reflow around a specific target, we need
+        need to generate a sequence which goes for the preceeding
+        raw to the following raw.
+        i.e. block - point - block - point - block
+        (where the central block is the target).
+        """
+        # There's probably a more efficient way than immediately
+        # materialising the raw_segments for the whole root, but
+        # it works. Optimise later.
+        all_raws = root_segment.raw_segments
+        idx = all_raws.index(target_segment)
+        pre_idx = idx - 1
+        post_idx = idx + 1
+        while pre_idx > 0 and all_raws[pre_idx].is_type(
+            "whitespace", "newline", "indent"
+        ):
+            pre_idx -= 1
+        while post_idx < len(all_raws) and all_raws[post_idx].is_type(
+            "whitespace", "newline", "indent"
+        ):
+            # TODO: This isn't covered with tests yet.
+            post_idx += 1  # pragma: no cover
+        segments = all_raws[pre_idx : post_idx + 1]
+        reflow_logger.debug(
+            "Generating ReflowSequence.from_around_target(). idx: %s. "
+            "slice: %s:%s. segments: %s",
+            idx,
+            pre_idx,
+            post_idx,
+            segments,
+        )
+        # Include the final index so +1
+        return cls.from_raw_segments(segments, root_segment)
+
+    def trailing_whitespace_fixes(self) -> List[LintFix]:
+        """Fix any trailing whitespace detected."""
+        fixes = []
+        for elem in self.elements:
+            if isinstance(elem, ReflowPoint):
+                fixes.extend(elem.trailing_whitespace_fixes())
+        return fixes

--- a/src/sqlfluff/utils/reflow/classes.py
+++ b/src/sqlfluff/utils/reflow/classes.py
@@ -204,7 +204,7 @@ class ReflowPoint(_ReflowElement):
                         reflow_logger.debug(
                             "    Detected existing fix %s", existing_fix
                         )
-                        if not fixes:
+                        if not fixes:  # pragma: no cover
                             raise ValueError(
                                 "Fixes detected, but none passed to .respace(). "
                                 "This will cause conflicts."
@@ -212,15 +212,16 @@ class ReflowPoint(_ReflowElement):
                         # Find the fix
                         for fix in fixes:
                             # Does it contain the insertion?
-                            # TODO: This feels ugly - why is eq for BaseSegment defined
-                            # so differently?!!?!???!? Shouldn't it all use uuids?
+                            # TODO: This feels ugly - eq for BaseSegment is different
+                            # to uuid matching for RawSegment. Perhaps this should be
+                            # more aligned. There might be a better way of doing this.
                             if (
                                 insertion
                                 and fix.edit
                                 and insertion.uuid in [elem.uuid for elem in fix.edit]
                             ):
                                 break
-                        else:
+                        else:  # pragma: no cover
                             reflow_logger.warning("Fixes %s", fixes)
                             raise ValueError(f"Couldn't find insertion for {insertion}")
                         # Mutate the existing fix
@@ -257,11 +258,13 @@ class ReflowPoint(_ReflowElement):
                                     edit=[WhitespaceSegment()],
                                 )
                             )
-                        else:
+                        else:  # pragma: no cover
                             NotImplementedError(
                                 "Not set up to handle a missing _after_ and _before_."
                             )
-                else:
+                else:  # pragma: no cover
+                    # TODO: This will get test coverage when configuration routines
+                    # are in properly.
                     raise NotImplementedError(
                         "Not set up to handle non-single whitespace rules."
                     )
@@ -451,7 +454,9 @@ class ReflowSequence:
         for idx, elem in enumerate(self.elements):
             if target in elem.segments:
                 return idx
-        raise ValueError(f"Target [{target}] not found in ReflowSequence.")
+        raise ValueError(  # pragma: no cover
+            f"Target [{target}] not found in ReflowSequence."
+        )
 
     def without(self, target: RawSegment) -> "ReflowSequence":
         """Returns a new reflow sequence without the specified segment.
@@ -463,11 +468,11 @@ class ReflowSequence:
         """
         removal_idx = self._find_element_idx_with(target)
         if removal_idx == 0 or removal_idx == len(self.elements) - 1:
-            raise NotImplementedError(
+            raise NotImplementedError(  # pragma: no cover
                 "Unexpected removal at one end of a ReflowSequence."
             )
         if isinstance(self.elements[removal_idx], ReflowPoint):
-            raise NotImplementedError(
+            raise NotImplementedError(  # pragma: no cover
                 "Not expected removal of whitespace in ReflowSequence."
             )
         merged_point = ReflowPoint(
@@ -495,7 +500,10 @@ class ReflowSequence:
         assert pos in ("before", "after")
         target_idx = self._find_element_idx_with(target)
         # Are we inserting something whitespacey...
-        if insertion.is_type("whitespace", "indent", "newline"):
+        # NOTE: I'm not sure we will _ever_ use this next section. Once
+        # more rules are using respace we should evaluate whether to keep
+        # this. We might decide that it will never exist.
+        if insertion.is_type("whitespace", "indent", "newline"):   # pragma: no cover
             # ... into a point?
             if isinstance(self.elements[target_idx], ReflowPoint):
                 # This is the easy case where we just append the new segment
@@ -527,7 +535,7 @@ class ReflowSequence:
                 segments=[insertion], root_segment=self.root_segment
             )
             if isinstance(self.elements[target_idx], ReflowPoint):
-                raise NotImplementedError(
+                raise NotImplementedError(  # pragma: no cover
                     "Can't insert relative to whitespace for now."
                 )
             elif pos == "before":
@@ -539,7 +547,10 @@ class ReflowSequence:
                     # Generate the fix to do the removal.
                     embodied_fixes=[LintFix.create_before(target, [insertion])],
                 )
-            elif pos == "after":
+            elif pos == "after":  # pragma: no cover
+                # TODO: This doesn't get coverage - should it even exist?
+                # Re-evaluate whether this code path is ever taken once more rules use
+                # this.
                 return ReflowSequence(
                     elements=list(self.elements[: target_idx + 1])
                     + [ReflowPoint([], root_segment=self.root_segment), new_block]

--- a/src/sqlfluff/utils/reflow/classes.py
+++ b/src/sqlfluff/utils/reflow/classes.py
@@ -5,7 +5,6 @@ from itertools import chain
 import logging
 from dataclasses import dataclass
 from typing import Iterator, List, Optional, Sequence, Tuple, Union, Type, cast
-from typing_extensions import Literal
 
 from sqlfluff.core.parser import BaseSegment, RawSegment
 from sqlfluff.core.parser.segments.raw import WhitespaceSegment
@@ -399,7 +398,7 @@ class ReflowSequence:
         cls,
         target_segment: RawSegment,
         root_segment: BaseSegment,
-        sides: Literal["before", "after", "both"] = "both",
+        sides: str = "both",
     ):
         """Generate a sequence around a target.
 
@@ -424,10 +423,12 @@ class ReflowSequence:
         # it works. Optimise later.
         all_raws = root_segment.raw_segments
         idx = all_raws.index(target_segment)
-        pre_idx = idx - 1
+        pre_idx = idx
         post_idx = idx + 1
         if sides in ("both", "before"):
-            while pre_idx > 0 and all_raws[pre_idx].is_type(
+            # Catch at least the previous segment
+            pre_idx -= 1
+            while pre_idx - 1 > 0 and all_raws[pre_idx].is_type(
                 "whitespace", "newline", "indent"
             ):
                 pre_idx -= 1
@@ -503,7 +504,7 @@ class ReflowSequence:
         # NOTE: I'm not sure we will _ever_ use this next section. Once
         # more rules are using respace we should evaluate whether to keep
         # this. We might decide that it will never exist.
-        if insertion.is_type("whitespace", "indent", "newline"):   # pragma: no cover
+        if insertion.is_type("whitespace", "indent", "newline"):  # pragma: no cover
             # ... into a point?
             if isinstance(self.elements[target_idx], ReflowPoint):
                 # This is the easy case where we just append the new segment

--- a/test/rules/yaml_test_cases_test.py
+++ b/test/rules/yaml_test_cases_test.py
@@ -19,7 +19,7 @@ ids, test_cases = load_test_cases(
 def test__rule_test_case(test_case, caplog):
     """Run the tests."""
     with caplog.at_level(logging.DEBUG, logger="sqlfluff.rules"):
-        with caplog.at_level(logging.DEBUG, logger="sqlfluff.utils.reflow"):
+        with caplog.at_level(logging.DEBUG, logger="sqlfluff.linter"):
             res = rules__test_helper(test_case)
             if res is not None and res != test_case.fail_str:
                 cfg = FluffConfig(configs=test_case.configs)

--- a/test/utils/reflow_test.py
+++ b/test/utils/reflow_test.py
@@ -1,0 +1,123 @@
+"""Tests for the reflow module."""
+
+import logging
+import pytest
+
+from sqlfluff.core import Linter, FluffConfig
+from sqlfluff.core.rules.base import LintFix
+
+from sqlfluff.utils.reflow.classes import ReflowSequence, ReflowBlock, ReflowPoint
+
+
+def parse_ansi_string(sql):
+    """Parse an ansi sql string for testing."""
+    cfg = FluffConfig(overrides={"dialect": "ansi"})
+    linter = Linter(config=cfg)
+    return linter.parse_string(sql).tree
+
+
+def assert_reflow_structure(sequence, StartClass, raw_elems):
+    """Assert a ReflowSequence has the defined structure."""
+    assert [
+        [seg.raw for seg in elem.segments] for elem in sequence.elements
+    ] == raw_elems
+    # We can assert all the classes just by knowing which we should start with
+    assert all(type(elem) is StartClass for elem in sequence.elements[::2])
+    OtherClass = ReflowBlock if StartClass is ReflowPoint else ReflowPoint
+    assert all(type(elem) is OtherClass for elem in sequence.elements[1::2])
+
+
+@pytest.mark.parametrize(
+    "raw_sql,StartClass,raw_elems",
+    [
+        (
+            "select 1 +2",
+            ReflowBlock,
+            [
+                ["select"],
+                # NOTE: The empty strings are indents and dedents
+                ["", " "],
+                ["1"],
+                [" "],
+                ["+"],
+                [],
+                ["2"],
+                # NOTE: The last element is the end of file marker.
+                # indent, end_of_file.
+                ["", ""],
+            ],
+        )
+    ],
+)
+def test_reflow_sequence_from_segments(raw_sql, StartClass, raw_elems, caplog):
+    """Test direct sequence contruction from segments."""
+    root = parse_ansi_string(raw_sql)
+    with caplog.at_level(logging.DEBUG, logger="sqlfluff.utils.reflow"):
+        result = ReflowSequence.from_raw_segments(root.raw_segments, root)
+    assert_reflow_structure(result, StartClass, raw_elems)
+
+
+@pytest.mark.parametrize(
+    "raw_sql,target_idx,target_raw,StartClass,raw_elems",
+    [
+        (
+            "select 1 +2",
+            5,
+            "+",
+            ReflowBlock,
+            [
+                # We should have expanded as far as the blocks either side
+                ["1"],
+                [" "],
+                ["+"],
+                [],
+                ["2"],
+            ],
+        ),
+        (
+            "select (1+2)",
+            5,
+            "1",
+            ReflowBlock,
+            [
+                # NOTE: We don't just stop at the indent, we go as far as code.
+                ["("],
+                # The indent sits in the point.
+                [""],
+                ["1"],
+                [],
+                ["+"],
+            ],
+        ),
+    ],
+)
+def test_reflow_sequence_from_around_target(
+    raw_sql, target_idx, target_raw, StartClass, raw_elems, caplog
+):
+    """Test direct sequence contruction from a target."""
+    root = parse_ansi_string(raw_sql)
+    target = root.raw_segments[target_idx]
+    # Check we're aiming at the right place
+    assert target.raw == target_raw
+    with caplog.at_level(logging.DEBUG, logger="sqlfluff.utils.reflow"):
+        result = ReflowSequence.from_around_target(target, root)
+    assert_reflow_structure(result, StartClass, raw_elems)
+
+
+@pytest.mark.parametrize(
+    "raw_sql,delete_indices",
+    [
+        ("SELECT      \n   4", [2]),
+        ("SELECT \n 4, \n 6", [2, 7]),
+        ("SELECT \n 4, \n 6  ", [2, 7, 12]),
+    ],
+)
+def test_reflow_sequence_trailing_whitespace_fixes(raw_sql, delete_indices, caplog):
+    """Test direct sequence contruction from a target."""
+    root = parse_ansi_string(raw_sql)
+    with caplog.at_level(logging.DEBUG, logger="sqlfluff.utils.reflow"):
+        sequence = ReflowSequence.from_root(root)
+    fixes = sequence.trailing_whitespace_fixes()
+    assert fixes == [
+        LintFix("delete", root.raw_segments[idx]) for idx in delete_indices
+    ]

--- a/test/utils/reflow_test.py
+++ b/test/utils/reflow_test.py
@@ -52,7 +52,7 @@ def assert_reflow_structure(sequence, StartClass, raw_elems):
 def test_reflow_sequence_from_segments(raw_sql, StartClass, raw_elems, caplog):
     """Test direct sequence contruction from segments."""
     root = parse_ansi_string(raw_sql)
-    with caplog.at_level(logging.DEBUG, logger="sqlfluff.utils.reflow"):
+    with caplog.at_level(logging.DEBUG, logger="sqlfluff.rules.reflow"):
         result = ReflowSequence.from_raw_segments(root.raw_segments, root)
     assert_reflow_structure(result, StartClass, raw_elems)
 
@@ -99,7 +99,7 @@ def test_reflow_sequence_from_around_target(
     target = root.raw_segments[target_idx]
     # Check we're aiming at the right place
     assert target.raw == target_raw
-    with caplog.at_level(logging.DEBUG, logger="sqlfluff.utils.reflow"):
+    with caplog.at_level(logging.DEBUG, logger="sqlfluff.rules.reflow"):
         result = ReflowSequence.from_around_target(target, root)
     assert_reflow_structure(result, StartClass, raw_elems)
 
@@ -115,7 +115,7 @@ def test_reflow_sequence_from_around_target(
 def test_reflow_sequence_trailing_whitespace_fixes(raw_sql, delete_indices, caplog):
     """Test direct sequence contruction from a target."""
     root = parse_ansi_string(raw_sql)
-    with caplog.at_level(logging.DEBUG, logger="sqlfluff.utils.reflow"):
+    with caplog.at_level(logging.DEBUG, logger="sqlfluff.rules.reflow"):
         sequence = ReflowSequence.from_root(root)
     fixes = sequence.trailing_whitespace_fixes()
     assert fixes == [


### PR DESCRIPTION
This is a start on #946 / #3673.

It also looks a bit different from when originally drafted. Some of that functionality was merged separately in #3766.

What it does do:
- Brings in frameworks for reflow in the `utils` library.
  - This is mainly based around a `ReflowSequence` which contains alternating `ReflowBlock` elements (which are the things we can reflow - essentially the things we _can't_ change) and `ReflowPoint` elements (which are the things that we can edit during a reflow).
- Migrates `L001` to the new reflow sequence framework.

Next steps would be:
- Bring the other "spacing" rules into the same framework: `L005`, `L006`, `L008`
- Bring `L007` into the framework (relationship between newlines and operators).
- Bring `L009` into the framework (file should end with newline).

The hard rules are going to be `L019` (leading/trailing commas) and `L003` (indentation) - but I think once they're in it will be pretty easy to build a `reflow` api (or even cli) command.