### PR TITLE
MySQL: support remaining constraint parts of CREATE/ALTER TABLE

### DIFF
--- a/test/fixtures/dialects/mysql/alter_table.sql
+++ b/test/fixtures/dialects/mysql/alter_table.sql
@@ -24,7 +24,16 @@ CHANGE COLUMN `birthday` `date_of_birth` INT(11) AFTER `name`;
 ALTER TABLE `users`
 DROP COLUMN `age`;
 
+ALTER TABLE `foo`.`bar`
+ADD CONSTRAINT `index_name` UNIQUE(`col_1`, `col_2`, `col_3`);
+
 ALTER TABLE `foo`.`bar` ADD UNIQUE `index_name`(`col_1`, `col_2`, `col_3`);
+
+ALTER TABLE `foo`.`bar`
+ADD CONSTRAINT `index_name` UNIQUE INDEX (`col_1`, `col_2`, `col_3`);
+
+ALTER TABLE `foo`.`bar`
+ADD UNIQUE INDEX `index_name`(`col_1`, `col_2`, `col_3`);
 
 ALTER TABLE `foo`.`bar` ADD INDEX `index_name`(`col_1`, `col_2`, `col_3`);
 

--- a/test/fixtures/dialects/mysql/alter_table.sql
+++ b/test/fixtures/dialects/mysql/alter_table.sql
@@ -37,4 +37,13 @@ ADD UNIQUE INDEX `index_name`(`col_1`, `col_2`, `col_3`);
 
 ALTER TABLE `foo`.`bar` ADD INDEX `index_name`(`col_1`, `col_2`, `col_3`);
 
+ALTER TABLE `foo`.`bar` ADD INDEX `index_name`(`col_1`, `col_2`, `col_3`)
+KEY_BLOCK_SIZE = 8;
+
+ALTER TABLE `foo`.`bar` ADD INDEX `index_name`(`col_1`, `col_2`, `col_3`)
+KEY_BLOCK_SIZE 8;
+
+ALTER TABLE `foo`.`bar` ADD INDEX `index_name`(`col_1`, `col_2`, `col_3`)
+KEY_BLOCK_SIZE 8 COMMENT 'index for col_1, col_2, col_3';
+
 ALTER TABLE `foo`.`bar` DROP INDEX `index_name`

--- a/test/fixtures/dialects/mysql/alter_table.yml
+++ b/test/fixtures/dialects/mysql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ca2b93e19e7f5f0cc1a224c467ae13cd8f18cf601596a66b40935babeb68a030
+_hash: e8d7f3711c85548f5ece0c48bc378f88cb5af8a43c94e6515f3290959d0d8a22
 file:
 - statement:
     alter_table_statement:
@@ -174,10 +174,89 @@ file:
       - quoted_identifier: '`bar`'
     - keyword: ADD
     - table_constraint:
+      - keyword: CONSTRAINT
+      - object_reference:
+          quoted_identifier: '`index_name`'
+      - keyword: UNIQUE
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: ADD
+    - table_constraint:
         keyword: UNIQUE
         index_reference:
           quoted_identifier: '`index_name`'
         bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: ADD
+    - table_constraint:
+      - keyword: CONSTRAINT
+      - object_reference:
+          quoted_identifier: '`index_name`'
+      - keyword: UNIQUE
+      - keyword: INDEX
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: ADD
+    - table_constraint:
+      - keyword: UNIQUE
+      - keyword: INDEX
+      - index_reference:
+          quoted_identifier: '`index_name`'
+      - bracketed:
         - start_bracket: (
         - column_reference:
             quoted_identifier: '`col_1`'

--- a/test/fixtures/dialects/mysql/alter_table.yml
+++ b/test/fixtures/dialects/mysql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5152af802d2f27c218ba95a163daa2e596e5c8053f5fc837129b619767b80fa1
+_hash: ca2b93e19e7f5f0cc1a224c467ae13cd8f18cf601596a66b40935babeb68a030
 file:
 - statement:
     alter_table_statement:
@@ -173,20 +173,21 @@ file:
       - dot: .
       - quoted_identifier: '`bar`'
     - keyword: ADD
-    - keyword: UNIQUE
-    - index_reference:
-        quoted_identifier: '`index_name`'
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          quoted_identifier: '`col_1`'
-      - comma: ','
-      - column_reference:
-          quoted_identifier: '`col_2`'
-      - comma: ','
-      - column_reference:
-          quoted_identifier: '`col_3`'
-      - end_bracket: )
+    - table_constraint:
+        keyword: UNIQUE
+        index_reference:
+          quoted_identifier: '`index_name`'
+        bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -197,20 +198,21 @@ file:
       - dot: .
       - quoted_identifier: '`bar`'
     - keyword: ADD
-    - keyword: INDEX
-    - index_reference:
-        quoted_identifier: '`index_name`'
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          quoted_identifier: '`col_1`'
-      - comma: ','
-      - column_reference:
-          quoted_identifier: '`col_2`'
-      - comma: ','
-      - column_reference:
-          quoted_identifier: '`col_3`'
-      - end_bracket: )
+    - table_constraint:
+        keyword: INDEX
+        index_reference:
+          quoted_identifier: '`index_name`'
+        bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     alter_table_statement:

