### PR TITLE
Fix bug where L034 should ignore INSERT or "CREATE TABLE AS SELECT" with CTE

### DIFF
--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -76,7 +76,7 @@ class JinjaTracer:
         trace_template = self.make_template(trace_template_str)
         trace_template_output = trace_template.render()
         # Split output by section. Each section has two possible formats.
-        trace_entries = list(regex.finditer(r"\0", trace_template_output))  # type: ignore[call-overload] # noqa: E501
+        trace_entries = list(regex.finditer(r"\0", trace_template_output))
         for match_idx, match in enumerate(trace_entries):
             pos1 = match.span()[0]
             try:

--- a/src/sqlfluff/rules/L034.py
+++ b/src/sqlfluff/rules/L034.py
@@ -94,8 +94,22 @@ class Rule_L034(BaseRule):
             "insert_statement", "set_expression"
         ):
             return None
+        if (
+            len(context.parent_stack) >= 3
+            and context.parent_stack[-3].is_type("insert_statement", "set_expression")
+            and context.parent_stack[-2].is_type("with_compound_statement")
+        ):
+            return None
         if len(context.parent_stack) >= 3 and context.parent_stack[-3].is_type(
             "create_table_statement", "merge_statement"
+        ):
+            return None
+        if (
+            len(context.parent_stack) >= 4
+            and context.parent_stack[-4].is_type(
+                "create_table_statement", "merge_statement"
+            )
+            and context.parent_stack[-2].is_type("with_compound_statement")
         ):
             return None
 

--- a/test/fixtures/rules/std_rule_cases/L034.yml
+++ b/test/fixtures/rules/std_rule_cases/L034.yml
@@ -121,6 +121,13 @@ test_insert_statements_ignored:
     FROM
       another_schema.another_table
 
+test_insert_statement_with_cte_ignored:
+  pass_str: |
+    INSERT INTO my_table
+    WITH my_cte AS (SELECT * FROM t1)
+    SELECT MAX(field1), field2
+    FROM t1
+
 test_merge_statements_ignored:
   pass_str: |
     MERGE INTO t
@@ -150,6 +157,14 @@ test_create_table_as_select_statements_ignored:
           rank_desc
       FROM
         another_schema.another_table
+    )
+
+test_create_table_as_select_with_cte_ignored:
+  pass_str: |
+    CREATE TABLE new_table AS (
+      WITH my_cte AS (SELECT * FROM t1)
+      SELECT MAX(field1), field2
+      FROM t1
     )
 
 test_fail_fix_explicit_column_references_1:

--- a/test/fixtures/rules/std_rule_cases/L034.yml
+++ b/test/fixtures/rules/std_rule_cases/L034.yml
@@ -143,6 +143,20 @@ test_merge_statements_ignored:
     WHEN NOT MATCHED THEN
     INSERT (b) VALUES (c)
 
+test_merge_statement_with_cte_ignored:
+  pass_str: |
+    MERGE INTO t
+    USING
+    (
+        WITH my_cte AS (SELECT * FROM t1)
+        SELECT MAX(field1), field2
+        FROM t1
+    ) AS u ON (a = b)
+    WHEN MATCHED THEN
+    UPDATE SET a = b
+    WHEN NOT MATCHED THEN
+    INSERT (b) VALUES (c)
+
 test_create_table_as_select_statements_ignored:
   pass_str: |
     CREATE TABLE new_table AS (


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #4105 
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
