### PR TITLE
Use "docker compose", not "docker-compose"

### DIFF
--- a/plugins/sqlfluff-templater-dbt/docker/shutdown
+++ b/plugins/sqlfluff-templater-dbt/docker/shutdown
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 my_path="$( cd "$(dirname "$0")"; pwd -P)"
-docker-compose -f ${my_path}/docker-compose.yml down -v --remove-orphans
+docker compose -f ${my_path}/docker-compose.yml down -v --remove-orphans

--- a/plugins/sqlfluff-templater-dbt/docker/startup
+++ b/plugins/sqlfluff-templater-dbt/docker/startup
@@ -4,5 +4,5 @@ export COMPOSE_DOCKER_CLI_BUILD=1
 export DOCKER_BUILDKIT=1
 my_path="$( cd "$(dirname "$0")"; pwd -P)"
 ${my_path}/shutdown
-docker-compose -f ${my_path}/docker-compose.yml build
-docker-compose -f ${my_path}/docker-compose.yml up -d
+docker compose -f ${my_path}/docker-compose.yml build
+docker compose -f ${my_path}/docker-compose.yml up -d


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
I'm setting up a new computer, and I noticed that the Docker dev scripts use `docker-compose`, which doesn't work anymore. `docker compose` is equivalent and still works.
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
