### PR TITLE
Bigquery spacing

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -101,6 +101,12 @@ spacing_after = touch
 [sqlfluff:layout:type:end_square_bracket]
 spacing_before = touch
 
+[sqlfluff:layout:type:start_angle_bracket]
+spacing_after = touch
+
+[sqlfluff:layout:type:end_angle_bracket]
+spacing_before = touch
+
 [sqlfluff:layout:type:casting_operator]
 spacing_before = touch
 spacing_after = touch:inline
@@ -123,17 +129,9 @@ spacing_within = touch:inline
 spacing_after = touch:inline
 
 [sqlfluff:layout:type:function_name]
+spacing_within = touch:inline
 spacing_after = touch:inline
 
-[sqlfluff:layout:type:select_except_clause]
-# This prevents space between EXCEPT following brackets:
-# e.g. SELECT * EXCEPT()
-spacing_within = touch:inline
-
-[sqlfluff:layout:type:select_replace_clause]
-# This prevents space between REPLACE following brackets:
-# e.g. SELECT * REPLACE()
-spacing_within = touch:inline
 
 [sqlfluff:layout:type:snowflake_semi_structured_expression]
 spacing_within = touch:inline

--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -119,7 +119,7 @@ def process_spacing(
                 removal_buffer.append(seg)
                 result_buffer.append(
                     LintResult(
-                        seg, [LintFix.delete(seg)], description="Stripping newlines."
+                        seg, [LintFix.delete(seg)], description="Unexpected line break."
                     )
                 )
                 # Carry on as though it wasn't here.

--- a/test/fixtures/linter/autofix/bigquery/006_fix_ignore_templating/after.sql
+++ b/test/fixtures/linter/autofix/bigquery/006_fix_ignore_templating/after.sql
@@ -1,4 +1,4 @@
-SELECT * EXCEPT({% include query %}) FROM
+SELECT * EXCEPT ({% include query %}) FROM
     (
         SELECT
             tbl1.*,

--- a/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -270,3 +270,13 @@ test_fail_snowflake_semi_structured_multi:
   configs:
     core:
       dialect: snowflake
+
+test_pass_bigquery_specific:
+  # Test a selection of bigquery specific spacings work.
+  # Specifically EXCEPT & qualified functions.
+  pass_str: |
+    SELECT * EXCEPT (order_id);
+    SELECT NET.HOST(LOWER(url)) AS host FROM urls;
+  configs:
+    core:
+      dialect: bigquery


### PR DESCRIPTION
This resolves a few issues in bigquery specific spacing raised during testing by @tunetheweb .

Specifically:
- spacing after `EXCEPT` and `REPLACE`.
- spacing around angle brackets.
- spacing around array type specifiers
- spacing within qualified function names.

In doing this I've also revised the parsing of array types more generally so that the "type" part of it is a distinct segment. This is partly necessary for the spacing rules to apply properly, but also I think it's more representative of how array literals are structured.