### PR TITLE
Deprecate doc decorators (replace with metaclass)

### DIFF
--- a/plugins/sqlfluff-plugin-example/src/example/rules.py
+++ b/plugins/sqlfluff-plugin-example/src/example/rules.py
@@ -10,11 +10,6 @@ from sqlfluff.core.rules import (
     RuleContext,
 )
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from typing import List, Type
 import os.path
 from sqlfluff.core.config import ConfigLoader
@@ -45,9 +40,6 @@ def get_configs_info() -> dict:
 
 # These two decorators allow plugins
 # to be displayed in the sqlfluff docs
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_Example_L001(BaseRule):
     """ORDER BY on these columns is forbidden!
 
@@ -77,6 +69,7 @@ class Rule_Example_L001(BaseRule):
     groups = ("all",)
     config_keywords = ["forbidden_columns"]
     crawl_behaviour = SegmentSeekerCrawler({"orderby_clause"})
+    is_fix_compatible = True
 
     def __init__(self, *args, **kwargs):
         """Overwrite __init__ to set config."""

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -33,7 +33,6 @@ from sqlfluff.core.parser import Lexer, Parser, RegexLexer
 from sqlfluff.core.file_helpers import get_encoding
 from sqlfluff.core.templaters import TemplatedFile
 from sqlfluff.core.rules import get_ruleset
-from sqlfluff.core.rules.doc_decorators import is_fix_compatible
 from sqlfluff.core.config import FluffConfig, ConfigLoader, progress_bar_configuration
 
 # Classes needed only for type checking
@@ -567,7 +566,7 @@ class Linter:
                     if (
                         fix
                         and not is_first_linter_pass()
-                        and not is_fix_compatible(crawler)
+                        and not crawler.is_fix_compatible
                     ):
                         continue
 

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -22,6 +22,7 @@ from itertools import chain
 import logging
 import pathlib
 import regex
+import re
 from typing import (
     cast,
     Iterable,
@@ -46,6 +47,7 @@ from sqlfluff.core.errors import SQLLintError, SQLFluffUserError
 from sqlfluff.core.parser.segments.base import SourceFix
 from sqlfluff.core.rules.context import RuleContext
 from sqlfluff.core.rules.crawlers import BaseCrawler
+from sqlfluff.core.rules.config_info import get_config_info
 from sqlfluff.core.templaters.base import RawFileSlice, TemplatedFile
 
 # The ghost of a rule (mostly used for testing)
@@ -477,7 +479,91 @@ class LintFix:
 EvalResultType = Union[LintResult, List[LintResult], None]
 
 
-class BaseRule:
+class RuleMetaclass(type):
+    """The metaclass for rules.
+
+    This metaclass provides provides auto-enrichment of the
+    rule docstring so that examples, groups, aliases and
+    names are added.
+
+    The reason we enrich the docstring is so that it can be
+    picked up by autodoc and all be displayed in the sqlfluff
+    docs.
+    """
+
+    # Precompile the search regex
+    _pattern = re.compile(
+        "(\\s{4}\\*\\*Anti-pattern\\*\\*|\\s{4}\\.\\. note::|"
+        "\\s\\s{4}\\*\\*Configuration\\*\\*)",
+        flags=re.MULTILINE,
+    )
+
+    def __new__(mcs, name, bases, class_dict):
+        """Generate a new class.
+
+        This takes the various defined values in the BaseRule class
+        and uses them to populate documentation in the final class
+        docstring so that it can be displayed in the sphinx docs.
+        """
+        # First, build up a buffer of entries to add to the docstring.
+        fix_docs = (
+            "    This rule is ``sqlfluff fix`` compatible.\n\n"
+            if class_dict.get("is_fix_compatible", False)
+            else ""
+        )
+        name_docs = (
+            f"    **Name**: ``{class_dict['name']}``\n\n"
+            if class_dict.get("name", "")
+            else ""
+        )
+        alias_docs = (
+            ("    **Aliases**: ``" + "``, ``".join(class_dict["aliases"]) + "``\n\n")
+            if class_dict.get("aliases", [])
+            else ""
+        )
+        groups_docs = (
+            ("    **Groups**: ``" + "``, ``".join(class_dict["groups"]) + "``\n\n")
+            if class_dict.get("groups", [])
+            else ""
+        )
+
+        config_docs = ""
+        if class_dict.get("config_keywords", []):
+            config_docs = "\n    **Configuration**\n"
+            config_info = get_config_info()
+            for keyword in sorted(class_dict["config_keywords"]):
+                try:
+                    info_dict = config_info[keyword]
+                except KeyError:  # pragma: no cover
+                    raise KeyError(
+                        "Config value {!r} for rule {} is not configured in "
+                        "`config_info`.".format(keyword, name)
+                    )
+                config_docs += "\n    * ``{}``: {}".format(
+                    keyword, info_dict["definition"]
+                )
+                if (
+                    config_docs[-1] != "."
+                    and config_docs[-1] != "?"
+                    and config_docs[-1] != "\n"
+                ):
+                    config_docs += "."
+                if "validation" in info_dict:
+                    config_docs += " Must be one of ``{}``.".format(
+                        info_dict["validation"]
+                    )
+            config_docs += "\n"
+
+        all_docs = fix_docs + name_docs + alias_docs + groups_docs + config_docs
+        # Modify the docstring using the search regex.
+        class_dict["__doc__"] = mcs._pattern.sub(
+            f"\n\n{all_docs}\n\n\\1", class_dict["__doc__"], count=1
+        )
+        # Use the stock __new__ method now we've adjusted the docstring.
+        return super().__new__(mcs, name, bases, class_dict)
+
+
+class BaseRule(metaclass=RuleMetaclass):
     """The base class for a rule.
 
     Args:
@@ -516,6 +602,10 @@ class BaseRule:
     # Optional set of aliases for the rule. Most often used for old codes which
     # referred to this rule.
     aliases: Tuple[str, ...] = ()
+
+    # Should we document this rule as fixable? Used by the metaclass to add
+    # a line to the docstring.
+    is_fix_compatible = False
 
     def __init__(self, code, description, **kwargs):
         self.description = description

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -509,7 +509,7 @@ class RuleMetaclass(type):
         assert (
             "__doc__" in class_dict
         ), f"Tried to define rule {name!r} without docstring."
