### PR TITLE
don't pickle the templater

### DIFF
--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -797,6 +797,12 @@ class FluffConfig:
         state = self.__dict__.copy()
         # Remove the unpicklable entries.
         del state["_plugin_manager"]
+        if "templater_obj" in state["_configs"]["core"]:
+            # If it's already removed, don't try again.
+            # The dbt templater doesn't pickle well, but isn't required
+            # within threaded operations. If it was, it could easily be
+            # rehydrated within the thread.
+            del state["_configs"]["core"]["templater_obj"]
         return state
 
     def __setstate__(self, state):  # pragma: no cover
@@ -812,6 +818,9 @@ class FluffConfig:
         # process invocations of sqlfluff. In the event that user registered
         # rules are used in a multi-process invocation, they will not be applied
         # in the child processes.
+        # NOTE: Likewise we don't reinstate the "templater_obj" config value
+        # which should also only be used in the main thread rather than child
+        # processes.
 
     @classmethod
     def from_root(

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -797,12 +797,10 @@ class FluffConfig:
         state = self.__dict__.copy()
         # Remove the unpicklable entries.
         del state["_plugin_manager"]
-        if "templater_obj" in state["_configs"]["core"]:
-            # If it's already removed, don't try again.
-            # The dbt templater doesn't pickle well, but isn't required
-            # within threaded operations. If it was, it could easily be
-            # rehydrated within the thread.
-            del state["_configs"]["core"]["templater_obj"]
+        # The dbt templater doesn't pickle well, but isn't required
+        # within threaded operations. If it was, it could easily be
+        # rehydrated within the thread.
+        state["_configs"]["core"].pop("templater_obj", None)
         return state
 
     def __setstate__(self, state):  # pragma: no cover

--- a/src/sqlfluff/core/linter/__init__.py
+++ b/src/sqlfluff/core/linter/__init__.py
@@ -1,6 +1,11 @@
 """Linter class and helper classes."""
 
-from sqlfluff.core.linter.common import RuleTuple, ParsedString, NoQaDirective
+from sqlfluff.core.linter.common import (
+    RuleTuple,
+    ParsedString,
+    NoQaDirective,
+    RenderedFile,
+)
 from sqlfluff.core.linter.linted_file import LintedFile
 from sqlfluff.core.linter.linting_result import LintingResult
 from sqlfluff.core.linter.linter import Linter
@@ -12,4 +17,5 @@ __all__ = (
     "LintedFile",
     "LintingResult",
     "Linter",
+    "RenderedFile",
 )

--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -19,7 +19,7 @@ from typing import Callable, List, Tuple, Iterator
 
 from sqlfluff.core import FluffConfig, Linter
 from sqlfluff.core.errors import SQLFluffSkipFile
-from sqlfluff.core.linter import LintedFile
+from sqlfluff.core.linter import LintedFile, RenderedFile
 
 linter_logger: logging.Logger = logging.getLogger("sqlfluff.linter")
 
@@ -37,7 +37,7 @@ class BaseRunner(ABC):
 
     pass_formatter = True
 
-    def iter_rendered(self, fnames: List[str]) -> Iterator[Tuple]:
+    def iter_rendered(self, fnames: List[str]) -> Iterator[Tuple[str, RenderedFile]]:
         """Iterate through rendered files ready for linting."""
         for fname in self.linter.templater.sequence_files(
             fnames, config=self.config, formatter=self.linter.formatter


### PR DESCRIPTION
In testing the 2.0.0a1 release, I repeatedly experienced pickling issues with the dbt templater.

The problem is in multi-threaded mode, that the `FluffConfig` object gets passed around, and the new dbt templater contains some non-pickle-happy objects. In child processes, the templater shouldn't be required (the same as the plugin manager), so this PR strips it out of the `FluffConfig` object before pickling.