### PR TITLE
Refactor path_to

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -78,6 +78,21 @@ class SourceFix:
         return hash((self.edit, self.source_slice.start, self.source_slice.stop))
 
 
+@dataclass()
+class PathStep:
+    """An element of the response to BaseSegment.path_to().
+
+    Attributes:
+        segment (:obj:`BaseSegment`): The segment in the chain.
+        idx (int): The index of the target within it's `segment`.
+        len (int): The number of childen `segment` has.
+    """
+
+    segment: "BaseSegment"
+    idx: int
+    len: int
+
+
 @dataclass
 class FixPatch:
     """An edit patch for a source file."""
@@ -1065,33 +1080,40 @@ class BaseSegment(metaclass=SegmentMetaclass):
                         no_recursive_seg_type=no_recursive_seg_type,
                     )
 
-    def path_to(self, other):
+    def path_to(self, other) -> List[PathStep]:
         """Given a segment which is assumed within self, get the intermediate segments.
 
         Returns:
-            :obj:`list` of segments, including the segment we're looking for.
-            None if not found.
-
+            :obj:`list` of :obj:`PathStep`, not including the segment we're looking
+                for. If `other` is not found, then empty list. This includes if
+                called on self.
         """
-        # Return self if we've found the segment.
+        # Return empty if we've found the segment.
         if self is other:
-            return [self]
+            return []  # pragma: no cover
 
         # Are we in the right ballpark?
         # NB: Comparisons have a higher precedence than `not`.
         if not self.get_start_loc() <= other.get_start_loc() <= self.get_end_loc():
-            return None
+            return []
 
         # Do we have any child segments at all?
         if not self.segments:
-            return None
+            return []
 
         # Check through each of the child segments
-        for seg in self.segments:
+        for idx, seg in enumerate(self.segments):
+            step = PathStep(self, idx, len(self.segments))
+            # Have we found the target?
+            if seg is other:
+                return [step]
+            # Is there a path to the target?
             res = seg.path_to(other)
             if res:
