### PR TITLE
Allow warnings for specific rules

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -229,6 +229,37 @@ The default values can be seen in `Default Configuration`_.
 
 See also: `Ignoring Errors & Files`_.
 
+Downgrading rules to warnings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To keep displaying violations for specific rules, but not have those
+issues lead to a failed run, rules can be downgraded to *warnings*.
+Rules set as *warnings* won't cause a file to fail, but will still
+be shown in the CLI to warn users of their presence.
+
+The configuration of this behaves very like :code:`exclude_rules`
+above:
+
+.. code-block:: cfg
+
+    [sqlfluff]
+    warnings = L019, L007
+
+With this configuration, files with no other issues (other than
+those set to warn) will pass. If there are still other issues, then
+the file will still fail, but will show both warnings and failures.
+
+.. code-block::
+
+    == [test.sql] PASS
+    L:   2 | P:   9 | L006 | WARNING: Missing whitespace before +
+    == [test2.sql] FAIL
+    L:   2 | P:   8 | L014 | Unquoted identifiers must be consistently upper case.
+    L:   2 | P:  11 | L006 | WARNING: Missing whitespace before +
+
+This is particularly useful as a transitional tool when considering
+the introduction on new rules on a project where you might want to
+make users aware of issues without blocking their workflow (yet).
 
 Layout & Spacing Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -669,26 +669,21 @@ class FluffConfig:
         self._configs["core"]["color"] = (
             False if self._configs["core"].get("nocolor", False) else None
         )
-        # Deal with potential ignore parameters
-        if self._configs["core"].get("ignore", None):
-            self._configs["core"]["ignore"] = _split_comma_separated_string(
-                self._configs["core"]["ignore"]
-            )
-        else:
-            self._configs["core"]["ignore"] = []
-        # Allowlists and denylists
-        if self._configs["core"].get("rules", None):
-            self._configs["core"]["rule_allowlist"] = _split_comma_separated_string(
-                self._configs["core"]["rules"]
-            )
-        else:
-            self._configs["core"]["rule_allowlist"] = None
-        if self._configs["core"].get("exclude_rules", None):
-            self._configs["core"]["rule_denylist"] = _split_comma_separated_string(
-                self._configs["core"]["exclude_rules"]
-            )
-        else:
-            self._configs["core"]["rule_denylist"] = None
+        # Handle inputs which are potentially comma separated strings
+        for in_key, out_key in [
+            # Deal with potential ignore & warning parameters
+            ("ignore", "ignore"),
+            ("warning", "warning"),
+            ("rules", "rule_allowlist"),
+            # Allowlists and denylists
+            ("exclude_rules", "rule_denylist"),
+        ]:
+            if self._configs["core"].get(in_key, None):
+                self._configs["core"][out_key] = _split_comma_separated_string(
+                    self._configs["core"][in_key]
+                )
+            else:
+                self._configs["core"][out_key] = []
         # Configure Recursion
         if self._configs["core"].get("recurse", 0) == 0:
             self._configs["core"]["recurse"] = True

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -673,7 +673,7 @@ class FluffConfig:
         for in_key, out_key in [
             # Deal with potential ignore & warning parameters
             ("ignore", "ignore"),
-            ("warning", "warning"),
+            ("warnings", "warnings"),
             ("rules", "rule_allowlist"),
             # Allowlists and denylists
             ("exclude_rules", "rule_denylist"),

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -20,6 +20,9 @@ output_line_length = 80
 runaway_limit = 10
 # Ignore errors by category (one or more of the following, separated by commas: lexing,linting,parsing,templating)
 ignore = None
+# Warn only for rule codes (one of more rule codes, seperated by commas: e.g. L001,L002)
+# Also works for templating and parsing errors by using TMP or PRS
+warnings = None
 # Ignore linting errors found within sections of code coming directly from
 # templated code (e.g. from within Jinja curly braces. Note that it does not
 # ignore errors from literal code found within template loops.

--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -1,5 +1,5 @@
 """Errors - these are closely linked to what used to be called violations."""
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 CheckTuple = Tuple[str, int, int]
 
@@ -18,10 +18,12 @@ class SQLBaseError(ValueError):
         line_pos=0,
         ignore=False,
         fatal=False,
+        warning=False,
         **kwargs
     ):
         self.fatal = fatal
         self.ignore = ignore
+        self.warning = warning
         if pos:
             self.line_no, self.line_pos = pos.source_position()
         else:
@@ -83,14 +85,19 @@ class SQLBaseError(ValueError):
             "description": self.desc(),
         }
 
-    def ignore_if_in(self, ignore_iterable):
+    def ignore_if_in(self, ignore_iterable: List[str]):
         """Ignore this violation if it matches the iterable."""
-        # Type conversion
-        if isinstance(ignore_iterable, str):  # pragma: no cover TODO?
-            ignore_iterable = []
-        # Ignoring
         if self._identifier in ignore_iterable:
             self.ignore = True
