### PR TITLE
raw_segments_with_ancestors

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -473,18 +473,19 @@ class BaseSegment(metaclass=SegmentMetaclass):
     @cached_property
     def raw_segments_with_ancestors(
         self,
-    ) -> List[Tuple["RawSegment", List["BaseSegment"]]]:
+    ) -> List[Tuple["RawSegment", List[PathStep]]]:
         """Returns a list of raw segments in this segment with the ancestors."""
         buffer = []
-        for seg in self.segments:
+        for idx, seg in enumerate(self.segments):
             # If it's a raw, yield it with this segment as the parent
+            new_step = [PathStep(self, idx, len(self.segments))]
             if seg.is_type("raw"):
-                buffer.append((seg, [self]))
+                buffer.append((seg, new_step))
             # If it's not, recurse - prepending self to the ancestor stack
             else:
                 buffer.extend(
                     [
-                        (raw_seg, [self] + stack)
+                        (raw_seg, new_step + stack)
                         for raw_seg, stack in seg.raw_segments_with_ancestors
                     ]
                 )

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -471,6 +471,26 @@ class BaseSegment(metaclass=SegmentMetaclass):
         return self.get_raw_segments()
 
     @cached_property
+    def raw_segments_with_ancestors(
+        self,
+    ) -> List[Tuple["RawSegment", List["BaseSegment"]]]:
+        """Returns a list of raw segments in this segment with the ancestors."""
+        buffer = []
+        for seg in self.segments:
+            # If it's a raw, yield it with this segment as the parent
+            if seg.is_type("raw"):
+                buffer.append((seg, [self]))
+            # If it's not, recurse - prepending self to the ancestor stack
+            else:
+                buffer.extend(
+                    [
+                        (raw_seg, [self] + stack)
+                        for raw_seg, stack in seg.raw_segments_with_ancestors
+                    ]
+                )
+        return buffer
+
+    @cached_property
     def source_fixes(self) -> List[SourceFix]:
         """Return any source fixes as list."""
         return list(chain.from_iterable(s.source_fixes for s in self.segments))
@@ -813,6 +833,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
             "raw_upper",
             "matched_length",
             "raw_segments",
+            "raw_segments_with_ancestors",
             "first_non_whitespace_segment_raw_upper",
             "source_fixes",
             "full_type_set",

--- a/test/core/parser/segments_base_test.py
+++ b/test/core/parser/segments_base_test.py
@@ -190,6 +190,9 @@ def test__parser__raw_segments_with_ancestors(raw_seg_list):
     test_seg = DummySegment([DummyAuxSegment(raw_seg_list[:1]), raw_seg_list[1]])
     # Result should be the same raw segment, but with appropriate parents
     assert test_seg.raw_segments_with_ancestors == [
-        (raw_seg_list[0], [test_seg, test_seg.segments[0]]),
-        (raw_seg_list[1], [test_seg]),
+        (
+            raw_seg_list[0],
+            [PathStep(test_seg, 0, 2), PathStep(test_seg.segments[0], 0, 1)],
+        ),
+        (raw_seg_list[1], [PathStep(test_seg, 1, 2)]),
     ]

--- a/test/core/parser/segments_base_test.py
+++ b/test/core/parser/segments_base_test.py
@@ -180,3 +180,16 @@ def test__parser__raw_get_raw_segments(raw_seg_list):
     """Test niche case of calling get_raw_segments on a raw segment."""
     for s in raw_seg_list:
         assert s.get_raw_segments() == [s]
+
+
+def test__parser__raw_segments_with_ancestors(raw_seg_list):
+    """Test raw_segments_with_ancestors.
+
+    This is used in the reflow module to assess parse depth.
+    """
+    test_seg = DummySegment([DummyAuxSegment(raw_seg_list[:1]), raw_seg_list[1]])
+    # Result should be the same raw segment, but with appropriate parents
+    assert test_seg.raw_segments_with_ancestors == [
+        (raw_seg_list[0], [test_seg, test_seg.segments[0]]),
+        (raw_seg_list[1], [test_seg]),
+    ]


### PR DESCRIPTION
This is another relatively standalone part of #3824.

It's slightly more abstract than the others as nothing in the codebase _uses_ the method yet, but it is well tested, and takes a little more logic out of the parent PR to make that more manageable.

This has already been partly reviewed by @barrywhart as part of the original PR so should look familiar.