### PR TITLE
MySQL: Fix create trigger

### DIFF
--- a/test/fixtures/dialects/mysql/create_trigger.sql
+++ b/test/fixtures/dialects/mysql/create_trigger.sql
@@ -1,0 +1,42 @@
+CREATE TRIGGER delete_members_after_transactions AFTER DELETE ON transactions
+FOR EACH ROW DELETE FROM members WHERE username NOT IN
+(SELECT UNIQUE(username) FROM transactions);
+
+
+
+CREATE TRIGGER some_trigger AFTER DELETE ON some_table
+FOR EACH ROW
+BEGIN
+    DELETE FROM some_table;
+    INSERT INTO some_table;
+END;
+
+
+CREATE TRIGGER ins_sum BEFORE INSERT ON account
+FOR EACH ROW SET @sum = @sum + NEW.amount;
+
+
+CREATE TRIGGER some_trigger AFTER DELETE ON some_table FOR EACH ROW DELETE FROM other_table;
+CREATE TRIGGER some_trigger BEFORE DELETE ON some_table FOR EACH ROW DELETE FROM other_table;
+CREATE TRIGGER some_trigger AFTER UPDATE ON some_table FOR EACH ROW DELETE FROM other_table;
+CREATE TRIGGER some_trigger BEFORE UPDATE ON some_table FOR EACH ROW DELETE FROM other_table;
+CREATE TRIGGER some_trigger AFTER INSERT ON some_table FOR EACH ROW DELETE FROM other_table;
+CREATE TRIGGER some_trigger BEFORE INSERT ON some_table FOR EACH ROW DELETE FROM other_table;
+
+
+CREATE TRIGGER some_trigger AFTER DELETE ON some_table FOR EACH ROW
+FOLLOWS some_other_trigger
+DELETE FROM other_table;
+CREATE TRIGGER some_trigger AFTER DELETE ON some_table FOR EACH ROW
+PRECEDES some_other_trigger
+DELETE FROM other_table;
+
+
+CREATE
+DEFINER=`root`@`127.0.0.1`
+TRIGGER ins_sum BEFORE INSERT ON account
+FOR EACH ROW SET @sum = @sum + NEW.amount;
+CREATE
+DEFINER=CURRENT_USER
+TRIGGER ins_sum BEFORE INSERT ON account
+FOR EACH ROW SET @sum = @sum + NEW.amount;

