### PR TITLE
Fix incorrect link to pre-commit docs

### DIFF
--- a/docs/source/production.rst
+++ b/docs/source/production.rst
@@ -86,6 +86,8 @@ such as:
 * Configuring `diff-quality` to return an error code if the quality is too low
 * Troubleshooting
 
+.. _using-pre-commit:
+
 Using `pre-commit`_
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/teamrollout.rst
+++ b/docs/source/teamrollout.rst
@@ -103,10 +103,10 @@ this an empowering experience that everyone can get involved with
 rather than *another piece of admin they need to do*.
 
 At this stage, you might also want to consider other tools in the
-SQLFluff ecosystem such as the `SQLFluff pre-commit hook`_ and
-the `SQLFluff VSCode plugin`_ or `SQLFluff online formatter`_.
+SQLFluff ecosystem such as the :ref:`SQLFluff pre-commit hook
+<using-pre-commit>` and the `SQLFluff VSCode plugin`_ or `SQLFluff
+online formatter`_.
 
-.. _`SQLFluff pre-commit hook`: https://github.com/sqlfluff/sqlfluff-github-actions
 .. _`SQLFluff VSCode plugin`: https://github.com/sqlfluff/vscode-sqlfluff
 .. _`SQLFluff online formatter`: https://online.sqlfluff.com/
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This was linking to a github action, but should link instead to the docs on using pre-commit with sqlfluff.

fixes #4404

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
