### PR TITLE
[issue_3794] allow to use 'usage' as identifier for postgres

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres_keywords.py
+++ b/src/sqlfluff/dialects/dialect_postgres_keywords.py
@@ -968,7 +968,7 @@ postgres_nondocs_keywords = [
     ("TIMESTAMPTZ", "non-reserved"),
     ("TIMING", "non-reserved"),
     ("UNSAFE", "non-reserved"),
-    ("USAGE", "reserved"),
+    ("USAGE", "non-reserved"),
     ("WAL", "non-reserved"),
 ]
 

--- a/test/fixtures/dialects/postgres/postgres_create_table.sql
+++ b/test/fixtures/dialects/postgres/postgres_create_table.sql
@@ -232,3 +232,10 @@ constraint_collate_constraints text UNIQUE COLLATE numeric NOT NULL PRIMARY KEY,
 constraints_collate text NOT NULL UNIQUE COLLATE numeric,
 collate_constraints text COLLATE numeric NOT NULL UNIQUE
 );
+
+
+-- Use non-reserved `usage` word as a table identifier
+CREATE TABLE IF NOT EXISTS quotas.usage(foo int);
+
+-- Use non-reserved `usage` word as a column identifier
+CREATE TABLE IF NOT EXISTS quotas.my_table(usage int);

--- a/test/fixtures/dialects/postgres/postgres_create_table.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4b2def462595301518c5209a8a2824737867d12032b225116ed1f2f14a2bf721
+_hash: 29d7815aa67937d53ce3bc0bec9bc8e0b0ffb2aa4cd08ea8ba1c807a60c09f0f
 file:
 - statement:
     create_table_statement:
@@ -1408,4 +1408,42 @@ file:
       - column_constraint_segment:
           keyword: UNIQUE
       - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: quotas
+      - dot: .
+      - naked_identifier: usage
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: foo
+        data_type:
+          keyword: int
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: quotas
+      - dot: .
+      - naked_identifier: my_table
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: usage
+        data_type:
+          keyword: int
+        end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Fixed #3794 

To be on safe side, I've just changed `usage` word to `non-reserved` and it solved the issue.
Was checking with [postgres documentation](https://www.postgresql.org/docs/current/sql-keywords-appendix.html), and it seems to be alright with Postgres.

### Are there any other side effects of this change that we should be aware of?
Probably not, at least tests didn't raise anything.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
