### PR TITLE
MySQL: Support optional "IF NOT EXISTS" with CREATE TRIGGER

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -2402,6 +2402,7 @@ class CreateTriggerStatementSegment(ansi.CreateTriggerStatementSegment):
         "CREATE",
         Ref("DefinerSegment", optional=True),
         "TRIGGER",
+        Ref("IfNotExistsGrammar", optional=True),
         Ref("TriggerReferenceSegment"),
         OneOf("BEFORE", "AFTER"),
         OneOf("INSERT", "UPDATE", "DELETE"),

--- a/test/fixtures/dialects/mysql/create_trigger.sql
+++ b/test/fixtures/dialects/mysql/create_trigger.sql
@@ -23,6 +23,8 @@ CREATE TRIGGER some_trigger BEFORE UPDATE ON some_table FOR EACH ROW DELETE FROM
 CREATE TRIGGER some_trigger AFTER INSERT ON some_table FOR EACH ROW DELETE FROM other_table;
 CREATE TRIGGER some_trigger BEFORE INSERT ON some_table FOR EACH ROW DELETE FROM other_table;
 
+CREATE TRIGGER IF NOT EXISTS some_trigger AFTER DELETE ON some_table
+FOR EACH ROW DELETE FROM other_table;
 
 CREATE TRIGGER some_trigger AFTER DELETE ON some_table FOR EACH ROW
 FOLLOWS some_other_trigger

--- a/test/fixtures/dialects/mysql/create_trigger.yml
+++ b/test/fixtures/dialects/mysql/create_trigger.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7fb6eed22eb59129a3735291e333697d6aca5ab3395cf817480a05b76b527dc4
+_hash: 3ac600fa9db5bca6f4e64fd5a6141a57ea55630707bd387061e56299e0a5430d
 file:
 - statement:
     create_trigger:
@@ -261,6 +261,34 @@ file:
         naked_identifier: some_trigger
     - keyword: BEFORE
     - keyword: INSERT
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: some_table
+    - keyword: FOR
+    - keyword: EACH
+    - keyword: ROW
+    - statement:
+        delete_statement:
+          keyword: DELETE
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: other_table
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - trigger_reference:
+        naked_identifier: some_trigger
+    - keyword: AFTER
+    - keyword: DELETE
     - keyword: 'ON'
     - table_reference:
         naked_identifier: some_table


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Add missing part of https://github.com/sqlfluff/sqlfluff/pull/3928

We can specify "IF NOT EXISTS" with CREATE TRIGGER statement
https://dev.mysql.com/doc/refman/8.0/en/create-trigger.html

Added example into test/fixtures/dialects/mysql/create_trigger.sql
which is valid as

```
mysql> CREATE TRIGGER IF NOT EXISTS some_trigger AFTER DELETE ON some_table
    -> FOR EACH ROW DELETE FROM other_table;
Query OK, 0 rows affected (0.06 sec)
```
(tested with MySQL 8.0.29)

A parse error occurred before the change:

```
$ sqlfluff lint test/fixtures/dialects/mysql/create_trigger.sql --dialect=mysql
== [test/fixtures/dialects/mysql/create_trigger.sql] FAIL
L:   3 | P:   1 | L003 | Expected 1 indentation, found 0 [compared to line 02]
L:  10 | P:   5 | L003 | Expected 0 indentations, found 1 [compared to line 09]
L:  11 | P:   5 | L003 | Expected 0 indentations, found 1 [compared to line 09]
L:  16 | P:  32 | L014 | Unquoted identifiers must be consistently lower case.
L:  19 | P:  93 | L016 | Line is too long.
L:  20 | P:  94 | L016 | Line is too long.
L:  21 | P:  93 | L016 | Line is too long.
L:  22 | P:  94 | L016 | Line is too long.
L:  23 | P:  93 | L016 | Line is too long.
L:  24 | P:  94 | L016 | Line is too long.
L:  26 | P:   1 |  PRS | Line 26, Position 1: Found unparsable section: 'CREATE
                       | TRIGGER IF NOT EXISTS some_trigge...'
L:  38 | P:   8 | L006 | Missing whitespace before =
L:  38 | P:   8 | L006 | Missing whitespace after =
L:  38 | P:   9 | L059 | Unnecessary quoted identifier `root`.
L:  38 | P:  16 | L057 | Do not use special characters in identifiers.
L:  40 | P:  32 | L014 | Unquoted identifiers must be consistently lower case.
L:  42 | P:   8 | L006 | Missing whitespace before =
L:  42 | P:   8 | L006 | Missing whitespace after =
L:  44 | P:  32 | L014 | Unquoted identifiers must be consistently lower case.
WARNING: Parsing errors found and dialect is set to 'mysql'. Have you configured your dialect correctly?
All Finished 📜 🎉!
```

tested with 52307754a042f472a745c325b2611adf4c7cbea2

After the change:

```
$ sqlfluff lint test/fixtures/dialects/mysql/create_trigger.sql --dialect=mysql
== [test/fixtures/dialects/mysql/create_trigger.sql] FAIL
L:   3 | P:   1 | L003 | Expected 1 indentation, found 0 [compared to line 02]
L:  10 | P:   5 | L003 | Expected 0 indentations, found 1 [compared to line 09]
L:  11 | P:   5 | L003 | Expected 0 indentations, found 1 [compared to line 09]
L:  16 | P:  32 | L014 | Unquoted identifiers must be consistently lower case.
L:  19 | P:  93 | L016 | Line is too long.
L:  20 | P:  94 | L016 | Line is too long.
L:  21 | P:  93 | L016 | Line is too long.
L:  22 | P:  94 | L016 | Line is too long.
L:  23 | P:  93 | L016 | Line is too long.
L:  24 | P:  94 | L016 | Line is too long.
L:  38 | P:   8 | L006 | Missing whitespace before =
L:  38 | P:   8 | L006 | Missing whitespace after =
L:  38 | P:   9 | L059 | Unnecessary quoted identifier `root`.
L:  38 | P:  16 | L057 | Do not use special characters in identifiers.
L:  40 | P:  32 | L014 | Unquoted identifiers must be consistently lower case.
L:  42 | P:   8 | L006 | Missing whitespace before =
L:  42 | P:   8 | L006 | Missing whitespace after =
L:  44 | P:  32 | L014 | Unquoted identifiers must be consistently lower case.
All Finished 📜 🎉!
```

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
