### PR TITLE
TSQL: ALTER TABLE

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2274,12 +2274,11 @@ class AlterTableStatementSegment(BaseSegment):
                 ),
                 Sequence(
                     "ALTER",
-                    Ref.keyword("COLUMN", optional=True),
+                    "COLUMN",
                     Ref("ColumnDefinitionSegment"),
                 ),
                 Sequence(
                     "ADD",
-                    Ref.keyword("COLUMN", optional=True),
                     Delimited(
                         Ref("ColumnDefinitionSegment"),
                     ),

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2273,12 +2273,16 @@ class AlterTableStatementSegment(BaseSegment):
                     OneOf(Ref("LiteralGrammar"), Ref("NakedIdentifierSegment")),
                 ),
                 Sequence(
-                    OneOf(
-                        "ADD",
-                        "ALTER",
-                    ),
+                    "ALTER",
                     Ref.keyword("COLUMN", optional=True),
                     Ref("ColumnDefinitionSegment"),
+                ),
+                Sequence(
+                    "ADD",
+                    Ref.keyword("COLUMN", optional=True),
+                    Delimited(
+                        Ref("ColumnDefinitionSegment"),
+                    ),
                 ),
                 Sequence(
                     "DROP",

--- a/test/fixtures/dialects/tsql/alter_table.sql
+++ b/test/fixtures/dialects/tsql/alter_table.sql
@@ -49,3 +49,8 @@ GO
 ALTER TABLE [Production].[ProductCostHistory]
 CHECK CONSTRAINT [FK_ProductCostHistory_Product_ProductID]
 GO
+
+ALTER TABLE my_table
+ADD my_col_1 INT
+  , my_col_2 INT
+GO

--- a/test/fixtures/dialects/tsql/alter_table.yml
+++ b/test/fixtures/dialects/tsql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bbbad5fb91e122e0f46727338e622d1b17156cc1f6123ecbfa43d4b7ff1067c6
+_hash: 35e3531dd187cbfb6d8d0781923e3625d94649975c274aacdbf0f8cd1a94a56c
 file:
 - batch:
     statement:
@@ -365,5 +365,24 @@ file:
       - keyword: CONSTRAINT
       - object_reference:
           quoted_identifier: '[FK_ProductCostHistory_Product_ProductID]'
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: my_table
+      - keyword: ADD
+      - column_definition:
+          naked_identifier: my_col_1
+          data_type:
+            data_type_identifier: INT
+      - comma: ','
+      - column_definition:
+          naked_identifier: my_col_2
+          data_type:
+            data_type_identifier: INT
 - go_statement:
     keyword: GO


### PR DESCRIPTION
### Brief summary of the change made
fixes https://github.com/sqlfluff/sqlfluff/issues/3913

Added support for adding multiple columns in a single alter table statement,

Another way this could of been done is by keeping "ADD" and "ALTER" in the same statement and then nest `ColumnDefinitionSegment` in a `Delimited` optional. This would have the side effect though of letting invalid syntax correctly parse. This is because ALTER COLUMN only allows a single column.

Happy with either solution.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

### References

https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql?view=sql-server-ver16
