### PR TITLE
Simplify lexing

### DIFF
--- a/src/sqlfluff/core/parser/lexer.py
+++ b/src/sqlfluff/core/parser/lexer.py
@@ -655,7 +655,7 @@ class Lexer:
 
         self.last_resort_lexer = last_resort_lexer or RegexLexer(
             "<unlexable>",
-            r"[^\t\n\,\.\ \-\+\*\\\/\'\"\;\:\[\]\(\)\|]*",
+            r"[^\t\n\ ]*",
             UnlexableSegment,
         )
 
@@ -687,7 +687,7 @@ class Lexer:
                 if not resort_res:  # pragma: no cover
                     # If we STILL can't match, then just panic out.
                     raise SQLLexError(
-                        f"Fatal. Unable to lex characters: {0!r}".format(
+                        "Fatal. Unable to lex characters: {0!r}".format(
                             res.forward_string[:10] + "..."
                             if len(res.forward_string) > 9
                             else res.forward_string


### PR DESCRIPTION
I think this resolves #4251 - which is really two small bugs:
1. The error is using `.format()` and a f-string, and so doesn't render the remaining characters properly.
2. For some trailing characters, the lexing error doesn't work as intended. In particular the `r"[^\t\n\,\.\ \-\+\*\\\/\'\"\;\:\[\]\(\)\|]*"` regex for unlexable characters was added in #185 (yes back in 2020!), and the commentary on that PR isn't clear on why so many characters are excluded.

The tests might fail on this PR, but if not - I think it's a sensible simplification.