### PR TITLE
toml: only install `toml` dependency if < Python 3.11 (otherwise use builtin `tomllib`)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ regex
 # For returning exceptions from multiprocessing.Pool.map()
 tblib
 # For parsing pyproject.toml
-toml
+toml; python_version < '3.11'
 # For handling progress bars
 tqdm
 # better type hints for older python versions

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,7 +96,7 @@ install_requires =
     # For returning exceptions from multiprocessing.Pool.map()
     tblib
     # For parsing pyproject.toml
-    toml
+    toml; python_version < '3.11'
     # For handling progress bars
     tqdm
     # better type hints for older python versions

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -4,6 +4,7 @@ import logging
 import os
 import os.path
 import configparser
+import sys
 from dataclasses import dataclass
 
 import pluggy
@@ -15,7 +16,10 @@ from sqlfluff.core.errors import SQLFluffUserError
 
 import appdirs
 
-import toml
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import toml as tomllib
 
 # Instantiate the config logger
 config_logger = logging.getLogger("sqlfluff.config")
@@ -347,7 +351,8 @@ class ConfigLoader:
         The return value is a list of tuples, were each tuple has two elements,
         the first is a tuple of paths, the second is the value at that path.
         """
-        config = toml.load(fpath)
+        with open(fpath, mode="r") as file:
+            config = tomllib.loads(file.read())
         tool = config.get("tool", {}).get("sqlfluff", {})
 
         return cls._walk_toml(tool)


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Now that Python 3.11+ supports reading `.toml` files with [the builtin `tomllib` module](https://docs.python.org/3/library/tomllib.html), we can just use that instead of installing the 3rd party package `toml`. On Python 3.10 and lower, `toml` will still be installed.

### Are there any other side effects of this change that we should be aware of?

No, I've just tested this on Python 3.8 and Python 3.11, so will see what the full `ci-tests` returns (might need to tweak the `# pragma: no cover` comment).

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
