### PR TITLE
Deduplicate violations in the source space

### DIFF
--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -1,5 +1,5 @@
 """Errors - these are closely linked to what used to be called violations."""
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Any
 
 CheckTuple = Tuple[str, int, int]
 
@@ -82,6 +82,18 @@ class SQLBaseError(ValueError):
             "code": self.rule_code(),
             "description": self.desc(),
         }
+
+    def check_tuple(self) -> CheckTuple:
+        """Get a tuple representing this error. Mostly for testing."""
+        return (
+            self.rule_code(),
+            self.line_no,
+            self.line_pos,
+        )
+
+    def source_signature(self) -> Tuple[Any, ...]:
+        """Return hashable source signature for deduplication."""
+        return (self.check_tuple(), self.desc())
 
     def ignore_if_in(self, ignore_iterable):
         """Ignore this violation if it matches the iterable."""
@@ -182,13 +194,21 @@ class SQLLintError(SQLBaseError):
             return True
         return False
 
-    def check_tuple(self) -> CheckTuple:
-        """Get a tuple representing this error. Mostly for testing."""
-        return (
-            self.rule.code,
-            self.line_no,
-            self.line_pos,
+    def source_signature(self) -> Tuple[Any, ...]:
+        """Return hashable source signature for deduplication.
+
+        For linting errors we need to dedupe on more than just location and
+        description, we also need to check the edits potentially made, both
+        in the templated file but also in the source.
+        """
+        fix_raws = tuple(
+            tuple(e.raw for e in f.edit) if f.edit else None for f in self.fixes
         )
+        source_fixes = tuple(
+            tuple(tuple(e.source_fixes) for e in f.edit) if f.edit else None
+            for f in self.fixes
+        )
+        return (self.check_tuple(), self.description, fix_raws, source_fixes)
 
     def __repr__(self):
         return "<SQLLintError: rule {} pos:{!r}, #fixes: {}, description: {}>".format(

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -54,13 +54,13 @@ class LintedFile(NamedTuple):
         """Make a list of check_tuples.
 
         This assumes that all the violations found are
-        linting violations (and therefore implement `check_tuple()`).
-        If they don't then this function raises that error.
+        linting violations. If they don't then this function
+        raises that error.
         """
         vs: List[CheckTuple] = []
         v: SQLLintError
         for v in self.get_violations():
-            if hasattr(v, "check_tuple"):
+            if isinstance(v, SQLLintError):
                 vs.append(v.check_tuple())
             elif raise_on_non_linting_violations:
                 raise v

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -83,19 +83,7 @@ class LintedFile(NamedTuple):
         new_violations = []
         dedupe_buffer = set()
         for v in violations:
-            # Check on:
-            # - Source location & code (check tuple)
-            # - description
-            # - fix raws
-            # - any source fixes.
-            fix_raws = tuple(
-                tuple(e.raw for e in f.edit) if f.edit else None for f in v.fixes
-            )
-            source_fixes = tuple(
-                tuple(tuple(e.source_fixes) for e in f.edit) if f.edit else None
-                for f in v.fixes
-            )
-            signature = (v.check_tuple(), v.description, fix_raws, source_fixes)
+            signature = v.source_signature()
             if signature not in dedupe_buffer:
                 new_violations.append(v)
                 dedupe_buffer.add(signature)

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -734,7 +734,8 @@ class Linter:
 
         linted_file = LintedFile(
             parsed.fname,
-            violations,
+            # Deduplicate violations
+            LintedFile.deduplicate_in_source_space(violations),
             time_dict,
             tree,
             ignore_mask=ignore_buff,

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -408,8 +408,6 @@ def test__linter__empty_file():
             [
                 ("L006", 3, 16),
                 ("L006", 3, 16),
-                ("L006", 3, 16),
-                ("L006", 3, 16),
                 ("L006", 3, 39),
                 ("L006", 3, 39),
             ],
@@ -417,7 +415,11 @@ def test__linter__empty_file():
     ],
 )
 def test__linter__mask_templated_violations(ignore_templated_areas, check_tuples):
-    """Test linter masks files properly around templated content."""
+    """Test linter masks files properly around templated content.
+
+    NOTE: this also tests deduplication of fixes which have the same
+    source position. i.e. `LintedFile.deduplicate_in_source_space()`.
+    """
     lntr = Linter(
         config=FluffConfig(
             overrides={

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -406,6 +406,9 @@ def test__linter__empty_file():
         (
             False,
             [
+                # there are still two of each because L006 checks
+                # for both *before* and *after* the operator.
+                # The deduplication filter makes sure there aren't 4.
                 ("L006", 3, 16),
                 ("L006", 3, 16),
                 ("L006", 3, 39),


### PR DESCRIPTION
This resolves #4040.

Duplicate violations (e.g. from multiple passes through a jinja loop) confuse the user and also end up just being deduplicated later. This filters them out early.