### PR TITLE
Fix type error in `get_rules` hook of plugin example

### DIFF
--- a/plugins/sqlfluff-plugin-example/src/example/rules.py
+++ b/plugins/sqlfluff-plugin-example/src/example/rules.py
@@ -12,13 +12,13 @@ from sqlfluff.core.rules.doc_decorators import (
     document_fix_compatible,
     document_groups,
 )
-from typing import List
+from typing import List, Type
 import os.path
 from sqlfluff.core.config import ConfigLoader
 
 
 @hookimpl
-def get_rules() -> List[BaseRule]:
+def get_rules() -> List[Type[BaseRule]]:
     """Get plugin rules."""
     return [Rule_Example_L001]
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

The `get_rules` function in the plugin example template had a type error. The function returns all the rule classes that are defined in the plugin. The return type was incorrectly annotated as `List[BaseRule]` which means a list of *instances* of `BaseRule` and not classes derived from `BaseRule`. Making it `List[Type[BaseRule]]` instead fixes the error.

For reference, the type error shown by pyright was:
```
Expression of type "list[Type[Rule_Example_L001]]" cannot be assigned to return type "List[BaseRule]"
...
  "Type[type]" is incompatible with "Type[BaseRule]"
```

### Are there any other side effects of this change that we should be aware of?

None (AFAICT)

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
