### PR TITLE
BigQuery: SELECT DISTINCT AS STRUCT

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -693,8 +693,8 @@ class SelectClauseModifierSegment(ansi.SelectClauseModifierSegment):
 
     match_grammar = Sequence(
         # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax
-        Sequence("AS", OneOf("STRUCT", "VALUE"), optional=True),
         OneOf("DISTINCT", "ALL", optional=True),
+        Sequence("AS", OneOf("STRUCT", "VALUE"), optional=True),
     )
 
 

--- a/test/fixtures/dialects/bigquery/select_struct.sql
+++ b/test/fixtures/dialects/bigquery/select_struct.sql
@@ -13,6 +13,10 @@ select as struct
   '1' as bb,
   2 as aa;
 
+select distinct as struct
+    '1' as bb,
+    2 as aa;
+
 -- Example of explicitly building a struct in a select clause.
 select
   struct(

--- a/test/fixtures/dialects/bigquery/select_struct.yml
+++ b/test/fixtures/dialects/bigquery/select_struct.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1904673c879383bfd4b5053b1af3ff5eda6317ab68619647a3910c79a2d0107a
+_hash: 099d904a7e9dcceb73016d13237d27d6770f4857540a51c53c5aff39529b5b81
 file:
 - statement:
     select_statement:
@@ -65,6 +65,26 @@ file:
       select_clause:
       - keyword: select
       - select_clause_modifier:
+        - keyword: as
+        - keyword: struct
+      - select_clause_element:
+          quoted_literal: "'1'"
+          alias_expression:
+            keyword: as
+            naked_identifier: bb
+      - comma: ','
+      - select_clause_element:
+          numeric_literal: '2'
+          alias_expression:
+            keyword: as
+            naked_identifier: aa
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: select
+      - select_clause_modifier:
+        - keyword: distinct
         - keyword: as
         - keyword: struct
       - select_clause_element:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

fixes https://github.com/sqlfluff/sqlfluff/issues/4339

I believe sqlfluff's parser had an error in the order of:

- `[ { DISTINCT | ALL } ]`; and
- `[ AS { STRUCT | VALUE } ]`.

so that sqlfluff would parse e.g.
```sql
SELECT AS STRUCT DISTINCT id FROM table;
```
which BigQuery does not parse, BigQuery's grammar for `SELECT` looks
like this:

> ```
> SELECT
>     [ { ALL | DISTINCT } ]
>     [ AS { STRUCT | VALUE } ]
>    select_list
> ```
> — https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_list

This commit changes the order of

- `[ { DISTINCT | ALL } ]`; and
- `[ AS { STRUCT | VALUE } ]`

so that sqlfluff parses what BigQuery parses, i.e. e.g.:
```sql
SELECT DISTINCT AS STRUCT id FROM table;
```

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.
- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
