### PR TITLE
Adjust TSQL Operators

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1789,7 +1789,7 @@ class AssignmentOperatorSegment(BaseSegment):
 
     type = "assignment_operator"
     match_grammar = OneOf(
-        Ref("EqualsSegment"),
+        Ref("RawEqualsSegment"),
         Sequence(
             OneOf(
                 Ref("PlusSegment"),
@@ -1801,7 +1801,7 @@ class AssignmentOperatorSegment(BaseSegment):
                 Ref("BitwiseOrSegment"),
                 Ref("BitwiseXorSegment"),
             ),
-            Ref("EqualsSegment"),
+            Ref("RawEqualsSegment"),
             allow_gaps=False,
         ),
     )

--- a/test/fixtures/dialects/tsql/create_function.yml
+++ b/test/fixtures/dialects/tsql/create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f5e00002a7c59c889b4a283b8c4cec06a04eb2247fa14abd2f6cada29edcbb12
+_hash: 4c002f668682103d0f48fae1d2ccc011e9b2866999d027077a39e237a07896e3
 file:
 - batch:
     statement:
@@ -47,8 +47,7 @@ file:
                   keyword: SET
                   parameter: '@ISOweek'
                   assignment_operator:
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    raw_comparison_operator: '='
                   expression:
                   - function:
                       function_name:
@@ -118,8 +117,7 @@ file:
                       keyword: SET
                       parameter: '@ISOweek'
                       assignment_operator:
-                        comparison_operator:
-                          raw_comparison_operator: '='
+                        raw_comparison_operator: '='
                       expression:
                         function:
                           function_name:
@@ -255,8 +253,7 @@ file:
                       keyword: SET
                       parameter: '@ISOweek'
                       assignment_operator:
-                        comparison_operator:
-                          raw_comparison_operator: '='
+                        raw_comparison_operator: '='
                       expression:
                         numeric_literal: '1'
                       statement_terminator: ;

--- a/test/fixtures/dialects/tsql/declare_with_following_statements.yml
+++ b/test/fixtures/dialects/tsql/declare_with_following_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9013ff18c7dda6a855445fac2ea3c7ea44f06b45a408fc6b51cbb373085a86fc
+_hash: efd2ca6bc014ba59a3b45dcdfcd08c6fff7bfbcbf298e92432055703cf140734
 file:
   batch:
     create_procedure_statement:
