### PR TITLE
show fatal errors regardless

### DIFF
--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -122,8 +122,9 @@ class LintedFile(NamedTuple):
             violations = [v for v in violations if v.rule_code() in rules]
         # Filter fixable
         if fixable is not None:
-            # Assume that fixable is true or false if not None
-            violations = [v for v in violations if v.fixable is fixable]
+            # Assume that fixable is true or false if not None.
+            # Fatal errors should always come through, regardless.
+            violations = [v for v in violations if v.fixable is fixable or v.fatal]
         # Filter ignorable violations
         if filter_ignore:
             violations = [v for v in violations if not v.ignore]


### PR DESCRIPTION
On the current `main` branch, if the user experiences a connection error while running `sqlfluff fix`, they don't get a reason why. They get:

```
> sqlfluff fix models\base\heap
==== finding fixable violations ====
=== [dbt templater] Sorting Nodes...
ERROR      Fatal linting error. Halting further linting.
  [4 templating/parsing errors found]
==== no fixable linting violations found ====
All Finished � �!
```

This happens because the connection error is `fatal` but not fixable - so gets filtered out in the context of fixable errors. This PR alters the error filtering so that fatal errors are always shown and they get this instead:

```
> sqlfluff fix models\base\heap
==== finding fixable violations ====
=== [dbt templater] Sorting Nodes...
== [models\base\heap\stg_heap__core_events_submit_any_form.sql] FAIL
L:   0 | P:   0 |  TMP | dbt error: Could not connect to Database
ERROR      Fatal linting error. Halting further linting.
  [4 templating/parsing errors found]
==== no fixable linting violations found ====
All Finished � �!
```

This means users can do something about it.

