### PR TITLE
Snowflake tag reference segment

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -974,6 +974,12 @@ class SequenceReferenceSegment(ObjectReferenceSegment):
     type = "sequence_reference"
 
 
+class TagReferenceSegment(ObjectReferenceSegment):
+    """A reference to a tag."""
+
+    type = "tag_reference"
+
+
 class TriggerReferenceSegment(ObjectReferenceSegment):
     """A reference to a trigger."""
 

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1837,7 +1837,7 @@ class AlterWarehouseStatementSegment(BaseSegment):
                 "UNSET",
                 OneOf(
                     Delimited(Ref("NakedIdentifierSegment")),
-                    Sequence("TAG", Delimited(Ref("NakedIdentifierSegment"))),
+                    Sequence("TAG", Delimited(Ref("TagReferenceSegment"))),
                 ),
             ),
         ),
@@ -1887,9 +1887,9 @@ class AlterShareStatementSegment(BaseSegment):
             Sequence(
                 "UNSET",
                 "TAG",
-                Ref("NakedIdentifierSegment"),
+                Ref("TagReferenceSegment"),
                 AnyNumberOf(
-                    Ref("CommaSegment"), Ref("NakedIdentifierSegment"), optional=True
+                    Ref("CommaSegment"), Ref("TagReferenceSegment"), optional=True
                 ),
             ),
             Sequence("UNSET", "COMMENT"),
@@ -1974,7 +1974,7 @@ class TagBracketedEqualsSegment(BaseSegment):
         Bracketed(
             Delimited(
                 Sequence(
-                    Ref("NakedIdentifierSegment"),
+                    Ref("TagReferenceSegment"),
                     Ref("EqualsSegment"),
                     Ref("QuotedLiteralSegment"),
                 )
@@ -1994,7 +1994,7 @@ class TagEqualsSegment(BaseSegment):
         "TAG",
         Delimited(
             Sequence(
-                Ref("NakedIdentifierSegment"),
+                Ref("TagReferenceSegment"),
                 Ref("EqualsSegment"),
                 Ref("QuotedLiteralSegment"),
             )
@@ -2827,7 +2827,7 @@ class AlterSchemaStatementSegment(BaseSegment):
                         "DEFAULT_DDL_COLLATION",
                         "COMMENT",
                     ),
-                    Sequence("TAG", Delimited(Ref("NakedIdentifierSegment"))),
+                    Sequence("TAG", Delimited(Ref("TagReferenceSegment"))),
                 ),
             ),
             Sequence(OneOf("ENABLE", "DISABLE"), Sequence("MANAGED", "ACCESS")),
@@ -3452,7 +3452,7 @@ class AlterViewStatementSegment(BaseSegment):
                 "SECURE",
             ),
             Sequence("SET", Ref("TagEqualsSegment")),
-            Sequence("UNSET", "TAG", Delimited(Ref("NakedIdentifierSegment"))),
+            Sequence("UNSET", "TAG", Delimited(Ref("TagReferenceSegment"))),
             Delimited(
                 Sequence(
                     "ADD",
@@ -3501,7 +3501,7 @@ class AlterViewStatementSegment(BaseSegment):
                             Ref("ColumnReferenceSegment"),
                             "UNSET",
                             "TAG",
-                            Delimited(Ref("NakedIdentifierSegment")),
+                            Delimited(Ref("TagReferenceSegment")),
                         ),
                     ),
                 ),