-                return [self] + res
-        return None  # pragma: no cover
+                return [step] + res
+
+        # Not found.
+        return []  # pragma: no cover
 
     def parse(
         self,
@@ -1488,7 +1510,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
 
         # If we're here, the segment doesn't match the original.
         linter_logger.debug(
-            "%s at %s: Original: [%r] Fixed: [%r]",
+            "# Changed Segment Found: %s at %s: Original: [%r] Fixed: [%r]",
             type(self).__name__,
             self.pos_marker.templated_slice,
             templated_raw,

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1087,8 +1087,13 @@ class BaseSegment(metaclass=SegmentMetaclass):
             :obj:`list` of :obj:`PathStep`, not including the segment we're looking
                 for. If `other` is not found, then empty list. This includes if
                 called on self.
+
+        The result of this should be interpreted as *the path from `self` to `other`*.
+        If the return value is `[]` (an empty list), that implies there is no path
+        from `self` to `other`. This would include the case where the two are the same
+        segment, as there is no path from a segment to itself.
         """
-        # Return empty if we've found the segment.
+        # Return empty if they are the same segment.
         if self is other:
             return []  # pragma: no cover
 

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -78,7 +78,7 @@ class SourceFix:
         return hash((self.edit, self.source_slice.start, self.source_slice.stop))
 
 
-@dataclass()
+@dataclass(frozen=True)
 class PathStep:
     """An element of the response to BaseSegment.path_to().
 

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1092,6 +1092,9 @@ class BaseSegment(metaclass=SegmentMetaclass):
         If the return value is `[]` (an empty list), that implies there is no path
         from `self` to `other`. This would include the case where the two are the same
         segment, as there is no path from a segment to itself.
+
+        Technically this could be seen as a "half open interval" of the path between
+        two segments: in that it includes the root segment, but not the leaf.
         """
         # Return empty if they are the same segment.
         if self is other:

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -84,7 +84,7 @@ class PathStep:
 
     Attributes:
         segment (:obj:`BaseSegment`): The segment in the chain.
-        idx (int): The index of the target within it's `segment`.
+        idx (int): The index of the target within its `segment`.
         len (int): The number of childen `segment` has.
     """
 

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -515,9 +515,9 @@ class Rule_L016(Rule_L003):
                     # long. That would imply that we've passed the root segment
                     # itself - but in that case - we should conclude it's not
                     # in a comment.
-                    if len(path) < 2:
+                    if len(path) < 1:
                         return False  # pragma: no cover
-                    parent = path[-2]
+                    parent = path[-1].segment
                     return parent.is_type("comment_clause", "comment_equals_clause")
 
                 literals_in_comments = quoted_literals.select(select_if=is_in_comment)

--- a/src/sqlfluff/rules/L026.py
+++ b/src/sqlfluff/rules/L026.py
@@ -172,7 +172,7 @@ class Rule_L026(BaseRule):
         #   statement, thus not expected to match a table in the FROM
         #   clause.
         if ref_path:
-            return any(seg.is_type("into_table_clause") for seg in ref_path)
+            return any(ps.segment.is_type("into_table_clause") for ps in ref_path)
         else:
             return False  # pragma: no cover
 

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -223,7 +223,12 @@ class Rule_L042(BaseRule):
                         path_to = selectable.selectable.path_to(
                             table_alias.from_expression_element
                         )
-                        if not any(seg.is_type(*parent_types) for seg in path_to):
+                        if not (
+                            # The from_expression_element
+                            table_alias.from_expression_element.is_type(*parent_types)
+                            # Or any of it's parents up to the selectable
+                            or any(ps.segment.is_type(*parent_types) for ps in path_to)
+                        ):
                             continue
                         if _is_correlated_subquery(
                             Segments(sc.query_tree.selectables[0].selectable),

--- a/src/sqlfluff/rules/L052.py
+++ b/src/sqlfluff/rules/L052.py
@@ -121,9 +121,9 @@ class Rule_L052(BaseRule):
         # Find statement segment containing the current segment.
         statement_segment = next(
             (
-                s
-                for s in (parent_segment.path_to(segment) or [])
-                if s.is_type("statement")
+                ps.segment
+                for ps in (parent_segment.path_to(segment) or [])
+                if ps.segment.is_type("statement")
             ),
             None,
         )
@@ -395,7 +395,7 @@ class Rule_L052(BaseRule):
                 seg = cast(RawSegment, seg)
                 self.logger.debug("Handling semi-colon: %s", seg)
                 res = self._handle_semicolon(seg, context.segment)
-            # Otherwise handle the end of the file seperately.
+            # Otherwise handle the end of the file separately.
             elif (
                 self.require_final_semicolon
                 and idx == len(context.segment.segments) - 1

--- a/src/sqlfluff/utils/analysis/select.py
+++ b/src/sqlfluff/utils/analysis/select.py
@@ -81,7 +81,8 @@ def get_select_statement_info(
         ref_path = segment.path_to(ref)
         # is it in a subselect? i.e. a select which isn't this one.
         if ref_path and any(
-            seg.is_type("select_statement") and seg is not segment for seg in ref_path
+            ps.segment.is_type("select_statement") and ps.segment is not segment
+            for ps in ref_path
         ):
             reference_buffer.remove(ref)
 

--- a/test/core/parser/segments_base_test.py
+++ b/test/core/parser/segments_base_test.py
@@ -8,6 +8,7 @@ from sqlfluff.core.parser import (
     BaseSegment,
     BaseFileSegment,
 )
+from sqlfluff.core.parser.segments.base import PathStep
 from sqlfluff.core.templaters import TemplatedFile
 from sqlfluff.core.parser.context import RootParseContext
 
@@ -52,15 +53,33 @@ def test__parser__base_segments_class_types():
 
 
 def test__parser__base_segments_descendant_type_set(raw_seg_list):
-    """Test the .descendant_type_set () method."""
+    """Test the .descendant_type_set() method."""
     test_seg = DummySegment([DummyAuxSegment(raw_seg_list)])
     assert test_seg.descendant_type_set == {"raw", "base", "dummy_aux"}
 
 
 def test__parser__base_segments_direct_descendant_type_set(raw_seg_list):
-    """Test the .direct_descendant_type_set () method."""
+    """Test the .direct_descendant_type_set() method."""
     test_seg = DummySegment([DummyAuxSegment(raw_seg_list)])
     assert test_seg.direct_descendant_type_set == {"base", "dummy_aux"}
+
+
+def test__parser__base_segments_path_to(raw_seg_list):
+    """Test the .path_to() method."""
+    test_seg_a = DummyAuxSegment(raw_seg_list)
+    test_seg_b = DummySegment([test_seg_a])
+    # With a direct parent/child relationship we only get
+    # one element of path.
+    assert test_seg_b.path_to(test_seg_a) == [PathStep(test_seg_b, 0, 1)]
+    # With a three segment chain - we get two path elements.
+    assert test_seg_b.path_to(raw_seg_list[0]) == [
+        PathStep(test_seg_b, 0, 1),
+        PathStep(test_seg_a, 0, 2),
+    ]
+    assert test_seg_b.path_to(raw_seg_list[1]) == [
+        PathStep(test_seg_b, 0, 1),
+        PathStep(test_seg_a, 1, 2),
+    ]
 
 
 def test__parser__base_segments_stubs():


### PR DESCRIPTION
This is another relatively separable part of #3847. It's a useful development alone and can be merged before the rest. That will also simplify the review of the other PR.

This changes the behaviour of `BaseSegment.path_to()`.

Previously it would return a `list` of segments. The first element of that list would be `self` and the last would be the segment passed as `other`. The others would be the segments between.

I noticed that many uses of `path_to` always cut the last element (i.e. slice `[:-1]`), and that there are use cases where we want to know more than just the lineage, but also where in the parent each child is.

This changes `path_to` to instead:
- ...return a `list` of `PathStep` (a `dataclass`), which combines the segment with a new `index` which states where in the parent the child was found. This is useful for understanding whether the segment was at the start or end of a parent.
- ...to return one _less_ element in that it will never return the `other` (i.e. the last element previously returned). This is partly because it was not often used, partly because anyone calling `path_to` already has access to that and mostly because it doesn't make sense to ask what index something is within itself.