### PR TITLE
don't consider templated whitespace

### DIFF
--- a/src/sqlfluff/utils/reflow/elements.py
+++ b/src/sqlfluff/utils/reflow/elements.py
@@ -222,10 +222,21 @@ class ReflowPoint(ReflowElement):
     """
 
     def _get_indent_segment(self) -> Optional[RawSegment]:
-        """Get the current indent segment (if there)."""
+        """Get the current indent segment (if there).
+
+        NOTE: This only returns _untemplated_ indents. If templated
+        newline or whitespace segments are found they are skipped.
+        """
         indent = None
         for seg in reversed(self.segments):
-            if seg.is_type("newline"):
+            if seg.pos_marker and not seg.pos_marker.is_literal():
+                # Skip any templated elements.
+                # NOTE: It must _have_ a position marker at this
+                # point however to take this route. A segment
+                # without a position marker at all, is an edit
+                # or insertion, and so should still be considered.
+                continue
+            elif seg.is_type("newline"):
                 return indent
             elif seg.is_type("whitespace"):
                 indent = seg

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -100,6 +100,19 @@ class _IndentLine:
     initial_indent_balance: int
     indent_points: List[_IndentPoint]
 
+    def __repr__(self):
+        """Compressed repr method to ease logging."""
+        return (
+            f"IndentLine(iib={self.initial_indent_balance}, ipts=["
+            + ", ".join(
+                f"iPt@{ip.idx}({ip.indent_impulse}, {ip.indent_trough}, "
+                f"{ip.initial_indent_balance}, {ip.last_line_break_idx}, "
+                f"{ip.is_line_break}, {ip.untaken_indents})"
+                for ip in self.indent_points
+            )
+            + "])"
+        )
+
     @classmethod
     def from_points(cls, indent_points: List[_IndentPoint]):
         # Catch edge case for first line where we'll start with a
@@ -849,14 +862,16 @@ def _lint_line_buffer_indents(
     This method returns fixes, including appropriate descriptions, to
     allow generation of LintResult objects directly from them.
     """
-    reflow_logger.debug(
-        "  Evaluate Line #%s [source line #%s]. FI %s",
+    reflow_logger.info(
+        "  Evaluate Line #%s [source line #%s]. idx=%s:%s. FI %s",
         elements[indent_line.indent_points[0].idx + 1]
         .segments[0]
         .pos_marker.working_line_no,
         elements[indent_line.indent_points[0].idx + 1]
         .segments[0]
         .pos_marker.source_position()[0],
+        indent_line.indent_points[0].idx,
+        indent_line.indent_points[-1].idx,
         forced_indents,
     )
     reflow_logger.debug(
@@ -868,7 +883,7 @@ def _lint_line_buffer_indents(
             ]
         ],
     )
-    reflow_logger.info("  Evaluate Line: %s. FI %s", indent_line, forced_indents)
+    reflow_logger.debug("  Evaluate Line: %s. FI %s", indent_line, forced_indents)
     results = []
 
     # First, handle starting indent.

--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -84,11 +84,18 @@ def process_spacing(
 
     # Loop through the existing segments looking for spacing.
     for seg in segment_buffer:
+        # If it has a position marker, but it's not literal, then
+        # it's a templated element and so we shouldn't consider it
+        # here.
+        if seg.pos_marker and not seg.pos_marker.is_literal():
+            continue
+
         # If it's whitespace, store it.
-        if seg.is_type("whitespace"):
+        elif seg.is_type("whitespace"):
             last_whitespace.append(seg)
 
         # If it's a newline, react accordingly.
+        # NOTE: This should only trigger on literal newlines.
         elif seg.is_type("newline", "end_of_file"):
             # Are we stripping newlines?
             if strip_newlines and seg.is_type("newline"):

--- a/test/fixtures/linter/autofix/ansi/024_remove_templated_errors/after.sql
+++ b/test/fixtures/linter/autofix/ansi/024_remove_templated_errors/after.sql
@@ -1,5 +1,5 @@
 -- Templated query aimed to test the BaseRule.remove_templated_errors()
 -- function's behavior of not modifying templated sections.
 SELECT
-   {{ par_wrap() }}
+    {{ par_wrap() }}
     , line_two AS line_two

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -1401,3 +1401,19 @@ test_fail_deny_implicit_indent:
   configs:
     indentation:
       allow_implicit_indents: False
+
+test_pass_templated_newlines:
+  # NOTE: The macro has many newlines in it,
+  # and the calling of it is indented. Check that
+  # this doesn't panic.
+  pass_str: |
+    {% macro my_macro() %}
+      
+      macro
+      + with_newlines
+
+    {% endmacro %}
+
+    SELECT
+        {{ my_macro() }} as awkward_indentation
+    FROM foo

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -1408,7 +1408,7 @@ test_pass_templated_newlines:
   # this doesn't panic.
   pass_str: |
     {% macro my_macro() %}
-      
+
       macro
       + with_newlines
 


### PR DESCRIPTION
Found this bug while testing the new 2.0.0a1 release (#4203). I think this is the last one we need before releasing that, but will confirm on that thread once I've done a little more testing.

This PR fixes a bug where the reindentation logic would panic when being passed a templated indent. The code which finds indent segments wasn't robust to that chance and so wasn't checking whether indents were templated or not. This fixes that (includes test case).

I improved some of the reflow logging too while I was in there which was hard to debug with.