### PR TITLE
MySQL: Support column character set and collation

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -628,6 +628,16 @@ class DeleteStatementSegment(BaseSegment):
     )
 
 
+class ColumnConstraintSegment(ansi.ColumnConstraintSegment):
+    """A column option; each CREATE TABLE column can have 0 or more."""
+
+    match_grammar: Matchable = OneOf(
+        ansi.ColumnConstraintSegment.match_grammar,
+        Sequence("CHARACTER", "SET", Ref("NakedIdentifierSegment")),
+        Sequence("COLLATE", Ref("NakedIdentifierSegment")),
+    )
+
+
 class IndexTypeGrammar(BaseSegment):
     """index_type in table_constraint."""
 

--- a/test/fixtures/dialects/mysql/create_table_column_charset.sql
+++ b/test/fixtures/dialects/mysql/create_table_column_charset.sql
@@ -1,0 +1,6 @@
+CREATE TABLE t1
+(
+    col1 VARCHAR(5)
+      CHARACTER SET latin1
+      COLLATE latin1_german1_ci
+);

--- a/test/fixtures/dialects/mysql/create_table_column_charset.yml
+++ b/test/fixtures/dialects/mysql/create_table_column_charset.yml
@@ -1,0 +1,33 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: d877ff3721ded5cdf94ae809105d1b8ecdb8905425ad65df255aa695f97fb89b
+file:
+  statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+        start_bracket: (
+        column_definition:
+        - naked_identifier: col1
+        - data_type:
+            data_type_identifier: VARCHAR
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '5'
+              end_bracket: )
+        - column_constraint_segment:
+          - keyword: CHARACTER
+          - keyword: SET
+          - naked_identifier: latin1
+        - column_constraint_segment:
+            keyword: COLLATE
+            naked_identifier: latin1_german1_ci
+        end_bracket: )
+  statement_terminator: ;


### PR DESCRIPTION
https://dev.mysql.com/doc/refman/8.0/en/charset-column.html


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #4191 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