--- a/test/fixtures/dialects/mysql/create_trigger.yml
+++ b/test/fixtures/dialects/mysql/create_trigger.yml
@@ -1,0 +1,406 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 7fb6eed22eb59129a3735291e333697d6aca5ab3395cf817480a05b76b527dc4
+file:
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: delete_members_after_transactions
+    - keyword: AFTER
+    - keyword: DELETE
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: transactions
+    - keyword: FOR
+    - keyword: EACH
+    - keyword: ROW
+    - statement:
+        delete_statement:
+          keyword: DELETE
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: members
+          where_clause:
+            keyword: WHERE
+            expression:
+            - column_reference:
+                naked_identifier: username
+            - keyword: NOT
+            - keyword: IN
+            - bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      function:
+                        function_name:
+                          function_name_identifier: UNIQUE
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: username
+                          end_bracket: )
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: transactions
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: some_trigger
+    - keyword: AFTER
+    - keyword: DELETE
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: some_table
+    - keyword: FOR
+    - keyword: EACH
+    - keyword: ROW
+    - statement:
+        transaction_statement:
+          keyword: BEGIN
+          statement:
+            delete_statement:
+              keyword: DELETE
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: some_table
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: some_table
+- statement_terminator: ;
+- statement:
+    transaction_statement:
+      keyword: END
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: ins_sum
+    - keyword: BEFORE
+    - keyword: INSERT
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: account
+    - keyword: FOR
+    - keyword: EACH
+    - keyword: ROW
+    - statement:
+        set_statement:
+          keyword: SET
+          variable: '@sum'
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+          - column_reference:
+              variable: '@sum'
+          - binary_operator: +
+          - column_reference:
+            - naked_identifier: NEW
+            - dot: .
+            - naked_identifier: amount
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: some_trigger
+    - keyword: AFTER
+    - keyword: DELETE
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: some_table
+    - keyword: FOR
+    - keyword: EACH
+    - keyword: ROW
+    - statement:
+        delete_statement:
+          keyword: DELETE
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: other_table
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: some_trigger
+    - keyword: BEFORE
+    - keyword: DELETE
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: some_table
+    - keyword: FOR
+    - keyword: EACH
+    - keyword: ROW
+    - statement:
+        delete_statement:
+          keyword: DELETE
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: other_table
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: some_trigger
+    - keyword: AFTER
+    - keyword: UPDATE
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: some_table
+    - keyword: FOR
+    - keyword: EACH
+    - keyword: ROW
+    - statement:
+        delete_statement:
+          keyword: DELETE
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: other_table
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: some_trigger
+    - keyword: BEFORE
+    - keyword: UPDATE
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: some_table
+    - keyword: FOR
+    - keyword: EACH
+    - keyword: ROW
+    - statement:
+        delete_statement:
+          keyword: DELETE
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: other_table
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: some_trigger
+    - keyword: AFTER
+    - keyword: INSERT
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: some_table
+    - keyword: FOR
+    - keyword: EACH
+    - keyword: ROW
+    - statement:
+        delete_statement:
+          keyword: DELETE
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: other_table
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: some_trigger
+    - keyword: BEFORE
+    - keyword: INSERT
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: some_table
+    - keyword: FOR
+    - keyword: EACH
+    - keyword: ROW
+    - statement:
+        delete_statement:
+          keyword: DELETE
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: other_table
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: some_trigger
+    - keyword: AFTER
+    - keyword: DELETE
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: some_table
+    - keyword: FOR
+    - keyword: EACH
+    - keyword: ROW
+    - keyword: FOLLOWS
+    - naked_identifier: some_other_trigger
+    - statement:
+        delete_statement:
+          keyword: DELETE
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: other_table
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: some_trigger
+    - keyword: AFTER
+    - keyword: DELETE
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: some_table
+    - keyword: FOR
+    - keyword: EACH
+    - keyword: ROW
+    - keyword: PRECEDES
+    - naked_identifier: some_other_trigger
+    - statement:
+        delete_statement:
+          keyword: DELETE
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: other_table
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - definer_segment:
+        keyword: DEFINER
+        comparison_operator:
+          raw_comparison_operator: '='
+        role_reference:
+        - quoted_identifier: '`root`'
+        - at_sign_literal: '@'
+        - quoted_identifier: '`127.0.0.1`'
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: ins_sum
+    - keyword: BEFORE
+    - keyword: INSERT
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: account
+    - keyword: FOR
+    - keyword: EACH
+    - keyword: ROW
+    - statement:
+        set_statement:
+          keyword: SET
+          variable: '@sum'
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+          - column_reference:
+              variable: '@sum'
+          - binary_operator: +
+          - column_reference:
+            - naked_identifier: NEW
+            - dot: .
+            - naked_identifier: amount
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - definer_segment:
+        keyword: DEFINER
+        comparison_operator:
+          raw_comparison_operator: '='
+        role_reference:
+          keyword: CURRENT_USER
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: ins_sum
+    - keyword: BEFORE
+    - keyword: INSERT
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: account
+    - keyword: FOR
+    - keyword: EACH
+    - keyword: ROW
+    - statement:
+        set_statement:
+          keyword: SET
+          variable: '@sum'
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+          - column_reference:
+              variable: '@sum'
+          - binary_operator: +
+          - column_reference:
+            - naked_identifier: NEW
+            - dot: .
+            - naked_identifier: amount
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
fixes #3917

`CREATE TRIGGER` should be now better handled for mysql.


### Are there any other side effects of this change that we should be aware of?
no

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
