### PR TITLE
Bugfix: Duckdb SELECT *

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -51,6 +51,7 @@ class SelectClauseElementSegment(ansi.SelectClauseElementSegment):
                         )
                     ),
                 ),
+                optional=True,
             ),
         ),
         Sequence(

--- a/test/fixtures/dialects/duckdb/select_exclude.sql
+++ b/test/fixtures/dialects/duckdb/select_exclude.sql
@@ -5,3 +5,5 @@ SELECT
     ff.* EXCLUDE cancellation
 FROM star_wars sw, firefly ff
 ;
+
+SELECT * FROM star_wars;

--- a/test/fixtures/dialects/duckdb/select_exclude.yml
+++ b/test/fixtures/dialects/duckdb/select_exclude.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 242d1eeab3eff81b4b5dbccabb71871da62ceacd2e365d03e84469e8fe0320af
+_hash: a1d2d32acf940f030e8c387c2b2f487c10e99d359a2bfad44face163eb61b380
 file:
 - statement:
     select_statement:
@@ -76,4 +76,20 @@ file:
                 naked_identifier: firefly
             alias_expression:
               naked_identifier: ff
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: star_wars
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
A missing optional meant that regular wildcard statements didn't work this fixes it.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
