### PR TITLE
fix(redshift): Allow keywords in qualified references

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -177,27 +177,6 @@ redshift_dialect.replace(
             anti_template=r"^(" + r"|".join(dialect.sets("reserved_keywords")) + r")$",
         )
     ),
-    ColumnReferenceSegment=Delimited(
-        Sequence(
-            ansi.ColumnReferenceSegment,
-            AnyNumberOf(Ref("ArrayAccessorSegment")),
-        ),
-        delimiter=OneOf(
-            Ref("DotSegment"), Sequence(Ref("DotSegment"), Ref("DotSegment"))
-        ),
-        terminator=OneOf(
-            "ON",
-            "AS",
-            "USING",
-            Ref("CommaSegment"),
-            Ref("CastOperatorSegment"),
-            Ref("BinaryOperatorGrammar"),
-            Ref("ColonSegment"),
-            Ref("DelimiterGrammar"),
-            Ref("JoinLikeClauseGrammar"),
-        ),
-        allow_gaps=False,
-    ),
 )
 
 redshift_dialect.patch_lexer_matchers(
@@ -2401,11 +2380,3 @@ class FunctionSegment(ansi.FunctionSegment):
             ),
         ),
     )
-
-
-class ColumnReferenceSegment(postgres.ColumnReferenceSegment):
-    """A reference to column, field or alias.
-
-    We override this for Redshift to allow keywords in fully qualified column
-    names (using Full segments) like it's done in Postgres.
-    """

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2401,3 +2401,11 @@ class FunctionSegment(ansi.FunctionSegment):
             ),
         ),
     )
+
+
+class ColumnReferenceSegment(postgres.ColumnReferenceSegment):
+    """A reference to column, field or alias.
+
+    We override this for Redshift to allow keywords in fully qualified column
+    names (using Full segments) like it's done in Postgres.
+    """

--- a/test/fixtures/dialects/redshift/redshift_datetime_cast.yml
+++ b/test/fixtures/dialects/redshift/redshift_datetime_cast.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c84076e9d4b74a2bfdccf350264599791e8750ca4e230ed265eaa28feec7fb2d
+_hash: e1d6433d0b92d9b0aacc83717bfcba25f33b9f1e9828d54fa8fda594376abe2c
 file:
 - statement:
     select_statement:
@@ -266,18 +266,18 @@ file:
       - comma: ','
       - select_clause_element:
           expression:
-          - column_reference:
+            column_reference:
             - naked_identifier: raw_data
             - dot: .
             - naked_identifier: identifier
-          - array_accessor:
+            array_accessor:
               start_square_bracket: '['
               numeric_literal: '0'
               end_square_bracket: ']'
-          - dot: .
-          - column_reference:
+            semi_structured_expression:
+              dot: .
               naked_identifier: value
-          - cast_expression:
+            cast_expression:
               casting_operator: '::'
               data_type:
                 keyword: VARCHAR

--- a/test/fixtures/dialects/redshift/redshift_super_data_type.yml
+++ b/test/fixtures/dialects/redshift/redshift_super_data_type.yml
@@ -3,22 +3,23 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8ccb74adc863fb3c44a010173d8b64666c6b05513e690fa1a1e5ca91460a3092
+_hash: 95fec3a8c9cb2409ac5fb423e32c22fb3a69967e3fc3b7675a043d48458ab61a
 file:
 - statement:
     select_statement:
       select_clause:
       - keyword: SELECT
       - select_clause_element:
-        - column_reference:
-            naked_identifier: c
-        - array_accessor:
-            start_square_bracket: '['
-            numeric_literal: '0'
-            end_square_bracket: ']'
-        - dot: .
-        - column_reference:
-            naked_identifier: col
+          expression:
+            column_reference:
+              naked_identifier: c
+            array_accessor:
+              start_square_bracket: '['
+              numeric_literal: '0'
+              end_square_bracket: ']'
+            semi_structured_expression:
+              dot: .
+              naked_identifier: col
       - comma: ','
       - select_clause_element:
           column_reference:
