### PR TITLE
Templated fix improvements and indentation

### DIFF
--- a/src/sqlfluff/core/parser/segments/meta.py
+++ b/src/sqlfluff/core/parser/segments/meta.py
@@ -233,7 +233,7 @@ class TemplateSegment(MetaSegment):
             raise ValueError(
                 "Cannot set raw of a template placeholder!"
             )  # pragma: no cover
-        
+
         if source_fixes or self.source_fixes:
             sf = (source_fixes or []) + (self.source_fixes + [])
         else:

--- a/src/sqlfluff/core/parser/segments/meta.py
+++ b/src/sqlfluff/core/parser/segments/meta.py
@@ -236,7 +236,9 @@ class TemplateSegment(MetaSegment):
 
         if source_fixes or self.source_fixes:
             sf = (source_fixes or []) + (self.source_fixes + [])
-        else:
+        else:  # pragma: no cover
+            # There's _usually_ a source fix if we're editing a templated
+            # segment - but not necessarily guaranteed.
             sf = None
         return self.__class__(
             pos_marker=self.pos_marker,

--- a/src/sqlfluff/core/parser/segments/meta.py
+++ b/src/sqlfluff/core/parser/segments/meta.py
@@ -165,7 +165,8 @@ class TemplateSegment(MetaSegment):
         block_uuid: Optional[UUID] = None,
     ):
         """Initialise a placeholder with the source code embedded."""
-        if not source_str:  # pragma: no cover
+        # NOTE: Empty string is ok, None is not.
+        if source_str is None:  # pragma: no cover
             raise ValueError("Cannot instantiate TemplateSegment without a source_str.")
         self.source_str = source_str
         self.block_type = block_type

--- a/src/sqlfluff/core/parser/segments/meta.py
+++ b/src/sqlfluff/core/parser/segments/meta.py
@@ -233,10 +233,15 @@ class TemplateSegment(MetaSegment):
             raise ValueError(
                 "Cannot set raw of a template placeholder!"
             )  # pragma: no cover
