### PR TITLE
Fix Windows CI check

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -139,7 +139,7 @@ jobs:
       with:
         files: ./coverage.xml
   python-windows-tests:
-    runs-on: windows-latest
+    runs-on: windows-2022
     name: Python 3.8 Windows tests
     steps:
     - name: Set git to use LF

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -139,7 +139,7 @@ jobs:
       with:
         files: ./coverage.xml
   python-windows-tests:
-    runs-on: windows-2022
+    runs-on: windows-latest
     name: Python 3.8 Windows tests
     steps:
     - name: Set git to use LF

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -139,7 +139,7 @@ jobs:
       with:
         files: ./coverage.xml
   python-windows-tests:
-    runs-on: windows-2022
+    runs-on: windows-2019
     name: Python 3.8 Windows tests
     steps:
     - name: Set git to use LF

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -139,7 +139,7 @@ jobs:
       with:
         files: ./coverage.xml
   python-windows-tests:
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: Python 3.8 Windows tests
     steps:
     - name: Set git to use LF

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,6 @@ coverage>=6.4
 hypothesis
 pytest
 pytest-cov
-pytest-sugar
 pytest-xdist
 # MyPy
 mypy


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Looks like Windows CI check is failing on many branches. See if pinning helps. https://github.com/sqlfluff/sqlfluff/actions/runs/3331475162/jobs/5511256473

### Are there any other side effects of this change that we should be aware of?
Eventually we'd get out of date if we pin? 🤷 

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
