### PR TITLE
Postgres: TABLESAMPLE query

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -246,6 +246,7 @@ postgres_dialect.add(
     ),
     CascadeRestrictGrammar=OneOf("CASCADE", "RESTRICT"),
     RightArrowSegment=StringParser("=>", SymbolSegment, type="right_arrow"),
+    BernoulliGrammer=StringParser("BERNOULLI", CodeSegment, type="non_keyword"),
 )
 
 postgres_dialect.replace(
@@ -1175,6 +1176,16 @@ class ForClauseSegment(BaseSegment):
             Sequence("SKIP", "LOCKED"),
             optional=True,
         ),
+    )
+
+
+class SamplingExpressionSegment(ansi.SamplingExpressionSegment):
+    """Overrides ANSI Statement. to allow TABLESAMPLE statements for Postgres."""
+
+    match_grammar = ansi.SamplingExpressionSegment.match_grammar.copy(
+        insert=[OneOf(Ref("BernoulliGrammer"), "SYSTEM")],
+        before=OneOf("BERNOULLI", "SYSTEM"),
+        remove=[OneOf("BERNOULLI", "SYSTEM")],
     )
 
 

--- a/test/fixtures/dialects/postgres/postgres_select.sql
+++ b/test/fixtures/dialects/postgres/postgres_select.sql
@@ -81,4 +81,6 @@ ORDER BY sync_time ASC
 FOR SHARE OF mytable1, mytable2 SKIP LOCKED
 LIMIT 1;
 
+Select * from foo TABLESAMPLE SYSTEM (10);
 
+Select * from foo TABLESAMPLE BERNOULLI (10);

--- a/test/fixtures/dialects/postgres/postgres_select.yml
+++ b/test/fixtures/dialects/postgres/postgres_select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 853194d18bbeb03a93c9e91a375c5273675fc2f8b33ff3a636a45c9ffa127a9c
+_hash: 5f02dcc7b7f77bac802dfa4ec4eed5bd2bc024d406fe5bd492a49f0e100e03af
 file:
 - statement:
     select_statement:
@@ -794,4 +794,50 @@ file:
       limit_clause:
         keyword: LIMIT
         numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: Select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foo
+            sample_expression:
+            - keyword: TABLESAMPLE
+            - keyword: SYSTEM
+            - bracketed:
+                start_bracket: (
+                numeric_literal: '10'
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: Select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foo
+            sample_expression:
+              keyword: TABLESAMPLE
+              non_keyword: BERNOULLI
+              bracketed:
+                start_bracket: (
+                numeric_literal: '10'
+                end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
fixes #4343 

Added a Postgres specific `SamplingExpressionSegment` to allow TABLESAMPLE queries to be executed.

Error was being thrown as `Bernoulli` is not considered a Keyword in Postgres. Because of this added a Grammer object to detect it and updated the Segment to detect it.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ X ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
