### PR TITLE
Only upload 3 sets of test results to codecov (possible workaround for hanging builds)

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -10,7 +10,7 @@ codecov:
   disable_default_path_fixes: no  # yamllint disable-line rule:truthy
   require_ci_to_pass: yes  # yamllint disable-line rule:truthy
   notify:
-    after_n_builds: 10
+    after_n_builds: 3
     wait_for_ci: yes  # yamllint disable-line rule:truthy
 
 coverage:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # We don't enforce coverage on older Python versions.
         python-version: [ '3.7', '3.8', '3.9', '3.10' ]
     name: Python ${{ matrix.python-version }} tests
     steps:
@@ -59,6 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # We enforce coverage on this, the latest Python version.
         python-version: [ '3.11' ]
     name: Python ${{ matrix.python-version }} tests
     steps:
@@ -138,6 +140,7 @@ jobs:
           - 5432:5432
     strategy:
       matrix:
+        # We don't enforce coverage on older dbt versions.
         dbt-version: [ 'dbt020', 'dbt021', 'dbt100' ]
     name: DBT Plugin ${{ matrix.dbt-version }} tests
     steps:
@@ -173,6 +176,7 @@ jobs:
           - 5432:5432
     strategy:
       matrix:
+        # We enforce coverage on this, the latest dbt version.
         dbt-version: [ 'dbt130' ]
     name: DBT Plugin ${{ matrix.dbt-version }} tests
     steps:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -41,7 +41,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+    name: Python ${{ matrix.python-version }} tests
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install tox
+    - name: Run the tests
+      run: |
+        tox -e py -- -n 2 test
+  python-version-tests-cov:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.11' ]
     name: Python ${{ matrix.python-version }} tests
     steps:
     - uses: actions/checkout@v3
@@ -120,7 +138,42 @@ jobs:
           - 5432:5432
     strategy:
       matrix:
-        dbt-version: [ 'dbt020', 'dbt021', 'dbt100', 'dbt130' ]
+        dbt-version: [ 'dbt020', 'dbt021', 'dbt100' ]
+    name: DBT Plugin ${{ matrix.dbt-version }} tests
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        pip install tox
+    - name: Run the tests
+      run: |
+        tox -e ${{ matrix.dbt-version }} -- plugins/sqlfluff-templater-dbt
+  dbt-tests-cov:
+    runs-on: ubuntu-latest
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: password
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+    strategy:
+      matrix:
+        dbt-version: [ 'dbt130' ]
     name: DBT Plugin ${{ matrix.dbt-version }} tests
     steps:
     - uses: actions/checkout@v3
@@ -202,10 +255,6 @@ jobs:
       # None of these test need temp dir set
       run: |
         python -m tox -e dbt100-winpy -- plugins/sqlfluff-templater-dbt
-    - name: Upload Coverage Report
-      uses: codecov/codecov-action@v1
-      with:
-        files: ./coverage.xml
   pip-test-pull-request:
     # Test that using pip install works as we've missed
     # some dependencies in the past - see #1842

--- a/src/sqlfluff/__init__.py
+++ b/src/sqlfluff/__init__.py
@@ -8,7 +8,7 @@ from sqlfluff.api import lint, fix, parse, list_rules, list_dialects
 # Import metadata (using importlib_metadata backport for python versions <3.8)
 if sys.version_info >= (3, 8):
     from importlib import metadata
-else:
+else:  # pragma: no cover
     import importlib_metadata as metadata
 
 __all__ = (

--- a/src/sqlfluff/core/cached_property.py
+++ b/src/sqlfluff/core/cached_property.py
@@ -3,7 +3,7 @@ import sys
 
 if sys.version_info >= (3, 8):
     from functools import cached_property
-else:
+else:  # pragma: no cover
     from backports.cached_property import cached_property
 
 __all__ = ("cached_property",)


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #4146 

Only require (and upload) coverage reports for:
* Python 3.11
* dbt 1.3.0
* Python Windows

Allegedly, uploading fewer coverage reports makes the coverage portion of the CI build less likely to hang.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
