### PR TITLE
SparkSQL: Fixed bug with `QUALIFY` usage without `WHERE` clause (applies also for Databricks dialect)

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -226,6 +226,7 @@ sparksql_dialect.replace(
         Sequence("DISTRIBUTE", "BY"),
         Sequence("SORT", "BY"),
         "HAVING",
+        "QUALIFY",
         Ref("SetOperatorSegment"),
         Ref("WithNoSchemaBindingClauseSegment"),
         Ref("WithDataClauseSegment"),

--- a/test/fixtures/dialects/sparksql/select_qualify.sql
+++ b/test/fixtures/dialects/sparksql/select_qualify.sql
@@ -2,6 +2,12 @@ SELECT
   item,
   RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
 FROM Produce
+QUALIFY rank <= 3;
+
+SELECT
+  item,
+  RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
+FROM Produce
 WHERE Produce.category = 'vegetable'
 QUALIFY rank <= 3;
 

--- a/test/fixtures/dialects/sparksql/select_qualify.yml
+++ b/test/fixtures/dialects/sparksql/select_qualify.yml
@@ -3,8 +3,61 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5ff1b5d063873e75af24c177fd0f32b7a0f45d1dcf56979b05845e2453e5aa81
+_hash: 6be6f8cc477e592f46d4295f5a1f1af51289aec2aac6d4a159d82733da3b4f62
 file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: item
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: RANK
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: category
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: purchases
+                  - keyword: DESC
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: Produce
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          column_reference:
+            naked_identifier: rank
+          comparison_operator:
+          - raw_comparison_operator: <
+          - raw_comparison_operator: '='
+          numeric_literal: '3'
+- statement_terminator: ;
 - statement:
     select_statement:
       select_clause:


### PR DESCRIPTION
### Brief summary of the change made
fixes #3929 

### Are there any other side effects of this change that we should be aware of?
No, AFAIK.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