@@ -71,8 +72,8 @@ file:
             start_square_bracket: '['
             numeric_literal: '0'
             end_square_bracket: ']'
-        - dot: .
-        - column_reference:
+        - semi_structured_expression:
+            dot: .
             naked_identifier: o_orderkey
         - keyword: IS
         - keyword: NOT
@@ -106,14 +107,14 @@ file:
                   bracketed:
                     start_bracket: (
                     expression:
-                    - column_reference:
+                      column_reference:
                         naked_identifier: c_orders
-                    - array_accessor:
+                      array_accessor:
                         start_square_bracket: '['
                         numeric_literal: '0'
                         end_square_bracket: ']'
-                    - dot: .
-                    - column_reference:
+                      semi_structured_expression:
+                        dot: .
                         naked_identifier: o_orderstatus
                     end_bracket: )
                 comparison_operator:
@@ -121,23 +122,23 @@ file:
                 quoted_literal: "'string'"
             - keyword: THEN
             - expression:
-              - column_reference:
+                column_reference:
                   naked_identifier: c_orders
-              - array_accessor:
+                array_accessor:
                   start_square_bracket: '['
                   numeric_literal: '0'
                   end_square_bracket: ']'
-              - dot: .
-              - column_reference:
+                semi_structured_expression:
+                  dot: .
                   naked_identifier: o_orderstatus
-              - cast_expression:
+                cast_expression:
                   casting_operator: '::'
                   data_type:
                     keyword: VARCHAR
-              - comparison_operator:
+                comparison_operator:
                 - raw_comparison_operator: <
                 - raw_comparison_operator: '='
-              - quoted_literal: "'P'"
+                quoted_literal: "'P'"
           - else_clause:
               keyword: ELSE
               expression:
@@ -149,27 +150,28 @@ file:
       select_clause:
       - keyword: SELECT
       - select_clause_element:
-        - column_reference:
-            naked_identifier: c
-        - array_accessor:
-          - start_square_bracket: '['
-          - numeric_literal: '0'
-          - end_square_bracket: ']'
-          - start_square_bracket: '['
-          - numeric_literal: '1'
-          - end_square_bracket: ']'
-          - start_square_bracket: '['
-          - numeric_literal: '2'
-          - end_square_bracket: ']'
-          - start_square_bracket: '['
-          - numeric_literal: '3'
-          - end_square_bracket: ']'
-          - start_square_bracket: '['
-          - numeric_literal: '4'
-          - end_square_bracket: ']'
-        - dot: .
-        - column_reference:
-            naked_identifier: col
+          expression:
+            column_reference:
+              naked_identifier: c
+            array_accessor:
+            - start_square_bracket: '['
+            - numeric_literal: '0'
+            - end_square_bracket: ']'
+            - start_square_bracket: '['
+            - numeric_literal: '1'
+            - end_square_bracket: ']'
+            - start_square_bracket: '['
+            - numeric_literal: '2'
+            - end_square_bracket: ']'
+            - start_square_bracket: '['
+            - numeric_literal: '3'
+            - end_square_bracket: ']'
+            - start_square_bracket: '['
+            - numeric_literal: '4'
+            - end_square_bracket: ']'
+            semi_structured_expression:
+              dot: .
+              naked_identifier: col
       - comma: ','
       - select_clause_element:
           column_reference:
@@ -233,26 +235,28 @@ file:
       select_clause:
       - keyword: SELECT
       - select_clause_element:
-        - column_reference:
-            naked_identifier: messages
-        - array_accessor:
-            start_square_bracket: '['
-            numeric_literal: '0'
-            end_square_bracket: ']'
-        - dot: .
-        - column_reference:
-            naked_identifier: format
+          expression:
+            column_reference:
+              naked_identifier: messages
+            array_accessor:
+              start_square_bracket: '['
+              numeric_literal: '0'
+              end_square_bracket: ']'
+            semi_structured_expression:
+              dot: .
+              naked_identifier: format
       - comma: ','
       - select_clause_element:
