### PR TITLE
fix issue with empty enum for postgres

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -4247,7 +4247,7 @@ class CreateTypeStatementSegment(BaseSegment):
         "TYPE",
         Ref("ObjectReferenceSegment"),
         Sequence("AS", OneOf("ENUM", "RANGE", optional=True), optional=True),
-        Bracketed(Delimited(Anything()), optional=True),
+        Bracketed(Delimited(Anything(), optional=True), optional=True),
     )
 
 

--- a/test/fixtures/dialects/postgres/postgres_create_type.sql
+++ b/test/fixtures/dialects/postgres/postgres_create_type.sql
@@ -1,5 +1,6 @@
 -- https://www.postgresql.org/docs/current/sql-createtype.html
 CREATE TYPE foo;
+CREATE TYPE bar AS ENUM ();
 CREATE TYPE bar AS ENUM ('foo', 'bar');
 CREATE TYPE foobar AS RANGE (SUBTYPE = FLOAT);
 CREATE TYPE barbar AS (INPUT = foo, OUTPUT = bar);

--- a/test/fixtures/dialects/postgres/postgres_create_type.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_type.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bedac00acaebdef7050023774a36f2434e0027fa6d250d67b643f689e70268b6
+_hash: b996a018c7e24a91965a3214b8747f2cf73dbe4b540672aaab01848ffdfe7356
 file:
 - statement:
     create_type_statement:
@@ -11,6 +11,18 @@ file:
     - keyword: TYPE
     - object_reference:
         naked_identifier: foo
+- statement_terminator: ;
+- statement:
+    create_type_statement:
+    - keyword: CREATE
+    - keyword: TYPE
+    - object_reference:
+        naked_identifier: bar
+    - keyword: AS
+    - keyword: ENUM
+    - bracketed:
+        start_bracket: (
+        end_bracket: )
 - statement_terminator: ;
 - statement:
     create_type_statement:


### PR DESCRIPTION
### Brief summary of the change made
fixes #3897 

### Are there any other side effects of this change that we should be aware of?
nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
