### PR TITLE
Snowflake semi-structured spacing

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -103,7 +103,7 @@ spacing_before = touch
 
 [sqlfluff:layout:type:casting_operator]
 spacing_before = touch
-spacing_after = touch
+spacing_after = touch:inline
 
 [sqlfluff:layout:type:comparison_operator]
 spacing_within = touch
@@ -134,6 +134,10 @@ spacing_within = touch:inline
 # This prevents space between REPLACE following brackets:
 # e.g. SELECT * REPLACE()
 spacing_within = touch:inline
+
+[sqlfluff:layout:type:snowflake_semi_structured_expression]
+spacing_within = touch:inline
+spacing_before = touch:inline
 
 [sqlfluff:layout:type:array_accessor]
 spacing_before = touch:inline

--- a/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -234,3 +234,39 @@ test_align_alias_inline_fail:
   fail_str: SELECT a   AS   b  ,   c   AS   d    FROM tbl
   fix_str: SELECT a AS b, c AS d FROM tbl
   configs: *align_alias
+
+test_pass_snowflake_semi_structured:
+  pass_str: "SELECT to_array(a.b:c) FROM d"
+  configs:
+    core:
+      dialect: snowflake
+
+test_fail_snowflake_semi_structured_single:
+  fail_str: |
+    SELECT
+      to_array(a.b : c) as d,
+      e : f : g::string as h
+    FROM j
+  fix_str: |
+    SELECT
+      to_array(a.b:c) as d,
+      e:f:g::string as h
+    FROM j
+  configs:
+    core:
+      dialect: snowflake
+
+test_fail_snowflake_semi_structured_multi:
+  fail_str: |
+    SELECT
+      to_array(a.b    :    c) as d,
+      e    :    f    :    g::string as h
+    FROM j
+  fix_str: |
+    SELECT
+      to_array(a.b:c) as d,
+      e:f:g::string as h
+    FROM j
+  configs:
+    core:
+      dialect: snowflake


### PR DESCRIPTION
2.0.0a6 LT01 doesn't handle snowflake semi structured spacing very well. This updates the default config accordingly.

People can also retrofit this to 2.0.0a6 by adding the following section to their config:
```cfg
[sqlfluff:layout:type:casting_operator]
spacing_after = touch:inline
[sqlfluff:layout:type:snowflake_semi_structured_expression]
spacing_within = touch:inline
spacing_before = touch:inline
```