### PR TITLE
Fix bug in sparksql SELECT statement termination at UNION #4050

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -3104,6 +3104,7 @@ class SelectClauseSegment(BaseSegment):
         terminator=OneOf(
             "FROM",
             "WHERE",
+            "UNION",
             Sequence("ORDER", "BY"),
             "LIMIT",
             "OVERLAPS",

--- a/test/fixtures/dialects/sparksql/select_union.sql
+++ b/test/fixtures/dialects/sparksql/select_union.sql
@@ -1,0 +1,3 @@
+SELECT 'a' AS col
+UNION
+SELECT 'b'

--- a/test/fixtures/dialects/sparksql/select_union.yml
+++ b/test/fixtures/dialects/sparksql/select_union.yml
@@ -1,0 +1,24 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 7d3287e0f23f3c2499b397b7a305afb90b1a5a09790a4c099961f2799e4f8dc5
+file:
+  statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            quoted_literal: "'a'"
+            alias_expression:
+              keyword: AS
+              naked_identifier: col
+    - set_operator:
+        keyword: UNION
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            quoted_literal: "'b'"


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #4050 

### Are there any other side effects of this change that we should be aware of?
No side effects

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
