### PR TITLE
Enable noqa using aliases and groups

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -262,7 +262,7 @@ class Linter:
     def parse_noqa(
         comment: str,
         line_no: int,
-        reference_map: Dict[str, List[str]],
+        reference_map: Dict[str, Set[str]],
     ):
         """Extract ignore mask entries from a comment string."""
         # Also trim any whitespace afterward
@@ -310,7 +310,7 @@ class Linter:
                         unexpanded_rules = tuple(
                             r.strip() for r in rule_part.split(",")
                         )
-                        expanded_rules = []
+                        expanded_rules: List[str] = []
                         for r in unexpanded_rules:
                             matched = False
                             for expanded in (
@@ -423,7 +423,7 @@ class Linter:
     def extract_ignore_from_comment(
         cls,
         comment: RawSegment,
-        reference_map: Dict[str, List[str]],
+        reference_map: Dict[str, Set[str]],
     ):
         """Extract ignore mask entries from a comment segment."""
         # Also trim any whitespace afterward
@@ -438,7 +438,7 @@ class Linter:
     def extract_ignore_mask_tree(
         cls,
         tree: BaseSegment,
-        reference_map: Dict[str, List[str]],
+        reference_map: Dict[str, Set[str]],
     ) -> Tuple[List[NoQaDirective], List[SQLBaseError]]:
         """Look for inline ignore comments and return NoQaDirectives."""
         ignore_buff: List[NoQaDirective] = []
@@ -459,7 +459,7 @@ class Linter:
         cls,
         source: str,
         inline_comment_regex: RegexLexer,
-        reference_map: Dict[str, List[str]],
+        reference_map: Dict[str, Set[str]],
     ) -> Tuple[List[NoQaDirective], List[SQLBaseError]]:
         """Look for inline ignore comments and return NoQaDirectives.
 

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -14,6 +14,7 @@ from typing import (
     Set,
     Tuple,
     Type,
+    Dict,
     cast,
 )
 
@@ -40,7 +41,7 @@ from sqlfluff.core.config import FluffConfig, ConfigLoader, progress_bar_configu
 from sqlfluff.core.parser.segments.base import BaseSegment, SourceFix
 from sqlfluff.core.parser.segments.meta import MetaSegment
 from sqlfluff.core.parser.segments.raw import RawSegment
-from sqlfluff.core.rules import BaseRule
+from sqlfluff.core.rules import BaseRule, RulePack
 
 from sqlfluff.core.linter.common import (
     RuleTuple,
@@ -93,21 +94,21 @@ class Linter:
         # Store references to user rule classes
         self.user_rules = user_rules or []
 
-    def get_ruleset(self, config: Optional[FluffConfig] = None) -> List[BaseRule]:
+    def get_rulepack(self, config: Optional[FluffConfig] = None) -> RulePack:
         """Get hold of a set of rules."""
         rs = get_ruleset()
         # Register any user rules
         for rule in self.user_rules:
             rs.register(rule)
         cfg = config or self.config
-        return rs.get_rulelist(config=cfg)
+        return rs.get_rulepack(config=cfg)
 
     def rule_tuples(self) -> List[RuleTuple]:
         """A simple pass through to access the rule tuples of the rule set."""
-        rs = self.get_ruleset()
+        rs = self.get_rulepack()
         return [
             RuleTuple(rule.code, rule.name, rule.description, rule.groups, rule.aliases)
-            for rule in rs
+            for rule in rs.rules
         ]
 
     # #### Static methods
@@ -261,7 +262,7 @@ class Linter:
     def parse_noqa(
         comment: str,
         line_no: int,
-        rule_codes: List[str],
+        reference_map: Dict[str, List[str]],
     ):
         """Extract ignore mask entries from a comment string."""
         # Also trim any whitespace afterward
@@ -311,20 +312,23 @@ class Linter:
                         )
                         expanded_rules = []
                         for r in unexpanded_rules:
-                            expanded_rule = [
-                                x
-                                for x in fnmatch.filter(rule_codes, r)
+                            matched = False
+                            for expanded in (
+                                reference_map[x]
+                                for x in fnmatch.filter(reference_map.keys(), r)
                                 if x not in expanded_rules
-                            ]
-                            if expanded_rule:
-                                expanded_rules.extend(expanded_rule)
-                            elif r not in expanded_rules:
+                            ):
+                                expanded_rules.extend(expanded)
+                                matched = True
+
+                            if not matched:
                                 # We were unable to expand the glob.
                                 # Therefore assume the user is referencing
                                 # a special error type (e.g. PRS, LXR, or TMP)
                                 # and add this to the list of rules to ignore.
                                 expanded_rules.append(r)
-                        rules = tuple(expanded_rules)
+                        # Sort for consistency
+                        rules = tuple(sorted(expanded_rules))
                     else:
                         rules = None
                     return NoQaDirective(line_no, rules, action)
@@ -419,13 +423,13 @@ class Linter:
     def extract_ignore_from_comment(
         cls,
         comment: RawSegment,
-        rule_codes: List[str],
+        reference_map: Dict[str, List[str]],
     ):
         """Extract ignore mask entries from a comment segment."""
         # Also trim any whitespace afterward
         comment_content = comment.raw_trimmed().strip()
         comment_line, _ = comment.pos_marker.source_position()
-        result = cls.parse_noqa(comment_content, comment_line, rule_codes)
+        result = cls.parse_noqa(comment_content, comment_line, reference_map)
         if isinstance(result, SQLParseError):
             result.segment = comment
         return result
@@ -434,14 +438,14 @@ class Linter:
     def extract_ignore_mask_tree(
         cls,
         tree: BaseSegment,
-        rule_codes: List[str],
+        reference_map: Dict[str, List[str]],
     ) -> Tuple[List[NoQaDirective], List[SQLBaseError]]:
         """Look for inline ignore comments and return NoQaDirectives."""
         ignore_buff: List[NoQaDirective] = []
         violations: List[SQLBaseError] = []
         for comment in tree.recursive_crawl("comment"):
             if comment.is_type("inline_comment"):
-                ignore_entry = cls.extract_ignore_from_comment(comment, rule_codes)
+                ignore_entry = cls.extract_ignore_from_comment(comment, reference_map)
                 if isinstance(ignore_entry, SQLParseError):
                     violations.append(ignore_entry)
                 elif ignore_entry:
@@ -455,7 +459,7 @@ class Linter:
         cls,
         source: str,
         inline_comment_regex: RegexLexer,
-        rule_codes: List[str],
+        reference_map: Dict[str, List[str]],
     ) -> Tuple[List[NoQaDirective], List[SQLBaseError]]:
         """Look for inline ignore comments and return NoQaDirectives.
 
