### PR TITLE
Athena: Add support for using underscore aliases

### DIFF
--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -15,6 +15,7 @@ from sqlfluff.core.parser import (
     OptionallyBracketed,
     Ref,
     RegexParser,
+    SegmentGenerator,
     Sequence,
     StringLexer,
     StringParser,
@@ -171,6 +172,15 @@ athena_dialect.replace(
     ),
     SimpleArrayTypeGrammar=Ref.keyword("ARRAY"),
     TrimParametersGrammar=Nothing(),
+    NakedIdentifierSegment=SegmentGenerator(
+        # Generate the anti template from the set of reserved keywords
+        lambda dialect: RegexParser(
+            r"([_]+|[A-Z0-9_]*[A-Z][A-Z0-9_]*)",
+            ansi.IdentifierSegment,
+            type="naked_identifier",
+            anti_template=r"^(" + r"|".join(dialect.sets("reserved_keywords")) + r")$",
+        )
+    ),
     SingleIdentifierGrammar=ansi_dialect.get_grammar("SingleIdentifierGrammar").copy(
         insert=[
             Ref("BackQuotedIdentifierSegment"),

--- a/test/fixtures/dialects/athena/select_underscore.sql
+++ b/test/fixtures/dialects/athena/select_underscore.sql
@@ -1,0 +1,13 @@
+SELECT 1 AS _;
+
+SELECT 1 AS __;
+
+SELECT a
+FROM (
+VALUES ('a'), ('b')
+) AS _(a);
+
+SELECT a
+FROM (
+VALUES ('a'), ('b')
+) AS __(a);

--- a/test/fixtures/dialects/athena/select_underscore.yml
+++ b/test/fixtures/dialects/athena/select_underscore.yml
@@ -1,0 +1,101 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 40356891ee431750530c54abf858185798c2811e5623e22a09be65c93258daf3
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: '1'
+          alias_expression:
+            keyword: AS
+            naked_identifier: _
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: '1'
+          alias_expression:
+            keyword: AS
+            naked_identifier: __
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'a'"
+                    end_bracket: )
+                - comma: ','
+                - bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'b'"
+                    end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: _
+              bracketed:
+                start_bracket: (
+                identifier_list:
+                  naked_identifier: a
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'a'"
+                    end_bracket: )
+                - comma: ','
+                - bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'b'"
+                    end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: __
+              bracketed:
+                start_bracket: (
+                identifier_list:
+                  naked_identifier: a
+                end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Add support for using underscores for aliases (`AS`).

Fixes https://github.com/sqlfluff/sqlfluff/issues/3678

### Are there any other side effects of this change that we should be aware of?

N/A

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
