### PR TITLE
Pull dbt CI tests forward to 1.1 and 1.4

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -150,7 +150,7 @@ jobs:
     strategy:
       matrix:
         # We don't enforce coverage on older dbt versions.
-        dbt-version: [ 'dbt100' ]
+        dbt-version: [ 'dbt110' ]
     name: DBT Plugin ${{ matrix.dbt-version }} tests
     steps:
     - uses: actions/checkout@v3
@@ -188,7 +188,7 @@ jobs:
     strategy:
       matrix:
         # We enforce coverage on this, the latest dbt version.
-        dbt-version: [ 'dbt130' ]
+        dbt-version: [ 'dbt140' ]
     name: DBT Plugin ${{ matrix.dbt-version }} tests
     steps:
     - uses: actions/checkout@v3
@@ -280,7 +280,7 @@ jobs:
       # Do not set explicitly temp dir for dbt as causes problems
       # None of these test need temp dir set
       run: |
-        python -m tox -e dbt130-winpy -- plugins/sqlfluff-templater-dbt
+        python -m tox -e dbt140-winpy -- plugins/sqlfluff-templater-dbt
   pip-test-pull-request:
     # Test that using pip install works as we've missed
     # some dependencies in the past - see #1842

--- a/constraints/dbt100.txt
+++ b/constraints/dbt100.txt
@@ -1,3 +1,0 @@
-dbt-core==1.0.0
-dbt-postgres==1.0.0
-markupsafe<=2.0.1

--- a/constraints/dbt110.txt
+++ b/constraints/dbt110.txt
@@ -1,0 +1,2 @@
+dbt-core~=1.1
+dbt-postgres~=1.1

--- a/constraints/dbt130-winpy.txt
+++ b/constraints/dbt130-winpy.txt
@@ -1,3 +1,0 @@
-dbt-core~=1.3
-dbt-postgres~=1.3
-markupsafe<=2.0.1

--- a/constraints/dbt130.txt
+++ b/constraints/dbt130.txt
@@ -1,2 +1,0 @@
-dbt-core~=1.3
-dbt-postgres~=1.3

--- a/constraints/dbt140-winpy.txt
+++ b/constraints/dbt140-winpy.txt
@@ -1,0 +1,3 @@
+dbt-core~=1.4
+dbt-postgres~=1.4
+markupsafe<=2.0.1

--- a/constraints/dbt140.txt
+++ b/constraints/dbt140.txt
@@ -1,0 +1,2 @@
+dbt-core~=1.4
+dbt-postgres~=1.4

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = generate-fixture-yml, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{37,38,39,310}, dbt{100,130}-py{37,38,39,310}, cov-report, bench, mypy, winpy, dbt{100,130}-winpy, yamllint
+envlist = generate-fixture-yml, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{37,38,39,310}, dbt{110,140}-py{37,38,39,310}, cov-report, bench, mypy, winpy, dbt{110,140}-winpy, yamllint
 
 [testenv]
 passenv = CI, CIRCLECI, CIRCLE_*, HOME, SQLFLUFF_BENCHMARK_API_KEY
@@ -11,14 +11,14 @@ setenv =
     COVERAGE_FILE = .coverage.{envname}
     winpy: TMPDIR = temp_pytest
     # Constrain dbt versions
-    dbt{100,130,}: PIP_CONSTRAINT=constraints/{envname}.txt
+    dbt{110,140,}: PIP_CONSTRAINT=constraints/{envname}.txt
 allowlist_externals =
     make
 pip_pre = false
 deps =
     -rrequirements_dev.txt
-    dbt{100,130,}: dbt-core
-    dbt{100,130,}: dbt-postgres
+    dbt{110,140,}: dbt-core
+    dbt{110,140,}: dbt-postgres
 # Include any other steps necessary for testing below.
 # {posargs} is there to allow us to specify specific tests, which
 # can then be invoked from tox by calling e.g.
@@ -30,7 +30,7 @@ commands =
     # number pinned to the same version number of the main sqlfluff library
     # so it _must_ be installed second in the context of a version which isn't
     # yet released (and so not available on pypi).
-    dbt{100,130,}: python -m pip install {toxinidir}/plugins/sqlfluff-templater-dbt
+    dbt{110,140,}: python -m pip install {toxinidir}/plugins/sqlfluff-templater-dbt
     # Add the example plugin.
     # NOTE: The trailing comma is important because in the github test suite
     # the python version is not specified and instead the "py" environment
@@ -38,7 +38,7 @@ commands =
     # still installs the relevant plugins.
     {py,winpy}{37,38,39,310,}: python -m pip install {toxinidir}/plugins/sqlfluff-plugin-example
     # For the dbt test cases install dependencies.
-    dbt{100,130,}: dbt deps --project-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project --profiles-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt
+    dbt{110,140,}: dbt deps --project-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project --profiles-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt
     # Clean up from previous tests
     python {toxinidir}/util.py clean-tests
     # Run tests


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
DBT 1.0 no longer compiles, due to https://github.com/dbt-labs/dbt-core/issues/7075

Pulling CI forward to 1.1 and 1.4 respectively

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
