### PR TITLE
Postgres: Support setting user properties using intrinsic ON & OFF values

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1286,7 +1286,12 @@ class AlterRoleStatementSegment(BaseSegment):
                         OneOf(
                             Sequence(
                                 OneOf("TO", Ref("EqualsSegment")),
-                                OneOf(Ref("QuotedLiteralSegment"), "DEFAULT"),
+                                OneOf(
+                                    Ref("QuotedLiteralSegment"),
+                                    "DEFAULT",
+                                    "ON",
+                                    "OFF",
+                                ),
                             ),
                             Sequence(
                                 "FROM",

--- a/test/fixtures/dialects/postgres/postgres_alter_database.sql
+++ b/test/fixtures/dialects/postgres/postgres_alter_database.sql
@@ -27,5 +27,7 @@ ALTER DATABASE db SET parameter1 = 'some_value';
 ALTER DATABASE db SET parameter1 = DEFAULT;
 ALTER DATABASE db SET parameter1 FROM CURRENT;
 
+ALTER USER some_user SET default_transaction_read_only = ON;
+
 ALTER DATABASE db RESET parameter1;
 ALTER DATABASE db RESET ALL;

--- a/test/fixtures/dialects/postgres/postgres_alter_database.yml
+++ b/test/fixtures/dialects/postgres/postgres_alter_database.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ab60c1beb820b1bc2a5122bd1ca0f722c4e14323e2cf3a50eb71013edcbd7d1b
+_hash: a825d9fed6996a22b4285be95b488003a962aa579f2d04f2e478075c2bc507d0
 file:
 - statement:
     alter_database_statement:
@@ -277,6 +277,19 @@ file:
     - parameter: parameter1
     - keyword: FROM
     - keyword: CURRENT
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: USER
+    - role_reference:
+        naked_identifier: some_user
+    - keyword: SET
+    - object_reference:
+        naked_identifier: default_transaction_read_only
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - keyword: 'ON'
 - statement_terminator: ;
 - statement:
     alter_database_statement:


### PR DESCRIPTION
### Brief summary of the change made
Fixes #3791 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
