### PR TITLE
Provide usage examples for new users

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -397,7 +397,15 @@ def get_linter_and_formatter(
     return Linter(config=cfg, formatter=formatter), formatter
 
 
-@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.group(
+    context_settings={"help_option_names": ["-h", "--help"]},
+    epilog="""\b\bExamples:\n
+  sqlfluff lint --dialect postgres .\n
+  sqlfluff lint --dialect postgres --rules L042 .\n
+  sqlfluff fix --dialect sqlite --rules L041,L042 src/queries\n
+  sqlfluff parse --dialect sqlite --templater jinja src/queries/common.sql
+""",
+)
 @click.version_option()
 def cli():
     """SQLFluff is a modular SQL linter for humans."""  # noqa D403

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -529,7 +529,8 @@ class FluffConfig:
 
             raise SQLFluffUserError(
                 "No dialect was specified. You must configure a dialect or "
-                "specify one on the command line. Available dialects:\n"
+                "specify one on the command line using --dialect after the "
+                "command. Available dialects:\n"
                 f"{', '.join([d.label for d in dialect_readout()])}"
             )
 


### PR DESCRIPTION
Adds usage examples to the main -h output covering the use and placement
of the `--dialect`, `--rules`, and `--templater` options.

Also amends the error output when a required `--dialect` option is
absent to explain how to specify a dialect on the command line.

fixes #3764

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
