### PR TITLE
Recode and disable L031 -> AL07

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -259,6 +259,12 @@ aliasing = explicit
 min_alias_length = None
 max_alias_length = None
 
+[sqlfluff:rules:aliasing.forbid]
+# Avoid table aliases in from clauses and join conditions.
+# Disabled by default for all dialects unless explicitly enabled.
+# We suggest instead using aliasing.length (AL06) in most cases.
+force_enable = False
+
 [sqlfluff:rules:convention.select_trailing_comma]
 # Trailing commas
 select_clause_trailing_comma = forbid
@@ -339,8 +345,3 @@ wildcard_policy = single
 [sqlfluff:rules:structure.subquery]
 # By default, allow subqueries in from clauses, but not join clauses
 forbid_subquery_in = join
-
-[sqlfluff:rules:L031]
-# Avoid table aliases in from clauses and join conditions.
-# Disabled for some dialects (e.g. bigquery)
-force_enable = False

--- a/src/sqlfluff/rules/aliasing/AL06.py
+++ b/src/sqlfluff/rules/aliasing/AL06.py
@@ -25,7 +25,7 @@ class Rule_AL06(BaseRule):
 
     Avoid aliases. Avoid short aliases when aliases are necessary.
 
-    See also: AL07.
+    See also: :class:`Rule_AL07`.
 
     .. code-block:: sql
 

--- a/src/sqlfluff/rules/aliasing/AL06.py
+++ b/src/sqlfluff/rules/aliasing/AL06.py
@@ -25,7 +25,7 @@ class Rule_AL06(BaseRule):
 
     Avoid aliases. Avoid short aliases when aliases are necessary.
 
-    See also: L031.
+    See also: AL07.
 
     .. code-block:: sql
 

