### PR TITLE
Support Removed warning on configs

### DIFF
--- a/plugins/sqlfluff-plugin-example/src/example/rules.py
+++ b/plugins/sqlfluff-plugin-example/src/example/rules.py
@@ -26,7 +26,7 @@ def get_rules() -> List[BaseRule]:
 @hookimpl
 def load_default_config() -> dict:
     """Loads the default configuration for the plugin."""
-    return ConfigLoader.get_global().load_default_config_file(
+    return ConfigLoader.get_global().load_config_file(
         file_dir=os.path.dirname(__file__),
         file_name="plugin_default_config.cfg",
     )

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -28,7 +28,7 @@ can still cache appropriately
 
 ConfigElemType = Tuple[Tuple[str, ...], Any]
 
-DEPRECATED_CONFIGS: Dict[Tuple[str, ...], Any] = {
+REMOVED_CONFIGS: Dict[Tuple[str, ...], Any] = {
     ("rules", "L003", "lint_templated_tokens"): ("No longer used."),
 }
 
@@ -285,13 +285,13 @@ class ConfigLoader:
 
     @staticmethod
     def _validate_configs(configs: Iterable[ConfigElemType], file_path):
-        """Validate config elements against deprecated list."""
+        """Validate config elements against removed list."""
         for k, _ in configs:
-            if k in DEPRECATED_CONFIGS:
+            if k in REMOVED_CONFIGS:
                 formatted_key = ":".join(k)
                 raise SQLFluffUserError(
-                    f"Config file {file_path} set deprecated config "
-                    f"value {formatted_key}.\n\n{DEPRECATED_CONFIGS[k]}\n\n"
+                    f"Config file {file_path} set an outdated config "
+                    f"value {formatted_key}.\n\n{REMOVED_CONFIGS[k]}\n\n"
                     "See https://docs.sqlfluff.com/en/stable/configuration.html"
                     " for more details."
                 )

--- a/src/sqlfluff/core/plugin/lib.py
+++ b/src/sqlfluff/core/plugin/lib.py
@@ -23,7 +23,7 @@ def get_templaters():
 @hookimpl
 def load_default_config() -> dict:
     """Loads the default configuration for the plugin."""
-    return ConfigLoader.get_global().load_default_config_file(
+    return ConfigLoader.get_global().load_config_file(
         file_dir=os.path.join(os.path.dirname(os.path.dirname(__file__))),
         file_name="default_config.cfg",
     )

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -5,7 +5,7 @@ import sys
 
 from sqlfluff.core import config, Linter, FluffConfig
 from sqlfluff.core.config import (
-    DEPRECATED_CONFIGS,
+    REMOVED_CONFIGS,
     ConfigLoader,
     nested_combine,
     dict_diff,
@@ -360,13 +360,13 @@ def test__config_missing_dialect():
 
 def test__config__validate_configs_direct():
     """Test _validate_configs method of ConfigLoader directly."""
-    # Make sure there _are_ deprecated configs.
-    assert DEPRECATED_CONFIGS
+    # Make sure there _are_ removed configs.
+    assert REMOVED_CONFIGS
     # Make sure all raise an error if validated
-    for k in DEPRECATED_CONFIGS:
+    for k in REMOVED_CONFIGS:
         with pytest.raises(SQLFluffUserError) as excinfo:
             ConfigLoader._validate_configs([(k, "foo")], "<test>")
-        assert "set deprecated config" in str(excinfo.value)
+        assert "set an outdated config" in str(excinfo.value)
 
 
 def test__config__validate_configs_indirect():
@@ -376,7 +376,7 @@ def test__config__validate_configs_indirect():
         FluffConfig(
             configs={
                 "core": {"dialect": "ansi"},
-                # This is a known deprecated value.
+                # This is a known removed value.
                 "rules": {"L003": {"lint_templated_tokens": True}},
             }
         )

--- a/test/fixtures/linter/autofix/snowflake/002_previously_parse_tree_damaging/.sqlfluff
+++ b/test/fixtures/linter/autofix/snowflake/002_previously_parse_tree_damaging/.sqlfluff
@@ -44,9 +44,6 @@ allow_scalar = True
 single_table_references = consistent
 unquoted_identifiers_policy = all
 
-[sqlfluff:rules:L003]
-lint_templated_tokens = True
-
 [sqlfluff:rules:L007]  # Keywords
 operator_new_lines = after
 


### PR DESCRIPTION
This is a fairly separable part of #3847, and can be merged separately. It will also simplify the review of that PR to take these changes out of it.

This allows particular config values to be marked as deprecated, prompting the user to remove them if they are set in a config. Optionally it also allows a configurable message to be set, informing the user how to update their config accordingly.