-        print(f"NEW: {name!r}, DICT: {class_dict}")
+
         # Build up a buffer of entries to add to the docstring.
         fix_docs = (
             "    This rule is ``sqlfluff fix`` compatible.\n\n"

--- a/src/sqlfluff/core/rules/doc_decorators.py
+++ b/src/sqlfluff/core/rules/doc_decorators.py
@@ -9,7 +9,7 @@ is now packaged in the BaseRule class via the RuleMetaclass.
 from sqlfluff.core.rules.base import rules_logger  # noqa
 
 
-def document_fix_compatible(cls):  # pragma: no cover
+def document_fix_compatible(cls):
     """Mark the rule as fixable in the documentation."""
     rules_logger.warning(
         f"{cls.__name__} uses the @document_fix_compatible decorator "
@@ -19,7 +19,7 @@ def document_fix_compatible(cls):  # pragma: no cover
     return cls
 
 
-def document_groups(cls):  # pragma: no cover
+def document_groups(cls):
     """Mark the rule as fixable in the documentation."""
     rules_logger.warning(
         f"{cls.__name__} uses the @document_groups decorator "
@@ -29,7 +29,7 @@ def document_groups(cls):  # pragma: no cover
     return cls
 
 
-def document_configuration(cls, **kwargs):  # pragma: no cover
+def document_configuration(cls, **kwargs):
     """Add a 'Configuration' section to a Rule docstring."""
     rules_logger.warning(
         f"{cls.__name__} uses the @document_configuration decorator "

--- a/src/sqlfluff/core/rules/doc_decorators.py
+++ b/src/sqlfluff/core/rules/doc_decorators.py
@@ -1,110 +1,39 @@
-"""A collection of decorators to modify rule docstrings for Sphinx."""
+"""A collection of decorators to modify rule docstrings for Sphinx.
 
-from sqlfluff.core.rules.config_info import get_config_info
+NOTE: All of these decorators are deprecated from SQLFluff 2.0.0 onwards.
+
+They are still included to allow a transition period, but the functionality
+is now packaged in the BaseRule class via the RuleMetaclass.
+"""
+
 from sqlfluff.core.rules.base import rules_logger  # noqa
-import re
 
 
-FIX_COMPATIBLE = "    This rule is ``sqlfluff fix`` compatible."
-
-
-def document_fix_compatible(cls):
+def document_fix_compatible(cls):  # pragma: no cover
     """Mark the rule as fixable in the documentation."""
-    # Match `**Anti-pattern**`, `.. note::` and `**Configuration**`,
-    # then insert fix_compatible before the first occurrences.
-    # We match `**Configuration**` here to make it work in all order of doc decorators
-    pattern = re.compile(
-        "(\\s{4}\\*\\*Anti-pattern\\*\\*|\\s{4}\\.\\. note::|"
-        "\\s{4}\\*\\*Configuration\\*\\*)",
-        flags=re.MULTILINE,
+    rules_logger.warning(
+        f"{cls.__name__} uses the @document_fix_compatible decorator "
+        "which is deprecated in SQLFluff 2.0.0. Remove the decorator "
+        "to resolve this warning."
     )
-    cls.__doc__ = pattern.sub(f"\n\n{FIX_COMPATIBLE}\n\n\\1", cls.__doc__, count=1)
     return cls
 
 
-def is_fix_compatible(cls) -> bool:
-    """Return whether the rule is documented as fixable."""
-    return FIX_COMPATIBLE in cls.__doc__
-
-
-def document_groups(cls):
+def document_groups(cls):  # pragma: no cover
     """Mark the rule as fixable in the documentation."""
-    # Match `**Anti-pattern**`, `.. note::` and `**Configuration**`,
-    # then insert group documentation    before the first occurrences.
-    # We match `**Configuration**` here to make it work in all order of doc decorators
-    pattern = re.compile(
-        "(\\s{4}\\*\\*Anti-pattern\\*\\*|\\s{4}\\.\\. note::|"
-        "\\s\\s{4}\\*\\*Configuration\\*\\*)",
-        flags=re.MULTILINE,
+    rules_logger.warning(
+        f"{cls.__name__} uses the @document_groups decorator "
+        "which is deprecated in SQLFluff 2.0.0. Remove the decorator "
+        "to resolve this warning."
     )
-
-    groups_docs = (
-        "\n    **Groups**: ``" + "``, ``".join(getattr(cls, "groups")) + "``\n"
-    )
-    cls.__doc__ = pattern.sub(f"\n\n{groups_docs}\n\n\\1", cls.__doc__, count=1)
     return cls
 
 
-def is_documenting_groups(cls) -> bool:
-    """Return whether the rule groups are documented."""
-    return "\n    **Groups**: " in cls.__doc__
-
-
-def document_configuration(cls, ruleset="std"):
-    """Add a 'Configuration' section to a Rule docstring.
-
-    Utilize the the metadata in config_info to dynamically
-    document the configuration options for a given rule.
-
-    This is a little hacky, but it allows us to propagate configuration
-    options in the docs, from a single source of truth.
-    """
-    if ruleset == "std":
-        config_info = get_config_info()
-    else:  # pragma: no cover
-        raise (
-            NotImplementedError(
-                "Add another config info dict for the new ruleset here!"
-            )
-        )
-
-    config_doc = "\n    **Configuration**\n"
-    try:
-        for keyword in sorted(cls.config_keywords):
-            try:
-                info_dict = config_info[keyword]
-            except KeyError:  # pragma: no cover
-                raise KeyError(
-                    "Config value {!r} for rule {} is not configured in "
-                    "`config_info`.".format(keyword, cls.__name__)
-                )
-            config_doc += "\n    * ``{}``: {}".format(keyword, info_dict["definition"])
-            if (
-                config_doc[-1] != "."
-                and config_doc[-1] != "?"
-                and config_doc[-1] != "\n"
-            ):
-                config_doc += "."
-            if "validation" in info_dict:
-                config_doc += " Must be one of ``{}``.".format(info_dict["validation"])
-    except AttributeError:
-        rules_logger.info(f"No config_keywords defined for {cls.__name__}")
-        return cls
-    # Add final blank line
-    config_doc += "\n"
-
-    if "**Anti-pattern**" in cls.__doc__:
-        # Match `**Anti-pattern**`, then insert configuration before
-        # the first occurrences
-        pattern = re.compile("(\\s{4}\\*\\*Anti-pattern\\*\\*)", flags=re.MULTILINE)
-        cls.__doc__ = pattern.sub(f"\n{config_doc}\n\\1", cls.__doc__, count=1)
-    else:
-        # Match last `\n` or `.`, then append configuration
-        pattern = re.compile("(\\.|\\n)$", flags=re.MULTILINE)
-        cls.__doc__ = pattern.sub(f"\\1\n{config_doc}\n", cls.__doc__, count=1)
+def document_configuration(cls, **kwargs):  # pragma: no cover
+    """Add a 'Configuration' section to a Rule docstring."""
+    rules_logger.warning(
+        f"{cls.__name__} uses the @document_configuration decorator "
+        "which is deprecated in SQLFluff 2.0.0. Remove the decorator "
+        "to resolve this warning."
+    )
     return cls
-
-
-def is_configurable(cls) -> bool:
-    """Return whether the rule is documented as fixable."""
-    return "**Configuration**" in cls.__doc__

--- a/src/sqlfluff/rules/L001.py
+++ b/src/sqlfluff/rules/L001.py
@@ -2,15 +2,9 @@
 from typing import List
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import RootOnlyCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.utils.reflow import ReflowSequence
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L001(BaseRule):
     """Unnecessary trailing whitespace.
 
@@ -40,6 +34,7 @@ class Rule_L001(BaseRule):
     aliases = ("LS01",)
     groups = ("all", "core", "layout", "spacing")
     crawl_behaviour = RootOnlyCrawler()
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> List[LintResult]:
         """Unnecessary trailing whitespace.

--- a/src/sqlfluff/rules/L002.py
+++ b/src/sqlfluff/rules/L002.py
@@ -3,16 +3,8 @@ from typing import Optional
 
 from sqlfluff.core.rules import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L002(BaseRule):
     """Mixed Tabs and Spaces in single whitespace.
 
@@ -49,6 +41,7 @@ class Rule_L002(BaseRule):
     aliases = ("LN01a",)
     groups = ("all", "core", "layout")
     crawl_behaviour = SegmentSeekerCrawler({"whitespace"}, provide_raw_stack=True)
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Mixed Tabs and Spaces in single whitespace.

--- a/src/sqlfluff/rules/L003.py
+++ b/src/sqlfluff/rules/L003.py
@@ -3,17 +3,9 @@ from typing import List
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import RootOnlyCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.utils.reflow.sequence import ReflowSequence
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L003(BaseRule):
     """Indentation not consistent with previous lines.
 
@@ -50,6 +42,7 @@ class Rule_L003(BaseRule):
     aliases = ("LN01b",)
     groups = ("all", "core", "layout")
     crawl_behaviour = RootOnlyCrawler()
+    is_fix_compatible = True
     targets_templated = True
     template_safe_fixes = True
     _adjust_anchors = True

--- a/src/sqlfluff/rules/L004.py
+++ b/src/sqlfluff/rules/L004.py
@@ -2,18 +2,9 @@
 from sqlfluff.core.parser import WhitespaceSegment
 from sqlfluff.core.rules import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
-
 from sqlfluff.utils.reflow.reindent import construct_single_indent
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L004(BaseRule):
     """Incorrect indentation type.
 
@@ -54,6 +45,7 @@ class Rule_L004(BaseRule):
     aliases = ("LN01c",)
     groups = ("all", "core", "layout")
     crawl_behaviour = SegmentSeekerCrawler({"whitespace"}, provide_raw_stack=True)
+    is_fix_compatible = True
 
     # TODO fix indents after text:
     # https://github.com/sqlfluff/sqlfluff/pull/590#issuecomment-739484190

--- a/src/sqlfluff/rules/L005.py
+++ b/src/sqlfluff/rules/L005.py
@@ -3,12 +3,9 @@ from typing import List
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.reflow.sequence import ReflowSequence
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L005(BaseRule):
     """Commas should not have whitespace directly before them.
 
@@ -44,6 +41,7 @@ class Rule_L005(BaseRule):
     aliases = ("LS02",)
     groups = ("all", "core", "layout", "spacing")
     crawl_behaviour = SegmentSeekerCrawler({"comma"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> List[LintResult]:
         """Commas should not have whitespace directly before them."""

--- a/src/sqlfluff/rules/L006.py
+++ b/src/sqlfluff/rules/L006.py
@@ -9,12 +9,9 @@ from sqlfluff.core.rules import (
     RuleContext,
 )
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.reflow import ReflowSequence
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L006(BaseRule):
     """Operators should be surrounded by a single whitespace.
 
@@ -46,6 +43,7 @@ class Rule_L006(BaseRule):
     crawl_behaviour = SegmentSeekerCrawler(
         {"binary_operator", "comparison_operator", "assignment_operator"}
     )
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> List[LintResult]:
         """Operators should be surrounded by a single whitespace.

--- a/src/sqlfluff/rules/L007.py
+++ b/src/sqlfluff/rules/L007.py
@@ -4,18 +4,9 @@ from typing import List
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.utils.reflow import ReflowSequence
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L007(BaseRule):
     """Operators should follow a standard for being before/after newlines.
 
@@ -58,6 +49,7 @@ class Rule_L007(BaseRule):
     aliases = ("LB03",)
     groups = ("all", "layout", "line-break")
     crawl_behaviour = SegmentSeekerCrawler({"binary_operator", "comparison_operator"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> List[LintResult]:
         """Operators should follow a standard for being before/after newlines.

--- a/src/sqlfluff/rules/L008.py
+++ b/src/sqlfluff/rules/L008.py
@@ -3,13 +3,9 @@ from typing import List
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
-
 from sqlfluff.utils.reflow.sequence import ReflowSequence
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L008(BaseRule):
     """Commas should be followed by a single whitespace unless followed by a comment.
 
@@ -41,6 +37,7 @@ class Rule_L008(BaseRule):
     aliases = ("LS04",)
     groups = ("all", "core", "layout", "spacing")
     crawl_behaviour = SegmentSeekerCrawler({"comma"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> List[LintResult]:
         """Commas should not have whitespace directly before them."""

--- a/src/sqlfluff/rules/L009.py
+++ b/src/sqlfluff/rules/L009.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Tuple
 from sqlfluff.core.parser import BaseSegment, NewlineSegment
 from sqlfluff.core.rules import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.crawlers import RootOnlyCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.functional import Segments, sp, tsp, FunctionalContext
 
 
@@ -31,8 +30,6 @@ def get_last_segment(segment: Segments) -> Tuple[List[BaseSegment], Segments]:
             return parent_stack, segment
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L009(BaseRule):
     """Files must end with a single trailing newline.
 
@@ -113,6 +110,7 @@ class Rule_L009(BaseRule):
     # Use the RootOnlyCrawler to only call _eval() ONCE, with the root segment.
     crawl_behaviour = RootOnlyCrawler()
     lint_phase = "post"
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Files must end with a single trailing newline.

--- a/src/sqlfluff/rules/L010.py
+++ b/src/sqlfluff/rules/L010.py
@@ -6,11 +6,6 @@ from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.rules import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.config_info import get_config_info
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 
 
 def is_capitalizable(character: str) -> bool:
@@ -20,9 +15,6 @@ def is_capitalizable(character: str) -> bool:
     return True
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L010(BaseRule):
     """Inconsistent capitalisation of keywords.
 
@@ -72,6 +64,7 @@ class Rule_L010(BaseRule):
     config_keywords = ["capitalisation_policy", "ignore_words", "ignore_words_regex"]
     # Human readable target elem for description
     _description_elem = "Keywords"
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[List[LintResult]]:
         """Inconsistent capitalisation of keywords.

--- a/src/sqlfluff/rules/L011.py
+++ b/src/sqlfluff/rules/L011.py
@@ -7,17 +7,9 @@ from sqlfluff.core.parser import (
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.utils.reflow import ReflowSequence
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L011(BaseRule):
     """Implicit/explicit aliasing of table.
 
@@ -49,6 +41,7 @@ class Rule_L011(BaseRule):
     groups: Tuple[str, ...] = ("all",)
     config_keywords = ["aliasing"]
     crawl_behaviour = SegmentSeekerCrawler({"alias_expression"}, provide_raw_stack=True)
+    is_fix_compatible = True
 
     _target_elems: List[Tuple[str, str]] = [
         ("type", "from_expression_element"),

--- a/src/sqlfluff/rules/L012.py
+++ b/src/sqlfluff/rules/L012.py
@@ -2,13 +2,10 @@
 from typing import Optional
 
 from sqlfluff.rules.L011 import Rule_L011
-from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 from sqlfluff.core.rules import LintResult, RuleContext
 from sqlfluff.utils.functional import FunctionalContext
 
 
-@document_groups
-@document_configuration
 class Rule_L012(Rule_L011):
     """Implicit/explicit aliasing of columns.
 

--- a/src/sqlfluff/rules/L013.py
+++ b/src/sqlfluff/rules/L013.py
@@ -3,12 +3,9 @@ from typing import Optional
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 from sqlfluff.utils.functional import Segments, sp, FunctionalContext
 
 
-@document_groups
-@document_configuration
 class Rule_L013(BaseRule):
     """Column expression without alias. Use explicit `AS` clause.
 

--- a/src/sqlfluff/rules/L014.py
+++ b/src/sqlfluff/rules/L014.py
@@ -5,11 +5,6 @@ from typing import Tuple, Optional, List
 from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.rules import LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.rules.L010 import Rule_L010
 
 
@@ -32,9 +27,6 @@ def identifiers_policy_applicable(
     return False
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L014(Rule_L010):
     """Inconsistent capitalisation of unquoted identifiers.
 
@@ -83,6 +75,7 @@ class Rule_L014(Rule_L010):
         "ignore_words_regex",
     ]
     _description_elem = "Unquoted identifiers"
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[List[LintResult]]:
         # Return None if identifier is case-sensitive property to enable Change

--- a/src/sqlfluff/rules/L015.py
+++ b/src/sqlfluff/rules/L015.py
@@ -4,13 +4,10 @@ from typing import Optional
 from sqlfluff.core.parser import KeywordSegment, WhitespaceSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.functional import sp, FunctionalContext
 from sqlfluff.utils.reflow.sequence import ReflowSequence
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L015(BaseRule):
     """``DISTINCT`` used with parentheses.
 
@@ -37,6 +34,7 @@ class Rule_L015(BaseRule):
 
     groups = ("all", "core")
     crawl_behaviour = SegmentSeekerCrawler({"select_clause", "function"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Looking for DISTINCT before a bracket.

--- a/src/sqlfluff/rules/L016.py
+++ b/src/sqlfluff/rules/L016.py
@@ -7,18 +7,10 @@ from sqlfluff.core.parser.segments import TemplateSegment
 from sqlfluff.core.rules import LintResult, RuleContext
 from sqlfluff.core.rules.base import BaseRule
 from sqlfluff.core.rules.crawlers import RootOnlyCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 
 from sqlfluff.utils.reflow.sequence import ReflowSequence
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L016(BaseRule):
     """Line is too long."""
 
@@ -28,6 +20,7 @@ class Rule_L016(BaseRule):
     template_safe_fixes = True
     _adjust_anchors = True
     _check_docstring = False
+    is_fix_compatible = True
 
     config_keywords = [
         "ignore_comment_lines",

--- a/src/sqlfluff/rules/L017.py
+++ b/src/sqlfluff/rules/L017.py
@@ -2,12 +2,9 @@
 
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.functional import sp, FunctionalContext
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L017(BaseRule):
     """Function name not immediately followed by parenthesis.
 
@@ -35,6 +32,7 @@ class Rule_L017(BaseRule):
 
     groups = ("all", "core")
     crawl_behaviour = SegmentSeekerCrawler({"function"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> LintResult:
         """Function name not immediately followed by bracket.

--- a/src/sqlfluff/rules/L018.py
+++ b/src/sqlfluff/rules/L018.py
@@ -10,17 +10,9 @@ from sqlfluff.core.parser import (
 
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.utils.functional import sp, FunctionalContext
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L018(BaseRule):
     """``WITH`` clause closing bracket should be on a new line.
 
@@ -54,6 +46,7 @@ class Rule_L018(BaseRule):
     crawl_behaviour = SegmentSeekerCrawler(
         {"with_compound_statement"}, provide_raw_stack=True
     )
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext):
         """WITH clause closing bracket should be aligned with WITH keyword.

--- a/src/sqlfluff/rules/L019.py
+++ b/src/sqlfluff/rules/L019.py
@@ -4,17 +4,9 @@ from typing import List
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.utils.reflow import ReflowSequence
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L019(BaseRule):
     """Leading/Trailing comma enforcement.
 
@@ -57,6 +49,7 @@ class Rule_L019(BaseRule):
     groups = ("all",)
     crawl_behaviour = SegmentSeekerCrawler({"comma"})
     _adjust_anchors = True
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> List[LintResult]:
         """Enforce comma placement.

--- a/src/sqlfluff/rules/L020.py
+++ b/src/sqlfluff/rules/L020.py
@@ -8,10 +8,8 @@ from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext, EvalResultType
 from sqlfluff.utils.analysis.select import get_select_statement_info
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_groups
 
 
-@document_groups
 class Rule_L020(BaseRule):
     """Table aliases should be unique within each clause.
 

--- a/src/sqlfluff/rules/L021.py
+++ b/src/sqlfluff/rules/L021.py
@@ -4,10 +4,8 @@ from typing import Optional
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.utils.functional import sp, FunctionalContext
-from sqlfluff.core.rules.doc_decorators import document_groups
 
 
-@document_groups
 class Rule_L021(BaseRule):
     """Ambiguous use of ``DISTINCT`` in a ``SELECT`` statement with ``GROUP BY``.
 

--- a/src/sqlfluff/rules/L022.py
+++ b/src/sqlfluff/rules/L022.py
@@ -5,16 +5,8 @@ from sqlfluff.core.parser import NewlineSegment
 
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L022(BaseRule):
     """Blank line expected but not found after CTE closing bracket.
 
@@ -46,6 +38,7 @@ class Rule_L022(BaseRule):
 
     groups = ("all", "core")
     crawl_behaviour = SegmentSeekerCrawler({"with_compound_statement"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[List[LintResult]]:
         """Blank line expected but not found after CTE definition."""

--- a/src/sqlfluff/rules/L023.py
+++ b/src/sqlfluff/rules/L023.py
@@ -4,14 +4,11 @@ from typing import List
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 from sqlfluff.utils.functional import FunctionalContext, sp
 from sqlfluff.utils.reflow.sequence import ReflowSequence
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L023(BaseRule):
     """Single whitespace expected after ``AS`` in ``WITH`` clause.
 
@@ -45,6 +42,7 @@ class Rule_L023(BaseRule):
     crawl_behaviour = SegmentSeekerCrawler({"common_table_expression"})
     target_keyword = "AS"
     strip_newlines = True
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> List[LintResult]:
         """Single whitespace expected in mother middle segment."""

--- a/src/sqlfluff/rules/L024.py
+++ b/src/sqlfluff/rules/L024.py
@@ -2,12 +2,9 @@
 
 
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.rules.L023 import Rule_L023
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L024(Rule_L023):
     """Single whitespace expected after ``USING`` in ``JOIN`` clause.
 
@@ -36,3 +33,4 @@ class Rule_L024(Rule_L023):
     crawl_behaviour = SegmentSeekerCrawler({"join_clause"})
     target_keyword = "USING"
     strip_newlines = False
+    is_fix_compatible = True

--- a/src/sqlfluff/rules/L025.py
+++ b/src/sqlfluff/rules/L025.py
@@ -18,7 +18,6 @@ from sqlfluff.core.rules import (
     EvalResultType,
 )
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.functional import Segments, sp
 from sqlfluff.core.dialects.common import AliasInfo
 
@@ -31,8 +30,6 @@ class L025Query(SelectCrawlerQuery):
     tbl_refs: Set[str] = field(default_factory=set)
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L025(BaseRule):
     """Tables should not be aliased if that alias is not used.
 
@@ -69,6 +66,7 @@ class Rule_L025(BaseRule):
         "snowflake",
         "tsql",
     ]
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> EvalResultType:
         violations: List[LintResult] = []

--- a/src/sqlfluff/rules/L026.py
+++ b/src/sqlfluff/rules/L026.py
@@ -15,7 +15,6 @@ from sqlfluff.core.rules import (
     EvalResultType,
 )
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 from sqlfluff.utils.functional import sp, FunctionalContext
 from sqlfluff.core.rules.reference import object_ref_matches_table
 
@@ -36,8 +35,6 @@ class L026Query(SelectCrawlerQuery):
     standalone_aliases: List[str] = field(default_factory=list)
 
 
-@document_groups
-@document_configuration
 class Rule_L026(BaseRule):
     """References cannot reference objects not present in ``FROM`` clause.
 

--- a/src/sqlfluff/rules/L027.py
+++ b/src/sqlfluff/rules/L027.py
@@ -4,11 +4,8 @@ from typing import List, Optional
 
 from sqlfluff.core.rules import LintResult
 from sqlfluff.rules.L020 import Rule_L020
-from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 
 
-@document_groups
-@document_configuration
 class Rule_L027(Rule_L020):
     """References should be qualified if select has more than one referenced table/view.
 

--- a/src/sqlfluff/rules/L028.py
+++ b/src/sqlfluff/rules/L028.py
@@ -16,20 +16,12 @@ from sqlfluff.core.rules import (
 )
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.utils.functional import sp, FunctionalContext
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.dialects.dialect_ansi import IdentifierSegment
 
 
 _START_TYPES = ["select_statement", "set_expression", "with_compound_statement"]
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L028(BaseRule):
     """References should be consistent in statements with a single table.
 
@@ -82,6 +74,7 @@ class Rule_L028(BaseRule):
     _dialects_with_structs = ["bigquery", "hive", "redshift"]
     # This could be turned into an option
     _fix_inconsistent_to = "qualified"
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> EvalResultType:
         """Override base class for dialects that use structs, or SELECT aliases."""

--- a/src/sqlfluff/rules/L029.py
+++ b/src/sqlfluff/rules/L029.py
@@ -4,12 +4,9 @@ from typing import Optional
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 from sqlfluff.rules.L014 import identifiers_policy_applicable
 
 
-@document_groups
-@document_configuration
 class Rule_L029(BaseRule):
     """Keywords should not be used as identifiers.
 

--- a/src/sqlfluff/rules/L030.py
+++ b/src/sqlfluff/rules/L030.py
@@ -3,17 +3,9 @@
 from typing import List, Tuple
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.rules.L010 import Rule_L010
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L030(Rule_L010):
     """Inconsistent capitalisation of function names.
 
@@ -54,6 +46,7 @@ class Rule_L030(Rule_L010):
         "ignore_words_regex",
     ]
     _description_elem = "Function names"
+    is_fix_compatible = True
 
     def _get_fix(self, segment, fixed_raw):
         return super()._get_fix(segment, fixed_raw)

--- a/src/sqlfluff/rules/L031.py
+++ b/src/sqlfluff/rules/L031.py
@@ -6,11 +6,6 @@ from typing import Generator, NamedTuple, Optional
 from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 
 from sqlfluff.utils.functional import sp, FunctionalContext
 
@@ -24,9 +19,6 @@ class TableAliasInfo(NamedTuple):
     alias_identifier_ref: BaseSegment
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L031(BaseRule):
     """Avoid table aliases in from clauses and join conditions.
 
@@ -88,6 +80,7 @@ class Rule_L031(BaseRule):
     config_keywords = ["force_enable"]
     crawl_behaviour = SegmentSeekerCrawler({"select_statement"})
     _dialects_disabled_by_default = ["bigquery"]
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Identify aliases in from clause and join conditions.

--- a/src/sqlfluff/rules/L032.py
+++ b/src/sqlfluff/rules/L032.py
@@ -8,14 +8,11 @@ from sqlfluff.core.parser.segments.raw import (
 )
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.functional import Segments, sp, FunctionalContext
 from sqlfluff.utils.analysis.select import get_select_statement_info
 from sqlfluff.dialects.dialect_ansi import ColumnReferenceSegment, IdentifierSegment
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L032(BaseRule):
     """Prefer specifying join keys instead of using ``USING``.
 
@@ -61,6 +58,7 @@ class Rule_L032(BaseRule):
 
     groups = ("all",)
     crawl_behaviour = SegmentSeekerCrawler({"join_clause"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Look for USING in a join clause."""

--- a/src/sqlfluff/rules/L033.py
+++ b/src/sqlfluff/rules/L033.py
@@ -6,10 +6,8 @@ from sqlfluff.core.parser import (
 
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_groups
 
 
-@document_groups
 class Rule_L033(BaseRule):
     """``UNION [DISTINCT|ALL]`` is preferred over just ``UNION``.
 

--- a/src/sqlfluff/rules/L034.py
+++ b/src/sqlfluff/rules/L034.py
@@ -10,11 +10,8 @@ from sqlfluff.core.rules import (
     RuleContext,
 )
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L034(BaseRule):
     """Select wildcards then simple targets before calculations and aggregates.
 
@@ -47,6 +44,7 @@ class Rule_L034(BaseRule):
 
     groups = ("all",)
     crawl_behaviour = SegmentSeekerCrawler({"select_clause"})
+    is_fix_compatible = True
 
     def _validate(self, i: int, segment: BaseSegment) -> None:
         # Check if we've seen a more complex select target element already

--- a/src/sqlfluff/rules/L035.py
+++ b/src/sqlfluff/rules/L035.py
@@ -3,12 +3,9 @@ from typing import Optional
 
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.functional import sp, FunctionalContext
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L035(BaseRule):
     """Do not specify ``else null`` in a case when statement (redundant).
 
@@ -40,6 +37,7 @@ class Rule_L035(BaseRule):
 
     groups = ("all",)
     crawl_behaviour = SegmentSeekerCrawler({"case_expression"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Find rule violations and provide fixes.

--- a/src/sqlfluff/rules/L036.py
+++ b/src/sqlfluff/rules/L036.py
@@ -8,11 +8,6 @@ from sqlfluff.core.parser import BaseSegment, NewlineSegment
 from sqlfluff.core.parser.segments.base import IdentitySet
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.utils.functional import Segments, sp, FunctionalContext
 
 
@@ -29,9 +24,6 @@ class SelectTargetsInfo(NamedTuple):
     pre_from_whitespace: List[BaseSegment]
 
 
-@document_groups
-@document_configuration
-@document_fix_compatible
 class Rule_L036(BaseRule):
     """Select targets should be on a new line unless there is only one select target.
 
@@ -80,6 +72,7 @@ class Rule_L036(BaseRule):
     groups = ("all",)
     config_keywords = ["wildcard_policy"]
     crawl_behaviour = SegmentSeekerCrawler({"select_clause"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext):
         self.wildcard_policy: str

--- a/src/sqlfluff/rules/L037.py
+++ b/src/sqlfluff/rules/L037.py
@@ -7,7 +7,6 @@ from sqlfluff.core.parser import WhitespaceSegment, KeywordSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
 class OrderByColumnInfo(NamedTuple):
@@ -17,8 +16,6 @@ class OrderByColumnInfo(NamedTuple):
     order: Optional[str]  # One of 'ASC'/'DESC'/None
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L037(BaseRule):
     """Ambiguous ordering directions for columns in order by clause.
 
@@ -46,6 +43,7 @@ class Rule_L037(BaseRule):
 
     groups = ("all",)
     crawl_behaviour = SegmentSeekerCrawler({"orderby_clause"})
+    is_fix_compatible = True
 
     @staticmethod
     def _get_orderby_info(segment: BaseSegment) -> List[OrderByColumnInfo]:

--- a/src/sqlfluff/rules/L038.py
+++ b/src/sqlfluff/rules/L038.py
@@ -6,16 +6,8 @@ from sqlfluff.core.parser import BaseSegment, SymbolSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.utils.functional import sp, FunctionalContext
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L038(BaseRule):
     """Trailing commas within select clause.
 
@@ -48,6 +40,7 @@ class Rule_L038(BaseRule):
     groups = ("all", "core")
     config_keywords = ["select_clause_trailing_comma"]
     crawl_behaviour = SegmentSeekerCrawler({"select_clause"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Trailing commas within select clause."""

--- a/src/sqlfluff/rules/L039.py
+++ b/src/sqlfluff/rules/L039.py
@@ -3,12 +3,9 @@ from typing import List, Optional
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import RootOnlyCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.reflow.sequence import ReflowSequence
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L039(BaseRule):
     """Unnecessary whitespace found.
 
@@ -34,6 +31,7 @@ class Rule_L039(BaseRule):
 
     groups = ("all", "core")
     crawl_behaviour = RootOnlyCrawler()
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[List[LintResult]]:
         """Unnecessary whitespace."""

--- a/src/sqlfluff/rules/L040.py
+++ b/src/sqlfluff/rules/L040.py
@@ -3,17 +3,9 @@
 from typing import Tuple, List
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.rules.L010 import Rule_L010
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L040(Rule_L010):
     """Inconsistent capitalisation of boolean/null literal.
 
@@ -62,3 +54,4 @@ class Rule_L040(Rule_L010):
     crawl_behaviour = SegmentSeekerCrawler({"null_literal", "boolean_literal"})
     _exclude_elements: List[Tuple[str, str]] = []
     _description_elem = "Boolean/null literals"
+    is_fix_compatible = True

--- a/src/sqlfluff/rules/L041.py
+++ b/src/sqlfluff/rules/L041.py
@@ -5,12 +5,9 @@ from sqlfluff.core.parser import NewlineSegment, WhitespaceSegment
 
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.functional import sp, FunctionalContext
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L041(BaseRule):
     """``SELECT`` modifiers (e.g. ``DISTINCT``) must be on the same line as ``SELECT``.
 
@@ -37,6 +34,7 @@ class Rule_L041(BaseRule):
 
     groups = ("all", "core")
     crawl_behaviour = SegmentSeekerCrawler({"select_clause"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Select clause modifiers must appear on same line as SELECT."""

--- a/src/sqlfluff/rules/L042.py
+++ b/src/sqlfluff/rules/L042.py
@@ -32,11 +32,6 @@ from sqlfluff.core.rules import (
 from sqlfluff.utils.analysis.select import get_select_statement_info
 from sqlfluff.utils.analysis.select_crawler import Query, Selectable, SelectCrawler
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.utils.functional.segment_predicates import (
     is_keyword,
     is_type,
@@ -66,9 +61,6 @@ class _NestedSubQuerySummary(NamedTuple):
     select_source_names: Set[str]
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L042(BaseRule):
     """Join/From clauses should not contain subqueries. Use CTEs instead.
 
@@ -115,6 +107,7 @@ class Rule_L042(BaseRule):
         "from": ["from_expression_element"],
         "both": ["join_clause", "from_expression_element"],
     }
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> EvalResultType:
         """Join/From clauses should not contain subqueries. Use CTEs instead."""

--- a/src/sqlfluff/rules/L043.py
+++ b/src/sqlfluff/rules/L043.py
@@ -10,12 +10,9 @@ from sqlfluff.core.parser.segments.base import BaseSegment
 
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.functional import Segments, sp, FunctionalContext
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L043(BaseRule):
     """Unnecessary ``CASE`` statement.
 
@@ -80,6 +77,7 @@ class Rule_L043(BaseRule):
 
     groups = ("all",)
     crawl_behaviour = SegmentSeekerCrawler({"case_expression"})
+    is_fix_compatible = True
 
     @staticmethod
     def _coalesce_fix_list(

--- a/src/sqlfluff/rules/L044.py
+++ b/src/sqlfluff/rules/L044.py
@@ -5,7 +5,6 @@ from sqlfluff.utils.analysis.select_crawler import Query, SelectCrawler
 from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_groups
 from sqlfluff.utils.functional import sp, FunctionalContext
 
 
@@ -19,7 +18,6 @@ class RuleFailure(Exception):
         self.anchor: BaseSegment = anchor
 
 
-@document_groups
 class Rule_L044(BaseRule):
     """Query produces an unknown number of result columns.
 

--- a/src/sqlfluff/rules/L045.py
+++ b/src/sqlfluff/rules/L045.py
@@ -4,10 +4,8 @@ from typing import Iterator
 from sqlfluff.core.rules import BaseRule, EvalResultType, LintResult, RuleContext
 from sqlfluff.utils.analysis.select_crawler import Query, SelectCrawler
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_groups
 
 
-@document_groups
 class Rule_L045(BaseRule):
     """Query defines a CTE (common-table expression) but does not use it.
 

--- a/src/sqlfluff/rules/L046.py
+++ b/src/sqlfluff/rules/L046.py
@@ -11,10 +11,8 @@ from sqlfluff.core.rules import (
 )
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.utils.functional import rsp, FunctionalContext
-from sqlfluff.core.rules.doc_decorators import document_groups
 
 
-@document_groups
 class Rule_L046(BaseRule):
     """Jinja tags should have a single whitespace on either side.
 

--- a/src/sqlfluff/rules/L047.py
+++ b/src/sqlfluff/rules/L047.py
@@ -3,17 +3,9 @@ from typing import Optional
 
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.utils.functional import sp, FunctionalContext
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L047(BaseRule):
     """Use consistent syntax to express "count number of rows".
 
@@ -63,6 +55,7 @@ class Rule_L047(BaseRule):
     groups = ("all", "core")
     config_keywords = ["prefer_count_1", "prefer_count_0"]
     crawl_behaviour = SegmentSeekerCrawler({"function"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Find rule violations and provide fixes."""

--- a/src/sqlfluff/rules/L048.py
+++ b/src/sqlfluff/rules/L048.py
@@ -5,12 +5,9 @@ from typing import List
 from sqlfluff.core.rules.base import BaseRule, LintResult
 from sqlfluff.core.rules.context import RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.reflow import ReflowSequence
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L048(BaseRule):
     """Quoted literals should be surrounded by a single whitespace.
 
@@ -41,6 +38,7 @@ class Rule_L048(BaseRule):
     crawl_behaviour = SegmentSeekerCrawler(
         {"quoted_literal", "date_constructor_literal"}
     )
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> List[LintResult]:
         """Quoted literals should be surrounded by a single whitespace."""

--- a/src/sqlfluff/rules/L049.py
+++ b/src/sqlfluff/rules/L049.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Union
 from sqlfluff.core.parser import KeywordSegment, WhitespaceSegment
 from sqlfluff.core.rules import LintResult, RuleContext, BaseRule
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.functional import sp, Segments
 from sqlfluff.utils.reflow import ReflowSequence
 
@@ -12,8 +11,6 @@ from sqlfluff.utils.reflow import ReflowSequence
 CorrectionListType = List[Union[WhitespaceSegment, KeywordSegment]]
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L049(BaseRule):
     """Comparisons with NULL should use "IS" or "IS NOT".
 
@@ -43,6 +40,7 @@ class Rule_L049(BaseRule):
 
     groups = ("all", "core")
     crawl_behaviour = SegmentSeekerCrawler({"comparison_operator"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Relational operators should not be used to check for NULL values."""

--- a/src/sqlfluff/rules/L050.py
+++ b/src/sqlfluff/rules/L050.py
@@ -4,11 +4,8 @@ from typing import Optional
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import RootOnlyCrawler
 from sqlfluff.utils.functional import Segments, sp, rsp
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L050(BaseRule):
     """Files must not begin with newlines or whitespace.
 
@@ -71,6 +68,7 @@ class Rule_L050(BaseRule):
     # Use the RootOnlyCrawler to only call _eval() ONCE, with the root segment.
     crawl_behaviour = RootOnlyCrawler()
     lint_phase = "post"
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Files must not begin with newlines or whitespace."""

--- a/src/sqlfluff/rules/L051.py
+++ b/src/sqlfluff/rules/L051.py
@@ -4,16 +4,8 @@ from sqlfluff.core.parser.segments.raw import KeywordSegment, WhitespaceSegment
 
 from sqlfluff.core.rules import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L051(BaseRule):
     """Join clauses should be fully qualified.
 
@@ -49,6 +41,7 @@ class Rule_L051(BaseRule):
     groups = ("all",)
     config_keywords = ["fully_qualify_join_types"]
     crawl_behaviour = SegmentSeekerCrawler({"join_clause"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Fully qualify JOINs."""

--- a/src/sqlfluff/rules/L052.py
+++ b/src/sqlfluff/rules/L052.py
@@ -7,11 +7,6 @@ from sqlfluff.core.parser.segments.raw import NewlineSegment, RawSegment
 
 from sqlfluff.core.rules import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.crawlers import RootOnlyCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.utils.functional import Segments, sp
 
 
@@ -24,9 +19,6 @@ class SegmentMoveContext(NamedTuple):
     whitespace_deletions: Segments
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L052(BaseRule):
     """Statements must end with a semi-colon.
 
@@ -63,6 +55,7 @@ class Rule_L052(BaseRule):
     groups = ("all",)
     config_keywords = ["multiline_newline", "require_final_semicolon"]
     crawl_behaviour = RootOnlyCrawler()
+    is_fix_compatible = True
 
     @staticmethod
     def _handle_preceding_inline_comments(

--- a/src/sqlfluff/rules/L053.py
+++ b/src/sqlfluff/rules/L053.py
@@ -5,11 +5,8 @@ from sqlfluff.core.parser.segments.base import IdentitySet
 from sqlfluff.core.rules import BaseRule, LintResult, LintFix, RuleContext
 from sqlfluff.core.rules.crawlers import RootOnlyCrawler
 from sqlfluff.utils.functional import Segments, sp
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L053(BaseRule):
     """Top-level statements should not be wrapped in brackets.
 
@@ -50,6 +47,7 @@ class Rule_L053(BaseRule):
 
     groups = ("all",)
     crawl_behaviour = RootOnlyCrawler()
+    is_fix_compatible = True
 
     @staticmethod
     def _iter_statements(file_segment):

--- a/src/sqlfluff/rules/L054.py
+++ b/src/sqlfluff/rules/L054.py
@@ -3,12 +3,9 @@ from typing import Optional, List
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 from sqlfluff.utils.functional import sp, FunctionalContext
 
 
-@document_groups
-@document_configuration
 class Rule_L054(BaseRule):
     """Inconsistent column references in ``GROUP BY/ORDER BY`` clauses.
 

--- a/src/sqlfluff/rules/L055.py
+++ b/src/sqlfluff/rules/L055.py
@@ -3,10 +3,8 @@ from typing import Optional
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_groups
 
 
-@document_groups
 class Rule_L055(BaseRule):
     """Use ``LEFT JOIN`` instead of ``RIGHT JOIN``.
 

--- a/src/sqlfluff/rules/L056.py
+++ b/src/sqlfluff/rules/L056.py
@@ -3,10 +3,8 @@ from typing import Optional
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_groups
 
 
-@document_groups
 class Rule_L056(BaseRule):
     r"""``SP_`` prefix should not be used for user-defined stored procedures in T-SQL.
 

--- a/src/sqlfluff/rules/L057.py
+++ b/src/sqlfluff/rules/L057.py
@@ -5,12 +5,9 @@ import regex
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 from sqlfluff.rules.L014 import identifiers_policy_applicable
 
 
-@document_groups
-@document_configuration
 class Rule_L057(BaseRule):
     """Do not use special characters in identifiers.
 

--- a/src/sqlfluff/rules/L058.py
+++ b/src/sqlfluff/rules/L058.py
@@ -3,14 +3,11 @@
 from sqlfluff.core.parser import NewlineSegment, WhitespaceSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.functional import sp, FunctionalContext
 
 from sqlfluff.utils.reflow.reindent import construct_single_indent
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L058(BaseRule):
     """Nested ``CASE`` statement in ``ELSE`` clause could be flattened.
 
@@ -47,6 +44,7 @@ class Rule_L058(BaseRule):
 
     groups = ("all",)
     crawl_behaviour = SegmentSeekerCrawler({"case_expression"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> LintResult:
         """Nested CASE statement in ELSE clause could be flattened."""

--- a/src/sqlfluff/rules/L059.py
+++ b/src/sqlfluff/rules/L059.py
@@ -7,17 +7,9 @@ import regex
 from sqlfluff.core.parser.segments.raw import CodeSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.utils.functional import sp, FunctionalContext
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L059(BaseRule):
     """Unnecessary quoted identifier.
 
@@ -89,6 +81,7 @@ class Rule_L059(BaseRule):
     ]
     crawl_behaviour = SegmentSeekerCrawler({"quoted_identifier", "naked_identifier"})
     _dialects_allowing_quotes_in_column_names = ["postgres", "snowflake"]
+    is_fix_compatible = True
 
     # Ignore "password_auth" type to allow quotes around passwords within
     # `CREATE USER` statements in Exasol dialect.

--- a/src/sqlfluff/rules/L060.py
+++ b/src/sqlfluff/rules/L060.py
@@ -5,11 +5,8 @@ from typing import Optional
 from sqlfluff.core.parser.segments.raw import CodeSegment
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L060(BaseRule):
     """Use ``COALESCE`` instead of ``IFNULL`` or ``NVL``.
 
@@ -43,6 +40,7 @@ class Rule_L060(BaseRule):
 
     groups = ("all",)
     crawl_behaviour = SegmentSeekerCrawler({"function_name_identifier"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Use ``COALESCE`` instead of ``IFNULL`` or ``NVL``."""

--- a/src/sqlfluff/rules/L061.py
+++ b/src/sqlfluff/rules/L061.py
@@ -5,12 +5,9 @@ from typing import Optional
 from sqlfluff.core.parser.segments.raw import SymbolSegment
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.functional import sp, FunctionalContext
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L061(BaseRule):
     """Use ``!=`` instead of ``<>`` for "not equal to" comparisons.
 
@@ -35,6 +32,7 @@ class Rule_L061(BaseRule):
 
     groups = ("all",)
     crawl_behaviour = SegmentSeekerCrawler({"comparison_operator"})
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Use ``!=`` instead of ``<>`` for "not equal to" comparison."""

--- a/src/sqlfluff/rules/L062.py
+++ b/src/sqlfluff/rules/L062.py
@@ -5,11 +5,8 @@ from typing import Optional
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_configuration, document_groups
 
 
-@document_groups
-@document_configuration
 class Rule_L062(BaseRule):
     """Block a list of configurable words from being used.
 

--- a/src/sqlfluff/rules/L063.py
+++ b/src/sqlfluff/rules/L063.py
@@ -6,17 +6,9 @@ from sqlfluff.core.rules.base import LintResult
 from sqlfluff.core.rules.context import RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.rules.L010 import Rule_L010
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L063(Rule_L010):
     """Inconsistent capitalisation of datatypes.
 
@@ -48,6 +40,7 @@ class Rule_L063(Rule_L010):
     name = "capitalisation.types"
     aliases = ("CP05",)
     groups = ("all", "capitalisation")
+    is_fix_compatible = True
 
     crawl_behaviour = SegmentSeekerCrawler(
         {

--- a/src/sqlfluff/rules/L064.py
+++ b/src/sqlfluff/rules/L064.py
@@ -6,19 +6,11 @@ import regex
 
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.utils.functional import rsp, FunctionalContext
 from sqlfluff.core.parser.markers import PositionMarker
 from sqlfluff.dialects.dialect_ansi import LiteralSegment
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L064(BaseRule):
     r"""Consistent usage of preferred quotes for quoted literals.
 
@@ -70,6 +62,7 @@ class Rule_L064(BaseRule):
     config_keywords = ["preferred_quoted_literal_style", "force_enable"]
     crawl_behaviour = SegmentSeekerCrawler({"literal"})
     targets_templated = True
+    is_fix_compatible = True
     _dialects_with_double_quoted_strings = [
         "bigquery",
         "hive",

--- a/src/sqlfluff/rules/L065.py
+++ b/src/sqlfluff/rules/L065.py
@@ -3,12 +3,9 @@ from typing import List
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 from sqlfluff.utils.reflow.sequence import ReflowSequence
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L065(BaseRule):
     """Set operators should be surrounded by newlines.
 
@@ -32,7 +29,7 @@ class Rule_L065(BaseRule):
     """
 
     groups = ("all",)
-
+    is_fix_compatible = True
     crawl_behaviour = SegmentSeekerCrawler({"set_operator"})
 
     def _eval(self, context: RuleContext) -> List[LintResult]:

--- a/src/sqlfluff/rules/L066.py
+++ b/src/sqlfluff/rules/L066.py
@@ -4,15 +4,9 @@ from typing import Optional
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_groups,
-)
 from sqlfluff.utils.functional import FunctionalContext
 
 
-@document_groups
-@document_configuration
 class Rule_L066(BaseRule):
     """Enforce table alias lengths in from clauses and join conditions.
 

--- a/src/sqlfluff/rules/L067.py
+++ b/src/sqlfluff/rules/L067.py
@@ -6,11 +6,6 @@ from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.utils.functional import sp, FunctionalContext, Segments
 
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.core.parser import (
     WhitespaceSegment,
     SymbolSegment,
@@ -19,9 +14,6 @@ from sqlfluff.core.parser import (
 )
 
 
-@document_groups
-@document_fix_compatible
-@document_configuration
 class Rule_L067(BaseRule):
     """Enforce consistent type casting style.
 
@@ -63,6 +55,7 @@ class Rule_L067(BaseRule):
     groups = ("all",)
     config_keywords = ["preferred_type_casting_style"]
     crawl_behaviour = SegmentSeekerCrawler({"function", "cast_expression"})
+    is_fix_compatible = True
 
     @staticmethod
     def _get_children(segments: Segments) -> Segments:

--- a/src/sqlfluff/rules/L068.py
+++ b/src/sqlfluff/rules/L068.py
@@ -4,10 +4,8 @@ from typing import Optional
 from sqlfluff.utils.analysis.select_crawler import Query, SelectCrawler, WildcardInfo
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_groups
 
 
-@document_groups
 class Rule_L068(BaseRule):
     """Queries within set query produce different numbers of columns.
 

--- a/src/sqlfluff/rules/L071.py
+++ b/src/sqlfluff/rules/L071.py
@@ -5,13 +5,10 @@ from typing import List, Optional
 from sqlfluff.core.rules.base import BaseRule, LintResult
 from sqlfluff.core.rules.context import RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import document_fix_compatible, document_groups
 
 from sqlfluff.utils.reflow.sequence import ReflowSequence
 
 
-@document_groups
-@document_fix_compatible
 class Rule_L071(BaseRule):
     """Parenthesis blocks should be surrounded by whitespaces.
 
@@ -38,6 +35,7 @@ class Rule_L071(BaseRule):
     crawl_behaviour = SegmentSeekerCrawler(
         {"start_bracket", "end_bracket"}, provide_raw_stack=True
     )
+    is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[List[LintResult]]:
         """Parenthesis blocks should be surrounded by whitespaces."""

--- a/test/core/rules/docstring_test.py
+++ b/test/core/rules/docstring_test.py
@@ -3,7 +3,6 @@ import pytest
 
 from sqlfluff import lint
 from sqlfluff.core.plugin.host import get_plugin_manager
-from sqlfluff.core.rules.doc_decorators import is_configurable, is_documenting_groups
 
 KEYWORD_ANTI = "    **Anti-pattern**"
 KEYWORD_BEST = "    **Best practice**"
@@ -40,27 +39,6 @@ def test_keyword_anti_before_best():
                     f"{rule.__name__} keyword {KEYWORD_BEST} appears before "
                     f"{KEYWORD_ANTI}"
                 )
-
-
-def test_config_decorator():
-    """Test rules with config_keywords have the @document_configuration decorator."""
-    for plugin_rules in get_plugin_manager().hook.get_rules():
-        for rule in plugin_rules:
-            if hasattr(rule, "config_keywords"):
-                assert is_configurable(rule), (
-                    f"Rule {rule.__name__} has config but is not decorated with "
-                    "@document_configuration to display that config."
-                )
-
-
-def test_groups_decorator():
-    """Test rules with groups have the @document_groups decorator."""
-    for plugin_rules in get_plugin_manager().hook.get_rules():
-        for rule in plugin_rules:
-            if hasattr(rule, "groups"):
-                assert is_documenting_groups(
-                    rule
-                ), f'Rule {rule.__name__} does not specify "@document_groups".'
 
 
 def test_backtick_replace():

--- a/test/core/rules/rules_test.py
+++ b/test/core/rules/rules_test.py
@@ -36,6 +36,7 @@ class Rule_T001(BaseRule):
 
     groups = ("all",)
     crawl_behaviour = SegmentSeekerCrawler({"whitespace"})
+    is_fix_compatible = True
 
     def _eval(self, context):
         """Stars make newlines."""
@@ -192,11 +193,13 @@ def test_rules_cannot_be_instantiated_without_declared_configs():
     """Ensure that new rules must be instantiated with config values."""
 
     class NewRule(BaseRule):
-        config_keywords = ["comma_style"]
+        """Testing Rule."""
 
-    new_rule = NewRule(code="L000", description="", comma_style="trailing")
-    assert new_rule.comma_style == "trailing"
-    # Error is thrown since "comma_style" is defined in class,
+        config_keywords = ["tab_space_size"]
+
+    new_rule = NewRule(code="L000", description="", tab_space_size=6)
+    assert new_rule.tab_space_size == 6
+    # Error is thrown since "tab_space_size" is defined in class,
     # but not upon instantiation
     with pytest.raises(ValueError):
         new_rule = NewRule(code="L000", description="")
@@ -210,6 +213,7 @@ def test_rules_configs_are_dynamically_documented():
 
         config_keywords = ["unquoted_identifiers_policy"]
 
+    print(f"RuleWithConfig.__doc__: {RuleWithConfig.__doc__!r}")
     assert "unquoted_identifiers_policy" in RuleWithConfig.__doc__
 
     class RuleWithoutConfig(BaseRule):
@@ -217,6 +221,7 @@ def test_rules_configs_are_dynamically_documented():
 
         pass
 
+    print(f"RuleWithoutConfig.__doc__: {RuleWithoutConfig.__doc__!r}")
     assert "Configuration" not in RuleWithoutConfig.__doc__
 
 

--- a/test/core/rules/rules_test.py
+++ b/test/core/rules/rules_test.py
@@ -213,20 +213,20 @@ def test_rules_cannot_be_instantiated_without_declared_configs():
 
 def test_rules_legacy_doc_decorators(caplog):
     """Ensure that the deprecated decorators can still be imported but do nothing."""
-
-    with caplog.at_level(logging.WARNING, logger="sqlfluff.rules"):
-
+    with caplog.at_level(logging.INFO, logger="sqlfluff.rules"):
         @document_fix_compatible
         @document_groups
         @document_configuration
         class NewRule(BaseRule):
             """Untouched Text."""
-
             pass
 
     # Check they didn't do anything to the docstring.
     assert NewRule.__doc__ == """Untouched Text."""
     # Check there are warnings.
+    print("Records:")
+    for record in caplog.records:
+        print(record)
     assert "uses the @document_fix_compatible decorator" in caplog.text
     assert "uses the @document_groups decorator" in caplog.text
     assert "uses the @document_configuration decorator" in caplog.text

--- a/test/core/rules/rules_test.py
+++ b/test/core/rules/rules_test.py
@@ -6,6 +6,11 @@ from sqlfluff.core.linter import RuleTuple
 from sqlfluff.core.parser.markers import PositionMarker
 from sqlfluff.core.rules import BaseRule, LintResult, LintFix
 from sqlfluff.core.rules import get_ruleset
+from sqlfluff.core.rules.doc_decorators import (
+    document_fix_compatible,
+    document_groups,
+    document_configuration,
+)
 from sqlfluff.core.rules.crawlers import RootOnlyCrawler, SegmentSeekerCrawler
 from sqlfluff.core.config import FluffConfig
 from sqlfluff.core.parser import WhitespaceSegment
@@ -203,6 +208,25 @@ def test_rules_cannot_be_instantiated_without_declared_configs():
     # but not upon instantiation
     with pytest.raises(ValueError):
         new_rule = NewRule(code="L000", description="")
+
+
+def test_rules_legacy_doc_decorators(caplog):
+    """Ensure that the deprecated decorators can still be imported but do nothing."""
+
+    @document_fix_compatible
+    @document_groups
+    @document_configuration
+    class NewRule(BaseRule):
+        """Untouched Text."""
+
+        pass
+
+    # Check they didn't do anything to the docstring.
+    assert NewRule.__doc__ == """Untouched Text."""
+    # Check there are warnings.
+    assert "uses the @document_fix_compatible decorator" in caplog.text
+    assert "uses the @document_groups decorator" in caplog.text
+    assert "uses the @document_configuration decorator" in caplog.text
 
 
 def test_rules_configs_are_dynamically_documented():

--- a/test/core/rules/rules_test.py
+++ b/test/core/rules/rules_test.py
@@ -213,12 +213,15 @@ def test_rules_cannot_be_instantiated_without_declared_configs():
 
 def test_rules_legacy_doc_decorators(caplog):
     """Ensure that the deprecated decorators can still be imported but do nothing."""
-    with caplog.at_level(logging.INFO, logger="sqlfluff.rules"):
+
+    with caplog.at_level(logging.WARNING):
+
         @document_fix_compatible
         @document_groups
         @document_configuration
         class NewRule(BaseRule):
             """Untouched Text."""
+
             pass
 
     # Check they didn't do anything to the docstring.

--- a/test/core/rules/rules_test.py
+++ b/test/core/rules/rules_test.py
@@ -7,11 +7,6 @@ from sqlfluff.core.parser.markers import PositionMarker
 from sqlfluff.core.rules import BaseRule, LintResult, LintFix
 from sqlfluff.core.rules import get_ruleset
 from sqlfluff.core.rules.crawlers import RootOnlyCrawler, SegmentSeekerCrawler
-from sqlfluff.core.rules.doc_decorators import (
-    document_configuration,
-    document_fix_compatible,
-    document_groups,
-)
 from sqlfluff.core.config import FluffConfig
 from sqlfluff.core.parser import WhitespaceSegment
 from sqlfluff.core.templaters.base import TemplatedFile
@@ -31,8 +26,6 @@ class Rule_T042(BaseRule):
         pass
 
 
-@document_groups
-@document_fix_compatible
 class Rule_T001(BaseRule):
     """A deliberately malicious rule.
 
@@ -212,7 +205,6 @@ def test_rules_cannot_be_instantiated_without_declared_configs():
 def test_rules_configs_are_dynamically_documented():
     """Ensure that rule configurations are added to the class docstring."""
 
-    @document_configuration
     class RuleWithConfig(BaseRule):
         """A new rule with configuration."""
 
@@ -220,7 +212,6 @@ def test_rules_configs_are_dynamically_documented():
 
     assert "unquoted_identifiers_policy" in RuleWithConfig.__doc__
 
-    @document_configuration
     class RuleWithoutConfig(BaseRule):
         """A new rule without configuration."""
 

--- a/test/core/rules/rules_test.py
+++ b/test/core/rules/rules_test.py
@@ -1,5 +1,6 @@
 """Tests for the standard set of rules."""
 import pytest
+import logging
 
 from sqlfluff.core import Linter
 from sqlfluff.core.linter import RuleTuple
@@ -213,13 +214,15 @@ def test_rules_cannot_be_instantiated_without_declared_configs():
 def test_rules_legacy_doc_decorators(caplog):
     """Ensure that the deprecated decorators can still be imported but do nothing."""
 
-    @document_fix_compatible
-    @document_groups
-    @document_configuration
-    class NewRule(BaseRule):
-        """Untouched Text."""
+    with caplog.at_level(logging.WARNING, logger="sqlfluff.rules"):
 
-        pass
+        @document_fix_compatible
+        @document_groups
+        @document_configuration
+        class NewRule(BaseRule):
+            """Untouched Text."""
+
+            pass
 
     # Check they didn't do anything to the docstring.
     assert NewRule.__doc__ == """Untouched Text."""

--- a/test/fixtures/rules/custom/L000.py
+++ b/test/fixtures/rules/custom/L000.py
@@ -1,8 +1,6 @@
 """Test std rule import."""
-from sqlfluff.core.rules.doc_decorators import document_groups
 
 
-@document_groups
 class Rule_L000:
     """Test std rule import."""
 

--- a/test/rules/yaml_test_cases_test.py
+++ b/test/rules/yaml_test_cases_test.py
@@ -7,7 +7,6 @@ from sqlfluff.utils.testing.rules import (
     rules__test_helper,
     get_rule_from_set,
 )
-from sqlfluff.core.rules.doc_decorators import is_fix_compatible
 from sqlfluff.core.config import FluffConfig
 
 ids, test_cases = load_test_cases(
@@ -24,10 +23,8 @@ def test__rule_test_case(test_case, caplog):
             if res is not None and res != test_case.fail_str:
                 cfg = FluffConfig(configs=test_case.configs)
                 rule = get_rule_from_set(test_case.rule, config=cfg)
-                assert is_fix_compatible(
-                    rule
-                ), f"Rule {test_case.rule} returned fixes but does not specify "
-                '"@document_fix_compatible".'
+                assert rule.is_fix_compatible, f"Rule {test_case.rule} returned "
+                'fixes but does not specify "is_fix_compatible = True".'
 
 
 def test__rule_test_global_config():


### PR DESCRIPTION
This is part of #4031.

This deprecates the `doc_decorators` for rules, and instead builds the functionality directly into the `BaseRule` using a metaclass (similar to what we did for the segment metaclass). This reduces lines of code by eliminating the necessity to add multiple decorators to all rules.

In the process, this also adds `aliases` & `name` to the documented values (along with config values, fix capability and groups). All of these are triggered directly by the presence of the relevant config values in the rule attributes. The only _additional_ value is to add an `is_fix_compatible` attribute on the `BaseRule` which can be overridden as a flag for whether the rule is fixable.

I think this solution is much more robust in many ways than the original implementation (the docstrings for the original admit that too!). This will have merge conflicts with some of my other open PRs, but I'd suggest that this one goes first.