--- a/src/sqlfluff/rules/aliasing/AL07.py
+++ b/src/sqlfluff/rules/aliasing/AL07.py
@@ -27,18 +27,18 @@ class Rule_AL07(BaseRule):
        <https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md>`_
        which notes that:
 
-       > Avoid table aliases in join conditions (especially initialisms) - it's
-       > harder to understand what the table called "c" is compared to "customers".
+        Avoid table aliases in join conditions (especially initialisms) - it's
+        harder to understand what the table called "c" is compared to "customers".
 
        This rule is controversial and for many larger databases avoiding alias is
        neither realistic nor desirable. In particular for BigQuery due to the
        complexity of backtick requirements and determining whether a name refers
-       to a project or dataset, and automated fixes can potentially break working
-       SQL code. For most users :ref:`Rule_AL06` is likely a more appropriate
+       to a project or dataset so automated fixes can potentially break working
+       SQL code. For most users :class:`Rule_AL06` is likely a more appropriate
        linting rule to drive a sensible behaviour around aliasing.
 
        The stricter treatment of aliases in this rule may be useful for more
-       focussed projects, or temporarily as a refactoring tool as the
+       focussed projects, or temporarily as a refactoring tool because the
        :code:`fix` routine of the rule can remove aliases.
 
        This rule is disabled by default for all dialects it can be enabled with

--- a/src/sqlfluff/rules/aliasing/__init__.py
+++ b/src/sqlfluff/rules/aliasing/__init__.py
@@ -8,9 +8,10 @@ from sqlfluff.rules.aliasing.AL03 import Rule_AL03
 from sqlfluff.rules.aliasing.AL04 import Rule_AL04
 from sqlfluff.rules.aliasing.AL05 import Rule_AL05
 from sqlfluff.rules.aliasing.AL06 import Rule_AL06
+from sqlfluff.rules.aliasing.AL07 import Rule_AL07
 
 
 @hookimpl
 def get_rules():
     """Get plugin rules."""
-    return [Rule_AL01, Rule_AL02, Rule_AL03, Rule_AL04, Rule_AL05, Rule_AL06]
+    return [Rule_AL01, Rule_AL02, Rule_AL03, Rule_AL04, Rule_AL05, Rule_AL06, Rule_AL07]

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -76,7 +76,6 @@ expected_output = """== [test/fixtures/linter/indentation_error_simple.sql] FAIL
 L:   2 | P:   1 | LT02 | Expected indent of 4 spaces. [layout.indent]
 L:   5 | P:  10 | CP01 | Keywords must be consistently upper case.
                        | [capitalisation.keywords]
-L:   5 | P:  13 | L031 | Avoid aliases in from clauses and join conditions.
 """
 
 
@@ -998,17 +997,6 @@ def test__cli__fix_loop_limit_behavior(sql, exit_code, tmpdir):
             "LT02",
             "select * from t",
         ),  # fix preceding whitespace
-        # L031 fix aliases in joins
-        (
-            "SELECT u.id, c.first_name, c.last_name, COUNT(o.user_id) "
-            "FROM users as u JOIN customers as c on u.id = c.user_id JOIN orders as o "
-            "on u.id = o.user_id;",
-            "L031",
-            "SELECT users.id, customers.first_name, customers.last_name, "
-            "COUNT(orders.user_id) "
-            "FROM users JOIN customers on users.id = customers.user_id JOIN orders on "
-            "users.id = orders.user_id;",
-        ),
     ],
 )
 def test__cli__command_fix_stdin(stdin, rules, stdout):
@@ -1304,7 +1292,7 @@ def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_
     print("Result length:", payload_length)
 
     if serialize == "human":
-        assert payload_length == 24 if write_file else 32
+        assert payload_length == 23 if write_file else 32
     elif serialize == "json":
         result = json.loads(result_payload)
         assert len(result) == 2
@@ -1320,7 +1308,7 @@ def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_
         # SQLFluff produces trailing newline
         if result[-1] == "":
             del result[-1]
-        assert len(result) == 12
+        assert len(result) == 11
     else:
         raise Exception
 

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -211,7 +211,7 @@ def test__linter__lint_string_vs_file(path):
 
 
 @pytest.mark.parametrize(
-    "rules,num_violations", [(None, 7), ("CP01", 2), (("LT01", "LT12", "L031"), 2)]
+    "rules,num_violations", [(None, 6), ("CP01", 2), (("LT01", "LT12"), 1)]
 )
 def test__linter__get_violations_filter_rules(rules, num_violations):
     """Test filtering violations by which rules were violated."""

--- a/test/fixtures/linter/aliases_in_join_error.sql
+++ b/test/fixtures/linter/aliases_in_join_error.sql
@@ -1,8 +1,0 @@
-SELECT
-    u.id,
-    c.first_name,
-    c.last_name,
-    COUNT(o.user_id)
-FROM users as u
-JOIN customers as c on u.id = c.user_id
-JOIN orders as o on u.id = o.user_id;

--- a/test/fixtures/linter/autofix/ansi/026_LT05_line_length_includes_earlier_fixes/.sqlfluff
+++ b/test/fixtures/linter/autofix/ansi/026_LT05_line_length_includes_earlier_fixes/.sqlfluff
@@ -1,0 +1,2 @@
+[sqlfluff:rules:aliasing.forbid]
+force_enable = true

--- a/test/fixtures/rules/std_rule_cases/AL07.yml
+++ b/test/fixtures/rules/std_rule_cases/AL07.yml
@@ -321,7 +321,7 @@ test_violation_locations:
       line_pos: 16
       name: aliasing.forbid
 
-test_fail_avoid_aliases_2:
+test_fail_fix_command:
   # Test originally from commands_test.py
   fail_str: |
     SELECT u.id, c.first_name, c.last_name, COUNT(o.user_id)
@@ -329,8 +329,8 @@ test_fail_avoid_aliases_2:
     on u.id = o.user_id;
   fix_str: |
     SELECT users.id, customers.first_name, customers.last_name, COUNT(orders.user_id)
-    FROM users JOIN customers on users.id = customers.user_id JOIN orders on
-    users.id = orders.user_id;
+    FROM users JOIN customers on users.id = customers.user_id JOIN orders
+    on users.id = orders.user_id;
   configs:
     rules:
       aliasing.forbid:

--- a/test/fixtures/rules/std_rule_cases/AL07.yml
+++ b/test/fixtures/rules/std_rule_cases/AL07.yml
@@ -1,13 +1,17 @@
-rule: L031
+rule: AL07
 
 test_pass_allow_self_join_alias:
-  # L031 Allow self-joins
+  # AL07 Allow self-joins
   pass_str: |
     select
       x.a,
       x_2.b
     from x
     left join x as x_2 on x.foreign_key = x.foreign_key
+  configs:
+    rules:
+      aliasing.forbid:
+        force_enable: true
 
 test_fail_avoid_aliases_1:
   fail_str: |
@@ -29,9 +33,13 @@ test_fail_avoid_aliases_1:
     FROM users
     JOIN customers on users.id = customers.user_id
     JOIN orders on users.id = orders.user_id;
+  configs:
+    rules:
+      aliasing.forbid:
+        force_enable: true
 
 test_fail_avoid_aliases_2:
-  # L031 order by
+  # AL07 order by
   fail_str: |
     SELECT
       u.id,
@@ -53,9 +61,13 @@ test_fail_avoid_aliases_2:
     JOIN customers on users.id = customers.user_id
     JOIN orders on users.id = orders.user_id
     order by orders.user_id desc
+  configs:
+    rules:
+      aliasing.forbid:
+        force_enable: true
 
 test_fail_avoid_aliases_3:
-  # L031 order by identifier which is the same raw as an alias but refers to a column
+  # AL07 order by identifier which is the same raw as an alias but refers to a column
   fail_str: |
     SELECT
       u.id,
@@ -77,19 +89,35 @@ test_fail_avoid_aliases_3:
     JOIN customers on users.id = customers.user_id
     JOIN orders on users.id = orders.user_id
     order by o desc
+  configs:
+    rules:
+      aliasing.forbid:
+        force_enable: true
 
 alias_single_char_identifiers:
   fail_str: "select b from tbl as a"
   fix_str: "select b from tbl"
+  configs:
+    rules:
+      aliasing.forbid:
+        force_enable: true
 
 alias_with_wildcard_identifier:
   fail_str: "select * from tbl as a"
   fix_str: "select * from tbl"
+  configs:
+    rules:
+      aliasing.forbid:
+        force_enable: true
 
 select_from_values:
   pass_str: |
     select *
     from values(1, 2, 3)
+  configs:
+    rules:
+      aliasing.forbid:
+        force_enable: true
 
 select_from_table_generator:
   pass_str: |
@@ -103,6 +131,9 @@ select_from_table_generator:
   configs:
     core:
       dialect: snowflake
+    rules:
+      aliasing.forbid:
+        force_enable: true
 
 issue_635:
   pass_str: |
@@ -118,6 +149,9 @@ issue_635:
   configs:
     core:
       dialect: snowflake
+    rules:
+      aliasing.forbid:
+        force_enable: true
 
 # This query was causing a runtime error in the rule.
 issue_239:
@@ -157,6 +191,10 @@ issue_610:
     FROM aaaaaa
     JOIN bbbbbb AS b ON b.a = aaaaaa.id
     JOIN bbbbbb AS b2 ON b2.other = b.id
+  configs:
+    rules:
+      aliasing.forbid:
+        force_enable: true
 
 issue_1589:
   pass_str: |
@@ -168,6 +206,10 @@ issue_1589:
               rnd>=t.v
          order by rnd
          limit 1)
+  configs:
+    rules:
+      aliasing.forbid:
+        force_enable: true
 
 issue_1639:
   fail_str: |
@@ -193,6 +235,9 @@ issue_1639:
   configs:
     core:
       dialect: tsql
+    rules:
+      aliasing.forbid:
+        force_enable: true
 
 test_fail_no_copy_code_out_of_template:
   # The rule wants to replace "t" with "foobar", but
@@ -206,6 +251,9 @@ test_fail_no_copy_code_out_of_template:
       jinja:
         context:
           source_table: foobar
+    rules:
+      aliasing.forbid:
+        force_enable: true
 
 test_bigquery_skip_multipart_names:
   pass_str: |
@@ -230,5 +278,45 @@ test_bigquery_force_enable:
     core:
       dialect: bigquery
     rules:
-      L031:
+      aliasing.forbid:
         force_enable: true
+
+test_violation_locations:
+  fail_str: |
+    SELECT
+        u.id,
+        c.first_name,
+        c.last_name,
+        COUNT(o.user_id)
+    FROM users as u
+    JOIN customers as c on u.id = c.user_id
+    JOIN orders as o on u.id = o.user_id;
+  fix_str: |
+    SELECT
+        users.id,
+        customers.first_name,
+        customers.last_name,
+        COUNT(orders.user_id)
+    FROM users
+    JOIN customers on users.id = customers.user_id
+    JOIN orders on users.id = orders.user_id;
+  configs:
+    rules:
+      aliasing.forbid:
+        force_enable: true
+  violations:
+    - code: AL07
+      description: Avoid aliases in from clauses and join conditions.
+      line_no: 6
+      line_pos: 15
+      name: aliasing.forbid
+    - code: AL07
+      description: Avoid aliases in from clauses and join conditions.
+      line_no: 7
+      line_pos: 19
+      name: aliasing.forbid
+    - code: AL07
+      description: Avoid aliases in from clauses and join conditions.
+      line_no: 8
+      line_pos: 16
+      name: aliasing.forbid

--- a/test/fixtures/rules/std_rule_cases/AL07.yml
+++ b/test/fixtures/rules/std_rule_cases/AL07.yml
@@ -320,3 +320,18 @@ test_violation_locations:
       line_no: 8
       line_pos: 16
       name: aliasing.forbid
+
+test_fail_avoid_aliases_2:
+  # Test originally from commands_test.py
+  fail_str: |
+    SELECT u.id, c.first_name, c.last_name, COUNT(o.user_id)
+    FROM users as u JOIN customers as c on u.id = c.user_id JOIN orders as o
+    on u.id = o.user_id;
+  fix_str: |
+    SELECT users.id, customers.first_name, customers.last_name, COUNT(orders.user_id)
+    FROM users JOIN customers on users.id = customers.user_id JOIN orders on
+    users.id = orders.user_id;
+  configs:
+    rules:
+      aliasing.forbid:
+        force_enable: true

--- a/test/rules/std_test.py
+++ b/test/rules/std_test.py
@@ -68,11 +68,6 @@ from sqlfluff.utils.testing.rules import assert_rule_raises_violations_in_file
         # Make sure that ignoring works as expected
         ("LT01", "operator_errors_ignore.sql", [(10, 8), (10, 9)]),
         (
-            "L031",
-            "aliases_in_join_error.sql",
-            [(6, 15), (7, 19), (8, 16)],
-        ),
-        (
             "JJ01",
             "heavy_templating.sql",
             [(12, 13), (12, 25)],


### PR DESCRIPTION
This is the _final part of the rules reorg_ and so closes #4031 .

As per discussion on slack:
- L031 confuses lots of new users.
- Some people still use it.
- The fixing routines are occasionally useful.

This PR migrates it to AL07 (`aliasing.forbid`), and also updated the `force_enable` behaviour (already present for BigQuery) to now apply to all dialects. In effect, this rule is always disabled unless explicitly enabled. This means users that want it can enable it, but for new users, they don't need to know about it, which should speed adoption and lead to less confusion.

I've also updated the docs with words to that effect - pointing users to AL06 (`aliasing.length`) as a better substitute in most cases.