### PR TITLE
Recognise || as an operator to avoid rule L006 flagging it

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -67,6 +67,7 @@ line_position = trailing
 
 [sqlfluff:layout:type:binary_operator]
 line_position = leading
+spacing_within = touch
 
 [sqlfluff:layout:type:statement_terminator]
 spacing_before = touch

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -66,8 +66,8 @@ spacing_before = touch
 line_position = trailing
 
 [sqlfluff:layout:type:binary_operator]
-line_position = leading
 spacing_within = touch
+line_position = leading
 
 [sqlfluff:layout:type:statement_terminator]
 spacing_before = touch

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -215,7 +215,6 @@ ansi_dialect.set_lexer_matchers(
         StringLexer("divide", "/", CodeSegment),
         StringLexer("percent", "%", CodeSegment),
         StringLexer("ampersand", "&", CodeSegment),
-        StringLexer("double_vertical_bar", "||", CodeSegment),
         StringLexer("vertical_bar", "|", CodeSegment),
         StringLexer("caret", "^", CodeSegment),
         StringLexer("star", "*", CodeSegment),
@@ -318,7 +317,6 @@ ansi_dialect.add(
     ModuloSegment=StringParser("%", SymbolSegment, type="binary_operator"),
     SlashSegment=StringParser("/", SymbolSegment, type="slash"),
     AmpersandSegment=StringParser("&", SymbolSegment, type="ampersand"),
-    ConcatSegment=StringParser("||", SymbolSegment, type="binary_operator"),
     PipeSegment=StringParser("|", SymbolSegment, type="pipe"),
     BitwiseXorSegment=StringParser("^", SymbolSegment, type="binary_operator"),
     LikeOperatorSegment=TypedParser("like_operator", ComparisonOperatorSegment),
@@ -2007,6 +2005,14 @@ class NotEqualToSegment(CompositeComparisonOperatorSegment):
         Sequence(
             Ref("RawLessThanSegment"), Ref("RawGreaterThanSegment"), allow_gaps=False
         ),
+    )
+
+
+class ConcatSegment(CompositeBinaryOperatorSegment):
+    """Concat operator."""
+
+    match_grammar: Matchable = Sequence(
+        Ref("PipeSegment"), Ref("PipeSegment"), allow_gaps=False
     )
 
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -215,6 +215,7 @@ ansi_dialect.set_lexer_matchers(
         StringLexer("divide", "/", CodeSegment),
         StringLexer("percent", "%", CodeSegment),
         StringLexer("ampersand", "&", CodeSegment),
+        StringLexer("double_vertical_bar", "||", CodeSegment),
         StringLexer("vertical_bar", "|", CodeSegment),
         StringLexer("caret", "^", CodeSegment),
         StringLexer("star", "*", CodeSegment),
@@ -317,6 +318,7 @@ ansi_dialect.add(
     ModuloSegment=StringParser("%", SymbolSegment, type="binary_operator"),
     SlashSegment=StringParser("/", SymbolSegment, type="slash"),
     AmpersandSegment=StringParser("&", SymbolSegment, type="ampersand"),
+    ConcatSegment=StringParser("||", SymbolSegment, type="binary_operator"),
     PipeSegment=StringParser("|", SymbolSegment, type="pipe"),
     BitwiseXorSegment=StringParser("^", SymbolSegment, type="binary_operator"),
     LikeOperatorSegment=TypedParser("like_operator", ComparisonOperatorSegment),
@@ -2005,14 +2007,6 @@ class NotEqualToSegment(CompositeComparisonOperatorSegment):
         Sequence(
             Ref("RawLessThanSegment"), Ref("RawGreaterThanSegment"), allow_gaps=False
         ),
-    )
-
-
-class ConcatSegment(CompositeBinaryOperatorSegment):
-    """Concat operator."""
-
-    match_grammar: Matchable = Sequence(
-        Ref("PipeSegment"), Ref("PipeSegment"), allow_gaps=False
     )
 
 

--- a/test/fixtures/rules/std_rule_cases/L006.yml
+++ b/test/fixtures/rules/std_rule_cases/L006.yml
@@ -86,3 +86,6 @@ pass_tsql_assignment_operator:
   configs:
     core:
       dialect: tsql
+
+pass_concat_string:
+  pass_str: SELECT 'barry' || 'pollard'


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fixes #4164 

### Are there any other side effects of this change that we should be aware of?

Nope. Missed change from #4083 

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
