### PR TITLE
Snowflake: ADD and DROP without COLUMN

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1527,7 +1527,7 @@ class AlterTableTableColumnActionSegment(BaseSegment):
         # Add Column
         Sequence(
             "ADD",
-            "COLUMN",
+            Ref.keyword("COLUMN", optional=True),
             # Handle Multiple Columns
             Delimited(
                 Sequence(

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1475,7 +1475,6 @@ class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
                 "OPTIMIZATION",
             ),
             Ref("AlterTableClusteringActionSegment"),
-            Ref("AlterTableTableColumnActionSegment"),
             Ref("AlterTableConstraintActionSegment"),
             # @TODO: constraintAction
             # @TODO: extTableColumnAction
@@ -1503,7 +1502,8 @@ class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
                 "ADD",
                 Ref("PrimaryKeyGrammar"),
                 Bracketed(Delimited(Ref("ColumnReferenceSegment"), optional=True)),
-            )
+            ),
+            Ref("AlterTableTableColumnActionSegment"),
             # @TODO: Set/unset TAG
             # @TODO: Unset table options
             # @TODO: Add/drop row access policies

--- a/test/fixtures/dialects/snowflake/snowflake_alter_table_column.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_table_column.sql
@@ -23,6 +23,9 @@ ALTER TABLE my_table ADD COLUMN my_column INTEGER WITH MASKING POLICY my_policy 
 ALTER TABLE reporting_tbl ADD COLUMN reporting_group VARCHAR
   COMMENT 'internal reporting group defined by DE team';
 
+-- without the word COLUMN
+ALTER TABLE rpt_enc_table ADD encounter_count INTEGER COMMENT 'count of encounters past year' ;
+
 -- Rename column
 ALTER TABLE empl_info RENAME COLUMN old_col_name TO new_col_name;
 
@@ -69,6 +72,7 @@ ALTER TABLE my_table DROP COLUMN column_1, column_2, column_3;
 -- IF EXISTS
 ALTER TABLE IF EXISTS my_table ADD COLUMN my_column INTEGER;
 ALTER TABLE IF EXISTS empl_info DROP COLUMN my_column;
+ALTER TABLE IF EXISTS empl_info DROP my_column;
 ALTER TABLE IF EXISTS empl_info RENAME COLUMN old_col_name TO new_col_name;
 
 -- DROP PRIMARY KEY

--- a/test/fixtures/dialects/snowflake/snowflake_alter_table_column.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_table_column.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ca8548d7f42a1ff1964b273ff4ae16434c6b5b94eee29bc8779240e1aecfa31f
+_hash: 22878f1f16fcd23b97eeabe2abce943e02764130cdad64ba43b7353535333d37
 file:
 - statement:
     alter_table_statement:
@@ -640,16 +640,13 @@ file:
       - naked_identifier: my_schema
       - dot: .
       - naked_identifier: my_table
-    - alter_table_table_column_action:
-        keyword: add
-        column_reference:
-          naked_identifier: PRIMARY
-        data_type:
-          data_type_identifier: KEY
-          bracketed:
-            start_bracket: (
-            expression:
-              column_reference:
-                naked_identifier: TABLE_ID
-            end_bracket: )
+    - alter_table_constraint_action:
+      - keyword: add
+      - keyword: PRIMARY
+      - keyword: KEY
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            naked_identifier: TABLE_ID
+          end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/snowflake_alter_table_column.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_table_column.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 039c55eb113779324abffb5d04be4857968710630bd0e260478a0ca41c3aaf1d
+_hash: ca8548d7f42a1ff1964b273ff4ae16434c6b5b94eee29bc8779240e1aecfa31f
 file:
 - statement:
     alter_table_statement:
@@ -255,6 +255,22 @@ file:
       - comment_clause:
           keyword: COMMENT
           quoted_literal: "'internal reporting group defined by DE team'"
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: rpt_enc_table
+    - alter_table_table_column_action:
+        keyword: ADD
+        column_reference:
+          naked_identifier: encounter_count
+        data_type:
+          data_type_identifier: INTEGER
+        comment_clause:
+          keyword: COMMENT
+          quoted_literal: "'count of encounters past year'"
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -583,6 +599,19 @@ file:
     - table_reference:
         naked_identifier: empl_info
     - alter_table_table_column_action:
+        keyword: DROP
+        column_reference:
+          naked_identifier: my_column
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: empl_info
+    - alter_table_table_column_action:
       - keyword: RENAME
       - keyword: COLUMN
       - column_reference:
@@ -613,14 +642,14 @@ file:
       - naked_identifier: my_table
     - alter_table_table_column_action:
         keyword: add
-        column_definition:
+        column_reference:
           naked_identifier: PRIMARY
-          data_type:
-            data_type_identifier: KEY
-            bracketed:
-              start_bracket: (
-              expression:
-                column_reference:
-                  naked_identifier: TABLE_ID
-              end_bracket: )
+        data_type:
+          data_type_identifier: KEY
+          bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: TABLE_ID
+            end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Closes https://github.com/sqlfluff/sqlfluff/issues/4048

[Docs](https://docs.snowflake.com/en/sql-reference/sql/alter-table.html) say `COLUMN` keyword isn't required for `ADD` or `DROP`:

<img width="930" alt="Screen Shot 2022-11-08 at 11 06 59 AM" src="https://user-images.githubusercontent.com/28961086/200653468-f0e694c4-af57-4679-bec2-df551c2641a3.png">

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
