### PR TITLE
T-SQL: Fix indendentation of OUTER APPLY

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -34,7 +34,6 @@ from sqlfluff.core.parser import (
     KeywordSegment,
     Matchable,
     MultiStringParser,
-    TypedParser,
     NewlineSegment,
     Nothing,
     OneOf,
@@ -48,6 +47,7 @@ from sqlfluff.core.parser import (
     StringLexer,
     StringParser,
     SymbolSegment,
+    TypedParser,
     WhitespaceSegment,
 )
 from sqlfluff.core.parser.segments.base import BracketedSegment
@@ -614,6 +614,8 @@ ansi_dialect.add(
             optional=True,
         ),
     ),
+    # This can be overwritten by dialects
+    ExtendedNaturalJoinKeywordsGrammar=Nothing(),
     NestedJoinGrammar=Nothing(),
     ReferentialActionGrammar=OneOf(
         "RESTRICT",
@@ -1561,6 +1563,13 @@ class JoinClauseSegment(BaseSegment):
         Sequence(
             Ref("NaturalJoinKeywordsGrammar"),
             Ref("JoinKeywordsGrammar"),
+            Indent,
+            Ref("FromExpressionElementSegment"),
+            Dedent,
+        ),
+        # Sometimes, a natural join might already include the keyword
+        Sequence(
+            Ref("ExtendedNaturalJoinKeywordsGrammar"),
             Indent,
             Ref("FromExpressionElementSegment"),
             Dedent,

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -419,8 +419,9 @@ tsql_dialect.replace(
         ),
         optional=True,
     ),
-    JoinKeywordsGrammar=OneOf("JOIN", "APPLY", Sequence("OUTER", "APPLY")),
+    JoinKeywordsGrammar=OneOf("JOIN", "APPLY"),
     NaturalJoinKeywordsGrammar=Ref.keyword("CROSS"),
+    ExtendedNaturalJoinKeywordsGrammar=Sequence("OUTER", "APPLY"),
     NestedJoinGrammar=Sequence(
         Indent,
         Ref("JoinClauseSegment"),

--- a/test/fixtures/dialects/tsql/outer_apply.sql
+++ b/test/fixtures/dialects/tsql/outer_apply.sql
@@ -1,0 +1,6 @@
+-- JOIN should not be parsed as nested in OUTER APPLY
+SELECT table1.*
+FROM table1
+OUTER APPLY table2
+INNER JOIN table3
+    ON table1.col = table3.col;

--- a/test/fixtures/dialects/tsql/outer_apply.yml
+++ b/test/fixtures/dialects/tsql/outer_apply.yml
@@ -1,0 +1,53 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 2c00e0d4150da03673fd39303dddebf447f51e071d6c0843ed313d8e708b8a37
+file:
+  batch:
+    statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                naked_identifier: table1
+                dot: .
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table1
+          - join_clause:
+            - keyword: OUTER
+            - keyword: APPLY
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: table2
+          - join_clause:
+            - keyword: INNER
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: table3
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - naked_identifier: table1
+                  - dot: .
+                  - naked_identifier: col
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: table3
+                  - dot: .
+                  - naked_identifier: col
+          statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -1149,3 +1149,33 @@ test_tsql_nested_join:
   configs:
     core:
       dialect: tsql
+
+test_tsql_outer_apply_indentation:
+  # Test for behavior in issue #3685
+  pass_str: |
+    SELECT table1.*
+    FROM table1
+    OUTER APPLY table2
+    INNER JOIN table3
+        ON table1.col = table3.col
+  configs:
+    core:
+      dialect: tsql
+
+test_tsql_outer_apply_indentation_fix:
+  # Test for behavior in issue #3685
+  fail_str: |
+    SELECT table1.*
+    FROM table1
+    OUTER APPLY table2
+        INNER JOIN table3
+            ON table1.col = table3.col
+  fix_str: |
+    SELECT table1.*
+    FROM table1
+    OUTER APPLY table2
+    INNER JOIN table3
+        ON table1.col = table3.col
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

This PR resolves #3685.


### Are there any other side effects of this change that we should be aware of?

n/a

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
