### PR TITLE
Filter out issues in unparsable sections

### DIFF
--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -595,6 +595,9 @@ class BaseRule:
             # Check whether this should be filtered out for being unparsable.
             # To do that we check the parents of the anchors (of the violation
             # and fixes) against the filter in the crawler.
+            # NOTE: We use `.passes_filter` here to do the test for unparsable
+            # to avoid duplicating code because that test is already implemented
+            # there.
             anchors = [lerr.segment] + [fix.anchor for fix in lerr.fixes]
             for anchor in anchors:
                 if not self.crawl_behaviour.passes_filter(anchor):  # pragma: no cover

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -603,7 +603,10 @@ class BaseRule:
                 if not self.crawl_behaviour.passes_filter(anchor):  # pragma: no cover
                     # NOTE: This clause is untested, because it's a hard to produce
                     # edge case. The latter clause is much more likely.
-                    linter_logger.info("Fix skipped due to anchor not passing filter.")
+                    linter_logger.info( 
+                        "Fix skipped due to anchor not passing filter: %s",
+                        anchor
+                    )
                     lerr = None
                     ignored = True
                     break
@@ -613,7 +616,8 @@ class BaseRule:
                     for ps in parent_stack
                 ):
                     linter_logger.info(
-                        "Fix skipped due to parent of anchor not passing filter."
+                        "Fix skipped due to parent of anchor not passing filter: %s",
+                        [ps.segment for ps in parent_stack]
                     )
                     lerr = None
                     ignored = True

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -603,9 +603,8 @@ class BaseRule:
                 if not self.crawl_behaviour.passes_filter(anchor):  # pragma: no cover
                     # NOTE: This clause is untested, because it's a hard to produce
                     # edge case. The latter clause is much more likely.
-                    linter_logger.info( 
-                        "Fix skipped due to anchor not passing filter: %s",
-                        anchor
+                    linter_logger.info(
+                        "Fix skipped due to anchor not passing filter: %s", anchor
                     )
                     lerr = None
                     ignored = True
@@ -617,7 +616,7 @@ class BaseRule:
                 ):
                     linter_logger.info(
                         "Fix skipped due to parent of anchor not passing filter: %s",
-                        [ps.segment for ps in parent_stack]
+                        [ps.segment for ps in parent_stack],
                     )
                     lerr = None
                     ignored = True

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -597,7 +597,9 @@ class BaseRule:
             # and fixes) against the filter in the crawler.
             anchors = [lerr.segment] + [fix.anchor for fix in lerr.fixes]
             for anchor in anchors:
-                if not self.crawl_behaviour.passes_filter(anchor):
+                if not self.crawl_behaviour.passes_filter(anchor):  # pragma: no cover
+                    # NOTE: This clause is untested, because it's a hard to produce
+                    # edge case. The latter clause is much more likely.
                     linter_logger.info("Fix skipped due to anchor not passing filter.")
                     lerr = None
                     ignored = True

--- a/src/sqlfluff/core/rules/crawlers.py
+++ b/src/sqlfluff/core/rules/crawlers.py
@@ -15,7 +15,16 @@ class BaseCrawler(ABC):
         self.works_on_unparsable = works_on_unparsable
 
     def passes_filter(self, segment: BaseSegment):
-        """Returns true if this segment considered at all."""
+        """Returns true if this segment considered at all.
+
+        This method is called during crawling but also
+        in evaluating the anchors for linting violations
+        and their fixes to make sure we don't get issues
+        with linting sections of queries that we can't
+        parse.
+
+        See `BaseRule._process_lint_result()`.
+        """
         return self.works_on_unparsable or not segment.is_type("unparsable")
 
     @abstractmethod


### PR DESCRIPTION
This partially addresses #3989. It fully addresses it in combination with #3942.

Rule crawlers (#3717) introduced more advanced crawling mechanisms and would filter out unparsable sections of code _before linting them_, however for rules which handle the own crawling this isn't sufficient - because they might still recurse down to sections of unparsable code. This PR filters violations after parsing to prune any which anchor on (or modify) unparsable code if that's set on the crawler.