### PR TITLE
Add a deprecation warning for removed config option.

### DIFF
--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Tuple, cast, TYPE_CHECKING
 from sqlfluff.core.parser import BaseSegment, RawSegment
 from sqlfluff.core.parser.segments.raw import WhitespaceSegment
 from sqlfluff.core.rules.base import LintFix, LintResult
+from sqlfluff.core.errors import SQLFluffUserError
 
 from sqlfluff.utils.reflow.helpers import pretty_segment_name
 
@@ -26,17 +27,29 @@ def _unpack_constraint(constraint: str, strip_newlines: bool):
 
     Used as a helper function in `determine_constraints`.
     """
+    # Check for deprecated options.
+    if constraint == "inline":  # pragma: no cover
+        reflow_logger.warning(
+            "Found 'inline' specified as a 'spacing_within' constraint. "
+            "This setting is deprecated and has been replaced by the more "
+            "explicit 'touch:inline'. Upgrade your configuration to "
+            "remove this warning."
+        )
+        constraint = "touch:inline"
+
     # Unless align, split.
     if constraint.startswith("align"):
         modifier = ""
     else:
         constraint, _, modifier = constraint.partition(":")
+
     if not modifier:
         pass
     elif modifier == "inline":
         strip_newlines = True
     else:  # pragma: no cover
-        raise NotImplementedError(f"Unexpected constraint modifier: {constraint}")
+        raise SQLFluffUserError(f"Unexpected constraint modifier: {constraint!r}")
+
     return constraint, strip_newlines
 
 
@@ -82,8 +95,8 @@ def determine_constraints(
         pass
     elif within_spacing:  # pragma: no cover
         assert prev_block
-        raise NotImplementedError(
-            f"Unexpected within constraint: {within_constraint} for "
+        raise SQLFluffUserError(
+            f"Unexpected within constraint: {within_constraint!r} for "
             f"{prev_block.depth_info.stack_class_types[idx]}"
         )
 


### PR DESCRIPTION
As part of revising layout config, I removed the `inline` option. @tunetheweb was still using it 😄 .

This adds a more helpful deprecation message and also auto-translates the value in the short term.

I've tested locally, but not adding to test suite because this should eventually be removed.