### PR TITLE
Array and Struct Spacing

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -145,6 +145,12 @@ spacing_within = touch
 [sqlfluff:layout:type:sized_array_type]
 spacing_within = touch
 
+[sqlfluff:layout:type:struct_type]
+spacing_within = touch:inline
+
+[sqlfluff:layout:type:typed_struct_literal]
+spacing_within = touch
+
 [sqlfluff:layout:type:snowflake_semi_structured_expression]
 spacing_within = touch:inline
 spacing_before = touch:inline

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -142,6 +142,9 @@ spacing_within = touch:inline
 [sqlfluff:layout:type:typed_array_literal]
 spacing_within = touch
 
+[sqlfluff:layout:type:sized_array_type]
+spacing_within = touch
+
 [sqlfluff:layout:type:snowflake_semi_structured_expression]
 spacing_within = touch:inline
 spacing_before = touch:inline

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -101,6 +101,12 @@ spacing_after = touch
 [sqlfluff:layout:type:end_square_bracket]
 spacing_before = touch
 
+[sqlfluff:layout:type:start_angle_bracket]
+spacing_after = touch
+
+[sqlfluff:layout:type:end_angle_bracket]
+spacing_before = touch
+
 [sqlfluff:layout:type:casting_operator]
 spacing_before = touch
 spacing_after = touch:inline
@@ -123,17 +129,9 @@ spacing_within = touch:inline
 spacing_after = touch:inline
 
 [sqlfluff:layout:type:function_name]
+spacing_within = touch:inline
 spacing_after = touch:inline
 
-[sqlfluff:layout:type:select_except_clause]
-# This prevents space between EXCEPT following brackets:
-# e.g. SELECT * EXCEPT()
-spacing_within = touch:inline
-
-[sqlfluff:layout:type:select_replace_clause]
-# This prevents space between REPLACE following brackets:
-# e.g. SELECT * REPLACE()
-spacing_within = touch:inline
 
 [sqlfluff:layout:type:snowflake_semi_structured_expression]
 spacing_within = touch:inline

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -111,6 +111,10 @@ spacing_before = touch
 spacing_before = touch
 spacing_after = touch:inline
 
+[sqlfluff:layout:type:slice]
+spacing_before = touch
+spacing_after = touch
+
 [sqlfluff:layout:type:comparison_operator]
 spacing_within = touch
 line_position = leading
@@ -132,6 +136,8 @@ spacing_after = touch:inline
 spacing_within = touch:inline
 spacing_after = touch:inline
 
+[sqlfluff:layout:type:array_type]
+spacing_within = touch:inline
 
 [sqlfluff:layout:type:snowflake_semi_structured_expression]
 spacing_within = touch:inline

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -139,6 +139,9 @@ spacing_after = touch:inline
 [sqlfluff:layout:type:array_type]
 spacing_within = touch:inline
 
+[sqlfluff:layout:type:typed_array_literal]
+spacing_within = touch
+
 [sqlfluff:layout:type:snowflake_semi_structured_expression]
 spacing_within = touch:inline
 spacing_before = touch:inline

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -568,8 +568,6 @@ ansi_dialect.add(
         ),
         OneOf(Sequence("ANY", "TYPE"), Ref("DatatypeSegment")),
     ),
-    # This is a placeholder for other dialects.
-    SimpleArrayTypeGrammar=Nothing(),
     AutoIncrementGrammar=Sequence("AUTO_INCREMENT"),
     # Base Expression element is the right thing to reference for everything
     # which functions as an expression, but could include literals.
@@ -744,12 +742,19 @@ class IntervalExpressionSegment(BaseSegment):
     )
 
 
+class ArrayTypeSegment(BaseSegment):
+    """Prefix for array literals specifying the type."""
+
+    type = "array_type"
+    match_grammar: Matchable = Nothing()
+
+
 class ArrayLiteralSegment(BaseSegment):
     """An array literal segment."""
 
     type = "array_literal"
     match_grammar: Matchable = Sequence(
-        Ref("SimpleArrayTypeGrammar", optional=True),
+        Ref("ArrayTypeSegment", optional=True),
         Bracketed(
             Delimited(Ref("BaseExpressionElementGrammar"), optional=True),
             bracket_type="square",

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -456,6 +456,7 @@ ansi_dialect.add(
         Ref("NullLiteralSegment"),
         Ref("DateTimeLiteralGrammar"),
         Ref("ArrayLiteralSegment"),
+        Ref("TypedArrayLiteralSegment"),
         Ref("ObjectLiteralSegment"),
     ),
     AndOperatorGrammar=StringParser("AND", BinaryOperatorSegment),
@@ -743,22 +744,36 @@ class IntervalExpressionSegment(BaseSegment):
 
 
 class ArrayTypeSegment(BaseSegment):
-    """Prefix for array literals specifying the type."""
+    """Prefix for array literals specifying the type.
+    
+    Often "ARRAY" or "ARRAY<type>"
+    """
 
     type = "array_type"
     match_grammar: Matchable = Nothing()
 
 
 class ArrayLiteralSegment(BaseSegment):
-    """An array literal segment."""
+    """An array literal segment.
+    
+    An unqualified array literal:
+    e.g. [1, 2, 3]
+    """
 
     type = "array_literal"
+    match_grammar: Matchable = Bracketed(
+        Delimited(Ref("BaseExpressionElementGrammar"), optional=True),
+        bracket_type="square",
+    )
+
+
+class TypedArrayLiteralSegment(BaseSegment):
+    """An array literal segment."""
+
+    type = "typed_array_literal"
     match_grammar: Matchable = Sequence(
-        Ref("ArrayTypeSegment", optional=True),
-        Bracketed(
-            Delimited(Ref("BaseExpressionElementGrammar"), optional=True),
-            bracket_type="square",
-        ),
+        Ref("ArrayTypeSegment"),
+        Ref("ArrayLiteralSegment"),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -777,6 +777,47 @@ class TypedArrayLiteralSegment(BaseSegment):
     )
 
 
+class StructTypeSegment(BaseSegment):
+    """Expression to construct a STRUCT datatype.
+
+    (Used in BigQuery for example)
+    """
+
+    type = "struct_type"
+    match_grammar: Matchable = Nothing()
+
+
+class StructLiteralSegment(BaseSegment):
+    """An array literal segment.
+    
+    An unqualified struct literal:
+    e.g. (1, 2 as foo, 3)
+
+    NOTE: This rarely exists without a preceding type
+    and exists mostly for structural & layout reasons.
+    """
+
+    type = "struct_literal"
+    match_grammar: Matchable = Bracketed(
+        Delimited(
+            Sequence(
+                Ref("BaseExpressionElementGrammar"),
+                Ref("AliasExpressionSegment", optional=True),
+            ),
+        ),
+    )
+
+
+class TypedStructLiteralSegment(BaseSegment):
+    """An array literal segment."""
+
+    type = "typed_struct_literal"
+    match_grammar: Matchable = Sequence(
+        Ref("StructTypeSegment"),
+        Ref("StructLiteralSegment"),
+    )
+
+
 class ObjectLiteralSegment(BaseSegment):
     """An object literal segment."""
 
@@ -1972,8 +2013,8 @@ ansi_dialect.add(
             Ref("SelectStatementSegment"),
             Ref("LiteralGrammar"),
             Ref("IntervalExpressionSegment"),
-            Ref("TypelessStructSegment"),
-            Ref("TypelessArraySegment"),
+            Ref("TypedStructLiteralSegment"),
+            Ref("ArrayExpressionSegment"),
             Ref("ColumnReferenceSegment"),
             # For triggers, we allow "NEW.*" but not just "*" nor "a.b.*"
             # So can't use WildcardIdentifierSegment nor WildcardExpressionSegment
@@ -2791,33 +2832,16 @@ class TableEndClauseSegment(BaseSegment):
     match_grammar: Matchable = Nothing()
 
 
-class TypelessStructSegment(BaseSegment):
-    """Expression to construct a STRUCT with implicit types.
-
-    (Yes in BigQuery for example)
-    """
-
-    type = "typeless_struct"
-    match_grammar: Matchable = Nothing()
-
-
-class TypelessArraySegment(BaseSegment):
+class ArrayExpressionSegment(BaseSegment):
     """Expression to construct a ARRAY from a subquery.
 
     (Yes in BigQuery for example)
+
+    NOTE: This differs from an array _literal_ in that it
+    takes the form of an expression.
     """
 
-    type = "typeless_array"
-    match_grammar: Matchable = Nothing()
-
-
-class StructTypeSegment(BaseSegment):
-    """Expression to construct a STRUCT datatype.
-
-    (Used in BigQuery for example)
-    """
-
-    type = "struct_type"
+    type = "array_expression"
     match_grammar: Matchable = Nothing()
 
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -753,6 +753,16 @@ class ArrayTypeSegment(BaseSegment):
     match_grammar: Matchable = Nothing()
 
 
+class SizedArrayTypeSegment(BaseSegment):
+    """Array type with a size."""
+
+    type = "sized_array_type"
+    match_grammar = Sequence(
+        Ref("ArrayTypeSegment"),
+        Ref("ArrayAccessorSegment"),
+    )
+
+
 class ArrayLiteralSegment(BaseSegment):
     """An array literal segment.
     

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -745,7 +745,7 @@ class IntervalExpressionSegment(BaseSegment):
 
 class ArrayTypeSegment(BaseSegment):
     """Prefix for array literals specifying the type.
-    
+
     Often "ARRAY" or "ARRAY<type>"
     """
 
@@ -765,7 +765,7 @@ class SizedArrayTypeSegment(BaseSegment):
 
 class ArrayLiteralSegment(BaseSegment):
     """An array literal segment.
-    
+
     An unqualified array literal:
     e.g. [1, 2, 3]
     """
@@ -799,7 +799,7 @@ class StructTypeSegment(BaseSegment):
 
 class StructLiteralSegment(BaseSegment):
     """An array literal segment.
-    
+
     An unqualified struct literal:
     e.g. (1, 2 as foo, 3)
 

--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -247,7 +247,27 @@ class ArrayTypeSegment(ansi.ArrayTypeSegment):
     """Prefix for array literals specifying the type."""
 
     type = "array_type"
-    match_grammar = Ref.keyword("ARRAY")
+    match_grammar = Sequence(
+        Ref.keyword("ARRAY"),
+        Ref("ArrayTypeSchemaSegment", optional=True),
+    )
+
+
+class ArrayTypeSchemaSegment(ansi.ArrayTypeSegment):
+    """Prefix for array literals specifying the type."""
+
+    type = "array_type_schema"
+    match_grammar = Bracketed(
+        Delimited(
+            Sequence(
+                Ref("DatatypeSegment"),
+                Ref("CommentGrammar", optional=True),
+            ),
+            bracket_pairs_set="angle_bracket_pairs",
+        ),
+        bracket_pairs_set="angle_bracket_pairs",
+        bracket_type="angle",
+    )
 
 
 class PrimitiveTypeSegment(BaseSegment):
@@ -333,20 +353,7 @@ class DatatypeSegment(BaseSegment):
                 bracket_type="angle",
             ),
         ),
-        Sequence(
-            "ARRAY",
-            Bracketed(
-                Delimited(
-                    Sequence(
-                        Ref("DatatypeSegment"),
-                        Ref("CommentGrammar", optional=True),
-                    ),
-                    bracket_pairs_set="angle_bracket_pairs",
-                ),
-                bracket_pairs_set="angle_bracket_pairs",
-                bracket_type="angle",
-            ),
-        ),
+        Ref("ArrayTypeSegment"),
         Sequence(
             "MAP",
             Bracketed(

--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -270,6 +270,34 @@ class ArrayTypeSchemaSegment(ansi.ArrayTypeSegment):
     )
 
 
+class StructTypeSegment(ansi.StructTypeSegment):
+    """Expression to construct a STRUCT datatype."""
+
+    match_grammar = Sequence(
+        "STRUCT",
+        Ref("StructTypeSchemaSegment", optional=True),
+    )
+
+
+class StructTypeSchemaSegment(BaseSegment):
+    """Expression to construct the schema of a STRUCT datatype."""
+
+    type = "struct_type_schema"
+    match_grammar = Bracketed(
+        Delimited(
+            Sequence(
+                Ref("NakedIdentifierSegment"),
+                Ref("ColonSegment"),
+                Ref("DatatypeSegment"),
+                Ref("CommentGrammar", optional=True),
+            ),
+            bracket_pairs_set="angle_bracket_pairs",
+        ),
+        bracket_pairs_set="angle_bracket_pairs",
+        bracket_type="angle",
+    )
+
+
 class PrimitiveTypeSegment(BaseSegment):
     """Support Athena subset of Hive types.
 
@@ -337,22 +365,7 @@ class DatatypeSegment(BaseSegment):
     type = "data_type"
     match_grammar = OneOf(
         Ref("PrimitiveTypeSegment"),
-        Sequence(
-            "STRUCT",
-            Bracketed(
-                Delimited(
-                    Sequence(
-                        Ref("NakedIdentifierSegment"),
-                        Ref("ColonSegment"),
-                        Ref("DatatypeSegment"),
-                        Ref("CommentGrammar", optional=True),
-                    ),
-                    bracket_pairs_set="angle_bracket_pairs",
-                ),
-                bracket_pairs_set="angle_bracket_pairs",
-                bracket_type="angle",
-            ),
-        ),
+        Ref("StructTypeSegment"),
         Ref("ArrayTypeSegment"),
         Sequence(
             "MAP",

--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -248,7 +248,7 @@ class ArrayTypeSegment(ansi.ArrayTypeSegment):
 
     type = "array_type"
     match_grammar = Sequence(
-        Ref.keyword("ARRAY"),
+        "ARRAY",
         Ref("ArrayTypeSchemaSegment", optional=True),
     )
 

--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -217,7 +217,6 @@ athena_dialect.replace(
         TypedParser("double_quote", ansi.LiteralSegment, type="quoted_literal"),
         TypedParser("back_quote", ansi.LiteralSegment, type="quoted_literal"),
     ),
-    SimpleArrayTypeGrammar=Ref.keyword("ARRAY"),
     TrimParametersGrammar=Nothing(),
     NakedIdentifierSegment=SegmentGenerator(
         # Generate the anti template from the set of reserved keywords
@@ -242,6 +241,13 @@ athena_dialect.replace(
         Ref("RightArrowOperator"),
     ),
 )
+
+
+class ArrayTypeSegment(ansi.ArrayTypeSegment):
+    """Prefix for array literals specifying the type."""
+
+    type = "array_type"
+    match_grammar = Ref.keyword("ARRAY")
 
 
 class PrimitiveTypeSegment(BaseSegment):

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1044,49 +1044,37 @@ class StructTypeSegment(ansi.StructTypeSegment):
 
     match_grammar = Sequence(
         "STRUCT",
-        Bracketed(
-            Delimited(  # Comma-separated list of field names/types
-                Sequence(
-                    OneOf(
-                        # ParameterNames can look like Datatypes so can't use
-                        # Optional=True here and instead do a OneOf in order
-                        # with DataType only first, followed by both.
+        Ref("StructTypeSchemaSegment", optional=True),
+    )
+
+
+class StructTypeSchemaSegment(BaseSegment):
+    """Expression to construct the schema of a STRUCT datatype."""
+
+    type = "struct_type_schema"
+    match_grammar = Bracketed(
+        Delimited(  # Comma-separated list of field names/types
+            Sequence(
+                OneOf(
+                    # ParameterNames can look like Datatypes so can't use
+                    # Optional=True here and instead do a OneOf in order
+                    # with DataType only first, followed by both.
+                    Ref("DatatypeSegment"),
+                    Sequence(
+                        Ref("ParameterNameSegment"),
                         Ref("DatatypeSegment"),
-                        Sequence(
-                            Ref("ParameterNameSegment"),
-                            Ref("DatatypeSegment"),
-                        ),
                     ),
-                    AnyNumberOf(Ref("ColumnConstraintSegment")),
-                    Ref("OptionsSegment", optional=True),
                 ),
+                AnyNumberOf(Ref("ColumnConstraintSegment")),
+                Ref("OptionsSegment", optional=True),
             ),
-            bracket_type="angle",
-            bracket_pairs_set="angle_bracket_pairs",
         ),
+        bracket_type="angle",
+        bracket_pairs_set="angle_bracket_pairs",
     )
 
 
-class TypelessStructSegment(ansi.TypelessStructSegment):
-    """Expression to construct a STRUCT with implicit types.
-
-    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#typeless_struct_syntax
-    """
-
-    match_grammar = Sequence(
-        "STRUCT",
-        Bracketed(
-            Delimited(
-                Sequence(
-                    Ref("BaseExpressionElementGrammar"),
-                    Ref("AliasExpressionSegment", optional=True),
-                ),
-            ),
-        ),
-    )
-
-
-class TypelessArraySegment(ansi.TypelessArraySegment):
+class ArrayExpressionSegment(ansi.ArrayExpressionSegment):
     """Expression to construct a ARRAY from a subquery.
 
     https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -203,14 +203,6 @@ bigquery_dialect.replace(
         Ref("NamedArgumentSegment"),
     ),
     TrimParametersGrammar=Nothing(),
-    SimpleArrayTypeGrammar=Sequence(
-        "ARRAY",
-        Bracketed(
-            Ref("DatatypeSegment"),
-            bracket_type="angle",
-            bracket_pairs_set="angle_bracket_pairs",
-        ),
-    ),
     # BigQuery allows underscore in parameter names, and also anything if quoted in
     # backticks
     ParameterNameSegment=OneOf(
@@ -309,6 +301,20 @@ bigquery_dialect.sets("angle_bracket_pairs").update(
         ("angle", "StartAngleBracketSegment", "EndAngleBracketSegment", False),
     ]
 )
+
+
+class ArrayTypeSegment(ansi.ArrayTypeSegment):
+    """Prefix for array literals specifying the type."""
+
+    type = "array_type"
+    match_grammar = Sequence(
+        "ARRAY",
+        Bracketed(
+            Ref("DatatypeSegment"),
+            bracket_type="angle",
+            bracket_pairs_set="angle_bracket_pairs",
+        ),
+    )
 
 
 class QualifyClauseSegment(BaseSegment):
@@ -1028,7 +1034,7 @@ class DatatypeSegment(ansi.DatatypeSegment):
             Bracketed(Delimited(Ref("NumericLiteralSegment")), optional=True),
         ),
         Sequence("ANY", "TYPE"),  # SQL UDFs can specify this "type"
-        Ref("SimpleArrayTypeGrammar"),
+        Ref("ArrayTypeSegment"),
         Ref("StructTypeSegment"),
     )
 

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -239,6 +239,34 @@ class ArrayTypeSegment(ansi.ArrayTypeSegment):
     )
 
 
