### PR TITLE
Handle long lines without trailing newlines gracefully (#4386)

### DIFF
--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -1419,9 +1419,23 @@ def lint_line_length(
         # Are there newlines in the element?
         # If not, add it to the buffer and wait to evaluate the line.
         # If yes, it's time to evaluate the line.
-        if not isinstance(elem, ReflowPoint) or not has_untemplated_newline(
-            cast(ReflowPoint, elem)
+
+        if isinstance(elem, ReflowPoint) and (
+            # Is it the end of the file?
+            # NOTE: Here, we're actually looking to see whether we're
+            # currently on the _point before the end of the file_ rather
+            # than actually on the final block. This is important because
+            # the following code assumes we're on a point and not a block.
+            # We're safe from indexing errors if we're on a point, because
+            # we know there's always a trailing block.
+            "end_of_file" in elements[i + 1].class_types
+            # Or is there a newline?
+            or has_untemplated_newline(cast(ReflowPoint, elem))
         ):
+            # In either case we want to process this, so carry on.
+            pass
+        else:
+            # Otherwise build up the buffer and loop around again.
             line_buffer.append(elem)
             continue
 

--- a/test/fixtures/rules/std_rule_cases/L016.yml
+++ b/test/fixtures/rules/std_rule_cases/L016.yml
@@ -16,6 +16,16 @@ test_fail_line_too_long_with_comments_1:
     core:
       max_line_length: 18
 
+test_fail_line_too_long_with_comments_1_no_newline:
+  # Check we move comments correctly, and that it
+  # still works when there isn't a trailing newline.
+  # https://github.com/sqlfluff/sqlfluff/issues/4386
+  fail_str: "SELECT 1 -- Some Comment"
+  fix_str: "-- Some Comment\nSELECT 1"
+  configs:
+    core:
+      max_line_length: 18
+
 test_fail_line_too_long_with_comments_2:
   # Check we can add newlines after dedents (with an indent).
   # NOTE: That for L016, we don't repair the initial indent


### PR DESCRIPTION
This resolves #4386 . Slight tweak to the long line logic so that we do still process the final line of files where the final line has no trailing newline.