### PR TITLE
Support parallel linting when many individual files specified

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -1167,36 +1167,67 @@ class Linter:
         processes: Optional[int] = None,
     ) -> LintingResult:
         """Lint an iterable of paths."""
-        paths_count = len(paths)
-
         # If no paths specified - assume local
-        if not paths_count:  # pragma: no cover
+        if not paths:  # pragma: no cover
             paths = (os.getcwd(),)
         # Set up the result to hold what we get back
         result = LintingResult()
 
-        progress_bar_paths = tqdm(
-            total=paths_count,
-            desc="path",
-            leave=False,
-            disable=paths_count <= 1 or progress_bar_configuration.disable_progress_bar,
-        )
+        expanded_paths: List[str] = []
+        expanded_path_to_linted_dir = {}
         for path in paths:
-            progress_bar_paths.set_description(f"path {path}")
+            linted_dir = LintedDir(path)
+            for fname in self.paths_from_path(
+                path,
+                ignore_non_existent_files=ignore_non_existent_files,
+                ignore_files=ignore_files,
+            ):
+                expanded_paths.append(fname)
+                expanded_path_to_linted_dir[fname] = linted_dir
 
-            # Iterate through files recursively in the specified directory (if it's a
-            # directory) or read the file directly if it's not
-            result.add(
-                self.lint_path(
-                    path,
-                    fix=fix,
-                    ignore_non_existent_files=ignore_non_existent_files,
-                    ignore_files=ignore_files,
-                    processes=processes,
+        files_count = len(expanded_paths)
+        if processes is None:
+            processes = self.config.get("processes", default=1)
+
+        # to avoid circular import
+        from sqlfluff.core.linter.runner import get_runner
+
+        runner, effective_processes = get_runner(
+            self,
+            self.config,
+            processes=processes,
+            allow_process_parallelism=self.allow_process_parallelism,
+        )
+
+        if self.formatter and effective_processes != 1:
+            self.formatter.dispatch_processing_header(effective_processes)
+
+        # Show files progress bar only when there is more than one.
+        first_path = os.path.basename(expanded_paths[0] if expanded_paths else "")
+        progress_bar_files = tqdm(
+            total=files_count,
+            desc=f"file {first_path}",
+            leave=False,
+            disable=files_count <= 1 or progress_bar_configuration.disable_progress_bar,
+        )
+
+        for i, linted_file in enumerate(runner.run(expanded_paths, fix), start=1):
+            linted_dir = expanded_path_to_linted_dir[linted_file.path]
+            linted_dir.add(linted_file)
+            # If any fatal errors, then stop iteration.
+            if any(v.fatal for v in linted_file.violations):  # pragma: no cover
+                linter_logger.error("Fatal linting error. Halting further linting.")
+                break
+
+            # Progress bar for files is rendered only when there is more than one file.
+            # Additionally, as it's updated after each loop, we need to get file name
+            # from the next loop. This is why `enumerate` starts with `1` and there
+            # is `i < len` to not exceed files list length.
+            progress_bar_files.update(n=1)
+            if i < len(expanded_paths):
+                progress_bar_files.set_description(
+                    f"file {os.path.basename(expanded_paths[i])}"
                 )
-            )
-
-            progress_bar_paths.update(1)
 
         result.stop_timer()
         return result

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -1177,6 +1177,7 @@ class Linter:
         expanded_path_to_linted_dir = {}
         for path in paths:
             linted_dir = LintedDir(path)
+            result.add(linted_dir)
             for fname in self.paths_from_path(
                 path,
                 ignore_non_existent_files=ignore_non_existent_files,

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -1204,7 +1204,7 @@ class Linter:
             self.formatter.dispatch_processing_header(effective_processes)
 
         # Show files progress bar only when there is more than one.
-        first_path = os.path.basename(expanded_paths[0] if expanded_paths else "")
+        first_path = expanded_paths[0] if expanded_paths else ""
         progress_bar_files = tqdm(
             total=files_count,
             desc=f"file {first_path}",
@@ -1226,9 +1226,7 @@ class Linter:
             # is `i < len` to not exceed files list length.
             progress_bar_files.update(n=1)
             if i < len(expanded_paths):
-                progress_bar_files.set_description(
-                    f"file {os.path.basename(expanded_paths[i])}"
-                )
+                progress_bar_files.set_description(f"file {expanded_paths[i]}")
 
         result.stop_timer()
         return result

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1271,15 +1271,16 @@ def test__cli__command_lint_nocolor(isatty, should_strip_ansi, capsys, tmpdir):
 )
 @pytest.mark.parametrize("write_file", [None, "outfile"])
 def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_path):
-    """Test the output output formats for multiple files.
+    """Test the output formats for multiple files.
 
     This tests runs both stdout checking and file checking.
     """
-    fpath = "test/fixtures/linter/indentation_errors.sql"
+    fpath1 = "test/fixtures/linter/indentation_errors.sql"
+    fpath2 = "test/fixtures/linter/multiple_sql_errors.sql"
 
     cmd_args = (
-        fpath,
-        fpath,
+        fpath1,
+        fpath2,
         "--format",
         serialize,
         "--disable-progress-bar",
@@ -1306,7 +1307,7 @@ def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_
         result_payload = result.output
 
     if serialize == "human":
-        assert len(result_payload.split("\n")) == 33 if write_file else 32
+        assert len(result_payload.split("\n")) == 27 if write_file else 32
     elif serialize == "json":
         result = json.loads(result_payload)
         assert len(result) == 2
@@ -1316,13 +1317,13 @@ def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_
     elif serialize == "github-annotation":
         result = json.loads(result_payload)
         filepaths = {r["file"] for r in result}
-        assert len(filepaths) == 1
+        assert len(filepaths) == 2
     elif serialize == "github-annotation-native":
         result = result_payload.split("\n")
         # SQLFluff produces trailing newline
         if result[-1] == "":
             del result[-1]
-        assert len(result) == 24
+        assert len(result) == 17
     else:
         raise Exception
 

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1715,8 +1715,14 @@ class TestProgressBars:
         )
         raw_output = repr(result.output)
 
-        assert r"\rfile test/fixtures/linter/passing.sql:" in raw_output
-        assert r"\rfile test/fixtures/linter/indentation_errors.sql:" in raw_output
+        assert (
+            r"\rfile test/fixtures/linter/passing.sql:".replace("/", os.sep)
+            in raw_output
+        )
+        assert (
+            r"\rfile test/fixtures/linter/indentation_errors.sql:".replace("/", os.sep)
+            in raw_output
+        )
         assert r"\rlint by rules:" in raw_output
         assert r"\rrule L001:" in raw_output
         assert r"\rrule L049:" in raw_output
@@ -1736,13 +1742,22 @@ class TestProgressBars:
         raw_output = repr(result.output)
 
         assert (
-            r"\rfile test/fixtures/linter/multiple_files/passing.1.sql:" in raw_output
+            r"\rfile test/fixtures/linter/multiple_files/passing.1.sql:".replace(
+                "/", os.sep
+            )
+            in raw_output
         )
         assert (
-            r"\rfile test/fixtures/linter/multiple_files/passing.2.sql:" in raw_output
+            r"\rfile test/fixtures/linter/multiple_files/passing.2.sql:".replace(
+                "/", os.sep
+            )
+            in raw_output
         )
         assert (
-            r"\rfile test/fixtures/linter/multiple_files/passing.3.sql:" in raw_output
+            r"\rfile test/fixtures/linter/multiple_files/passing.3.sql:".replace(
+                "/", os.sep
+            )
+            in raw_output
         )
         assert r"\rlint by rules:" in raw_output
         assert r"\rrule L001:" in raw_output

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1735,9 +1735,15 @@ class TestProgressBars:
         )
         raw_output = repr(result.output)
 
-        assert r"\rfile passing.1.sql:" in raw_output
-        assert r"\rfile passing.2.sql:" in raw_output
-        assert r"\rfile passing.3.sql:" in raw_output
+        assert (
+            r"\rfile test/fixtures/linter/multiple_files/passing.1.sql:" in raw_output
+        )
+        assert (
+            r"\rfile test/fixtures/linter/multiple_files/passing.2.sql:" in raw_output
+        )
+        assert (
+            r"\rfile test/fixtures/linter/multiple_files/passing.3.sql:" in raw_output
+        )
         assert r"\rlint by rules:" in raw_output
         assert r"\rrule L001:" in raw_output
         assert r"\rrule L049:" in raw_output

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1715,12 +1715,15 @@ class TestProgressBars:
         )
         raw_output = repr(result.output)
 
+        sep = os.sep
+        if sys.platform == "win32":
+            sep *= 2
         assert (
-            r"\rfile test/fixtures/linter/passing.sql:".replace("/", os.sep)
+            r"\rfile test/fixtures/linter/passing.sql:".replace("/", sep)
             in raw_output
         )
         assert (
-            r"\rfile test/fixtures/linter/indentation_errors.sql:".replace("/", os.sep)
+            r"\rfile test/fixtures/linter/indentation_errors.sql:".replace("/", sep)
             in raw_output
         )
         assert r"\rlint by rules:" in raw_output
@@ -1741,21 +1744,24 @@ class TestProgressBars:
         )
         raw_output = repr(result.output)
 
+        sep = os.sep
+        if sys.platform == "win32":
+            sep *= 2
         assert (
             r"\rfile test/fixtures/linter/multiple_files/passing.1.sql:".replace(
-                "/", os.sep
+                "/", sep
             )
             in raw_output
         )
         assert (
             r"\rfile test/fixtures/linter/multiple_files/passing.2.sql:".replace(
-                "/", os.sep
+                "/", sep
             )
             in raw_output
         )
         assert (
             r"\rfile test/fixtures/linter/multiple_files/passing.3.sql:".replace(
-                "/", os.sep
+                "/", sep
             )
             in raw_output
         )

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1715,8 +1715,8 @@ class TestProgressBars:
         )
         raw_output = repr(result.output)
 
-        assert r"\rpath test/fixtures/linter/passing.sql:" in raw_output
-        assert r"\rpath test/fixtures/linter/indentation_errors.sql:" in raw_output
+        assert r"\rfile test/fixtures/linter/passing.sql:" in raw_output
+        assert r"\rfile test/fixtures/linter/indentation_errors.sql:" in raw_output
         assert r"\rlint by rules:" in raw_output
         assert r"\rrule L001:" in raw_output
         assert r"\rrule L049:" in raw_output

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1314,7 +1314,7 @@ def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_
     print("## End Payload")
 
     if serialize == "human":
-        assert payload_length == 27 if write_file else 32
+        assert payload_length == 26 if write_file else 32
     elif serialize == "json":
         result = json.loads(result_payload)
         assert len(result) == 2
@@ -1726,8 +1726,7 @@ class TestProgressBars:
         if sys.platform == "win32":
             sep *= 2
         assert (
-            r"\rfile test/fixtures/linter/passing.sql:".replace("/", sep)
-            in raw_output
+            r"\rfile test/fixtures/linter/passing.sql:".replace("/", sep) in raw_output
         )
         assert (
             r"\rfile test/fixtures/linter/indentation_errors.sql:".replace("/", sep)


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #4077 
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
