### PR TITLE
fix(test): Return ParseExample namedtuple in get_parse_fixtures

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -30,6 +30,8 @@ yaml.add_representer(str, quoted_presenter)
 
 
 class ParseExample(NamedTuple):
+    """A tuple representing an example SQL file to parse."""
+
     dialect: str
     sqlfile: str
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,7 @@
 import hashlib
 import io
 import os
+from typing import NamedTuple
 
 import pytest
 import yaml
@@ -28,6 +29,11 @@ from sqlfluff.core.templaters import TemplatedFile
 yaml.add_representer(str, quoted_presenter)
 
 
+class ParseExample(NamedTuple):
+    dialect: str
+    sqlfile: str
+
+
 def get_parse_fixtures(fail_on_missing_yml=False):
     """Search for all parsing fixtures."""
     parse_success_examples = []
@@ -44,7 +50,7 @@ def get_parse_fixtures(fail_on_missing_yml=False):
             if f.endswith(".sql"):
                 root = f[:-4]
                 # only look for sql files
-                parse_success_examples.append((d, f))
+                parse_success_examples.append(ParseExample(d, f))
                 # Look for the code_only version of the structure
                 y = root + ".yml"
                 if y in dirlist:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes: #3906 

This allows the usage of dot notation in `test/generate_parse_fixture_yml.py::_is_matching_criteria` when running `tox -e generate-fixture-yml -- --new-only`.

### Are there any other side effects of this change that we should be aware of?
Type hints are now match runtime types.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

AFAIK no tests are needed, but happy to add some if deemed necessary.