### PR TITLE
diff-quality plugin: Print invalid JSON on parse failure

### DIFF
--- a/src/sqlfluff/diff_quality_plugin.py
+++ b/src/sqlfluff/diff_quality_plugin.py
@@ -60,12 +60,17 @@ class SQLFluffViolationReporter(QualityReporter):
         output = self.reports if self.reports else self._run_sqlfluff(src_paths)
         for o in output:
             # Load and parse SQLFluff JSON output.
-            report = json.loads(o)
-            for file in report:
-                self.violations_dict[file["filepath"]] = [
-                    Violation(v["line_no"], v["description"])
-                    for v in file["violations"]
-                ]
+            try:
+                report = json.loads(o)
+            except json.JSONDecodeError as e:  # pragma: no cover
+                print(f"Error parsing JSON output ({e}): {repr(o)}")
+                raise
+            else:
+                for file in report:
+                    self.violations_dict[file["filepath"]] = [
+                        Violation(v["line_no"], v["description"])
+                        for v in file["violations"]
+                    ]
         return self.violations_dict
 
     def _run_sqlfluff(self, src_paths):


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
