### PR TITLE
fix: Click output to stderr on errors

### DIFF
--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -514,18 +514,22 @@ class OutputStreamFormatter:
         lint_result.discard_fixes_for_lint_errors_in_files_with_tmp_or_prs_errors()
         if total_errors:
             click.echo(
-                self.colorize(
+                message=self.colorize(
                     f"  [{total_errors} templating/parsing errors found]", Color.red
-                )
+                ),
+                color=self.plain_output,
+                err=True,
             )
             if num_filtered_errors < total_errors:
                 color = Color.red if num_filtered_errors else Color.green
                 click.echo(
-                    self.colorize(
+                    message=self.colorize(
                         f"  [{num_filtered_errors} templating/parsing errors "
                         f'remaining after "ignore"]',
-                        color,
-                    )
+                        color=color,
+                    ),
+                    color=not self.plain_output,
+                    err=num_filtered_errors > 0,
                 )
         return EXIT_FAIL if num_filtered_errors else EXIT_SUCCESS
 

--- a/test/cli/formatters_test.py
+++ b/test/cli/formatters_test.py
@@ -1,16 +1,20 @@
 """The Test file for CLI Formatters."""
-
+import pathlib
 import re
+import textwrap
 
-from sqlfluff.core import FluffConfig
-from sqlfluff.core.enums import Color
-from sqlfluff.core.rules import RuleGhost
-from sqlfluff.core.parser import RawSegment
-from sqlfluff.core.parser.markers import PositionMarker
-from sqlfluff.core.errors import SQLLintError
-from sqlfluff.core.templaters.base import TemplatedFile
+import pytest
+
+from sqlfluff.cli.commands import fix
 from sqlfluff.cli.formatters import OutputStreamFormatter
 from sqlfluff.cli.outputstream import FileOutput
+from sqlfluff.core import FluffConfig
+from sqlfluff.core.enums import Color
+from sqlfluff.core.errors import SQLLintError
+from sqlfluff.core.parser import RawSegment
+from sqlfluff.core.parser.markers import PositionMarker
+from sqlfluff.core.rules import RuleGhost
+from sqlfluff.core.templaters.base import TemplatedFile
 
 
 def escape_ansi(line):
@@ -74,3 +78,48 @@ def test__cli__helpers__cli_table(tmpdir):
     txt = formatter.cli_table(vals, col_width=7, divider_char="|", label_color=None)
     # NB: No trailing newline
     assert txt == "a:    3|b:    c\nd: 4.77|e:    9"
+
+
+@pytest.mark.parametrize(
+    "sql,fix_args,expected,stderr_contains",
+    [
+        (
+            (
+                "CREATE TABLE IF NOT EXISTS vuln.software_name_dictionary("
+                "id SERIAL PRIMARY KEY"
+                "rule VARCHAR(30)"
+                ");"
+            ),
+            ["--force", "--dialect", "postgres", "--disable_progress_bar", "--nocolor"],
+            (
+                "CREATE TABLE IF NOT EXISTS vuln.software_name_dictionary("
+                "id SERIAL PRIMARY KEY"
+                "rule VARCHAR(30)"
+                ");"
+            ),
+            "1 templating/parsing errors found",
+        )
+    ],
+)
+def test__cli__fix_no_corrupt_file_contents(
+    sql, fix_args, expected, stderr_contains, tmpdir, capfd
+):
+    """Test how the fix cli command creates files.
+
+    Ensure there is no incorrect output from stderr
+    that makes it to the file.
+    """
+    tmp_path = pathlib.Path(str(tmpdir))
+    filepath = tmp_path / "testing.sql"
+    filepath.write_text(textwrap.dedent(sql))
+
+    with tmpdir.as_cwd():
+        with pytest.raises(SystemExit):
+            fix(fix_args)
+    out, err = capfd.readouterr()
+    with open(tmp_path / "testing.sql", "r") as fin:
+        actual = fin.read()
+
+    assert actual.strip() == expected.strip()
+    assert "All Finished!" in out
+    assert stderr_contains in err


### PR DESCRIPTION
- Output to stderr using click
- Use unused color var
- Pass color flag to click
fixes #3892
+ref: https://github.com/sqlfluff/sqlfluff/issues/3892


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
