### PR TITLE
[BUGFIX] Changing cwd temporarily on manifest load as dbt is not using project_dir to read/write target folder

### DIFF
--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -143,8 +143,16 @@ class DbtTemplater(JinjaTemplater):
         # dbt 0.20.* and onward
         from dbt.parser.manifest import ManifestLoader
 
-        self.dbt_manifest = ManifestLoader.get_full_manifest(self.dbt_config)
-
+        # self.dbt_manifest = ManifestLoader.get_full_manifest(self.dbt_config)
+        old_cwd = os.getcwd()
+        try:
+            # Changing cwd temporarily as dbt is not using project_dir to
+            # read/write `target/partial_parse.msgpack`. This can be undone when
+            # https://github.com/dbt-labs/dbt-core/issues/6055 is solved.
+            os.chdir(self.project_dir)
+            self.dbt_manifest = ManifestLoader.get_full_manifest(self.dbt_config)
+        finally:
+            os.chdir(old_cwd)
         return self.dbt_manifest
 
     @cached_property

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -143,7 +143,6 @@ class DbtTemplater(JinjaTemplater):
         # dbt 0.20.* and onward
         from dbt.parser.manifest import ManifestLoader
 
-        # self.dbt_manifest = ManifestLoader.get_full_manifest(self.dbt_config)
         old_cwd = os.getcwd()
         try:
             # Changing cwd temporarily as dbt is not using project_dir to

--- a/plugins/sqlfluff-templater-dbt/test/linter_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/linter_test.py
@@ -66,8 +66,11 @@ templater = "dbt"
 dialect = "postgres"
 
 [tool.sqlfluff.templater.dbt]
-project_dir = "dir1/dir2/dbt/dbt_project"
-""",
+project_dir = "{tmp_base_dir}/dir1/dir2/dbt/dbt_project"
+profiles_dir = "{tmp_base_dir}/dir1/dir2/dbt/profiles_yml"
+""".format(
+                tmp_base_dir=tmp_base_dir
+            ),
             file=f,
         )
     try:

--- a/plugins/sqlfluff-templater-dbt/test/linter_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/linter_test.py
@@ -3,6 +3,7 @@
 import os
 import os.path
 import shutil
+import sys
 
 import pytest
 
@@ -40,6 +41,10 @@ def test__linter__lint_ephemeral_3_level(project_dir):  # noqa
     lntr.lint_path(path=model_file_path)
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="Fails on GitHub Windows with: Paths don't have the same drive",
+)
 def test_dbt_target_dir(tmpdir):
     """Test with dbt project in subdir that target/ is created in the correct place.
 

--- a/plugins/sqlfluff-templater-dbt/test/linter_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/linter_test.py
@@ -2,6 +2,7 @@
 
 import os
 import os.path
+import shutil
 
 import pytest
 
@@ -39,11 +40,16 @@ def test__linter__lint_ephemeral_3_level(project_dir):  # noqa
     lntr.lint_path(path=model_file_path)
 
 
-def test_dbt_target_dir():
+def test_dbt_target_dir(tmpdir):
     """Test with dbt project in subdir that target/ is created in the correct place.
 
     https://github.com/sqlfluff/sqlfluff/issues/2895
     """
+    old_path = os.path.abspath(
+        "plugins/sqlfluff-templater-dbt/test/fixtures/dbt/.sqlfluff"
+    )
+    new_path = str(tmpdir.join(".sqlfluff"))
+    shutil.move(old_path, new_path)
     assert not os.path.exists("target")
     with open("pyproject.toml", "w") as f:
         print(
@@ -73,3 +79,4 @@ project_dir = "plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project"
         )
     finally:
         os.unlink("pyproject.toml")
+        shutil.move(new_path, old_path)

--- a/plugins/sqlfluff-templater-dbt/test/linter_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/linter_test.py
@@ -53,23 +53,24 @@ def test_dbt_target_dir(tmpdir):
         "plugins/sqlfluff-templater-dbt/test/fixtures/dbt",
         tmp_dbt_dir,
     )
+    os.unlink(os.path.join(tmp_dbt_dir, ".sqlfluff"))
     old_cwd = os.getcwd()
     # Invoke SQLFluff from <<tmpdir>>, linting a file in the dbt project at
     # <<tmp_project_dir>>/dir1/dir2/dbt/dbt_project. Prior to the bug fix, a
     # "target" directory would incorrectly be created in <<tmp_project_dir>>.
     # (It should be created in <<tmp_project_dir>>/dir1/dir2/dbt/dbt_project.)
     os.chdir(tmp_base_dir)
-    with open("pyproject.toml", "w") as f:
+    with open(".sqlfluff", "w") as f:
         print(
-            """[tool.sqlfluff.core]
-templater = "dbt"
-dialect = "postgres"
+            """[sqlfluff]
+templater = dbt
+dialect = postgres
 
-[tool.sqlfluff.templater.dbt]
-project_dir = "{tmp_base_dir}/dir1/dir2/dbt/dbt_project"
-profiles_dir = "{tmp_base_dir}/dir1/dir2/dbt/profiles_yml"
+[sqlfluff:templater:dbt]
+project_dir = {tmp_base_dir}/dir1/dir2/dbt/dbt_project
+profiles_dir = {old_cwd}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/profiles_yml
 """.format(
-                tmp_base_dir=tmp_base_dir
+                old_cwd=old_cwd, tmp_base_dir=tmp_base_dir
             ),
             file=f,
         )

