### PR TITLE
Bump after_n_builds to 10

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -10,7 +10,7 @@ codecov:
   disable_default_path_fixes: no  # yamllint disable-line rule:truthy
   require_ci_to_pass: yes  # yamllint disable-line rule:truthy
   notify:
-    after_n_builds: 9
+    after_n_builds: 10
     wait_for_ci: yes  # yamllint disable-line rule:truthy
 
 coverage:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,7 +8,7 @@ codecov:
     - "github.com"
   max_report_age: 24
   disable_default_path_fixes: no  # yamllint disable-line rule:truthy
-  require_ci_to_pass: yes  # yamllint disable-line rule:truthy
+  require_ci_to_pass: no  # yamllint disable-line rule:truthy
   notify:
     after_n_builds: 10
     wait_for_ci: yes  # yamllint disable-line rule:truthy

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,7 +8,7 @@ codecov:
     - "github.com"
   max_report_age: 24
   disable_default_path_fixes: no  # yamllint disable-line rule:truthy
-  require_ci_to_pass: no  # yamllint disable-line rule:truthy
+  require_ci_to_pass: yes  # yamllint disable-line rule:truthy
   notify:
     after_n_builds: 10
     wait_for_ci: yes  # yamllint disable-line rule:truthy


### PR DESCRIPTION
Since we added a Python 3.11 required CI test.

https://sqlfluff.slack.com/archives/G01G58WRJNR/p1667926639893419?thread_ts=1667922270.894929&cid=G01G58WRJNR