### PR TITLE
BigQuery: parse "AS description" part of assert expressions

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -464,6 +464,14 @@ class AssertStatementSegment(BaseSegment):
     match_grammar: Matchable = Sequence(
         "ASSERT",
         Ref("ExpressionSegment"),
+        Sequence(
+            "AS",
+            OneOf(
+                Ref("SingleQuotedLiteralSegment"),
+                Ref("DoubleQuotedLiteralSegment"),
+            ),
+            optional=True,
+        ),
     )
 
 

--- a/test/fixtures/dialects/bigquery/assert.sql
+++ b/test/fixtures/dialects/bigquery/assert.sql
@@ -1,0 +1,11 @@
+ASSERT (
+  (SELECT COUNT(*) FROM UNNEST([1, 2, 3, 4, 5, 6])) > 5
+) AS 'Table must contain more than 5 rows.';
+
+ASSERT
+  EXISTS(
+    SELECT X
+    FROM UNNEST([7877, 7879, 7883, 7901, 7907]) AS X
+    WHERE X = 7919
+  )
+AS 'Column X must contain the value 7919';

--- a/test/fixtures/dialects/bigquery/assert.yml
+++ b/test/fixtures/dialects/bigquery/assert.yml
@@ -1,0 +1,114 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 22c4c59aa20ff6975daccb6e8dd8da9b0c33c1bb97c7426f9ac80f4e94f33fbc
+file:
+- statement:
+    assert_statement:
+    - keyword: ASSERT
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      function:
+                        function_name:
+                          function_name_identifier: COUNT
+                        bracketed:
+                          start_bracket: (
+                          star: '*'
+                          end_bracket: )
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          function:
+                            function_name:
+                              function_name_identifier: UNNEST
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                array_literal:
+                                - start_square_bracket: '['
+                                - numeric_literal: '1'
+                                - comma: ','
+                                - numeric_literal: '2'
+                                - comma: ','
+                                - numeric_literal: '3'
+                                - comma: ','
+                                - numeric_literal: '4'
+                                - comma: ','
+                                - numeric_literal: '5'
+                                - comma: ','
+                                - numeric_literal: '6'
+                                - end_square_bracket: ']'
+                              end_bracket: )
+              end_bracket: )
+            comparison_operator:
+              raw_comparison_operator: '>'
+            numeric_literal: '5'
+          end_bracket: )
+    - keyword: AS
+    - quoted_literal: "'Table must contain more than 5 rows.'"
+- statement_terminator: ;
+- statement:
+    assert_statement:
+    - keyword: ASSERT
+    - expression:
+        keyword: EXISTS
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                column_reference:
+                  naked_identifier: X
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    function:
+                      function_name:
+                        function_name_identifier: UNNEST
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          array_literal:
+                          - start_square_bracket: '['
+                          - numeric_literal: '7877'
+                          - comma: ','
+                          - numeric_literal: '7879'
+                          - comma: ','
+                          - numeric_literal: '7883'
+                          - comma: ','
+                          - numeric_literal: '7901'
+                          - comma: ','
+                          - numeric_literal: '7907'
+                          - end_square_bracket: ']'
+                        end_bracket: )
+                  alias_expression:
+                    keyword: AS
+                    naked_identifier: X
+            where_clause:
+              keyword: WHERE
+              expression:
+                column_reference:
+                  naked_identifier: X
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '7919'
+          end_bracket: )
+    - keyword: AS
+    - quoted_literal: "'Column X must contain the value 7919'"
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #4395

### Are there any other side effects of this change that we should be aware of?
no

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
