### PR TITLE
BigQuery: correct query syntax for single column `UNPIVOT` clauses

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1779,16 +1779,22 @@ class FromUnpivotExpressionSegment(BaseSegment):
             optional=True,
         ),
         OneOf(
+            # single column unpivot
             Bracketed(
                 Ref("SingleIdentifierGrammar"),
                 "FOR",
                 Ref("SingleIdentifierGrammar"),
                 "IN",
                 Bracketed(
-                    Delimited(Ref("SingleIdentifierGrammar")),
-                    Ref("UnpivotAliasExpressionSegment", optional=True),
+                    Delimited(
+                        Sequence(
+                            Delimited(Ref("SingleIdentifierGrammar")),
+                            Ref("UnpivotAliasExpressionSegment", optional=True),
+                        ),
+                    ),
                 ),
             ),
+            # multi column unpivot
             Bracketed(
                 Bracketed(
                     Delimited(

--- a/test/fixtures/dialects/bigquery/select_unpivot.sql
+++ b/test/fixtures/dialects/bigquery/select_unpivot.sql
@@ -7,6 +7,9 @@ SELECT * FROM Produce
 UNPIVOT(sales FOR quarter IN (Q1, Q2, Q3, Q4));
 
 SELECT * FROM Produce
+UNPIVOT(sales FOR quarter IN (Q1 AS 1, Q2 AS 2, Q3 AS 3, Q4 AS 4));
+
+SELECT * FROM Produce
 UNPIVOT INCLUDE NULLS (sales FOR quarter IN (Q1, Q2, Q3, Q4));
 
 SELECT * FROM Produce

--- a/test/fixtures/dialects/bigquery/select_unpivot.yml
+++ b/test/fixtures/dialects/bigquery/select_unpivot.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f277aef81cf2ed68a5440c23a66868f475d0cbf1af04e44fbf9cd38b923c1d21
+_hash: 7ae3af309e693b3d3a22d339e25a49727a20c9575cebaf26d47657c313dc9bdd
 file:
 - statement:
     with_compound_statement:
@@ -114,6 +114,53 @@ file:
               - naked_identifier: Q3
               - comma: ','
               - naked_identifier: Q4
+              - end_bracket: )
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: Produce
+          from_unpivot_expression:
+            keyword: UNPIVOT
+            bracketed:
+            - start_bracket: (
+            - naked_identifier: sales
+            - keyword: FOR
+            - naked_identifier: quarter
+            - keyword: IN
+            - bracketed:
+              - start_bracket: (
+              - naked_identifier: Q1
+              - alias_expression:
+                  keyword: AS
+                  numeric_literal: '1'
+              - comma: ','
+              - naked_identifier: Q2
+              - alias_expression:
+                  keyword: AS
+                  numeric_literal: '2'
+              - comma: ','
+              - naked_identifier: Q3
+              - alias_expression:
+                  keyword: AS
+                  numeric_literal: '3'
+              - comma: ','
+              - naked_identifier: Q4
+              - alias_expression:
+                  keyword: AS
+                  numeric_literal: '4'
               - end_bracket: )
             - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Previous parsing of the BigQuery `UNPIVOT` clause misplaced the single value unpivot case's row value aliases, as it is according to the [documentation](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#unpivot_operator
).

Here the syntax parsing is correctly applied and an additional test case is added to cover this combination.

Fixes #4486

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
