### PR TITLE
MySQL: More support for index definition in CREATE TABLE

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -582,56 +582,127 @@ class DeleteStatementSegment(BaseSegment):
     )
 
 
+class IndexTypeGrammar(BaseSegment):
+    """index_type in `CREATE TABLE` statement.
+
+    https://dev.mysql.com/doc/refman/8.0/en/create-table.html
+    """
+
+    type = "index_type"
+    match_grammar = Sequence(
+        "USING",
+        OneOf("BTREE", "HASH"),
+    )
+
+
+class IndexOptionsSegment(BaseSegment):
+    """index_option in `CREATE TABLE` statement.
+
+    https://dev.mysql.com/doc/refman/8.0/en/create-table.html
+    """
+
+    type = "index_option"
+    match_grammar = AnySetOf(
+        Sequence(
+            "KEY_BLOCK_SIZE",
+            Ref("EqualsSegment", optional=True),
+            Ref("NumericLiteralSegment"),
+        ),
+        Ref("IndexTypeGrammar"),
+        Sequence("WITH", "PARSER", Ref("ObjectReferenceSegment")),
+        Ref("CommentClauseSegment"),
+        OneOf("VISIBLE", "INVISIBLE"),
+        Sequence(
+            "ENGINE_ATTRIBUTE",
+            Ref("EqualsSegment", optional=True),
+            Ref("QuotedLiteralSegment"),
+        ),
+        Sequence(
+            "SECONDARY_ENGINE_ATTRIBUTE",
+            Ref("EqualsSegment", optional=True),
+            Ref("QuotedLiteralSegment"),
+        ),
+    )
+
+
 class TableConstraintSegment(BaseSegment):
-    """A table constraint, e.g. for CREATE TABLE."""
+    """A table constraint, e.g. for CREATE TABLE.
+
+    https://dev.mysql.com/doc/refman/8.0/en/create-table.html
+    """
 
     type = "table_constraint"
     # Later add support for CHECK constraint, others?
     # e.g. CONSTRAINT constraint_1 PRIMARY KEY(column_1)
