### PR TITLE
Allow function names to have a leading underscore

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -349,7 +349,7 @@ ansi_dialect.add(
     VersionIdentifierSegment=RegexParser(r"[A-Z0-9_.]*", IdentifierSegment),
     ParameterNameSegment=RegexParser(r"[A-Z][A-Z0-9_]*", CodeSegment, type="parameter"),
     FunctionNameIdentifierSegment=RegexParser(
-        r"[A-Z][A-Z0-9_]*",
+        r"[A-Z_][A-Z0-9_]*",
         CodeSegment,
         type="function_name_identifier",
     ),

--- a/test/fixtures/dialects/ansi/functions_a.sql
+++ b/test/fixtures/dialects/ansi/functions_a.sql
@@ -1,4 +1,6 @@
 SELECT
     DATE(t), ROUND(b, 2),
     LEFT(right(s, 5), LEN(s + 6)) as compound
-FROM tbl_b
+FROM tbl_b;
+
+SELECT _custom_function(5) as test_column;

--- a/test/fixtures/dialects/ansi/functions_a.yml
+++ b/test/fixtures/dialects/ansi/functions_a.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bce31208bf7372db2c80a7234fa531cc2fbe5ba46697eea28c04df664095218f
+_hash: cddea2ed2c29465ac50497915f3647aa81be4ffb94314bf52367a5bfaee996d7
 file:
-  statement:
+- statement:
     select_statement:
       select_clause:
       - keyword: SELECT
@@ -77,3 +77,21 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: tbl_b
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: _custom_function
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '5'
+              end_bracket: )
+          alias_expression:
+            keyword: as
+            naked_identifier: test_column
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
fixes #4376
Added underscore as valid leading character for function names.


### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
