### PR TITLE
Trigger CI tests for merge groups

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -17,6 +17,11 @@ on:
   push:
     branches:
       - main
+  merge_group:
+    # Merge Queue checks requested. This feature is still in beta
+    # from Github and so may need updating later.
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
+    types: [checks_requested]
 
 jobs:
   linting:


### PR DESCRIPTION
I tried to enable the "merge queue" again, and the tests never ran. I think this should resolve that. See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group