### PR TITLE
Fix #4255 (Fix exception on mixed indent description)

### DIFF
--- a/src/sqlfluff/utils/reflow/elements.py
+++ b/src/sqlfluff/utils/reflow/elements.py
@@ -166,9 +166,21 @@ class ReflowBlock(ReflowElement):
 
 
 def _indent_description(indent: str):
-    """Construct a human readable description of the indent."""
+    """Construct a human readable description of the indent.
+
+    NOTE: We operate assuming that the "correct" indent is
+    never a mix of tabs and spaces. That means if the provided
+    indent *does* contain both that this description is likely
+    a case where we are matching a pre-existing indent, and can
+    assume that the *description* of that indent is non-critical.
+    To handle that situation gracefully we just return "Mixed Indent".
+
+    See: https://github.com/sqlfluff/sqlfluff/issues/4255
+    """
     if indent == "":
         return "no indent"
+    elif " " in indent and "\t" in indent:
+        return "mixed indent"
     elif indent[0] == " ":
         assert all(c == " " for c in indent)
         return f"indent of {len(indent)} spaces"

--- a/test/fixtures/rules/std_rule_cases/L019.yml
+++ b/test/fixtures/rules/std_rule_cases/L019.yml
@@ -328,3 +328,37 @@ trailing_comma_with_templated_column_2:
         {{ "c1
     " }}, c2 AS days_since
     FROM logs
+
+leading_comma_fix_mixed_indent:
+  # See: https://github.com/sqlfluff/sqlfluff/issues/4255
+  # NOTE: Undisturbed mixed indent.
+  fail_str: |
+    select B
+    	  ,C
+    from A
+  fix_str: |
+    select B,
+    	  C
+    from A
+  configs:
+    layout:
+      type:
+        comma:
+          line_position: trailing
+
+trailing_comma_fix_mixed_indent:
+  # See: https://github.com/sqlfluff/sqlfluff/issues/4255
+  # NOTE: Undisturbed mixed indent.
+  fail_str: |
+    select B,
+    	  C
+    from A
+  fix_str: |
+    select B
+    	  , C
+    from A
+  configs:
+    layout:
+      type:
+        comma:
+          line_position: leading


### PR DESCRIPTION
This resolves #4255 . The problem arises from trying to make a description for a mixed indent, which we don't actually need. This resolves that gracefully by providing a generic "mixed indent" return so that things can complete nicely.