### PR TITLE
Bracket complex expressions before applying :: operator in Rule L067

### DIFF
--- a/src/sqlfluff/rules/L067.py
+++ b/src/sqlfluff/rules/L067.py
@@ -174,11 +174,20 @@ class Rule_L067(BaseRule):
         context: RuleContext, shorthand_arg_1: BaseSegment, shorthand_arg_2: BaseSegment
     ) -> List[LintFix]:
         """Generate list of fixes to convert CAST and CONVERT to ShorthandCast."""
-        edits = [
-            shorthand_arg_1,
-            SymbolSegment("::", type="casting_operator"),
-            shorthand_arg_2,
-        ]
+        if len(shorthand_arg_1.raw_segments) > 1:
+            edits = [
+                SymbolSegment("(", type="start_bracket"),
+                shorthand_arg_1,
+                SymbolSegment(")", type="end_bracket"),
+            ]
+        else:
+            edits = [shorthand_arg_1]
+        edits.extend(
+            [
+                SymbolSegment("::", type="casting_operator"),
+                shorthand_arg_2,
+            ]
+        )
 
         fixes = [
             LintFix.replace(

--- a/test/fixtures/rules/std_rule_cases/L067.yml
+++ b/test/fixtures/rules/std_rule_cases/L067.yml
@@ -320,3 +320,37 @@ test_pass_when_dialect_is_teradata:
   configs:
     core:
       dialect: teradata
+
+
+test_fail_parenthesize_expression_when_config_shorthand_from_cast:
+  fail_str: |
+    select
+        id::int,
+        cast(calendar_date||' 11:00:00' as timestamp) as calendar_datetime
+    from foo;
+  fix_str: |
+    select
+        id::int,
+        (calendar_date||' 11:00:00')::timestamp as calendar_datetime
+    from foo;
+  configs:
+    rules:
+      L067:
+        preferred_type_casting_style: shorthand
+
+
+test_fail_parenthesize_expression_when_config_shorthand_from_convert:
+  fail_str: |
+    select
+        id::int,
+        convert(timestamp, calendar_date||' 11:00:00') as calendar_datetime
+    from foo;
+  fix_str: |
+    select
+        id::int,
+        (calendar_date||' 11:00:00')::timestamp as calendar_datetime
+    from foo;
+  configs:
+    rules:
+      L067:
+        preferred_type_casting_style: shorthand


### PR DESCRIPTION
### Brief summary of the change made

This surrounds complex expressions with `()` before fixing a cast or convert to a shorthand cast using the `::` operator. Without this change, the cast would be applied to only part of the appropriate expression.

fixes #4301

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
