### PR TITLE
Postgres: AS MATERIALIZED support

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -4300,7 +4300,7 @@ class CTEDefinitionSegment(ansi.CTEDefinitionSegment):
         Ref("SingleIdentifierGrammar"),
         Ref("CTEColumnList", optional=True),
         "AS",
-        Sequence("NOT", "MATERIALIZED", optional=True),
+        Sequence(Ref.keyword("NOT", optional=True), "MATERIALIZED", optional=True),
         Bracketed(
             # Ephemeral here to subdivide the query.
             Ref("SelectableGrammar", ephemeral_name="SelectableGrammar")

--- a/test/fixtures/dialects/postgres/postgres_with.sql
+++ b/test/fixtures/dialects/postgres/postgres_with.sql
@@ -1,3 +1,9 @@
+WITH w AS MATERIALIZED (
+    SELECT * FROM other_table
+)
+SELECT * FROM w AS w1 JOIN w AS w2 ON w1.key = w2.ref
+WHERE w2.key = 123;
+
 WITH w AS NOT MATERIALIZED (
     SELECT * FROM big_table
 )

--- a/test/fixtures/dialects/postgres/postgres_with.yml
+++ b/test/fixtures/dialects/postgres/postgres_with.yml
@@ -3,8 +3,82 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 54e36cd157ed51f1b6e1d291ba93aa5eaa2c2a18744dd35bb06ee2cbbd7fce20
+_hash: a90e3937826e06152bd3b304e9fdb8584d462c1ef71ea388d62ba57cc5fd3ce7
 file:
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+      - naked_identifier: w
+      - keyword: AS
+      - keyword: MATERIALIZED
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: other_table
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: w
+              alias_expression:
+                keyword: AS
+                naked_identifier: w1
+            join_clause:
+              keyword: JOIN
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: w
+                alias_expression:
+                  keyword: AS
+                  naked_identifier: w2
+              join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - naked_identifier: w1
+                  - dot: .
+                  - naked_identifier: key
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: w2
+                  - dot: .
+                  - naked_identifier: ref
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+            - naked_identifier: w2
+            - dot: .
+            - naked_identifier: key
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '123'
+- statement_terminator: ;
 - statement:
     with_compound_statement:
       keyword: WITH


### PR DESCRIPTION


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Make the `NOT` optional in expressions like `WITH name AS NOT MATERIALIZED (...)`.

See https://www.postgresql.org/docs/15/queries-with.html#id-1.5.6.12.7

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
