### PR TITLE
`DATABRICKS`: Add Support for Delta Live Tables (DLT) Syntax

### DIFF
--- a/docs/source/dialects.rst
+++ b/docs/source/dialects.rst
@@ -86,7 +86,17 @@ Databricks
 
 The dialect `Databricks`_ is an alias for the :ref:`sparksql_dialect_ref`.
 
+Since Databricks `builds on top of`_ Apache Spark, the Spark SQL dialect holds
+most of the definitions of common commands and structures.
+
+Specifics to Databricks, such as Delta Live Table syntax, are added to the Spark
+SQL dialect to simplify implementation and prevent code duplication for minor
+syntax updates. This follows SQLFluff's philosophy of not being strict in adhering
+to dialect specifications to permit slightly wider set of functions than actually
+available in a given dialect.
+
 .. _`Databricks`: https://databricks.com/
+.. _`builds on top of` : https://www.databricks.com/spark/comparing-databricks-to-apache-spark
 
 .. _db2_dialect_ref:
 
@@ -180,7 +190,8 @@ SparkSQL
 
 The dialect for Apache `Spark SQL`_. It inherits from :ref:`ansi_dialect_ref`
 and includes relevant syntax from :ref:`hive_dialect_ref` for commands that
-permit Hive Format.
+permit Hive Format. Spark SQL extensions provided by the `Delta Lake`_ project
+are also implemented in this dialect.
 
 This implementation focuses on the `Ansi Compliant Mode`_ introduced in
 Spark3, instead of being Hive Compliant. The introduction of ANSI Compliance
@@ -189,6 +200,7 @@ provides better data quality and easier migration from traditional DBMS.
 Versions of Spark prior to 3.x will only support the Hive dialect.
 
 .. _`Spark SQL`: https://spark.apache.org/docs/latest/sql-ref.html
+.. _`Delta Lake`: https://docs.delta.io/latest/quick-start.html#set-up-apache-spark-with-delta-lake
 .. _`Ansi Compliant Mode`: https://spark.apache.org/docs/latest/sql-ref-ansi-compliance.html
 
 .. _sqlite_dialect_ref:

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -207,6 +207,7 @@ sparksql_dialect.replace(
         Ref("SetOperatorSegment"),
         Ref("WithNoSchemaBindingClauseSegment"),
         Ref("WithDataClauseSegment"),
+        "KEYS",
     ),
     TemporaryGrammar=Sequence(
         Sequence("GLOBAL", optional=True),
@@ -314,7 +315,6 @@ sparksql_dialect.replace(
         "QUALIFY",
         "WINDOW",
     ),
-    PreTableFunctionKeywordsGrammar=Ref("FunctionNameSegment"),
 )
 
 sparksql_dialect.add(
@@ -2447,6 +2447,7 @@ class AliasExpressionSegment(ansi.AliasExpressionSegment):
                 "WINDOW",
                 "PIVOT",
                 "KEYS",
+                "FROM",
             ),
         ),
     )
@@ -2884,7 +2885,8 @@ class ConstraintStatementSegment(BaseSegment):
 
 
 class ApplyChangesIntoStatementSegment(BaseSegment):
