### PR TITLE
Fix #4024 example plugin unit tests import

### DIFF
--- a/plugins/sqlfluff-plugin-example/test/rules/rule_test_cases_test.py
+++ b/plugins/sqlfluff-plugin-example/test/rules/rule_test_cases_test.py
@@ -1,7 +1,7 @@
 """Runs the rule test cases."""
 import os
 import pytest
-from sqlfluff.testing.rules import load_test_cases, rules__test_helper
+from sqlfluff.utils.testing.rules import load_test_cases, rules__test_helper
 
 ids, test_cases = load_test_cases(
     test_cases_path=os.path.join(


### PR DESCRIPTION
### Brief summary of the change made

- Fix a broken import in the example plugin.
- Fixes #4024 

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist

I don't believe any item below applies here. But it'd be great of course if the example plugin unit tests would run in CI.

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