--- a/test/fixtures/dialects/mysql/alter_table.yml
+++ b/test/fixtures/dialects/mysql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e8d7f3711c85548f5ece0c48bc378f88cb5af8a43c94e6515f3290959d0d8a22
+_hash: 41fcfee6a93246aff99c4bb64693cda8eff625400fa30d5fd23e5063cf327638
 file:
 - statement:
     alter_table_statement:
@@ -292,6 +292,95 @@ file:
         - column_reference:
             quoted_identifier: '`col_3`'
         - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: ADD
+    - table_constraint:
+        keyword: INDEX
+        index_reference:
+          quoted_identifier: '`index_name`'
+        bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
+        index_option:
+          keyword: KEY_BLOCK_SIZE
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '8'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: ADD
+    - table_constraint:
+        keyword: INDEX
+        index_reference:
+          quoted_identifier: '`index_name`'
+        bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
+        index_option:
+          keyword: KEY_BLOCK_SIZE
+          numeric_literal: '8'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '`foo`'
+      - dot: .
+      - quoted_identifier: '`bar`'
+    - keyword: ADD
+    - table_constraint:
+        keyword: INDEX
+        index_reference:
+          quoted_identifier: '`index_name`'
+        bracketed:
+        - start_bracket: (
+        - column_reference:
+            quoted_identifier: '`col_1`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_2`'
+        - comma: ','
+        - column_reference:
+            quoted_identifier: '`col_3`'
+        - end_bracket: )
+        index_option:
+          keyword: KEY_BLOCK_SIZE
+          numeric_literal: '8'
+          comment_clause:
+            keyword: COMMENT
+            quoted_literal: "'index for col_1, col_2, col_3'"
 - statement_terminator: ;
 - statement:
     alter_table_statement:

--- a/test/fixtures/dialects/mysql/check_constraint.sql
+++ b/test/fixtures/dialects/mysql/check_constraint.sql
@@ -1,0 +1,15 @@
+CREATE TABLE t1
+(
+  CHECK (c1 <> c2),
+  c1 INT CHECK (c1 > 10),
+  c2 INT CONSTRAINT c2_positive CHECK (c2 > 0),
+  c3 INT CHECK (c3 < 100),
+  CONSTRAINT c1_nonzero CHECK (c1 <> 0),
+  CHECK (c1 > c3)
+);
+
+ALTER TABLE t1
+ALTER CHECK c2_positive NOT ENFORCED;
+
+ALTER TABLE t1
+DROP CONSTRAINT c1_nonzero;

--- a/test/fixtures/dialects/mysql/check_constraint.yml
+++ b/test/fixtures/dialects/mysql/check_constraint.yml
@@ -1,0 +1,134 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 819548e097fc750b37e657682d090047d51f01a458161bb97c18b26796a51181
+file:
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - table_constraint:
+          keyword: CHECK
+          bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: c1
+            - comparison_operator:
+              - raw_comparison_operator: <
+              - raw_comparison_operator: '>'
+            - column_reference:
+                naked_identifier: c2
+            end_bracket: )
+      - comma: ','
+      - column_definition:
+          naked_identifier: c1
+          data_type:
+            data_type_identifier: INT
+          column_constraint_segment:
+            keyword: CHECK
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: c1
+                comparison_operator:
+                  raw_comparison_operator: '>'
+                numeric_literal: '10'
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          naked_identifier: c2
+          data_type:
+            data_type_identifier: INT
+          column_constraint_segment:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: c2_positive
+          - keyword: CHECK
+          - bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: c2
+                comparison_operator:
+                  raw_comparison_operator: '>'
+                numeric_literal: '0'
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          naked_identifier: c3
+          data_type:
+            data_type_identifier: INT
+          column_constraint_segment:
+            keyword: CHECK
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: c3
+                comparison_operator:
+                  raw_comparison_operator: <
+                numeric_literal: '100'
+              end_bracket: )
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: c1_nonzero
+        - keyword: CHECK
+        - bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: c1
+              comparison_operator:
+              - raw_comparison_operator: <
+              - raw_comparison_operator: '>'
+              numeric_literal: '0'
+            end_bracket: )
+      - comma: ','
+      - table_constraint:
+          keyword: CHECK
+          bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: c1
+            - comparison_operator:
+                raw_comparison_operator: '>'
+            - column_reference:
+                naked_identifier: c3
+            end_bracket: )
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - keyword: ALTER
+    - keyword: CHECK
+    - object_reference:
+        naked_identifier: c2_positive
+    - keyword: NOT
+    - keyword: ENFORCED
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - keyword: DROP
+    - keyword: CONSTRAINT
+    - object_reference:
+        naked_identifier: c1_nonzero
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Continuing from https://github.com/sqlfluff/sqlfluff/pull/3826, I implemented all the parts related to constraints in CREATE TABLE and ALTER TABLE, including CHECK constraint support.

https://dev.mysql.com/doc/refman/8.0/en/create-table.html
https://dev.mysql.com/doc/refman/8.0/en/alter-table.html

### Are there any other side effects of this change that we should be aware of?

* It reuses TableConstraintSegment in ALTER TABLE ADD CONSTRAINT, the parse structure of ALTER changes.
* It reuses IndexOptionsSegment in ALTER TABLE, where (SECONDARY_)ENGINE_ATTRIBUTE is not allowed. I think it is not the linter's job to check for all syntax errors, and I did to avoid maintaining each for CREATE TABLE and ALTER TABLE.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