+class StructTypeSegment(ansi.StructTypeSegment):
+    """Expression to construct a STRUCT datatype."""
+
+    match_grammar = Sequence(
+        "STRUCT",
+        Ref("StructTypeSchemaSegment", optional=True),
+    )
+
+
+class StructTypeSchemaSegment(BaseSegment):
+    """Expression to construct the schema of a STRUCT datatype."""
+
+    type = "struct_type_schema"
+    match_grammar = Bracketed(
+        Delimited(
+            Sequence(
+                Ref("NakedIdentifierSegment"),
+                Ref("ColonSegment"),
+                Ref("DatatypeSegment"),
+                Ref("CommentGrammar", optional=True),
+            ),
+            bracket_pairs_set="angle_bracket_pairs",
+        ),
+        bracket_pairs_set="angle_bracket_pairs",
+        bracket_type="angle",
+    )
+
+
 class CreateDatabaseStatementSegment(BaseSegment):
     """A `CREATE DATABASE` statement."""
 
@@ -477,22 +505,7 @@ class DatatypeSegment(BaseSegment):
                 bracket_type="angle",
             ),
         ),
-        Sequence(
-            "STRUCT",
-            Bracketed(
-                Delimited(
-                    Sequence(
-                        Ref("NakedIdentifierSegment"),
-                        Ref("ColonSegment"),
-                        Ref("DatatypeSegment"),
-                        Ref("CommentGrammar", optional=True),
-                    ),
-                    bracket_pairs_set="angle_bracket_pairs",
-                ),
-                bracket_pairs_set="angle_bracket_pairs",
-                bracket_type="angle",
-            ),
-        ),
+        Ref("StructTypeSegment"),
         Sequence(
             "UNIONTYPE",
             Bracketed(

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -147,7 +147,6 @@ hive_dialect.replace(
         TypedParser("double_quote", ansi.LiteralSegment, type="quoted_literal"),
         TypedParser("back_quote", ansi.LiteralSegment, type="quoted_literal"),
     ),
-    SimpleArrayTypeGrammar=Ref.keyword("ARRAY"),
     TrimParametersGrammar=Nothing(),
     SingleIdentifierGrammar=ansi_dialect.get_grammar("SingleIdentifierGrammar").copy(
         insert=[
@@ -223,6 +222,13 @@ hive_dialect.replace(
         ]
     ),
 )
+
+
+class ArrayTypeSegment(ansi.ArrayTypeSegment):
+    """Prefix for array literals specifying the type."""
+
+    type = "array_type"
+    match_grammar = Ref.keyword("ARRAY")
 
 
 class CreateDatabaseStatementSegment(BaseSegment):
@@ -503,8 +509,8 @@ class DatatypeSegment(BaseSegment):
                     Ref("ExpressionSegment", optional=True), bracket_type="square"
                 )
             ),
-            Ref("SimpleArrayTypeGrammar"),
-            Sequence(Ref("SimpleArrayTypeGrammar"), Ref("ArrayLiteralSegment")),
+            Ref("ArrayTypeSegment"),
+            Sequence(Ref("ArrayTypeSegment"), Ref("ArrayLiteralSegment")),
             optional=True,
         ),
     )

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -493,6 +493,7 @@ class DatatypeSegment(BaseSegment):
     match_grammar = OneOf(
         Ref("PrimitiveTypeSegment"),
         Ref("ArrayTypeSegment"),
+        Ref("SizedArrayTypeSegment"),
         Sequence(
             "MAP",
             Bracketed(
@@ -515,17 +516,6 @@ class DatatypeSegment(BaseSegment):
                 bracket_pairs_set="angle_bracket_pairs",
                 bracket_type="angle",
             ),
-        ),
-        # array types
-        OneOf(
-            AnyNumberOf(
-                Bracketed(
-                    Ref("ExpressionSegment", optional=True), bracket_type="square"
-                )
-            ),
-            Ref("ArrayTypeSegment"),
-            Ref("SizedArrayTypeSegment"),
-            optional=True,
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -510,7 +510,7 @@ class DatatypeSegment(BaseSegment):
                 )
             ),
             Ref("ArrayTypeSegment"),
-            Sequence(Ref("ArrayTypeSegment"), Ref("ArrayLiteralSegment")),
+            Ref("SizedArrayTypeSegment"),
             optional=True,
         ),
     )

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -228,7 +228,15 @@ class ArrayTypeSegment(ansi.ArrayTypeSegment):
     """Prefix for array literals specifying the type."""
 
     type = "array_type"
-    match_grammar = Ref.keyword("ARRAY")
+    match_grammar = Sequence(
+        "ARRAY",
+        Bracketed(
+            Ref("DatatypeSegment"),
+            bracket_type="angle",
+            bracket_pairs_set="angle_bracket_pairs",
+            optional=True,
+        ),
+    )
 
 
 class CreateDatabaseStatementSegment(BaseSegment):
@@ -456,14 +464,7 @@ class DatatypeSegment(BaseSegment):
     type = "data_type"
     match_grammar = OneOf(
         Ref("PrimitiveTypeSegment"),
-        Sequence(
-            "ARRAY",
-            Bracketed(
-                Ref("DatatypeSegment"),
-                bracket_pairs_set="angle_bracket_pairs",
-                bracket_type="angle",
-            ),
-        ),
+        Ref("ArrayTypeSegment"),
         Sequence(
             "MAP",
             Bracketed(

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -701,7 +701,7 @@ class DatatypeSegment(ansi.DatatypeSegment):
                 )
             ),
             Ref("ArrayTypeSegment"),
-            Sequence(Ref("ArrayTypeSegment"), Ref("ArrayLiteralSegment")),
+            Ref("SizedArrayTypeSegment"),
             optional=True,
         ),
     )
@@ -712,6 +712,16 @@ class ArrayTypeSegment(ansi.ArrayTypeSegment):
 
     type = "array_type"
     match_grammar = Ref.keyword("ARRAY")
+
+
+class SizedArrayTypeSegment(ansi.ArrayTypeSegment):
+    """Prefix for array literals specifying the type."""
+
+    type = "sized_array_type"
+    match_grammar = Sequence(
+        Ref("ArrayTypeSegment"),
+        Ref("ArrayAccessorSegment"),
+    )
 
 
 class CreateFunctionStatementSegment(ansi.CreateFunctionStatementSegment):

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -421,7 +421,6 @@ postgres_dialect.replace(
         ],
         before=Ref("ArrayLiteralSegment"),
     ),
-    SimpleArrayTypeGrammar=Ref.keyword("ARRAY"),
     FromClauseTerminatorGrammar=ansi_dialect.get_grammar(
         "FromClauseTerminatorGrammar"
     ).copy(
@@ -701,11 +700,18 @@ class DatatypeSegment(ansi.DatatypeSegment):
                     Ref("ExpressionSegment", optional=True), bracket_type="square"
                 )
             ),
-            Ref("SimpleArrayTypeGrammar"),
-            Sequence(Ref("SimpleArrayTypeGrammar"), Ref("ArrayLiteralSegment")),
+            Ref("ArrayTypeSegment"),
+            Sequence(Ref("ArrayTypeSegment"), Ref("ArrayLiteralSegment")),
             optional=True,
         ),
     )
+
+
+class ArrayTypeSegment(ansi.ArrayTypeSegment):
+    """Prefix for array literals specifying the type."""
+
+    type = "array_type"
+    match_grammar = Ref.keyword("ARRAY")
 
 
 class CreateFunctionStatementSegment(ansi.CreateFunctionStatementSegment):

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -714,16 +714,6 @@ class ArrayTypeSegment(ansi.ArrayTypeSegment):
     match_grammar = Ref.keyword("ARRAY")
 
 
