### PR TITLE
Hive: Add support for LATERAL VIEW clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -324,6 +324,46 @@ class CreateTableStatementSegment(BaseSegment):
     )
 
 
+class FromExpressionElementSegment(ansi.FromExpressionElementSegment):
+    """Modified from ANSI to allow for `LATERAL VIEW` clause."""
+
+    match_grammar = ansi.FromExpressionElementSegment.match_grammar.copy(
+        insert=[
+            AnyNumberOf(Ref("LateralViewClauseSegment")),
+        ],
+        after=Ref("SamplingExpressionSegment"),
+    )
+
+
+class LateralViewClauseSegment(BaseSegment):
+    """A `LATERAL VIEW` in a `FROM` clause.
+
+    https://cwiki.apache.org/confluence/display/hive/languagemanual+lateralview
+    """
+
+    type = "lateral_view_clause"
+
+    match_grammar = Sequence(
+        Indent,
+        "LATERAL",
+        "VIEW",
+        Ref.keyword("OUTER", optional=True),
+        Ref("FunctionSegment"),
+        # NB: AliasExpressionSegment is not used here for table
+        # or column alias because `AS` is optional within it
+        # (and in most scenarios). Here it's explicitly defined
+        # for when it is required and not allowed.
+        Ref("SingleIdentifierGrammar", optional=True),
+        Sequence(
+            "AS",
+            Delimited(
+                Ref("SingleIdentifierGrammar"),
+            ),
+        ),
+        Dedent,
+    )
+
+
 class PrimitiveTypeSegment(BaseSegment):
     """Primitive data types."""
 

--- a/test/fixtures/dialects/hive/select_lateral_view.sql
+++ b/test/fixtures/dialects/hive/select_lateral_view.sql
@@ -1,0 +1,19 @@
+SELECT pageid, adid
+FROM pageAds
+LATERAL VIEW explode(adid_list) adTable AS adid;
+
+SELECT adid, count(1)
+FROM pageAds LATERAL VIEW explode(adid_list) adTable AS adid
+GROUP BY adid;
+
+SELECT * FROM exampleTable
+LATERAL VIEW explode(col1) myTable1 AS myCol1
+LATERAL VIEW explode(myCol1) myTable2 AS myCol2;
+
+SELECT myCol1, myCol2 FROM baseTable
+LATERAL VIEW explode(col1) myTable1 AS myCol1
+LATERAL VIEW explode(col2) myTable2 AS myCol2;
+
+SELECT * FROM src LATERAL VIEW explode(array()) C AS a limit 10;
+
+SELECT * FROM src LATERAL VIEW OUTER explode(array()) C AS a limit 10;

--- a/test/fixtures/dialects/hive/select_lateral_view.yml
+++ b/test/fixtures/dialects/hive/select_lateral_view.yml
@@ -1,0 +1,258 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 42595fd8445bfd6551382c053b6f52b96f0690bd47979028dff4cfd3d862add3
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: pageid
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: adid
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: pageAds
+            lateral_view_clause:
+            - keyword: LATERAL
+            - keyword: VIEW
+            - function:
+                function_name:
+                  function_name_identifier: explode
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: adid_list
+                  end_bracket: )
+            - naked_identifier: adTable
+            - keyword: AS
+            - naked_identifier: adid
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: adid
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '1'
+              end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: pageAds
+            lateral_view_clause:
+            - keyword: LATERAL
+            - keyword: VIEW
+            - function:
+                function_name:
+                  function_name_identifier: explode
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: adid_list
+                  end_bracket: )
+            - naked_identifier: adTable
+            - keyword: AS
+            - naked_identifier: adid
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: adid
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+          - table_expression:
+              table_reference:
+                naked_identifier: exampleTable
+          - lateral_view_clause:
+            - keyword: LATERAL
+            - keyword: VIEW
+            - function:
+                function_name:
+                  function_name_identifier: explode
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: col1
+                  end_bracket: )
+            - naked_identifier: myTable1
+            - keyword: AS
+            - naked_identifier: myCol1
+          - lateral_view_clause:
+            - keyword: LATERAL
+            - keyword: VIEW
+            - function:
+                function_name:
+                  function_name_identifier: explode
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: myCol1
+                  end_bracket: )
+            - naked_identifier: myTable2
+            - keyword: AS
+            - naked_identifier: myCol2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: myCol1
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: myCol2
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+          - table_expression:
+              table_reference:
+                naked_identifier: baseTable
+          - lateral_view_clause:
+            - keyword: LATERAL
+            - keyword: VIEW
+            - function:
+                function_name:
+                  function_name_identifier: explode
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: col1
+                  end_bracket: )
+            - naked_identifier: myTable1
+            - keyword: AS
+            - naked_identifier: myCol1
+          - lateral_view_clause:
+            - keyword: LATERAL
+            - keyword: VIEW
+            - function:
+                function_name:
+                  function_name_identifier: explode
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: col2
+                  end_bracket: )
+            - naked_identifier: myTable2
+            - keyword: AS
+            - naked_identifier: myCol2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: src
+            lateral_view_clause:
+            - keyword: LATERAL
+            - keyword: VIEW
+            - function:
+                function_name:
+                  function_name_identifier: explode
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    function:
+                      function_name:
+                        function_name_identifier: array
+                      bracketed:
+                        start_bracket: (
+                        end_bracket: )
+                  end_bracket: )
+            - naked_identifier: C
+            - keyword: AS
+            - naked_identifier: a
+      limit_clause:
+        keyword: limit
+        numeric_literal: '10'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: src
+            lateral_view_clause:
+            - keyword: LATERAL
+            - keyword: VIEW
+            - keyword: OUTER
+            - function:
+                function_name:
+                  function_name_identifier: explode
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    function:
+                      function_name:
+                        function_name_identifier: array
+                      bracketed:
+                        start_bracket: (
+                        end_bracket: )
+                  end_bracket: )
+            - naked_identifier: C
+            - keyword: AS
+            - naked_identifier: a
+      limit_clause:
+        keyword: limit
+        numeric_literal: '10'
+- statement_terminator: ;


### PR DESCRIPTION

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Add support for `LATERAL VIEW` clause by following the approach put forth in the SparkQL dialect.

See: https://cwiki.apache.org/confluence/display/hive/languagemanual+lateralview

Fixes https://github.com/sqlfluff/sqlfluff/issues/3161

### Are there any other side effects of this change that we should be aware of?

N/A

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