--- a/plugins/sqlfluff-templater-dbt/test/linter_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/linter_test.py
@@ -46,17 +46,18 @@ def test_dbt_target_dir(tmpdir):
     https://github.com/sqlfluff/sqlfluff/issues/2895
     """
     tmp_base_dir = str(tmpdir)
-    tmp_project_dir = os.path.join(tmp_base_dir, "dir1", "dir2", "dbt_project")
-    os.makedirs(os.path.dirname(tmp_project_dir))
+    tmp_dbt_dir = os.path.join(tmp_base_dir, "dir1", "dir2", "dbt")
+    # tmp_project_dir = os.path.join(tmp_dbt_dir, "dbt_project")
+    os.makedirs(os.path.dirname(tmp_dbt_dir))
     shutil.copytree(
-        "plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project",
-        tmp_project_dir,
+        "plugins/sqlfluff-templater-dbt/test/fixtures/dbt",
+        tmp_dbt_dir,
     )
     old_cwd = os.getcwd()
     # Invoke SQLFluff from <<tmpdir>>, linting a file in the dbt project at
-    # <<tmp_project_dir>>/dir1/dir2. Prior to the bug fix, a "target" directory
-    # would incorrectly be created in <<tmp_project_dir>>. (It should be created
-    # in <<tmp_project_dir>>/dir1/dir2/dbt_project.)
+    # <<tmp_project_dir>>/dir1/dir2/dbt/dbt_project. Prior to the bug fix, a
+    # "target" directory would incorrectly be created in <<tmp_project_dir>>.
+    # (It should be created in <<tmp_project_dir>>/dir1/dir2/dbt/dbt_project.)
     os.chdir(tmp_base_dir)
     with open("pyproject.toml", "w") as f:
         print(
@@ -65,7 +66,7 @@ templater = "dbt"
 dialect = "postgres"
 
 [tool.sqlfluff.templater.dbt]
-project_dir = "dir1/dir2/dbt_project"
+project_dir = "dir1/dir2/dbt/dbt_project"
 """,
             file=f,
         )
@@ -75,11 +76,11 @@ project_dir = "dir1/dir2/dbt_project"
             args=[
                 lint,
                 [
-                    "dir1/dir2/dbt_project/models/my_new_project/use_dbt_utils.sql",
+                    "dir1/dir2/dbt/dbt_project/models/my_new_project/use_dbt_utils.sql",
                 ],
             ],
         )
         assert not os.path.exists("target")
