### PR TITLE
Fix type annotation of user_rules in `Linter`

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -4,7 +4,18 @@ import fnmatch
 import os
 import time
 import logging
-from typing import Any, List, Sequence, Optional, Tuple, cast, Iterable, Iterator, Set
+from typing import (
+    Any,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    cast,
+)
 
 import pathspec
 import regex
@@ -59,7 +70,7 @@ class Linter:
         formatter: Any = None,
         dialect: Optional[str] = None,
         rules: Optional[List[str]] = None,
-        user_rules: Optional[List[BaseRule]] = None,
+        user_rules: Optional[List[Type[BaseRule]]] = None,
         exclude_rules: Optional[List[str]] = None,
     ) -> None:
         # Store the config object


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fixes #3973

`user_rules` now correctly takes in any class inherited from `BaseRule` instead of expecting an instance of such a class.

This resolves some type errors arising from the wrong annotation in `test/core/rules/rules_test.py`.

### Are there any other side effects of this change that we should be aware of?

N/A

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
