### PR TITLE
Bug fix: dbt templater ignores .sqlfluff file encoding on Windows

### DIFF
--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -22,6 +22,8 @@ from dbt import flags
 from jinja2 import Environment
 from jinja2_simple_tags import StandaloneTag
 
+from sqlfluff.cli.formatters import OutputStreamFormatter
+from sqlfluff.core import FluffConfig
 from sqlfluff.core.cached_property import cached_property
 from sqlfluff.core.errors import SQLTemplaterError, SQLFluffSkipFile
 
@@ -323,15 +325,22 @@ class DbtTemplater(JinjaTemplater):
                 )
 
     @large_file_check
-    def process(self, *, fname, in_str=None, config=None, formatter=None):
+    def process(
+        self,
+        *,
+        fname: str,
+        in_str: Optional[str] = None,
+        config: Optional[FluffConfig] = None,
+        formatter: Optional[OutputStreamFormatter] = None,
+    ):
         """Compile a dbt model and return the compiled SQL.
 
         Args:
-            fname (:obj:`str`): Path to dbt model(s)
-            in_str (:obj:`str`, optional): This is ignored for dbt
-            config (:obj:`FluffConfig`, optional): A specific config to use for this
+            fname: Path to dbt model(s)
+            in_str: fname contents using configured encoding
+            config: A specific config to use for this
                 templating operation. Only necessary for some templaters.
-            formatter (:obj:`CallbackFormatter`): Optional object for output.
+            formatter: Optional object for output.
         """
         # Stash the formatter if provided to use in cached methods.
         self.formatter = formatter
@@ -515,10 +524,7 @@ class DbtTemplater(JinjaTemplater):
                     "dbt templater compilation failed silently, check your "
                     "configuration by running `dbt compile` directly."
                 )
-
-            with open(fname) as source_dbt_model:
-                source_dbt_sql = source_dbt_model.read()
-
+            source_dbt_sql = in_str
             if not source_dbt_sql.rstrip().endswith("-%}"):
                 n_trailing_newlines = len(source_dbt_sql) - len(
                     source_dbt_sql.rstrip("\n")

--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/models/my_new_project/utf8/.sqlfluff
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/models/my_new_project/utf8/.sqlfluff
@@ -1,0 +1,4 @@
+[sqlfluff]
+dialect = ansi
+rules = L010
+encoding = utf-8

--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/models/my_new_project/utf8/test.sql
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/models/my_new_project/utf8/test.sql
@@ -1,0 +1,9 @@
+{{
+	config(materialized='table')
+}}
+
+SELECT
+    FIRST_COLUMN,
+    SECOND_COLUMN
+FROM TABLE_TO_TEST
+where TYPE_OF_TEST = 'TESTING ÅÄÖ'

--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/models/my_new_project/utf8/test.sql.fixed
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/models/my_new_project/utf8/test.sql.fixed
@@ -1,0 +1,9 @@
+{{
+	config(materialized='table')
+}}
+
+SELECT
+    FIRST_COLUMN,
+    SECOND_COLUMN
+FROM TABLE_TO_TEST
+WHERE TYPE_OF_TEST = 'TESTING ÅÄÖ'

--- a/plugins/sqlfluff-templater-dbt/test/rules_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/rules_test.py
@@ -1,6 +1,7 @@
 """Tests for the standard set of rules."""
 import pytest
 import os
+from pathlib import Path
 
 from sqlfluff.core import Linter
 from sqlfluff.core.config import FluffConfig
@@ -44,15 +45,10 @@ def test__rules__fix_utf8(project_dir):  # noqa
     # TODO: Check contents of file:
     # ./plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/models/my_new_project/utf8/testFIXED.sql
     # Against a git file, similar to the autofix tests
-    fixed_path = os.path.join(project_dir, "models/my_new_project/utf8/testFIXED.sql")
-    cmp_filepath = os.path.join(
-        project_dir, "models/my_new_project/utf8/test.sql.fixed"
-    )
-    with open(fixed_path, "rb") as fixed_file:
-        fixed_buff = fixed_file.read()
-    # Read the comparison file
-    with open(cmp_filepath, "rb") as comp_file:
-        comp_buff = comp_file.read()
+    fixed_path = Path(project_dir) / "models/my_new_project/utf8/testFIXED.sql"
+    cmp_filepath = Path(project_dir) / "models/my_new_project/utf8/test.sql.fixed"
+    fixed_buff = fixed_path.read_text("utf8")
+    comp_buff = cmp_filepath.read_text("utf8")
 
     # Assert that we fixed as expected
     assert fixed_buff == comp_buff

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -105,9 +105,10 @@ def test_dbt_profiles_dir_env_var_uppercase(
 
 
 def _run_templater_and_verify_result(dbt_templater, project_dir, fname):  # noqa: F811
+    path = Path(project_dir) / "models/my_new_project" / fname
     templated_file, _ = dbt_templater.process(
-        in_str="",
-        fname=os.path.join(project_dir, "models/my_new_project/", fname),
+        in_str=path.read_text(),
+        fname=str(path),
         config=FluffConfig(configs=DBT_FLUFF_CONFIG),
     )
     template_output_folder_path = Path(
@@ -237,9 +238,10 @@ def test__templater_dbt_templating_test_lex(
         source_dbt_sql = source_dbt_model.read()
     n_trailing_newlines = len(source_dbt_sql) - len(source_dbt_sql.rstrip("\n"))
     lexer = Lexer(config=FluffConfig(configs=DBT_FLUFF_CONFIG))
+    path = Path(project_dir) / fname
     templated_file, _ = dbt_templater.process(
-        in_str="",
-        fname=os.path.join(project_dir, fname),
+        in_str=path.read_text(),
+        fname=str(path),
         config=FluffConfig(configs=DBT_FLUFF_CONFIG),
     )
     tokens, lex_vs = lexer.lex(templated_file)
@@ -469,9 +471,11 @@ def test__context_in_config_is_loaded(
     config_dict["templater"]["dbt"]["context"] = context
     config = FluffConfig(config_dict)
 
-    fname = os.path.abspath(os.path.join(project_dir, model_path))
+    path = Path(project_dir) / model_path
 
-    processed, violations = dbt_templater.process(in_str="", fname=fname, config=config)
+    processed, violations = dbt_templater.process(
+        in_str=path.read_text(), fname=str(path), config=config
+    )
 
     assert violations == []
     assert str(var_value) in processed.templated_str


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3585, #3729 

Actually, it was ignoring the encoding on *every* platform, but for some reason, it seemed to work on other (non-Windows) platforms even with the bug.
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
