### PR TITLE
Improve Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,14 @@ WORKDIR /app
 ENV VIRTUAL_ENV /app/.venv
 RUN python -m venv $VIRTUAL_ENV
 ENV PATH $VIRTUAL_ENV/bin:$PATH
-RUN pip install --upgrade pip setuptools wheel
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 
 # Install requirements separately
 # to take advantage of layer caching.
 # N.B. we extract the requirements from setup.cfg
 COPY setup.cfg .
 RUN python -c "import configparser; c = configparser.ConfigParser(); c.read('setup.cfg'); print(c['options']['install_requires'])" > requirements.txt
-RUN pip install --upgrade -r requirements.txt
+RUN pip install --no-cache-dir --upgrade -r requirements.txt
 
 # Copy minimal set of SQLFluff package files.
 COPY MANIFEST.in .
@@ -23,7 +23,7 @@ COPY setup.py .
 COPY src ./src
 
 # Install sqlfluff package.
-RUN pip install --no-dependencies .
+RUN pip install --no-cache-dir --no-dependencies .
 
 # Switch to non-root user.
 USER 5000


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

The change I made:
* I added the `--no-cache-dir` to the `pip` command to disable the package cache.


Impact on the image size:
* Image size before repair: 208.15 MB
* Image size after repair: 196.42 MB
* Difference: 11.74 MB (5.64%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,