-        assert os.path.exists("dir1/dir2/dbt_project/target")
+        assert os.path.exists("dir1/dir2/dbt/dbt_project/target")
     finally:
         os.chdir(old_cwd)

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -375,8 +375,8 @@ def test__templater_dbt_handle_exceptions(
             config=FluffConfig(configs=DBT_FLUFF_CONFIG, overrides={"dialect": "ansi"}),
         )
     finally:
-        get_adapter(dbt_templater.dbt_config).connections.release()
         os.rename(target_fpath, src_fpath)
+        get_adapter(dbt_templater.dbt_config).connections.release()
     assert violations
     # NB: Replace slashes to deal with different platform paths being returned.
     assert violations[0].desc().replace("\\", "/").startswith(exception_msg)
@@ -417,8 +417,8 @@ def test__templater_dbt_handle_database_connection_failure(
             config=FluffConfig(configs=DBT_FLUFF_CONFIG),
         )
     finally:
-        get_adapter(dbt_templater.dbt_config).connections.release()
         os.rename(target_fpath, src_fpath)
+        get_adapter(dbt_templater.dbt_config).connections.release()
     assert violations
     # NB: Replace slashes to deal with different platform paths being returned.
     assert (

--- a/src/sqlfluff/utils/testing/cli.py
+++ b/src/sqlfluff/utils/testing/cli.py
@@ -1,0 +1,29 @@
+"""Testing utils for working with the CLIs."""
+from click.testing import CliRunner
+
+
+def invoke_assert_code(
+    ret_code=0,
+    args=None,
+    kwargs=None,
+    cli_input=None,
+    mix_stderr=True,
+    output_contains="",
+):
+    """Invoke a command and check return code."""
+    args = args or []
+    kwargs = kwargs or {}
+    if cli_input:
+        kwargs["input"] = cli_input
+    runner = CliRunner(mix_stderr=mix_stderr)
+    result = runner.invoke(*args, **kwargs)
+    # Output the CLI code for debugging
+    print(result.output)
+    # Check return codes
+    if output_contains != "":
+        assert output_contains in result.output
+    if ret_code == 0:
+        if result.exception:
+            raise result.exception
+    assert ret_code == result.exit_code
+    return result

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -34,6 +34,7 @@ from sqlfluff.cli.commands import (
 )
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult
 from sqlfluff.core.parser.segments.raw import CommentSegment
+from sqlfluff.utils.testing.cli import invoke_assert_code
 
 re_ansi_escape = re.compile(r"\x1b[^m]*m")
 
@@ -68,33 +69,6 @@ def logging_cleanup():
 def contains_ansi_escape(s: str) -> bool:
     """Does the string contain ANSI escape codes (e.g. color)?"""
     return re_ansi_escape.search(s) is not None
-
-
-def invoke_assert_code(
-    ret_code=0,
-    args=None,
-    kwargs=None,
-    cli_input=None,
-    mix_stderr=True,
-    output_contains="",
-):
-    """Invoke a command and check return code."""
-    args = args or []
-    kwargs = kwargs or {}
-    if cli_input:
-        kwargs["input"] = cli_input
-    runner = CliRunner(mix_stderr=mix_stderr)
-    result = runner.invoke(*args, **kwargs)
-    # Output the CLI code for debugging
-    print(result.output)
-    # Check return codes
-    if output_contains != "":
-        assert output_contains in result.output
-    if ret_code == 0:
-        if result.exception:
-            raise result.exception
-    assert ret_code == result.exit_code
-    return result
 
 
 expected_output = """== [test/fixtures/linter/indentation_error_simple.sql] FAIL


### PR DESCRIPTION
Co-authored-by: ssassi@sophilabs.com


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes https://github.com/sqlfluff/sqlfluff/issues/2895

`sqlfluff-templater-dbt` uses `dbt.parser.manifest` from `dbt-core`, which has [this bug](https://github.com/dbt-labs/dbt-core/issues/6055).
This is a workaround to avoid such issue.
This PR replaces #3957.

Test cases pending.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
