### PR TITLE
Allowed Naked Identifiers

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1731,7 +1731,10 @@ class CreateTableAsStatementSegment(BaseSegment):
                                 Ref("ParameterNameSegment"),
                                 Sequence(
                                     Ref("EqualsSegment"),
-                                    Ref("LiteralGrammar"),
+                                    OneOf(
+                                        Ref("LiteralGrammar"),
+                                        Ref("NakedIdentifierSegment"),
+                                    ),
                                     optional=True,
                                 ),
                             )

--- a/test/fixtures/dialects/postgres/postgres_create_table_as.sql
+++ b/test/fixtures/dialects/postgres/postgres_create_table_as.sql
@@ -124,3 +124,12 @@ select
     , column_2
     , column_3
 from tablename;
+
+create temp table a_new_table
+with (appendoptimized = true, compresstype = zstd) as
+select
+    column_1
+    , column_2
+    , column_3
+from schema.tablename
+group by 1, 2, 3;

--- a/test/fixtures/dialects/postgres/postgres_create_table_as.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_table_as.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a173e35f5a32531d5851dea1cdff082b24fc506d293846086600078659ff8300
+_hash: 1ae3c61fd8e9753e50ab692f5949825c30fa47744146dc30d1fa774fca367f3d
 file:
 - statement:
     create_table_as_statement:
@@ -605,4 +605,57 @@ file:
               table_expression:
                 table_reference:
                   naked_identifier: tablename
+- statement_terminator: ;
+- statement:
+    create_table_as_statement:
+    - keyword: create
+    - keyword: temp
+    - keyword: table
+    - table_reference:
+        naked_identifier: a_new_table
+    - keyword: with
+    - bracketed:
+      - start_bracket: (
+      - parameter: appendoptimized
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - boolean_literal: 'true'
+      - comma: ','
+      - parameter: compresstype
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - naked_identifier: zstd
+      - end_bracket: )
+    - keyword: as
+    - select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            column_reference:
+              naked_identifier: column_1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: column_2
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: column_3
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: schema
+                - dot: .
+                - naked_identifier: tablename
+        groupby_clause:
+        - keyword: group
+        - keyword: by
+        - numeric_literal: '1'
+        - comma: ','
+        - numeric_literal: '2'
+        - comma: ','
+        - numeric_literal: '3'
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
fixes https://github.com/sqlfluff/sqlfluff/issues/4297

Allows non quoted strings as parameter values in the storage parameters.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
