### PR TITLE
MySQL: Support REPLACE statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -1039,6 +1039,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("InsertRowAliasSegment"),
             Ref("FlushStatementSegment"),
             Ref("LoadDataSegment"),
+            Ref("ReplaceSegment"),
         ],
     )
 
@@ -2352,7 +2353,7 @@ class LoadDataSegment(BaseSegment):
         "INTO",
         "TABLE",
         Ref("TableReferenceSegment"),
-        Sequence("PARTITION", Ref("SelectPartitionClauseSegment"), optional=True),
+        Ref("SelectPartitionClauseSegment", optional=True),
         Sequence("CHARACTER", "SET", Ref("NakedIdentifierSegment"), optional=True),
         Sequence(
             OneOf("FIELDS", "COLUMNS"),
@@ -2387,6 +2388,40 @@ class LoadDataSegment(BaseSegment):
             "SET",
             Ref("Expression_B_Grammar"),
             optional=True,
+        ),
+    )
+
+
+class ReplaceSegment(BaseSegment):
+    """A `REPLACE` statement.
+
+    As per https://dev.mysql.com/doc/refman/8.0/en/replace.html
+    """
+
+    type = "replace_statement"
+
+    match_grammar = Sequence(
+        "REPLACE",
+        OneOf("LOW_PRIORITY", "DELAYED", optional=True),
+        Sequence("INTO", optional=True),
+        Ref("TableReferenceSegment"),
+        Ref("SelectPartitionClauseSegment", optional=True),
+        OneOf(
+            Sequence(
+                Ref("BracketedColumnReferenceListGrammar", optional=True),
+                Ref("ValuesClauseSegment"),
+            ),
+            Ref("SetClauseListSegment"),
+            Sequence(
+                Ref("BracketedColumnReferenceListGrammar", optional=True),
+                OneOf(
+                    Ref("SelectableGrammar"),
+                    Sequence(
+                        "TABLE",
+                        Ref("TableReferenceSegment"),
+                    ),
+                ),
+            ),
         ),
     )
 

--- a/test/fixtures/dialects/mysql/load_data.sql
+++ b/test/fixtures/dialects/mysql/load_data.sql
@@ -1,5 +1,6 @@
 LOAD DATA INFILE '/var/lib/mysql-files/libaccess.csv' INTO TABLE libaccess FIELDS TERMINATED BY '\t' OPTIONALLY ENCLOSED BY '"' IGNORE 1 LINES;
 LOAD DATA INFILE 'data.txt' INTO TABLE db2.my_table;
+LOAD DATA INFILE 'data.txt' INTO TABLE db2.my_table PARTITION (partition_name);
 LOAD DATA INFILE '/tmp/test.txt' INTO TABLE test
   FIELDS TERMINATED BY ','  LINES STARTING BY 'xxx';
 LOAD DATA INFILE '/tmp/test.txt' INTO TABLE test IGNORE 1 LINES;

--- a/test/fixtures/dialects/mysql/load_data.yml
+++ b/test/fixtures/dialects/mysql/load_data.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 43ac195d144b262728a8d04751851aab3a843cadc9ab23a1cb316486872a093b
+_hash: 2d0a01865822c5dbbf9fc9d91f606ad76c05ede0b97e42f286267cb7c58df743
 file:
 - statement:
     load_data_statement:
@@ -39,6 +39,26 @@ file:
       - naked_identifier: db2
       - dot: .
       - naked_identifier: my_table
+- statement_terminator: ;
+- statement:
+    load_data_statement:
+    - keyword: LOAD
+    - keyword: DATA
+    - keyword: INFILE
+    - quoted_literal: "'data.txt'"
+    - keyword: INTO
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db2
+      - dot: .
+      - naked_identifier: my_table
+    - partition_clause:
+        keyword: PARTITION
+        bracketed:
+          start_bracket: (
+          object_reference:
+            naked_identifier: partition_name
+          end_bracket: )
 - statement_terminator: ;
 - statement:
     load_data_statement:

