### PR TITLE
Fix Spark comparison parsing

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -61,7 +61,7 @@ sparksql_dialect.patch_lexer_matchers(
         # == and <=> are valid equal operations
         # <=> is a non-null equals in Spark SQL
         # https://spark.apache.org/docs/latest/api/sql/index.html#_10
-        RegexLexer("equals", r"=|==|<=>", CodeSegment),
+        RegexLexer("equals", r"==|<=>|=", CodeSegment),
         # identifiers are delimited with `
         # within a delimited identifier, ` is used to escape special characters,
         # including `

--- a/test/fixtures/dialects/sparksql/select_from_values.sql
+++ b/test/fixtures/dialects/sparksql/select_from_values.sql
@@ -20,3 +20,4 @@ select * from values ( 1 , 2 ) , ( 3 , 4 );
 select * from values 1 , 2 , values 3 , 4;
 select * from values (1) , (2);
 select * from values 1 , 2 , values 3 , 4;
+select 1 + 2 == 3 from values 1;

--- a/test/fixtures/dialects/sparksql/select_from_values.yml
+++ b/test/fixtures/dialects/sparksql/select_from_values.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b75326dd391b69165d78a89558a7359b26a2066fce03823648592d3ded367fb5
+_hash: ce7928fc2eb0db606e323705e960d94706705a2700edd13c1870024f60f3f1e0
 file:
 - statement:
     select_statement:
@@ -734,4 +734,25 @@ file:
               - comma: ','
               - expression:
                   numeric_literal: '4'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          expression:
+          - numeric_literal: '1'
+          - binary_operator: +
+          - numeric_literal: '2'
+          - comparison_operator: ==
+          - numeric_literal: '3'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              values_clause:
+                keyword: values
+                expression:
+                  numeric_literal: '1'
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

Current code would always catch `=` and never `==`
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
