### PR TITLE
Classify self contained set statements as templated

### DIFF
--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -1038,13 +1038,15 @@ from my_table
             ],
         ),
         (
-            # Test for issue 2835. There's no space between "col" and "="
+            # Test for issue 2835. There's no space between "col" and "=".
+            # Also tests for issue 3750 that self contained set statements
+            # are parsed as "templated" and not "block_start".
             """{% set col= "col1" %}
 SELECT {{ col }}
 """,
             None,
             [
-                ("block_start", slice(0, 21, None), slice(0, 0, None)),
+                ("templated", slice(0, 21, None), slice(0, 0, None)),
                 ("literal", slice(21, 29, None), slice(0, 8, None)),
                 ("templated", slice(29, 38, None), slice(8, 12, None)),
                 ("literal", slice(38, 39, None), slice(12, 13, None)),
@@ -1082,6 +1084,8 @@ FROM SOME_TABLE
         (
             # Third test for issue 2835. This was the original SQL provided in
             # the issue report.
+            # Also tests for issue 3750 that self contained set statements
+            # are parsed as "templated" and not "block_start".
             """{% set whitelisted= [
     {'name': 'COL_1'},
     {'name': 'COL_2'},
@@ -1099,7 +1103,7 @@ FROM SOME_TABLE
 """,
             None,
             [
-                ("block_start", slice(0, 94, None), slice(0, 0, None)),
+                ("templated", slice(0, 94, None), slice(0, 0, None)),
                 ("literal", slice(94, 96, None), slice(0, 2, None)),
                 ("block_start", slice(96, 128, None), slice(2, 2, None)),
                 ("literal", slice(128, 133, None), slice(2, 2, None)),

--- a/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if/after.sql
+++ b/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if/after.sql
@@ -4,13 +4,13 @@
   'table2'] %}
 
 {% for product in products %}
-SELECT
-    brand,
-    country_code,
-    category,
-    name,
-    id
-FROM
-    {{ product }}
-{% if not loop.last -%} UNION ALL {%- endif %}
+    SELECT
+        brand,
+        country_code,
+        category,
+        name,
+        id
+    FROM
+        {{ product }}
+    {% if not loop.last -%} UNION ALL {%- endif %}
 {% endfor %}

--- a/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if2/after.sql
+++ b/test/fixtures/linter/autofix/ansi/016_index_error_with_jinja_if2/after.sql
@@ -4,14 +4,14 @@
   'table2'] %}
 
 {% for product in products %}
-SELECT
-    brand,
-    country_code,
-    category,
-    name,
-    id
-FROM
-    {{ product }}
-{% if not loop.last %} UNION ALL {% endif %}
+    SELECT
+        brand,
+        country_code,
+        category,
+        name,
+        id
+    FROM
+        {{ product }}
+    {% if not loop.last %} UNION ALL {% endif %}
 {% endfor %}
 ORDER BY 1

--- a/test/fixtures/linter/autofix/ansi/018_l003_indent_templated_code/after.sql
+++ b/test/fixtures/linter/autofix/ansi/018_l003_indent_templated_code/after.sql
@@ -2,10 +2,10 @@
 {% set products =  ['table1'] %}
 
 {% for product in products %}
-SELECT
-    brand,
-    country_code
-FROM
-    {{ product }}
-{% if not loop.last -%} UNION ALL {%- endif %}
+    SELECT
+        brand,
+        country_code
+    FROM
+        {{ product }}
+    {% if not loop.last -%} UNION ALL {%- endif %}
 {% endfor %}


### PR DESCRIPTION
This resolves #3750.

Based on the existing logic to appropriately distinguish between the two kinds of `set` expression. This changes the `block_type` for the self contained type so that they are correctly indented.