### PR TITLE
Add Snowflake dialect ALTER ROLE segment

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -2937,7 +2937,7 @@ class AlterRoleStatementSegment(BaseSegment):
     match_grammar = Sequence(
         "ALTER",
         "ROLE",
-        Sequence("IF", "EXISTS", optional=True),
+        Ref("IfExistsGrammar", optional=True),
         Ref("RoleReferenceSegment"),
         OneOf(
             Sequence(

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1009,6 +1009,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("PutStatementSegment"),
             Ref("RemoveStatementSegment"),
             Ref("CreateDatabaseFromShareStatementSegment"),
+            Ref("AlterRoleStatementSegment"),
         ],
         remove=[
             Ref("CreateIndexStatementSegment"),
@@ -2923,6 +2924,48 @@ class CreateSchemaStatementSegment(ansi.CreateSchemaStatementSegment):
         Sequence("WITH", "MANAGED", "ACCESS", optional=True),
         Ref("SchemaObjectParamsSegment", optional=True),
         Ref("TagBracketedEqualsSegment", optional=True),
+    )
+
+
+class AlterRoleStatementSegment(BaseSegment):
+    """An `ALTER ROLE` statement.
+
+    https://docs.snowflake.com/en/sql-reference/sql/alter-role.html
+    """
+
+    type = "alter_role_statement"
+    match_grammar = Sequence(
+        "ALTER",
+        "ROLE",
+        Sequence("IF", "EXISTS", optional=True),
+        Ref("RoleReferenceSegment"),
+        OneOf(
+            Sequence(
+                "SET",
+                OneOf(
+                    Ref("RoleReferenceSegment"),
+                    Ref("TagEqualsSegment"),
+                    Sequence(
+                        "COMMENT", Ref("EqualsSegment"), Ref("QuotedLiteralSegment")
+                    ),
+                ),
+            ),
+            Sequence(
+                "UNSET",
+                OneOf(
+                    Ref("RoleReferenceSegment"),
+                    Sequence("TAG", Delimited(Ref("TagReferenceSegment"))),
+                    Sequence("COMMENT"),
+                ),
+            ),
+            Sequence(
+                "RENAME",
+                "TO",
+                OneOf(
+                    Ref("RoleReferenceSegment"),
+                ),
+            ),
+        ),
     )
 
 

--- a/test/fixtures/dialects/snowflake/snowflake_alter_role.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_role.sql
@@ -1,0 +1,10 @@
+ALTER ROLE IF EXISTS "test_role" RENAME TO "prod_role";
+ALTER ROLE "test_role" RENAME TO "prod_role";
+ALTER ROLE IF EXISTS "test_role" SET COMMENT = 'test_comment';
+ALTER ROLE IF EXISTS "test_role" UNSET COMMENT;
+ALTER ROLE "test_role" SET COMMENT = 'test_comment';
+ALTER ROLE "test_role" UNSET COMMENT;
+ALTER ROLE IF EXISTS "test_role" SET TAG TAG1 = 'value1';
+ALTER ROLE IF EXISTS "test_role" SET TAG TAG1 = 'value1', TAG1 = 'value2', TAG1 = 'value3';
+ALTER ROLE IF EXISTS "test_role" UNSET TAG TAG1;
+ALTER ROLE IF EXISTS "test_role" UNSET TAG TAG1, TAG2, TAG3;

--- a/test/fixtures/dialects/snowflake/snowflake_alter_role.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_role.yml
@@ -1,0 +1,157 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 72a427cac4910bd00b0e70ccbc8fea04c0d16f25ddc293b83871cfb5d25b05d3
+file:
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - keyword: IF
+    - keyword: EXISTS
+    - role_reference:
+        quoted_identifier: '"test_role"'
+    - keyword: RENAME
+    - keyword: TO
+    - role_reference:
+        quoted_identifier: '"prod_role"'
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - role_reference:
+        quoted_identifier: '"test_role"'
+    - keyword: RENAME
+    - keyword: TO
+    - role_reference:
+        quoted_identifier: '"prod_role"'
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - keyword: IF
+    - keyword: EXISTS
+    - role_reference:
+        quoted_identifier: '"test_role"'
+    - keyword: SET
+    - keyword: COMMENT
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'test_comment'"
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - keyword: IF
+    - keyword: EXISTS
+    - role_reference:
+        quoted_identifier: '"test_role"'
+    - keyword: UNSET
+    - role_reference:
+        naked_identifier: COMMENT
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - role_reference:
+        quoted_identifier: '"test_role"'
+    - keyword: SET
+    - keyword: COMMENT
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'test_comment'"
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - role_reference:
+        quoted_identifier: '"test_role"'
+    - keyword: UNSET
+    - role_reference:
+        naked_identifier: COMMENT
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - keyword: IF
+    - keyword: EXISTS
+    - role_reference:
+        quoted_identifier: '"test_role"'
+    - keyword: SET
+    - tag_equals:
+        keyword: TAG
+        tag_reference:
+          naked_identifier: TAG1
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'value1'"
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - keyword: IF
+    - keyword: EXISTS
+    - role_reference:
+        quoted_identifier: '"test_role"'
+    - keyword: SET
+    - tag_equals:
+      - keyword: TAG
+      - tag_reference:
+          naked_identifier: TAG1
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'value1'"
+      - comma: ','
+      - tag_reference:
+          naked_identifier: TAG1
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'value2'"
+      - comma: ','
+      - tag_reference:
+          naked_identifier: TAG1
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'value3'"
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - keyword: IF
+    - keyword: EXISTS
+    - role_reference:
+        quoted_identifier: '"test_role"'
+    - keyword: UNSET
+    - keyword: TAG
+    - tag_reference:
+        naked_identifier: TAG1
+- statement_terminator: ;
+- statement:
+    alter_role_statement:
+    - keyword: ALTER
+    - keyword: ROLE
+    - keyword: IF
+    - keyword: EXISTS
+    - role_reference:
+        quoted_identifier: '"test_role"'
+    - keyword: UNSET
+    - keyword: TAG
+    - tag_reference:
+        naked_identifier: TAG1
+    - comma: ','
+    - tag_reference:
+        naked_identifier: TAG2
+    - comma: ','
+    - tag_reference:
+        naked_identifier: TAG3
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

- Added a Snowflake dialect segment for [ALTER ROLE](https://docs.snowflake.com/en/sql-reference/sql/alter-role)
- Makes progress on #3479

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
