### PR TITLE
Add a sqlfluff format CLI command

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -971,24 +971,6 @@ def fix(
     default=None,
     help="An optional suffix to add to fixed files.",
 )
-@click.option(
-    "--FIX-EVEN-UNPARSABLE",
-    is_flag=True,
-    default=None,
-    help=(
-        "Enables fixing of files that have templating or parse errors. "
-        "Note that the similar-sounding '--ignore' or 'noqa' features merely "
-        "prevent errors from being *displayed*. For safety reasons, the 'fix'"
-        "command will not make any fixes in files that have templating or parse "
-        "errors unless '--FIX-EVEN-UNPARSABLE' is enabled on the command line"
-        "or in the .sqlfluff config file."
-    ),
-)
-@click.option(
-    "--show-lint-violations",
-    is_flag=True,
-    help="Show lint violations",
-)
 @click.argument("paths", nargs=-1, type=click.Path(allow_dash=True))
 def cli_format(
     paths: Tuple[str],
@@ -999,7 +981,6 @@ def cli_format(
     disable_progress_bar: Optional[bool] = False,
     extra_config_path: Optional[str] = None,
     ignore_local_config: bool = False,
-    show_lint_violations: bool = False,
     **kwargs,
 ) -> None:
     """Autoformat SQL files.
@@ -1041,7 +1022,6 @@ def cli_format(
     config = get_config(
         extra_config_path, ignore_local_config, require_dialect=False, **kwargs
     )
-    fix_even_unparsable = config.get("fix_even_unparsable")
     output_stream = make_output_stream(
         config, None, os.devnull if fixing_stdin else None
     )
@@ -1062,18 +1042,18 @@ def cli_format(
 
     # handle stdin case. should output formatted sql to stdout and nothing else.
     if fixing_stdin:
-        _stdin_fix(lnt, formatter, fix_even_unparsable)
+        _stdin_fix(lnt, formatter, fix_even_unparsable=False)
     else:
         _paths_fix(
             lnt,
             formatter,
             paths,
             processes,
-            fix_even_unparsable,
-            True,  # Always force in format mode.
-            fixed_suffix,
-            bench,
-            show_lint_violations,
+            fix_even_unparsable=False,
+            force=True,  # Always force in format mode.
+            fixed_suffix=fixed_suffix,
+            bench=bench,
+            show_lint_violations=False,
             warn_force=False,  # don't warn about being in force mode.
         )
 

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -311,6 +311,33 @@ def core_options(f: Callable) -> Callable:
     return f
 
 
+def lint_options(f: Callable) -> Callable:
+    """Add lint operation options to commands via a decorator.
+
+    These are cli commands that do linting, i.e. `lint` and `fix`.
+    """
+    f = click.option(
+        "-p",
+        "--processes",
+        type=int,
+        default=None,
+        help=(
+            "The number of parallel processes to run. Positive numbers work as "
+            "expected. Zero and negative numbers will work as number_of_cpus - "
+            "number. e.g  -1 means all cpus except one. 0 means all cpus."
+        ),
+    )(f)
+    f = click.option(
+        "--disable_progress_bar",
+        "--disable-progress-bar",
+        is_flag=True,
+        help="Disables progress bars.",
+        cls=DeprecatedOption,
+        deprecated=["--disable_progress_bar"],
+    )(f)
+    return f
+
+
 def get_config(
     extra_config_path: Optional[str] = None,
     ignore_local_config: bool = False,
@@ -460,6 +487,7 @@ def dump_file_payload(filename: Optional[str], payload: str):
 @cli.command(cls=DeprecatedOptionsCommand)
 @common_options
 @core_options
+@lint_options
 @click.option(
     "-f",
     "--format",
@@ -497,25 +525,6 @@ def dump_file_payload(filename: Optional[str], payload: str):
     "--disregard-sqlfluffignores",
     is_flag=True,
     help="Perform the operation regardless of .sqlfluffignore configurations",
-)
-@click.option(
-    "-p",
-    "--processes",
-    type=int,
-    default=None,
-    help=(
-        "The number of parallel processes to run. Positive numbers work as "
-        "expected. Zero and negative numbers will work as number_of_cpus - "
-        "number. e.g  -1 means all cpus except one. 0 means all cpus."
-    ),
-)
-@click.option(
-    "--disable_progress_bar",
-    "--disable-progress-bar",
-    is_flag=True,
-    help="Disables progress bars.",
-    cls=DeprecatedOption,
-    deprecated=["--disable_progress_bar"],
 )
 @click.option(
     "--persist-timing",
@@ -698,6 +707,7 @@ def do_fixes(lnt, result, formatter=None, **kwargs):
 @cli.command(cls=DeprecatedOptionsCommand)
 @common_options
 @core_options
+@lint_options
 @click.option(
     "-f",
     "--force",
@@ -712,25 +722,6 @@ def do_fixes(lnt, result, formatter=None, **kwargs):
     "--fixed-suffix",
     default=None,
     help="An optional suffix to add to fixed files.",
-)
-@click.option(
-    "-p",
-    "--processes",
-    type=int,
-    default=None,
-    help=(
-        "The number of parallel processes to run. Positive numbers work as "
-        "expected. Zero and negative numbers will work as number_of_cpus - "
-        "number. e.g  -1 means all cpus except one. 0 means all cpus."
-    ),
-)
-@click.option(
-    "--disable_progress_bar",
-    "--disable-progress-bar",
-    is_flag=True,
-    help="Disables progress bars.",
-    cls=DeprecatedOption,
-    deprecated=["--disable_progress_bar"],
 )
 @click.option(
     "--FIX-EVEN-UNPARSABLE",

--- a/src/sqlfluff/rules/capitalisation/CP05.py
+++ b/src/sqlfluff/rules/capitalisation/CP05.py
@@ -39,7 +39,7 @@ class Rule_CP05(Rule_CP01):
 
     name = "capitalisation.types"
     aliases = ("L063",)
-    groups = ("all", "capitalisation")
+    groups = ("all", "core", "capitalisation")
     is_fix_compatible = True
 
     crawl_behaviour = SegmentSeekerCrawler(

--- a/src/sqlfluff/rules/jinja/JJ01.py
+++ b/src/sqlfluff/rules/jinja/JJ01.py
@@ -48,7 +48,9 @@ class Rule_JJ01(BaseRule):
     # sections.
     crawl_behaviour = SegmentSeekerCrawler({"raw"})
     targets_templated = True
-    is_fix_compatible = True
+    # NOTE: This rule does return fixes, but when is_fix_compatible
+    # is set, it spirals.
+    # is_fix_compatible = True
 
     @staticmethod
     def _get_whitespace_ends(s: str) -> Tuple[str, str, str, str, str]:
@@ -118,7 +120,7 @@ class Rule_JJ01(BaseRule):
                     "Tag found @ %s: %r ", context.segment.pos_marker, stripped
                 )
 
-                # Dedupe using a memory of source indexes.
+                # Deduplicate using a memory of source indexes.
                 # This is important because several positions in the
                 # templated file may refer to the same position in the
                 # source file and we only want to get one violation.

--- a/src/sqlfluff/rules/jinja/JJ01.py
+++ b/src/sqlfluff/rules/jinja/JJ01.py
@@ -48,6 +48,7 @@ class Rule_JJ01(BaseRule):
     # sections.
     crawl_behaviour = SegmentSeekerCrawler({"raw"})
     targets_templated = True
+    is_fix_compatible = True
 
     @staticmethod
     def _get_whitespace_ends(s: str) -> Tuple[str, str, str, str, str]:

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1038,6 +1038,28 @@ def test__cli__command_fix_stdin(stdin, rules, stdout):
     assert result.output == stdout
 
 
+@pytest.mark.parametrize(
+    "stdin,stdout",
+    [
+        ("select * from t\n", "select * from t\n"),  # no change
+        (
+            "   select    *    FRoM     t    ",
+            "select * from t\n",
+        ),
+    ],
+)
+def test__cli__command_format_stdin(stdin, stdout):
+    """Check stdin input for fix works."""
+    result = invoke_assert_code(
+        args=[
+            cli_format,
+            ("-", "--disable-progress-bar", "--dialect=ansi"),
+        ],
+        cli_input=stdin,
+    )
+    assert result.output == stdout
+
+
 def test__cli__command_fix_stdin_logging_to_stderr(monkeypatch):
     """Check that logging goes to stderr when stdin is passed to fix."""
     perfect_sql = "select col from table"

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -28,6 +28,7 @@ from sqlfluff.cli.commands import (
     version,
     rules,
     fix,
+    cli_format,
     parse,
     dialects,
     get_config,
@@ -486,6 +487,32 @@ def test__cli__command_lint_parse(command):
                 "y",
             ),
             1,
+        ),
+        # Format
+        (
+            (
+                cli_format,
+                [
+                    "--fixed-suffix",
+                    "_fix",
+                    "test/fixtures/linter/whitespace_errors.sql",
+                ],
+            ),
+            0,
+        ),
+        # Format (specifying rules)
+        (
+            (
+                cli_format,
+                [
+                    "--rules",
+                    "LT01",
+                    "--fixed-suffix",
+                    "_fix",
+                    "test/fixtures/linter/whitespace_errors.sql",
+                ],
+            ),
+            2,
         ),
         # Template syntax error in macro file
         (

--- a/test/fixtures/linter/.gitignore
+++ b/test/fixtures/linter/.gitignore
@@ -1,0 +1,2 @@
+# Results of fixed tests
+*_fix.sql


### PR DESCRIPTION
Ok this is a long time coming. This resolves #2436 and adds the `sqlfluff format` CLI command.

It's basically a variant on `sqlfluff fix`, but with a hardcoded set of rules. This has a nice upside that if someone is using `exclude_rules`, they can still exclude rules - but they can't enable additional ones, so it remains fairly safe.

As a first pass I've added the following rules to the command:
- All of the capitalisation rules: `capitalisation`
- All of the layout rules: `layout`
- `ambiguous.union`
- `convention.not_equal`
- `convention.coalesce`
- `convention.select_trailing_comma`
- `convention.is_null`
- `jinja.padding`
- `structure.distinct`

I haven't added _extensive_ testing, because the majority of the machinery is the same as `sqlfluff fix`. There should be enough here to get coverage.

How to review (@barrywhart):
1. I've moved several common `click` arguments into `@lint_options`. No changes to the functionality, just a reorg. Those options are `--processes` and `--disable-progress-bar`. That happens in the first commit in the PR afc6ec3ac913ccad4fb3b4c10fe6772cc8e5f10e
2. I've broken out the original `fix` command into two branches (and two methods), one for stdin fixing (`_stdin_fix()`) and one for file based fixing (`_paths_fix()`) - both are used in `fix` and `format`. No functionality changes - just refactor.
3. Introduce the `cli_format()` method to support `sqlfluff format` cli command. It's mostly a copy paste of `sqlfluff fix` but with several things removed or changed to simplify things. Specifically, it hard codes the `rules` argument and always sets the `force` argument.