### PR TITLE
:bug: Check verbosity level of pytest run before running certain tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -277,3 +277,20 @@ def fail_on_parse_error_after_fix(monkeypatch):
         "_report_conflicting_fixes_same_anchor",
         raise_error_conflicting_fixes_same_anchor,
     )
+
+
+@pytest.fixture(autouse=True)
+def test_verbosity_level(request):
+    """Report the verbosity level for a given pytest run.
+
+    For example:
+
+    $ pytest -vv
+    Has a verbosity level of 2
+
+    While:
+
+    $ pytest
+    Has a verbosity level of 0
+    """
+    return request.config.getoption("verbose")

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -46,7 +46,7 @@ def test_rules__test_helper_skipped_when_test_case_skipped():
     skipped_test.match("Skip this one for now")
 
 
-def test_rules__test_helper_has_variable_introspection():
+def test_rules__test_helper_has_variable_introspection(test_verbosity_level):
     """Make sure the helper gives variable introspection information on failure."""
     rule_test_case = RuleTestCase(
         rule="L003",
@@ -66,5 +66,6 @@ def test_rules__test_helper_has_variable_introspection():
     )
     with pytest.raises(AssertionError) as skipped_test:
         rules__test_helper(rule_test_case)
-    # Enough to check that a query diff is displayed
-    skipped_test.match("select")
+    if test_verbosity_level >= 2:
+        # Enough to check that a query diff is displayed
+        skipped_test.match("select")


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This is a little "quality of life" for those of us who just want to call `pytest` directly when running the test suite, instead of `tox`

This test failed when I just ran `pytest`, but succeeded when I ran `pytest -vv`. This is because "select" only appeared in the output when the verbosity level was at least two. Felt like the simplest change to just double check the verbosity level of the test run before deciding to check for this regex match


### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
