### PR TITLE
Add errors and fails to pytest summary

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
     # Clean up from previous tests
     python {toxinidir}/util.py clean-tests
     # Run tests
-    pytest -vv -rs --cov=sqlfluff --cov-report=xml {posargs: {toxinidir}/test} -m "not integration_test"
+    pytest -vv -rsfE --cov=sqlfluff --cov-report=xml {posargs: {toxinidir}/test} -m "not integration_test"
 
 [testenv:cov-init]
 setenv =
@@ -71,10 +71,10 @@ skip_install = true
 commands = flake8
 
 [testenv:ruleslinting]
-commands = pytest -vv -rs --cov=sqlfluff --cov-report=xml {posargs: {toxinidir}/test} -m "integration_test"
+commands = pytest -vv -rsfE --cov=sqlfluff --cov-report=xml {posargs: {toxinidir}/test} -m "integration_test"
 
 [testenv:doctests]
-commands = pytest -vv -rs --cov=sqlfluff --cov-report=xml --doctest-modules {posargs: {toxinidir}/src}
+commands = pytest -vv -rsfE --cov=sqlfluff --cov-report=xml --doctest-modules {posargs: {toxinidir}/src}
 
 [testenv:yamllint]
 skip_install = true


### PR DESCRIPTION
Some of our test suites are really long and it's hard to work out which tests have failed. This adds _fails_ and _errors_ to the summary at the end of the pytest run which is otherwise just showing the _skipped_ tests as currently.