-    """
+    """A statement ingest CDC data a target table.
+
     https://docs.databricks.com/workflows/delta-live-tables/delta-live-tables-cdc.html#sql
     """
 
@@ -2899,7 +2901,7 @@ class ApplyChangesIntoStatementSegment(BaseSegment):
         Indent,
         Ref("TableExpressionSegment"),
         Dedent,
-        Ref("FromExpressionElementSegment"),
+        Ref("FromClauseSegment"),
         Sequence(
             "KEYS",
             Indent,
@@ -2945,5 +2947,5 @@ class ApplyChangesIntoStatementSegment(BaseSegment):
             "TYPE",
             Ref("NumericLiteralSegment"),
             optional=True,
-        )
+        ),
     )

--- a/src/sqlfluff/dialects/dialect_sparksql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_sparksql_keywords.py
@@ -289,4 +289,14 @@ UNRESERVED_KEYWORDS = [
     "HISTORY",
     "RETAIN",
     "RUN",
+    # Databricks - Delta Live Tables
+    "CHANGES",
+    "DELETES",
+    "EXPECT",
+    "FAIL",
+    "LIVE",
+    "SCD",
+    "STREAMING",
+    "UPDATES",
+    "VIOLATION",
 ]

--- a/test/fixtures/dialects/sparksql/databricks_dlt_apply_changes_into.sql
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_apply_changes_into.sql
@@ -1,0 +1,45 @@
+-- Create and populate the target table.
+CREATE OR REFRESH STREAMING LIVE TABLE target;
+
+APPLY CHANGES INTO live.target
+FROM STREAM(cdc_data.users)
+KEYS (user_id)
+APPLY AS DELETE WHEN operation = "DELETE"
+APPLY AS TRUNCATE WHEN operation = "TRUNCATE"
+SEQUENCE BY sequence_num
+COLUMNS * EXCEPT (operation, sequence_num)
+STORED AS SCD TYPE 1;
+
+-- Create and populate the target table.
+CREATE OR REFRESH STREAMING LIVE TABLE target;
+
+APPLY CHANGES INTO live.target
+FROM STREAM(cdc_data.users)
+KEYS (userid)
+APPLY AS DELETE WHEN operation = "DELETE"
+SEQUENCE BY sequencenum
+COLUMNS * EXCEPT (operation, sequencenum)
+STORED AS SCD TYPE 2;
+
+-- Create and populate the target table.
+CREATE OR REFRESH STREAMING LIVE TABLE target;
+
+APPLY CHANGES INTO live.target
+FROM STREAM(cdc_data.users)
+KEYS (userid)
+SEQUENCE BY sequencenum
+COLUMNS * EXCEPT (operation, sequencenum);
+
+-- Create and populate the target table.
+CREATE OR REFRESH STREAMING LIVE TABLE target;
+
+APPLY CHANGES INTO live.target
+FROM STREAM(cdc_data.users)
+KEYS (user_id)
+IGNORE NULL UPDATES
+WHERE state = "NY"
+APPLY AS DELETE WHEN operation = "DELETE"
+APPLY AS TRUNCATE WHEN operation = "TRUNCATE"
+SEQUENCE BY sequence_num
+COLUMNS * EXCEPT (operation, sequence_num)
+STORED AS SCD TYPE 1;

--- a/test/fixtures/dialects/sparksql/databricks_dlt_apply_changes_into.yml
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_apply_changes_into.yml
@@ -1,0 +1,314 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 5e45c610ddacccbffcbf4ed49cd0db81a4283d99450908feee8fd16b86c4f242
+file:
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REFRESH
+    - keyword: STREAMING
+    - keyword: LIVE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: target
+- statement_terminator: ;
+- statement:
+    apply_changes_into_statement:
+    - keyword: APPLY
+    - keyword: CHANGES
+    - keyword: INTO
+    - table_expression:
+        table_reference:
+        - naked_identifier: live
+        - dot: .
+        - naked_identifier: target
+    - from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: STREAM
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                    - naked_identifier: cdc_data
+                    - dot: .
+                    - naked_identifier: users
+                  end_bracket: )
+    - keyword: KEYS
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: user_id
+        end_bracket: )
+    - keyword: APPLY
+    - keyword: AS
+    - keyword: DELETE
+    - keyword: WHEN
+    - column_reference:
+        naked_identifier: operation
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: '"DELETE"'
+    - keyword: APPLY
+    - keyword: AS
+    - keyword: TRUNCATE
+    - keyword: WHEN
+    - column_reference:
+        naked_identifier: operation
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: '"TRUNCATE"'
+    - keyword: SEQUENCE
+    - keyword: BY
+    - column_reference:
+        naked_identifier: sequence_num
+    - keyword: COLUMNS
+    - star: '*'
+    - keyword: EXCEPT
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: operation
+      - comma: ','
+      - column_reference:
+          naked_identifier: sequence_num
+      - end_bracket: )
+    - keyword: STORED
+    - keyword: AS
+    - keyword: SCD
+    - keyword: TYPE
+    - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REFRESH
+    - keyword: STREAMING
+    - keyword: LIVE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: target
+- statement_terminator: ;
+- statement:
+    apply_changes_into_statement:
+    - keyword: APPLY
+    - keyword: CHANGES
+    - keyword: INTO
+    - table_expression:
+        table_reference:
+        - naked_identifier: live
+        - dot: .
+        - naked_identifier: target
+    - from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: STREAM
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                    - naked_identifier: cdc_data
+                    - dot: .
+                    - naked_identifier: users
+                  end_bracket: )
+    - keyword: KEYS
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: userid
+        end_bracket: )
+    - keyword: APPLY
+    - keyword: AS
+    - keyword: DELETE
+    - keyword: WHEN
+    - column_reference:
+        naked_identifier: operation
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: '"DELETE"'
+    - keyword: SEQUENCE
+    - keyword: BY
+    - column_reference:
+        naked_identifier: sequencenum
+    - keyword: COLUMNS
+    - star: '*'
+    - keyword: EXCEPT
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: operation
+      - comma: ','
+      - column_reference:
+          naked_identifier: sequencenum
+      - end_bracket: )
+    - keyword: STORED
+    - keyword: AS
+    - keyword: SCD
+    - keyword: TYPE
+    - numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REFRESH
+    - keyword: STREAMING
+    - keyword: LIVE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: target
+- statement_terminator: ;
+- statement:
+    apply_changes_into_statement:
+    - keyword: APPLY
+    - keyword: CHANGES
+    - keyword: INTO
+    - table_expression:
+        table_reference:
+        - naked_identifier: live
+        - dot: .
+        - naked_identifier: target
+    - from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: STREAM
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                    - naked_identifier: cdc_data
+                    - dot: .
+                    - naked_identifier: users
+                  end_bracket: )
+    - keyword: KEYS
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: userid
+        end_bracket: )
+    - keyword: SEQUENCE
+    - keyword: BY
+    - column_reference:
+        naked_identifier: sequencenum
+    - keyword: COLUMNS
+    - star: '*'
+    - keyword: EXCEPT
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: operation
+      - comma: ','
+      - column_reference:
+          naked_identifier: sequencenum
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REFRESH
+    - keyword: STREAMING
+    - keyword: LIVE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: target
+- statement_terminator: ;
+- statement:
+    apply_changes_into_statement:
+    - keyword: APPLY
+    - keyword: CHANGES
+    - keyword: INTO
+    - table_expression:
+        table_reference:
+        - naked_identifier: live
+        - dot: .
+        - naked_identifier: target
+    - from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: STREAM
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                    - naked_identifier: cdc_data
+                    - dot: .
+                    - naked_identifier: users
+                  end_bracket: )
+    - keyword: KEYS
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: user_id
+        end_bracket: )
+    - keyword: IGNORE
+    - keyword: 'NULL'
+    - keyword: UPDATES
+    - where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: state
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: '"NY"'
+    - keyword: APPLY
+    - keyword: AS
+    - keyword: DELETE
+    - keyword: WHEN
+    - column_reference:
+        naked_identifier: operation
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: '"DELETE"'
+    - keyword: APPLY
+    - keyword: AS
+    - keyword: TRUNCATE
+    - keyword: WHEN
+    - column_reference:
+        naked_identifier: operation
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: '"TRUNCATE"'
+    - keyword: SEQUENCE
+    - keyword: BY
+    - column_reference:
+        naked_identifier: sequence_num
+    - keyword: COLUMNS
+    - star: '*'
+    - keyword: EXCEPT
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: operation
+      - comma: ','
+      - column_reference:
+          naked_identifier: sequence_num
+      - end_bracket: )
+    - keyword: STORED
+    - keyword: AS
+    - keyword: SCD
+    - keyword: TYPE
+    - numeric_literal: '1'
+- statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/databricks_dlt_constraint.sql
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_constraint.sql
@@ -1,0 +1,7 @@
+CONSTRAINT valid_timestamp EXPECT (event_ts > '2012-01-01');
+
+CONSTRAINT valid_current_page EXPECT (
+    current_page_id IS NOT NULL AND current_page_title IS NOT NULL
+) ON VIOLATION DROP ROW;
+
+CONSTRAINT valid_count EXPECT (count > 0) ON VIOLATION FAIL UPDATE;

--- a/test/fixtures/dialects/sparksql/databricks_dlt_constraint.yml
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_constraint.yml
@@ -1,0 +1,69 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: fd300f1b1bc9dccbe8ecd3468cbdbbdca0735b35f2d8d32cd5cde71a1ab936dd
+file:
+- statement:
+    constraint_statement:
+    - keyword: CONSTRAINT
+    - object_reference:
+        naked_identifier: valid_timestamp
+    - keyword: EXPECT
+    - bracketed:
+        start_bracket: (
+        expression:
+          column_reference:
+            naked_identifier: event_ts
+          comparison_operator:
+            raw_comparison_operator: '>'
+          quoted_literal: "'2012-01-01'"
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    constraint_statement:
+    - keyword: CONSTRAINT
+    - object_reference:
+        naked_identifier: valid_current_page
+    - keyword: EXPECT
+    - bracketed:
+        start_bracket: (
+        expression:
+        - column_reference:
+            naked_identifier: current_page_id
+        - keyword: IS
+        - keyword: NOT
+        - keyword: 'NULL'
+        - binary_operator: AND
+        - column_reference:
+            naked_identifier: current_page_title
+        - keyword: IS
+        - keyword: NOT
+        - keyword: 'NULL'
+        end_bracket: )
+    - keyword: 'ON'
+    - keyword: VIOLATION
+    - keyword: DROP
+    - keyword: ROW
+- statement_terminator: ;
+- statement:
+    constraint_statement:
+    - keyword: CONSTRAINT
+    - object_reference:
+        naked_identifier: valid_count
+    - keyword: EXPECT
+    - bracketed:
+        start_bracket: (
+        expression:
+          column_reference:
+            naked_identifier: count
+          comparison_operator:
+            raw_comparison_operator: '>'
+          numeric_literal: '0'
+        end_bracket: )
+    - keyword: 'ON'
+    - keyword: VIOLATION
+    - keyword: FAIL
+    - keyword: UPDATE
+- statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/databricks_dlt_create_table.sql
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_create_table.sql
@@ -1,5 +1,3 @@
--- https://docs.databricks.com/workflows/delta-live-tables/delta-live-tables-sql-ref.html#create-table
-
 CREATE OR REFRESH LIVE TABLE taxi_raw
 AS SELECT
     a,
@@ -16,13 +14,13 @@ CREATE OR REFRESH STREAMING LIVE TABLE customers_bronze
 AS SELECT
     a,
     b
-FROM cloud_files("/databricks-datasets/retail-org/customers/", "csv");
+FROM CLOUD_FILES("/databricks-datasets/retail-org/customers/", "csv");
 
 CREATE OR REFRESH STREAMING LIVE TABLE customers_silver
 AS SELECT
     a,
     b
-FROM stream(live.customers_bronze);
+FROM STREAM(live.customers_bronze);
 
 CREATE OR REFRESH TEMPORARY LIVE TABLE filtered_data
 AS SELECT
@@ -34,4 +32,4 @@ CREATE OR REFRESH TEMPORARY STREAMING LIVE TABLE customers_silver
 AS SELECT
     a,
     b
-FROM stream(live.customers_bronze);
+FROM STREAM(live.customers_bronze);

--- a/test/fixtures/dialects/sparksql/databricks_dlt_create_table.sql
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_create_table.sql
@@ -1,0 +1,37 @@
+-- https://docs.databricks.com/workflows/delta-live-tables/delta-live-tables-sql-ref.html#create-table
+
+CREATE OR REFRESH LIVE TABLE taxi_raw
+AS SELECT
+    a,
+    b
+FROM JSON.`/databricks-datasets/nyctaxi/sample/json/`;
+
+CREATE OR REFRESH LIVE TABLE filtered_data
+AS SELECT
+    a,
+    b
+FROM live.taxi_raw;
+
+CREATE OR REFRESH STREAMING LIVE TABLE customers_bronze
+AS SELECT
+    a,
+    b
+FROM cloud_files("/databricks-datasets/retail-org/customers/", "csv");
+
+CREATE OR REFRESH STREAMING LIVE TABLE customers_silver
+AS SELECT
+    a,
+    b
+FROM stream(live.customers_bronze);
+
+CREATE OR REFRESH TEMPORARY LIVE TABLE filtered_data
+AS SELECT
+    a,
+    b
+FROM live.taxi_raw;
+
+CREATE OR REFRESH TEMPORARY STREAMING LIVE TABLE customers_silver
+AS SELECT
+    a,
+    b
+FROM stream(live.customers_bronze);

--- a/test/fixtures/dialects/sparksql/databricks_dlt_create_table.yml
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_create_table.yml
@@ -1,0 +1,213 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9750d4c4207e59c2192fde953b250ed0456fd3ab755f5e21b24309d66f934273
+file:
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REFRESH
+    - keyword: LIVE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: taxi_raw
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                file_reference:
+                  keyword: JSON
+                  dot: .
+                  quoted_identifier: '`/databricks-datasets/nyctaxi/sample/json/`'
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REFRESH
+    - keyword: LIVE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: filtered_data
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: live
+                - dot: .
+                - naked_identifier: taxi_raw
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REFRESH
+    - keyword: STREAMING
+    - keyword: LIVE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: customers_bronze
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                function:
+                  function_name:
+                    function_name_identifier: CLOUD_FILES
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: '"/databricks-datasets/retail-org/customers/"'
+                  - comma: ','
+                  - expression:
+                      quoted_literal: '"csv"'
+                  - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REFRESH
+    - keyword: STREAMING
+    - keyword: LIVE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: customers_silver
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                function:
+                  function_name:
+                    function_name_identifier: STREAM
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                      - naked_identifier: live
+                      - dot: .
+                      - naked_identifier: customers_bronze
+                    end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REFRESH
+    - keyword: TEMPORARY
+    - keyword: LIVE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: filtered_data
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: live
+                - dot: .
+                - naked_identifier: taxi_raw
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REFRESH
+    - keyword: TEMPORARY
+    - keyword: STREAMING
+    - keyword: LIVE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: customers_silver
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                function:
+                  function_name:
+                    function_name_identifier: STREAM
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                      - naked_identifier: live
+                      - dot: .
+                      - naked_identifier: customers_bronze
+                    end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/databricks_dlt_create_view.sql
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_create_view.sql
@@ -1,0 +1,13 @@
+-- https://docs.databricks.com/workflows/delta-live-tables/delta-live-tables-sql-ref.html#create-view
+
+CREATE TEMPORARY LIVE VIEW filtered_data
+AS SELECT
+    a,
+    b
+FROM live.taxi_raw;
+
+CREATE TEMPORARY STREAMING LIVE VIEW customers_silver
+AS SELECT
+    a,
+    b
+FROM stream(live.customers_bronze);

--- a/test/fixtures/dialects/sparksql/databricks_dlt_create_view.yml
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_create_view.yml
@@ -1,0 +1,73 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 408ecb04633aa2ae4271bb41dd60e415eb94b20cde131120e50c133b6f3d536e
+file:
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: TEMPORARY
+    - keyword: LIVE
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: filtered_data
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: live
+                - dot: .
+                - naked_identifier: taxi_raw
+- statement_terminator: ;
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: TEMPORARY
+    - keyword: STREAMING
+    - keyword: LIVE
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: customers_silver
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                function:
+                  function_name:
+                    function_name_identifier: stream
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                      - naked_identifier: live
+                      - dot: .
+                      - naked_identifier: customers_bronze
+                    end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
- `sparksql_dialect`
   - Update `CreateTableStatementSegment` and `CreateViewStatementSegment` in SparkSQL to add DLT keywords
   - Create `ConstraintStatementSegment` and `ApplyChangesIntoStatementSegment` for new DLT Statements
- `sparksql_dialect_keywords`
   - add new DLT unreserved keywords
- `tests/fixtures/dialects/sparksql/`
   - Test cases for `CREATE TABLE`, `CREATE VIEW`, `CONTRAINTS`, `APPLY CHANGES INTO` statements for DLT
- `docs/dialects.rst`
   - update docs to clarify that `Delta Lake` expressions are implemented in SparkSQL
   - update docs to clarify that `Databricks` syntax is implemented in SparkSQL and why


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