--- a/test/fixtures/dialects/mysql/replace.sql
+++ b/test/fixtures/dialects/mysql/replace.sql
@@ -1,0 +1,43 @@
+REPLACE tbl_name VALUES (1, 2);
+
+REPLACE tbl_name VALUES (DEFAULT, DEFAULT);
+
+REPLACE tbl_name VALUES (1, 2), (11, 22);
+
+REPLACE tbl_name VALUE (1, 2), (11, 22);
+
+REPLACE tbl_name (col1, col2) VALUES (1, 2);
+
+REPLACE tbl_name (col1, col2) VALUES ROW(1, 2), ROW(11, 22);
+
+REPLACE LOW_PRIORITY tbl_name VALUES (1, 2);
+
+REPLACE DELAYED tbl_name VALUES (1, 2);
+
+REPLACE LOW_PRIORITY INTO tbl_name VALUES (1, 2);
+
+REPLACE tbl_name PARTITION (partition_name) VALUES (1, 2);
+
+REPLACE tbl_name SET col1 = 1, col2 = 2;
+
+REPLACE LOW_PRIORITY tbl_name SET col1 = 1, col2 = 2;
+
+REPLACE DELAYED tbl_name SET col1 = 1, col2 = 2;
+
+REPLACE LOW_PRIORITY INTO tbl_name SET col1 = 1, col2 = 2;
+
+REPLACE tbl_name PARTITION (partition_name) SET col1 = 1, col2 = 2;
+
+REPLACE tbl_name SELECT * FROM table_name;
+
+REPLACE tbl_name TABLE table_name;
+
+REPLACE LOW_PRIORITY tbl_name TABLE table_name;
+
+REPLACE DELAYED tbl_name TABLE table_name;
+
+REPLACE LOW_PRIORITY INTO tbl_name TABLE table_name;
+
+REPLACE tbl_name (col1, col2) TABLE table_name;
+
+REPLACE tbl_name PARTITION (partition_name) TABLE table_name;

