### PR TITLE
Snowflake: Allow multiple unpivot

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -509,7 +509,7 @@ snowflake_dialect.replace(
             Ref("ConnectByClauseSegment"),
             Ref("FromBeforeExpressionSegment"),
             Ref("FromPivotExpressionSegment"),
-            Ref("FromUnpivotExpressionSegment"),
+            AnyNumberOf(Ref("FromUnpivotExpressionSegment")),
             Ref("SamplingExpressionSegment"),
             min_times=1,
         ),

--- a/test/fixtures/dialects/snowflake/snowflake_pivot.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_pivot.sql
@@ -4,3 +4,10 @@ PIVOT (min(f_val) FOR f_id IN (1, 2)) AS f (a, b);
 
 SELECT * FROM my_tbl
 UNPIVOT (val FOR col_name IN (a, b));
+
+select
+*
+from table_a
+unpivot (a for b in (col_1, col_2, col_3))
+unpivot (c for d in (col_a, col_b, col_c))
+;

--- a/test/fixtures/dialects/snowflake/snowflake_pivot.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_pivot.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 37df5646cd5d4db6264d866fd5aa7909ccfad9e82c47235c53adc53ec510d4ca
+_hash: 57ff3afe4fe78cf0a36a3a3a561a8ebd0578fbb29eb444fdb7f84cfcd389cca3
 file:
 - statement:
     select_statement:
@@ -82,6 +82,56 @@ file:
               - naked_identifier: a
               - comma: ','
               - naked_identifier: b
+              - end_bracket: )
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+        - from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table_a
+        - from_unpivot_expression:
+            keyword: unpivot
+            bracketed:
+            - start_bracket: (
+            - naked_identifier: a
+            - keyword: for
+            - naked_identifier: b
+            - keyword: in
+            - bracketed:
+              - start_bracket: (
+              - naked_identifier: col_1
+              - comma: ','
+              - naked_identifier: col_2
+              - comma: ','
+              - naked_identifier: col_3
+              - end_bracket: )
+            - end_bracket: )
+        - from_unpivot_expression:
+            keyword: unpivot
+            bracketed:
+            - start_bracket: (
+            - naked_identifier: c
+            - keyword: for
+            - naked_identifier: d
+            - keyword: in
+            - bracketed:
+              - start_bracket: (
+              - naked_identifier: col_a
+              - comma: ','
+              - naked_identifier: col_b
+              - comma: ','
+              - naked_identifier: col_c
               - end_bracket: )
             - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Closes https://github.com/sqlfluff/sqlfluff/issues/4241

I wasn't sure if two unpivots was really possible, but [StackOverflow has it](https://stackoverflow.com/a/64331728/3869802).

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
