### PR TITLE
Fix passenv to work with tox 4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = generate-fixture-yml, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{37,38,39,310}, dbt{017,018,019,020,021,100,130}-py{37,38,39,310}, cov-report, bench, mypy, winpy, dbt{017,018,019,020,021,100,130}-winpy, yamllint
 
 [testenv]
-passenv = CI CIRCLECI CIRCLE_* HOME SQLFLUFF_BENCHMARK_API_KEY
+passenv = CI, CIRCLECI, CIRCLE_*, HOME, SQLFLUFF_BENCHMARK_API_KEY
 # Have option to explicitly set TMPDIR for python as on GitHub Action Windows
 # machines it doesn't read this from env and resets to system default, which
 # is often on different drive (C) from working dir (D), which causes problems.

--- a/util.py
+++ b/util.py
@@ -69,9 +69,6 @@ def benchmark(cmd, runs, from_file):
     # Try and detect a CI environment
     if "CI" in os.environ:
         click.echo("CI detected!")
-        # available_vars = [var for var in os.environ.keys()]
-        # if var.startswith('CIRCLE')
-        # click.echo("Available keys: {0!r}".format(available_vars))
         commit_hash = os.environ.get("GITHUB_SHA", None)
         post_results = True
         click.echo(f"Commit hash is: {commit_hash!r}")


### PR DESCRIPTION
### Brief summary of the change made

tox4 changes passenv to a comma-separated list, rather than space-separated: https://github.com/tox-dev/tox/issues/2658

### Are there any other side effects of this change that we should be aware of?

This is only really important for CI (which uses latest tox), so think it should be OK even for v3 users.

I also removed the last remaining references to CIRCLECI [that we replaced with GitHub Actions  a long time ago](https://github.com/sqlfluff/sqlfluff/pull/1361).

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
