### PR TITLE
SQLite: Add support for table-level CHECK constraint

### DIFF
--- a/test/fixtures/dialects/sqlite/create_table_check.sql
+++ b/test/fixtures/dialects/sqlite/create_table_check.sql
@@ -1,0 +1,4 @@
+CREATE TABLE foo(
+    num NUMBER NOT NULL,
+    CHECK (num > 0)
+);

--- a/test/fixtures/dialects/sqlite/create_table_check.yml
+++ b/test/fixtures/dialects/sqlite/create_table_check.yml
@@ -1,0 +1,36 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 5465c2be405342b8e453437cd27526acc01a94128274719114d7fe0e3ae8a665
+file:
+  statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: foo
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          naked_identifier: num
+          data_type:
+            data_type_identifier: NUMBER
+          column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+        comma: ','
+        table_constraint:
+          keyword: CHECK
+          bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: num
+              comparison_operator:
+                raw_comparison_operator: '>'
+              numeric_literal: '0'
+            end_bracket: )
+        end_bracket: )
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Add support for table-level `CHECK` constraint by following the approach put forth in the PostgreSQL dialect.

See: https://www.sqlite.org/syntax/table-constraint.html

Fixes #3553 

### Are there any other side effects of this change that we should be aware of?

Increases footprint of SQLite dialect due to inability to effectively override `ansi.TableConstraintSegment.match_grammar`.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
