### PR TITLE
Fix #4485

### DIFF
--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -803,7 +803,7 @@ def _deduce_line_current_indent(
         else:
             reflow_logger.debug("    Handling as initial leading whitespace")
             for indent_seg in elements[0].segments[::-1]:
-                if indent_seg.is_type("whitespace"):
+                if indent_seg.is_type("whitespace") and not indent_seg.is_templated:
                     break
             # Handle edge case of no whitespace, but with newline.
             if not indent_seg.is_type("whitespace"):
@@ -819,6 +819,7 @@ def _deduce_line_current_indent(
         # It's a consumed indent.
         return cast(TemplateSegment, indent_seg).source_str.split("\n")[-1] or ""
     elif not indent_seg.pos_marker or not indent_seg.is_templated:
+        # It's a literal
         assert "\n" not in indent_seg.raw, f"Found newline in indent: {indent_seg}"
         return indent_seg.raw
     else:  # pragma: no cover

--- a/test/utils/reflow/reindent_test.py
+++ b/test/utils/reflow/reindent_test.py
@@ -617,7 +617,7 @@ def test_reflow__crawl_indent_points(raw_sql_in, points_out, default_config, cap
             # NOTE: This looks a little strange, but what's important
             # here is that it doesn't raise an exception.
             "\n   \n   \nSELECT 1",
-        )
+        ),
     ],
 )
 def test_reflow__lint_indent_points(raw_sql_in, raw_sql_out, default_config, caplog):

--- a/test/utils/reflow/reindent_test.py
+++ b/test/utils/reflow/reindent_test.py
@@ -610,6 +610,14 @@ def test_reflow__crawl_indent_points(raw_sql_in, points_out, default_config, cap
             "    \n"
             "  \n",
         ),
+        # Test leading templated newlines.
+        # https://github.com/sqlfluff/sqlfluff/issues/4485
+        (
+            "{{ '\\n   \\n   ' }}\nSELECT 1",
+            # NOTE: This looks a little strange, but what's important
+            # here is that it doesn't raise an exception.
+            "\n   \n   \nSELECT 1",
+        )
     ],
 )
 def test_reflow__lint_indent_points(raw_sql_in, raw_sql_out, default_config, caplog):


### PR DESCRIPTION
This resolves #4485. Bug was when there's a templated element on the first line, no literal whitespace, but the templated element _contains_ whitespace, but it preceded by a newline - we'd incorrectly identify the indent.

Sounds like a niche case, but as demonstrated in the original issue - I think actually quite probable.