### PR TITLE
Reflow centralisation 3: L065 (set operators)

### DIFF
--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -28,7 +28,17 @@ can still cache appropriately
 
 ConfigElemType = Tuple[Tuple[str, ...], Any]
 
-REMOVED_CONFIGS: Dict[Tuple[str, ...], Any] = {
+DEPRECATED_CONFIGS: Dict[Tuple[str, ...], Any] = {
+    ("rules", "L007", "operator_new_lines"): (
+        "Use the line_position config in the appropriate "
+        "sqlfluff:layout section (e.g. sqlfluff:layout:type"
+        ":binary_operator)."
+    ),
+    ("rules", "L019", "comma_style"): (
+        "Use the line_position config in the appropriate "
+        "sqlfluff:layout section (e.g. sqlfluff:layout:type"
+        ":comma)."
+    ),
     ("rules", "L003", "lint_templated_tokens"): ("No longer used."),
 }
 

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -28,7 +28,7 @@ can still cache appropriately
 
 ConfigElemType = Tuple[Tuple[str, ...], Any]
 
-DEPRECATED_CONFIGS: Dict[Tuple[str, ...], Any] = {
+REMOVED_CONFIGS: Dict[Tuple[str, ...], Any] = {
     ("rules", "L007", "operator_new_lines"): (
         "Use the line_position config in the appropriate "
         "sqlfluff:layout section (e.g. sqlfluff:layout:type"

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -70,6 +70,9 @@ line_position = trailing
 [sqlfluff:layout:type:end_of_file]
 spacing_before = touch
 
+[sqlfluff:layout:type:set_operator]
+line_position = alone:strict
+
 [sqlfluff:layout:type:start_bracket]
 spacing_after = touch
 

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -65,6 +65,10 @@ line_position = leading
 
 [sqlfluff:layout:type:statement_terminator]
 spacing_before = touch
+line_position = trailing
+
+[sqlfluff:layout:type:end_of_file]
+spacing_before = touch
 
 [sqlfluff:layout:type:start_bracket]
 spacing_after = touch

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -58,6 +58,10 @@ template_blocks_indent = True
 
 [sqlfluff:layout:type:comma]
 spacing_before = touch
+line_position = trailing
+
+[sqlfluff:layout:type:binary_operator]
+line_position = leading
 
 [sqlfluff:layout:type:statement_terminator]
 spacing_before = touch
@@ -80,6 +84,7 @@ spacing_after = touch
 
 [sqlfluff:layout:type:comparison_operator]
 spacing_within = touch
+line_position = leading
 
 [sqlfluff:layout:type:object_reference]
 spacing_within = inline

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -113,9 +113,6 @@ unquoted_identifiers_policy = all
 [sqlfluff:rules:L003]
 hanging_indents = True
 
-[sqlfluff:rules:L007]
-operator_new_lines = after
-
 [sqlfluff:rules:L010]
 # Keywords
 capitalisation_policy = consistent

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -343,16 +343,14 @@ class LintedFile(NamedTuple):
             # Deal with the easy cases of 1) New code at end 2) only literals
             if not local_type_list or set(local_type_list) == {"literal"}:
                 linter_logger.info(
-                    "      * Keeping patch on new or literal-only section: %s",
-                    patch,
+                    "      * Keeping patch on new or literal-only section.",
                 )
                 filtered_source_patches.append(patch)
                 dedupe_buffer.append(patch.dedupe_tuple())
             # Handle the easy case of an explicit source fix
             elif patch.patch_category == "source":
                 linter_logger.info(
-                    "      * Keeping explicit source fix patch: %s",
-                    patch,
+                    "      * Keeping explicit source fix patch.",
                 )
                 filtered_source_patches.append(patch)
                 dedupe_buffer.append(patch.dedupe_tuple())
@@ -362,8 +360,7 @@ class LintedFile(NamedTuple):
                 and patch.source_slice.start == local_raw_slices[0].source_idx
             ):
                 linter_logger.info(
-                    "      * Keeping insertion patch on slice boundary: %s",
-                    patch,
+                    "      * Keeping insertion patch on slice boundary.",
                 )
                 filtered_source_patches.append(patch)
                 dedupe_buffer.append(patch.dedupe_tuple())

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -236,8 +236,9 @@ class LintFix:
                 detail = f"create:{new_detail!r}"
         else:
             detail = ""  # pragma: no cover TODO?
-        return "<LintFix: {} @{} {}>".format(
-            self.edit_type, self.anchor.pos_marker, detail
+        return (
+            f"<LintFix: {self.edit_type} {self.anchor.get_type()}"
+            f"@{self.anchor.pos_marker} {detail}>"
         )
 
     def __eq__(self, other):

--- a/src/sqlfluff/rules/L007.py
+++ b/src/sqlfluff/rules/L007.py
@@ -85,6 +85,19 @@ class Rule_L007(BaseRule):
         if not fixes:
             return LintResult()
 
-        # TODO: Still need to incorporate the nicer formatted description
-        # in based on the current config.
-        return LintResult(context.segment, fixes)
+        seg_type = context.segment.class_types.intersection(
+            {"binary_operator", "comparison_operator"}
+        ).pop()
+        desired_position = context.config.get(
+            "line_position", ("layout", "type", seg_type)
+        )
+
+        return LintResult(
+            context.segment,
+            fixes,
+            description=(
+                after_description
+                if desired_position == "leading"
+                else before_description
+            ),
+        )

--- a/src/sqlfluff/rules/L007.py
+++ b/src/sqlfluff/rules/L007.py
@@ -1,16 +1,13 @@
 """Implementation of Rule L007."""
-import copy
-from typing import List
-from sqlfluff.core.parser.segments.base import BaseSegment
-from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.crawlers import ParentOfSegmentCrawler
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
     document_groups,
 )
-from sqlfluff.utils.functional import Segments, FunctionalContext, sp
+from sqlfluff.utils.reflow import ReflowSequence
 
 after_description = "Operators near newlines should be after, not before the newline"
 before_description = "Operators near newlines should be before, not after the newline"
@@ -58,10 +55,9 @@ class Rule_L007(BaseRule):
     """
 
     groups = ("all",)
-    config_keywords = ["operator_new_lines"]
-    crawl_behaviour = ParentOfSegmentCrawler({"binary_operator", "comparison_operator"})
+    crawl_behaviour = SegmentSeekerCrawler({"binary_operator", "comparison_operator"})
 
-    def _eval(self, context: RuleContext) -> List[LintResult]:
+    def _eval(self, context: RuleContext) -> LintResult:
         """Operators should follow a standard for being before/after newlines.
 
         We use the memory to keep track of whitespace up to now, and
@@ -70,95 +66,25 @@ class Rule_L007(BaseRule):
 
         We only trigger if we have an operator FOLLOWED BY a newline
         before the next meaningful code segment.
-
         """
-        relevent_types = ["binary_operator", "comparison_operator"]
-        segment = FunctionalContext(context).segment
-        # bring var to this scope so as to only have one type ignore
-        operator_new_lines: str = self.operator_new_lines  # type: ignore
-        expr = segment.children()
-        operator_segments = segment.children(sp.is_type(*relevent_types))
-        results: List[LintResult] = []
-        # If len(operator_segments) == 0 this will essentially not run
-        for operator in operator_segments:
-            start = expr.reversed().select(start_seg=operator).first(sp.is_code())
-            end = expr.select(start_seg=operator).first(sp.is_code())
-            res = [
-                expr.select(start_seg=start.get(), stop_seg=operator),
-                expr.select(start_seg=operator, stop_seg=end.get()),
-            ]
-            # anchor and change els are reversed in the before case
-            if operator_new_lines == "before":
-                res = [els.reversed() for els in reversed(res)]
+        # The way we apply this is to create reflow sequences around each operator.
+        # If there isn't a newline on either side, then ignore it for now.
+        # Going any further than that is probably deeper reflow than we want
+        # for now.
 
-            change_list, anchor_list = res
-            # If the anchor side of the list has no newline
-            # then everything is ok already
-            if not anchor_list.any(
-                sp.and_(sp.is_type("newline"), sp.not_(sp.is_templated()))
-            ):
-                continue
-
-            # If the operator is on a line by itself, that's okay regardless of
-            # the 'operator_new_lines' setting.
-            newline_after_operator = expr.select(
-                sp.or_(sp.is_code(), sp.is_type("newline")), start_seg=operator
-            ).first(sp.is_type("newline"))
-            newline_before_operator = (
-                expr.reversed()
-                .select(sp.or_(sp.is_code(), sp.is_type("newline")), start_seg=operator)
-                .first(sp.is_type("newline"))
+        fixes = (
+            ReflowSequence.from_around_target(
+                context.segment,
+                root_segment=context.parent_stack[0],
+                config=context.config,
             )
-            if newline_after_operator and newline_before_operator:
-                continue
+            .rebreak()
+            .get_fixes()
+        )
 
-            insert_anchor = anchor_list.last().get()
-            assert insert_anchor, "Insert Anchor must be present"
-            lint_res = _generate_fixes(
-                operator_new_lines,
-                change_list,
-                operator,
-                insert_anchor,
-            )
-            results.append(lint_res)
+        if not fixes:
+            return LintResult()
 
-        return results
-
-
-def _generate_fixes(
-    operator_new_lines: str,
-    change_list: Segments,
-    operator: BaseSegment,
-    insert_anchor: BaseSegment,
-) -> LintResult:
-    # Duplicate the change list and append the operator
-    inserts: List[BaseSegment] = [
-        *change_list,
-        operator,
-    ]
-
-    if operator_new_lines == "before":
-        # We do yet another reverse here,
-        # This could be avoided but makes all "changes" relate to "before" config state
-        inserts = [*reversed(inserts)]
-
-    # ensure to insert in the right place
-    edit_type = "create_before" if operator_new_lines == "before" else "create_after"
-    fixes = [
-        # Insert elements reversed
-        LintFix(
-            edit_type=edit_type,
-            edit=map(lambda el: copy.deepcopy(el), reversed(inserts)),
-            anchor=insert_anchor,
-        ),
-        # remove the Op
-        LintFix.delete(operator),
-        # Delete the original elements (related to insert)
-        *change_list.apply(LintFix.delete),
-    ]
-    desc = before_description if operator_new_lines == "before" else after_description
-    return LintResult(
-        anchor=operator,
-        description=desc,
-        fixes=fixes,
-    )
+        # TODO: Still need to incorporate the nicer formatted description
+        # in based on the current config.
+        return LintResult(context.segment, fixes)

--- a/src/sqlfluff/rules/L019.py
+++ b/src/sqlfluff/rules/L019.py
@@ -54,6 +54,7 @@ class Rule_L019(BaseRule):
 
     groups = ("all",)
     crawl_behaviour = SegmentSeekerCrawler({"comma"})
+    _adjust_anchors = True
 
     def _eval(self, context: RuleContext) -> LintResult:
         """Enforce comma placement.

--- a/src/sqlfluff/rules/L019.py
+++ b/src/sqlfluff/rules/L019.py
@@ -1,15 +1,13 @@
 """Implementation of Rule L019."""
 
-from typing import Any, Dict, Optional, Tuple
-
-from sqlfluff.core.parser import RawSegment, WhitespaceSegment
-from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.core.rules.doc_decorators import (
     document_configuration,
     document_fix_compatible,
     document_groups,
 )
+from sqlfluff.utils.reflow import ReflowSequence
 
 
 @document_groups
@@ -54,48 +52,10 @@ class Rule_L019(BaseRule):
         FROM foo
     """
 
-    groups = ("all", "core")
-    # Crawling all raw is expensive, but this rule triggers on a lot
-    # including whitespace, newline and final segments, which means
-    # there isn't much benefit to being more specific.
-    crawl_behaviour = SegmentSeekerCrawler({"raw"}, provide_raw_stack=True)
-    config_keywords = ["comma_style"]
+    groups = ("all",)
+    crawl_behaviour = SegmentSeekerCrawler({"comma"})
 
-    @staticmethod
-    def _last_comment_seg(raw_stack):
-        """Trace the raw stack back to the most recent comment segment.
-
-        A return value of `None` indicates no code segments preceding the current
-        position.
-        """
-        for segment in raw_stack[::-1]:
-            if segment.is_comment:
-                return segment
-        return None
-
-    @staticmethod
-    def _last_code_seg(raw_stack: Tuple[RawSegment, ...]) -> Optional[RawSegment]:
-        """Trace the raw stack back to the most recent code segment.
-
-        A return value of `None` indicates no code segments preceding the current
-        position.
-        """
-        for segment in raw_stack[::-1]:
-            if segment.is_code or segment.is_type("newline"):
-                return segment
-        return None
-
-    @staticmethod
-    def _get_following_seg(
-        raw_stack: Tuple[RawSegment, ...], segment: RawSegment
-    ) -> RawSegment:
-        """Given a segment in raw_stack, return the segment following."""
-        idx = raw_stack.index(segment)
-        if idx < len(raw_stack):
-            return raw_stack[idx + 1]
-        raise ValueError("No following segment available")  # pragma: no cover
-
-    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+    def _eval(self, context: RuleContext) -> LintResult:
         """Enforce comma placement.
 
         For leading commas we're looking for trailing commas, so
@@ -107,135 +67,19 @@ class Rule_L019(BaseRule):
         leading comma to a trailing comma. We add whitespace after the leading
         comma when converting a trailing comma to a leading comma.
         """
-        # Config type hints
-        self.comma_style: str
+        fixes = (
+            ReflowSequence.from_around_target(
+                context.segment,
+                root_segment=context.parent_stack[0],
+                config=context.config,
+            )
+            .rebreak()
+            .get_fixes()
+        )
 
-        if not context.memory:
-            memory: Dict[str, Any] = {
-                # Trailing comma keys
-                #
-                # Do we have a fix in place for removing a leading
-                # comma violation, and inserting a new trailing comma?
-                "insert_trailing_comma": False,
-                # A list of whitespace segments that come after a
-                # leading comma violation, to be removed during fixing.
-                "whitespace_deletions": None,
-                # The leading comma violation segment to be removed during fixing
-                "last_leading_comma_seg": None,
-                # The newline segment where we're going to insert our new trailing
-                # comma during fixing
-                "anchor_for_new_trailing_comma_seg": None,
-                #
-                # Leading comma keys
-                #
-                # Do we have a fix in place for removing a trailing
-                # comma violation, and inserting a new leading comma?
-                "insert_leading_comma": False,
-                # The trailing comma violation segment to be removed during fixing
-                "last_trailing_comma_segment": None,
-            }
-        else:
-            memory = context.memory
+        if not fixes:
+            return LintResult()
 
-        if self.comma_style == "trailing":
-            # A comma preceded by a new line == a leading comma
-            if context.segment.is_type("comma"):
-                last_seg = self._last_code_seg(context.raw_stack)
-                if (
-                    last_seg
-                    and last_seg.is_type("newline")
-                    and not last_seg.is_templated
-                ):
-                    # Recorded where the fix should be applied
-                    memory["last_leading_comma_seg"] = context.segment
-                    last_comment_seg = self._last_comment_seg(context.raw_stack)
-                    inline_comment = (
-                        last_comment_seg.pos_marker.line_no
-                        == last_seg.pos_marker.line_no
-                        if last_comment_seg
-                        else False
-                    )
-                    # If we have a comment right before the newline, then anchor
-                    # the fix at the comment instead
-                    memory["anchor_for_new_trailing_comma_seg"] = (
-                        last_seg if not inline_comment else last_comment_seg
-                    )
-                    # Trigger fix routine
-                    memory["insert_trailing_comma"] = True
-                    memory["whitespace_deletions"] = []
-                    return LintResult(memory=memory)
-            # Have we found a leading comma violation?
-            if memory["insert_trailing_comma"]:
-                # Search for trailing whitespace to delete after the leading
-                # comma violation
-                if context.segment.is_type("whitespace"):
-                    memory["whitespace_deletions"] += [context.segment]
-                    return LintResult(memory=memory)
-                else:
-                    # We've run out of whitespace to delete, time to fix
-                    last_leading_comma_seg = memory["last_leading_comma_seg"]
-                    # Scan backwards to find the last code segment, skipping
-                    # over lines that are either entirely blank or just a
-                    # comment. We want to place the comma immediately after it.
-                    last_code_seg = None
-                    while last_code_seg is None or last_code_seg.is_type("newline"):
-                        last_code_seg = self._last_code_seg(
-                            context.raw_stack[
-                                : context.raw_stack.index(
-                                    last_code_seg
-                                    if last_code_seg
-                                    else memory["last_leading_comma_seg"]
-                                )
-                            ]
-                        )
-                    return LintResult(
-                        anchor=last_leading_comma_seg,
-                        description="Found leading comma. Expected only trailing.",
-                        fixes=[
-                            LintFix.delete(last_leading_comma_seg),
-                            *[
-                                LintFix.delete(d)
-                                for d in memory["whitespace_deletions"]
-                            ],
-                            LintFix.create_before(
-                                anchor_segment=self._get_following_seg(
-                                    context.raw_stack, last_code_seg
-                                ),
-                                edit_segments=[last_leading_comma_seg],
-                            ),
-                        ],
-                    )
-
-        elif self.comma_style == "leading":
-            # A new line preceded by a comma == a trailing comma
-            if context.segment.is_type("newline"):
-                last_seg = self._last_code_seg(context.raw_stack)
-                # no code precedes the current position: no issue
-                if last_seg is None:
-                    return None
-                if last_seg.is_type("comma") and not context.segment.is_templated:
-                    # Trigger fix routine
-                    memory["insert_leading_comma"] = True
-                    # Record where the fix should be applied
-                    memory["last_trailing_comma_segment"] = last_seg
-                    return LintResult(memory=memory)
-            # Have we found a trailing comma violation?
-            if memory["insert_leading_comma"]:
-                # Only insert the comma here if this isn't a comment/whitespace segment
-                if context.segment.is_code:
-                    last_comma_seg = memory["last_trailing_comma_segment"]
-                    # Create whitespace to insert after the new leading comma
-                    new_whitespace_seg = WhitespaceSegment()
-                    return LintResult(
-                        anchor=last_comma_seg,
-                        description="Found trailing comma. Expected only leading.",
-                        fixes=[
-                            LintFix.delete(last_comma_seg),
-                            LintFix.create_before(
-                                anchor_segment=context.segment,
-                                edit_segments=[last_comma_seg, new_whitespace_seg],
-                            ),
-                        ],
-                    )
-        # Otherwise, no issue
-        return None
+        # TODO: Still need to incorporate the nicer formatted description
+        # in based on the current config.
+        return LintResult(context.segment, fixes)

--- a/src/sqlfluff/rules/L065.py
+++ b/src/sqlfluff/rules/L065.py
@@ -1,11 +1,10 @@
 """Implementation of Rule L065."""
-from typing import List, Optional, Iterable
+from typing import List
 
-from sqlfluff.utils.functional import sp, FunctionalContext
-from sqlfluff.core.parser import BaseSegment, NewlineSegment
-from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.crawlers import ParentOfSegmentCrawler
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
+from sqlfluff.utils.reflow.sequence import ReflowSequence
 
 
 @document_groups
@@ -15,7 +14,7 @@ class Rule_L065(BaseRule):
 
     **Anti-pattern**
 
-    In this example, `UNION ALL` is not on a line ifself.
+    In this example, `UNION ALL` is not on a line itself.
 
     .. code-block:: sql
 
@@ -34,9 +33,7 @@ class Rule_L065(BaseRule):
 
     groups = ("all",)
 
-    # Still define target elems for functional steps later
-    _target_elems = ("set_operator",)
-    crawl_behaviour = ParentOfSegmentCrawler({"set_operator"})
+    crawl_behaviour = SegmentSeekerCrawler({"set_operator"})
 
     def _eval(self, context: RuleContext) -> List[LintResult]:
         """Set operators should be surrounded by newlines.
@@ -46,116 +43,53 @@ class Rule_L065(BaseRule):
 
         In particular, as part of this rule we allow multiple NewLineSegments.
         """
-        segment = FunctionalContext(context).segment
-
-        expression = segment.children()
-        set_operator_segments = segment.children(sp.is_type(*self._target_elems))
-        # We should always find some as children because of the ParentOfSegmentCrawler
-        assert set_operator_segments
-        results: List[LintResult] = []
-
-        # If len(set_operator) == 0 this will essentially not run
-        for set_operator in set_operator_segments:
-            preceeding_code = (
-                expression.reversed().select(start_seg=set_operator).first(sp.is_code())
+        fixes = (
+            ReflowSequence.from_around_target(
+                context.segment,
+                root_segment=context.parent_stack[0],
+                config=context.config,
             )
-            following_code = expression.select(start_seg=set_operator).first(
-                sp.is_code()
+            .rebreak()
+            .get_fixes()
+        )
+        assert context.segment.pos_marker
+        pre_fixes = [
+            fix
+            for fix in fixes
+            if fix.anchor.pos_marker
+            and fix.anchor.pos_marker.working_loc
+            < context.segment.pos_marker.working_loc
+        ]
+        post_fixes = [
+            fix
+            for fix in fixes
+            if fix.anchor.pos_marker
+            and fix.anchor.pos_marker.working_loc
+            > context.segment.pos_marker.working_loc
+        ]
+
+        results = []
+        if pre_fixes:
+            results.append(
+                LintResult(
+                    anchor=context.segment,
+                    description=(
+                        "Set operators should be surrounded by newlines. "
+                        f"Missing newline before set operator {context.segment.raw}."
+                    ),
+                    fixes=fixes,
+                )
             )
-            res = {
-                "before": expression.select(
-                    start_seg=preceeding_code.get(), stop_seg=set_operator
-                ),
-                "after": expression.select(
-                    start_seg=set_operator, stop_seg=following_code.get()
-                ),
-            }
-
-            newline_before_set_operator = res["before"].first(sp.is_type("newline"))
-            newline_after_set_operator = res["after"].first(sp.is_type("newline"))
-
-            # If there is a whitespace directly preceeding/following the set operator we
-            # are replacing it with a newline later.
-            preceeding_whitespace = res["before"].first(sp.is_type("whitespace")).get()
-            following_whitespace = res["after"].first(sp.is_type("whitespace")).get()
-
-            if newline_before_set_operator and newline_after_set_operator:
-                continue
-            elif not newline_before_set_operator and newline_after_set_operator:
-                results.append(
-                    LintResult(
-                        anchor=set_operator,
-                        description=(
-                            "Set operators should be surrounded by newlines. "
-                            f"Missing newline before set operator {set_operator.raw}."
-                        ),
-                        fixes=_generate_fixes(whitespace_segment=preceeding_whitespace),
-                    )
+        if post_fixes:
+            results.append(
+                LintResult(
+                    anchor=context.segment,
+                    description=(
+                        "Set operators should be surrounded by newlines. "
+                        f"Missing newline after set operator {context.segment.raw}."
+                    ),
+                    fixes=fixes,
                 )
-            elif newline_before_set_operator and not newline_after_set_operator:
-                results.append(
-                    LintResult(
-                        anchor=set_operator,
-                        description=(
-                            "Set operators should be surrounded by newlines. "
-                            f"Missing newline after set operator {set_operator.raw}."
-                        ),
-                        fixes=_generate_fixes(whitespace_segment=following_whitespace),
-                    )
-                )
-            else:
-                preceeding_whitespace_fixes = _generate_fixes(
-                    whitespace_segment=preceeding_whitespace
-                )
-                following_whitespace_fixes = _generate_fixes(
-                    whitespace_segment=following_whitespace
-                )
-
-                # make mypy happy
-                assert isinstance(preceeding_whitespace_fixes, Iterable)
-                assert isinstance(following_whitespace_fixes, Iterable)
-
-                fixes = []
-                fixes.extend(preceeding_whitespace_fixes)
-                fixes.extend(following_whitespace_fixes)
-
-                results.append(
-                    LintResult(
-                        anchor=set_operator,
-                        description=(
-                            "Set operators should be surrounded by newlines. "
-                            "Missing newline before and after set operator "
-                            f"{set_operator.raw}."
-                        ),
-                        fixes=fixes,
-                    )
-                )
+            )
 
         return results
-
-
-def _generate_fixes(
-    whitespace_segment: Optional[BaseSegment],
-) -> Optional[List[LintFix]]:
-
-    if whitespace_segment:
-        return [
-            LintFix.replace(
-                anchor_segment=whitespace_segment,
-                # NB: Currently we are just inserting a Newline here. This alone will
-                # produce not properly indented SQL. We rely on L003 to deal with
-                # indentation later.
-                # As a future improvement we could maybe add WhitespaceSegment( ... )
-                # here directly.
-                edit_segments=[NewlineSegment()],
-            )
-        ]
-    else:
-        # We should rarely reach here as set operators are always surrounded by either
-        # WhitespaceSegment or NewlineSegment.
-        # However, in exceptional cases the WhitespaceSegment might be enclosed in the
-        # surrounding segment hierachy and not accessible by the rule logic.
-        # At the time of writing this is true for `tsql` as covered in the test
-        # `test_fail_autofix_in_tsql_disabled`. If we encounter such case, we skip
-        # fixing.
-        return []

--- a/src/sqlfluff/utils/functional/segment_predicates.py
+++ b/src/sqlfluff/utils/functional/segment_predicates.py
@@ -108,7 +108,7 @@ def is_whitespace() -> Callable[[BaseSegment], bool]:
     return _
 
 
-def is_templated() -> Callable[[BaseSegment], bool]:
+def is_templated() -> Callable[[BaseSegment], bool]:  # pragma: no cover
     """Returns a function that checks if segment is templated."""
 
     def _(segment: BaseSegment) -> bool:

--- a/src/sqlfluff/utils/reflow/config.py
+++ b/src/sqlfluff/utils/reflow/config.py
@@ -91,8 +91,8 @@ class ReflowConfig:
         When fetching the config for a single class type for a simple block
         we should just get an appropriate simple config back.
         >>> cfg = ReflowConfig.from_dict({"comma": {"spacing_before": "touch"}})
-        >>> cfg.get_block_config({"comma"})
-        BlockConfig(spacing_before='touch', spacing_after='single', spacing_within=None)
+        >>> cfg.get_block_config({"comma"})  # doctest: +ELLIPSIS
+        BlockConfig(spacing_before='touch', spacing_after='single', ...)
         """
         # set intersection to get the class types which matter
         configured_types = self.config_types.intersection(block_class_types)

--- a/src/sqlfluff/utils/reflow/config.py
+++ b/src/sqlfluff/utils/reflow/config.py
@@ -20,12 +20,14 @@ class BlockConfig:
     spacing_before: str = "single"
     spacing_after: str = "single"
     spacing_within: Optional[str] = None
+    line_position: Optional[str] = None
 
     def incorporate(
         self,
         before: Optional[str] = None,
         after: Optional[str] = None,
         within: Optional[str] = None,
+        line_position: Optional[str] = None,
         config: Optional[ConfigElementType] = None,
     ):
         """Mutate the config based on additional information."""
@@ -38,6 +40,9 @@ class BlockConfig:
         )
         self.spacing_within = (
             within or config.get("spacing_within", None) or self.spacing_within
+        )
+        self.line_position = (
+            line_position or config.get("line_position", None) or self.line_position
         )
 
 
@@ -100,7 +105,8 @@ class ReflowConfig:
         # we're at one end (if depth info provided).
         if depth_info:
             parent_start, parent_end = True, True
-            for idx, pos in enumerate(depth_info.stack_positions[::-1]):
+            for idx, key in enumerate(depth_info.stack_hashes[::-1]):
+                _, _, pos = depth_info.stack_positions[key]
                 # Work out if we're allowed to claim the parent.
                 if pos not in ("solo", "start"):
                     parent_start = False

--- a/src/sqlfluff/utils/reflow/depthmap.py
+++ b/src/sqlfluff/utils/reflow/depthmap.py
@@ -2,7 +2,7 @@
 
 import logging
 from dataclasses import dataclass
-from typing import FrozenSet, List, Sequence, Tuple, Type
+from typing import FrozenSet, List, Sequence, Tuple, Type, Dict
 
 from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.parser.segments.base import PathStep
@@ -33,7 +33,7 @@ class DepthInfo:
     # This is a convenience cache to speed up operations.
     stack_hash_set: FrozenSet[int]
     stack_class_types: Tuple[FrozenSet[str], ...]
-    stack_positions: Tuple[str, ...]
+    stack_positions: Dict[int, Tuple[int, int, str]]
 
     @classmethod
     def from_raw_and_stack(cls, raw: RawSegment, stack: Sequence[PathStep]):
@@ -44,7 +44,10 @@ class DepthInfo:
             stack_hashes=stack_hashes,
             stack_hash_set=frozenset(stack_hashes),
             stack_class_types=tuple(frozenset(ps.segment.class_types) for ps in stack),
-            stack_positions=tuple(_stack_pos_interpreter(ps) for ps in stack),
+            stack_positions={
+                hash(ps.segment): (ps.idx, ps.len, _stack_pos_interpreter(ps))
+                for ps in stack
+            },
         )
 
     def common_with(self, other: "DepthInfo") -> Tuple[int, ...]:
@@ -63,12 +66,15 @@ class DepthInfo:
         if amount == 0:
             # The trivial case.
             return self
+        new_hash_set = self.stack_hash_set.difference(self.stack_hashes[-amount:])
         return self.__class__(
             stack_depth=self.stack_depth - amount,
             stack_hashes=self.stack_hashes[:-amount],
-            stack_hash_set=self.stack_hash_set.difference(self.stack_hashes[-amount:]),
+            stack_hash_set=new_hash_set,
             stack_class_types=self.stack_class_types[:-amount],
-            stack_positions=self.stack_positions[:-amount],
+            stack_positions={
+                k: v for k, v in self.stack_positions.items() if k in new_hash_set
+            },
         )
 
 

--- a/src/sqlfluff/utils/reflow/elements.py
+++ b/src/sqlfluff/utils/reflow/elements.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Set, Tuple, Type, cast
 
 from sqlfluff.core.parser import BaseSegment, RawSegment
-from sqlfluff.core.parser.segments.raw import WhitespaceSegment
+from sqlfluff.core.parser.segments.raw import NewlineSegment, WhitespaceSegment
 from sqlfluff.core.rules.base import LintFix
 
 from sqlfluff.utils.reflow.config import ReflowConfig
@@ -33,6 +33,13 @@ class ReflowElement:
         """Get the current raw representation."""
         return "".join(seg.raw for seg in self.segments)
 
+    def num_newlines(self) -> int:
+        """How many newlines does this element contain?"""
+        return sum(
+            bool(seg.class_types.intersection({"newline", "end_of_file"}))
+            for seg in self.segments
+        )
+
 
 @dataclass(frozen=True)
 class ReflowBlock(ReflowElement):
@@ -54,10 +61,15 @@ class ReflowBlock(ReflowElement):
     # - any:            don't enforce any spacing rules
     spacing_before: str
     spacing_after: str
+    # - None:           the default (no particular preference)
+    # - leading:        prefer newline before
+    # - trailing:       prefer newline after
+    line_position: Optional[str]
     # The depth info is used in determining where to put line breaks.
     depth_info: DepthInfo
     # This stores relevant configs for segments in the stack.
     stack_spacing_configs: Dict[int, str]
+    line_position_configs: Dict[int, str]
 
     @classmethod
     def from_config(
@@ -68,18 +80,23 @@ class ReflowBlock(ReflowElement):
         # Populate any spacing_within config.
         # TODO: This needs decent unit tests - not just what happens in rules.
         stack_spacing_configs = {}
+        line_position_configs = {}
         for hash, class_types in zip(
             depth_info.stack_hashes, depth_info.stack_class_types
         ):
-            spacing_within = config.get_block_config(class_types).spacing_within
-            if spacing_within:
-                stack_spacing_configs[hash] = spacing_within
+            cfg = config.get_block_config(class_types)
+            if cfg.spacing_within:
+                stack_spacing_configs[hash] = cfg.spacing_within
+            if cfg.line_position:
+                line_position_configs[hash] = cfg.line_position
         return cls(
             segments=segments,
             spacing_before=block_config.spacing_before,
             spacing_after=block_config.spacing_after,
+            line_position=block_config.line_position,
             depth_info=depth_info,
             stack_spacing_configs=stack_spacing_configs,
+            line_position_configs=line_position_configs,
         )
 
 
@@ -392,6 +409,7 @@ class ReflowPoint(ReflowElement):
         next_block: Optional[ReflowBlock],
         segment_buffer: List[RawSegment],
         existing_fixes: List[LintFix],
+        anchor_on: str = "before",
     ) -> Tuple[List[RawSegment], List[LintFix], bool]:
         """Ensure spacing is the right size.
 
@@ -467,7 +485,8 @@ class ReflowPoint(ReflowElement):
                     fix.edit = fix.edit + [cast(BaseSegment, WhitespaceSegment())]
             else:
                 reflow_logger.debug("    Not Detected existing fix. Creating new")
-                if prev_block:
+                # Take into account hint on where to anchor if given.
+                if prev_block and anchor_on != "after":
                     new_fixes.append(
                         LintFix(
                             "create_after",
@@ -475,8 +494,7 @@ class ReflowPoint(ReflowElement):
                             edit=[WhitespaceSegment()],
                         )
                     )
-                # TODO: We should have a test which covers this clause.
-                elif next_block:  # pragma: no cover
+                elif next_block:
                     new_fixes.append(
                         LintFix(
                             "create_before",
@@ -497,6 +515,99 @@ class ReflowPoint(ReflowElement):
 
         return segment_buffer, existing_fixes + new_fixes, edited
 
+    def _get_indent_segment(self) -> Optional[RawSegment]:
+        """Get the current indent segment (if there)."""
+        for seg in reversed(self.segments):
+            if seg.is_type("newline", "end_of_file"):
+                return None
+            elif seg.is_type("whitespace"):
+                return seg
+        return None
+
+    def get_indent(self) -> Optional[str]:
+        """Get the current indent (if there)."""
+        seg = self._get_indent_segment()
+        return seg.raw if seg else None
+
+    def indent_to(
+        self,
+        desired_indent: str,
+        after: Optional[BaseSegment] = None,
+        before: Optional[BaseSegment] = None,
+    ) -> Tuple[List[LintFix], "ReflowPoint"]:
+        """Coerce a point to have a particular indent.
+
+        If the point currently contains no newlines, one will
+        be introduced and any trailing whitespace will be effectively
+        removed.
+
+        More specifically, the newline is _inserted_ before the existing
+        whitespace, with the new indent being a replacement for that
+        same whitespace.
+        """
+        # Get the indent (or in the case of no newline, the last whitespace)
+        indent_seg = self._get_indent_segment()
+        if self.num_newlines():
+            # There is already a newline.
+            if indent_seg:
+                # Coerce existing indent to desired.
+                if indent_seg.raw == desired_indent:
+                    # trivial case. indent already correct
+                    return [], self
+                new_indent = indent_seg.edit(desired_indent)
+                idx = self.segments.index(indent_seg)
+                return [LintFix.replace(indent_seg, [new_indent])], ReflowPoint(
+                    list(self.segments[:idx])
+                    + [new_indent]
+                    + list(self.segments[idx + 1 :])
+                )
+            else:
+                # There is a newline, but no indent. Make one after the newline
+                idx = max(
+                    i for i, seg in enumerate(self.segments) if seg.is_type("newline")
+                )
+                new_indent = WhitespaceSegment(desired_indent)
+                return [
+                    LintFix.create_after(self.segments[idx], [new_indent])
+                ], ReflowPoint(
+                    list(self.segments[: idx + 1])
+                    + [new_indent]
+                    + list(self.segments[idx + 1 :])
+                )
+        else:
+            # There isn't currently a newline.
+            new_newline = NewlineSegment()
+            if not indent_seg:
+                # There isn't a whitespace segment either. We need to insert one.
+                # Do we have an anchor?
+                new_indent = WhitespaceSegment(desired_indent)
+                if not before and not after:
+                    raise NotImplementedError(
+                        "Not set up to handle empty points in this "
+                        "scenario without provided before/after "
+                        f"anchor: {self.segments}"
+                    )
+                # Otherwise make a new indent, attached to the relevant anchor.
+                elif before:
+                    fix = LintFix.create_before(before, [new_newline, new_indent])
+                else:
+                    assert after  # mypy hint
+                    fix = LintFix.create_after(after, [new_newline, new_indent])
+                new_point = ReflowPoint([new_newline, new_indent])
+            else:
+                # There is whitespace. Coerce it to the right indent and add
+                # a newline _before_
+                idx = self.segments.index(indent_seg)
+                new_indent = indent_seg.edit(desired_indent)
+                fix = LintFix.replace(indent_seg, [new_newline, new_indent])
+                new_point = ReflowPoint(
+                    list(self.segments[:idx])
+                    + [new_newline, new_indent]
+                    + list(self.segments[idx + 1 :])
+                )
+
+            return [fix], new_point
+
     def respace_point(
         self,
         prev_block: Optional[ReflowBlock],
@@ -504,6 +615,7 @@ class ReflowPoint(ReflowElement):
         root_segment: BaseSegment,
         fixes: List[LintFix],
         strip_newlines: bool = False,
+        anchor_on: str = "before",
     ) -> Tuple[List[LintFix], "ReflowPoint"]:
         """Respace a point based on given constraints.
 
@@ -531,7 +643,10 @@ class ReflowPoint(ReflowElement):
         # Is there a newline?
         # NOTE: We do this based on the segment buffer rather than self.class_types
         # because we may have just removed any present newlines in the buffer.
-        if any(seg.is_type("newline", "end_of_file") for seg in segment_buffer):
+        if (
+            any(seg.is_type("newline", "end_of_file") for seg in segment_buffer)
+            and not strip_newlines
+        ):
             # Most of this section should be handled as _Indentation_.
             # BUT: There is one case we should handle here.
             # If we find that the last whitespace has a newline
@@ -595,6 +710,7 @@ class ReflowPoint(ReflowElement):
                     next_block,
                     segment_buffer,
                     fixes,
+                    anchor_on=anchor_on,
                 )
                 if edited:
                     reflow_logger.debug("    Modified fix buffer: %s", fixes)

