### PR TITLE
Remove is_template

### DIFF
--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -355,7 +355,6 @@ class Bracketed(Sequence):
                 if (
                     seg.is_meta
                     and cast(MetaSegment, seg).indent_val > 0
-                    and not cast(MetaSegment, seg).is_template
                 ):
                     meta_idx = idx
                     break

--- a/src/sqlfluff/core/parser/lexer.py
+++ b/src/sqlfluff/core/parser/lexer.py
@@ -538,7 +538,6 @@ class Lexer:
                     lexer_logger.debug("      INDENT")
                     segment_buffer.append(
                         Indent(
-                            is_template=True,
                             pos_marker=PositionMarker.from_point(
                                 placeholder_slice.stop,
                                 element.template_slice.start,

--- a/src/sqlfluff/core/parser/segments/meta.py
+++ b/src/sqlfluff/core/parser/segments/meta.py
@@ -16,10 +16,6 @@ class MetaSegment(RawSegment):
     indent_val = 0
     is_meta = True
 
-    def __init__(self, is_template=False, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.is_template = is_template
-
     @staticmethod
     def _suffix():
         """Return any extra output required at the end when logging.


### PR DESCRIPTION
This appears to be hardly used as a kwarg. This is a draft PR to see if we can remove it. If tests fail I'll keep it but document it better.