### PR TITLE
MySQL: Implement (key_part, ...) in index definitions

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -692,7 +692,7 @@ class TableConstraintSegment(BaseSegment):
                     OneOf("INDEX", "KEY", optional=True),
                     Ref("IndexReferenceSegment", optional=True),
                     Ref("IndexTypeGrammar", optional=True),
-                    Ref("BracketedColumnReferenceListGrammar"),
+                    Ref("BracketedKeyPartListGrammar"),
                     Ref("IndexOptionsSegment", optional=True),
                 ),
                 # PRIMARY KEY [index_type] (key_part,...) [index_option] ...
@@ -700,7 +700,7 @@ class TableConstraintSegment(BaseSegment):
                     Ref("PrimaryKeyGrammar"),
                     Ref("IndexTypeGrammar", optional=True),
                     # Columns making up PRIMARY KEY constraint
-                    Ref("BracketedColumnReferenceListGrammar"),
+                    Ref("BracketedKeyPartListGrammar"),
                     Ref("IndexOptionsSegment", optional=True),
                 ),
                 # FOREIGN KEY [index_name] (col_name,...) reference_definition
@@ -748,7 +748,7 @@ class TableConstraintSegment(BaseSegment):
             OneOf("INDEX", "KEY"),
             Ref("IndexReferenceSegment", optional=True),
             Ref("IndexTypeGrammar", optional=True),
-            Ref("BracketedColumnReferenceListGrammar"),
+            Ref("BracketedKeyPartListGrammar"),
             Ref("IndexOptionsSegment", optional=True),
         ),
         # {FULLTEXT | SPATIAL} [INDEX | KEY] [index_name] (key_part,...)
@@ -757,7 +757,7 @@ class TableConstraintSegment(BaseSegment):
             OneOf("FULLTEXT", "SPATIAL"),
             OneOf("INDEX", "KEY", optional=True),
             Ref("IndexReferenceSegment", optional=True),
-            Ref("BracketedColumnReferenceListGrammar"),
+            Ref("BracketedKeyPartListGrammar"),
             Ref("IndexOptionsSegment", optional=True),
         ),
     )
@@ -834,6 +834,24 @@ mysql_dialect.add(
         # the correct capitalisation policy.
         OneOf("ON", "OFF"),
         OneOf("TRUE", "FALSE"),
+    ),
+    # (key_part, ...)
+    # key_part: {col_name [(length)] | (expr)} [ASC | DESC]
+    # https://dev.mysql.com/doc/refman/8.0/en/create-table.html
+    # https://dev.mysql.com/doc/refman/8.0/en/alter-table.html
+    BracketedKeyPartListGrammar=Bracketed(
+        Delimited(
+            Sequence(
+                OneOf(
+                    Ref("ColumnReferenceSegment"),
+                    Sequence(
+                        Ref("ColumnReferenceSegment"),
+                        Bracketed(Ref("NumericLiteralSegment")),
+                    ),
+                ),
+                OneOf("ASC", "DESC", optional=True),
+            ),
+        ),
     ),
 )
 

--- a/test/fixtures/dialects/mysql/create_table_index.sql
+++ b/test/fixtures/dialects/mysql/create_table_index.sql
@@ -2,7 +2,11 @@ CREATE TABLE foo (
   id INT UNSIGNED AUTO_INCREMENT NOT NULL,
   a TEXT(500),
   b INT,
+  c INT,
   PRIMARY KEY (id) COMMENT 'primary key (id)',
   FULLTEXT `idx_a` (a) COMMENT 'index (a)',
-  INDEX `idx_b` (b) COMMENT 'index (b)'
+  INDEX `idx_prefix_a` (a(20)),
+  INDEX `idx_b` (b) COMMENT 'index (b)',
+  INDEX `idx_desc_b` (b DESC),
+  INDEX `idx_asc_c` (c ASC)
 ) ENGINE=InnoDB;

--- a/test/fixtures/dialects/mysql/create_table_index.yml
+++ b/test/fixtures/dialects/mysql/create_table_index.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4dede9571dafbf9136e3725f05afe85293bd1beb457aa05c4ae7238cece9d78c
+_hash: 40c32eb27d8d8dc065fe6ac0e484d6b1f9ffffaf63230c70c66d24d20c93d5da
 file:
   statement:
     create_table_statement:
@@ -39,6 +39,11 @@ file:
           data_type:
             data_type_identifier: INT
       - comma: ','
+      - column_definition:
+          naked_identifier: c
+          data_type:
+            data_type_identifier: INT
+      - comma: ','
       - table_constraint:
         - keyword: PRIMARY
         - keyword: KEY
@@ -69,6 +74,20 @@ file:
       - table_constraint:
           keyword: INDEX
           index_reference:
+            quoted_identifier: '`idx_prefix_a`'
+          bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: a
+            bracketed:
+              start_bracket: (
+              numeric_literal: '20'
+              end_bracket: )
+            end_bracket: )
+      - comma: ','
+      - table_constraint:
+          keyword: INDEX
+          index_reference:
             quoted_identifier: '`idx_b`'
           bracketed:
             start_bracket: (
@@ -79,6 +98,28 @@ file:
             comment_clause:
               keyword: COMMENT
               quoted_literal: "'index (b)'"
+      - comma: ','
+      - table_constraint:
+          keyword: INDEX
+          index_reference:
+            quoted_identifier: '`idx_desc_b`'
+          bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: b
+            keyword: DESC
+            end_bracket: )
+      - comma: ','
+      - table_constraint:
+          keyword: INDEX
+          index_reference:
+            quoted_identifier: '`idx_asc_c`'
+          bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: c
+            keyword: ASC
+            end_bracket: )
       - end_bracket: )
     - parameter: ENGINE
     - comparison_operator:


### PR DESCRIPTION
It also adds support for index prefixes:
https://dev.mysql.com/doc/refman/8.0/en/column-indexes.html#column-indexes-prefix


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #3886 

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