-        - column_reference:
-            naked_identifier: messages
-        - array_accessor:
-            start_square_bracket: '['
-            numeric_literal: '0'
-            end_square_bracket: ']'
-        - dot: .
-        - column_reference:
-            naked_identifier: topic
+          expression:
+            column_reference:
+              naked_identifier: messages
+            array_accessor:
+              start_square_bracket: '['
+              numeric_literal: '0'
+              end_square_bracket: ']'
+            semi_structured_expression:
+              dot: .
+              naked_identifier: topic
       from_clause:
         keyword: FROM
         from_expression:
@@ -263,37 +267,38 @@ file:
       where_clause:
         keyword: WHERE
         expression:
-        - column_reference:
+          column_reference:
             naked_identifier: messages
-        - array_accessor:
+          array_accessor:
             start_square_bracket: '['
             numeric_literal: '0'
             end_square_bracket: ']'
-        - dot: .
-        - column_reference:
+          semi_structured_expression:
+          - dot: .
           - naked_identifier: payload
           - dot: .
           - naked_identifier: payload
           - dot: .
           - quoted_identifier: '"assetId"'
-        - comparison_operator:
+          comparison_operator:
             raw_comparison_operator: '>'
-        - numeric_literal: '0'
+          numeric_literal: '0'
 - statement_terminator: ;
 - statement:
     select_statement:
       select_clause:
       - keyword: SELECT
       - select_clause_element:
-        - column_reference:
-            naked_identifier: messages
-        - array_accessor:
-            start_square_bracket: '['
-            numeric_literal: '0'
-            end_square_bracket: ']'
-        - dot: .
-        - column_reference:
-            naked_identifier: format
+          expression:
+            column_reference:
+              naked_identifier: messages
+            array_accessor:
+              start_square_bracket: '['
+              numeric_literal: '0'
+              end_square_bracket: ']'
+            semi_structured_expression:
+              dot: .
+              naked_identifier: format
       - comma: ','
       - select_clause_element:
           function:
@@ -302,14 +307,14 @@ file:
             bracketed:
               start_bracket: (
               expression:
-              - column_reference:
+                column_reference:
                   naked_identifier: messages
-              - array_accessor:
+                array_accessor:
                   start_square_bracket: '['
                   numeric_literal: '0'
                   end_square_bracket: ']'
-              - dot: .
-              - column_reference:
+                semi_structured_expression:
+                  dot: .
                   naked_identifier: topic
               end_bracket: )
       from_clause:
@@ -322,32 +327,33 @@ file:
       where_clause:
         keyword: WHERE
         expression:
-        - column_reference:
+          column_reference:
             naked_identifier: messages
-        - array_accessor:
+          array_accessor:
             start_square_bracket: '['
             numeric_literal: '0'
             end_square_bracket: ']'
-        - dot: .
-        - column_reference:
+          semi_structured_expression:
+          - dot: .
           - naked_identifier: payload
           - dot: .
           - naked_identifier: payload
           - dot: .
           - quoted_identifier: '"assetId"'
-        - comparison_operator:
+          comparison_operator:
             raw_comparison_operator: '>'
-        - quoted_literal: "'abc'"
+          quoted_literal: "'abc'"
       groupby_clause:
       - keyword: GROUP
       - keyword: BY
-      - column_reference:
-          naked_identifier: messages
-      - array_accessor:
-          start_square_bracket: '['
-          numeric_literal: '0'
-          end_square_bracket: ']'
-      - dot: .
-      - column_reference:
-          naked_identifier: format
+      - expression:
+          column_reference:
+            naked_identifier: messages
+          array_accessor:
+            start_square_bracket: '['
+            numeric_literal: '0'
+            end_square_bracket: ']'
+          semi_structured_expression:
+            dot: .
+            naked_identifier: format
 - statement_terminator: ;

