### PR TITLE
sparksql dialect to support lambda expressions (->)

### DIFF
--- a/test/fixtures/dialects/sparksql/select_aggregate.sql
+++ b/test/fixtures/dialects/sparksql/select_aggregate.sql
@@ -1,0 +1,2 @@
+SELECT aggregate(array(1, 2, 3), 0, (acc, x) -> acc + x); -- 6
+SELECT aggregate(array(1, 2, 3), 0, (acc, x) -> acc + x, acc -> acc * 10); -- 60

--- a/test/fixtures/dialects/sparksql/select_aggregate.yml
+++ b/test/fixtures/dialects/sparksql/select_aggregate.yml
@@ -1,0 +1,108 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: b7198b63537da7d91157d9a4a03aa8ce3d41efc3d77ba91cf9c24a67289be401
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: aggregate
+            bracketed:
+            - start_bracket: (
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: array
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '3'
+                  - end_bracket: )
+            - comma: ','
+            - expression:
+                numeric_literal: '0'
+            - comma: ','
+            - expression:
+              - bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: acc
+                - comma: ','
+                - column_reference:
+                    naked_identifier: x
+                - end_bracket: )
+              - binary_operator: ->
+              - column_reference:
+                  naked_identifier: acc
+              - binary_operator: +
+              - column_reference:
+                  naked_identifier: x
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: aggregate
+            bracketed:
+            - start_bracket: (
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: array
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '3'
+                  - end_bracket: )
+            - comma: ','
+            - expression:
+                numeric_literal: '0'
+            - comma: ','
+            - expression:
+              - bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: acc
+                - comma: ','
+                - column_reference:
+                    naked_identifier: x
+                - end_bracket: )
+              - binary_operator: ->
+              - column_reference:
+                  naked_identifier: acc
+              - binary_operator: +
+              - column_reference:
+                  naked_identifier: x
+            - comma: ','
+            - expression:
+              - column_reference:
+                  naked_identifier: acc
+              - binary_operator: ->
+              - column_reference:
+                  naked_identifier: acc
+              - binary_operator: '*'
+              - numeric_literal: '10'
+            - end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/select_reduce.sql
+++ b/test/fixtures/dialects/sparksql/select_reduce.sql
@@ -1,0 +1,6 @@
+SELECT reduce(array(1, 2, 3), 0, (acc, x) -> acc + x); -- 6
+SELECT reduce(array(1, 2, 3), 0, (acc, x) -> acc + x, acc -> acc * 10); -- 60
+SELECT reduce(array(1, 2, 3, 4), -- 2.5
+              named_struct('sum', 0, 'cnt', 0),
+              (acc, x) -> named_struct('sum', acc.sum + x, 'cnt', acc.cnt + 1),
+              acc -> acc.sum / acc.cnt) AS avg;

--- a/test/fixtures/dialects/sparksql/select_reduce.yml
+++ b/test/fixtures/dialects/sparksql/select_reduce.yml
@@ -1,0 +1,213 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 93aace8b77b3e70fda02a7619b32803f9cceb0bf0e23e8af8a0c47f645eb15e8
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: reduce
+            bracketed:
+            - start_bracket: (
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: array
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '3'
+                  - end_bracket: )
+            - comma: ','
+            - expression:
+                numeric_literal: '0'
+            - comma: ','
+            - expression:
+              - bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: acc
+                - comma: ','
+                - column_reference:
+                    naked_identifier: x
+                - end_bracket: )
+              - binary_operator: ->
+              - column_reference:
+                  naked_identifier: acc
+              - binary_operator: +
+              - column_reference:
+                  naked_identifier: x
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: reduce
+            bracketed:
+            - start_bracket: (
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: array
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '3'
+                  - end_bracket: )
+            - comma: ','
+            - expression:
+                numeric_literal: '0'
+            - comma: ','
+            - expression:
+              - bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: acc
+                - comma: ','
+                - column_reference:
+                    naked_identifier: x
+                - end_bracket: )
+              - binary_operator: ->
+              - column_reference:
+                  naked_identifier: acc
+              - binary_operator: +
+              - column_reference:
+                  naked_identifier: x
+            - comma: ','
+            - expression:
+              - column_reference:
+                  naked_identifier: acc
+              - binary_operator: ->
+              - column_reference:
+                  naked_identifier: acc
+              - binary_operator: '*'
+              - numeric_literal: '10'
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: reduce
+            bracketed:
+            - start_bracket: (
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: array
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '3'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '4'
+                  - end_bracket: )
+            - comma: ','
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: named_struct
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'sum'"
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '0'
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'cnt'"
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '0'
+                  - end_bracket: )
+            - comma: ','
+            - expression:
+                bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: acc
+                - comma: ','
+                - column_reference:
+                    naked_identifier: x
+                - end_bracket: )
+                binary_operator: ->
+                function:
+                  function_name:
+                    function_name_identifier: named_struct
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'sum'"
+                  - comma: ','
+                  - expression:
+                    - column_reference:
+                      - naked_identifier: acc
+                      - dot: .
+                      - naked_identifier: sum
+                    - binary_operator: +
+                    - column_reference:
+                        naked_identifier: x
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'cnt'"
+                  - comma: ','
+                  - expression:
+                      column_reference:
+                      - naked_identifier: acc
+                      - dot: .
+                      - naked_identifier: cnt
+                      binary_operator: +
+                      numeric_literal: '1'
+                  - end_bracket: )
+            - comma: ','
+            - expression:
+              - column_reference:
+                  naked_identifier: acc
+              - binary_operator: ->
+              - column_reference:
+                - naked_identifier: acc
+                - dot: .
+                - naked_identifier: sum
+              - binary_operator: /
+              - column_reference:
+                - naked_identifier: acc
+                - dot: .
+                - naked_identifier: cnt
+            - end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: avg
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Implements https://github.com/sqlfluff/sqlfluff/issues/3373.

Credits to @cmotta for implementing the same for athena dialect in https://github.com/sqlfluff/sqlfluff/pull/3551 – it was easy to follow the approach taken there.

### Are there any other side effects of this change that we should be aware of?

Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.