### PR TITLE
Require importlib_metadata >=1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,8 @@ colorama>=0.3
 # Used for diffcover plugin
 diff-cover>=2.5.0
 # importlib_metadata backport for python 3.7
-importlib_metadata; python_version < '3.8'
+# Require versions with .distributions https://github.com/sqlfluff/sqlfluff/issues/3763
+importlib_metadata>=1.0.0; python_version < '3.8'
 Jinja2
 # Used for .sqlfluffignore
 pathspec

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,8 @@ install_requires =
     # Used for diffcover plugin
     diff-cover>=2.5.0
     # importlib_metadata backport for python 3.7
-    importlib_metadata; python_version < '3.8'
+    # Require versions with .distributions https://github.com/sqlfluff/sqlfluff/issues/3763
+    importlib_metadata>=1.0.0; python_version < '3.8'
     Jinja2
     # Used for .sqlfluffignore
     pathspec


### PR DESCRIPTION
Resolves #3763.

For users of py 3.7, it appears that `pluggly` has an unexpressed dependency on a relatively modern version of `importlib_metadata`. This ensures we have a modern enough version. Really we only need `0.9`, but that's a very old version, so this requires the first `1.0.0` version.