### PR TITLE
Include the filename in critical exceptions

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,7 @@
 # code linting and formatting
 flake8
 flake8-docstrings
+pydocstyle<6.2.0  # See: https://github.com/PyCQA/pydocstyle/issues/618
 black>=22.1.0
 flake8-black>=0.2.4
 # documentation checks

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -593,8 +593,12 @@ class BaseRule:
             # Any exception at this point would halt the linter and
             # cause the user to get no results
             except Exception as e:
+                # If a filename is present, include it in the critical exception.
                 self.logger.critical(
-                    f"Applying rule {self.code} threw an Exception: {e}", exc_info=True
+                    f"Applying rule {self.code} to {fname!r} threw an Exception: {e}"
+                    if fname
+                    else f"Applying rule {self.code} threw an Exception: {e}",
+                    exc_info=True,
                 )
                 assert context.segment.pos_marker
                 exception_line, _ = context.segment.pos_marker.source_position()

--- a/src/sqlfluff/utils/reflow/sequence.py
+++ b/src/sqlfluff/utils/reflow/sequence.py
@@ -232,18 +232,15 @@ class ReflowSequence:
         """Generate a sequence around a target.
 
         Args:
-            target_segment (:obj:`RawSegment`):
-                The segment to center around when considering the sequence
-                to construct.
-            root_segment (:obj:`BaseSegment`):
-                The relevant root segment (usually the base :obj:`FileSegment`).
-            config (:obj:`FluffConfig`):
-                A config object from which to load the spacing behaviours
-                of different segments.
-            sides (:obj:`str`):
-                Limit the reflow sequence to just one side of the target.
-                Default is two sided ("both"), but set to "before" or "after"
-                to limit to either side.
+            target_segment (:obj:`RawSegment`): The segment to center
+                around when considering the sequence to construct.
+            root_segment (:obj:`BaseSegment`): The relevant root
+                segment (usually the base :obj:`FileSegment`).
+            config (:obj:`FluffConfig`): A config object from which
+                to load the spacing behaviours of different segments.
+            sides (:obj:`str`): Limit the reflow sequence to just one
+                side of the target. Default is two sided ("both"), but
+                set to "before" or "after" to limit to either side.
 
 
         **NOTE**: We don't just expand to the first block around the
@@ -465,15 +462,14 @@ class ReflowSequence:
         """Returns a new :obj:`ReflowSequence` with points respaced.
 
         Args:
-            strip_newlines (:obj:`bool`):
-                Optionally strip newlines before respacing. This is
-                primarily used on focused sequences to coerce objects
-                onto a single line. This does not apply any prioritisation
-                to which line breaks to remove and so is not a substitute
-                for the full `reindent` or `reflow` methods.
-            filter (:obj:`str`):
-                Optionally filter which reflow points to respace.
-                Default configuration is `all`. Other options
+            strip_newlines (:obj:`bool`): Optionally strip newlines
+                before respacing. This is primarily used on focused
+                sequences to coerce objects onto a single line. This
+                does not apply any prioritisation to which line breaks
+                to remove and so is not a substitute for the full
+                `reindent` or `reflow` methods.
+            filter (:obj:`str`): Optionally filter which reflow points
+                to respace. Default configuration is `all`. Other options
                 are `line_break` which only respaces points containing
                 a `newline` or followed by an `end_of_file` marker, or
                 `inline` which is the inverse of `line_break`. This is

--- a/src/sqlfluff/utils/reflow/sequence.py
+++ b/src/sqlfluff/utils/reflow/sequence.py
@@ -232,15 +232,18 @@ class ReflowSequence:
         """Generate a sequence around a target.
 
         Args:
-            target_segment (:obj:`RawSegment`): The segment to center
-                around when considering the sequence to construct.
-            root_segment (:obj:`BaseSegment`): The relevant root
-                segment (usually the base :obj:`FileSegment`).
-            config (:obj:`FluffConfig`): A config object from which
-                to load the spacing behaviours of different segments.
-            sides (:obj:`str`): Limit the reflow sequence to just one
-                side of the target. Default is two sided ("both"), but
-                set to "before" or "after" to limit to either side.
+            target_segment (:obj:`RawSegment`):
+                The segment to center around when considering the sequence
+                to construct.
+            root_segment (:obj:`BaseSegment`):
+                The relevant root segment (usually the base :obj:`FileSegment`).
+            config (:obj:`FluffConfig`):
+                A config object from which to load the spacing behaviours
+                of different segments.
+            sides (:obj:`str`):
+                Limit the reflow sequence to just one side of the target.
+                Default is two sided ("both"), but set to "before" or "after"
+                to limit to either side.
 
 
         **NOTE**: We don't just expand to the first block around the
@@ -462,14 +465,15 @@ class ReflowSequence:
         """Returns a new :obj:`ReflowSequence` with points respaced.
 
         Args:
-            strip_newlines (:obj:`bool`): Optionally strip newlines
-                before respacing. This is primarily used on focused
-                sequences to coerce objects onto a single line. This
-                does not apply any prioritisation to which line breaks
-                to remove and so is not a substitute for the full
-                `reindent` or `reflow` methods.
-            filter (:obj:`str`): Optionally filter which reflow points
-                to respace. Default configuration is `all`. Other options
+            strip_newlines (:obj:`bool`):
+                Optionally strip newlines before respacing. This is
+                primarily used on focused sequences to coerce objects
+                onto a single line. This does not apply any prioritisation
+                to which line breaks to remove and so is not a substitute
+                for the full `reindent` or `reflow` methods.
+            filter (:obj:`str`):
+                Optionally filter which reflow points to respace.
+                Default configuration is `all`. Other options
                 are `line_break` which only respaces points containing
                 a `newline` or followed by an `end_of_file` marker, or
                 `inline` which is the inverse of `line_break`. This is


### PR DESCRIPTION
Critical errors are great, but when debugging new releases it's really annoying that the filename isn't mentioned in the error directly. This adds the filename to the output (when there is one - it fails nicely when not).