@@ -3983,7 +3983,7 @@ class AlterPipeSegment(BaseSegment):
             ),
             Sequence(
                 "UNSET",
-                Sequence("TAG", Delimited(Ref("NakedIdentifierSegment"))),
+                Sequence("TAG", Delimited(Ref("TagReferenceSegment"))),
             ),
             Sequence(
                 "REFRESH",
@@ -4888,7 +4888,7 @@ class AlterStreamStatementSegment(BaseSegment):
             Sequence(
                 "UNSET",
                 OneOf(
-                    Sequence("TAG", Delimited(Ref("NakedIdentifierSegment"))),
+                    Sequence("TAG", Delimited(Ref("TagReferenceSegment"))),
                     "COMMENT",
                 ),
             ),

--- a/test/fixtures/dialects/snowflake/snowflake_alter_external_table.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_external_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d18cf30b49749b2f879ef2161d131cdba0ff5fc279442ebbd71f1d4e47f7dd58
+_hash: c0751db5f967c630dd66c3871d4bef30ce025709822b5b06459e5dc9a9684971
 file:
 - statement:
     alter_external_table_statement:
@@ -127,12 +127,14 @@ file:
     - keyword: set
     - tag_equals:
       - keyword: tag
-      - naked_identifier: foo
+      - tag_reference:
+          naked_identifier: foo
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'foo'"
       - comma: ','
-      - naked_identifier: bar
+      - tag_reference:
+          naked_identifier: bar
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'bar'"
@@ -147,7 +149,8 @@ file:
     - keyword: unset
     - tag_equals:
         keyword: tag
-        naked_identifier: foo
+        tag_reference:
+          naked_identifier: foo
         comparison_operator:
           raw_comparison_operator: '='
         quoted_literal: "'foo'"

--- a/test/fixtures/dialects/snowflake/snowflake_alter_materialized_view.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_materialized_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a940e0a52c2ce42862e5c44fc4f854eebbf6bb2eed5c2029e48502ed818363a1
+_hash: 192741ab32ee2d3df2200d491d4b887d936aa68354c14a1c3db809ce07be80f9
 file:
 - statement:
     alter_materialized_view_statement:
@@ -117,7 +117,8 @@ file:
     - keyword: set
     - tag_equals:
         keyword: tag
-        naked_identifier: my_tag
+        tag_reference:
+          naked_identifier: my_tag
         comparison_operator:
           raw_comparison_operator: '='
         quoted_literal: "'my tag'"
@@ -132,7 +133,8 @@ file:
     - keyword: unset
     - tag_equals:
         keyword: tag
-        naked_identifier: my_tag
+        tag_reference:
+          naked_identifier: my_tag
         comparison_operator:
           raw_comparison_operator: '='
         quoted_literal: "'not my tag anymore'"

--- a/test/fixtures/dialects/snowflake/snowflake_alter_pipe.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_pipe.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5c016dda202d7df66b87ee1595c2c887fc8752ccbeaccb08752ce467a20e75d5
+_hash: e420ce149b11c2ab44311a50476ee4c4f43a319f0b7b6a34155d1edc20d13011
 file:
 - statement:
     alter_pipe_segment:
@@ -82,12 +82,14 @@ file:
     - keyword: set
     - tag_equals:
       - keyword: tag
-      - naked_identifier: tag1
+      - tag_reference:
+          naked_identifier: tag1
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'value1'"
       - comma: ','
-      - naked_identifier: tag2
+      - tag_reference:
+          naked_identifier: tag2
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'value2'"
@@ -118,7 +120,9 @@ file:
         naked_identifier: mypipe
     - keyword: unset
     - keyword: tag
-    - naked_identifier: foo
+    - tag_reference:
+        naked_identifier: foo
     - comma: ','
-    - naked_identifier: bar
+    - tag_reference:
+        naked_identifier: bar
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/snowflake_alter_schema.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_schema.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: baf250a0c6905431cf7bd5c3ae55c22ebdf464964992a98ac96c83b8575eec36
+_hash: 787f8d6df91da83e973c5393b0fa2722db5b8e6b47d6fead71c4bb9eb4149a98
 file:
 - statement:
     alter_schema_statement:
@@ -61,12 +61,14 @@ file:
     - keyword: set
     - tag_equals:
       - keyword: tag
-      - naked_identifier: tag1
+      - tag_reference:
+          naked_identifier: tag1
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'value1'"
       - comma: ','
-      - naked_identifier: tag2
+      - tag_reference:
+          naked_identifier: tag2
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'value2'"
@@ -99,7 +101,9 @@ file:
         naked_identifier: schema1
     - keyword: unset
     - keyword: tag
-    - naked_identifier: foo
+    - tag_reference:
+        naked_identifier: foo
     - comma: ','
-    - naked_identifier: bar
+    - tag_reference:
+        naked_identifier: bar
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/snowflake_alter_share.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_share.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e6cb4cd5a2b0952e5df8c90d7238b651d5e742a1cec07f71afcff89f2713583a
+_hash: 599ea38dd18bb92d1a5e4769ba772c97c5928c2251ca5937247bdfb075b8cf1c
 file:
 - statement:
     alter_share_statement:
@@ -76,7 +76,8 @@ file:
     - keyword: SET
     - tag_equals:
         keyword: TAG
-        naked_identifier: tag1
+        tag_reference:
+          naked_identifier: tag1
         comparison_operator:
           raw_comparison_operator: '='
         quoted_literal: "'value1'"
@@ -91,12 +92,14 @@ file:
     - keyword: SET
     - tag_equals:
       - keyword: TAG
-      - naked_identifier: tag1
+      - tag_reference:
+          naked_identifier: tag1
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'value1'"
       - comma: ','
-      - naked_identifier: tag2
+      - tag_reference:
+          naked_identifier: tag2
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'value2'"
@@ -108,7 +111,8 @@ file:
     - naked_identifier: MY_SHARE
     - keyword: UNSET
     - keyword: TAG
-    - naked_identifier: tag1
+    - tag_reference:
+        naked_identifier: tag1
 - statement_terminator: ;
 - statement:
     alter_share_statement:
@@ -117,9 +121,11 @@ file:
     - naked_identifier: MY_SHARE
     - keyword: UNSET
     - keyword: TAG
-    - naked_identifier: tag1
+    - tag_reference:
+        naked_identifier: tag1
     - comma: ','
-    - naked_identifier: tag2
+    - tag_reference:
+        naked_identifier: tag2
 - statement_terminator: ;
 - statement:
     alter_share_statement:

--- a/test/fixtures/dialects/snowflake/snowflake_alter_stream.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_stream.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1bbe3f883fc45f3df4bb453d9b2b4448e70d27fcbd1c885cdcc87b3578f7e3b0
+_hash: 17f8528b83595086c1d083d69e10b12016496e6955fe336060e376b71ee8d3ad
 file:
 - statement:
     alter_stream_statement:
@@ -29,7 +29,8 @@ file:
     - keyword: set
     - tag_equals:
         keyword: tag
-        naked_identifier: mytag
+        tag_reference:
+          naked_identifier: mytag
         comparison_operator:
           raw_comparison_operator: '='
         quoted_literal: "'myvalue'"
@@ -49,12 +50,14 @@ file:
     - boolean_literal: 'FALSE'
     - tag_equals:
       - keyword: TAG
-      - naked_identifier: mytag1
+      - tag_reference:
+          naked_identifier: mytag1
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'myvalue1'"
       - comma: ','
-      - naked_identifier: mytag2
+      - tag_reference:
+          naked_identifier: mytag2
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'myvalue2'"
@@ -100,7 +103,9 @@ file:
         naked_identifier: mystream
     - keyword: unset
     - keyword: tag
-    - naked_identifier: mytag1
+    - tag_reference:
+        naked_identifier: mytag1
     - comma: ','
-    - naked_identifier: mytag2
+    - tag_reference:
+        naked_identifier: mytag2
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/snowflake_alter_warehouse.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_warehouse.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 264ee2e99d6b6cbf570585634d2a9951d01685e48da47c447d54eb33ea4e5c5f
+_hash: 4665ce4dc4718052ca9b6e69c12240d80062e18fdd955eda3471183c70e3a40e
 file:
 - statement:
     alter_warehouse_statement:
@@ -180,7 +180,8 @@ file:
     - keyword: set
     - tag_equals:
         keyword: TAG
-        naked_identifier: thetag
+        tag_reference:
+          naked_identifier: thetag
         comparison_operator:
           raw_comparison_operator: '='
         quoted_literal: "'tag1'"
@@ -193,12 +194,14 @@ file:
     - keyword: set
     - tag_equals:
       - keyword: TAG
-      - naked_identifier: thetag1
+      - tag_reference:
+          naked_identifier: thetag1
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'tag1'"
       - comma: ','
-      - naked_identifier: thetag2
+      - tag_reference:
+          naked_identifier: thetag2
       - comparison_operator:
           raw_comparison_operator: '='
       - quoted_literal: "'tag2'"

--- a/test/fixtures/dialects/snowflake/snowflake_create_schema.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_create_schema.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: eed3060f41e8069e3a69783e69a256fa4efb6e75648ea0daca4b4aee76a48bea
+_hash: c1647483237fdfbd031edde7d795dda66cf0ba600d18a8c7917579a97f8e7daf
 file:
 - statement:
     create_clone_statement:
@@ -82,12 +82,14 @@ file:
         keyword: tag
         bracketed:
         - start_bracket: (
-        - naked_identifier: tag1
+        - tag_reference:
+            naked_identifier: tag1
         - comparison_operator:
             raw_comparison_operator: '='
         - quoted_literal: "'foo'"
         - comma: ','
-        - naked_identifier: tag2
+        - tag_reference:
+            naked_identifier: tag2
         - comparison_operator:
             raw_comparison_operator: '='
         - quoted_literal: "'bar'"

--- a/test/fixtures/dialects/snowflake/snowflake_create_table.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_create_table.sql
@@ -85,4 +85,12 @@ create table test_schema.test_table (test_column NUMBER autoincrement (0, 1));
 create or replace table test_schema.test_table (test_column NUMBER autoincrement (0, 1));
 create table test_schema.test_table (test_column INTEGER AUTOINCREMENT);
 
-CREATE TABLE test_table (test_column NUMBER WITH MASKING POLICY my_policy USING(test_column, test_column > 10))
+CREATE TABLE test_table (test_column NUMBER WITH MASKING POLICY my_policy USING(test_column, test_column > 10));
+
+CREATE OR REPLACE TABLE SCHEMA1.TABLE1
+(
+    "COL1" varchar(128) NOT NULL,
+    "COL2" varchar(128) NOT NULL
+) CHANGE_TRACKING = TRUE WITH TAG (
+    account_objects.tags.IRM = '{"IRM":[{"Primary":"ABC123"}]}'
+);

--- a/test/fixtures/dialects/snowflake/snowflake_create_table.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a1c71be10afb88d4c7412bb82152520a33ddb68b1ecfa93cc246aa691da1c93a
+_hash: f129c0ed25dce015cf4484c67e3a57ce68f78628c9943e586eb4dc68d2a72e9d
 file:
 - statement:
     create_table_statement:
@@ -840,3 +840,62 @@ file:
                 numeric_literal: '10'
               end_bracket: )
         end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: SCHEMA1
+      - dot: .
+      - naked_identifier: TABLE1
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          quoted_identifier: '"COL1"'
+          data_type:
+            data_type_identifier: varchar
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '128'
+              end_bracket: )
+          column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '"COL2"'
+          data_type:
+            data_type_identifier: varchar
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '128'
+              end_bracket: )
+          column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+      - end_bracket: )
+    - keyword: CHANGE_TRACKING
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'TRUE'
+    - tag_bracketed_equals:
+      - keyword: WITH
+      - keyword: TAG
+      - bracketed:
+          start_bracket: (
+          tag_reference:
+          - naked_identifier: account_objects
+          - dot: .
+          - naked_identifier: tags
+          - dot: .
+          - naked_identifier: IRM
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'{\"IRM\":[{\"Primary\":\"ABC123\"}]}'"
+          end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/snowflake_create_view.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_create_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 75a90cd7c9d69dc64006a01c1b9e33a82e8d37cffe312967e14609fffd22a8a5
+_hash: 9f772bc88c75e2432f84b2e89cbe89a1bb2e3025ffa560b01d89a3a96a335baf
 file:
 - statement:
     create_view_statement:
@@ -206,12 +206,14 @@ file:
       - keyword: TAG
       - bracketed:
         - start_bracket: (
-        - naked_identifier: foo
+        - tag_reference:
+            naked_identifier: foo
         - comparison_operator:
             raw_comparison_operator: '='
         - quoted_literal: "'bar'"
         - comma: ','
-        - naked_identifier: hello
+        - tag_reference:
+            naked_identifier: hello
         - comparison_operator:
             raw_comparison_operator: '='
         - quoted_literal: "'world'"


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
This creates a TagReferenceSegment in Snowflake, and replaces all of its non-shared refs with this segment. Allows for db/schema scoped tags.
Fixes #3786

### Are there any other side effects of this change that we should be aware of?
No, it only affects Snowflake. Added the TagReferenceSegment to ANSI for reusability.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
