### PR TITLE
SparkSQL: Support DIV binary operator

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -339,6 +339,19 @@ sparksql_dialect.replace(
         "QUALIFY",
         "WINDOW",
     ),
+    ArithmeticBinaryOperatorGrammar=OneOf(
+        Ref("PlusSegment"),
+        Ref("MinusSegment"),
+        Ref("DivideSegment"),
+        Ref("MultiplySegment"),
+        Ref("ModuloSegment"),
+        Ref("BitwiseAndSegment"),
+        Ref("BitwiseOrSegment"),
+        Ref("BitwiseXorSegment"),
+        Ref("BitwiseLShiftSegment"),
+        Ref("BitwiseRShiftSegment"),
+        Ref("DivBinaryOperatorSegment")
+    ),
     BinaryOperatorGrammar=OneOf(
         Ref("ArithmeticBinaryOperatorGrammar"),
         Ref("StringBinaryOperatorGrammar"),
@@ -659,6 +672,13 @@ sparksql_dialect.insert_lexer_matchers(
     ],
     before="like_operator",
 )
+
+
+class DivBinaryOperatorSegment(BaseSegment):
+    """DIV type binary_operator."""
+
+    type = "binary_operator"
+    match_grammar = Ref.keyword("DIV")
 
 
 class QualifyClauseSegment(BaseSegment):

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -350,7 +350,7 @@ sparksql_dialect.replace(
         Ref("BitwiseXorSegment"),
         Ref("BitwiseLShiftSegment"),
         Ref("BitwiseRShiftSegment"),
-        Ref("DivBinaryOperatorSegment")
+        Ref("DivBinaryOperatorSegment"),
     ),
     BinaryOperatorGrammar=OneOf(
         Ref("ArithmeticBinaryOperatorGrammar"),

--- a/test/fixtures/dialects/sparksql/select_div.sql
+++ b/test/fixtures/dialects/sparksql/select_div.sql
@@ -1,0 +1,1 @@
+SELECT 3 DIV 2;

--- a/test/fixtures/dialects/sparksql/select_div.yml
+++ b/test/fixtures/dialects/sparksql/select_div.yml
@@ -1,0 +1,18 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 51cb10bd9421e08eb8915768a600cb5424ff64f19b8ecc513413f82ea2da8a15
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '3'
+          - binary_operator:
+              keyword: DIV
+          - numeric_literal: '2'
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
SparkSQL, support DIV binary operator
Fixes #4117 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
