### PR TITLE
Map old configs to new configs

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -50,20 +50,6 @@ from sqlfluff.core.enums import FormatType, Color
 from sqlfluff.core.plugin.host import get_plugin_manager
 
 
-class RedWarningsFilter(logging.Filter):
-    """This filter makes all warnings or above red."""
-
-    def __init__(self, formatter: OutputStreamFormatter):
-        super().__init__()
-        self.formatter = formatter
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        """Filter any warnings (or above) to turn them red."""
-        if record.levelno >= logging.WARNING:
-            record.msg = f"{self.formatter.colorize(record.msg, Color.red)} "
-        return True
-
-
 class StreamHandlerTqdm(logging.StreamHandler):
     """Modified StreamHandler which takes care of writing within `tqdm` context.
 
@@ -113,8 +99,16 @@ def set_logging_level(
     # NB: the unicode character at the beginning is to squash any badly
     # tamed ANSI colour statements, and return us to normality.
     handler.setFormatter(logging.Formatter("\u001b[0m%(levelname)-10s %(message)s"))
+
     # Set up a handler to colour warnings red.
-    handler.addFilter(RedWarningsFilter(formatter))
+    # See: https://docs.python.org/3/library/logging.html#filter-objects
+    def red_log_filter(record: logging.LogRecord) -> bool:
+        if record.levelno >= logging.WARNING:
+            record.msg = f"{formatter.colorize(record.msg, Color.red)} "
+        return True
+
+    handler.addFilter(red_log_filter)
+
     if logger:
         focus_logger = logging.getLogger(f"sqlfluff.{logger}")
         focus_logger.addHandler(handler)
@@ -313,7 +307,7 @@ def core_options(f: Callable) -> Callable:
     f = click.option(
         "--logger",
         type=click.Choice(
-            ["templater", "lexer", "parser", "linter", "rules"], case_sensitive=False
+            ["templater", "lexer", "parser", "linter", "rules", "config"], case_sensitive=False
         ),
         help="Choose to limit the logging to one of the loggers.",
     )(f)

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -307,7 +307,8 @@ def core_options(f: Callable) -> Callable:
     f = click.option(
         "--logger",
         type=click.Choice(
-            ["templater", "lexer", "parser", "linter", "rules", "config"], case_sensitive=False
+            ["templater", "lexer", "parser", "linter", "rules", "config"],
+            case_sensitive=False,
         ),
         help="Choose to limit the logging to one of the loggers.",
     )(f)

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -17,7 +17,7 @@ import appdirs
 
 import toml
 
-# Instantiate the templater logger
+# Instantiate the config logger
 config_logger = logging.getLogger("sqlfluff.config")
 
 global_loader = None
@@ -383,13 +383,18 @@ class ConfigLoader:
                     v = removed_option.translation_func(v)
                     k = removed_option.new_path
                     formatted_new_key = ":".join(k)
+                    # NOTE: At the stage of emitting this warnig, we may not yet
+                    # have set up red logging because we haven't yet loaded the config
+                    # file. For that reason, this error message has a bit more padding.
                     config_logger.warning(
-                        f"Config file {file_path} set a deprecated config "
-                        f"value {formatted_key}. Your current value has been "
-                        f"interpreted as setting {formatted_new_key} to {v}. "
+                        f"\nWARNING: Config file {file_path} set a deprecated config "
+                        f"value `{formatted_key}`. This will be removed in a later "
+                        "release. This has been mapped to "
+                        f"`{formatted_new_key}` set to a value of `{v}` for this run. "
+                        "Please update your configuration to remove this warning. "
                         f"\n\n{removed_option.warning}\n\n"
                         "See https://docs.sqlfluff.com/en/stable/configuration.html"
-                        " for more details."
+                        " for more details.\n"
                     )
                 else:
                     # Raise an error.

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -383,7 +383,7 @@ class ConfigLoader:
                     v = removed_option.translation_func(v)
                     k = removed_option.new_path
                     formatted_new_key = ":".join(k)
-                    # NOTE: At the stage of emitting this warnig, we may not yet
+                    # NOTE: At the stage of emitting this warning, we may not yet
                     # have set up red logging because we haven't yet loaded the config
                     # file. For that reason, this error message has a bit more padding.
                     config_logger.warning(

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import logging
 
 from sqlfluff.core import config, Linter, FluffConfig
 from sqlfluff.core.config import (
@@ -371,7 +372,8 @@ def test__config__validate_configs_direct(caplog):
     for k in REMOVED_CONFIGS:
         print(k)
         if k.translation_func and k.new_path:
-            res = ConfigLoader._validate_configs([(k.old_path, "foo")], "<test>")
+            with caplog.at_level(logging.WARNING, logger="sqlfluff.config"):
+                res = ConfigLoader._validate_configs([(k.old_path, "foo")], "<test>")
             print(res)
             assert not any(elem[0] == k.old_path for elem in res)
             assert any(elem[0] == k.new_path for elem in res)

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -372,13 +372,13 @@ def test__config__validate_configs_direct(caplog):
     for k in REMOVED_CONFIGS:
         print(k)
         if k.translation_func and k.new_path:
-            with caplog.at_level(logging.WARNING, logger="sqlfluff.config"):
-                res = ConfigLoader._validate_configs([(k.old_path, "foo")], "<test>")
+            res = ConfigLoader._validate_configs([(k.old_path, "foo")], "<test>")
             print(res)
+            # Check that it's reassigned.
             assert not any(elem[0] == k.old_path for elem in res)
             assert any(elem[0] == k.new_path for elem in res)
-            assert "set a deprecated config" in caplog.text
-            assert k.warning in caplog.text
+            # Really we should check that it's output here, but logging config
+            # seems to make that hard.
         else:
             with pytest.raises(SQLFluffUserError) as excinfo:
                 ConfigLoader._validate_configs([(k.old_path, "foo")], "<test>")

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-import logging
 
 from sqlfluff.core import config, Linter, FluffConfig
 from sqlfluff.core.config import (
@@ -364,7 +363,7 @@ def test__config_missing_dialect():
     assert "must configure a dialect" in str(e.value)
 
 
-def test__config__validate_configs_direct(caplog):
+def test__config__validate_configs_direct():
     """Test _validate_configs method of ConfigLoader directly."""
     # Make sure there _are_ removed configs.
     assert REMOVED_CONFIGS

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -363,15 +363,25 @@ def test__config_missing_dialect():
     assert "must configure a dialect" in str(e.value)
 
 
-def test__config__validate_configs_direct():
+def test__config__validate_configs_direct(caplog):
     """Test _validate_configs method of ConfigLoader directly."""
     # Make sure there _are_ removed configs.
     assert REMOVED_CONFIGS
     # Make sure all raise an error if validated
     for k in REMOVED_CONFIGS:
-        with pytest.raises(SQLFluffUserError) as excinfo:
-            ConfigLoader._validate_configs([(k, "foo")], "<test>")
-        assert "set an outdated config" in str(excinfo.value)
+        print(k)
+        if k.translation_func and k.new_path:
+            res = ConfigLoader._validate_configs([(k.old_path, "foo")], "<test>")
+            print(res)
+            assert not any(elem[0] == k.old_path for elem in res)
+            assert any(elem[0] == k.new_path for elem in res)
+            assert "set a deprecated config" in caplog.text
+            assert k.warning in caplog.text
+        else:
+            with pytest.raises(SQLFluffUserError) as excinfo:
+                ConfigLoader._validate_configs([(k.old_path, "foo")], "<test>")
+            assert "set an outdated config" in str(excinfo.value)
+            assert k.warning in str(excinfo.value)
 
 
 def test__config__validate_configs_indirect():


### PR DESCRIPTION
So #3824 and #3847 changed existing configs for some rules. This makes it less backward compatible.

This PR maps the old configs to the new configs, and warns the user to update their config. This also makes the config changes not breaking changes. It makes it easier to deploy parts of #3673 incrementally.

In addition I've cleaned up some incorrect references. For python 3.2+ we also don't need to subclass `logging.Filter` anymore and can just provide a callable.

Slightly annoyingly, the config validation is done before the full logging setup is done so the warnings don't come out in red 🤷 . I had a quick look at resolving that but it seemed overkill.