### PR TITLE
Fix mypy issue with regex

### DIFF
--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -76,7 +76,7 @@ class JinjaTracer:
         trace_template = self.make_template(trace_template_str)
         trace_template_output = trace_template.render()
         # Split output by section. Each section has two possible formats.
-        trace_entries = list(regex.finditer(r"\0", trace_template_output))
+        trace_entries = list(regex.finditer(r"\0", trace_template_output))  # type: ignore[call-overload]
         for match_idx, match in enumerate(trace_entries):
             pos1 = match.span()[0]
             try:

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -76,7 +76,7 @@ class JinjaTracer:
         trace_template = self.make_template(trace_template_str)
         trace_template_output = trace_template.render()
         # Split output by section. Each section has two possible formats.
-        trace_entries = list(regex.finditer(r"\0", trace_template_output))  # type: ignore[call-overload]
+        trace_entries = list(regex.finditer(r"\0", trace_template_output))  # type: ignore[call-overload] # noqa: E501
         for match_idx, match in enumerate(trace_entries):
             pos1 = match.span()[0]
             try:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
I saw a mypy error in the build for #3976. Can't reproduce it locally, but this was the error:
```
src/sqlfluff/core/templaters/slicers/tracer.py:79: error: No overload variant of "list" matches argument type "Scanner[str]"  [call-overload]
src/sqlfluff/core/templaters/slicers/tracer.py:79: note: Possible overload variants:
src/sqlfluff/core/templaters/slicers/tracer.py:79: note:     def [_T] __init__(self) -> List[_T]
src/sqlfluff/core/templaters/slicers/tracer.py:79: note:     def [_T] __init__(self, Iterable[_T], /) -> List[_T]
```

This PR adds a `type: ignore` comment to that line.
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
