### PR TITLE
MySQL: Treat double quotes the same as single quotes

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -63,6 +63,12 @@ mysql_dialect.patch_lexer_matchers(
             CodeSegment,
             segment_kwargs={"type": "single_quote"},
         ),
+        RegexLexer(
+            "double_quote",
+            r'(?s)("(?:\\"|""|\\\\|[^"])*"(?!"))',
+            CodeSegment,
+            segment_kwargs={"type": "double_quote"},
+        ),
     ]
 )
 
@@ -150,19 +156,17 @@ mysql_dialect.replace(
             Ref("NumericLiteralSegment"),
         ),
     ),
-    QuotedLiteralSegment=OneOf(
-        AnyNumberOf(
-            # MySQL allows whitespace-concatenated string literals (#1488).
-            # Since these string literals can have comments between them,
-            # we use grammar to handle this.
-            TypedParser(
-                "single_quote",
-                ansi.LiteralSegment,
-                type="quoted_literal",
-            ),
-            min_times=1,
+    QuotedLiteralSegment=AnyNumberOf(
+        # MySQL allows whitespace-concatenated string literals (#1488).
+        # Since these string literals can have comments between them,
+        # we use grammar to handle this.
+        TypedParser(
+            "single_quote",
+            ansi.LiteralSegment,
+            type="quoted_literal",
         ),
         Ref("DoubleQuotedLiteralSegment"),
+        min_times=1,
     ),
     UniqueKeyGrammar=Sequence(
         "UNIQUE",

--- a/test/fixtures/dialects/mysql/quoted_literal.sql
+++ b/test/fixtures/dialects/mysql/quoted_literal.sql
@@ -1,36 +1,75 @@
 SELECT '';
 
+SELECT "";
+
 SELECT '''';
+
+SELECT """";
 
 SELECT '
 
 ';
 
+SELECT "
+
+";
+
 SELECT '''aaa''';
+
+SELECT """aaa""";
 
 SELECT '
 ''
 ';
 
+SELECT "
+""
+";
+
 SELECT 'foo'
 'bar';
+
+SELECT "foo"
+"bar";
 
 SELECT 'foo'   'bar';
 
+SELECT "foo"   "bar";
+
+SELECT 'foo'   "bar";
+
 SELECT 'foo'
 
 
 'bar';
+
+SELECT "foo"
+
+
+"bar";
 
 SELECT 'foo' -- some comment
 'bar';
 
+SELECT "foo" -- some comment
+"bar";
+
 SELECT 'foo' /*  some comment */ 'bar';
+
+SELECT "foo" /*  some comment */ "bar";
 
 UPDATE table1 SET column1 = 'baz\'s';
 
+UPDATE table1 SET column1 = "baz\"s";
+
 SELECT 'terminating MySQL-y escaped single-quote bazs\'';
+
+SELECT "terminating MySQL-y escaped double-quote bazs\"";
 
 SELECT 'terminating ANSI-ish escaped single-quote ''';
 
+SELECT "terminating ANSI-ish escaped double-quote """;
+
 SELECT '\\';
+
+SELECT "\\";

--- a/test/fixtures/dialects/mysql/quoted_literal.yml
+++ b/test/fixtures/dialects/mysql/quoted_literal.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e238dea9b30482930eb19617901656496154b66b07f366f298e75c1baec99681
+_hash: 2f87d8252b0b31dabebfcb159b1a7833cc00684b7aaa53286c32683fcceaaba2
 file:
 - statement:
     select_statement:
@@ -17,7 +17,21 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
+          quoted_literal: '""'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
           quoted_literal: "''''"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          quoted_literal: '""""'
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -31,7 +45,21 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
+          quoted_literal: "\"\n\n\""
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
           quoted_literal: "'''aaa'''"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          quoted_literal: '"""aaa"""'
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -45,8 +73,7 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-        - quoted_literal: "'foo'"
-        - quoted_literal: "'bar'"
+          quoted_literal: "\"\n\"\"\n\""
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -61,8 +88,8 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-        - quoted_literal: "'foo'"
-        - quoted_literal: "'bar'"
+        - quoted_literal: '"foo"'
+        - quoted_literal: '"bar"'
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -77,8 +104,64 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
+        - quoted_literal: '"foo"'
+        - quoted_literal: '"bar"'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+        - quoted_literal: "'foo'"
+        - quoted_literal: '"bar"'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
         - quoted_literal: "'foo'"
         - quoted_literal: "'bar'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+        - quoted_literal: '"foo"'
+        - quoted_literal: '"bar"'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+        - quoted_literal: "'foo'"
+        - quoted_literal: "'bar'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+        - quoted_literal: '"foo"'
+        - quoted_literal: '"bar"'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+        - quoted_literal: "'foo'"
+        - quoted_literal: "'bar'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+        - quoted_literal: '"foo"'
+        - quoted_literal: '"bar"'
 - statement_terminator: ;
 - statement:
     update_statement:
@@ -98,11 +181,35 @@ file:
           quoted_literal: "'baz\\'s'"
 - statement_terminator: ;
 - statement:
+    update_statement:
+      keyword: UPDATE
+      from_expression:
+        from_expression_element:
+          table_expression:
+            table_reference:
+              naked_identifier: table1
+      set_clause_list:
+        keyword: SET
+        set_clause:
+          column_reference:
+            naked_identifier: column1
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: '"baz\"s"'
+- statement_terminator: ;
+- statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
           quoted_literal: "'terminating MySQL-y escaped single-quote bazs\\''"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          quoted_literal: '"terminating MySQL-y escaped double-quote bazs\""'
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -116,5 +223,19 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
+          quoted_literal: '"terminating ANSI-ish escaped double-quote """'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
           quoted_literal: "'\\\\'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          quoted_literal: '"\\"'
 - statement_terminator: ;


### PR DESCRIPTION
To support concatenation of double quoted string literals


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #3870 

### Are there any other side effects of this change that we should be aware of?
no

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
