### PR TITLE
Codecov migration

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -78,6 +78,8 @@ jobs:
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v3
       with:
+        # Public token to allow coverage from forks to work.
+        token: fd44b020-c716-4f72-b5f3-03fa20119956
         files: ./coverage.xml
   other-tests:
     runs-on: ubuntu-latest
@@ -196,6 +198,8 @@ jobs:
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v3
       with:
+        # Public token to allow coverage from forks to work.
+        token: fd44b020-c716-4f72-b5f3-03fa20119956
         files: ./coverage.xml
   python-windows-tests:
     runs-on: windows-latest
@@ -229,6 +233,8 @@ jobs:
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v3
       with:
+        # Public token to allow coverage from forks to work.
+        token: fd44b020-c716-4f72-b5f3-03fa20119956
         files: ./coverage.xml
   python-windows-dbt-tests:
     runs-on: windows-latest

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -76,9 +76,10 @@ jobs:
       run: |
         tox -e py -- -n 2 test
     - name: Upload Coverage Report
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
+        verbose: true # For debugging codecov uploads
   other-tests:
     runs-on: ubuntu-latest
     strategy:
@@ -194,9 +195,10 @@ jobs:
       run: |
         tox -e ${{ matrix.dbt-version }} -- plugins/sqlfluff-templater-dbt
     - name: Upload Coverage Report
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
+        verbose: true # For debugging codecov uploads
   python-windows-tests:
     runs-on: windows-latest
     name: Python 3.10 Windows tests
@@ -227,9 +229,10 @@ jobs:
         mkdir temp_pytest
         python -m tox -e winpy -- -n 2 test
     - name: Upload Coverage Report
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
+        verbose: true # For debugging codecov uploads
   python-windows-dbt-tests:
     runs-on: windows-latest
     name: DBT Plugin Python 3.10 Windows tests

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -79,7 +79,6 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
-        verbose: true # For debugging codecov uploads
   other-tests:
     runs-on: ubuntu-latest
     strategy:
@@ -198,7 +197,6 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
-        verbose: true # For debugging codecov uploads
   python-windows-tests:
     runs-on: windows-latest
     name: Python 3.10 Windows tests
@@ -232,7 +230,6 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
-        verbose: true # For debugging codecov uploads
   python-windows-dbt-tests:
     runs-on: windows-latest
     name: DBT Plugin Python 3.10 Windows tests

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -63,6 +63,7 @@ indented_joins = False
 indented_ctes = False
 indented_using_on = True
 indented_on_contents = True
+allow_implicit_indents = False
 template_blocks_indent = True
 # This is a comma seperated list of elements to skip
 # indentation edits to.


### PR DESCRIPTION
This might fail but I hope it works.

The reason codecov isn't reporting is that the `Python 3.10 Windows tests` job isn't reporting. The error we're getting is `{'detail': ErrorDetail(string='Missing "owner" argument. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}`. We're currently using the v1 uploader and that has been officially sunset: https://github.com/codecov/codecov-action.

This updates to v3 (and hopefully solves our codecov issues).

See here for example: https://github.com/sqlfluff/sqlfluff/actions/runs/3749312506/jobs/6367654414