### PR TITLE
Fix #4367

### DIFF
--- a/src/sqlfluff/utils/reflow/elements.py
+++ b/src/sqlfluff/utils/reflow/elements.py
@@ -455,8 +455,12 @@ class ReflowPoint(ReflowElement):
                     return [], self
 
                 for idx in range(len(self.segments) - 1, -1, -1):
+                    # NOTE: Must be a _literal_ newline, not a templated one.
+                    # https://github.com/sqlfluff/sqlfluff/issues/4367
                     if self.segments[idx].is_type("newline"):
-                        break
+                        if self.segments[idx].pos_marker.is_literal():
+                            break
+
                 new_indent = WhitespaceSegment(desired_indent)
                 return [
                     LintResult(

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -1767,3 +1767,24 @@ test_fix_implicit_indents_4467_b:
     indentation:
       allow_implicit_indents: true
       tab_space_size: 2
+
+test_fix_macro_indents_4367:
+  # https://github.com/sqlfluff/sqlfluff/issues/4367
+  fail_str: |
+    {% macro my_macro(col) %}
+        {{ col }}
+    {% endmacro %}
+    SELECT
+        something,
+    {{ my_macro("mycol") }},
+        something_else
+    FROM mytable
+  fix_str: |
+    {% macro my_macro(col) %}
+        {{ col }}
+    {% endmacro %}
+    SELECT
+        something,
+        {{ my_macro("mycol") }},
+        something_else
+    FROM mytable


### PR DESCRIPTION
This resolves #4367 .

When handling cases with a newline, but no indent (i.e. an unindented line), where the first element on that line contained templated elements *and* where those templated elements contained newlines _before_ and code elements - the indentation logic would attach any fixes to the wrong newline, and likely pick the templated one and not the literal one.

This resolves that.