### PR TITLE
fix(RF06/L059): allows configuring prefer_quoted_keywords to deconflict with L029

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -362,6 +362,7 @@ ignore_words_regex = None
 [sqlfluff:rules:references.quoting]
 # Policy on quoted and unquoted identifiers
 prefer_quoted_identifiers = False
+prefer_quoted_keywords = False
 ignore_words = None
 ignore_words_regex = None
 force_enable = False

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -161,6 +161,13 @@ STANDARD_CONFIG_INFO_DICT = {
             "Defaults to ``False``."
         ),
     },
+    "prefer_quoted_keywords": {
+        "validation": [True, False],
+        "definition": (
+            "If ``True``, requires every keyword used as an identifier to be quoted. "
+            "Defaults to ``False``."
+        ),
+    },
     "blocked_words": {
         "definition": (
             "Optional, comma-separated list of blocked words which should not be used "

--- a/test/fixtures/rules/std_rule_cases/RF06.yml
+++ b/test/fixtures/rules/std_rule_cases/RF06.yml
@@ -380,3 +380,21 @@ test_fail_quoted_column_postgres_force_enable:
     rules:
       references.quoting:
         force_enable: true
+
+test_pass_prefer_quoted_keywords_athena:
+  pass_str: SELECT 1 AS "metadata"
+  configs:
+    rules:
+      references.quoting:
+        prefer_quoted_keywords: true
+    core:
+      dialect: athena
+
+test_fail_prefer_quoted_keywords_athena:
+  fail_str: SELECT 1 AS metadata
+  configs:
+    rules:
+      references.quoting:
+        prefer_quoted_keywords: true
+    core:
+      dialect: athena


### PR DESCRIPTION
### L059 supports requiring all keywords to be quoted
Fixes #4310 which is about L029 and L059 being in conflict with each other where one wants unreserved keywords quoted and one doesn't, so it's impossible to make both happy without adding specific keywords to the ignore list.

### Are there any other side effects of this change that we should be aware of?
Default behavior should remain the same, new behavior is behind a flag that defaults to off

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