@@ -468,7 +472,7 @@ class Linter:
             match = inline_comment_regex.search(line) if line else None
             if match:
                 ignore_entry = cls.parse_noqa(
-                    line[match[0] : match[1]], idx + 1, rule_codes
+                    line[match[0] : match[1]], idx + 1, reference_map
                 )
                 if isinstance(ignore_entry, SQLParseError):
                     violations.append(ignore_entry)  # pragma: no cover
@@ -483,7 +487,7 @@ class Linter:
         cls,
         tree: BaseSegment,
         config: FluffConfig,
-        rule_set: List[BaseRule],
+        rule_pack: RulePack,
         fix: bool = False,
         fname: Optional[str] = None,
         templated_file: Optional[TemplatedFile] = None,
@@ -506,12 +510,13 @@ class Linter:
 
         # Dispatch the output for the lint header
         if formatter:
-            formatter.dispatch_lint_header(fname, sorted(r.code for r in rule_set))
+            formatter.dispatch_lint_header(fname, sorted(rule_pack.codes()))
 
         # Look for comment segments which might indicate lines to ignore.
         if not config.get("disable_noqa"):
-            rule_codes = [r.code for r in rule_set]
-            ignore_buff, ivs = cls.extract_ignore_mask_tree(tree, rule_codes)
+            ignore_buff, ivs = cls.extract_ignore_mask_tree(
+                tree, rule_pack.reference_map
+            )
             initial_linting_errors += ivs
         else:
             ignore_buff = []
@@ -531,10 +536,10 @@ class Linter:
         for phase in phases:
             if len(phases) > 1:
                 rules_this_phase = [
-                    rule for rule in rule_set if rule.lint_phase == phase
+                    rule for rule in rule_pack.rules if rule.lint_phase == phase
                 ]
             else:
