### PR TITLE
Fix #4249 (TSQL block comment indents)

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -179,6 +179,7 @@ tsql_dialect.patch_lexer_matchers(
                 r"[^\S\r\n]+",
                 WhitespaceSegment,
             ),
+            segment_kwargs={"type": "block_comment"},
         ),
         RegexLexer(
             "code", r"[0-9a-zA-Z_#@]+", CodeSegment

--- a/test/fixtures/rules/std_rule_cases/L003.yml
+++ b/test/fixtures/rules/std_rule_cases/L003.yml
@@ -1570,3 +1570,19 @@ test_fail_coverage_indent_trough:
         FROM foo
     )
     SELECT a FROM bar
+
+test_indented_comment_tsql:
+  # TSQL redefines the block_comment. This checks that is done correctly.
+  # https://github.com/sqlfluff/sqlfluff/issues/4249
+  pass_str: |
+    /*
+
+        Author:                     tester
+        Create date:                2021-03-16
+
+    */
+
+    SELECT 1 AS a
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
This resolves #4249 .

The redefinition of `block_comment` in the `tsql` dialect was missing the `type` argument required for the fix in #4240 to work.