### PR TITLE
MYSQL: improve lexing for single-quoted strings

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -46,18 +46,20 @@ mysql_dialect.patch_lexer_matchers(
         ),
         # Pattern breakdown:
         # (?s)                     DOTALL (dot matches newline)
-        #     ('')+?               group1 match consecutive single quotes
-        #     (?!')                negative lookahead single quote
-        #     |(                   group2 start
-        #         '.*?             single quote wildcard zero or more, lazy
-        #         (?<!'|\\)        negative lookbehind: no single quote or backslash
-        #         (?:'')*          non-capturing group: consecutive single quotes
-        #         '                single quote
+        #     (                    group1 start
+        #         '                single quote (start)
+        #         (?:              non-capturing group: begin
+        #             \\'          MySQL escaped single-quote
+        #             |''          or ANSI escaped single-quotes
+        #             |\\\\        or consecutive [escaped] backslashes
+        #             |[^']        or anything besides a single-quote
+        #         )*               non-capturing group: end (zero or more times)
+        #         '                single quote (end of the single-quoted string)
         #         (?!')            negative lookahead: not single quote
-        #     )                    group2 end
+        #     )                    group1 end
         RegexLexer(
             "single_quote",
-            r"(?s)('')+?(?!')|('.*?(?<!'|\\)(?:'')*'(?!'))",
+            r"(?s)('(?:\\'|''|\\\\|[^'])*'(?!'))",
             CodeSegment,
             segment_kwargs={"type": "single_quote"},
         ),

--- a/test/fixtures/dialects/mysql/load_data.sql
+++ b/test/fixtures/dialects/mysql/load_data.sql
@@ -26,3 +26,5 @@ LOAD DATA INFILE 'file.txt'
 LOAD DATA INFILE 'file.txt'
   INTO TABLE t1
   (column1, @dummy, column2, @dummy, column3);
+LOAD DATA INFILE '/local/access_log' INTO TABLE tbl_name
+  FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"' ESCAPED BY '\\'

--- a/test/fixtures/dialects/mysql/load_data.yml
+++ b/test/fixtures/dialects/mysql/load_data.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7610b5ec0a154c31730562158b16546585d4a37fa41e73ebf38f4d2b5db87091
+_hash: 43ac195d144b262728a8d04751851aab3a843cadc9ab23a1cb316486872a093b
 file:
 - statement:
     load_data_statement:
@@ -244,3 +244,24 @@ file:
           naked_identifier: column3
       - end_bracket: )
 - statement_terminator: ;
+- statement:
+    load_data_statement:
+    - keyword: LOAD
+    - keyword: DATA
+    - keyword: INFILE
+    - quoted_literal: "'/local/access_log'"
+    - keyword: INTO
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: tbl_name
+    - keyword: FIELDS
+    - keyword: TERMINATED
+    - keyword: BY
+    - quoted_literal: "','"
+    - keyword: OPTIONALLY
+    - keyword: ENCLOSED
+    - keyword: BY
+    - quoted_literal: "'\"'"
+    - keyword: ESCAPED
+    - keyword: BY
+    - quoted_literal: "'\\\\'"

--- a/test/fixtures/dialects/mysql/quoted_literal.sql
+++ b/test/fixtures/dialects/mysql/quoted_literal.sql
@@ -28,3 +28,9 @@ SELECT 'foo' -- some comment
 SELECT 'foo' /*  some comment */ 'bar';
 
 UPDATE table1 SET column1 = 'baz\'s';
+
+SELECT 'terminating MySQL-y escaped single-quote bazs\'';
+
+SELECT 'terminating ANSI-ish escaped single-quote ''';
+
+SELECT '\\';

--- a/test/fixtures/dialects/mysql/quoted_literal.yml
+++ b/test/fixtures/dialects/mysql/quoted_literal.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7bb75ea6f3705b2f28817dd648782e2d8746f87643b04a8cae2e68f2f276fc47
+_hash: e238dea9b30482930eb19617901656496154b66b07f366f298e75c1baec99681
 file:
 - statement:
     select_statement:
@@ -96,4 +96,25 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           quoted_literal: "'baz\\'s'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          quoted_literal: "'terminating MySQL-y escaped single-quote bazs\\''"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          quoted_literal: "'terminating ANSI-ish escaped single-quote '''"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          quoted_literal: "'\\\\'"
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #3830 
The RegEx for the MySQL lexer is distinctly simpler now, I think. This removed the special case for `''` and just treats that as a "standard" single-quoted string.

### Are there any other side effects of this change that we should be aware of?
Shouldn't be.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - Added: `.sql`/`.yml` parser test cases in `test/fixtures/dialects/mysql`
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