@@ -89,8 +89,7 @@ file:
                 keyword: SET
                 parameter: '@EOMONTH'
                 assignment_operator:
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  raw_comparison_operator: '='
                 expression:
                   bracketed:
                     start_bracket: (
@@ -102,8 +101,7 @@ file:
                 keyword: SET
                 parameter: '@EOMONTH'
                 assignment_operator:
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  raw_comparison_operator: '='
                 expression:
                   bracketed:
                     start_bracket: (

--- a/test/fixtures/dialects/tsql/function_with_variable.yml
+++ b/test/fixtures/dialects/tsql/function_with_variable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 303a92979610a1d5c54d822f3cfe4eedc68c90f74610c7e955be8e2529e38421
+_hash: a4f778729ae8ba6dcd284c585c2f3167abdc3a32fadc7682c3c620a00161f1db
 file:
   batch:
     statement:
@@ -46,8 +46,7 @@ file:
                   keyword: SET
                   parameter: '@result'
                   assignment_operator:
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    raw_comparison_operator: '='
                   expression:
                     numeric_literal: '4'
             - statement:

--- a/test/fixtures/dialects/tsql/hints.yml
+++ b/test/fixtures/dialects/tsql/hints.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: eeab16a5d253654456bd6dfb921b0de87110742f93451e56a9c5f697e4c3d014
+_hash: e43dd4231a12a1515781ca109632f9fdbb660030b474b3b475f0f99735425dd0
 file:
 - batch:
     statement:
@@ -649,8 +649,7 @@ file:
             column_reference:
               naked_identifier: ListPrice
             assignment_operator:
-              comparison_operator:
-                raw_comparison_operator: '='
+              raw_comparison_operator: '='
             expression:
               column_reference:
                 naked_identifier: ListPrice

--- a/test/fixtures/dialects/tsql/if_else.yml
+++ b/test/fixtures/dialects/tsql/if_else.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 80890f68625e258cea1cda0d83a4ac3758b29fa0a28ee0c9bcea13ca0ca4d559
+_hash: a434408ffdec3fdb7fdd83fea832c56515bd7d363716de0a1723a87358567d20
 file:
   batch:
   - statement:
@@ -160,8 +160,7 @@ file:
             keyword: set
             parameter: '@var'
             assignment_operator:
-              comparison_operator:
-                raw_comparison_operator: '='
+              raw_comparison_operator: '='
             expression:
               numeric_literal: '1'
             statement_terminator: ;

--- a/test/fixtures/dialects/tsql/merge.yml
+++ b/test/fixtures/dialects/tsql/merge.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1512c510d95e9b9cccca4e086c97b64e67ae562c49fc44d23cadb82c1c1e4198
+_hash: d45a12ff4b2f569952339683d90192ef155a18140378f82e54bad347f3a3e74e
 file:
 - batch:
     statement:
@@ -65,8 +65,7 @@ file:
                   - dot: .
                   - naked_identifier: l_id
                   assignment_operator:
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    raw_comparison_operator: '='
                   expression:
                     column_reference:
                     - naked_identifier: src
@@ -79,8 +78,7 @@ file:
                   - dot: .
                   - naked_identifier: e_date_to
                   assignment_operator:
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    raw_comparison_operator: '='
                   expression:
                     column_reference:
                     - naked_identifier: src
@@ -189,8 +187,7 @@ file:
                     - dot: .
                     - naked_identifier: cc_name
                     assignment_operator:
-                      comparison_operator:
-                        raw_comparison_operator: '='
+                      raw_comparison_operator: '='
                     expression:
                       column_reference:
                       - naked_identifier: src
@@ -203,8 +200,7 @@ file:
                     - dot: .
                     - naked_identifier: cc_description
                     assignment_operator:
-                      comparison_operator:
-                        raw_comparison_operator: '='
+                      raw_comparison_operator: '='
                     expression:
                       column_reference:
                       - naked_identifier: src
@@ -306,8 +302,7 @@ file:
                   - dot: .
                   - naked_identifier: c_name
                   assignment_operator:
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    raw_comparison_operator: '='
                   expression:
                     column_reference:
                     - naked_identifier: src
@@ -320,8 +315,7 @@ file:
                   - dot: .
                   - naked_identifier: col1
                   assignment_operator:
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    raw_comparison_operator: '='
                   expression:
                     column_reference:
                     - naked_identifier: src
@@ -334,8 +328,7 @@ file:
                   - dot: .
                   - naked_identifier: col2
                   assignment_operator:
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    raw_comparison_operator: '='
                   expression:
                     column_reference:
                     - naked_identifier: src
@@ -454,8 +447,7 @@ file:
                   - dot: .
                   - naked_identifier: col1
                   assignment_operator:
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    raw_comparison_operator: '='
                   expression:
                     quoted_literal: "'N'"
               - comma: ','
@@ -465,8 +457,7 @@ file:
                   - dot: .
                   - naked_identifier: col2
                   assignment_operator:
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    raw_comparison_operator: '='
                   expression:
                     column_reference:
                       naked_identifier: col2
@@ -535,8 +526,7 @@ file:
                   column_reference:
                     naked_identifier: Name
                   assignment_operator:
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    raw_comparison_operator: '='
                   expression:
                     column_reference:
                     - naked_identifier: src
@@ -737,8 +727,7 @@ file:
                   - dot: .
                   - naked_identifier: Quantity
                   assignment_operator:
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    raw_comparison_operator: '='
                   expression:
                   - column_reference:
                     - naked_identifier: tgt
@@ -756,8 +745,7 @@ file:
                   - dot: .
                   - naked_identifier: ModifiedDate
                   assignment_operator:
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    raw_comparison_operator: '='
                   expression:
                     function:
                       function_name:
@@ -937,8 +925,7 @@ file:
                   - dot: .
                   - naked_identifier: Quantity
                   assignment_operator:
-                    comparison_operator:
-                      raw_comparison_operator: '='
+                    raw_comparison_operator: '='
                   expression:
                   - column_reference:
                     - naked_identifier: pi
@@ -1092,8 +1079,7 @@ file:
                                 column_reference:
                                   naked_identifier: columnC
                                 assignment_operator:
-                                  comparison_operator:
-                                    raw_comparison_operator: '='
+                                  raw_comparison_operator: '='
                                 expression:
                                   column_reference:
                                   - naked_identifier: src

--- a/test/fixtures/dialects/tsql/set_statements.yml
+++ b/test/fixtures/dialects/tsql/set_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e851d87e3ebda5d3ec6f3ca26f5469e0df1d1b0ac631d9604af720ae8d102689
+_hash: 8ff80c388ac8b168e59fdfdbfacafea0a6e3483c6c36156a99ea33dcae05c1c0
 file:
   batch:
   - statement:
@@ -20,8 +20,7 @@ file:
         keyword: SET
         parameter: '@param1'
         assignment_operator:
-          comparison_operator:
-            raw_comparison_operator: '='
+          raw_comparison_operator: '='
         expression:
           numeric_literal: '1'
         statement_terminator: ;
@@ -30,15 +29,13 @@ file:
       - keyword: SET
       - parameter: '@param1'
       - assignment_operator:
-          comparison_operator:
-            raw_comparison_operator: '='
+          raw_comparison_operator: '='
       - expression:
           numeric_literal: '1'
       - comma: ','
       - parameter: '@param2'
       - assignment_operator:
-          comparison_operator:
-            raw_comparison_operator: '='
+          raw_comparison_operator: '='
       - expression:
           numeric_literal: '2'
       - statement_terminator: ;
@@ -47,16 +44,14 @@ file:
       - keyword: SET
       - parameter: '@param1'
       - assignment_operator:
-          comparison_operator:
-            raw_comparison_operator: '='
+          raw_comparison_operator: '='
       - expression:
           column_reference:
             quoted_identifier: '"test, test"'
       - comma: ','
       - parameter: '@param2'
       - assignment_operator:
-          comparison_operator:
-            raw_comparison_operator: '='
+          raw_comparison_operator: '='
       - expression:
           numeric_literal: '2'
       - statement_terminator: ;
@@ -65,8 +60,7 @@ file:
       - keyword: SET
       - parameter: '@param1'
       - assignment_operator:
-          comparison_operator:
-            raw_comparison_operator: '='
+          raw_comparison_operator: '='
       - expression:
           bracketed:
           - start_bracket: (
@@ -79,8 +73,7 @@ file:
       - comma: ','
       - parameter: '@param2'
       - assignment_operator:
-          comparison_operator:
-            raw_comparison_operator: '='
+          raw_comparison_operator: '='
       - expression:
           numeric_literal: '2'
       - statement_terminator: ;
@@ -90,48 +83,42 @@ file:
       - parameter: '@param1'
       - assignment_operator:
           binary_operator: +
-          comparison_operator:
-            raw_comparison_operator: '='
+          raw_comparison_operator: '='
       - expression:
           numeric_literal: '1'
       - comma: ','
       - parameter: '@param2'
       - assignment_operator:
           binary_operator: '-'
-          comparison_operator:
-            raw_comparison_operator: '='
+          raw_comparison_operator: '='
       - expression:
           numeric_literal: '2'
       - comma: ','
       - parameter: '@param3'
       - assignment_operator:
           binary_operator: '*'
-          comparison_operator:
-            raw_comparison_operator: '='
+          raw_comparison_operator: '='
       - expression:
           numeric_literal: '3'
       - comma: ','
       - parameter: '@param4'
       - assignment_operator:
           binary_operator: /
-          comparison_operator:
-            raw_comparison_operator: '='
+          raw_comparison_operator: '='
       - expression:
           numeric_literal: '4'
       - comma: ','
       - parameter: '@param5'
       - assignment_operator:
           binary_operator: '%'
-          comparison_operator:
-            raw_comparison_operator: '='
+          raw_comparison_operator: '='
       - expression:
           numeric_literal: '5'
       - comma: ','
       - parameter: '@param5'
       - assignment_operator:
           binary_operator: ^
-          comparison_operator:
-            raw_comparison_operator: '='
+          raw_comparison_operator: '='
       - expression:
           numeric_literal: '6'
       - comma: ','
@@ -139,8 +126,7 @@ file:
       - assignment_operator:
           binary_operator:
             ampersand: '&'
-          comparison_operator:
-            raw_comparison_operator: '='
+          raw_comparison_operator: '='
       - expression:
           numeric_literal: '7'
       - comma: ','
@@ -148,8 +134,7 @@ file:
       - assignment_operator:
           binary_operator:
             pipe: '|'
-          comparison_operator:
-            raw_comparison_operator: '='
+          raw_comparison_operator: '='
       - expression:
           numeric_literal: '8'
       - statement_terminator: ;

--- a/test/fixtures/dialects/tsql/stored_procedure_begin_end.yml
+++ b/test/fixtures/dialects/tsql/stored_procedure_begin_end.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f9e1fac5b61620be692a6788ab340558c42aea8eaf0f8cb0122995c92557adf7
+_hash: 2994b0898ee3fa4c6a39ccc0a26d004d90582cc796255ec0b85138cbb33401b7
 file:
 - batch:
     create_procedure_statement:
@@ -213,8 +213,7 @@ file:
                     keyword: SET
                     parameter: '@v_nSysErrorNum'
                     assignment_operator:
-                      comparison_operator:
-                        raw_comparison_operator: '='
+                      raw_comparison_operator: '='
                     expression:
                       function:
                         function_name:
@@ -228,8 +227,7 @@ file:
                     keyword: SET
                     parameter: '@v_vchCode'
                     assignment_operator:
-                      comparison_operator:
-                        raw_comparison_operator: '='
+                      raw_comparison_operator: '='
                     expression:
                       function:
                         function_name:
@@ -243,8 +241,7 @@ file:
                     keyword: SET
                     parameter: '@v_vchMsg'
                     assignment_operator:
-                      comparison_operator:
-                        raw_comparison_operator: '='
+                      raw_comparison_operator: '='
                     expression:
                       quoted_literal: "N'Missing control type.'"
                     statement_terminator: ;
@@ -253,8 +250,7 @@ file:
                     keyword: SET
                     parameter: '@v_vchMsg'
                     assignment_operator:
-                      comparison_operator:
-                        raw_comparison_operator: '='
+                      raw_comparison_operator: '='
                     expression:
                     - parameter: '@v_vchMsg'
                     - binary_operator: +

--- a/test/fixtures/dialects/tsql/system-variables.yml
+++ b/test/fixtures/dialects/tsql/system-variables.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 16ee861ffacdc80133052b99b8ce0559c901a48d4342937e72dd5aac2e7c1b97
+_hash: be997bb95ccd1ed890e72a446c3418a44eb32babce3c243dd4b5aeca6f9b528d
 file:
 - batch:
   - statement:
@@ -19,8 +19,7 @@ file:
             column_reference:
               naked_identifier: JobTitle
             assignment_operator:
-              comparison_operator:
-                raw_comparison_operator: '='
+              raw_comparison_operator: '='
             expression:
               quoted_literal: "N'Executive'"
         where_clause:

--- a/test/fixtures/dialects/tsql/triggers.yml
+++ b/test/fixtures/dialects/tsql/triggers.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5004c7943db9940697b546dbae8f8053c5060bb03e5c625652b9ea5bbe9a0803
+_hash: 223d772b3217880363965fe815cb6fb2c44fc4bc1c3fcc3c5d2c8b2c5af2313e
 file:
 - batch:
     statement:
@@ -448,8 +448,7 @@ file:
                 column_reference:
                   naked_identifier: PDW_LAST_UPDATED
                 assignment_operator:
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  raw_comparison_operator: '='
                 expression:
                   function:
                     function_name:
@@ -538,8 +537,7 @@ file:
                 column_reference:
                   naked_identifier: PDW_LAST_UPDATED
                 assignment_operator:
-                  comparison_operator:
-                    raw_comparison_operator: '='
+                  raw_comparison_operator: '='
                 expression:
                   function:
                     function_name:

--- a/test/fixtures/dialects/tsql/update.yml
+++ b/test/fixtures/dialects/tsql/update.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 51cea7f86c4be1b83f868067d11bcbd0c221335a114248ff60d4d47d239851a8
+_hash: cdd60df88890b377d4ce4b9d89ed051cf80ae7dc18aa073042dae4b191abb466
 file:
   batch:
   - statement:
@@ -19,8 +19,7 @@ file:
             column_reference:
               quoted_identifier: '[Flg]'
             assignment_operator:
-              comparison_operator:
-                raw_comparison_operator: '='
+              raw_comparison_operator: '='
             expression:
               numeric_literal: '1'
         where_clause:
@@ -74,8 +73,7 @@ file:
             - naked_identifier: rn
             assignment_operator:
               binary_operator: +
-              comparison_operator:
-                raw_comparison_operator: '='
+              raw_comparison_operator: '='
             expression:
               numeric_literal: '1'
         from_clause:
@@ -119,8 +117,7 @@ file:
             column_reference:
               naked_identifier: deleted
             assignment_operator:
-              comparison_operator:
-                raw_comparison_operator: '='
+              raw_comparison_operator: '='
             expression:
               numeric_literal: '1'
         output_clause:


### PR DESCRIPTION
This is part of #3824.

Given it might be a bit longer until that gets merged, it seems sensible to merge this part earlier because it's easily separable.

This makes more precise use of `RawEqualsSegment` in TSQL rather than the existing use of `EqualsSegment`.