### PR TITLE
L037: insert ASC just after column_reference

### DIFF
--- a/test/fixtures/rules/std_rule_cases/L037.yml
+++ b/test/fixtures/rules/std_rule_cases/L037.yml
@@ -24,3 +24,8 @@ test_desc_unspecified:
 
 test_desc_asc:
   pass_str: SELECT * FROM t ORDER BY a DESC, b ASC
+
+
+test_nulls_last:
+  fail_str: SELECT * FROM t ORDER BY a DESC, b NULLS LAST
+  fix_str: SELECT * FROM t ORDER BY a DESC, b ASC NULLS LAST


### PR DESCRIPTION
Fixed unparseable query generated for NULLS FIRST, NULLS LAST


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #4136 

### Are there any other side effects of this change that we should be aware of?
nothing

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
