### PR TITLE
Snowflake: ALTER STORAGE INTEGRATION segment

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1010,6 +1010,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("RemoveStatementSegment"),
             Ref("CreateDatabaseFromShareStatementSegment"),
             Ref("AlterRoleStatementSegment"),
+            Ref("AlterStorageIntegrationSegment"),
         ],
         remove=[
             Ref("CreateIndexStatementSegment"),
@@ -1964,6 +1965,104 @@ class AlterShareStatementSegment(BaseSegment):
                 ),
             ),
             Sequence("UNSET", "COMMENT"),
+        ),
+    )
+
+
+class AlterStorageIntegrationSegment(BaseSegment):
+    """An `ALTER STORAGE INTEGRATION` statement.
+
+    https://docs.snowflake.com/en/sql-reference/sql/alter-storage-integration
+    """
+
+    type = "alter_storage_integration_statement"
+
+    match_grammar = Sequence(
+        "ALTER",
+        Ref.keyword("STORAGE", optional=True),
+        "INTEGRATION",
+        Ref("IfExistsGrammar", optional=True),
+        Ref("ObjectReferenceSegment"),
+        OneOf(
+            Sequence(
+                "SET",
+                OneOf(
+                    Ref("TagEqualsSegment", optional=True),
+                    AnySetOf(
+                        Sequence(
+                            "COMMENT", Ref("EqualsSegment"), Ref("QuotedLiteralSegment")
+                        ),
+                        Sequence(
+                            "ENABLED",
+                            Ref("EqualsSegment"),
+                            Ref("BooleanLiteralGrammar"),
+                        ),
+                        OneOf(
+                            AnySetOf(
+                                Sequence(
+                                    "STORAGE_AWS_ROLE_ARN",
+                                    Ref("EqualsSegment"),
+                                    Ref("QuotedLiteralSegment"),
+                                ),
+                                Sequence(
+                                    "STORAGE_AWS_OBJECT_ACL",
+                                    Ref("EqualsSegment"),
+                                    Ref("QuotedLiteralSegment"),
+                                ),
+                            ),
+                            AnySetOf(
+                                Sequence(
+                                    "AZURE_TENANT_ID",
+                                    Ref("EqualsSegment"),
+                                    Ref("QuotedLiteralSegment"),
+                                ),
+                            ),
+                        ),
+                        Sequence(
+                            "STORAGE_ALLOWED_LOCATIONS",
+                            Ref("EqualsSegment"),
+                            OneOf(
+                                Bracketed(
+                                    Delimited(
+                                        OneOf(
+                                            Ref("S3Path"),
+                                            Ref("GCSPath"),
+                                            Ref("AzureBlobStoragePath"),
+                                        )
+                                    )
+                                ),
+                                Bracketed(
+                                    Ref("QuotedStarSegment"),
+                                ),
+                            ),
+                        ),
+                        Sequence(
+                            "STORAGE_BLOCKED_LOCATIONS",
+                            Ref("EqualsSegment"),
+                            Bracketed(
+                                Delimited(
+                                    OneOf(
+                                        Ref("S3Path"),
+                                        Ref("GCSPath"),
+                                        Ref("AzureBlobStoragePath"),
+                                    )
+                                )
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            Sequence(
+                "UNSET",
+                OneOf(
+                    Sequence(
+                        "TAG", Delimited(Ref("TagReferenceSegment")), optional=True
+                    ),
+                    "COMMENT",
+                    "ENABLED",
+                    "STORAGE_BLOCKED_LOCATIONS",
+                ),
+            ),
         ),
     )
 

--- a/test/fixtures/dialects/snowflake/snowflake_alter_storage_integration.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_storage_integration.sql
@@ -1,0 +1,114 @@
+alter storage integration test_integration set
+    tag tag1 = 'value1';
+
+alter storage integration test_integration set
+    tag tag1 = 'value1', tag2 = 'value2';
+
+alter storage integration test_integration
+    set comment = 'test comment';
+
+alter storage integration test_integration unset
+    comment;
+
+alter storage integration test_integration unset
+    tag tag1, tag2;
+
+alter storage integration if exists test_integration unset
+    tag tag1, tag2;
+
+alter storage integration test_integration unset
+     enabled;
+
+alter storage integration test_integration unset
+    comment;
+
+alter storage integration test_integration unset
+    storage_blocked_locations;
+
+alter storage integration test_integration set
+    enabled = true;
+
+alter storage integration test_integration
+    set enabled = false
+    comment = 'test comment';
+
+alter storage integration test_integration set
+    comment = 'test comment'
+    enabled = false;
+
+alter storage integration test_integration set
+    storage_aws_role_arn = 'test_role_arn';
+
+alter storage integration test_integration set
+    storage_aws_object_acl = 'test_object_acl';
+
+alter storage integration test_integration set
+    azure_tenant_id = 'test_azure_tenant_id';
+
+alter storage integration s3_int set
+  storage_aws_role_arn = 'arn:aws:iam::001234567890:role/myrole'
+  enabled = true
+  storage_allowed_locations = (
+    's3://mybucket1', 's3://mybucket2/'
+  );
+
+alter storage integration gcs_int set
+  enabled = true
+  storage_allowed_locations = (
+    'gcs://mybucket1/path1/',
+    'gcs://mybucket2/path2/'
+  );
+
+alter storage integration azure_int set
+  enabled = true
+  azure_tenant_id = 'a123b4c5-1234-123a-a12b-1a23b45678c9'
+  storage_allowed_locations = (
+    'azure://myaccount.blob.core.windows.net/mycontainer/path1/',
+    'azure://myaccount.blob.core.windows.net/mycontainer/path2/'
+  );
+
+alter storage integration s3_int set
+  storage_aws_role_arn = 'arn:aws:iam::001234567890:role/myrole'
+  enabled = true
+  storage_allowed_locations = ('*')
+  storage_blocked_locations = (
+    's3://mybucket3/path3/', 's3://mybucket4/path4/'
+    );
+
+
+alter storage integration gcs_int set
+  enabled = true
+  storage_allowed_locations = ('*')
+  storage_blocked_locations = (
+    'gcs://mybucket3/path3/', 'gcs://mybucket4/path4/'
+    );
+
+
+alter storage integration azure_int set
+  enabled = true
+  azure_tenant_id = 'a123b4c5-1234-123a-a12b-1a23b45678c9'
+  storage_allowed_locations = ('*')
+  storage_blocked_locations = (
+    'azure://myaccount.blob.core.windows.net/mycontainer/path3/',
+    'azure://myaccount.blob.core.windows.net/mycontainer/path4/'
+    );
+
+alter storage integration azure_int set
+  enabled = true
+  comment = 'test_comment'
+  azure_tenant_id = 'a123b4c5-1234-123a-a12b-1a23b45678c9'
+  storage_allowed_locations = ('*')
+  storage_blocked_locations = (
+    'azure://myaccount.blob.core.windows.net/mycontainer/path3/',
+    'azure://myaccount.blob.core.windows.net/mycontainer/path4/'
+    );
+
+alter storage integration if exists azure_int set
+  enabled = true
+  comment = 'test_comment'
+  azure_tenant_id = 'a123b4c5-1234-123a-a12b-1a23b45678c9'
+  storage_allowed_locations = ('*')
+  storage_blocked_locations = (
+    'azure://myaccount.blob.core.windows.net/mycontainer/path3/',
+    'azure://myaccount.blob.core.windows.net/mycontainer/path4/'
+    );

--- a/test/fixtures/dialects/snowflake/snowflake_alter_storage_integration.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_storage_integration.yml
@@ -1,0 +1,461 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9f3c2e27d2d0d69837f87b5cf9864a70a48856d013b05649a9170d67acfde55d
+file:
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: test_integration
+    - keyword: set
+    - tag_equals:
+        keyword: tag
+        tag_reference:
+          naked_identifier: tag1
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'value1'"
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: test_integration
+    - keyword: set
+    - tag_equals:
+      - keyword: tag
+      - tag_reference:
+          naked_identifier: tag1
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'value1'"
+      - comma: ','
+      - tag_reference:
+          naked_identifier: tag2
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'value2'"
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: test_integration
+    - keyword: set
+    - keyword: comment
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'test comment'"
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: test_integration
+    - keyword: unset
+    - keyword: comment
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: test_integration
+    - keyword: unset
+    - keyword: tag
+    - tag_reference:
+        naked_identifier: tag1
+    - comma: ','
+    - tag_reference:
+        naked_identifier: tag2
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - keyword: if
+    - keyword: exists
+    - object_reference:
+        naked_identifier: test_integration
+    - keyword: unset
+    - keyword: tag
+    - tag_reference:
+        naked_identifier: tag1
+    - comma: ','
+    - tag_reference:
+        naked_identifier: tag2
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: test_integration
+    - keyword: unset
+    - keyword: enabled
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: test_integration
+    - keyword: unset
+    - keyword: comment
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: test_integration
+    - keyword: unset
+    - keyword: storage_blocked_locations
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: test_integration
+    - keyword: set
+    - keyword: enabled
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'true'
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: test_integration
+    - keyword: set
+    - keyword: enabled
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'false'
+    - keyword: comment
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'test comment'"
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: test_integration
+    - keyword: set
+    - keyword: comment
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'test comment'"
+    - keyword: enabled
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'false'
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: test_integration
+    - keyword: set
+    - keyword: storage_aws_role_arn
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'test_role_arn'"
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: test_integration
+    - keyword: set
+    - keyword: storage_aws_object_acl
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'test_object_acl'"
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: test_integration
+    - keyword: set
+    - keyword: azure_tenant_id
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'test_azure_tenant_id'"
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: s3_int
+    - keyword: set
+    - keyword: storage_aws_role_arn
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'arn:aws:iam::001234567890:role/myrole'"
+    - keyword: enabled
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'true'
+    - keyword: storage_allowed_locations
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+      - start_bracket: (
+      - bucket_path: "'s3://mybucket1'"
+      - comma: ','
+      - bucket_path: "'s3://mybucket2/'"
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: gcs_int
+    - keyword: set
+    - keyword: enabled
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'true'
+    - keyword: storage_allowed_locations
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+      - start_bracket: (
+      - bucket_path: "'gcs://mybucket1/path1/'"
+      - comma: ','
+      - bucket_path: "'gcs://mybucket2/path2/'"
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: azure_int
+    - keyword: set
+    - keyword: enabled
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'true'
+    - keyword: azure_tenant_id
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'a123b4c5-1234-123a-a12b-1a23b45678c9'"
+    - keyword: storage_allowed_locations
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+      - start_bracket: (
+      - bucket_path: "'azure://myaccount.blob.core.windows.net/mycontainer/path1/'"
+      - comma: ','
+      - bucket_path: "'azure://myaccount.blob.core.windows.net/mycontainer/path2/'"
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: s3_int
+    - keyword: set
+    - keyword: storage_aws_role_arn
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'arn:aws:iam::001234567890:role/myrole'"
+    - keyword: enabled
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'true'
+    - keyword: storage_allowed_locations
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+        start_bracket: (
+        quoted_star: "'*'"
+        end_bracket: )
+    - keyword: storage_blocked_locations
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+      - start_bracket: (
+      - bucket_path: "'s3://mybucket3/path3/'"
+      - comma: ','
+      - bucket_path: "'s3://mybucket4/path4/'"
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: gcs_int
+    - keyword: set
+    - keyword: enabled
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'true'
+    - keyword: storage_allowed_locations
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+        start_bracket: (
+        quoted_star: "'*'"
+        end_bracket: )
+    - keyword: storage_blocked_locations
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+      - start_bracket: (
+      - bucket_path: "'gcs://mybucket3/path3/'"
+      - comma: ','
+      - bucket_path: "'gcs://mybucket4/path4/'"
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: azure_int
+    - keyword: set
+    - keyword: enabled
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'true'
+    - keyword: azure_tenant_id
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'a123b4c5-1234-123a-a12b-1a23b45678c9'"
+    - keyword: storage_allowed_locations
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+        start_bracket: (
+        quoted_star: "'*'"
+        end_bracket: )
+    - keyword: storage_blocked_locations
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+      - start_bracket: (
+      - bucket_path: "'azure://myaccount.blob.core.windows.net/mycontainer/path3/'"
+      - comma: ','
+      - bucket_path: "'azure://myaccount.blob.core.windows.net/mycontainer/path4/'"
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - object_reference:
+        naked_identifier: azure_int
+    - keyword: set
+    - keyword: enabled
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'true'
+    - keyword: comment
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'test_comment'"
+    - keyword: azure_tenant_id
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'a123b4c5-1234-123a-a12b-1a23b45678c9'"
+    - keyword: storage_allowed_locations
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+        start_bracket: (
+        quoted_star: "'*'"
+        end_bracket: )
+    - keyword: storage_blocked_locations
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+      - start_bracket: (
+      - bucket_path: "'azure://myaccount.blob.core.windows.net/mycontainer/path3/'"
+      - comma: ','
+      - bucket_path: "'azure://myaccount.blob.core.windows.net/mycontainer/path4/'"
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_storage_integration_statement:
+    - keyword: alter
+    - keyword: storage
+    - keyword: integration
+    - keyword: if
+    - keyword: exists
+    - object_reference:
+        naked_identifier: azure_int
+    - keyword: set
+    - keyword: enabled
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'true'
+    - keyword: comment
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'test_comment'"
+    - keyword: azure_tenant_id
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'a123b4c5-1234-123a-a12b-1a23b45678c9'"
+    - keyword: storage_allowed_locations
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+        start_bracket: (
+        quoted_star: "'*'"
+        end_bracket: )
+    - keyword: storage_blocked_locations
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+      - start_bracket: (
+      - bucket_path: "'azure://myaccount.blob.core.windows.net/mycontainer/path3/'"
+      - comma: ','
+      - bucket_path: "'azure://myaccount.blob.core.windows.net/mycontainer/path4/'"
+      - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

- Adds support for the [Snowflake Alter Storage Integration statement](https://docs.snowflake.com/en/sql-reference/sql/alter-storage-integration)
- Makes progress on #3479 

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
