### PR TITLE
Enable variable reference names to have leading underscore for snowflake dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -192,7 +192,7 @@ snowflake_dialect.add(
         type="variable",
     ),
     ReferencedVariableNameSegment=RegexParser(
-        r"\$[A-Z][A-Z0-9_]*",
+        r"\$[A-Z_][A-Z0-9_]*",
         CodeSegment,
         type="variable",
         trim_chars=("$"),

--- a/test/fixtures/dialects/snowflake/snowflake_set_call_variable.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_set_call_variable.sql
@@ -1,0 +1,3 @@
+SET _VARIABLE1 = 'Hello World';
+
+SELECT $_VARIABLE1;

--- a/test/fixtures/dialects/snowflake/snowflake_set_call_variable.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_set_call_variable.yml
@@ -1,0 +1,23 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: f3cb485972fb6c848837633114e0e19a37f062a1b47d1540c782986f5a70996f
+file:
+- statement:
+    set_statement:
+      keyword: SET
+      variable: _VARIABLE1
+      comparison_operator:
+        raw_comparison_operator: '='
+      expression:
+        quoted_literal: "'Hello World'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          variable: $_VARIABLE1
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fix parsing error when references to variables to have leading underscore. fixes #4086 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