--- a/test/fixtures/dialects/mysql/replace.yml
+++ b/test/fixtures/dialects/mysql/replace.yml
@@ -1,0 +1,430 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 45188ef87789eed9f796536a6b1b2b5910c6232cfa641faa4914824087d321f3
+file:
+- statement:
+    replace_statement:
+      keyword: REPLACE
+      table_reference:
+        naked_identifier: tbl_name
+      values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    replace_statement:
+      keyword: REPLACE
+      table_reference:
+        naked_identifier: tbl_name
+      values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - keyword: DEFAULT
+        - comma: ','
+        - keyword: DEFAULT
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    replace_statement:
+      keyword: REPLACE
+      table_reference:
+        naked_identifier: tbl_name
+      values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '11'
+        - comma: ','
+        - expression:
+            numeric_literal: '22'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    replace_statement:
+      keyword: REPLACE
+      table_reference:
+        naked_identifier: tbl_name
+      values_clause:
+      - keyword: VALUE
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '11'
+        - comma: ','
+        - expression:
+            numeric_literal: '22'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    replace_statement:
+      keyword: REPLACE
+      table_reference:
+        naked_identifier: tbl_name
+      bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: col1
+      - comma: ','
+      - column_reference:
+          naked_identifier: col2
+      - end_bracket: )
+      values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    replace_statement:
+      keyword: REPLACE
+      table_reference:
+        naked_identifier: tbl_name
+      bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: col1
+      - comma: ','
+      - column_reference:
+          naked_identifier: col2
+      - end_bracket: )
+      values_clause:
+      - keyword: VALUES
+      - keyword: ROW
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - end_bracket: )
+      - comma: ','
+      - keyword: ROW
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '11'
+        - comma: ','
+        - expression:
+            numeric_literal: '22'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    replace_statement:
+    - keyword: REPLACE
+    - keyword: LOW_PRIORITY
+    - table_reference:
+        naked_identifier: tbl_name
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    replace_statement:
+    - keyword: REPLACE
+    - keyword: DELAYED
+    - table_reference:
+        naked_identifier: tbl_name
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    replace_statement:
+    - keyword: REPLACE
+    - keyword: LOW_PRIORITY
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: tbl_name
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    replace_statement:
+      keyword: REPLACE
+      table_reference:
+        naked_identifier: tbl_name
+      partition_clause:
+        keyword: PARTITION
+        bracketed:
+          start_bracket: (
+          object_reference:
+            naked_identifier: partition_name
+          end_bracket: )
+      values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    replace_statement:
+      keyword: REPLACE
+      table_reference:
+        naked_identifier: tbl_name
+      set_clause_list:
+      - keyword: SET
+      - set_clause:
+          column_reference:
+            naked_identifier: col1
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+      - comma: ','
+      - set_clause:
+          column_reference:
+            naked_identifier: col2
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    replace_statement:
+    - keyword: REPLACE
+    - keyword: LOW_PRIORITY
+    - table_reference:
+        naked_identifier: tbl_name
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+          column_reference:
+            naked_identifier: col1
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+      - comma: ','
+      - set_clause:
+          column_reference:
+            naked_identifier: col2
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    replace_statement:
+    - keyword: REPLACE
+    - keyword: DELAYED
+    - table_reference:
+        naked_identifier: tbl_name
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+          column_reference:
+            naked_identifier: col1
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+      - comma: ','
+      - set_clause:
+          column_reference:
+            naked_identifier: col2
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    replace_statement:
+    - keyword: REPLACE
+    - keyword: LOW_PRIORITY
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: tbl_name
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+          column_reference:
+            naked_identifier: col1
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+      - comma: ','
+      - set_clause:
+          column_reference:
+            naked_identifier: col2
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    replace_statement:
+      keyword: REPLACE
+      table_reference:
+        naked_identifier: tbl_name
+      partition_clause:
+        keyword: PARTITION
+        bracketed:
+          start_bracket: (
+          object_reference:
+            naked_identifier: partition_name
+          end_bracket: )
+      set_clause_list:
+      - keyword: SET
+      - set_clause:
+          column_reference:
+            naked_identifier: col1
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+      - comma: ','
+      - set_clause:
+          column_reference:
+            naked_identifier: col2
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    replace_statement:
+      keyword: REPLACE
+      table_reference:
+        naked_identifier: tbl_name
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table_name
+- statement_terminator: ;
+- statement:
+    replace_statement:
+    - keyword: REPLACE
+    - table_reference:
+        naked_identifier: tbl_name
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table_name
+- statement_terminator: ;
+- statement:
+    replace_statement:
+    - keyword: REPLACE
+    - keyword: LOW_PRIORITY
+    - table_reference:
+        naked_identifier: tbl_name
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table_name
+- statement_terminator: ;
+- statement:
+    replace_statement:
+    - keyword: REPLACE
+    - keyword: DELAYED
+    - table_reference:
+        naked_identifier: tbl_name
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table_name
+- statement_terminator: ;
+- statement:
+    replace_statement:
+    - keyword: REPLACE
+    - keyword: LOW_PRIORITY
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: tbl_name
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table_name
+- statement_terminator: ;
+- statement:
+    replace_statement:
+    - keyword: REPLACE
+    - table_reference:
+        naked_identifier: tbl_name
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: col1
+      - comma: ','
+      - column_reference:
+          naked_identifier: col2
+      - end_bracket: )
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table_name
+- statement_terminator: ;
+- statement:
+    replace_statement:
+    - keyword: REPLACE
+    - table_reference:
+        naked_identifier: tbl_name
+    - partition_clause:
+        keyword: PARTITION
+        bracketed:
+          start_bracket: (
+          object_reference:
+            naked_identifier: partition_name
+          end_bracket: )
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table_name
+- statement_terminator: ;


### PR DESCRIPTION
Also fixes usage of SelectPartitionClauseSegment in LoadDataSegment


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #3947 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
