### PR TITLE
hotfix to config migration

### DIFF
--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -47,7 +47,7 @@ REMOVED_CONFIGS = [
             ":binary_operator)."
         ),
         ("layout", "type", "binary_operator", "line_position"),
-        (lambda x: "trailing" if x == "after" else "leading"),
+        (lambda x: "trailing" if x == "before" else "leading"),
     ),
     _RemovedConfig(
         ("rules", "comma_style"),


### PR DESCRIPTION
As noted by @tunetheweb - the recent release auto-migrates configs the wrong way around. this is a fix for that.