-    match_grammar = Sequence(
-        Sequence(  # [ CONSTRAINT <Constraint name> ]
-            "CONSTRAINT", Ref("ObjectReferenceSegment"), optional=True
-        ),
-        OneOf(
-            Sequence(  # UNIQUE [INDEX | KEY] [index_name] ( column_name [, ... ] )
-                "UNIQUE",
-                OneOf("INDEX", "KEY", optional=True),
-                Ref("ObjectReferenceSegment", optional=True),
-                Ref("BracketedColumnReferenceListGrammar"),
-                # Later add support for index_parameters?
+    match_grammar = OneOf(
+        Sequence(
+            Sequence(  # [ CONSTRAINT <Constraint name> ]
+                "CONSTRAINT", Ref("ObjectReferenceSegment"), optional=True
             ),
-            Sequence(  # PRIMARY KEY ( column_name [, ... ] ) index_parameters
-                Ref("PrimaryKeyGrammar"),
-                # Columns making up PRIMARY KEY constraint
-                Ref("BracketedColumnReferenceListGrammar"),
-                # Later add support for index_parameters?
-            ),
-            Sequence(  # FOREIGN KEY ( column_name [, ... ] )
-                # REFERENCES reftable [ ( refcolumn [, ... ] ) ]
-                Ref("ForeignKeyGrammar"),
-                # Local columns making up FOREIGN KEY constraint
-                Ref("BracketedColumnReferenceListGrammar"),
-                "REFERENCES",
-                Ref("ColumnReferenceSegment"),
-                # Foreign columns making up FOREIGN KEY constraint
-                Ref("BracketedColumnReferenceListGrammar"),
-                # Later add support for [MATCH FULL/PARTIAL/SIMPLE] ?
-                # Later add support for [ ON DELETE/UPDATE action ] ?
-                AnyNumberOf(
-                    Sequence(
-                        "ON",
-                        OneOf("DELETE", "UPDATE"),
-                        OneOf(
-                            "RESTRICT",
-                            "CASCADE",
-                            Sequence("SET", "NULL"),
-                            Sequence("NO", "ACTION"),
-                            Sequence("SET", "DEFAULT"),
+            OneOf(
+                # UNIQUE [INDEX | KEY] [index_name] [index_type] (key_part,...)
+                # [index_option] ...
+                Sequence(
+                    "UNIQUE",
+                    OneOf("INDEX", "KEY", optional=True),
+                    Ref("IndexReferenceSegment", optional=True),
+                    Ref("IndexTypeGrammar", optional=True),
+                    Ref("BracketedColumnReferenceListGrammar"),
+                    Ref("IndexOptionsSegment", optional=True),
+                ),
+                # PRIMARY KEY [index_type] (key_part,...) [index_option] ...
+                Sequence(
+                    Ref("PrimaryKeyGrammar"),
+                    Ref("IndexTypeGrammar", optional=True),
+                    # Columns making up PRIMARY KEY constraint
+                    Ref("BracketedColumnReferenceListGrammar"),
+                    Ref("IndexOptionsSegment", optional=True),
+                ),
+                # FOREIGN KEY [index_name] (col_name,...) reference_definition
+                Sequence(
+                    # REFERENCES reftable [ ( refcolumn [, ... ] ) ]
+                    Ref("ForeignKeyGrammar"),
+                    # Local columns making up FOREIGN KEY constraint
+                    Ref("BracketedColumnReferenceListGrammar"),
+                    "REFERENCES",
+                    Ref("ColumnReferenceSegment"),
+                    # Foreign columns making up FOREIGN KEY constraint
+                    Ref("BracketedColumnReferenceListGrammar"),
+                    # Later add support for [MATCH FULL/PARTIAL/SIMPLE] ?
+                    # Later add support for [ ON DELETE/UPDATE action ] ?
+                    AnyNumberOf(
+                        Sequence(
+                            "ON",
+                            OneOf("DELETE", "UPDATE"),
+                            OneOf(
+                                "RESTRICT",
+                                "CASCADE",
+                                Sequence("SET", "NULL"),
+                                Sequence("NO", "ACTION"),
+                                Sequence("SET", "DEFAULT"),
+                            ),
+                            optional=True,
                         ),
-                        optional=True,
                     ),
                 ),
             ),
+        ),
+        # {INDEX | KEY} [index_name] [index_type] (key_part,...) [index_option] ...
+        Sequence(
+            OneOf("INDEX", "KEY"),
+            Ref("IndexReferenceSegment", optional=True),
+            Ref("IndexTypeGrammar", optional=True),
+            Ref("BracketedColumnReferenceListGrammar"),
+            Ref("IndexOptionsSegment", optional=True),
+        ),
+        # {FULLTEXT | SPATIAL} [INDEX | KEY] [index_name] (key_part,...)
+        # [index_option] ...
+        Sequence(
+            OneOf("FULLTEXT", "SPATIAL"),
+            OneOf("INDEX", "KEY", optional=True),
+            Ref("IndexReferenceSegment", optional=True),
+            Ref("BracketedColumnReferenceListGrammar"),
+            Ref("IndexOptionsSegment", optional=True),
         ),
     )
 
@@ -983,15 +1054,15 @@ class AlterTableStatementSegment(BaseSegment):
                     Ref.keyword("UNIQUE", optional=True),
                     OneOf("INDEX", "KEY", optional=True),
                     Ref("IndexReferenceSegment"),
-                    Sequence("USING", OneOf("BTREE", "HASH"), optional=True),
+                    Ref("IndexTypeGrammar", optional=True),
                     Ref("BracketedColumnReferenceListGrammar"),
                     AnySetOf(
                         Sequence(
                             "KEY_BLOCK_SIZE",
-                            Ref("EqualsSegment"),
+                            Ref("EqualsSegment", optional=True),
                             Ref("NumericLiteralSegment"),
                         ),
-                        Sequence("USING", OneOf("BTREE", "HASH")),
+                        Ref("IndexTypeGrammar"),
                         Sequence("WITH", "PARSER", Ref("ObjectReferenceSegment")),
                         Ref("CommentClauseSegment"),
                         OneOf("VISIBLE", "INVISIBLE"),

--- a/test/fixtures/dialects/mysql/create_table_constraint_unique.yml
+++ b/test/fixtures/dialects/mysql/create_table_constraint_unique.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 96f9a77f9dc9ba035cba3c4b23ce569c6be40576e83b4727167298f9c9549133
+_hash: dc9e42ca7dac29e96e7c93596f533e5ccef4a0db1fe35bb1f46c8aaff86b57f5
 file:
   statement:
     create_table_statement:
@@ -31,7 +31,7 @@ file:
       - comma: ','
       - table_constraint:
           keyword: UNIQUE
-          object_reference:
+          index_reference:
             naked_identifier: idx_c
           bracketed:
             start_bracket: (
@@ -51,7 +51,7 @@ file:
       - table_constraint:
         - keyword: UNIQUE
         - keyword: KEY
-        - object_reference:
+        - index_reference:
             naked_identifier: idx_a
         - bracketed:
             start_bracket: (
@@ -71,7 +71,7 @@ file:
       - table_constraint:
         - keyword: UNIQUE
         - keyword: INDEX
-        - object_reference:
+        - index_reference:
             naked_identifier: idx_b
         - bracketed:
             start_bracket: (

--- a/test/fixtures/dialects/mysql/create_table_index.sql
+++ b/test/fixtures/dialects/mysql/create_table_index.sql
@@ -1,0 +1,8 @@
+CREATE TABLE foo (
+  id INT UNSIGNED AUTO_INCREMENT NOT NULL,
+  a TEXT(500),
+  b INT,
+  PRIMARY KEY (id) COMMENT 'primary key (id)',
+  FULLTEXT `idx_a` (a) COMMENT 'index (a)',
+  INDEX `idx_b` (b) COMMENT 'index (b)'
+) ENGINE=InnoDB;

--- a/test/fixtures/dialects/mysql/create_table_index.yml
+++ b/test/fixtures/dialects/mysql/create_table_index.yml
@@ -1,0 +1,87 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 4dede9571dafbf9136e3725f05afe85293bd1beb457aa05c4ae7238cece9d78c
+file:
+  statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: foo
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+        - naked_identifier: id
+        - data_type:
+            data_type_identifier: INT
+            keyword: UNSIGNED
+        - column_constraint_segment:
+            keyword: AUTO_INCREMENT
+        - column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+      - comma: ','
+      - column_definition:
+          naked_identifier: a
+          data_type:
+            data_type_identifier: TEXT
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '500'
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          naked_identifier: b
+          data_type:
+            data_type_identifier: INT
+      - comma: ','
+      - table_constraint:
+        - keyword: PRIMARY
+        - keyword: KEY
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: id
+            end_bracket: )
+        - index_option:
+            comment_clause:
+              keyword: COMMENT
+              quoted_literal: "'primary key (id)'"
+      - comma: ','
+      - table_constraint:
+          keyword: FULLTEXT
+          index_reference:
+            quoted_identifier: '`idx_a`'
+          bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: a
+            end_bracket: )
+          index_option:
+            comment_clause:
+              keyword: COMMENT
+              quoted_literal: "'index (a)'"
+      - comma: ','
+      - table_constraint:
+          keyword: INDEX
+          index_reference:
+            quoted_identifier: '`idx_b`'
+          bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: b
+            end_bracket: )
+          index_option:
+            comment_clause:
+              keyword: COMMENT
+              quoted_literal: "'index (b)'"
+      - end_bracket: )
+    - parameter: ENGINE
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - parameter: InnoDB
+  statement_terminator: ;

--- a/test/fixtures/dialects/mysql/create_table_primary_foreign_keys.yml
+++ b/test/fixtures/dialects/mysql/create_table_primary_foreign_keys.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9a8a93f23a2a7112743fa0c9d1a5e26aad4d078fe87dc9f03d0c79ff9f765fde
+_hash: fb91070986ad8b8e82dd3bd9b793200a0ed9398192aa045f0361fdcae06af34b
 file:
 - statement:
     create_table_statement:
@@ -49,16 +49,15 @@ file:
           data_type:
             data_type_identifier: INT
       - comma: ','
-      - column_definition:
-          naked_identifier: INDEX
-          data_type:
-            data_type_identifier: par_ind
-            bracketed:
-              start_bracket: (
-              expression:
-                column_reference:
-                  naked_identifier: parent_id
-              end_bracket: )
+      - table_constraint:
+          keyword: INDEX
+          index_reference:
+            naked_identifier: par_ind
+          bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: parent_id
+            end_bracket: )
       - comma: ','
       - table_constraint:
         - keyword: FOREIGN


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #3817

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
