### PR TITLE
feat: Optional numerics for postgres arrays

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -494,25 +494,46 @@ class PsqlVariableGrammar(BaseSegment):
 
 
 class ArrayAccessorSegment(ansi.ArrayAccessorSegment):
-    """Overwrites Array Accessor in ANSI to allow n many consecutive brackets."""
+    """Overwrites Array Accessor in ANSI to allow n many consecutive brackets.
+
+    Postgres can also have array access like python [:2] or [2:] so
+    numbers on either side of the slice segment are optional.
+    """
 
     match_grammar = Sequence(
         AnyNumberOf(
             Bracketed(
                 Sequence(
                     OneOf(
-                        Ref("QualifiedNumericLiteralSegment"),
-                        Ref("NumericLiteralSegment"),
-                    ),
-                    Sequence(
-                        Ref("SliceSegment"),
                         OneOf(
                             Ref("QualifiedNumericLiteralSegment"),
                             Ref("NumericLiteralSegment"),
                         ),
-                        optional=True,
+                        Sequence(
+                            OneOf(
+                                Ref("QualifiedNumericLiteralSegment"),
+                                Ref("NumericLiteralSegment"),
+                                optional=True,
+                            ),
+                            Ref("SliceSegment"),
+                            OneOf(
+                                Ref("QualifiedNumericLiteralSegment"),
+                                Ref("NumericLiteralSegment"),
+                            ),
+                        ),
+                        Sequence(
+                            OneOf(
+                                Ref("QualifiedNumericLiteralSegment"),
+                                Ref("NumericLiteralSegment"),
+                            ),
+                            Ref("SliceSegment"),
+                            OneOf(
+                                Ref("QualifiedNumericLiteralSegment"),
+                                Ref("NumericLiteralSegment"),
+                                optional=True,
+                            ),
+                        ),
                     ),
-                    optional=True,
                 ),
                 bracket_type="square",
             )

--- a/test/dialects/postgres_test.py
+++ b/test/dialects/postgres_test.py
@@ -30,6 +30,10 @@ from sqlfluff.dialects.dialect_postgres_keywords import (
         ("SelectClauseElementSegment", "c is not null as c_notnull"),
         ("SelectClauseElementSegment", "c isnull as c_isnull"),
         ("SelectClauseElementSegment", "c notnull as c_notnull"),
+        ("ArrayAccessorSegment", "[2:10]"),
+        ("ArrayAccessorSegment", "[:10]"),
+        ("ArrayAccessorSegment", "[2:]"),
+        ("ArrayAccessorSegment", "[2]"),
     ],
 )
 def test_dialect_postgres_specific_segment_parses(


### PR DESCRIPTION
Adjust the ArrayAccessorSegment to parse empty sides of an array.
i.e. [:2] or [2:]

fixes #3842
+ref: https://github.com/sqlfluff/sqlfluff/issues/3842


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
