### PR TITLE
[BUGFIX] Changing cwd temporarily on manifest load as dbt is not using `project_dir` to read/write target folder

### DIFF
--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -143,7 +143,13 @@ class DbtTemplater(JinjaTemplater):
         # dbt 0.20.* and onward
         from dbt.parser.manifest import ManifestLoader
 
-        self.dbt_manifest = ManifestLoader.get_full_manifest(self.dbt_config)
+        try:
+            # Changing cwd temporarily as dbt is not using project_dir to read/write `target/partial_parse.msgpack`
+            os.chdir(self.project_dir)
+
+            self.dbt_manifest = ManifestLoader.get_full_manifest(self.dbt_config)
+        finally:
+            os.chdir(self.working_dir)
 
         return self.dbt_manifest
 

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -144,7 +144,9 @@ class DbtTemplater(JinjaTemplater):
         from dbt.parser.manifest import ManifestLoader
 
         try:
-            # Changing cwd temporarily as dbt is not using project_dir to read/write `target/partial_parse.msgpack`
+            # Changing cwd temporarily as dbt is not using project_dir to
+            # read/write `target/partial_parse.msgpack`. This can be undone when
+            # https://github.com/dbt-labs/dbt-core/issues/6055 is solved.
             os.chdir(self.project_dir)
 
             self.dbt_manifest = ManifestLoader.get_full_manifest(self.dbt_config)


### PR DESCRIPTION
### Brief summary of the change made

Fixes #2895

templater-dbt uses `dbt.parser.manifest` from `dbt-core`, which has [this bug](https://github.com/dbt-labs/dbt-core/issues/6055).
This is a workaround to avoid such issue.

Test cases pending.
