### PR TITLE
Consolidate comma style configs

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -124,7 +124,6 @@ For example:
    tab_space_size = 4
    max_line_length = 80
    indent_unit = space
-   comma_style = trailing
    allow_scalar = True
    single_table_references = consistent
    unquoted_identifiers_policy = all

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -50,6 +50,17 @@ REMOVED_CONFIGS = [
         (lambda x: "trailing" if x == "after" else "leading"),
     ),
     _RemovedConfig(
+        ("rules", "comma_style"),
+        (
+            "Use the line_position config in the appropriate "
+            "sqlfluff:layout section (e.g. sqlfluff:layout:type"
+            ":comma)."
+        ),
+        ("layout", "type", "comma", "line_position"),
+        (lambda x: x),
+    ),
+    # L019 used to have a more specific version of the same /config itself.
+    _RemovedConfig(
         ("rules", "L019", "comma_style"),
         (
             "Use the line_position config in the appropriate "

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -116,7 +116,6 @@ apply_dbt_builtins = True
 tab_space_size = 4
 max_line_length = 80
 indent_unit = space
-comma_style = trailing
 allow_scalar = True
 single_table_references = consistent
 unquoted_identifiers_policy = all

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -34,10 +34,6 @@ STANDARD_CONFIG_INFO_DICT = {
             "indentation of a file."
         ),
     },
-    "comma_style": {
-        "validation": ["leading", "trailing"],
-        "definition": "The comma style to enforce.",
-    },
     "allow_scalar": {
         "validation": [True, False],
         "definition": (

--- a/src/sqlfluff/rules/L022.py
+++ b/src/sqlfluff/rules/L022.py
@@ -45,14 +45,10 @@ class Rule_L022(BaseRule):
     """
 
     groups = ("all", "core")
-    config_keywords = ["comma_style"]
     crawl_behaviour = SegmentSeekerCrawler({"with_compound_statement"})
 
     def _eval(self, context: RuleContext) -> Optional[List[LintResult]]:
         """Blank line expected but not found after CTE definition."""
-        # Config type hints
-        self.comma_style: str
-
         error_buffer = []
         assert context.segment.is_type("with_compound_statement")
         # First we need to find all the commas, the end brackets, the
@@ -76,7 +72,7 @@ class Rule_L022(BaseRule):
             blank_lines = 0
             comma_line_idx = None
             line_blank = False
-            comma_style = None
+            comma_style: str
             line_starts = {}
             comment_lines = []
 

--- a/test/core/rules/rules_test.py
+++ b/test/core/rules/rules_test.py
@@ -106,9 +106,9 @@ def test_rules_configs_are_dynamically_documented():
     class RuleWithConfig(BaseRule):
         """A new rule with configuration."""
 
-        config_keywords = ["comma_style"]
+        config_keywords = ["max_line_length"]
 
-    assert "comma_style" in RuleWithConfig.__doc__
+    assert "max_line_length" in RuleWithConfig.__doc__
 
     @document_configuration
     class RuleWithoutConfig(BaseRule):

--- a/test/fixtures/rules/std_rule_cases/L022.yml
+++ b/test/fixtures/rules/std_rule_cases/L022.yml
@@ -151,10 +151,6 @@ test_fail_oneline_cte_leading_comma:
     select * from my_cte
     cross join other_cte
 
-  configs:
-    rules:
-      comma_style: leading
-
 test_fail_cte_floating_comma:
   # Fixes cte with a floating comma
   fail_str: |

--- a/test/fixtures/rules/std_rule_cases/L022.yml
+++ b/test/fixtures/rules/std_rule_cases/L022.yml
@@ -151,6 +151,13 @@ test_fail_oneline_cte_leading_comma:
     select * from my_cte
     cross join other_cte
 
+  # NOTE: we're using the global comma position config
+  configs:
+    layout:
+      type:
+        comma:
+          line_position: leading
+
 test_fail_cte_floating_comma:
   # Fixes cte with a floating comma
   fail_str: |

--- a/test/rules/std_test.py
+++ b/test/rules/std_test.py
@@ -103,7 +103,6 @@ def test__rules__std_file(rule, path, violations):
         {"tab_space_size": "blah"},
         {"max_line_length": "blah"},
         {"indent_unit": "blah"},
-        {"comma_style": "blah"},
         {"allow_scalar": "blah"},
         {"single_table_references": "blah"},
         {"unquoted_identifiers_policy": "blah"},


### PR DESCRIPTION
Most of the references to `comma_style` were removed in #3847 . At that stage I didn't however clear up a few of the other references, in particular scattered across the config files.

`L022` was one still using the old config which raises risks for confusion. This PR migrates that rule off the old config and onto the new one. It _doesn't_ migrate the rule onto the reflow codebase itself because we don't yet have the capability to insert blank lines in that code (I'll make a note to cover that later).

While I was in there I simplified the nesting of the logic a little, but the intent is unchanged.