### PR TITLE
Allow the use of libraries in macro definitions

### DIFF
--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -286,6 +286,10 @@ class JinjaTemplater(PythonTemplater):
         live_context = super().get_context(fname=fname, config=config)
         # Apply dbt builtin functions if we're allowed.
         if config:
+            # first make libraries available in the context
+            # so they can be used by the macros too
+            live_context.update(self._extract_libraries_from_config(config=config))
+
             apply_dbt_builtins = config.get_section(
                 (self.templater_selector, self.name, "apply_dbt_builtins")
             )
@@ -316,7 +320,6 @@ class JinjaTemplater(PythonTemplater):
                 )
             )
 
-            live_context.update(self._extract_libraries_from_config(config=config))
         return live_context
 
     def template_builder(

--- a/test/fixtures/templater/jinja_j_libraries/.sqlfluff
+++ b/test/fixtures/templater/jinja_j_libraries/.sqlfluff
@@ -1,2 +1,3 @@
 [sqlfluff:templater:jinja]
+load_macros_from_path=macros
 library_path=libs

--- a/test/fixtures/templater/jinja_j_libraries/jinja.sql
+++ b/test/fixtures/templater/jinja_j_libraries/jinja.sql
@@ -1,3 +1,3 @@
 SELECT 56
-FROM {{ foo.schema }}.{{ foo.table("xyz") }}
+FROM {{ foo.schema }}.{{ table_proxy("xyz") }}
 WHERE {{ bar.equals("x", 23) }}

--- a/test/fixtures/templater/jinja_j_libraries/macros/table_proxy.sql
+++ b/test/fixtures/templater/jinja_j_libraries/macros/table_proxy.sql
@@ -1,0 +1,1 @@
+{% macro table_proxy(tbl) %}{{ foo.table(tbl) }}{% endmacro %}


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
I ran into an issue where I used a library (`adapter.something`) inside a macro, but it failed the sqlfluff linting. The fix is easier than the recursive macro pattern, because I just had to make sure to load the libraries in the context before continuing with the macros.

Extended the unit test to see that it also works now when the library is mentioned inside of a macro.


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