-                rules_this_phase = rule_set
+                rules_this_phase = rule_pack.rules
             for loop in range(loop_limit if phase == "main" else 2):
 
                 def is_first_linter_pass():
@@ -550,7 +555,7 @@ class Linter:
                 if is_first_linter_pass():
                     # In order to compute initial_linting_errors correctly, need
                     # to run all rules on the first loop of the main phase.
-                    rules_this_phase = rule_set
+                    rules_this_phase = rule_pack.rules
                 progress_bar_crawler = tqdm(
                     rules_this_phase,
                     desc="lint by rules",
@@ -693,7 +698,7 @@ class Linter:
     def lint_parsed(
         cls,
         parsed: ParsedString,
-        rule_set: List[BaseRule],
+        rule_pack: RulePack,
         fix: bool = False,
         formatter: Any = None,
         encoding: str = "utf8",
@@ -708,7 +713,7 @@ class Linter:
             tree, initial_linting_errors, ignore_buff = cls.lint_fix_parsed(
                 parsed.tree,
                 config=parsed.config,
-                rule_set=rule_set,
+                rule_pack=rule_pack,
                 fix=fix,
                 fname=parsed.fname,
                 templated_file=parsed.templated_file,
@@ -736,7 +741,7 @@ class Linter:
                         for lm in parsed.config.get("dialect_obj").lexer_matchers
                         if lm.name == "inline_comment"
                     ][0],
-                    [r.code for r in rule_set],
+                    rule_pack.reference_map,
                 )
                 violations += ignore_violations
 
@@ -775,7 +780,7 @@ class Linter:
     def lint_rendered(
         cls,
         rendered: RenderedFile,
-        rule_set: List[BaseRule],
+        rule_pack: RulePack,
         fix: bool = False,
         formatter: Any = None,
     ) -> LintedFile:
@@ -783,7 +788,7 @@ class Linter:
         parsed = cls.parse_rendered(rendered)
         return cls.lint_parsed(
             parsed,
-            rule_set=rule_set,
+            rule_pack=rule_pack,
             fix=fix,
             formatter=formatter,
             encoding=rendered.encoding,
@@ -893,11 +898,11 @@ class Linter:
     ) -> Tuple[BaseSegment, List[SQLBaseError]]:
         """Return the fixed tree and violations from lintfix when we're fixing."""
         config = config or self.config
-        rule_set = self.get_ruleset(config=config)
+        rule_pack = self.get_rulepack(config=config)
         fixed_tree, violations, _ = self.lint_fix_parsed(
             tree,
             config,
-            rule_set,
+            rule_pack,
             fix=True,
             fname=fname,
             templated_file=templated_file,
@@ -914,11 +919,11 @@ class Linter:
     ) -> List[SQLBaseError]:
         """Return just the violations from lintfix when we're only linting."""
         config = config or self.config
-        rule_set = self.get_ruleset(config=config)
+        rule_pack = self.get_rulepack(config=config)
         _, violations, _ = self.lint_fix_parsed(
             tree,
             config,
-            rule_set,
+            rule_pack,
             fix=False,
             fname=fname,
             templated_file=templated_file,
@@ -949,11 +954,11 @@ class Linter:
             config=config,
         )
         # Get rules as appropriate
-        rule_set = self.get_ruleset(config=config)
+        rule_pack = self.get_rulepack(config=config)
         # Lint the file and return the LintedFile
         return self.lint_parsed(
             parsed,
-            rule_set,
+            rule_pack,
             fix=fix,
             formatter=self.formatter,
             encoding=encoding,

--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -58,13 +58,13 @@ class BaseRunner(ABC):
         """
         for fname, rendered in self.iter_rendered(fnames):
             # Generate a fresh ruleset
-            rule_set = self.linter.get_ruleset(config=rendered.config)
+            rule_pack = self.linter.get_rulepack(config=rendered.config)
             yield (
                 fname,
                 functools.partial(
                     self.linter.lint_rendered,
                     rendered,
-                    rule_set,
+                    rule_pack,
                     fix,
                     # Formatters may or may not be passed. They don't pickle
                     # nicely so aren't appropriate in a multiprocessing world.

--- a/src/sqlfluff/core/rules/__init__.py
+++ b/src/sqlfluff/core/rules/__init__.py
@@ -2,6 +2,7 @@
 
 from sqlfluff.core.rules.base import (
     RuleSet,
+    RulePack,
     BaseRule,
     LintResult,
     LintFix,
@@ -40,6 +41,7 @@ def get_ruleset(name: str = "standard") -> RuleSet:
 __all__ = (
     "get_ruleset",
     "RuleSet",
+    "RulePack",
     "BaseRule",
     "LintResult",
     "LintFix",

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -966,10 +966,22 @@ class RulePack:
     The reason for this object is that rules are filtered and instantiated
     into this pack in the main process when running in multi-processing mode so
     that user defined rules can be used without reference issues.
+
+    Attributes:
+        rules (:obj:`list` of :obj:`BaseRule`): A filtered list of instantiated
+            rules to be applied to a given file.
+        reference_map (:obj:`dict`): A mapping of rule references to the codes
+            they refer to, e.g. `{"my_ref": {"L001", "L002"}}`. The references
+            (i.e. the keys) may be codes, groups, aliases or names. The values
+            of the mapping are sets of rule codes *only*. This object acts as
+            a lookup to be able to translate selectors (which may contain
+            diverse references) into a consolidated list of rule codes. This
+            mapping contains the full set of rules, rather than just the filtered
+            set present in the `rules` attribute.
     """
 
     rules: List[BaseRule]
-    reference_map: Dict[str, List[str]]
+    reference_map: Dict[str, Set[str]]
 
     def codes(self) -> Iterator[str]:
         """Returns an iterator through the codes contained in the pack."""
@@ -1108,7 +1120,7 @@ class RuleSet:
         return cls
 
     def _expand_rule_refs(
-        self, glob_list: List[str], reference_map: Dict[str, List[str]]
+        self, glob_list: List[str], reference_map: Dict[str, Set[str]]
     ) -> Set[str]:
         """Expand a list of rule references into a list of rule codes.
 
@@ -1127,7 +1139,7 @@ class RuleSet:
 
         return expanded_rule_set
 
-    def rule_reference_map(self) -> Dict[str, List[str]]:
+    def rule_reference_map(self) -> Dict[str, Set[str]]:
         """Generate a rule reference map for looking up rules.
 
         Generate the master reference map. The priority order is:
@@ -1136,11 +1148,11 @@ class RuleSet:
         the alias is wrong)
         """
         valid_codes: Set[str] = set(self._register.keys())
-        reference_map: Dict[str, List[str]] = {code: [code] for code in valid_codes}
+        reference_map: Dict[str, Set[str]] = {code: {code} for code in valid_codes}
 
         # Generate name map.
-        name_map: Dict[str, List[str]] = {
-            manifest.name: [manifest.code]
+        name_map: Dict[str, Set[str]] = {
+            manifest.name: {manifest.code}
             for manifest in self._register.values()
             if manifest.name
         }
@@ -1156,7 +1168,7 @@ class RuleSet:
         reference_map = {**name_map, **reference_map}
 
         # Generate the group map.
-        group_map: DefaultDict[str, List[str]] = defaultdict(list)
+        group_map: DefaultDict[str, Set[str]] = defaultdict(set)
         for manifest in self._register.values():
             for group in manifest.groups:
                 if group in reference_map:
@@ -1169,12 +1181,12 @@ class RuleSet:
                         reference_map[group],
                     )
                 else:
-                    group_map[group].append(manifest.code)
+                    group_map[group].add(manifest.code)
         # Incorporate after all checks are done.
         reference_map = {**group_map, **reference_map}
 
         # Generate the alias map.
-        alias_map: DefaultDict[str, List[str]] = defaultdict(list)
+        alias_map: DefaultDict[str, Set[str]] = defaultdict(set)
         for manifest in self._register.values():
             for alias in manifest.aliases:
                 if alias in reference_map:
@@ -1187,7 +1199,7 @@ class RuleSet:
                         reference_map[alias],
                     )
                 else:
-                    alias_map[alias].append(manifest.code)
+                    alias_map[alias].add(manifest.code)
         # Incorporate after all checks are done.
         return {**alias_map, **reference_map}
 
@@ -1196,10 +1208,6 @@ class RuleSet:
 
         We use the config both for allowlisting and denylisting, but also
         for configuring the rules given the given config.
-
-        Returns:
-            :obj:`list` of instantiated :obj:`BaseRule`.
-
         """
         # Validate all generic rule configs
         self._validate_config_options(config)

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -34,6 +34,7 @@ from typing import (
     Dict,
     Type,
     DefaultDict,
+    Iterator,
 )
 from collections import namedtuple, defaultdict
 
@@ -955,6 +956,26 @@ class RuleManifest:
     rule_class: Type[BaseRule]
 
 
+@dataclass
+class RulePack:
+    """A bundle of rules to be applied.
+
+    This contains a set of rules, post filtering but also contains the mapping
+    required to interpret any noqa messages found in files.
+
+    The reason for this object is that rules are filtered and instantiated
+    into this pack in the main process when running in multi-processing mode so
+    that user defined rules can be used without reference issues.
+    """
+
+    rules: List[BaseRule]
+    reference_map: Dict[str, List[str]]
+
+    def codes(self) -> Iterator[str]:
+        """Returns an iterator through the codes contained in the pack."""
+        return (r.code for r in self.rules)
+
+
 class RuleSet:
     """Class to define a ruleset.
 
@@ -1106,23 +1127,14 @@ class RuleSet:
 
         return expanded_rule_set
 
-    def get_rulelist(self, config) -> List[BaseRule]:
-        """Use the config to return the appropriate rules.
+    def rule_reference_map(self) -> Dict[str, List[str]]:
+        """Generate a rule reference map for looking up rules.
 
-        We use the config both for allowlisting and denylisting, but also
-        for configuring the rules given the given config.
-
-        Returns:
-            :obj:`list` of instantiated :obj:`BaseRule`.
-
+        Generate the master reference map. The priority order is:
+        codes > names > groups > aliases
+        (i.e. if there's a collision between a name and an alias - we assume
+        the alias is wrong)
         """
-        # Validate all generic rule configs
-        self._validate_config_options(config)
-
-        # Generate the master reference map. The priority order is:
-        # codes > names > groups > aliases
-        # (i.e. if there's a collision between a name and an
-        # alias - we assume the alias is wrong.)
         valid_codes: Set[str] = set(self._register.keys())
         reference_map: Dict[str, List[str]] = {code: [code] for code in valid_codes}
 
@@ -1177,7 +1189,27 @@ class RuleSet:
                 else:
                     alias_map[alias].append(manifest.code)
         # Incorporate after all checks are done.
-        reference_map = {**alias_map, **reference_map}
+        return {**alias_map, **reference_map}
+
+    def get_rulepack(self, config) -> RulePack:
+        """Use the config to return the appropriate rules.
+
+        We use the config both for allowlisting and denylisting, but also
+        for configuring the rules given the given config.
+
+        Returns:
+            :obj:`list` of instantiated :obj:`BaseRule`.
+
+        """
+        # Validate all generic rule configs
+        self._validate_config_options(config)
+
+        # Generate the master reference map. The priority order is:
+        # codes > names > groups > aliases
+        # (i.e. if there's a collision between a name and an
+        # alias - we assume the alias is wrong.)
+        valid_codes: Set[str] = set(self._register.keys())
+        reference_map = self.rule_reference_map()
 
         # The lists here are lists of references, which might be codes,
         # names, aliases or groups.
@@ -1245,7 +1277,7 @@ class RuleSet:
             # Instantiate when ready
             instantiated_rules.append(rule_class(**kwargs))
 
-        return instantiated_rules
+        return RulePack(instantiated_rules, reference_map)
 
     def copy(self):
         """Return a copy of self with a separate register."""

--- a/src/sqlfluff/utils/testing/rules.py
+++ b/src/sqlfluff/utils/testing/rules.py
@@ -52,7 +52,7 @@ def load_test_cases(
 
 def get_rule_from_set(code, config):
     """Fetch a rule from the rule set."""
-    for r in get_ruleset().get_rulelist(config=config):
+    for r in get_ruleset().get_rulepack(config=config):
         if r.code == code:  # pragma: no cover
             return r
     raise ValueError(f"{code!r} not in {get_ruleset()!r}")

--- a/src/sqlfluff/utils/testing/rules.py
+++ b/src/sqlfluff/utils/testing/rules.py
@@ -52,7 +52,7 @@ def load_test_cases(
 
 def get_rule_from_set(code, config):
     """Fetch a rule from the rule set."""
-    for r in get_ruleset().get_rulepack(config=config):
+    for r in get_ruleset().get_rulepack(config=config).rules:
         if r.code == code:  # pragma: no cover
             return r
     raise ValueError(f"{code!r} not in {get_ruleset()!r}")

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -487,7 +487,7 @@ def test__linter__encoding(fname, config_encoding, lexerror):
 
 
 # noqa tests require a rule_set, therefore we construct dummy rule set for glob matching.
-dummy_rule_codes = [r.code for r in Linter().get_ruleset()]
+dummy_rule_map = Linter().get_rulepack().reference_map
 
 
 @pytest.mark.parametrize(
@@ -506,8 +506,9 @@ dummy_rule_codes = [r.code for r in Linter().get_ruleset()]
             "Inline comment before inline ignore -- noqa:L001,L002",
             NoQaDirective(0, ("L001", "L002"), None),
         ),
+        # Test selection with rule globs
         (
-            "Inline comment before inline ignore -- noqa:L04*",
+            "noqa:L04*",
             NoQaDirective(
                 0,
                 (
@@ -525,11 +526,39 @@ dummy_rule_codes = [r.code for r in Linter().get_ruleset()]
                 None,
             ),
         ),
+        # Test selection with aliases.
+        (
+            "noqa:LN01a",
+            NoQaDirective(0, ("L002",), None),
+        ),
+        # Test selection with alias globs.
+        (
+            "noqa:LN01*",
+            NoQaDirective(
+                0,
+                (
+                    "L002",
+                    "L003",
+                    "L004",
+                ),
+                None,
+            ),
+        ),
+        # Test selection with names.
+        (
+            "noqa:capitalisation.keywords",
+            NoQaDirective(0, ("L010",), None),
+        ),
+        # Test selection with groups.
+        (
+            "noqa:capitalisation",
+            NoQaDirective(0, ("L010", "L014", "L030", "L040", "L063"), None),
+        ),
     ],
 )
 def test_parse_noqa(input, expected):
     """Test correct of "noqa" comments."""
-    result = Linter.parse_noqa(input, 0, rule_codes=dummy_rule_codes)
+    result = Linter.parse_noqa(input, 0, reference_map=dummy_rule_map)
     if not isinstance(expected, type):
         assert result == expected
     else:
@@ -540,7 +569,7 @@ def test_parse_noqa(input, expected):
 def test_parse_noqa_no_dups():
     """Test overlapping glob expansions don't return duplicate rules in noqa."""
     result = Linter.parse_noqa(
-        comment="noqa:L0*5,L01*", line_no=0, rule_codes=dummy_rule_codes
+        comment="noqa:L0*5,L01*", line_no=0, reference_map=dummy_rule_map
     )
     assert len(result.rules) == len(set(result.rules))
 
@@ -736,7 +765,7 @@ def test_linted_file_ignore_masked_violations(
     noqa: dict, violations: List[SQLBaseError], expected
 ):
     """Test that _ignore_masked_violations() correctly filters violations."""
-    ignore_mask = [Linter.parse_noqa(rule_codes=dummy_rule_codes, **c) for c in noqa]
+    ignore_mask = [Linter.parse_noqa(reference_map=dummy_rule_map, **c) for c in noqa]
     lf = linter.LintedFile(
         path="",
         violations=violations,

--- a/test/rules/std_test.py
+++ b/test/rules/std_test.py
@@ -130,4 +130,4 @@ def test_improper_configs_are_rejected(rule_config_dict):
         configs={"rules": rule_config_dict}, overrides={"dialect": "ansi"}
     )
     with pytest.raises(ValueError):
-        get_ruleset().get_rulelist(config)
+        get_ruleset().get_rulepack(config)


### PR DESCRIPTION
This is part of #4031 and builds on #4399 .

The original PR added the option to use aliases and groups in rule selection, this extends that functionality to the `--noqa` option.

To do that involved a bit more than expected, because we need to be able to pass around an accurate `reference_map` (so allow any references to be interpreted). Rule lists are generated in the main thread and then passed around, complicating the issue.

This PR introduces a `RulePack` class which replaces all the locations where previously we would use a list of instantiated rules (`List[BaseRule]`). This contains the same list of rules, but also the reference map used in creation. This means any time we have a list of rules, we have a map of references to use in any other selection locations.