### PR TITLE
Bug in operator precedence

### DIFF
--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -1364,7 +1364,7 @@ def _rebreak_priorities(spans: List[_RebreakSpan]) -> Dict[int, int]:
         # so for now it feels ok that it's coded here - it also wouldn't
         # be a breaking change at that point so no pressure to release
         # it early.
-        span_raw = span.target.raw
+        span_raw = span.target.raw_upper
         priority = 6  # Default to 6 for now i.e. the same as '+'
         # Override priority for specific precedence.
         if span_raw == ",":

--- a/test/fixtures/rules/std_rule_cases/LT05.yml
+++ b/test/fixtures/rules/std_rule_cases/LT05.yml
@@ -585,3 +585,21 @@ test_fail_do_not_fix_noqa:
         col3
     FROM
         really_really_really_really_really_really_long_schema_name.TABLE1 -- noqa: L014
+
+test_operator_precedence:
+  fail_str: |
+    SELECT *
+    FROM foo
+    left join abcdef_abcd_details
+        on foo.abcdefgh_id = abcdef_abcd_details.abcdefgh_id and abcdef_abcd_details.abcdef_abcdef_abcdef_abcdef = 1
+  fix_str: |
+    SELECT *
+    FROM foo
+    left join abcdef_abcd_details
+        on
+            foo.abcdefgh_id = abcdef_abcd_details.abcdefgh_id
+            and abcdef_abcd_details.abcdef_abcdef_abcdef_abcdef = 1
+  configs:
+    core:
+      max_line_length: 100
+      dialect: snowflake


### PR DESCRIPTION
Found a small bug in operator precedence while testing 2.0.0a6. This resolves that.

Lowercase `and` operators were picked up with a different precedence to uppercase `AND` because we were using `.raw` and not `.raw_upper`.