--- a/test/fixtures/dialects/redshift/select_keywords.sql
+++ b/test/fixtures/dialects/redshift/select_keywords.sql
@@ -1,0 +1,12 @@
+SELECT pg_namespace.nspname AS constraint_schema, pg_constraint.conname AS constraint_name FROM pg_namespace, pg_constraint WHERE pg_namespace.oid = pg_constraint.connamespace;
+
+-- As taken from: https://docs.aws.amazon.com/redshift/latest/dg/c_join_PG_examples.html
+create view tables_vw as
+select distinct(id) table_id
+,trim(datname)   db_name
+,trim(nspname)   schema_name
+,trim(relname)   table_name
+from stv_tbl_perm
+join pg_class on pg_class.oid = stv_tbl_perm.id
+join pg_namespace on pg_namespace.oid = relnamespace
+join pg_database on pg_database.oid = stv_tbl_perm.db_id;

--- a/test/fixtures/dialects/redshift/select_keywords.yml
+++ b/test/fixtures/dialects/redshift/select_keywords.yml
@@ -1,0 +1,179 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 66bd867c845d06047b20ecb4c54371d7ec41ffaa8a00d82a85dd0d4759c88c10
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: pg_namespace
+          - dot: .
+          - naked_identifier: nspname
+          alias_expression:
+            keyword: AS
+            naked_identifier: constraint_schema
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: pg_constraint
+          - dot: .
+          - naked_identifier: conname
+          alias_expression:
+            keyword: AS
+            naked_identifier: constraint_name
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: pg_namespace
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: pg_constraint
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: pg_namespace
+            dot: .
+            naked_identifier_all: oid
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: pg_constraint
+          - dot: .
+          - naked_identifier: connamespace
+- statement_terminator: ;
+- statement:
+    create_view_statement:
+    - keyword: create
+    - keyword: view
+    - table_reference:
+        naked_identifier: tables_vw
+    - keyword: as
+    - select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_modifier:
+            keyword: distinct
+        - select_clause_element:
+            expression:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: id
+                end_bracket: )
+            alias_expression:
+              naked_identifier: table_id
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: trim
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: datname
+                end_bracket: )
+            alias_expression:
+              naked_identifier: db_name
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: trim
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: nspname
+                end_bracket: )
+            alias_expression:
+              naked_identifier: schema_name
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: trim
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: relname
+                end_bracket: )
+            alias_expression:
+              naked_identifier: table_name
+        from_clause:
+          keyword: from
+          from_expression:
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: stv_tbl_perm
+          - join_clause:
+              keyword: join
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: pg_class
+              join_on_condition:
+                keyword: 'on'
+                expression:
+                - column_reference:
+                    naked_identifier: pg_class
+                    dot: .
+                    naked_identifier_all: oid
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: stv_tbl_perm
+                  - dot: .
+                  - naked_identifier: id
+          - join_clause:
+              keyword: join
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: pg_namespace
+              join_on_condition:
+                keyword: 'on'
+                expression:
+                - column_reference:
+                    naked_identifier: pg_namespace
+                    dot: .
+                    naked_identifier_all: oid
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                    naked_identifier: relnamespace
+          - join_clause:
+              keyword: join
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: pg_database
+              join_on_condition:
+                keyword: 'on'
+                expression:
+                - column_reference:
+                    naked_identifier: pg_database
+                    dot: .
+                    naked_identifier_all: oid
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: stv_tbl_perm
+                  - dot: .
+                  - naked_identifier: db_id
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes: #3512

### Are there any other side effects of this change that we should be aware of?

A couple of `.yml` test fixtures where automatically re-created by `tox -e generate-fixture-yml -- --dialect redshift`. AFAIK this should be harmless.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