+        
+        if source_fixes or self.source_fixes:
+            sf = (source_fixes or []) + (self.source_fixes + [])
+        else:
+            sf = None
         return self.__class__(
             pos_marker=self.pos_marker,
             source_str=source_str if source_str is not None else self.source_str,
             block_type=self.block_type,
-            source_fixes=source_fixes or self.source_fixes,
+            source_fixes=sf,
             block_uuid=self.block_uuid,
         )

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -672,7 +672,7 @@ def _lint_line_starting_indent(
             fixes = [
                 LintFix.replace(
                     init_seg,
-                    [init_seg.edit(source_fixes=[src_fix])],
+                    [init_seg.edit(source_fixes=[src_fix], source_str="")],
                 )
             ]
         else:

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -587,7 +587,7 @@ def _deduce_line_current_indent(
             # Is the placeholder a consumed whitespace?
             if seg.source_str.startswith((" ", "\t")):
                 indent_seg = seg
-        # Otherwise it's n initial leading literal whitespace.
+        # Otherwise it's an initial leading literal whitespace.
         else:
             reflow_logger.debug("    Handling as initial leading whitespace")
             for indent_seg in elements[0].segments[::-1]:

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -678,6 +678,7 @@ def _lint_line_starting_indent(
     if indent_points[0].idx == 0 and not indent_points[0].is_line_break:
         init_seg = elements[indent_points[0].idx].segments[0]
         if init_seg.is_type("placeholder"):
+            init_seg = cast(TemplateSegment, init_seg)
             # If it's a placeholder initial indent, then modify the placeholder
             # to remove the indent from it.
             src_fix = SourceFix(

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -7,7 +7,7 @@ from typing import Iterator, List, Optional, Set, Tuple, cast, Dict, DefaultDict
 from dataclasses import dataclass
 from sqlfluff.core.errors import SQLFluffUserError
 
-from sqlfluff.core.parser.segments import Indent
+from sqlfluff.core.parser.segments import Indent, SourceFix
 
 from sqlfluff.core.parser import (
     RawSegment,
@@ -578,16 +578,24 @@ def _deduce_line_current_indent(
         0
     ].pos_marker.working_loc == (1, 1):
         # No last_line_break_idx, but this is a point. It's the first line.
-        # Get the last whitespace element.
-        # TODO: We don't currently handle the leading swallowed whitespace case.
-        # That could be added here, but it's an edge case which can be done
-        # at a later date easily. For now it won't get picked up.
-        for indent_seg in elements[0].segments[::-1]:
-            if indent_seg.is_type("whitespace"):
-                break
-        # Handle edge case of no whitespace, but with newline.
-        if not indent_seg.is_type("whitespace"):
-            indent_seg = None
+
+        # First check whether this is a first line with a leading
+        # placeholder.
+        if elements[0].segments[0].is_type("placeholder"):
+            reflow_logger.debug("    Handling as initial leading placeholder")
+            seg = cast(TemplateSegment, elements[0].segments[0])
+            # Is the placeholder a consumed whitespace?
+            if seg.source_str.startswith((" ", "\t")):
+                indent_seg = seg
+        # Otherwise it's n initial leading literal whitespace.
+        else:
+            reflow_logger.debug("    Handling as initial leading whitespace")
+            for indent_seg in elements[0].segments[::-1]:
+                if indent_seg.is_type("whitespace"):
+                    break
+            # Handle edge case of no whitespace, but with newline.
+            if not indent_seg.is_type("whitespace"):
+                indent_seg = None
 
     if not indent_seg:
         return ""
@@ -652,10 +660,28 @@ def _lint_line_starting_indent(
 
     # Initial point gets special handling if it has no newlines.
     if indent_points[0].idx == 0 and not indent_points[0].is_line_break:
+        init_seg = elements[indent_points[0].idx].segments[0]
+        if init_seg.is_type("placeholder"):
+            # If it's a placeholder initial indent, then modify the placeholder
+            # to remove the indent from it.
+            src_fix = SourceFix(
+                "",
+                source_slice=slice(0, len(current_indent) + 1),
+                templated_slice=slice(0, 0),
+            )
+            fixes = [
+                LintFix.replace(
+                    init_seg,
+                    [init_seg.edit(source_fixes=[src_fix])],
+                )
+            ]
+        else:
+            # Otherwise it's just initial whitespace. Remove it.
+            fixes = [LintFix.delete(seg) for seg in initial_point.segments]
         new_results = [
             LintResult(
                 initial_point.segments[0],
-                [LintFix.delete(seg) for seg in initial_point.segments],
+                fixes,
                 description="First line should not be indented.",
                 source="reflow.indent.existing",
             )

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -1437,3 +1437,15 @@ test_fail_fix_beside_templated:
         FROM t
         WHERE c < 0
     {% endif %}
+
+test_fail_hard_templated_indents:
+  # Test for consumed initial indents and consumed line indents.
+  # https://github.com/sqlfluff/sqlfluff/issues/4230
+  fail_str: |
+      {%- if true -%}
+    SELECT * FROM {{ "t1" }}
+      {%- endif %}
+  fix_str: |
+    {%- if true -%}
+        SELECT * FROM {{ "t1" }}
+    {%- endif %}

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -1441,11 +1441,14 @@ test_fail_fix_beside_templated:
 test_fail_hard_templated_indents:
   # Test for consumed initial indents and consumed line indents.
   # https://github.com/sqlfluff/sqlfluff/issues/4230
-  fail_str: |
+  # NOTE: We're using a block indentation indicator because the
+  # test query has initial leading whitespace.
+  # https://yaml.org/spec/1.2.2/#8111-block-indentation-indicator
+  fail_str: |2
       {%- if true -%}
     SELECT * FROM {{ "t1" }}
       {%- endif %}
-  fix_str: |
+  fix_str: |2
     {%- if true -%}
         SELECT * FROM {{ "t1" }}
     {%- endif %}

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -449,7 +449,7 @@ test_fail_consecutive_hangers_implicit:
         and f like 'f%'
   configs:
     indentation:
-      allow_implicit_indents: True
+      allow_implicit_indents: true
 
 test_fail_clean_reindent_fix:
   # A "clean" indent is where the previous line ends with an
@@ -1382,7 +1382,7 @@ test_pass_implicit_indent:
         AND b
   configs:
     indentation:
-      allow_implicit_indents: True
+      allow_implicit_indents: true
 
 test_fail_deny_implicit_indent:
   # Test for ImplicitIndent.
@@ -1400,7 +1400,7 @@ test_fail_deny_implicit_indent:
         AND b
   configs:
     indentation:
-      allow_implicit_indents: False
+      allow_implicit_indents: false
 
 test_pass_templated_newlines:
   # NOTE: The macro has many newlines in it,
@@ -1531,4 +1531,3 @@ test_fail_hard_templated_indents:
     {%- if true -%}
         SELECT * FROM {{ "t1" }}
     {%- endif %}
-

--- a/test/fixtures/rules/std_rule_cases/L016.yml
+++ b/test/fixtures/rules/std_rule_cases/L016.yml
@@ -490,7 +490,7 @@ test_fix_implicit_indent:
     core:
       max_line_length: 45
     indentation:
-      allow_implicit_indents: True
+      allow_implicit_indents: true
 
 test_fix_no_implicit_indent:
   # Test explicitly preventing implicit indents.
@@ -530,4 +530,4 @@ test_fix_no_implicit_indent:
     core:
       max_line_length: 45
     indentation:
-      allow_implicit_indents: False
+      allow_implicit_indents: false


### PR DESCRIPTION
This resolves #4230 .

It also brings in fixes to a few issues presented by the test query from the issue above:
1. Handing leading templated whitespace on the first line.
2. Allowing multiple source fixes in a single segment.
3. Allowing the `source_str` of a templated segment to be an empty string.