### PR TITLE
fix: Click output to stderr on errors

### DIFF
--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -514,18 +514,22 @@ class OutputStreamFormatter:
         lint_result.discard_fixes_for_lint_errors_in_files_with_tmp_or_prs_errors()
         if total_errors:
             click.echo(
-                self.colorize(
+                message=self.colorize(
                     f"  [{total_errors} templating/parsing errors found]", Color.red
-                )
+                ),
+                color=self.plain_output,
+                err=True
             )
             if num_filtered_errors < total_errors:
                 color = Color.red if num_filtered_errors else Color.green
                 click.echo(
-                    self.colorize(
+                    message=self.colorize(
                         f"  [{num_filtered_errors} templating/parsing errors "
                         f'remaining after "ignore"]',
-                        color,
-                    )
+                        color=color
+                    ),
+                    color=not self.plain_output,
+                    err=num_filtered_errors > 0
                 )
         return EXIT_FAIL if num_filtered_errors else EXIT_SUCCESS
 

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -678,7 +678,7 @@ def test__cli__command__fix(rule, fname):
     with open(fname) as test_file:
         generic_roundtrip_test(test_file, rule)
 
-
+# Money maker
 @pytest.mark.parametrize(
     "sql,fix_args,fixed,exit_code",
     [
@@ -798,6 +798,17 @@ def test__cli__command__fix(rule, fname):
             ],
             1,
         ),
+        (
+            """
+            CREATE TABLE IF NOT EXISTS vuln.software_name_dictionary(
+            id SERIAL PRIMARY KEY,
+            rule VARCHAR(30),
+            );
+            """,
+            ["--force", "--dialect", "postgres", "--disable_progress_bar", "--nocolor"],
+            None,
+            1
+        )
     ],
     ids=[
         "1_lint_error_1_unsuppressed_parse_error",
@@ -807,6 +818,7 @@ def test__cli__command__fix(rule, fname):
         "0_lint_errors_1_suppressed_parse_error",
         "1_lint_error_1_unsuppressed_parse_error_FIX_EVEN_UNPARSABLE",
         "2_files_with_lint_errors_1_unsuppressed_parse_error",
+        "1_lint_error_1_unsuppressed_parse_error_postgres",
     ],
 )
 def test__cli__fix_error_handling_behavior(sql, fix_args, fixed, exit_code, tmpdir):


### PR DESCRIPTION
- Output to stderr using click
- Use unused color var
- Pass color flag to click

+ref: https://github.com/sqlfluff/sqlfluff/issues/3892


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
