### PR TITLE
Allow standalone aliases in L027

### DIFF
--- a/src/sqlfluff/rules/L027.py
+++ b/src/sqlfluff/rules/L027.py
@@ -91,6 +91,9 @@ class Rule_L027(Rule_L020):
                 and r.raw not in col_alias_names
                 # Allow columns defined in a USING expression.
                 and r.raw not in using_cols
+                # Allow columns defined as standalone aliases
+                # (e.g. value table functions from bigquery)
+                and r.raw not in standalone_aliases
             ):
                 violation_buff.append(
                     LintResult(

--- a/test/fixtures/rules/std_rule_cases/L027.yml
+++ b/test/fixtures/rules/std_rule_cases/L027.yml
@@ -61,12 +61,34 @@ test_allow_date_parts_as_function_parameter_snowflake:
     core:
       dialect: snowflake
 
-test_ignore_value_table_functions:
+test_ignore_value_table_functions_when_counting_tables:
+  # Allow use of unnested value tables from bigquery without counting as a
+  # table reference. This test passes despite unqualified reference
+  # because we "only select from one table"
+  pass_str: |
+    select
+        unqualified_reference_from_table_a,
+        _t_start
+    from a
+    left join unnest(generate_timestamp_array(
+            '2020-01-01', '2020-01-30', interval 1 day)) as _t_start
+        on true
+  configs:
+    core:
+      dialect: bigquery
+
+test_ignore_value_table_functions_when_counting_unqualified_aliases:
+  # Allow use of unnested value tables from bigquery without qualification.
+  # The function `unnest` returns a table which is only one unnamed column.
+  # This is impossible to qualify further, and as such the rule allows it.
   pass_str: |
     select
         a.*,
+        b.*,
         _t_start
     from a
+    left join b
+        on true
     left join unnest(generate_timestamp_array(
             '2020-01-01', '2020-01-30', interval 1 day)) as _t_start
         on true


### PR DESCRIPTION
This is related to #356.
The previous fix of this issue (https://github.com/sqlfluff/sqlfluff/pull/722/files) ended up passing a parameter
to rule L027 for `value_table_function_aliases`, but not actually exempting these aliases from the rule.

It seems to me that the test case then passes because the result of the `unnest` function call is not counted as a table
reference, rather than passing because it is ok to use "unqualified" references for value tables (they are impossible
to qualify).

As such, I have added a new testcase `test_ignore_value_table_functions_when_counting_unqualified_aliases` which fails
on main, but passes with this fix.
