### PR TITLE
Add QUALIFY to SparkSQL dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -584,6 +584,28 @@ sparksql_dialect.insert_lexer_matchers(
 )
 
 
+class QualifyClauseSegment(BaseSegment):
+    """A `QUALIFY` clause like in `SELECT`."""
+
+    type = "qualify_clause"
+    match_grammar = StartsWith(
+        "QUALIFY",
+        terminator=OneOf(
+            "WINDOW",
+            Sequence("ORDER", "BY"),
+            "LIMIT"
+        ),
+        enforce_whitespace_preceding_terminator=True,
+    )
+
+    parse_grammar = Sequence(
+        "QUALIFY",
+        Indent,
+        OptionallyBracketed(Ref("ExpressionSegment")),
+        Dedent,
+    )
+
+
 # Hive Segments
 class RowFormatClauseSegment(hive.RowFormatClauseSegment):
     """`ROW FORMAT` clause in a CREATE HIVEFORMAT TABLE statement."""
@@ -1453,6 +1475,9 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
 
     match_grammar = ansi.UnorderedSelectStatementSegment.match_grammar
     parse_grammar = ansi.UnorderedSelectStatementSegment.parse_grammar.copy(
+        insert=[
+            Ref("QualifyClauseSegment", optional=True)
+        ],
         # Removing non-valid clauses that exist in ANSI dialect
         remove=[Ref("OverlapsClauseSegment", optional=True)]
     )
@@ -1471,6 +1496,11 @@ class SelectStatementSegment(ansi.SelectStatementSegment):
             Ref("SortByClauseSegment", optional=True),
         ],
         before=Ref("LimitClauseSegment", optional=True),
+    ).copy(
+        insert=[
+            Ref("QualifyClauseSegment", optional=True)
+        ],
+        before=Ref("OrderByClauseSegment", optional=True)
     )
 
 

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -590,11 +590,7 @@ class QualifyClauseSegment(BaseSegment):
     type = "qualify_clause"
     match_grammar = StartsWith(
         "QUALIFY",
-        terminator=OneOf(
-            "WINDOW",
-            Sequence("ORDER", "BY"),
-            "LIMIT"
-        ),
+        terminator=OneOf("WINDOW", Sequence("ORDER", "BY"), "LIMIT"),
         enforce_whitespace_preceding_terminator=True,
     )
 
@@ -1475,11 +1471,9 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
 
     match_grammar = ansi.UnorderedSelectStatementSegment.match_grammar
     parse_grammar = ansi.UnorderedSelectStatementSegment.parse_grammar.copy(
-        insert=[
-            Ref("QualifyClauseSegment", optional=True)
-        ],
+        insert=[Ref("QualifyClauseSegment", optional=True)],
         # Removing non-valid clauses that exist in ANSI dialect
-        remove=[Ref("OverlapsClauseSegment", optional=True)]
+        remove=[Ref("OverlapsClauseSegment", optional=True)],
     )
 
 
