### PR TITLE
Ensure diff-quality runs the correct SQLFluff

### DIFF
--- a/src/sqlfluff/diff_quality_plugin.py
+++ b/src/sqlfluff/diff_quality_plugin.py
@@ -22,7 +22,7 @@ class SQLFluffDriver(QualityDriver):
 
     def __init__(self):
         super().__init__(
-            "sqlfluff",
+            [sys.executable, "-m", "sqlfluff.cli.commands"],
             [".sql"],
             [
                 s.encode(sys.getfilesystemencoding())


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes a potential issue I think some users are seeing. If `diff-quality` just runs `sqlfluff`, it may run a different installation (and version) of SQLFluff than intended. This change ensures it runs the one that's installed in the same virtualenv as `diff-quality` itself.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