+
+    def warning_if_in(self, warning_iterable: List[str]):
+        """Warning only for this violation if it matches the iterable.
+
+        Designed for rule codes so works with L001, L00X but also TMP or PRS
+        for templating and parsing errors.
+        """
+        if self.rule_code() in warning_iterable:
+            self.warning = True
 
 
 class SQLTemplaterError(SQLBaseError):

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -71,6 +71,7 @@ class LintedFile(NamedTuple):
         rules: Optional[Union[str, Tuple[str, ...]]] = None,
         types: Optional[Union[Type[SQLBaseError], Iterable[Type[SQLBaseError]]]] = None,
         filter_ignore: bool = True,
+        filter_warning: bool = True,
         fixable: Optional[bool] = None,
     ) -> list:
         """Get a list of violations, respecting filters and ignore options.
@@ -105,6 +106,9 @@ class LintedFile(NamedTuple):
             # Ignore any rules in the ignore mask
             if self.ignore_mask:
                 violations = self.ignore_masked_violations(violations, self.ignore_mask)
+        # Filter warning violations
+        if filter_warning:
+            violations = [v for v in violations if not v.warning]
         return violations
 
     @staticmethod

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -732,7 +732,7 @@ class Linter:
         # We process the ignore config here if appropriate
         for violation in violations:
             violation.ignore_if_in(parsed.config.get("ignore"))
-            violation.warning_if_in(parsed.config.get("warning"))
+            violation.warning_if_in(parsed.config.get("warnings"))
 
         linted_file = LintedFile(
             parsed.fname,

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -731,6 +731,7 @@ class Linter:
         # We process the ignore config here if appropriate
         for violation in violations:
             violation.ignore_if_in(parsed.config.get("ignore"))
+            violation.warning_if_in(parsed.config.get("warning"))
 
         linted_file = LintedFile(
             parsed.fname,

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -240,7 +240,7 @@ class LintingResult:
     def count_tmp_prs_errors(self) -> Tuple[int, int]:
         """Count templating or parse errors before and after filtering."""
         total_errors = self.num_violations(
-            types=self.TMP_PRS_ERROR_TYPES, filter_ignore=False
+            types=self.TMP_PRS_ERROR_TYPES, filter_ignore=False, filter_warning=False
         )
         num_filtered_errors = 0
         for linted_dir in self.paths:
@@ -253,13 +253,15 @@ class LintingResult:
     def discard_fixes_for_lint_errors_in_files_with_tmp_or_prs_errors(self) -> None:
         """Discard lint fixes for files with templating or parse errors."""
         total_errors = self.num_violations(
-            types=self.TMP_PRS_ERROR_TYPES, filter_ignore=False
+            types=self.TMP_PRS_ERROR_TYPES, filter_ignore=False, filter_warning=False
         )
         if total_errors:
             for linted_dir in self.paths:
                 for linted_file in linted_dir.files:
                     num_errors = linted_file.num_violations(
-                        types=self.TMP_PRS_ERROR_TYPES, filter_ignore=False
+                        types=self.TMP_PRS_ERROR_TYPES,
+                        filter_ignore=False,
+                        filter_warning=False,
                     )
                     if num_errors:
                         # File has errors. Discard all the SQLLintError fixes:

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -564,6 +564,32 @@ def test__cli__command_lint_ignore_local_config():
     assert "L012" in result.output.strip()
 
 
+def test__cli__command_lint_warning():
+    """Test that configuring warnings works.
+
+    For this test the warnings are configured using
+    inline config in the file. That's more for simplicity
+    however the code paths should be the same if it's
+    configured in a file.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        lint,
+        [
+            "test/fixtures/cli/warning_a.sql",
+        ],
+    )
+    # Because we're only warning. The command should pass.
+    assert result.exit_code == 0
+    # The output should still say PASS.
+    assert "PASS" in result.output.strip()
+    # But should also contain the warnings.
+    assert (
+        "L:   4 | P:   9 | L006 | WARNING: Missing whitespace before +"
+        in result.output.strip()
+    )
+
+
 def test__cli__command_versioning():
     """Check version command."""
     # Get the package version info

--- a/test/fixtures/cli/warning_a.sql
+++ b/test/fixtures/cli/warning_a.sql
@@ -1,4 +1,4 @@
 -- This file should fail _only_ for spacing around +
 -- We explicit configure that rule to only warn.
--- sqlfluff:warning:L006
+-- sqlfluff:warnings:L006
 SELECT 1+2

--- a/test/fixtures/cli/warning_a.sql
+++ b/test/fixtures/cli/warning_a.sql
@@ -1,0 +1,4 @@
+-- This file should fail _only_ for spacing around +
+-- We explicit configure that rule to only warn.
+-- sqlfluff:warning:L006
+SELECT 1+2


### PR DESCRIPTION
This resolves #201 (THE OLDEST OUTSTANDING ISSUE 🚀 ) - only took over 2 yrs.

This delivers almost exactly against the spec outlined in that original issue.

Rules can be configured as warnings, in which case they're displayed as such, but don't fail the file.