### PR TITLE
sparksql: added * EXCEPT for SELECT clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -2992,3 +2992,49 @@ class ApplyChangesIntoStatementSegment(BaseSegment):
             optional=True,
         ),
     )
+
+
+class WildcardExpressionSegment(ansi.WildcardExpressionSegment):
+    """An extension of the star expression for Databricks."""
+
+    match_grammar = ansi.WildcardExpressionSegment.match_grammar.copy(
+        insert=[
+            # Optional EXCEPT clause
+            # https://docs.databricks.com/release-notes/runtime/9.0.html#exclude-columns-in-select--public-preview
+            Ref("ExceptClauseSegment", optional=True),
+        ]
+    )
+
+
+class ExceptClauseSegment(BaseSegment):
+    """SELECT * EXCEPT clause."""
+
+    type = "select_except_clause"
+    match_grammar = Sequence(
+        "EXCEPT",
+        Bracketed(Delimited(Ref("SingleIdentifierGrammar"))),
+    )
+
+
+class SelectClauseSegment(BaseSegment):
+    """A group of elements in a select target statement.
+
+    It's very similar to `SelectClauseSegment` from `dialect_ansi` except does not
+    have set `SetOperatorSegment` as possible terminator - this is to avoid issues
+    with wrongly recognized `EXCEPT`.
+    """
+
+    type = "select_clause"
+    match_grammar: Matchable = StartsWith(
+        "SELECT",
+        terminator=OneOf(
+            "FROM",
+            "WHERE",
+            Sequence("ORDER", "BY"),
+            "LIMIT",
+            "OVERLAPS",
+        ),
+        enforce_whitespace_preceding_terminator=True,
+    )
+
+    parse_grammar: Matchable = Ref("SelectClauseSegmentGrammar")

--- a/test/fixtures/dialects/sparksql/select_star_except.sql
+++ b/test/fixtures/dialects/sparksql/select_star_except.sql
@@ -1,0 +1,7 @@
+select * except (col) from table_name where row_no = 1;
+
+select *
+except (col)
+from table_name where row_no = 1;
+
+select * except (col1, col2, col3, col4, col5) from table_name where row_no = 1;

--- a/test/fixtures/dialects/sparksql/select_star_except.yml
+++ b/test/fixtures/dialects/sparksql/select_star_except.yml
@@ -1,0 +1,105 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: cf951c121772e7daad8ad73fa0d9ad5377c234e3d698b732a743316409429048
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_except_clause:
+              keyword: except
+              bracketed:
+                start_bracket: (
+                naked_identifier: col
+                end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table_name
+      where_clause:
+        keyword: where
+        expression:
+          column_reference:
+            naked_identifier: row_no
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_except_clause:
+              keyword: except
+              bracketed:
+                start_bracket: (
+                naked_identifier: col
+                end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table_name
+      where_clause:
+        keyword: where
+        expression:
+          column_reference:
+            naked_identifier: row_no
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_except_clause:
+              keyword: except
+              bracketed:
+              - start_bracket: (
+              - naked_identifier: col1
+              - comma: ','
+              - naked_identifier: col2
+              - comma: ','
+              - naked_identifier: col3
+              - comma: ','
+              - naked_identifier: col4
+              - comma: ','
+              - naked_identifier: col5
+              - end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table_name
+      where_clause:
+        keyword: where
+        expression:
+          column_reference:
+            naked_identifier: row_no
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
fixes #3687

I've went with @tunetheweb suggestion ([here](https://github.com/sqlfluff/sqlfluff/issues/3687#issuecomment-1214455418)), but still got problems - because it was confusing that new `EXCEPT` with the one from `SetOperatorSegment` as far I can tell. Didn't find how to control that except adding, for sparksql, `SelectClauseSegment` with removed possibility of `SetOperatorSegment` as terminator.
Well, it works now, tests are passing, but not sure how good is that.

### Are there any other side effects of this change that we should be aware of?
no

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
