### PR TITLE
Added Varying Keyword to allowed data type segments

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1496,6 +1496,8 @@ class DatatypeSegment(BaseSegment):
             Ref("DatatypeIdentifierSegment"),
             Bracketed(Ref("DatatypeIdentifierSegment"), bracket_type="square"),
         ),
+        # Stop Gap until explicit Data Types as only relevent for character
+        Ref.keyword("VARYING", optional=True),
         Bracketed(
             OneOf(
                 "MAX",

--- a/test/fixtures/dialects/tsql/select.sql
+++ b/test/fixtures/dialects/tsql/select.sql
@@ -98,8 +98,8 @@ SELECT
 	[following]	= count(*) over(order by object_id ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING),
 
     EqualsAlias = ColumnName,
-    OtherColumnName AS AsAlias
-
+    OtherColumnName AS AsAlias,
+	cast(1 as character varying(1)),
+	cast([central] as int)
 
 FROM dbo . all_pop
-

--- a/test/fixtures/dialects/tsql/select.yml
+++ b/test/fixtures/dialects/tsql/select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7630efe8a7ecc90a37d262198a0df9e9db21e846a122560e8cd1f28f945a070f
+_hash: b4c21fdb7c7da799ab0928832c963cdd888a8559e6fb7725b83c77a834b99422
 file:
   batch:
     statement:
@@ -822,6 +822,39 @@ file:
             alias_expression:
               keyword: AS
               naked_identifier: AsAlias
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                keyword: cast
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '1'
+                keyword: as
+                data_type:
+                  data_type_identifier: character
+                  keyword: varying
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      numeric_literal: '1'
+                    end_bracket: )
+                end_bracket: )
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                keyword: cast
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    quoted_identifier: '[central]'
+                keyword: as
+                data_type:
+                  data_type_identifier: int
+                end_bracket: )
         from_clause:
           keyword: FROM
           from_expression:


### PR DESCRIPTION
### Brief summary of the change made
fixes https://github.com/sqlfluff/sqlfluff/issues/4095

Added optional `VARYING` keyword to data type segment for TSQL only. This could of either been done here or on the `DatatypeIdentifierSegment`. Since changing `DatatypeIdentifierSegment` would mean significant impact to the regex parsing I felt that the change here was safer.

Added additional test cases to check and validate.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
