### PR TITLE
Resolve #4184 (index error in L007)

### DIFF
--- a/src/sqlfluff/utils/reflow/rebreak.py
+++ b/src/sqlfluff/utils/reflow/rebreak.py
@@ -348,9 +348,24 @@ def rebreak_sequence(
                     lint_results=[],
                     anchor_on="after",
                 )
+
+                # Handle the potential case of an empty point.
+                # https://github.com/sqlfluff/sqlfluff/issues/4184
+                for i in range(loc.next.pre_code_pt_idx):
+                    if elem_buff[loc.next.pre_code_pt_idx - i].segments:
+                        create_anchor = elem_buff[
+                            loc.next.pre_code_pt_idx - i
+                        ].segments[-1]
+                        break
+                else:  # pragma: no cover
+                    # NOTE: We don't test this because we *should* always find
+                    # _something_ to anchor the creation on, even if we're
+                    # unlucky enough not to find it on the first pass.
+                    raise NotImplementedError("Could not find anchor for creation.")
+
                 fixes.append(
                     LintFix.create_after(
-                        elem_buff[loc.next.pre_code_pt_idx].segments[-1],
+                        create_anchor,
                         [loc.target],
                     )
                 )

--- a/test/fixtures/rules/std_rule_cases/L007.yml
+++ b/test/fixtures/rules/std_rule_cases/L007.yml
@@ -247,3 +247,17 @@ passes_operator_alone_on_line:
       'asdf'
       ||
       'jklm'
+
+fixes_tuple_error_issue:
+  # https://github.com/sqlfluff/sqlfluff/issues/4184
+  # NB: This one isn't fixable.
+  fail_str: |
+    select * from foo
+    where c is not null and -- comment
+        {% if true -%}a >= b and
+        -- comment.
+        {% endif %}
+        true
+  configs:
+    indentation:
+      template_blocks_indent: false


### PR DESCRIPTION
This resolves #4184.

That issue came from an edge case where the previous point might contain no segments. This adds logic to search backward to look past any empty points. In most cases, it won't need to search further than the first - so I don't expect any performance hits.