@@ -1497,10 +1491,8 @@ class SelectStatementSegment(ansi.SelectStatementSegment):
         ],
         before=Ref("LimitClauseSegment", optional=True),
     ).copy(
-        insert=[
-            Ref("QualifyClauseSegment", optional=True)
-        ],
-        before=Ref("OrderByClauseSegment", optional=True)
+        insert=[Ref("QualifyClauseSegment", optional=True)],
+        before=Ref("OrderByClauseSegment", optional=True),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_sparksql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_sparksql_keywords.py
@@ -197,6 +197,7 @@ UNRESERVED_KEYWORDS = [
     "PRINCIPALS",
     "PROPERTIES",
     "PURGE",
+    "QUALIFY",
     "QUERY",
     "RANGE",
     "RECORDREADER",

--- a/test/fixtures/dialects/sparksql/select_qualify.sql
+++ b/test/fixtures/dialects/sparksql/select_qualify.sql
@@ -1,0 +1,51 @@
+SELECT
+  item,
+  RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
+FROM Produce
+WHERE Produce.category = 'vegetable'
+QUALIFY rank <= 3;
+
+SELECT
+  item,
+  RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
+FROM Produce
+WHERE Produce.category = 'vegetable'
+QUALIFY rank <= 3
+ORDER BY item;
+
+SELECT
+  item,
+  RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
+FROM Produce
+WHERE Produce.category = 'vegetable'
+QUALIFY rank <= 3
+LIMIT 5;
+
+SELECT
+  item,
+  RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
+FROM Produce
+WHERE Produce.category = 'vegetable'
+QUALIFY rank <= 3
+ORDER BY item
+LIMIT 5;
+
+SELECT
+  item,
+  RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
+FROM Produce
+WHERE Produce.category = 'vegetable'
+QUALIFY rank <= 3
+LIMIT 5;
+
+SELECT
+  item,
+  RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
+FROM Produce
+WINDOW item_window AS (
+  PARTITION BY category
+  ORDER BY purchases
+  ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING)
+WHERE Produce.category = 'vegetable'
+QUALIFY rank <= 3
+ORDER BY item

--- a/test/fixtures/dialects/sparksql/select_qualify.yml
+++ b/test/fixtures/dialects/sparksql/select_qualify.yml
@@ -1,0 +1,436 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 5ff1b5d063873e75af24c177fd0f32b7a0f45d1dcf56979b05845e2453e5aa81
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: item
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: RANK
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: category
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: purchases
+                  - keyword: DESC
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: Produce
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+          - naked_identifier: Produce
+          - dot: .
+          - naked_identifier: category
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'vegetable'"
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          column_reference:
+            naked_identifier: rank
+          comparison_operator:
+          - raw_comparison_operator: <
+          - raw_comparison_operator: '='
+          numeric_literal: '3'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: item
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: RANK
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: category
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: purchases
+                  - keyword: DESC
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: Produce
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+          - naked_identifier: Produce
+          - dot: .
+          - naked_identifier: category
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'vegetable'"
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          column_reference:
+            naked_identifier: rank
+          comparison_operator:
+          - raw_comparison_operator: <
+          - raw_comparison_operator: '='
+          numeric_literal: '3'
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: item
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: item
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: RANK
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: category
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: purchases
+                  - keyword: DESC
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: Produce
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+          - naked_identifier: Produce
+          - dot: .
+          - naked_identifier: category
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'vegetable'"
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          column_reference:
+            naked_identifier: rank
+          comparison_operator:
+          - raw_comparison_operator: <
+          - raw_comparison_operator: '='
+          numeric_literal: '3'
+      limit_clause:
+        keyword: LIMIT
+        numeric_literal: '5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: item
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: RANK
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: category
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: purchases
+                  - keyword: DESC
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: Produce
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+          - naked_identifier: Produce
+          - dot: .
+          - naked_identifier: category
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'vegetable'"
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          column_reference:
+            naked_identifier: rank
+          comparison_operator:
+          - raw_comparison_operator: <
+          - raw_comparison_operator: '='
+          numeric_literal: '3'
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: item
+      limit_clause:
+        keyword: LIMIT
+        numeric_literal: '5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: item
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: RANK
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: category
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: purchases
+                  - keyword: DESC
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: Produce
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+          - naked_identifier: Produce
+          - dot: .
+          - naked_identifier: category
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'vegetable'"
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          column_reference:
+            naked_identifier: rank
+          comparison_operator:
+          - raw_comparison_operator: <
+          - raw_comparison_operator: '='
+          numeric_literal: '3'
+      limit_clause:
+        keyword: LIMIT
+        numeric_literal: '5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: item
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: RANK
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: category
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: purchases
+                  - keyword: DESC
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: Produce
+            named_window:
+              keyword: WINDOW
+              named_window_expression:
+                naked_identifier: item_window
+                keyword: AS
+                bracketed:
+                  start_bracket: (
+                  window_specification:
+                    partitionby_clause:
+                    - keyword: PARTITION
+                    - keyword: BY
+                    - expression:
+                        column_reference:
+                          naked_identifier: category
+                    orderby_clause:
+                    - keyword: ORDER
+                    - keyword: BY
+                    - column_reference:
+                        naked_identifier: purchases
+                    frame_clause:
+                    - keyword: ROWS
+                    - keyword: BETWEEN
+                    - numeric_literal: '2'
+                    - keyword: PRECEDING
+                    - keyword: AND
+                    - numeric_literal: '2'
+                    - keyword: FOLLOWING
+                  end_bracket: )
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+          - naked_identifier: Produce
+          - dot: .
+          - naked_identifier: category
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'vegetable'"
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          column_reference:
+            naked_identifier: rank
+          comparison_operator:
+          - raw_comparison_operator: <
+          - raw_comparison_operator: '='
+          numeric_literal: '3'
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: item


### PR DESCRIPTION
### Brief summary of the change made

fixes #3555 by adding the QUALIFY statement to the Spark SQL dialect.


### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
