### PR TITLE
Fix #4215

### DIFF
--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -488,6 +488,11 @@ class BaseRule:
     _works_on_unparsable = True
     _adjust_anchors = False
     targets_templated = False
+    # Some fix routines do their own checking for whether their fixes
+    # are safe around templated elements. For those - the default
+    # safety checks might be inappropriate. In those cases, set
+    # template_safe_fixes to True.
+    template_safe_fixes = False
 
     # Lint loop / crawl behavior. When appropriate, rules can (and should)
     # override these values to make linting faster.
@@ -661,7 +666,10 @@ class BaseRule:
     def _process_lint_result(
         self, res, templated_file, ignore_mask, new_lerrs, new_fixes, root
     ):
-        self.discard_unsafe_fixes(res, templated_file)
+        # Unless the rule declares that it's already template safe. Do safety
+        # checks.
+        if not self.template_safe_fixes:
+            self.discard_unsafe_fixes(res, templated_file)
         lerr = res.to_linting_error(rule=self)
         ignored = False
         if lerr:

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -348,20 +348,13 @@ class LintFix:
         # include the area of code "within" the area of insertion, not the other
         # side.
         adjust_boundary = 1 if not within_only else 0
-        raw_edit = "".join(seg.raw for seg in self.edit) if self.edit else ""
-        # create_before - or a replace behaving like a create_before.
-        if self.edit_type == "create_before" or (
-            self.edit_type == "replace" and raw_edit.endswith(self.anchor.raw)
-        ):
+        if self.edit_type == "create_before":
             # Consider the first position of the anchor segment and the
             # position just before it.
             templated_slices = [
                 slice(anchor_slice.start - 1, anchor_slice.start + adjust_boundary),
             ]
-        # create_after - or a replace behaving like a create_after.
-        elif self.edit_type == "create_after" or (
-            self.edit_type == "replace" and raw_edit.startswith(self.anchor.raw)
-        ):
+        elif self.edit_type == "create_after":
             # Consider the last position of the anchor segment and the
             # character just after it.
             templated_slices = [
@@ -811,7 +804,6 @@ class BaseRule:
         block_indices: Set[int] = set()
         for fix in lint_result.fixes:
             fix_slices = fix.get_fix_slices(templated_file, within_only=True)
-            linter_logger.warning("FIX SLICES: %s", fix_slices)
             for fix_slice in fix_slices:
                 # Ignore fix slices that exist only in the source. For purposes
                 # of this check, it's not meaningful to say that a fix "touched"

--- a/src/sqlfluff/rules/L003.py
+++ b/src/sqlfluff/rules/L003.py
@@ -48,6 +48,7 @@ class Rule_L003(BaseRule):
     groups = ("all", "core")
     crawl_behaviour = RootOnlyCrawler()
     targets_templated = True
+    template_safe_fixes = True
     _adjust_anchors = True
 
     def _eval(self, context: RuleContext) -> List[LintResult]:

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -25,6 +25,7 @@ class Rule_L016(BaseRule):
     groups = ("all", "core")
     crawl_behaviour = RootOnlyCrawler()
     targets_templated = True
+    template_safe_fixes = True
     _adjust_anchors = True
     _check_docstring = False
 

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -1417,3 +1417,23 @@ test_pass_templated_newlines:
     SELECT
         {{ my_macro() }} as awkward_indentation
     FROM foo
+
+test_fail_fix_beside_templated:
+  # Check that templated code checks aren't too aggressive.
+  # https://github.com/sqlfluff/sqlfluff/issues/4215
+  fail_str: |
+    {% if False %}
+    SELECT 1
+    {% else %}
+    SELECT c
+    FROM t
+    WHERE c < 0
+    {% endif %}
+  fix_str: |
+    {% if False %}
+    SELECT 1
+    {% else %}
+        SELECT c
+        FROM t
+        WHERE c < 0
+    {% endif %}


### PR DESCRIPTION
Templated code checks were a bit aggressive, and for the places that a `replace` is kind of behaving like a `create_before` or `create_after`, we can utilise that fact and relax a little. This fixes #4215.