### PR TITLE
Fix #4253 (incorrect trigger of L006 around placeholders)

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -120,6 +120,13 @@ spacing_within = inline
 spacing_before = any
 spacing_after = any
 
+[sqlfluff:layout:type:placeholder]
+# Placeholders exist "outside" the rendered SQL syntax
+# so we shouldn't enforce any particular spacing around
+# them.
+spacing_before = any
+spacing_after = any
+
 # By setting a selection of clauses to "alone", we hint to the reflow
 # algorithm that in the case of a long single line statement, the
 # first place to add newlines would be around these clauses.

--- a/test/fixtures/rules/std_rule_cases/L006.yml
+++ b/test/fixtures/rules/std_rule_cases/L006.yml
@@ -89,3 +89,21 @@ pass_tsql_assignment_operator:
 
 pass_concat_string:
   pass_str: SELECT 'barry' || 'pollard'
+
+test_pass_placeholder_spacing:
+  # Test for spacing issues around placeholders
+  # https://github.com/sqlfluff/sqlfluff/issues/4253
+  pass_str: |
+    {% set is_dev_environment = true %}
+
+    SELECT *
+    FROM table
+    WHERE
+        some_col IS TRUE
+        {% if is_dev_environment %}
+            AND created_at >= DATE_SUB(CURRENT_DATE, INTERVAL 7 DAY)
+        {% else %}
+            AND created_at >= DATE_SUB(CURRENT_DATE, INTERVAL 30 DAY)
+        {% endif %}
+        AND TRUE
+    ;


### PR DESCRIPTION
Placeholders shouldn't trigger spacing rules because they don't exist in the rendered SQL. This adds the `any` config for their spacing so we don't try to enforce anything.

There's probably something more subtle we could do here, but this will work for 99% of people. Ideally we would still complain if there was too much whitespace, but not if there wasn't enough. That isn't currently a configuration option however.