### PR TITLE
Fix bug in example rule plugin

### DIFF
--- a/plugins/sqlfluff-plugin-example/src/example/rules.py
+++ b/plugins/sqlfluff-plugin-example/src/example/rules.py
@@ -73,7 +73,7 @@ class Rule_Example_L001(BaseRule):
 
     groups = ("all",)
     config_keywords = ["forbidden_columns"]
-    crawl_behaviour = SegmentSeekerCrawler({"column_reference"})
+    crawl_behaviour = SegmentSeekerCrawler({"orderby_clause"})
 
     def __init__(self, *args, **kwargs):
         """Overwrite __init__ to set config."""
@@ -83,12 +83,11 @@ class Rule_Example_L001(BaseRule):
         ]
 
     def _eval(self, context: RuleContext):
-        """We should not use ORDER BY."""
-        if context.segment.is_type("orderby_clause"):
-            for seg in context.segment.segments:
-                col_name = seg.raw.lower()
-                if col_name in self.forbidden_columns:
-                    return LintResult(
-                        anchor=seg,
-                        description=f"Column `{col_name}` not allowed in ORDER BY.",
-                    )
+        """We should not ORDER BY forbidden_columns."""
+        for seg in context.segment.segments:
+            col_name = seg.raw.lower()
+            if col_name in self.forbidden_columns:
+                return LintResult(
+                    anchor=seg,
+                    description=f"Column `{col_name}` not allowed in ORDER BY.",
+                )

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -76,7 +76,7 @@ class JinjaTracer:
         trace_template = self.make_template(trace_template_str)
         trace_template_output = trace_template.render()
         # Split output by section. Each section has two possible formats.
-        trace_entries = list(regex.finditer(r"\0", trace_template_output))  # type: ignore[call-overload] # noqa: E501
+        trace_entries = list(regex.finditer(r"\0", trace_template_output))
         for match_idx, match in enumerate(trace_entries):
             pos1 = match.span()[0]
             try:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
I manually tested the example rule and noticed it didn't work. Looks like a bug introduced when adding new crawling behavior.
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