--- a/src/sqlfluff/utils/reflow/sequence.py
+++ b/src/sqlfluff/utils/reflow/sequence.py
@@ -872,7 +872,10 @@ class ReflowSequence:
                 if not elem_buff[loc.next_nl_idx].num_newlines():
                     reflow_logger.debug("  Found missing newline after in alone case")
                     fixes, next_point = next_point.indent_to(
-                        self._deduce_line_indent(loc.target.raw_segments[-1]),
+                        # Even though we're inserting after, insert at indent of
+                        # the _start_ of the target. This ensures we're in line
+                        # with the target itself.
+                        self._deduce_line_indent(loc.target.raw_segments[0]),
                         after=loc.target,
                     )
                     # Update the point in the buffer
@@ -886,6 +889,7 @@ class ReflowSequence:
                     # but there isn't an unambiguous way to do this, because we
                     # can't be sure what the comments are referring to.
                     # Given that, we take the simple option.
+                    # TODO: When we've implemented more stuff, maybe revisit this.
                     fixes, prev_point = prev_point.indent_to(
                         self._deduce_line_indent(loc.target.raw_segments[0]),
                         before=loc.target,

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -31,7 +31,9 @@ config_a = {
 
 config_b = {
     "core": {"rules": "L007", "dialect": "ansi"},
-    "rules": {"L007": {"operator_new_lines": "before"}},
+    "layout": {
+        "type": {"comma": {"line_position": "trailing", "spacing_before": "touch"}}
+    },
 }
 
 
@@ -315,7 +317,10 @@ def test__config__get_section():
     cfg = FluffConfig(config_b)
 
     assert cfg.get_section("core").get("rules", None) == "L007"
-    assert cfg.get_section(["rules", "L007"]) == {"operator_new_lines": "before"}
+    assert cfg.get_section(["layout", "type", "comma"]) == {
+        "line_position": "trailing",
+        "spacing_before": "touch",
+    }
     assert cfg.get_section("non_existent") is None
 
 
@@ -327,11 +332,11 @@ def test__config__get():
     assert cfg.get("rulez") is None
     assert cfg.get("rulez", section="core", default=123) == 123
     assert (
-        cfg.get("operator_new_lines", section=["rules", "L007"], default=None)
-        == "before"
+        cfg.get("line_position", section=["layout", "type", "comma"], default=None)
+        == "trailing"
     )
     assert (
-        cfg.get("operator_new_lines", section=["rules", "ASDFSDG007"], default=None)
+        cfg.get("line_position", section=["layout", "type", "ASDFSDG007"], default=None)
         is None
     )
 

--- a/test/fixtures/linter/autofix/ansi/019_trailing_comma_to_leading/.sqlfluff
+++ b/test/fixtures/linter/autofix/ansi/019_trailing_comma_to_leading/.sqlfluff
@@ -1,2 +1,2 @@
-[sqlfluff:rules:L019]
-comma_style=leading
+[sqlfluff:layout:type:comma]
+line_position = leading

--- a/test/fixtures/linter/autofix/snowflake/002_previously_parse_tree_damaging/.sqlfluff
+++ b/test/fixtures/linter/autofix/snowflake/002_previously_parse_tree_damaging/.sqlfluff
@@ -15,9 +15,6 @@ line_position = leading
 tab_space_size = 2
 max_line_length = 120
 
-[sqlfluff:rules:L007]  # Keywords
-operator_new_lines = after
-
 [sqlfluff:rules:L010]  # Keywords
 capitalisation_policy = upper
 

--- a/test/fixtures/linter/autofix/snowflake/002_previously_parse_tree_damaging/.sqlfluff
+++ b/test/fixtures/linter/autofix/snowflake/002_previously_parse_tree_damaging/.sqlfluff
@@ -1,48 +1,19 @@
 [sqlfluff]
-verbose = 0
-nocolor = False
 dialect = snowflake
 templater = jinja
-rules = None
 exclude_rules = L011,L016,L031,L034,L035
-recurse = 0
 output_line_length = 120
-runaway_limit = 10
-ignore = None
-ignore_templated_areas = True
-encoding = autodetect
-disable_noqa = False
-sql_file_exts = .sql,.sql.j2,.dml
-fix_even_unparsable = False
 
-[sqlfluff:indentation]
-indented_joins = False
-indented_ctes = False
-indented_using_on = True
-template_blocks_indent = True
+[sqlfluff:layout:type:binary_operator]
+line_position = leading
 
-[sqlfluff:templater]
-unwrap_wrapped_queries = True
-
-[sqlfluff:templater:jinja]
-apply_dbt_builtins = True
-
-[sqlfluff:templater:jinja:macros]
-dbt_ref = {% macro ref(model_ref) %}{{model_ref}}{% endmacro %}
-dbt_source = {% macro source(source_name, table) %}{{source_name}}_{{table}}{% endmacro %}
-dbt_config = {% macro config() %}{% for k in kwargs %}{% endfor %}{% endmacro %}
-dbt_var = {% macro var(variable, default='') %}item{% endmacro %}
-dbt_is_incremental = {% macro is_incremental() %}True{% endmacro %}
+[sqlfluff:layout:type:comparison_operator]
+line_position = leading
 
 # Some rules can be configured directly from the config common to other rules.
 [sqlfluff:rules]
 tab_space_size = 2
 max_line_length = 120
-indent_unit = space
-comma_style = leading
-allow_scalar = True
-single_table_references = consistent
-unquoted_identifiers_policy = all
 
 [sqlfluff:rules:L007]  # Keywords
 operator_new_lines = after
@@ -50,41 +21,11 @@ operator_new_lines = after
 [sqlfluff:rules:L010]  # Keywords
 capitalisation_policy = upper
 
-[sqlfluff:rules:L011]  # Table aliasing
-aliasing = implicit
-
-[sqlfluff:rules:L012]  # Column aliasing
-aliasing = explicit
-
 [sqlfluff:rules:L013]  # Column expressions
 allow_scalar = False
 
 [sqlfluff:rules:L014]  # Unquoted identifiers
 extended_capitalisation_policy = lower
 
-[sqlfluff:rules:L016]
-ignore_comment_lines = False
-
-[sqlfluff:rules:L029]  # Keyword identifiers
-unquoted_identifiers_policy = aliases
-
 [sqlfluff:rules:L030]  # Function names
 extended_capitalisation_policy = lower
-
-[sqlfluff:rules:L038]
-select_clause_trailing_comma = forbid
-
-[sqlfluff:rules:L040]  # Null & Boolean Literals
-capitalisation_policy = consistent
-
-[sqlfluff:rules:L042]
-# By default, allow subqueries in FROM clauses, but not JOIN clauses.
-forbid_subquery_in = join
-
-[sqlfluff:rules:L047]  # Consistent syntax to count all rows
-prefer_count_1 = False
-prefer_count_0 = False
-
-[sqlfluff:rules:L052]  # Statements must end with a semi-colon
-multiline_newline = True
-require_final_semicolon = True

--- a/test/fixtures/linter/autofix/snowflake/002_previously_parse_tree_damaging/after.sql
+++ b/test/fixtures/linter/autofix/snowflake/002_previously_parse_tree_damaging/after.sql
@@ -10,5 +10,4 @@ ON
   src.foo = tgt.foo
 WHEN MATCHED THEN
   UPDATE SET
-    tgt.foo = src.foo
-;
+    tgt.foo = src.foo;

--- a/test/fixtures/rules/std_rule_cases/L007.yml
+++ b/test/fixtures/rules/std_rule_cases/L007.yml
@@ -54,9 +54,13 @@ passes_on_before_explicit:
         + b
     from foo
   configs: &operator_after
-    rules:
-      L007:
-        operator_new_lines: after
+    layout:
+      type:
+        binary_operator:
+          line_position: leading
+        comparison_operator:
+          line_position: leading
+
 
 fails_on_after_explicit:
   fail_str: |
@@ -71,6 +75,37 @@ fails_on_after_explicit:
     from foo
   configs: *operator_after
 
+fails_on_after_multi_explicit:
+  fail_str: |
+    SELECT
+        *
+    FROM
+      foo
+    WHERE
+        (g > z) AND
+        (
+          (a = 'a' AND b = 'b') OR
+          (a = 'a' AND b = 'e') OR
+          (a = 'c' AND b = 'g') OR
+          (a = 'c' AND b = 'e') OR
+          1 = 1
+        );
+  fix_str: |
+    SELECT
+        *
+    FROM
+      foo
+    WHERE
+        (g > z)
+        AND (
+          (a = 'a' AND b = 'b')
+          OR (a = 'a' AND b = 'e')
+          OR (a = 'c' AND b = 'g')
+          OR (a = 'c' AND b = 'e')
+          OR 1 = 1
+        );
+  configs: *operator_after
+
 fails_on_before_override:
   fail_str: |
     select
@@ -83,9 +118,12 @@ fails_on_before_override:
         b
     from foo
   configs: &operator_before
-    rules:
-      L007:
-        operator_new_lines: before
+    layout:
+      type:
+        binary_operator:
+          line_position: trailing
+        comparison_operator:
+          line_position: trailing
 
 passes_on_after_override:
   pass_str: |
@@ -98,18 +136,83 @@ passes_on_after_override:
 fails_on_before_override_with_comment_order:
   fail_str: |
     select
-        a
-        -- comment1!
+        a -- comment1!
         -- comment2!
+        -- comment3!
         + b
     from foo
   fix_str: |
     select
-        a +
-        -- comment1!
+        a + -- comment1!
         -- comment2!
+        -- comment3!
         b
     from foo
+  configs: *operator_before
+
+fails_on_after_override_with_comment_order:
+  fail_str: |
+    select
+        a + -- comment1!
+        -- comment2!
+        -- comment3!
+        b
+    from foo
+  fix_str: |
+    select
+        a -- comment1!
+        -- comment2!
+        -- comment3!
+        + b
+    from foo
+  configs: *operator_after
+
+# Fix the different variations of problematic comments in a leading case.
+fails_leading_with_comments:
+  fail_str: |
+    SELECT
+      1 +
+      /* foo */ 2,
+      1 + -- foo
+      2,
+      1 /* foo */ +
+      2,
+      1 /* foo */ + -- foo
+      /* foo */ 2
+  fix_str: |
+    SELECT
+      1
+      /* foo */ + 2,
+      1 -- foo
+      + 2,
+      1 /* foo */
+      + 2,
+      1 /* foo */ -- foo
+      /* foo */ + 2
+  configs: *operator_after
+
+# Fix the different variations of problematic comments in a trailing case.
+fails_trailing_with_comments:
+  fail_str: |
+    SELECT
+      1
+      + /* foo */ 2,
+      1 -- foo
+      + 2,
+      1
+      /* foo */ + 2,
+      1 -- foo
+      /* foo */ + /* foo */ 2
+  fix_str: |
+    SELECT
+      1 +
+      /* foo */ 2,
+      1 + -- foo
+      2,
+      1 +
+      /* foo */ 2,
+      1 + -- foo
+      /* foo */ /* foo */ 2
   configs: *operator_before
 
 passes_templated_newline:

--- a/test/fixtures/rules/std_rule_cases/L019.yml
+++ b/test/fixtures/rules/std_rule_cases/L019.yml
@@ -38,9 +38,10 @@ leading_commas_allowed:
     FROM c
 
   configs:
-    rules:
-      L019:
-        comma_style: leading
+    layout:
+      type:
+        comma:
+          line_position: leading
 
 leading_commas_allowed_with_header:
   pass_str: |
@@ -51,9 +52,10 @@ leading_commas_allowed_with_header:
     FROM c
 
   configs:
-    rules:
-      L019:
-        comma_style: leading
+    layout:
+      type:
+        comma:
+          line_position: leading
 
 leading_comma_violations_in_with_statement:
   fail_str: |
@@ -98,9 +100,10 @@ leading_commas_allowed_in_with_statement:
     SELECT * FROM table_3
 
   configs:
-    rules:
-      L019:
-        comma_style: leading
+    layout:
+      type:
+        comma:
+          line_position: leading
 
 trailing_comma_violations:
   fail_str: |
@@ -115,9 +118,10 @@ trailing_comma_violations:
         FROM c
 
   configs:
-    rules:
-      L019:
-        comma_style: leading
+    layout:
+      type:
+        comma:
+          line_position: leading
 
 trailing_commas_allowed:
   pass_str: |
@@ -195,9 +199,10 @@ leading_comma_fixing_flows_around_comments:
         )
 
   configs:
-    rules:
-      L019:
-        comma_style: leading
+    layout:
+      type:
+        comma:
+          line_position: leading
 
 trailing_comma_move_past_several_comment_lines:
   fail_str: |
@@ -270,9 +275,10 @@ leading_comma_move_past_several_comment_lines:
       # earlier version for the trailing comma case, commas were being moved
       # "through" comment blocks one line per pass. Too lazy!
       runaway_limit: 2
-    rules:
-      L019:
-        comma_style: leading
+    layout:
+      type:
+        comma:
+          line_position: leading
 
 leading_comma_with_templated_column_1:
   fail_str: |
@@ -286,9 +292,10 @@ leading_comma_with_templated_column_1:
         , {{ "c2" }} AS days_since
     FROM logs
   configs:
-    rules:
-      L019:
-        comma_style: leading
+    layout:
+      type:
+        comma:
+          line_position: leading
 
 leading_comma_with_templated_column_2:
   pass_str: |
@@ -298,9 +305,10 @@ leading_comma_with_templated_column_2:
     c2" }} AS days_since
     FROM logs
   configs:
-    rules:
-      L019:
-        comma_style: leading
+    layout:
+      type:
+        comma:
+          line_position: leading
 
 trailing_comma_with_templated_column_1:
   fail_str: |

--- a/test/fixtures/rules/std_rule_cases/L065.yml
+++ b/test/fixtures/rules/std_rule_cases/L065.yml
@@ -110,13 +110,5 @@ test_fail_simple_fix_bigquery_intersect_distinct_before_and_after:
     core:
       dialect: bigquery
 
-test_fail_autofix_in_tsql_disabled:
-  fail_str: |
-    SELECT supplyID, supplier
-    FROM dbo.SUPPLY1
-    UNION ALL
-    SELECT supplyID, supplier
-    FROM dbo.SUPPLY2
-  configs:
-    core:
-      dialect: tsql
+# NOTE: We used to exclude TSQL from fixing these queries, but
+# the reflow logic now enables this.

--- a/test/rules/std_L007_test.py
+++ b/test/rules/std_L007_test.py
@@ -8,7 +8,7 @@ from sqlfluff.rules.L007 import after_description, before_description
 
 
 def test__rules__std_L007_default():
-    """Verify that L007 returns the correct error message for default (after)."""
+    """Verify that L007 returns the correct error message for default (trailing)."""
     sql = """
         SELECT
             a,
@@ -23,8 +23,8 @@ def test__rules__std_L007_default():
     assert after_description in [r["description"] for r in result]
 
 
-def test__rules__std_L007_after():
-    """Verify orrect error message when after is explicitly used."""
+def test__rules__std_L007_leading():
+    """Verify correct error message when leading is used."""
     sql = """
         SELECT
             a,
@@ -35,7 +35,7 @@ def test__rules__std_L007_after():
             b = 2
     """
     config = FluffConfig(
-        configs={"rules": {"L007": {"operator_new_lines": "after"}}},
+        configs={"layout": {"type": {"binary_operator": {"line_position": "leading"}}}},
         overrides={"dialect": "ansi"},
     )
     # The sqlfluff.lint API doesn't allow us to pass config so need to do what it does
@@ -46,8 +46,8 @@ def test__rules__std_L007_after():
     assert after_description in [r["description"] for r in result]
 
 
-def test__rules__std_L007_before():
-    """Verify that L007 returns the correct error message when before is used."""
+def test__rules__std_L007_trailing():
+    """Verify correct error message when trailing is used."""
     sql = """
         SELECT
             a,
@@ -58,7 +58,9 @@ def test__rules__std_L007_before():
             AND b = 2
     """
     config = FluffConfig(
-        configs={"rules": {"L007": {"operator_new_lines": "before"}}},
+        configs={
+            "layout": {"type": {"binary_operator": {"line_position": "trailing"}}}
+        },
         overrides={"dialect": "ansi"},
     )
     # The sqlfluff.lint API doesn't allow us to pass config so need to do what it does

--- a/test/rules/std_test.py
+++ b/test/rules/std_test.py
@@ -25,7 +25,6 @@ from sqlfluff.utils.testing.rules import assert_rule_raises_violations_in_file
         # NB The newline before the comma, should report on the comma, not the newline
         # for clarity.
         ("L005", "whitespace_errors.sql", [(2, 9)]),
-        ("L019", "whitespace_errors.sql", [(4, 1)]),
         # Check we get comma (with incorrect trailing space) whitespace errors,
         # but also no false positives on line 4 or 5.
         ("L008", "whitespace_errors.sql", [(3, 12)]),

--- a/test/utils/reflow/rebreak_test.py
+++ b/test/utils/reflow/rebreak_test.py
@@ -1,0 +1,132 @@
+"""Tests for rebreak methods.
+
+Specifically:
+- ReflowSequence.rebreak()
+- ReflowPoint.indent_to()
+- ReflowPoint.get_indent()
+"""
+
+import logging
+import pytest
+
+from sqlfluff.core import Linter
+
+from sqlfluff.utils.reflow.sequence import ReflowSequence
+
+
+def parse_ansi_string(sql, config):
+    """Parse an ansi sql string for testing."""
+    linter = Linter(config=config)
+    return linter.parse_string(sql).tree
+
+
+@pytest.mark.parametrize(
+    "raw_sql_in,raw_sql_out",
+    [
+        # Trivial Case
+        ("select 1", "select 1"),
+        # These rely on the default config being for leading operators
+        ("select 1\n+2", "select 1\n+2"),
+        ("select 1+\n2", "select 1\n+ 2"),  # NOTE: Implicit respace.
+        ("select\n  1 +\n  2", "select\n  1\n  + 2"),
+        ("select\n  1 +\n  -- comment\n  2", "select\n  1\n  -- comment\n  + 2"),
+        # These rely on the details config being for trailing commas
+        ("select a,b", "select a,b"),
+        ("select a\n,b", "select a,\nb"),
+        ("select\n  a\n  , b", "select\n  a,\n  b"),
+        ("select\n    a\n    , b", "select\n    a,\n    b"),
+        ("select\n  a\n    , b", "select\n  a,\n    b"),
+        ("select\n  a\n  -- comment\n  , b", "select\n  a,\n  -- comment\n  b"),
+    ],
+)
+def test_reflow__sequence_rebreak_root(raw_sql_in, raw_sql_out, default_config, caplog):
+    """Test the ReflowSequence.rebreak() method directly.
+
+    Focussed around a whole segment.
+    """
+    root = parse_ansi_string(raw_sql_in, default_config)
+    print(root.stringify())
+    seq = ReflowSequence.from_root(root, config=default_config)
+    for idx, elem in enumerate(seq.elements):
+        print(idx, elem)
+
+    with caplog.at_level(logging.DEBUG, logger="sqlfluff.rules.reflow"):
+        new_seq = seq.rebreak()
+
+    print(new_seq.get_fixes())
+    assert new_seq.get_raw() == raw_sql_out
+
+
+@pytest.mark.parametrize(
+    "raw_sql_in,target_idx,seq_sql_in,seq_sql_out",
+    [
+        ("select 1+\n(2+3)", 4, "1+\n(", "1\n+ ("),
+        ("select a,\n(b+c)", 4, "a,\n(", "a,\n("),
+        ("select a\n  , (b+c)", 6, "a\n  , (", "a,\n  ("),
+        # Here we don't have enough context to rebreak it so
+        # it should be left unaltered.
+        ("select a,\n(b+c)", 6, ",\n(b", ",\n(b"),
+        # This intentionally targets an incomplete span.
+        ("select a<=b", 4, "a<=", "a<="),
+    ],
+)
+def test_reflow__sequence_rebreak_target(
+    raw_sql_in, target_idx, seq_sql_in, seq_sql_out, default_config, caplog
+):
+    """Test the ReflowSequence.rebreak() method directly.
+
+    Focussed around a target segment. This intentionally
+    stretches some of the span logic.
+    """
+    root = parse_ansi_string(raw_sql_in, default_config)
+    print(root.stringify())
+    target = root.raw_segments[target_idx]
+    print("Target: ", target)
+    seq = ReflowSequence.from_around_target(target, root, config=default_config)
+    for idx, elem in enumerate(seq.elements):
+        print(idx, elem)
+    assert seq.get_raw() == seq_sql_in
+
+    with caplog.at_level(logging.DEBUG, logger="sqlfluff.rules.reflow"):
+        new_seq = seq.rebreak()
+
+    print(new_seq.get_fixes())
+    assert new_seq.get_raw() == seq_sql_out
+
+
+@pytest.mark.parametrize(
+    "raw_sql_in,elem_idx,indent_to,point_sql_out",
+    [
+        # Trivial Case
+        ("select\n  1", 1, "  ", "\n  "),
+        # Change existing indents
+        ("select\n  1", 1, "    ", "\n    "),
+        ("select\n  1", 1, " ", "\n "),
+        ("select\n1", 1, "  ", "\n  "),
+        ("select\n  1", 1, "", "\n"),
+        # Create new indents
+        ("select 1", 1, "  ", "\n  "),
+        ("select 1", 1, " ", "\n "),
+        ("select 1", 1, "", "\n"),
+        ("select      1", 1, "  ", "\n  "),
+    ],
+)
+def test_reflow__point_indent_to(
+    raw_sql_in, elem_idx, indent_to, point_sql_out, default_config, caplog
+):
+    """Test the ReflowPoint.indent_to() method directly."""
+    root = parse_ansi_string(raw_sql_in, default_config)
+    print(root.stringify())
+    seq = ReflowSequence.from_root(root, config=default_config)
+    elem = seq.elements[elem_idx]
+    print("Element: ", elem)
+
+    with caplog.at_level(logging.DEBUG, logger="sqlfluff.rules.reflow"):
+        new_fixes, new_point = elem.indent_to(
+            indent_to,
+            before=seq.elements[elem_idx - 1].segments[-1],
+            after=seq.elements[elem_idx + 1].segments[0],
+        )
+
+    print(new_fixes)
+    assert new_point.raw == point_sql_out

--- a/test/utils/reflow/respace_test.py
+++ b/test/utils/reflow/respace_test.py
@@ -40,9 +40,7 @@ def test_reflow__sequence_respace(
 ):
     """Test the ReflowSequence.respace() method directly."""
     root = parse_ansi_string(raw_sql_in, default_config)
-    seq = ReflowSequence.from_raw_segments(
-        root.raw_segments, root, config=default_config
-    )
+    seq = ReflowSequence.from_root(root, config=default_config)
 
     with caplog.at_level(logging.DEBUG, logger="sqlfluff.rules.reflow"):
         new_seq = seq.respace(**kwargs)
@@ -87,9 +85,7 @@ def test_reflow__point_respace_point(
     That should be a seperate more specific test.
     """
     root = parse_ansi_string(raw_sql_in, default_config)
-    seq = ReflowSequence.from_raw_segments(
-        root.raw_segments, root, config=default_config
-    )
+    seq = ReflowSequence.from_root(root, config=default_config)
     pnt = seq.elements[point_idx]
     assert isinstance(pnt, ReflowPoint)
 

--- a/test/utils/reflow/sequence_test.py
+++ b/test/utils/reflow/sequence_test.py
@@ -42,9 +42,10 @@ def assert_reflow_structure(sequence, StartClass, raw_elems):
                 ["+"],
                 [],
                 ["2"],
-                # NOTE: The last element is the end of file marker.
-                # indent, end_of_file.
-                ["", ""],
+                # indent (as point)
+                [""],
+                # end_of_file (as block)
+                [""],
             ],
         )
     ],
@@ -209,8 +210,10 @@ def test_reflow_sequence_from_around_target_non_raw(default_config, caplog):
             ["SELECT"],
             ["", " "],
             ["1"],
-            # dedent - ws - end_of_file
-            ["", "     ", ""],
+            # dedent - ws
+            ["", "     "],
+            # end of file
+            [""],
         ],
     )
 


### PR DESCRIPTION
This is a draft for now. It builds on top of #3847 and is part of #3673.

This brings L065 into the reflow logic. To do that it makes a few key changes:
- `end_of_file` is not a `ReflowBlock` rather than in a `ReflowPoint`. This dramatically simplifies end of file handling.
- `ReflowSequence.insert()` will support non-raw segments as a `target`, similar to the functionality already offered by `ReflowSequence.replace()`.
- `line_position` will support additional features including `alone` (which forces a `ReflowBlock` to be both preceded and followed by newlines) and [TBD] a `strict` option on top of `leading`, `trailing` and `alone` which disallows the scenario where there isn't a newline on either side.