### PR TITLE
Implicit indent fixes #4467

### DIFF
--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -539,15 +539,11 @@ def _crawl_indent_points(
             # because files should always have a trailing IndentBlock containing
             # an "end_of_file" marker, and so the final IndentPoint should always
             # have _something_ after it.
-            reflow_logger.warning("Bal: %s", (indent_balance, untaken_indents))
             following_class_types = elements[idx + 1].class_types
-            ids = elem.get_indent_impulse(allow_implicit_indents, following_class_types)
-            reflow_logger.warning("Foo: %s", ids)
             indent_stats = IndentStats.from_combination(
                 cached_indent_stats,
-                ids,
+                elem.get_indent_impulse(allow_implicit_indents, following_class_types),
             )
-            reflow_logger.warning("Baz: %s", indent_stats)
 
             # Was there a cache?
             if cached_indent_stats:

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -1736,3 +1736,34 @@ test_fail_mixed_tabs_and_spaces:
   # NOTE: This used to be L002 (rather than L003)
   fail_str: "SELECT\n \t 1"
   fix_str: "SELECT\n    1"
+
+test_fix_implicit_indents_4467_a:
+  # https://github.com/sqlfluff/sqlfluff/issues/4467
+  fail_str: |
+    SELECT *
+    FROM d
+    LEFT JOIN l
+      ON d.a = l.a
+        AND d.b = l.b
+  fix_str: |
+    SELECT *
+    FROM d
+    LEFT JOIN l
+        ON d.a = l.a
+            AND d.b = l.b
+  configs:
+    indentation:
+      allow_implicit_indents: true
+
+test_fix_implicit_indents_4467_b:
+  # https://github.com/sqlfluff/sqlfluff/issues/4467
+  pass_str: |
+    SELECT *
+    FROM d
+    LEFT JOIN l
+      ON d.a = l.a
+        AND d.b = l.b
+  configs:
+    indentation:
+      allow_implicit_indents: true
+      tab_space_size: 2


### PR DESCRIPTION
This resolves #4467 .

The `indent_stats` object is always relative to the incoming indent (because it's just the _effect_ of a single `IndentPoint`). We weren't correcting for that when implicit indents were found in deeper indents.

Also making a small logging change which makes things more readable for this kind of debugging.