### PR TITLE
Snowflake: Fix Alter Warehouse

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1891,7 +1891,7 @@ class AlterWarehouseStatementSegment(BaseSegment):
                 Ref("NakedIdentifierSegment"),
             ),
             Sequence(
-                Ref("NakedIdentifierSegment"),
+                Ref("NakedIdentifierSegment", optional=True),
                 "SET",
                 OneOf(
                     AnyNumberOf(

--- a/test/fixtures/dialects/snowflake/snowflake_alter_warehouse.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_warehouse.sql
@@ -21,3 +21,7 @@ alter warehouse LOAD_WH SET MAX_CONCURRENCY_LEVEL = 1;
 alter warehouse LOAD_WH UNSET STATEMENT_QUEUED_TIMEOUT_IN_SECONDS;
 alter warehouse LOAD_WH UNSET WAREHOUSE_SIZE;
 alter warehouse LOAD_WH UNSET WAREHOUSE_SIZE, WAIT_FOR_COMPLETION;
+
+-- Real Life Use Cases Taken from Issue 4342 https://github.com/sqlfluff/sqlfluff/issues/4342
+ALTER WAREHOUSE SET WAREHOUSE_SIZE='X-LARGE';
+alter warehouse set warehouse_size=medium

--- a/test/fixtures/dialects/snowflake/snowflake_alter_warehouse.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_warehouse.sql
@@ -22,6 +22,5 @@ alter warehouse LOAD_WH UNSET STATEMENT_QUEUED_TIMEOUT_IN_SECONDS;
 alter warehouse LOAD_WH UNSET WAREHOUSE_SIZE;
 alter warehouse LOAD_WH UNSET WAREHOUSE_SIZE, WAIT_FOR_COMPLETION;
 
--- Real Life Use Cases Taken from Issue 4342 https://github.com/sqlfluff/sqlfluff/issues/4342
 ALTER WAREHOUSE SET WAREHOUSE_SIZE='X-LARGE';
 alter warehouse set warehouse_size=medium

--- a/test/fixtures/dialects/snowflake/snowflake_alter_warehouse.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_warehouse.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4665ce4dc4718052ca9b6e69c12240d80062e18fdd955eda3471183c70e3a40e
+_hash: 6aef694b439b392aca42cbf1d8e3d55dd6b90b9c6489ff07af83528e281a1fdc
 file:
 - statement:
     alter_warehouse_statement:
@@ -271,3 +271,24 @@ file:
     - comma: ','
     - naked_identifier: WAIT_FOR_COMPLETION
 - statement_terminator: ;
+- statement:
+    alter_warehouse_statement:
+    - keyword: ALTER
+    - keyword: WAREHOUSE
+    - keyword: SET
+    - warehouse_object_properties:
+        keyword: WAREHOUSE_SIZE
+        comparison_operator:
+          raw_comparison_operator: '='
+        warehouse_size: "'X-LARGE'"
+- statement_terminator: ;
+- statement:
+    alter_warehouse_statement:
+    - keyword: alter
+    - keyword: warehouse
+    - keyword: set
+    - warehouse_object_properties:
+        keyword: warehouse_size
+        comparison_operator:
+          raw_comparison_operator: '='
+        warehouse_size: medium


### PR DESCRIPTION
### Brief summary of the change made
Added optional parameter on the Snowflake Alter Warehouse SET command step.

While the documentation lists that field as required by first running `USE WAREHOUSE` or selecting a Warehouse prior to running the command it will target the active selected warehouse.

https://github.com/sqlfluff/sqlfluff/issues/4342

### Pull Request checklist
- [ X ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
