### PR TITLE
Fix flake8 issue with segment_predicates.py

### DIFF
--- a/src/sqlfluff/utils/functional/segment_predicates.py
+++ b/src/sqlfluff/utils/functional/segment_predicates.py
@@ -16,7 +16,6 @@ from sqlfluff.utils.functional.templated_file_slices import TemplatedFileSlices
 from sqlfluff.core.templaters.base import (
     RawFileSlice,
     TemplatedFile,
-    TemplatedFileSlice,
 )
 
 
@@ -193,7 +192,6 @@ def templated_slices(
     # want it. It's easy enough to do this ourselves.
     start = segment.pos_marker.templated_slice.start
     stop = segment.pos_marker.templated_slice.stop
-    slice_: TemplatedFileSlice
     templated_slices = [
         slice_
         for slice_ in templated_file.sliced_file


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->
Fixes this flake8 build error:
```
./src/sqlfluff/utils/functional/segment_predicates.py:196:5: F842 local variable 'slice_' is annotated but never used
```

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