-class SizedArrayTypeSegment(ansi.ArrayTypeSegment):
-    """Prefix for array literals specifying the type."""
-
-    type = "sized_array_type"
-    match_grammar = Sequence(
-        Ref("ArrayTypeSegment"),
-        Ref("ArrayAccessorSegment"),
-    )
-
-
 class CreateFunctionStatementSegment(ansi.CreateFunctionStatementSegment):
     """A `CREATE FUNCTION` statement.
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -465,7 +465,7 @@ tsql_dialect.replace(
             Ref("LiteralGrammar"),
             Ref("ColumnReferenceSegment"),
             Sequence(
-                Ref("SimpleArrayTypeGrammar", optional=True), Ref("ArrayLiteralSegment")
+                Ref("ArrayTypeSegment", optional=True), Ref("ArrayLiteralSegment")
             ),
         ),
         Ref("Accessor_Grammar", optional=True),

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -464,9 +464,8 @@ tsql_dialect.replace(
             Ref("SelectStatementSegment"),
             Ref("LiteralGrammar"),
             Ref("ColumnReferenceSegment"),
-            Sequence(
-                Ref("ArrayTypeSegment", optional=True), Ref("ArrayLiteralSegment")
-            ),
+            Ref("TypedArrayLiteralSegment"),
+            Ref("ArrayLiteralSegment"),
         ),
         Ref("Accessor_Grammar", optional=True),
         allow_gaps=True,

--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -119,7 +119,7 @@ def process_spacing(
                 removal_buffer.append(seg)
                 result_buffer.append(
                     LintResult(
-                        seg, [LintFix.delete(seg)], description="Stripping newlines."
+                        seg, [LintFix.delete(seg)], description="Unexpected line break."
                     )
                 )
                 # Carry on as though it wasn't here.

--- a/test/fixtures/dialects/athena/create_array_table.yml
+++ b/test/fixtures/dialects/athena/create_array_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 20fae2f3644122606b3fdb758612208ef7bec3740a0eb66f4bb8865b88268343
+_hash: 2fe50ad709b60c1e739fec5ef4841d766e9f03bb56d46500ff6d673bb5e0ece5
 file:
 - statement:
     create_table_statement:
@@ -16,12 +16,14 @@ file:
         column_definition:
           naked_identifier: c1
           data_type:
-            keyword: array
-            start_angle_bracket: <
-            data_type:
-              primitive_type:
-                keyword: integer
-            end_angle_bracket: '>'
+            array_type:
+              keyword: array
+              array_type_schema:
+                start_angle_bracket: <
+                data_type:
+                  primitive_type:
+                    keyword: integer
+                end_angle_bracket: '>'
         end_bracket: )
     - keyword: LOCATION
     - quoted_literal: "'...'"
@@ -37,14 +39,16 @@ file:
         bracketed:
           start_bracket: (
           expression:
-            array_literal:
-            - keyword: ARRAY
-            - start_square_bracket: '['
-            - numeric_literal: '1'
-            - comma: ','
-            - numeric_literal: '2'
-            - comma: ','
-            - numeric_literal: '3'
-            - end_square_bracket: ']'
+            typed_array_literal:
+              array_type:
+                keyword: ARRAY
+              array_literal:
+              - start_square_bracket: '['
+              - numeric_literal: '1'
+              - comma: ','
+              - numeric_literal: '2'
+              - comma: ','
+              - numeric_literal: '3'
+              - end_square_bracket: ']'
           end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/athena/create_external_table.yml
+++ b/test/fixtures/dialects/athena/create_external_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c477f9eec8a7f403850f8c889f12d7effdafd774bd0da9b4a473f346ff133a1d
+_hash: 68b5d13306d23d5e9b8c3df0bd4c40672178cb10f21bdb196c90cd0549a27744
 file:
 - statement:
     create_table_statement:
@@ -74,12 +74,14 @@ file:
       - keyword: bucketed_by
       - comparison_operator:
           raw_comparison_operator: '='
-      - array_literal:
-          keyword: ARRAY
-          start_square_bracket: '['
-          column_reference:
-            naked_identifier: column_name
-          end_square_bracket: ']'
+      - typed_array_literal:
+          array_type:
+            keyword: ARRAY
+          array_literal:
+            start_square_bracket: '['
+            column_reference:
+              naked_identifier: column_name
+            end_square_bracket: ']'
       - comma: ','
       - keyword: bucket_count
       - comparison_operator:

--- a/test/fixtures/dialects/athena/create_external_table_struct.yml
+++ b/test/fixtures/dialects/athena/create_external_table_struct.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ccb8cbfb25c805ab9a3e17dd51435b413f14c0ed420a691d989fa634733670cb
+_hash: 02a71f810091ee83c7d409ce6521263ea4063d017bee6cccd54bc366e1c6192e
 file:
   statement:
     create_table_statement:
@@ -49,20 +49,22 @@ file:
       - column_definition:
           naked_identifier: app
           data_type:
-          - keyword: struct
-          - start_angle_bracket: <
-          - naked_identifier: appName
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: string
-          - comma: ','
-          - naked_identifier: adamId
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: string
-          - end_angle_bracket: '>'
+            struct_type:
+              keyword: struct
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: appName
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: string
+              - comma: ','
+              - naked_identifier: adamId
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: string
+              - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           naked_identifier: servingStatus
@@ -97,38 +99,42 @@ file:
       - column_definition:
           naked_identifier: totalBudget
           data_type:
-          - keyword: struct
-          - start_angle_bracket: <
-          - naked_identifier: amount
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: int
-          - comma: ','
-          - naked_identifier: currency
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: string
-          - end_angle_bracket: '>'
+            struct_type:
+              keyword: struct
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: amount
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: int
+              - comma: ','
+              - naked_identifier: currency
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: string
+              - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           naked_identifier: dailyBudget
           data_type:
-          - keyword: struct
-          - start_angle_bracket: <
-          - naked_identifier: amount
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: int
-          - comma: ','
-          - naked_identifier: currency
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: string
-          - end_angle_bracket: '>'
+            struct_type:
+              keyword: struct
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: amount
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: int
+              - comma: ','
+              - naked_identifier: currency
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: string
+              - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           naked_identifier: displayStatus
@@ -229,74 +235,82 @@ file:
       - column_definition:
           naked_identifier: avgCPA
           data_type:
-          - keyword: struct
-          - start_angle_bracket: <
-          - naked_identifier: amount
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: int
-          - comma: ','
-          - naked_identifier: currency
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: string
-          - end_angle_bracket: '>'
+            struct_type:
+              keyword: struct
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: amount
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: int
+              - comma: ','
+              - naked_identifier: currency
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: string
+              - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           naked_identifier: avgCPT
           data_type:
-          - keyword: struct
-          - start_angle_bracket: <
-          - naked_identifier: amount
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: int
-          - comma: ','
-          - naked_identifier: currency
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: string
-          - end_angle_bracket: '>'
+            struct_type:
+              keyword: struct
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: amount
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: int
+              - comma: ','
+              - naked_identifier: currency
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: string
+              - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           naked_identifier: avgCPM
           data_type:
-          - keyword: struct
-          - start_angle_bracket: <
-          - naked_identifier: amount
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: int
-          - comma: ','
-          - naked_identifier: currency
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: string
-          - end_angle_bracket: '>'
+            struct_type:
+              keyword: struct
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: amount
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: int
+              - comma: ','
+              - naked_identifier: currency
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: string
+              - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           naked_identifier: localSpend
           data_type:
-          - keyword: struct
-          - start_angle_bracket: <
-          - naked_identifier: amount
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: int
-          - comma: ','
-          - naked_identifier: currency
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: string
-          - end_angle_bracket: '>'
+            struct_type:
+              keyword: struct
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: amount
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: int
+              - comma: ','
+              - naked_identifier: currency
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: string
+              - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           naked_identifier: conversionRate

--- a/test/fixtures/dialects/athena/create_external_table_struct.yml
+++ b/test/fixtures/dialects/athena/create_external_table_struct.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 26e46fc3a0b1ef5006e5d68bca65c9e73261c0e2636e412e2380d03585798a97
+_hash: ccb8cbfb25c805ab9a3e17dd51435b413f14c0ed420a691d989fa634733670cb
 file:
   statement:
     create_table_statement:
@@ -79,12 +79,14 @@ file:
       - column_definition:
           naked_identifier: countriesOrRegions
           data_type:
-            keyword: array
-            start_angle_bracket: <
-            data_type:
-              primitive_type:
-                keyword: string
-            end_angle_bracket: '>'
+            array_type:
+              keyword: array
+              array_type_schema:
+                start_angle_bracket: <
+                data_type:
+                  primitive_type:
+                    keyword: string
+                end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           naked_identifier: modificationTime
@@ -137,12 +139,14 @@ file:
       - column_definition:
           naked_identifier: supplySources
           data_type:
-            keyword: array
-            start_angle_bracket: <
-            data_type:
-              primitive_type:
-                keyword: string
-            end_angle_bracket: '>'
+            array_type:
+              keyword: array
+              array_type_schema:
+                start_angle_bracket: <
+                data_type:
+                  primitive_type:
+                    keyword: string
+                end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           naked_identifier: adChannelType

--- a/test/fixtures/dialects/athena/create_map_table.yml
+++ b/test/fixtures/dialects/athena/create_map_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: af0f6c74864151dc04c1c6a55906440142be34683908bea474351ba01e5adcbf
+_hash: b76d812198af12824cf2a75c4ce6081d8d52e8d55f0a8edc982fba49bc54c7e7
 file:
 - statement:
     create_table_statement:
@@ -45,22 +45,26 @@ file:
               bracketed:
               - start_bracket: (
               - expression:
-                  array_literal:
-                  - keyword: ARRAY
-                  - start_square_bracket: '['
-                  - quoted_literal: "'foo'"
-                  - comma: ','
-                  - quoted_literal: "'bar'"
-                  - end_square_bracket: ']'
+                  typed_array_literal:
+                    array_type:
+                      keyword: ARRAY
+                    array_literal:
+                    - start_square_bracket: '['
+                    - quoted_literal: "'foo'"
+                    - comma: ','
+                    - quoted_literal: "'bar'"
+                    - end_square_bracket: ']'
               - comma: ','
               - expression:
-                  array_literal:
-                  - keyword: ARRAY
-                  - start_square_bracket: '['
-                  - numeric_literal: '1'
-                  - comma: ','
-                  - numeric_literal: '2'
-                  - end_square_bracket: ']'
+                  typed_array_literal:
+                    array_type:
+                      keyword: ARRAY
+                    array_literal:
+                    - start_square_bracket: '['
+                    - numeric_literal: '1'
+                    - comma: ','
+                    - numeric_literal: '2'
+                    - end_square_bracket: ']'
               - end_bracket: )
           end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/athena/create_partitioned_table.yml
+++ b/test/fixtures/dialects/athena/create_partitioned_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f93983ce5ceb29e93f96471d453262d066872f6216586a81c91e09f3295b6025
+_hash: c5ce1d7c663f64372f59dfc0f2028db823240dbb4eeb85312cb99f45af4edca5
 file:
 - statement:
     create_table_statement:
@@ -17,11 +17,13 @@ file:
         keyword: partitioned_by
         comparison_operator:
           raw_comparison_operator: '='
-        array_literal:
-          keyword: ARRAY
-          start_square_bracket: '['
-          quoted_literal: "'l_shipdate'"
-          end_square_bracket: ']'
+        typed_array_literal:
+          array_type:
+            keyword: ARRAY
+          array_literal:
+            start_square_bracket: '['
+            quoted_literal: "'l_shipdate'"
+            end_square_bracket: ']'
         end_bracket: )
     - keyword: AS
     - select_statement:
@@ -154,11 +156,13 @@ file:
       - keyword: partitioning
       - comparison_operator:
           raw_comparison_operator: '='
-      - array_literal:
-          keyword: ARRAY
-          start_square_bracket: '['
-          quoted_literal: "'month(dt)'"
-          end_square_bracket: ']'
+      - typed_array_literal:
+          array_type:
+            keyword: ARRAY
+          array_literal:
+            start_square_bracket: '['
+            quoted_literal: "'month(dt)'"
+            end_square_bracket: ']'
       - comma: ','
       - keyword: vacuum_min_snapshots_to_keep
       - comparison_operator:

--- a/test/fixtures/dialects/athena/create_struct_table.yml
+++ b/test/fixtures/dialects/athena/create_struct_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7130c86043f2ead72468ba09fc450805dad8cfebff1b8069ee443fad7856e87c
+_hash: 83dd94e5079631bf1bc7d5abce6bbffad6f7717340bb7f857b3cd96048df7f97
 file:
 - statement:
     create_table_statement:
@@ -16,24 +16,26 @@ file:
         column_definition:
           naked_identifier: c1
           data_type:
-          - keyword: struct
-          - start_angle_bracket: <
-          - naked_identifier: name
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: varchar
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '10'
-                  end_bracket: )
-          - comma: ','
-          - naked_identifier: age
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: integer
-          - end_angle_bracket: '>'
+            struct_type:
+              keyword: struct
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: name
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: varchar
+                    bracketed:
+                      start_bracket: (
+                      numeric_literal: '10'
+                      end_bracket: )
+              - comma: ','
+              - naked_identifier: age
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: integer
+              - end_angle_bracket: '>'
         end_bracket: )
     - keyword: LOCATION
     - quoted_literal: "'...'"

--- a/test/fixtures/dialects/athena/create_table_as_select.yml
+++ b/test/fixtures/dialects/athena/create_table_as_select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: abf81ee9ace798cb2eb60dcd9cd07450e8176ffe0cc16ff318a091a2c47de691
+_hash: 910d1634c67b90facb16c20670e54e39bdfd55df92bf42b4c4fcb5940377dd27
 file:
   statement:
     create_table_statement:
@@ -27,11 +27,13 @@ file:
       - keyword: partitioned_by
       - comparison_operator:
           raw_comparison_operator: '='
-      - array_literal:
-          keyword: array
-          start_square_bracket: '['
-          quoted_literal: "'load_date'"
-          end_square_bracket: ']'
+      - typed_array_literal:
+          array_type:
+            keyword: array
+          array_literal:
+            start_square_bracket: '['
+            quoted_literal: "'load_date'"
+            end_square_bracket: ']'
       - end_bracket: )
     - keyword: AS
     - select_statement:

--- a/test/fixtures/dialects/athena/select_array_of_rows.yml
+++ b/test/fixtures/dialects/athena/select_array_of_rows.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e62576d94377d6c4eb95311e7ab6a2e58fc10e53584c027551305513850de441
+_hash: 246b131824ddd434f87567ae1f0cf10a63055d0c33282c264e12c5f22081cd9c
 file:
   statement:
     select_statement:
@@ -11,35 +11,37 @@ file:
         keyword: SELECT
         select_clause_element:
           expression:
-            array_literal:
-              keyword: ARRAY
-              start_square_bracket: '['
-              function:
-                function_name:
-                  function_name_identifier: CAST
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: ROW
+            typed_array_literal:
+              array_type:
+                keyword: ARRAY
+              array_literal:
+                start_square_bracket: '['
+                function:
+                  function_name:
+                    function_name_identifier: CAST
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      function:
+                        function_name:
+                          function_name_identifier: ROW
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            numeric_literal: '1'
+                          end_bracket: )
+                    keyword: AS
+                    data_type:
+                      keyword: ROW
                       bracketed:
                         start_bracket: (
-                        expression:
-                          numeric_literal: '1'
+                        naked_identifier: x
+                        data_type:
+                          primitive_type:
+                            keyword: INT
                         end_bracket: )
-                  keyword: AS
-                  data_type:
-                    keyword: ROW
-                    bracketed:
-                      start_bracket: (
-                      naked_identifier: x
-                      data_type:
-                        primitive_type:
-                          keyword: INT
-                      end_bracket: )
-                  end_bracket: )
-              end_square_bracket: ']'
+                    end_bracket: )
+                end_square_bracket: ']'
             array_accessor:
               start_square_bracket: '['
               numeric_literal: '1'

--- a/test/fixtures/dialects/athena/select_filter.yml
+++ b/test/fixtures/dialects/athena/select_filter.yml
@@ -3,24 +3,26 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a6b6aff3b1fe6fbbae5a9c418ef0bca8cf90abf31cd2f5e56c17a35f4d00fb53
+_hash: 3ce1960064878f554ec38c21008d429dadfab54d4103c548b97dc79020a5c74f
 file:
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          array_literal:
-          - keyword: ARRAY
-          - start_square_bracket: '['
-          - numeric_literal: '5'
-          - comma: ','
-          - null_literal: 'NULL'
-          - comma: ','
-          - numeric_literal: '7'
-          - comma: ','
-          - null_literal: 'NULL'
-          - end_square_bracket: ']'
+          typed_array_literal:
+            array_type:
+              keyword: ARRAY
+            array_literal:
+            - start_square_bracket: '['
+            - numeric_literal: '5'
+            - comma: ','
+            - null_literal: 'NULL'
+            - comma: ','
+            - numeric_literal: '7'
+            - comma: ','
+            - null_literal: 'NULL'
+            - end_square_bracket: ']'
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -33,10 +35,12 @@ file:
             bracketed:
             - start_bracket: (
             - expression:
-                array_literal:
-                  keyword: ARRAY
-                  start_square_bracket: '['
-                  end_square_bracket: ']'
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                    start_square_bracket: '['
+                    end_square_bracket: ']'
             - comma: ','
             - expression:
                 column_reference:
@@ -56,19 +60,21 @@ file:
             bracketed:
             - start_bracket: (
             - expression:
-                array_literal:
-                - keyword: ARRAY
-                - start_square_bracket: '['
-                - numeric_literal: '5'
-                - comma: ','
-                - numeric_literal:
-                    sign_indicator: '-'
-                    numeric_literal: '6'
-                - comma: ','
-                - null_literal: 'NULL'
-                - comma: ','
-                - numeric_literal: '7'
-                - end_square_bracket: ']'
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '5'
+                  - comma: ','
+                  - numeric_literal:
+                      sign_indicator: '-'
+                      numeric_literal: '6'
+                  - comma: ','
+                  - null_literal: 'NULL'
+                  - comma: ','
+                  - numeric_literal: '7'
+                  - end_square_bracket: ']'
             - comma: ','
             - expression:
               - column_reference:
@@ -92,17 +98,19 @@ file:
             bracketed:
             - start_bracket: (
             - expression:
-                array_literal:
-                - keyword: ARRAY
-                - start_square_bracket: '['
-                - numeric_literal: '5'
-                - comma: ','
-                - null_literal: 'NULL'
-                - comma: ','
-                - numeric_literal: '7'
-                - comma: ','
-                - null_literal: 'NULL'
-                - end_square_bracket: ']'
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '5'
+                  - comma: ','
+                  - null_literal: 'NULL'
+                  - comma: ','
+                  - numeric_literal: '7'
+                  - comma: ','
+                  - null_literal: 'NULL'
+                  - end_square_bracket: ']'
             - comma: ','
             - expression:
               - column_reference:

--- a/test/fixtures/dialects/athena/select_map.yml
+++ b/test/fixtures/dialects/athena/select_map.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6eb56f8f6b59aa57411f65d6f1e127fc47b936ca17cf53843296c210aae65551
+_hash: 1abe1b4ebaac883e5732f0f6422bbb001f44fd562b9a834fec52ecb40e785427
 file:
 - statement:
     select_statement:
@@ -35,26 +35,30 @@ file:
                   bracketed:
                   - start_bracket: (
                   - expression:
-                      array_literal:
-                      - keyword: ARRAY
-                      - start_square_bracket: '['
-                      - quoted_literal: "'first'"
-                      - comma: ','
-                      - quoted_literal: "'last'"
-                      - comma: ','
-                      - quoted_literal: "'age'"
-                      - end_square_bracket: ']'
+                      typed_array_literal:
+                        array_type:
+                          keyword: ARRAY
+                        array_literal:
+                        - start_square_bracket: '['
+                        - quoted_literal: "'first'"
+                        - comma: ','
+                        - quoted_literal: "'last'"
+                        - comma: ','
+                        - quoted_literal: "'age'"
+                        - end_square_bracket: ']'
                   - comma: ','
                   - expression:
-                      array_literal:
-                      - keyword: ARRAY
-                      - start_square_bracket: '['
-                      - quoted_literal: "'Bob'"
-                      - comma: ','
-                      - quoted_literal: "'Smith'"
-                      - comma: ','
-                      - quoted_literal: "'35'"
-                      - end_square_bracket: ']'
+                      typed_array_literal:
+                        array_type:
+                          keyword: ARRAY
+                        array_literal:
+                        - start_square_bracket: '['
+                        - quoted_literal: "'Bob'"
+                        - comma: ','
+                        - quoted_literal: "'Smith'"
+                        - comma: ','
+                        - quoted_literal: "'35'"
+                        - end_square_bracket: ']'
                   - end_bracket: )
                 alias_expression:
                   keyword: AS
@@ -91,16 +95,20 @@ file:
                   bracketed:
                   - start_bracket: (
                   - expression:
-                      array_literal:
-                        keyword: ARRAY
-                        start_square_bracket: '['
-                        end_square_bracket: ']'
+                      typed_array_literal:
+                        array_type:
+                          keyword: ARRAY
+                        array_literal:
+                          start_square_bracket: '['
+                          end_square_bracket: ']'
                   - comma: ','
                   - expression:
-                      array_literal:
-                        keyword: ARRAY
-                        start_square_bracket: '['
-                        end_square_bracket: ']'
+                      typed_array_literal:
+                        array_type:
+                          keyword: ARRAY
+                        array_literal:
+                          start_square_bracket: '['
+                          end_square_bracket: ']'
                   - end_bracket: )
             - comma: ','
             - expression:
@@ -133,26 +141,30 @@ file:
                   bracketed:
                   - start_bracket: (
                   - expression:
-                      array_literal:
-                      - keyword: ARRAY
-                      - start_square_bracket: '['
-                      - numeric_literal: '10'
-                      - comma: ','
-                      - numeric_literal: '20'
-                      - comma: ','
-                      - numeric_literal: '30'
-                      - end_square_bracket: ']'
+                      typed_array_literal:
+                        array_type:
+                          keyword: ARRAY
+                        array_literal:
+                        - start_square_bracket: '['
+                        - numeric_literal: '10'
+                        - comma: ','
+                        - numeric_literal: '20'
+                        - comma: ','
+                        - numeric_literal: '30'
+                        - end_square_bracket: ']'
                   - comma: ','
                   - expression:
-                      array_literal:
-                      - keyword: ARRAY
-                      - start_square_bracket: '['
-                      - quoted_literal: "'a'"
-                      - comma: ','
-                      - null_literal: 'null'
-                      - comma: ','
-                      - quoted_literal: "'c'"
-                      - end_square_bracket: ']'
+                      typed_array_literal:
+                        array_type:
+                          keyword: ARRAY
+                        array_literal:
+                        - start_square_bracket: '['
+                        - quoted_literal: "'a'"
+                        - comma: ','
+                        - null_literal: 'null'
+                        - comma: ','
+                        - quoted_literal: "'c'"
+                        - end_square_bracket: ']'
                   - end_bracket: )
             - comma: ','
             - expression:
@@ -189,26 +201,30 @@ file:
                   bracketed:
                   - start_bracket: (
                   - expression:
-                      array_literal:
-                      - keyword: ARRAY
-                      - start_square_bracket: '['
-                      - quoted_literal: "'k1'"
-                      - comma: ','
-                      - quoted_literal: "'k2'"
-                      - comma: ','
-                      - quoted_literal: "'k3'"
-                      - end_square_bracket: ']'
+                      typed_array_literal:
+                        array_type:
+                          keyword: ARRAY
+                        array_literal:
+                        - start_square_bracket: '['
+                        - quoted_literal: "'k1'"
+                        - comma: ','
+                        - quoted_literal: "'k2'"
+                        - comma: ','
+                        - quoted_literal: "'k3'"
+                        - end_square_bracket: ']'
                   - comma: ','
                   - expression:
-                      array_literal:
-                      - keyword: ARRAY
-                      - start_square_bracket: '['
-                      - numeric_literal: '20'
-                      - comma: ','
-                      - numeric_literal: '3'
-                      - comma: ','
-                      - numeric_literal: '15'
-                      - end_square_bracket: ']'
+                      typed_array_literal:
+                        array_type:
+                          keyword: ARRAY
+                        array_literal:
+                        - start_square_bracket: '['
+                        - numeric_literal: '20'
+                        - comma: ','
+                        - numeric_literal: '3'
+                        - comma: ','
+                        - numeric_literal: '15'
+                        - end_square_bracket: ']'
                   - end_bracket: )
             - comma: ','
             - expression:

--- a/test/fixtures/dialects/athena/select_reduce.yml
+++ b/test/fixtures/dialects/athena/select_reduce.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ad1d9abd13e8ba86dee71e83e8d19856891b3a75a42f45960e554444de1cc8f7
+_hash: feb95eedec538fb26ced4e00655755b22b368d8bd2dc4ad12e3460e80692ec73
 file:
 - statement:
     select_statement:
@@ -16,10 +16,12 @@ file:
             bracketed:
             - start_bracket: (
             - expression:
-                array_literal:
-                  keyword: ARRAY
-                  start_square_bracket: '['
-                  end_square_bracket: ']'
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                    start_square_bracket: '['
+                    end_square_bracket: ']'
             - comma: ','
             - expression:
                 numeric_literal: '0'
@@ -59,15 +61,17 @@ file:
             bracketed:
             - start_bracket: (
             - expression:
-                array_literal:
-                - keyword: ARRAY
-                - start_square_bracket: '['
-                - numeric_literal: '5'
-                - comma: ','
-                - numeric_literal: '20'
-                - comma: ','
-                - numeric_literal: '50'
-                - end_square_bracket: ']'
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '5'
+                  - comma: ','
+                  - numeric_literal: '20'
+                  - comma: ','
+                  - numeric_literal: '50'
+                  - end_square_bracket: ']'
             - comma: ','
             - expression:
                 numeric_literal: '0'
@@ -107,17 +111,19 @@ file:
             bracketed:
             - start_bracket: (
             - expression:
-                array_literal:
-                - keyword: ARRAY
-                - start_square_bracket: '['
-                - numeric_literal: '5'
-                - comma: ','
-                - numeric_literal: '20'
-                - comma: ','
-                - null_literal: 'NULL'
-                - comma: ','
-                - numeric_literal: '50'
-                - end_square_bracket: ']'
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '5'
+                  - comma: ','
+                  - numeric_literal: '20'
+                  - comma: ','
+                  - null_literal: 'NULL'
+                  - comma: ','
+                  - numeric_literal: '50'
+                  - end_square_bracket: ']'
             - comma: ','
             - expression:
                 numeric_literal: '0'
@@ -157,17 +163,19 @@ file:
             bracketed:
             - start_bracket: (
             - expression:
-                array_literal:
-                - keyword: ARRAY
-                - start_square_bracket: '['
-                - numeric_literal: '5'
-                - comma: ','
-                - numeric_literal: '20'
-                - comma: ','
-                - null_literal: 'NULL'
-                - comma: ','
-                - numeric_literal: '50'
-                - end_square_bracket: ']'
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '5'
+                  - comma: ','
+                  - numeric_literal: '20'
+                  - comma: ','
+                  - null_literal: 'NULL'
+                  - comma: ','
+                  - numeric_literal: '50'
+                  - end_square_bracket: ']'
             - comma: ','
             - expression:
                 numeric_literal: '0'
@@ -217,17 +225,19 @@ file:
             bracketed:
             - start_bracket: (
             - expression:
-                array_literal:
-                - keyword: ARRAY
-                - start_square_bracket: '['
-                - numeric_literal: '5'
-                - comma: ','
-                - numeric_literal: '20'
-                - comma: ','
-                - null_literal: 'NULL'
-                - comma: ','
-                - numeric_literal: '50'
-                - end_square_bracket: ']'
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '5'
+                  - comma: ','
+                  - numeric_literal: '20'
+                  - comma: ','
+                  - null_literal: 'NULL'
+                  - comma: ','
+                  - numeric_literal: '50'
+                  - end_square_bracket: ']'
             - comma: ','
             - expression:
                 numeric_literal: '0'
@@ -284,13 +294,15 @@ file:
             bracketed:
             - start_bracket: (
             - expression:
-                array_literal:
-                - keyword: ARRAY
-                - start_square_bracket: '['
-                - numeric_literal: '2147483647'
-                - comma: ','
-                - numeric_literal: '1'
-                - end_square_bracket: ']'
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '2147483647'
+                  - comma: ','
+                  - numeric_literal: '1'
+                  - end_square_bracket: ']'
             - comma: ','
             - expression:
                 function:
@@ -341,17 +353,19 @@ file:
             bracketed:
             - start_bracket: (
             - expression:
-                array_literal:
-                - keyword: ARRAY
-                - start_square_bracket: '['
-                - numeric_literal: '5'
-                - comma: ','
-                - numeric_literal: '6'
-                - comma: ','
-                - numeric_literal: '10'
-                - comma: ','
-                - numeric_literal: '20'
-                - end_square_bracket: ']'
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '5'
+                  - comma: ','
+                  - numeric_literal: '6'
+                  - comma: ','
+                  - numeric_literal: '10'
+                  - comma: ','
+                  - numeric_literal: '20'
+                  - end_square_bracket: ']'
             - comma: ','
             - expression:
                 function:

--- a/test/fixtures/dialects/athena/select_row.yml
+++ b/test/fixtures/dialects/athena/select_row.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 608d3688543a3a624af4fb15522faaaa90f88ffdf0f8ab0560761d0fb4793891
+_hash: f7fa9aefe356b727b9a732c5acbae4cb77decee6ec6a4925dfc537c64194b225
 file:
 - statement:
     select_statement:
@@ -67,35 +67,37 @@ file:
         keyword: SELECT
         select_clause_element:
           expression:
-            array_literal:
-              keyword: ARRAY
-              start_square_bracket: '['
-              function:
-                function_name:
-                  function_name_identifier: CAST
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: ROW
+            typed_array_literal:
+              array_type:
+                keyword: ARRAY
+              array_literal:
+                start_square_bracket: '['
+                function:
+                  function_name:
+                    function_name_identifier: CAST
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      function:
+                        function_name:
+                          function_name_identifier: ROW
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            numeric_literal: '1'
+                          end_bracket: )
+                    keyword: AS
+                    data_type:
+                      keyword: ROW
                       bracketed:
                         start_bracket: (
-                        expression:
-                          numeric_literal: '1'
+                        naked_identifier: x
+                        data_type:
+                          primitive_type:
+                            keyword: INT
                         end_bracket: )
-                  keyword: AS
-                  data_type:
-                    keyword: ROW
-                    bracketed:
-                      start_bracket: (
-                      naked_identifier: x
-                      data_type:
-                        primitive_type:
-                          keyword: INT
-                      end_bracket: )
-                  end_bracket: )
-              end_square_bracket: ']'
+                    end_bracket: )
+                end_square_bracket: ']'
             array_accessor:
               start_square_bracket: '['
               numeric_literal: '1'
@@ -121,35 +123,37 @@ file:
                   bracketed:
                   - start_bracket: (
                   - expression:
-                      array_literal:
-                        keyword: ARRAY
-                        start_square_bracket: '['
-                        function:
-                          function_name:
-                            function_name_identifier: CAST
-                          bracketed:
-                            start_bracket: (
-                            expression:
-                              function:
-                                function_name:
-                                  function_name_identifier: ROW
+                      typed_array_literal:
+                        array_type:
+                          keyword: ARRAY
+                        array_literal:
+                          start_square_bracket: '['
+                          function:
+                            function_name:
+                              function_name_identifier: CAST
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                function:
+                                  function_name:
+                                    function_name_identifier: ROW
+                                  bracketed:
+                                    start_bracket: (
+                                    expression:
+                                      quoted_literal: "''"
+                                    end_bracket: )
+                              keyword: AS
+                              data_type:
+                                keyword: ROW
                                 bracketed:
                                   start_bracket: (
-                                  expression:
-                                    quoted_literal: "''"
+                                  naked_identifier: id
+                                  data_type:
+                                    primitive_type:
+                                      keyword: varchar
                                   end_bracket: )
-                            keyword: AS
-                            data_type:
-                              keyword: ROW
-                              bracketed:
-                                start_bracket: (
-                                naked_identifier: id
-                                data_type:
-                                  primitive_type:
-                                    keyword: varchar
-                                end_bracket: )
-                            end_bracket: )
-                        end_square_bracket: ']'
+                              end_bracket: )
+                          end_square_bracket: ']'
                   - comma: ','
                   - expression:
                       function:
@@ -188,18 +192,20 @@ file:
                 - start_bracket: (
                 - naked_identifier: approvers
                 - data_type:
-                    keyword: ARRAY
-                    start_angle_bracket: <
-                    data_type:
-                      keyword: ROW
-                      bracketed:
-                        start_bracket: (
-                        naked_identifier: id
+                    array_type:
+                      keyword: ARRAY
+                      array_type_schema:
+                        start_angle_bracket: <
                         data_type:
-                          primitive_type:
-                            keyword: varchar
-                        end_bracket: )
-                    end_angle_bracket: '>'
+                          keyword: ROW
+                          bracketed:
+                            start_bracket: (
+                            naked_identifier: id
+                            data_type:
+                              primitive_type:
+                                keyword: varchar
+                            end_bracket: )
+                        end_angle_bracket: '>'
                 - comma: ','
                 - naked_identifier: performer
                 - data_type:

--- a/test/fixtures/dialects/athena/unload_select.yml
+++ b/test/fixtures/dialects/athena/unload_select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fee23c92023bf3d3cc4811b1bde6f35bc684d179d3f3ed3377345add96fe6e4d
+_hash: 97416e6461f0ca98486c4cddc02056d41faa0e64cfda38300f45495e37e58571
 file:
   statement:
     unload_statement:
@@ -51,11 +51,13 @@ file:
       - keyword: partitioned_by
       - comparison_operator:
           raw_comparison_operator: '='
-      - array_literal:
-          keyword: ARRAY
-          start_square_bracket: '['
-          column_reference:
-            naked_identifier: field_2
-          end_square_bracket: ']'
+      - typed_array_literal:
+          array_type:
+            keyword: ARRAY
+          array_literal:
+            start_square_bracket: '['
+            column_reference:
+              naked_identifier: field_2
+            end_square_bracket: ']'
       - end_bracket: )
   statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/alter_table_add_column.yml
+++ b/test/fixtures/dialects/bigquery/alter_table_add_column.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 398b8e5b6d0f28c241cd03e18b1fda012d2cdc26d8987629f78285251855c7df
+_hash: 11ca5f74cdd2c59f465e6e8a9e7a57d7717e10129695dcec229045391f266f4a
 file:
 - statement:
     alter_table_statement:
@@ -35,11 +35,12 @@ file:
     - column_definition:
         naked_identifier: C
         data_type:
-          keyword: ARRAY
-          start_angle_bracket: <
-          data_type:
-            data_type_identifier: NUMERIC
-          end_angle_bracket: '>'
+          array_type:
+            keyword: ARRAY
+            start_angle_bracket: <
+            data_type:
+              data_type_identifier: NUMERIC
+            end_angle_bracket: '>'
     - comma: ','
     - keyword: ADD
     - keyword: COLUMN
@@ -71,38 +72,40 @@ file:
         naked_identifier: A
         data_type:
           struct_type:
-          - keyword: STRUCT
-          - start_angle_bracket: <
-          - parameter: B
-          - data_type:
-              data_type_identifier: GEOGRAPHY
-          - comma: ','
-          - parameter: C
-          - data_type:
-              keyword: ARRAY
-              start_angle_bracket: <
-              data_type:
+            keyword: STRUCT
+            struct_type_schema:
+            - start_angle_bracket: <
+            - parameter: B
+            - data_type:
+                data_type_identifier: GEOGRAPHY
+            - comma: ','
+            - parameter: C
+            - data_type:
+                array_type:
+                  keyword: ARRAY
+                  start_angle_bracket: <
+                  data_type:
+                    data_type_identifier: INT64
+                  end_angle_bracket: '>'
+            - comma: ','
+            - parameter: D
+            - data_type:
                 data_type_identifier: INT64
-              end_angle_bracket: '>'
-          - comma: ','
-          - parameter: D
-          - data_type:
-              data_type_identifier: INT64
-          - column_constraint_segment:
-            - keyword: NOT
-            - keyword: 'NULL'
-          - comma: ','
-          - parameter: E
-          - data_type:
-              data_type_identifier: TIMESTAMP
-          - options_segment:
-              keyword: OPTIONS
-              bracketed:
-                start_bracket: (
-                parameter: description
-                comparison_operator:
-                  raw_comparison_operator: '='
-                quoted_literal: '"creation time"'
-                end_bracket: )
-          - end_angle_bracket: '>'
+            - column_constraint_segment:
+              - keyword: NOT
+              - keyword: 'NULL'
+            - comma: ','
+            - parameter: E
+            - data_type:
+                data_type_identifier: TIMESTAMP
+            - options_segment:
+                keyword: OPTIONS
+                bracketed:
+                  start_bracket: (
+                  parameter: description
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  quoted_literal: '"creation time"'
+                  end_bracket: )
+            - end_angle_bracket: '>'
 - statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/create_js_function_complex_types.yml
+++ b/test/fixtures/dialects/bigquery/create_js_function_complex_types.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 22d3deb680071f3dd8bc74a94c9209caa5ca703db4d73db66266ad291c4162cf
+_hash: 8f953523c623c2f0f692913757e4e5b6b3166da87fe5b8f571796a8e326977cb
 file:
   statement:
     create_function_statement:
@@ -21,77 +21,85 @@ file:
         - comma: ','
         - parameter: foo2
         - data_type:
-            keyword: ARRAY
-            start_angle_bracket: <
-            data_type:
-              data_type_identifier: STRING
-            end_angle_bracket: '>'
+            array_type:
+              keyword: ARRAY
+              start_angle_bracket: <
+              data_type:
+                data_type_identifier: STRING
+              end_angle_bracket: '>'
         - comma: ','
         - parameter: foo3
         - data_type:
             struct_type:
               keyword: STRUCT
-              start_angle_bracket: <
-              parameter: x
-              data_type:
-                data_type_identifier: INT64
-              end_angle_bracket: '>'
+              struct_type_schema:
+                start_angle_bracket: <
+                parameter: x
+                data_type:
+                  data_type_identifier: INT64
+                end_angle_bracket: '>'
         - comma: ','
         - parameter: foo4
         - data_type:
             struct_type:
-            - keyword: STRUCT
-            - start_angle_bracket: <
-            - parameter: x
-            - data_type:
-                data_type_identifier: INT64
-            - comma: ','
-            - parameter: y
-            - data_type:
-                data_type_identifier: INT64
-            - end_angle_bracket: '>'
+              keyword: STRUCT
+              struct_type_schema:
+              - start_angle_bracket: <
+              - parameter: x
+              - data_type:
+                  data_type_identifier: INT64
+              - comma: ','
+              - parameter: y
+              - data_type:
+                  data_type_identifier: INT64
+              - end_angle_bracket: '>'
         - comma: ','
         - parameter: foo5
         - data_type:
             struct_type:
-            - keyword: STRUCT
-            - start_angle_bracket: <
-            - parameter: a
-            - data_type:
-                keyword: ARRAY
-                start_angle_bracket: <
-                data_type:
-                  data_type_identifier: FLOAT
-                end_angle_bracket: '>'
-            - comma: ','
-            - parameter: b
-            - data_type:
-                struct_type:
-                - keyword: STRUCT
-                - start_angle_bracket: <
-                - parameter: x
-                - data_type:
-                    data_type_identifier: INT64
-                - comma: ','
-                - parameter: y
-                - data_type:
-                    data_type_identifier: INT64
-                - end_angle_bracket: '>'
-            - end_angle_bracket: '>'
+              keyword: STRUCT
+              struct_type_schema:
+              - start_angle_bracket: <
+              - parameter: a
+              - data_type:
+                  array_type:
+                    keyword: ARRAY
+                    start_angle_bracket: <
+                    data_type:
+                      data_type_identifier: FLOAT
+                    end_angle_bracket: '>'
+              - comma: ','
+              - parameter: b
+              - data_type:
+                  struct_type:
+                    keyword: STRUCT
+                    struct_type_schema:
+                    - start_angle_bracket: <
+                    - parameter: x
+                    - data_type:
+                        data_type_identifier: INT64
+                    - comma: ','
+                    - parameter: y
+                    - data_type:
+                        data_type_identifier: INT64
+                    - end_angle_bracket: '>'
+              - end_angle_bracket: '>'
         - end_bracket: )
     - keyword: RETURNS
     - data_type:
         struct_type:
           keyword: STRUCT
-          start_angle_bracket: <
-          parameter: product_id
-          data_type:
-            keyword: ARRAY
+          struct_type_schema:
             start_angle_bracket: <
+            parameter: product_id
             data_type:
-              data_type_identifier: INT64
+              array_type:
+                keyword: ARRAY
+                start_angle_bracket: <
+                data_type:
+                  data_type_identifier: INT64
+                end_angle_bracket: '>'
             end_angle_bracket: '>'
-          end_angle_bracket: '>'
     - function_definition:
       - keyword: LANGUAGE
       - naked_identifier: js

--- a/test/fixtures/dialects/bigquery/create_js_function_options_library_array.yml
+++ b/test/fixtures/dialects/bigquery/create_js_function_options_library_array.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b89918d7a2b4acf619eee92c26d81ea5d2f81e95e75467199209512ea4c8bab4
+_hash: 61c3e66ff3de5079c9134b67ac6d4eb08d90ccbeeb79ef35a01d5588eee8a2a5
 file:
   statement:
     create_function_statement:
@@ -21,21 +21,23 @@ file:
           end_bracket: )
     - keyword: RETURNS
     - data_type:
-        keyword: ARRAY
-        start_angle_bracket: <
-        data_type:
-          struct_type:
-          - keyword: STRUCT
-          - start_angle_bracket: <
-          - parameter: product_id
-          - data_type:
-              data_type_identifier: INT64
-          - comma: ','
-          - parameter: rating
-          - data_type:
-              data_type_identifier: FLOAT64
-          - end_angle_bracket: '>'
-        end_angle_bracket: '>'
+        array_type:
+          keyword: ARRAY
+          start_angle_bracket: <
+          data_type:
+            struct_type:
+              keyword: STRUCT
+              struct_type_schema:
+              - start_angle_bracket: <
+              - parameter: product_id
+              - data_type:
+                  data_type_identifier: INT64
+              - comma: ','
+              - parameter: rating
+              - data_type:
+                  data_type_identifier: FLOAT64
+              - end_angle_bracket: '>'
+          end_angle_bracket: '>'
     - function_definition:
       - keyword: LANGUAGE
       - naked_identifier: js

--- a/test/fixtures/dialects/bigquery/create_js_function_quoted_name.yml
+++ b/test/fixtures/dialects/bigquery/create_js_function_quoted_name.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3993c0772fbe5340d14cae2a13a7bc07e29807131bc3956a3c846110328c483f
+_hash: 4a4cb38f3e6f423ed83783a235c1c7ac5c0a268cfd2a4903b20ccba8352d5faa
 file:
   statement:
     create_function_statement:
@@ -23,15 +23,17 @@ file:
     - data_type:
         struct_type:
           keyword: STRUCT
-          start_angle_bracket: <
-          parameter: '`$=`'
-          data_type:
-            keyword: ARRAY
+          struct_type_schema:
             start_angle_bracket: <
+            parameter: '`$=`'
             data_type:
-              data_type_identifier: INT64
+              array_type:
+                keyword: ARRAY
+                start_angle_bracket: <
+                data_type:
+                  data_type_identifier: INT64
+                end_angle_bracket: '>'
             end_angle_bracket: '>'
-          end_angle_bracket: '>'
     - function_definition:
       - keyword: LANGUAGE
       - naked_identifier: js

--- a/test/fixtures/dialects/bigquery/create_js_function_underscore_name.yml
+++ b/test/fixtures/dialects/bigquery/create_js_function_underscore_name.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fb5243cbabbf08a55a04c661b274c8e5e4dd127218aaa6ed061caf338165eb08
+_hash: dd3ec6684af84a81c35279fd471dd61e0f8e6b4947388c123b76bd6d21cb80ea
 file:
   statement:
     create_function_statement:
@@ -23,15 +23,17 @@ file:
     - data_type:
         struct_type:
           keyword: STRUCT
-          start_angle_bracket: <
-          parameter: _product_id
-          data_type:
-            keyword: ARRAY
+          struct_type_schema:
             start_angle_bracket: <
+            parameter: _product_id
             data_type:
-              data_type_identifier: INT64
+              array_type:
+                keyword: ARRAY
+                start_angle_bracket: <
+                data_type:
+                  data_type_identifier: INT64
+                end_angle_bracket: '>'
             end_angle_bracket: '>'
-          end_angle_bracket: '>'
     - function_definition:
       - keyword: LANGUAGE
       - naked_identifier: js

--- a/test/fixtures/dialects/bigquery/create_table_column_options.yml
+++ b/test/fixtures/dialects/bigquery/create_table_column_options.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 739a8e7f8f105b16fc898fe7c28ec270b485e155f93df0877a0b35d9ad15320f
+_hash: 7c6425d4b2c260947fda76839d8c852def220cf4d503f57679b1e8a198e0dd73
 file:
 - statement:
     create_table_statement:
@@ -67,29 +67,7 @@ file:
           data_type:
             struct_type:
               keyword: STRUCT
-              start_angle_bracket: <
-              parameter: col1
-              data_type:
-                data_type_identifier: INT64
-              options_segment:
-                keyword: OPTIONS
-                bracketed:
-                  start_bracket: (
-                  parameter: description
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  quoted_literal: '"An INTEGER field in a STRUCT"'
-                  end_bracket: )
-              end_angle_bracket: '>'
-      - comma: ','
-      - column_definition:
-          naked_identifier: y
-          data_type:
-            keyword: ARRAY
-            start_angle_bracket: <
-            data_type:
-              struct_type:
-                keyword: STRUCT
+              struct_type_schema:
                 start_angle_bracket: <
                 parameter: col1
                 data_type:
@@ -101,9 +79,34 @@ file:
                     parameter: description
                     comparison_operator:
                       raw_comparison_operator: '='
-                    quoted_literal: '"An INTEGER field in a REPEATED STRUCT"'
+                    quoted_literal: '"An INTEGER field in a STRUCT"'
                     end_bracket: )
                 end_angle_bracket: '>'
-            end_angle_bracket: '>'
+      - comma: ','
+      - column_definition:
+          naked_identifier: y
+          data_type:
+            array_type:
+              keyword: ARRAY
+              start_angle_bracket: <
+              data_type:
+                struct_type:
+                  keyword: STRUCT
+                  struct_type_schema:
+                    start_angle_bracket: <
+                    parameter: col1
+                    data_type:
+                      data_type_identifier: INT64
+                    options_segment:
+                      keyword: OPTIONS
+                      bracketed:
+                        start_bracket: (
+                        parameter: description
+                        comparison_operator:
+                          raw_comparison_operator: '='
+                        quoted_literal: '"An INTEGER field in a REPEATED STRUCT"'
+                        end_bracket: )
+                    end_angle_bracket: '>'
+              end_angle_bracket: '>'
       - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/declare_variable.yml
+++ b/test/fixtures/dialects/bigquery/declare_variable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a7344a57c0e59ce697ccfabc4e78ada5ea7a5f53123ec3a8839bca556863d42d
+_hash: 0854d63975062f8193290e2ec7cfee33038b33404ad8ce59bb6cb165d20e4c7e
 file:
 - statement:
     declare_segment:
@@ -69,11 +69,12 @@ file:
       keyword: declare
       naked_identifier: arr1
       data_type:
-        keyword: array
-        start_angle_bracket: <
-        data_type:
-          data_type_identifier: string
-        end_angle_bracket: '>'
+        array_type:
+          keyword: array
+          start_angle_bracket: <
+          data_type:
+            data_type_identifier: string
+          end_angle_bracket: '>'
 - statement_terminator: ;
 - statement:
     declare_segment:
@@ -101,11 +102,12 @@ file:
     - keyword: declare
     - naked_identifier: arr4
     - data_type:
-        keyword: array
-        start_angle_bracket: <
-        data_type:
-          data_type_identifier: string
-        end_angle_bracket: '>'
+        array_type:
+          keyword: array
+          start_angle_bracket: <
+          data_type:
+            data_type_identifier: string
+          end_angle_bracket: '>'
     - keyword: default
     - array_literal:
       - start_square_bracket: '['
@@ -119,15 +121,16 @@ file:
       keyword: declare
       naked_identifier: arr5
       data_type:
-        keyword: array
-        start_angle_bracket: <
-        data_type:
-          data_type_identifier: string
-          bracketed:
-            start_bracket: (
-            numeric_literal: '10'
-            end_bracket: )
-        end_angle_bracket: '>'
+        array_type:
+          keyword: array
+          start_angle_bracket: <
+          data_type:
+            data_type_identifier: string
+            bracketed:
+              start_bracket: (
+              numeric_literal: '10'
+              end_bracket: )
+          end_angle_bracket: '>'
 - statement_terminator: ;
 - statement:
     declare_segment:
@@ -135,16 +138,17 @@ file:
       naked_identifier: str1
       data_type:
         struct_type:
-        - keyword: struct
-        - start_angle_bracket: <
-        - parameter: f1
-        - data_type:
-            data_type_identifier: string
-        - comma: ','
-        - parameter: f2
-        - data_type:
-            data_type_identifier: string
-        - end_angle_bracket: '>'
+          keyword: struct
+          struct_type_schema:
+          - start_angle_bracket: <
+          - parameter: f1
+          - data_type:
+              data_type_identifier: string
+          - comma: ','
+          - parameter: f2
+          - data_type:
+              data_type_identifier: string
+          - end_angle_bracket: '>'
 - statement_terminator: ;
 - statement:
     declare_segment:
@@ -152,26 +156,29 @@ file:
     - naked_identifier: str2
     - data_type:
         struct_type:
-        - keyword: struct
-        - start_angle_bracket: <
-        - parameter: f1
-        - data_type:
-            data_type_identifier: string
-        - comma: ','
-        - parameter: f2
-        - data_type:
-            data_type_identifier: string
-        - end_angle_bracket: '>'
+          keyword: struct
+          struct_type_schema:
+          - start_angle_bracket: <
+          - parameter: f1
+          - data_type:
+              data_type_identifier: string
+          - comma: ','
+          - parameter: f2
+          - data_type:
+              data_type_identifier: string
+          - end_angle_bracket: '>'
     - keyword: default
     - expression:
-        typeless_struct:
-          keyword: struct
-          bracketed:
-          - start_bracket: (
-          - quoted_literal: "'one'"
-          - comma: ','
-          - quoted_literal: "'two'"
-          - end_bracket: )
+        typed_struct_literal:
+          struct_type:
+            keyword: struct
+          struct_literal:
+            bracketed:
+            - start_bracket: (
+            - quoted_literal: "'one'"
+            - comma: ','
+            - quoted_literal: "'two'"
+            - end_bracket: )
 - statement_terminator: ;
 - statement:
     declare_segment:
@@ -179,14 +186,16 @@ file:
     - naked_identifier: str3
     - keyword: default
     - expression:
-        typeless_struct:
-          keyword: struct
-          bracketed:
-          - start_bracket: (
-          - quoted_literal: "'one'"
-          - comma: ','
-          - quoted_literal: "'two'"
-          - end_bracket: )
+        typed_struct_literal:
+          struct_type:
+            keyword: struct
+          struct_literal:
+            bracketed:
+            - start_bracket: (
+            - quoted_literal: "'one'"
+            - comma: ','
+            - quoted_literal: "'two'"
+            - end_bracket: )
 - statement_terminator: ;
 - statement:
     declare_segment:
@@ -194,16 +203,17 @@ file:
     - naked_identifier: str4
     - data_type:
         struct_type:
-        - keyword: struct
-        - start_angle_bracket: <
-        - parameter: f1
-        - data_type:
-            data_type_identifier: string
-        - comma: ','
-        - parameter: f2
-        - data_type:
-            data_type_identifier: string
-        - end_angle_bracket: '>'
+          keyword: struct
+          struct_type_schema:
+          - start_angle_bracket: <
+          - parameter: f1
+          - data_type:
+              data_type_identifier: string
+          - comma: ','
+          - parameter: f2
+          - data_type:
+              data_type_identifier: string
+          - end_angle_bracket: '>'
     - keyword: default
     - tuple:
         bracketed:
@@ -219,24 +229,25 @@ file:
       naked_identifier: str5
       data_type:
         struct_type:
-        - keyword: struct
-        - start_angle_bracket: <
-        - parameter: f1
-        - data_type:
-            data_type_identifier: string
-            bracketed:
-              start_bracket: (
-              numeric_literal: '10'
-              end_bracket: )
-        - comma: ','
-        - parameter: f2
-        - data_type:
-            data_type_identifier: string
-            bracketed:
-              start_bracket: (
-              numeric_literal: '10'
-              end_bracket: )
-        - end_angle_bracket: '>'
+          keyword: struct
+          struct_type_schema:
+          - start_angle_bracket: <
+          - parameter: f1
+          - data_type:
+              data_type_identifier: string
+              bracketed:
+                start_bracket: (
+                numeric_literal: '10'
+                end_bracket: )
+          - comma: ','
+          - parameter: f2
+          - data_type:
+              data_type_identifier: string
+              bracketed:
+                start_bracket: (
+                numeric_literal: '10'
+                end_bracket: )
+          - end_angle_bracket: '>'
 - statement_terminator: ;
 - statement:
     declare_segment:

--- a/test/fixtures/dialects/bigquery/select_example.yml
+++ b/test/fixtures/dialects/bigquery/select_example.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9a1622e165a454bcedc9eab2e974496e441c538bb14c13433e87435932355b34
+_hash: 491a329ef29ec67c85dc1e8a11e0ec17fbb9c706fb8e37b921f66636221f5dfe
 file:
   statement:
     with_compound_statement:
@@ -30,7 +30,7 @@ file:
             - comma: ','
             - select_clause_element:
                 expression:
-                  typeless_array:
+                  array_expression:
                     keyword: ARRAY
                     bracketed:
                       start_bracket: (

--- a/test/fixtures/dialects/bigquery/select_mixture_of_array_literals.yml
+++ b/test/fixtures/dialects/bigquery/select_mixture_of_array_literals.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e49b6d2bea54dae9c4a29e63e5f8dbc165525e0b9b91100b981a377ab6dfa1c1
+_hash: 3c6a61c9511ce41ea4c65521418a499d0eaec7ada60c045a035beb52bf1161e9
 file:
   statement:
     select_statement:
@@ -21,15 +21,17 @@ file:
             end_square_bracket: ']'
       - comma: ','
       - select_clause_element:
-          array_literal:
-            keyword: ARRAY
-            start_angle_bracket: <
-            data_type:
-              data_type_identifier: BOOLEAN
-            end_angle_bracket: '>'
-            start_square_bracket: '['
-            boolean_literal: 'false'
-            end_square_bracket: ']'
+          typed_array_literal:
+            array_type:
+              keyword: ARRAY
+              start_angle_bracket: <
+              data_type:
+                data_type_identifier: BOOLEAN
+              end_angle_bracket: '>'
+            array_literal:
+              start_square_bracket: '['
+              boolean_literal: 'false'
+              end_square_bracket: ']'
       - comma: ','
       - select_clause_element:
           array_literal:
@@ -41,15 +43,17 @@ file:
             naked_identifier: strcol1
       - comma: ','
       - select_clause_element:
-          array_literal:
-            keyword: ARRAY
-            start_angle_bracket: <
-            data_type:
-              data_type_identifier: string
-            end_angle_bracket: '>'
-            start_square_bracket: '['
-            quoted_literal: "'b'"
-            end_square_bracket: ']'
+          typed_array_literal:
+            array_type:
+              keyword: ARRAY
+              start_angle_bracket: <
+              data_type:
+                data_type_identifier: string
+              end_angle_bracket: '>'
+            array_literal:
+              start_square_bracket: '['
+              quoted_literal: "'b'"
+              end_square_bracket: ']'
           alias_expression:
             keyword: AS
             naked_identifier: strcol2
@@ -64,15 +68,17 @@ file:
             naked_identifier: numcol1
       - comma: ','
       - select_clause_element:
-          array_literal:
-            keyword: ARRAY
-            start_angle_bracket: <
-            data_type:
-              data_type_identifier: NUMERIC
-            end_angle_bracket: '>'
-            start_square_bracket: '['
-            numeric_literal: '1.4'
-            end_square_bracket: ']'
+          typed_array_literal:
+            array_type:
+              keyword: ARRAY
+              start_angle_bracket: <
+              data_type:
+                data_type_identifier: NUMERIC
+              end_angle_bracket: '>'
+            array_literal:
+              start_square_bracket: '['
+              numeric_literal: '1.4'
+              end_square_bracket: ']'
           alias_expression:
             keyword: AS
             naked_identifier: numcol2
@@ -81,29 +87,31 @@ file:
           array_literal:
             start_square_bracket: '['
             expression:
-              typeless_struct:
-                keyword: STRUCT
-                bracketed:
-                - start_bracket: (
-                - quoted_literal: '"Rudisha"'
-                - alias_expression:
-                    keyword: AS
-                    naked_identifier: name
-                - comma: ','
-                - array_literal:
-                  - start_square_bracket: '['
-                  - numeric_literal: '23.4'
+              typed_struct_literal:
+                struct_type:
+                  keyword: STRUCT
+                struct_literal:
+                  bracketed:
+                  - start_bracket: (
+                  - quoted_literal: '"Rudisha"'
+                  - alias_expression:
+                      keyword: AS
+                      naked_identifier: name
                   - comma: ','
-                  - numeric_literal: '26.3'
-                  - comma: ','
-                  - numeric_literal: '26.4'
-                  - comma: ','
-                  - numeric_literal: '26.1'
-                  - end_square_bracket: ']'
-                - alias_expression:
-                    keyword: AS
-                    naked_identifier: splits
-                - end_bracket: )
+                  - array_literal:
+                    - start_square_bracket: '['
+                    - numeric_literal: '23.4'
+                    - comma: ','
+                    - numeric_literal: '26.3'
+                    - comma: ','
+                    - numeric_literal: '26.4'
+                    - comma: ','
+                    - numeric_literal: '26.1'
+                    - end_square_bracket: ']'
+                  - alias_expression:
+                      keyword: AS
+                      naked_identifier: splits
+                  - end_bracket: )
             end_square_bracket: ']'
           alias_expression:
             keyword: AS

--- a/test/fixtures/dialects/bigquery/select_struct.yml
+++ b/test/fixtures/dialects/bigquery/select_struct.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 099d904a7e9dcceb73016d13237d27d6770f4857540a51c53c5aff39529b5b81
+_hash: 886daa26e3b50467bf7f6a7be24692fe49125414ffc523e1eb4c7efc91067e16
 file:
 - statement:
     select_statement:
@@ -17,7 +17,7 @@ file:
       - comma: ','
       - select_clause_element:
           expression:
-            typeless_array:
+            array_expression:
               keyword: array
               bracketed:
                 start_bracket: (
@@ -105,26 +105,28 @@ file:
         keyword: select
         select_clause_element:
           expression:
-            typeless_struct:
-              keyword: struct
-              bracketed:
-              - start_bracket: (
-              - column_reference:
-                - naked_identifier: bar
-                - dot: .
-                - naked_identifier: bar_id
-              - alias_expression:
-                  keyword: as
-                  naked_identifier: id
-              - comma: ','
-              - column_reference:
-                - naked_identifier: bar
-                - dot: .
-                - naked_identifier: bar_name
-              - alias_expression:
-                  keyword: as
-                  naked_identifier: bar
-              - end_bracket: )
+            typed_struct_literal:
+              struct_type:
+                keyword: struct
+              struct_literal:
+                bracketed:
+                - start_bracket: (
+                - column_reference:
+                  - naked_identifier: bar
+                  - dot: .
+                  - naked_identifier: bar_id
+                - alias_expression:
+                    keyword: as
+                    naked_identifier: id
+                - comma: ','
+                - column_reference:
+                  - naked_identifier: bar
+                  - dot: .
+                  - naked_identifier: bar_name
+                - alias_expression:
+                    keyword: as
+                    naked_identifier: bar
+                - end_bracket: )
           alias_expression:
             keyword: as
             naked_identifier: bar
@@ -178,39 +180,42 @@ file:
                 bracketed:
                   start_bracket: (
                   expression:
-                    array_literal:
-                    - keyword: ARRAY
-                    - start_angle_bracket: <
-                    - data_type:
-                        struct_type:
-                        - keyword: STRUCT
-                        - start_angle_bracket: <
-                        - parameter: col_1
-                        - data_type:
-                            data_type_identifier: STRING
-                        - comma: ','
-                        - parameter: col_2
-                        - data_type:
-                            data_type_identifier: STRING
-                        - end_angle_bracket: '>'
-                    - end_angle_bracket: '>'
-                    - start_square_bracket: '['
-                    - expression:
-                        bracketed:
-                        - start_bracket: (
-                        - quoted_literal: "'hello'"
-                        - comma: ','
-                        - quoted_literal: "'world'"
-                        - end_bracket: )
-                    - comma: ','
-                    - expression:
-                        bracketed:
-                        - start_bracket: (
-                        - quoted_literal: "'hi'"
-                        - comma: ','
-                        - quoted_literal: "'there'"
-                        - end_bracket: )
-                    - end_square_bracket: ']'
+                    typed_array_literal:
+                      array_type:
+                        keyword: ARRAY
+                        start_angle_bracket: <
+                        data_type:
+                          struct_type:
+                            keyword: STRUCT
+                            struct_type_schema:
+                            - start_angle_bracket: <
+                            - parameter: col_1
+                            - data_type:
+                                data_type_identifier: STRING
+                            - comma: ','
+                            - parameter: col_2
+                            - data_type:
+                                data_type_identifier: STRING
+                            - end_angle_bracket: '>'
+                        end_angle_bracket: '>'
+                      array_literal:
+                      - start_square_bracket: '['
+                      - expression:
+                          bracketed:
+                          - start_bracket: (
+                          - quoted_literal: "'hello'"
+                          - comma: ','
+                          - quoted_literal: "'world'"
+                          - end_bracket: )
+                      - comma: ','
+                      - expression:
+                          bracketed:
+                          - start_bracket: (
+                          - quoted_literal: "'hi'"
+                          - comma: ','
+                          - quoted_literal: "'there'"
+                          - end_bracket: )
+                      - end_square_bracket: ']'
                   end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -219,71 +224,78 @@ file:
       - keyword: SELECT
       - select_clause_element:
           expression:
-            struct_type:
-              keyword: STRUCT
-              start_angle_bracket: <
-              data_type:
-                data_type_identifier: int64
-              end_angle_bracket: '>'
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '5'
-              end_bracket: )
+            typed_struct_literal:
+              struct_type:
+                keyword: STRUCT
+                struct_type_schema:
+                  start_angle_bracket: <
+                  data_type:
+                    data_type_identifier: int64
+                  end_angle_bracket: '>'
+              struct_literal:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '5'
+                  end_bracket: )
       - comma: ','
       - select_clause_element:
           expression:
-            struct_type:
-              keyword: STRUCT
-              start_angle_bracket: <
-              data_type:
-                data_type_identifier: date
-              end_angle_bracket: '>'
-            bracketed:
-              start_bracket: (
-              expression:
-                quoted_literal: '"2011-05-05"'
-              end_bracket: )
+            typed_struct_literal:
+              struct_type:
+                keyword: STRUCT
+                struct_type_schema:
+                  start_angle_bracket: <
+                  data_type:
+                    data_type_identifier: date
+                  end_angle_bracket: '>'
+              struct_literal:
+                bracketed:
+                  start_bracket: (
+                  quoted_literal: '"2011-05-05"'
+                  end_bracket: )
       - comma: ','
       - select_clause_element:
           expression:
-            struct_type:
-            - keyword: STRUCT
-            - start_angle_bracket: <
-            - parameter: x
-            - data_type:
-                data_type_identifier: int64
-            - comma: ','
-            - parameter: y
-            - data_type:
-                data_type_identifier: string
-            - end_angle_bracket: '>'
-            bracketed:
-            - start_bracket: (
-            - expression:
-                numeric_literal: '1'
-            - comma: ','
-            - expression:
-                column_reference:
-                - naked_identifier: t
-                - dot: .
-                - naked_identifier: str_col
-            - end_bracket: )
+            typed_struct_literal:
+              struct_type:
+                keyword: STRUCT
+                struct_type_schema:
+                - start_angle_bracket: <
+                - parameter: x
+                - data_type:
+                    data_type_identifier: int64
+                - comma: ','
+                - parameter: y
+                - data_type:
+                    data_type_identifier: string
+                - end_angle_bracket: '>'
+              struct_literal:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '1'
+                  comma: ','
+                  column_reference:
+                  - naked_identifier: t
+                  - dot: .
+                  - naked_identifier: str_col
+                  end_bracket: )
       - comma: ','
       - select_clause_element:
           expression:
-            struct_type:
-              keyword: STRUCT
-              start_angle_bracket: <
-              data_type:
-                data_type_identifier: int64
-              end_angle_bracket: '>'
-            bracketed:
-              start_bracket: (
-              expression:
-                column_reference:
-                  naked_identifier: int_col
-              end_bracket: )
+            typed_struct_literal:
+              struct_type:
+                keyword: STRUCT
+                struct_type_schema:
+                  start_angle_bracket: <
+                  data_type:
+                    data_type_identifier: int64
+                  end_angle_bracket: '>'
+              struct_literal:
+                bracketed:
+                  start_bracket: (
+                  column_reference:
+                    naked_identifier: int_col
+                  end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -291,16 +303,18 @@ file:
         keyword: SELECT
         select_clause_element:
           expression:
-            typeless_struct:
-              keyword: STRUCT
-              bracketed:
-              - start_bracket: (
-              - column_reference:
-                  naked_identifier: some_field
-              - comma: ','
-              - column_reference:
-                  naked_identifier: some_other_field
-              - end_bracket: )
+            typed_struct_literal:
+              struct_type:
+                keyword: STRUCT
+              struct_literal:
+                bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: some_field
+                - comma: ','
+                - column_reference:
+                    naked_identifier: some_other_field
+                - end_bracket: )
           alias_expression:
             keyword: AS
             naked_identifier: col

--- a/test/fixtures/dialects/bigquery/select_typeless_struct_inside_function.yml
+++ b/test/fixtures/dialects/bigquery/select_typeless_struct_inside_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7c04ee8c9f925904cdc9cb7e006f1bb3fcc6b131a147151e2d9d0c2b74af92ac
+_hash: c95046c9221d495e525f8bdbc766233769c7389747bc4042ae8b8ddf6f8ebeca
 file:
 - statement:
     select_statement:
@@ -11,24 +11,28 @@ file:
         keyword: SELECT
         select_clause_element:
           expression:
-            typeless_struct:
-              keyword: STRUCT
-              bracketed:
-                start_bracket: (
-                expression:
-                  typeless_struct:
-                    keyword: STRUCT
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '1'
-                      alias_expression:
-                        keyword: AS
-                        naked_identifier: b
-                      end_bracket: )
-                alias_expression:
-                  keyword: AS
-                  naked_identifier: a
-                end_bracket: )
+            typed_struct_literal:
+              struct_type:
+                keyword: STRUCT
+              struct_literal:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    typed_struct_literal:
+                      struct_type:
+                        keyword: STRUCT
+                      struct_literal:
+                        bracketed:
+                          start_bracket: (
+                          numeric_literal: '1'
+                          alias_expression:
+                            keyword: AS
+                            naked_identifier: b
+                          end_bracket: )
+                  alias_expression:
+                    keyword: AS
+                    naked_identifier: a
+                  end_bracket: )
           alias_expression:
             keyword: AS
             naked_identifier: foo
@@ -44,22 +48,24 @@ file:
             bracketed:
               start_bracket: (
               expression:
-                typeless_struct:
-                  keyword: STRUCT
-                  bracketed:
-                  - start_bracket: (
-                  - column_reference:
-                      naked_identifier: a
-                  - alias_expression:
-                      keyword: AS
-                      naked_identifier: a
-                  - comma: ','
-                  - column_reference:
-                      naked_identifier: b
-                  - alias_expression:
-                      keyword: AS
-                      naked_identifier: b
-                  - end_bracket: )
+                typed_struct_literal:
+                  struct_type:
+                    keyword: STRUCT
+                  struct_literal:
+                    bracketed:
+                    - start_bracket: (
+                    - column_reference:
+                        naked_identifier: a
+                    - alias_expression:
+                        keyword: AS
+                        naked_identifier: a
+                    - comma: ','
+                    - column_reference:
+                        naked_identifier: b
+                    - alias_expression:
+                        keyword: AS
+                        naked_identifier: b
+                    - end_bracket: )
               end_bracket: )
       from_clause:
         keyword: FROM

--- a/test/fixtures/dialects/bigquery/select_with_offset_2.yml
+++ b/test/fixtures/dialects/bigquery/select_with_offset_2.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 75e49530984992ff87e54e238cb77e823a9e6484475b723c439faca5747acb2b
+_hash: ece671bded750655c13f51467cb244bc1db9c8c9b97b074605788d583db69f80
 file:
   statement:
     select_statement:
@@ -11,7 +11,7 @@ file:
         keyword: SELECT
         select_clause_element:
           expression:
-            typeless_array:
+            array_expression:
               keyword: ARRAY
               bracketed:
                 start_bracket: (

--- a/test/fixtures/dialects/bigquery/typeless_array.yml
+++ b/test/fixtures/dialects/bigquery/typeless_array.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5070e22ad719d285be0755f97cf110793ba0f45bb27f5bb6cb7f7a4e28127e13
+_hash: 153865d0743d678de44de1f4629c346e170b04476e09b91ae2b671f31bef4d7b
 file:
   statement:
     select_statement:
@@ -11,7 +11,7 @@ file:
         keyword: SELECT
         select_clause_element:
           expression:
-            typeless_array:
+            array_expression:
               keyword: ARRAY
               bracketed:
                 start_bracket: (

--- a/test/fixtures/dialects/bigquery/typeless_struct.yml
+++ b/test/fixtures/dialects/bigquery/typeless_struct.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c8a4ce0043e8afa1675113c93ec6f9b85a230ecc31e7f5a2bb0fc4dd6ac5e824
+_hash: 6e5ae6640110e593f6849562ffcd1161fe6ccefbadb97693bc80e003c4e935c8
 file:
 - statement:
     select_statement:
@@ -19,36 +19,40 @@ file:
                 boolean_literal: 'TRUE'
             - comma: ','
             - expression:
-                typeless_struct:
-                  keyword: STRUCT
-                  bracketed:
-                  - start_bracket: (
-                  - quoted_literal: "'hello'"
-                  - alias_expression:
-                      keyword: AS
-                      naked_identifier: greeting
-                  - comma: ','
-                  - quoted_literal: "'world'"
-                  - alias_expression:
-                      keyword: AS
-                      naked_identifier: subject
-                  - end_bracket: )
+                typed_struct_literal:
+                  struct_type:
+                    keyword: STRUCT
+                  struct_literal:
+                    bracketed:
+                    - start_bracket: (
+                    - quoted_literal: "'hello'"
+                    - alias_expression:
+                        keyword: AS
+                        naked_identifier: greeting
+                    - comma: ','
+                    - quoted_literal: "'world'"
+                    - alias_expression:
+                        keyword: AS
+                        naked_identifier: subject
+                    - end_bracket: )
             - comma: ','
             - expression:
-                typeless_struct:
-                  keyword: STRUCT
-                  bracketed:
-                  - start_bracket: (
-                  - quoted_literal: "'hi'"
-                  - alias_expression:
-                      keyword: AS
-                      naked_identifier: greeting
-                  - comma: ','
-                  - quoted_literal: "'there'"
-                  - alias_expression:
-                      keyword: AS
-                      naked_identifier: subject
-                  - end_bracket: )
+                typed_struct_literal:
+                  struct_type:
+                    keyword: STRUCT
+                  struct_literal:
+                    bracketed:
+                    - start_bracket: (
+                    - quoted_literal: "'hi'"
+                    - alias_expression:
+                        keyword: AS
+                        naked_identifier: greeting
+                    - comma: ','
+                    - quoted_literal: "'there'"
+                    - alias_expression:
+                        keyword: AS
+                        naked_identifier: subject
+                    - end_bracket: )
             - end_bracket: )
           alias_expression:
             keyword: AS
@@ -91,26 +95,28 @@ file:
                   - naked_identifier: xxx
               - keyword: THEN
               - expression:
-                  typeless_struct:
-                    keyword: STRUCT
-                    bracketed:
-                    - start_bracket: (
-                    - column_reference:
-                      - naked_identifier: a
-                      - dot: .
-                      - naked_identifier: xxx
-                    - alias_expression:
-                        keyword: AS
-                        naked_identifier: M
-                    - comma: ','
-                    - column_reference:
-                      - naked_identifier: b
-                      - dot: .
-                      - naked_identifier: xxx
-                    - alias_expression:
-                        keyword: AS
-                        naked_identifier: N
-                    - end_bracket: )
+                  typed_struct_literal:
+                    struct_type:
+                      keyword: STRUCT
+                    struct_literal:
+                      bracketed:
+                      - start_bracket: (
+                      - column_reference:
+                        - naked_identifier: a
+                        - dot: .
+                        - naked_identifier: xxx
+                      - alias_expression:
+                          keyword: AS
+                          naked_identifier: M
+                      - comma: ','
+                      - column_reference:
+                        - naked_identifier: b
+                        - dot: .
+                        - naked_identifier: xxx
+                      - alias_expression:
+                          keyword: AS
+                          naked_identifier: N
+                      - end_bracket: )
             - keyword: END
           alias_expression:
             keyword: AS

--- a/test/fixtures/dialects/hive/array_types.yml
+++ b/test/fixtures/dialects/hive/array_types.yml
@@ -3,25 +3,27 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ae7c029c61edcc47c841a14b2575a6025ddafe6b24eb425b83a25f5241c2b741
+_hash: 703561cc4a19243823ae4bb0768e333f8a24d41beb5f3f9cb4406b66ac180ced
 file:
 - statement:
     select_statement:
       select_clause:
         keyword: select
         select_clause_element:
-          array_literal:
-          - keyword: array
-          - start_square_bracket: '['
-          - column_reference:
-              naked_identifier: a
-          - comma: ','
-          - column_reference:
-              naked_identifier: b
-          - comma: ','
-          - column_reference:
-              naked_identifier: c
-          - end_square_bracket: ']'
+          typed_array_literal:
+            array_type:
+              keyword: array
+            array_literal:
+            - start_square_bracket: '['
+            - column_reference:
+                naked_identifier: a
+            - comma: ','
+            - column_reference:
+                naked_identifier: b
+            - comma: ','
+            - column_reference:
+                naked_identifier: c
+            - end_square_bracket: ']'
           alias_expression:
             keyword: as
             naked_identifier: arr
@@ -55,17 +57,19 @@ file:
                 bracketed:
                   start_bracket: (
                   expression:
-                    array_literal:
-                    - keyword: array
-                    - start_square_bracket: '['
-                    - numeric_literal: '1'
-                    - comma: ','
-                    - numeric_literal: '3'
-                    - comma: ','
-                    - numeric_literal: '6'
-                    - comma: ','
-                    - numeric_literal: '12'
-                    - end_square_bracket: ']'
+                    typed_array_literal:
+                      array_type:
+                        keyword: array
+                      array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '3'
+                      - comma: ','
+                      - numeric_literal: '6'
+                      - comma: ','
+                      - numeric_literal: '12'
+                      - end_square_bracket: ']'
                   end_bracket: )
             alias_expression:
               keyword: as
@@ -87,35 +91,37 @@ file:
             bracketed:
               start_bracket: (
               expression:
-                array_literal:
-                - keyword: array
-                - start_square_bracket: '['
-                - function:
-                    function_name:
-                      function_name_identifier: row
-                    bracketed:
-                    - start_bracket: (
-                    - expression:
-                        quoted_literal: "'pending.freebet'"
-                    - comma: ','
-                    - expression:
-                        column_reference:
-                          naked_identifier: pending_fb
-                    - end_bracket: )
-                - comma: ','
-                - function:
-                    function_name:
-                      function_name_identifier: row
-                    bracketed:
-                    - start_bracket: (
-                    - expression:
-                        quoted_literal: "'bonus.balance'"
-                    - comma: ','
-                    - expression:
-                        column_reference:
-                          naked_identifier: bonus
-                    - end_bracket: )
-                - end_square_bracket: ']'
+                typed_array_literal:
+                  array_type:
+                    keyword: array
+                  array_literal:
+                  - start_square_bracket: '['
+                  - function:
+                      function_name:
+                        function_name_identifier: row
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          quoted_literal: "'pending.freebet'"
+                      - comma: ','
+                      - expression:
+                          column_reference:
+                            naked_identifier: pending_fb
+                      - end_bracket: )
+                  - comma: ','
+                  - function:
+                      function_name:
+                        function_name_identifier: row
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          quoted_literal: "'bonus.balance'"
+                      - comma: ','
+                      - expression:
+                          column_reference:
+                            naked_identifier: bonus
+                      - end_bracket: )
+                  - end_square_bracket: ']'
               end_bracket: )
       from_clause:
         keyword: from
@@ -132,15 +138,17 @@ file:
       select_clause:
         keyword: select
         select_clause_element:
-          array_literal:
-          - keyword: array
-          - start_square_bracket: '['
-          - quoted_literal: "'a'"
-          - comma: ','
-          - quoted_literal: "'b'"
-          - comma: ','
-          - quoted_literal: "'c'"
-          - end_square_bracket: ']'
+          typed_array_literal:
+            array_type:
+              keyword: array
+            array_literal:
+            - start_square_bracket: '['
+            - quoted_literal: "'a'"
+            - comma: ','
+            - quoted_literal: "'b'"
+            - comma: ','
+            - quoted_literal: "'c'"
+            - end_square_bracket: ']'
           alias_expression:
             keyword: as
             naked_identifier: arr
@@ -159,13 +167,15 @@ file:
       select_clause:
         keyword: select
         select_clause_element:
-          array_literal:
-            keyword: array
-            start_square_bracket: '['
-            quoted_literal: "'a'"
-            comma: ','
-            null_literal: 'null'
-            end_square_bracket: ']'
+          typed_array_literal:
+            array_type:
+              keyword: array
+            array_literal:
+              start_square_bracket: '['
+              quoted_literal: "'a'"
+              comma: ','
+              null_literal: 'null'
+              end_square_bracket: ']'
           alias_expression:
             keyword: as
             naked_identifier: arr
@@ -184,10 +194,12 @@ file:
       select_clause:
         keyword: select
         select_clause_element:
-          array_literal:
-            keyword: array
-            start_square_bracket: '['
-            end_square_bracket: ']'
+          typed_array_literal:
+            array_type:
+              keyword: array
+            array_literal:
+              start_square_bracket: '['
+              end_square_bracket: ']'
           alias_expression:
             keyword: as
             naked_identifier: arr

--- a/test/fixtures/dialects/hive/create_table_datatypes.yml
+++ b/test/fixtures/dialects/hive/create_table_datatypes.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 049d7b4751c32d8c8387eda398d38964105340e733dfe259657f8fe1aea38c4f
+_hash: c6a65da897c214b67c7d4439f51c9e0ae4129bb02aecadaecc30a8ff02087cbb
 file:
   statement:
     create_table_statement:
@@ -48,12 +48,13 @@ file:
       - column_definition:
           naked_identifier: col5
           data_type:
-            keyword: ARRAY
-            start_angle_bracket: <
-            data_type:
-              primitive_type:
-                keyword: double
-            end_angle_bracket: '>'
+            array_type:
+              keyword: ARRAY
+              start_angle_bracket: <
+              data_type:
+                primitive_type:
+                  keyword: double
+              end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           naked_identifier: col6
@@ -82,13 +83,14 @@ file:
           - naked_identifier: field2
           - colon: ':'
           - data_type:
-              keyword: ARRAY
-              start_angle_bracket: <
-              data_type:
-                primitive_type:
-                - keyword: double
-                - keyword: precision
-              end_angle_bracket: '>'
+              array_type:
+                keyword: ARRAY
+                start_angle_bracket: <
+                data_type:
+                  primitive_type:
+                  - keyword: double
+                  - keyword: precision
+                end_angle_bracket: '>'
           - comma: ','
           - naked_identifier: field3
           - colon: ':'
@@ -121,12 +123,13 @@ file:
                 keyword: string
           - comma: ','
           - data_type:
-              keyword: ARRAY
-              start_angle_bracket: <
-              data_type:
-                primitive_type:
-                  keyword: char
-              end_angle_bracket: '>'
+              array_type:
+                keyword: ARRAY
+                start_angle_bracket: <
+                data_type:
+                  primitive_type:
+                    keyword: char
+                end_angle_bracket: '>'
           - end_angle_bracket: '>'
       - end_bracket: )
   statement_terminator: ;

--- a/test/fixtures/dialects/hive/create_table_datatypes.yml
+++ b/test/fixtures/dialects/hive/create_table_datatypes.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c6a65da897c214b67c7d4439f51c9e0ae4129bb02aecadaecc30a8ff02087cbb
+_hash: 1c0c9996996949b39b8d78939103b1432d2f93cf5744ac8016ec6b3998c4c244
 file:
   statement:
     create_table_statement:
@@ -72,46 +72,48 @@ file:
       - column_definition:
           naked_identifier: col7
           data_type:
-          - keyword: STRUCT
-          - start_angle_bracket: <
-          - naked_identifier: field1
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: boolean
-          - comma: ','
-          - naked_identifier: field2
-          - colon: ':'
-          - data_type:
-              array_type:
-                keyword: ARRAY
-                start_angle_bracket: <
-                data_type:
+            struct_type:
+              keyword: STRUCT
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: field1
+              - colon: ':'
+              - data_type:
                   primitive_type:
-                  - keyword: double
-                  - keyword: precision
-                end_angle_bracket: '>'
-          - comma: ','
-          - naked_identifier: field3
-          - colon: ':'
-          - data_type:
-            - keyword: UNIONTYPE
-            - start_angle_bracket: <
-            - data_type:
-                primitive_type:
-                  keyword: string
-            - comma: ','
-            - data_type:
-                primitive_type:
-                  keyword: decimal
-                  bracketed:
-                  - start_bracket: (
-                  - numeric_literal: '10'
-                  - comma: ','
-                  - numeric_literal: '2'
-                  - end_bracket: )
-            - end_angle_bracket: '>'
-          - end_angle_bracket: '>'
+                    keyword: boolean
+              - comma: ','
+              - naked_identifier: field2
+              - colon: ':'
+              - data_type:
+                  array_type:
+                    keyword: ARRAY
+                    start_angle_bracket: <
+                    data_type:
+                      primitive_type:
+                      - keyword: double
+                      - keyword: precision
+                    end_angle_bracket: '>'
+              - comma: ','
+              - naked_identifier: field3
+              - colon: ':'
+              - data_type:
+                - keyword: UNIONTYPE
+                - start_angle_bracket: <
+                - data_type:
+                    primitive_type:
+                      keyword: string
+                - comma: ','
+                - data_type:
+                    primitive_type:
+                      keyword: decimal
+                      bracketed:
+                      - start_bracket: (
+                      - numeric_literal: '10'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_bracket: )
+                - end_angle_bracket: '>'
+              - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           naked_identifier: col8

--- a/test/fixtures/dialects/postgres/postgres_array.yml
+++ b/test/fixtures/dialects/postgres/postgres_array.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2de80fba7147430d59c89a94ff122d4f4da8d4e6ac743e44b7ffd53fa66c3098
+_hash: 15d2a03d75017e771f8b71e06ded7c07f89a71e982ebf9a51c64dc5269297299
 file:
 - statement:
     select_statement:
@@ -11,46 +11,52 @@ file:
         keyword: SELECT
         select_clause_element:
           expression:
-          - array_literal:
-            - keyword: ARRAY
-            - start_square_bracket: '['
-            - numeric_literal: '1'
-            - comma: ','
-            - numeric_literal: '2'
-            - end_square_bracket: ']'
+          - typed_array_literal:
+              array_type:
+                keyword: ARRAY
+              array_literal:
+              - start_square_bracket: '['
+              - numeric_literal: '1'
+              - comma: ','
+              - numeric_literal: '2'
+              - end_square_bracket: ']'
           - binary_operator:
             - pipe: '|'
             - pipe: '|'
-          - array_literal:
-            - keyword: ARRAY
-            - start_square_bracket: '['
-            - numeric_literal: '3'
-            - comma: ','
-            - numeric_literal: '4'
-            - end_square_bracket: ']'
+          - typed_array_literal:
+              array_type:
+                keyword: ARRAY
+              array_literal:
+              - start_square_bracket: '['
+              - numeric_literal: '3'
+              - comma: ','
+              - numeric_literal: '4'
+              - end_square_bracket: ']'
 - statement_terminator: ;
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          array_literal:
-          - keyword: ARRAY
-          - start_square_bracket: '['
-          - array_literal:
+          typed_array_literal:
+            array_type:
+              keyword: ARRAY
+            array_literal:
             - start_square_bracket: '['
-            - quoted_literal: "'meeting'"
+            - array_literal:
+              - start_square_bracket: '['
+              - quoted_literal: "'meeting'"
+              - comma: ','
+              - quoted_literal: "'lunch'"
+              - end_square_bracket: ']'
             - comma: ','
-            - quoted_literal: "'lunch'"
+            - array_literal:
+              - start_square_bracket: '['
+              - quoted_literal: "'training'"
+              - comma: ','
+              - quoted_literal: "'presentation'"
+              - end_square_bracket: ']'
             - end_square_bracket: ']'
-          - comma: ','
-          - array_literal:
-            - start_square_bracket: '['
-            - quoted_literal: "'training'"
-            - comma: ','
-            - quoted_literal: "'presentation'"
-            - end_square_bracket: ']'
-          - end_square_bracket: ']'
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -176,36 +182,40 @@ file:
             quoted_literal: "'Bill'"
         - comma: ','
         - expression:
-            array_literal:
-            - keyword: ARRAY
-            - start_square_bracket: '['
-            - numeric_literal: '10000'
-            - comma: ','
-            - numeric_literal: '10000'
-            - comma: ','
-            - numeric_literal: '10000'
-            - comma: ','
-            - numeric_literal: '10000'
-            - end_square_bracket: ']'
+            typed_array_literal:
+              array_type:
+                keyword: ARRAY
+              array_literal:
+              - start_square_bracket: '['
+              - numeric_literal: '10000'
+              - comma: ','
+              - numeric_literal: '10000'
+              - comma: ','
+              - numeric_literal: '10000'
+              - comma: ','
+              - numeric_literal: '10000'
+              - end_square_bracket: ']'
         - comma: ','
         - expression:
-            array_literal:
-            - keyword: ARRAY
-            - start_square_bracket: '['
-            - array_literal:
+            typed_array_literal:
+              array_type:
+                keyword: ARRAY
+              array_literal:
               - start_square_bracket: '['
-              - quoted_literal: "'meeting'"
+              - array_literal:
+                - start_square_bracket: '['
+                - quoted_literal: "'meeting'"
+                - comma: ','
+                - quoted_literal: "'lunch'"
+                - end_square_bracket: ']'
               - comma: ','
-              - quoted_literal: "'lunch'"
+              - array_literal:
+                - start_square_bracket: '['
+                - quoted_literal: "'training'"
+                - comma: ','
+                - quoted_literal: "'presentation'"
+                - end_square_bracket: ']'
               - end_square_bracket: ']'
-            - comma: ','
-            - array_literal:
-              - start_square_bracket: '['
-              - quoted_literal: "'training'"
-              - comma: ','
-              - quoted_literal: "'presentation'"
-              - end_square_bracket: ']'
-            - end_square_bracket: ']'
         - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -222,36 +232,40 @@ file:
             quoted_literal: "'Carol'"
         - comma: ','
         - expression:
-            array_literal:
-            - keyword: ARRAY
-            - start_square_bracket: '['
-            - numeric_literal: '20000'
-            - comma: ','
-            - numeric_literal: '25000'
-            - comma: ','
-            - numeric_literal: '25000'
-            - comma: ','
-            - numeric_literal: '25000'
-            - end_square_bracket: ']'
+            typed_array_literal:
+              array_type:
+                keyword: ARRAY
+              array_literal:
+              - start_square_bracket: '['
+              - numeric_literal: '20000'
+              - comma: ','
+              - numeric_literal: '25000'
+              - comma: ','
+              - numeric_literal: '25000'
+              - comma: ','
+              - numeric_literal: '25000'
+              - end_square_bracket: ']'
         - comma: ','
         - expression:
-            array_literal:
-            - keyword: ARRAY
-            - start_square_bracket: '['
-            - array_literal:
+            typed_array_literal:
+              array_type:
+                keyword: ARRAY
+              array_literal:
               - start_square_bracket: '['
-              - quoted_literal: "'breakfast'"
+              - array_literal:
+                - start_square_bracket: '['
+                - quoted_literal: "'breakfast'"
+                - comma: ','
+                - quoted_literal: "'consulting'"
+                - end_square_bracket: ']'
               - comma: ','
-              - quoted_literal: "'consulting'"
+              - array_literal:
+                - start_square_bracket: '['
+                - quoted_literal: "'meeting'"
+                - comma: ','
+                - quoted_literal: "'lunch'"
+                - end_square_bracket: ']'
               - end_square_bracket: ']'
-            - comma: ','
-            - array_literal:
-              - start_square_bracket: '['
-              - quoted_literal: "'meeting'"
-              - comma: ','
-              - quoted_literal: "'lunch'"
-              - end_square_bracket: ']'
-            - end_square_bracket: ']'
         - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -387,25 +401,29 @@ file:
             bracketed:
               start_bracket: (
               expression:
-              - array_literal:
-                - keyword: ARRAY
-                - start_square_bracket: '['
-                - numeric_literal: '1'
-                - comma: ','
-                - numeric_literal: '2'
-                - end_square_bracket: ']'
+              - typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '1'
+                  - comma: ','
+                  - numeric_literal: '2'
+                  - end_square_bracket: ']'
               - binary_operator:
                 - pipe: '|'
                 - pipe: '|'
-              - array_literal:
-                - keyword: ARRAY
-                - start_square_bracket: '['
-                - numeric_literal: '3'
-                - comma: ','
-                - numeric_literal: '4'
-                - comma: ','
-                - numeric_literal: '5'
-                - end_square_bracket: ']'
+              - typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '3'
+                  - comma: ','
+                  - numeric_literal: '4'
+                  - comma: ','
+                  - numeric_literal: '5'
+                  - end_square_bracket: ']'
               end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -419,33 +437,37 @@ file:
             bracketed:
               start_bracket: (
               expression:
-              - array_literal:
-                - keyword: ARRAY
-                - start_square_bracket: '['
-                - numeric_literal: '1'
-                - comma: ','
-                - numeric_literal: '2'
-                - end_square_bracket: ']'
+              - typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '1'
+                  - comma: ','
+                  - numeric_literal: '2'
+                  - end_square_bracket: ']'
               - binary_operator:
                 - pipe: '|'
                 - pipe: '|'
-              - array_literal:
-                - keyword: ARRAY
-                - start_square_bracket: '['
-                - array_literal:
+              - typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
                   - start_square_bracket: '['
-                  - numeric_literal: '3'
+                  - array_literal:
+                    - start_square_bracket: '['
+                    - numeric_literal: '3'
+                    - comma: ','
+                    - numeric_literal: '4'
+                    - end_square_bracket: ']'
                   - comma: ','
-                  - numeric_literal: '4'
+                  - array_literal:
+                    - start_square_bracket: '['
+                    - numeric_literal: '5'
+                    - comma: ','
+                    - numeric_literal: '6'
+                    - end_square_bracket: ']'
                   - end_square_bracket: ']'
-                - comma: ','
-                - array_literal:
-                  - start_square_bracket: '['
-                  - numeric_literal: '5'
-                  - comma: ','
-                  - numeric_literal: '6'
-                  - end_square_bracket: ']'
-                - end_square_bracket: ']'
               end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -454,13 +476,15 @@ file:
         keyword: SELECT
         select_clause_element:
           expression:
-            array_literal:
-            - keyword: ARRAY
-            - start_square_bracket: '['
-            - numeric_literal: '1'
-            - comma: ','
-            - numeric_literal: '2'
-            - end_square_bracket: ']'
+            typed_array_literal:
+              array_type:
+                keyword: ARRAY
+              array_literal:
+              - start_square_bracket: '['
+              - numeric_literal: '1'
+              - comma: ','
+              - numeric_literal: '2'
+              - end_square_bracket: ']'
             binary_operator:
             - pipe: '|'
             - pipe: '|'
@@ -477,23 +501,25 @@ file:
             bracketed:
             - start_bracket: (
             - expression:
-                array_literal:
-                - keyword: ARRAY
-                - start_square_bracket: '['
-                - quoted_literal: "'sun'"
-                - comma: ','
-                - quoted_literal: "'mon'"
-                - comma: ','
-                - quoted_literal: "'tue'"
-                - comma: ','
-                - quoted_literal: "'wed'"
-                - comma: ','
-                - quoted_literal: "'thu'"
-                - comma: ','
-                - quoted_literal: "'fri'"
-                - comma: ','
-                - quoted_literal: "'sat'"
-                - end_square_bracket: ']'
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - quoted_literal: "'sun'"
+                  - comma: ','
+                  - quoted_literal: "'mon'"
+                  - comma: ','
+                  - quoted_literal: "'tue'"
+                  - comma: ','
+                  - quoted_literal: "'wed'"
+                  - comma: ','
+                  - quoted_literal: "'thu'"
+                  - comma: ','
+                  - quoted_literal: "'fri'"
+                  - comma: ','
+                  - quoted_literal: "'sat'"
+                  - end_square_bracket: ']'
             - comma: ','
             - expression:
                 quoted_literal: "'mon'"
@@ -611,15 +637,17 @@ file:
                   bracketed:
                     start_bracket: (
                     expression:
-                      array_literal:
-                      - keyword: ARRAY
-                      - start_square_bracket: '['
-                      - column_reference:
-                          naked_identifier: id
-                      - comma: ','
-                      - column_reference:
-                          naked_identifier: vertical
-                      - end_square_bracket: ']'
+                      typed_array_literal:
+                        array_type:
+                          keyword: ARRAY
+                        array_literal:
+                        - start_square_bracket: '['
+                        - column_reference:
+                            naked_identifier: id
+                        - comma: ','
+                        - column_reference:
+                            naked_identifier: vertical
+                        - end_square_bracket: ']'
                     end_bracket: )
               end_bracket: )
             array_accessor:

--- a/test/fixtures/dialects/postgres/postgres_create_view.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3122a61beb5e03eed4b5f1e764c205bc6c02f0d9e546c241aafcfb72fd7e7ec5
+_hash: 5d8742acb927b6adcc3e21676374283245b2728799fab3748bfb7389c5db4897
 file:
 - statement:
     create_view_statement:
@@ -431,10 +431,12 @@ file:
           - select_clause_element:
               expression:
                 cast_expression:
-                  array_literal:
-                    keyword: ARRAY
-                    start_square_bracket: '['
-                    end_square_bracket: ']'
+                  typed_array_literal:
+                    array_type:
+                      keyword: ARRAY
+                    array_literal:
+                      start_square_bracket: '['
+                      end_square_bracket: ']'
                   casting_operator: '::'
                   data_type:
                     keyword: INTEGER
@@ -451,12 +453,14 @@ file:
           - select_clause_element:
               expression:
                 cast_expression:
-                  array_literal:
-                    keyword: ARRAY
-                    start_square_bracket: '['
-                    column_reference:
-                      quoted_identifier: '"name"'
-                    end_square_bracket: ']'
+                  typed_array_literal:
+                    array_type:
+                      keyword: ARRAY
+                    array_literal:
+                      start_square_bracket: '['
+                      column_reference:
+                        quoted_identifier: '"name"'
+                      end_square_bracket: ']'
                   casting_operator: '::'
                   data_type:
                     keyword: text
@@ -469,12 +473,14 @@ file:
           - select_clause_element:
               expression:
                 cast_expression:
-                  array_literal:
-                    keyword: ARRAY
-                    start_square_bracket: '['
-                    column_reference:
-                      quoted_identifier: '"group_id"'
-                    end_square_bracket: ']'
+                  typed_array_literal:
+                    array_type:
+                      keyword: ARRAY
+                    array_literal:
+                      start_square_bracket: '['
+                      column_reference:
+                        quoted_identifier: '"group_id"'
+                      end_square_bracket: ']'
                   casting_operator: '::'
                   data_type:
                     keyword: INTEGER

--- a/test/fixtures/dialects/postgres/postgres_datatypes.yml
+++ b/test/fixtures/dialects/postgres/postgres_datatypes.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b963f0d5a9b17503d32869e874ae5adcdec741f8bc10c218931bb8c5a559a7b9
+_hash: 67fe4cda699b59e407814faa7e106c8b83eaf551895a6a36e63a45b15a8e92de
 file:
 - statement:
     create_table_statement:
@@ -679,12 +679,13 @@ file:
           naked_identifier: f
       - data_type:
           keyword: money
-          array_type:
-            keyword: ARRAY
-          array_literal:
-            start_square_bracket: '['
-            numeric_literal: '7'
-            end_square_bracket: ']'
+          sized_array_type:
+            array_type:
+              keyword: ARRAY
+            array_accessor:
+              start_square_bracket: '['
+              numeric_literal: '7'
+              end_square_bracket: ']'
       - end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/postgres/postgres_datatypes.yml
+++ b/test/fixtures/dialects/postgres/postgres_datatypes.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4b44f5e6db8bbe365f3f41a7aa8f58f4b1ae4a9a66f0e725efc213d27108012d
+_hash: b963f0d5a9b17503d32869e874ae5adcdec741f8bc10c218931bb8c5a559a7b9
 file:
 - statement:
     create_table_statement:
@@ -671,15 +671,17 @@ file:
       - column_reference:
           naked_identifier: e
       - data_type:
-        - keyword: money
-        - keyword: ARRAY
+          keyword: money
+          array_type:
+            keyword: ARRAY
       - comma: ','
       - column_reference:
           naked_identifier: f
       - data_type:
-        - keyword: money
-        - keyword: ARRAY
-        - array_literal:
+          keyword: money
+          array_type:
+            keyword: ARRAY
+          array_literal:
             start_square_bracket: '['
             numeric_literal: '7'
             end_square_bracket: ']'

--- a/test/fixtures/linter/autofix/bigquery/006_fix_ignore_templating/after.sql
+++ b/test/fixtures/linter/autofix/bigquery/006_fix_ignore_templating/after.sql
@@ -1,4 +1,4 @@
-SELECT * EXCEPT({% include query %}) FROM
+SELECT * EXCEPT ({% include query %}) FROM
     (
         SELECT
             tbl1.*,

--- a/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -280,3 +280,33 @@ test_pass_bigquery_specific:
   configs:
     core:
       dialect: bigquery
+
+test_pass_bigquery_specific_arrays_1:
+  # An example of _no whitespace_ after an array type
+  pass_str: |
+    SELECT ARRAY<FLOAT64>[1, 2, 3] AS floats;
+  configs:
+    core:
+      dialect: bigquery
+
+test_pass_bigquery_specific_arrays_2:
+  # An example of _whitespace_ after an array type
+  pass_str: |
+    CREATE TEMPORARY FUNCTION DoSomething(param1 STRING, param2 STRING)
+    RETURNS ARRAY<STRING> LANGUAGE js AS """Some JS""";
+
+    SELECT DoSomething(col1) FROM table1
+  configs:
+    core:
+      dialect: bigquery
+
+test_pass_bigquery_specific_structs:
+  # Test spacing of complex STRUCT brackets
+  pass_str: |
+    create table testing.array_struct_tbl (
+        address_array_of_nested_structs
+        ARRAY<STRUCT<coll STRUCT<col1_1 STRING, col1_2 INT64>, col2 STRING>>
+    )
+  configs:
+    core:
+      dialect: bigquery

--- a/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -270,3 +270,13 @@ test_fail_snowflake_semi_structured_multi:
   configs:
     core:
       dialect: snowflake
+
+test_pass_bigquery_specific:
+  # Test a selection of bigquery specific spacings work.
+  # Specifically EXCEPT & qualified functions.
+  pass_str: |
+    SELECT * EXCEPT (order_id);
+    SELECT NET.HOST(LOWER(url)) AS host FROM urls;
+  configs:
+    core:
+      dialect: bigquery


### PR DESCRIPTION
This is a continuation of #4508 .

To enable correct spacing of `ARRAY` and `STRUCT` declarations, this adds some more structures. While I'm adding them to enabled the spacing, this also allows a much more consistent treatment of both expressions across all dialects. There was quite a difference between many, with all of them trying to achieve roughly the same thing.

I do wonder whether `athena` should depend more directly on `hive`, but in any case this adds:
- `array_literal` and `struct_literal` which take the form `[x,y,z]` or `(x,y,z)` (NOTE: they _don't_ include the `ARRAY` or `STRUCT` specifiers). I expect that `struct_literal` without that qualification will be rare, but the structure stands.
- `array_type` and `struct_type` which take the form of `ARRAY` or `STRUCT` in most dialects, but some also allow type qualification, such as `ARRAY<int>`. `STRUCT<...>` is also supported in some, but the `<...>` portion is wrapped in a `struct_type_schema` segment to isolate it from spacing rules.
- `typed_struct_literal` and `typed_array_literal` which are the combination of the above, i.e. `ARRAY<int>[1,3,4]` or `STRUCT<...>(...)`.

The spacing rules are then defined within `typed_x_literal` and `x_type` which achieves the spacing desired (as shown by the bigquery tests).