### PR TITLE
Revert some changes to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,20 +19,22 @@ deps =
     -rrequirements_dev.txt
     dbt{100,130,}: dbt-core
     dbt{100,130,}: dbt-postgres
-    # Install the plugins as required
-    # dbt plugin if required.
-    dbt{100,130,}: {toxinidir}/plugins/sqlfluff-templater-dbt
-    # Add the example plugin.
-    # NOTE: The trailing comma is important because in the github test suite
-    # the python version is not specified and instead the "py" environment
-    # is invoked. Leaving the trailing comma ensures that this environment
-    # still installs the relevant plugins.
-    {py,winpy}{37,38,39,310,}: {toxinidir}/plugins/sqlfluff-plugin-example
 # Include any other steps necessary for testing below.
 # {posargs} is there to allow us to specify specific tests, which
 # can then be invoked from tox by calling e.g.
 # tox -e py35 -- project/tests/test_file.py::TestClassName::test_method
 commands =
+    # Install the plugins as required.
+    # NOTE: We do them here, so that when version numbers update, we don't
+    # get install errors for version conflicts.
+    # dbt plugin if required.
+    dbt{100,130,}: python -m pip install {toxinidir}/plugins/sqlfluff-templater-dbt
+    # Add the example plugin.
+    # NOTE: The trailing comma is important because in the github test suite
+    # the python version is not specified and instead the "py" environment
+    # is invoked. Leaving the trailing comma ensures that this environment
+    # still installs the relevant plugins.
+    {py,winpy}{37,38,39,310,}: python -m pip install {toxinidir}/plugins/sqlfluff-plugin-example
     # For the dbt test cases install dependencies.
     dbt{100,130,}: dbt deps --project-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project --profiles-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt
     # Clean up from previous tests

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,10 @@ deps =
 commands =
     # Install the plugins as required.
     # NOTE: We do them here, so that when version numbers update, we don't
-    # get install errors for version conflicts.
-    # dbt plugin if required.
+    # get install errors for version conflicts. The dbt templater has a version
+    # number pinned to the same version number of the main sqlfluff library
+    # so it _must_ be installed second in the context of a version which isn't
+    # yet released (and so not available on pypi).
     dbt{100,130,}: python -m pip install {toxinidir}/plugins/sqlfluff-templater-dbt
     # Add the example plugin.
     # NOTE: The trailing comma is important because in the github test suite


### PR DESCRIPTION
This hopefully solves the install errors we saw when releasing 2.0.0a5. In that case the dbt templater was failing to install because we were trying to install it _before_ sqlfluff, and it couldn't find a matching version number on pypi.

This partially reverts some of the changes made in #4399. I now understand better why things were originally that way and I've added better comments to explain that.