### PR TITLE
Resolve #1146 (log propagation)

### DIFF
--- a/src/sqlfluff/utils/testing/logging.py
+++ b/src/sqlfluff/utils/testing/logging.py
@@ -15,6 +15,7 @@ https://github.com/pytest-dev/pytest/issues/3697#issuecomment-792129636
 """
 
 import logging
+from typing import Iterator
 from contextlib import contextmanager
 
 from _pytest.logging import LogCaptureHandler, _remove_ansi_escape_sequences
@@ -36,7 +37,7 @@ class FluffLogHandler(LogCaptureHandler):
 
 
 @contextmanager
-def fluff_log_catcher(level: int, logger_name: str) -> FluffLogHandler:
+def fluff_log_catcher(level: int, logger_name: str) -> Iterator[FluffLogHandler]:
     """Context manager that sets the level for capturing of logs.
 
     After the end of the 'with' statement the level is restored to its

--- a/src/sqlfluff/utils/testing/logging.py
+++ b/src/sqlfluff/utils/testing/logging.py
@@ -1,0 +1,61 @@
+"""This is a modified log capture mechanism which reliably works.
+
+So that logs are handled appropriately by the CLI, sqlfluff
+modifies the root logger in a way that can conflict with pytest.
+
+See: https://github.com/pytest-dev/pytest/issues/3697
+
+This fixture returns a context manager to handle them better
+and enable testing of logs while working around the restrictions
+of setting the `propagate` attribute of the logger in each test.
+
+Code adapted from:
+https://github.com/pytest-dev/pytest/issues/3697#issuecomment-792129636
+
+"""
+
+import logging
+from contextlib import contextmanager
+
+from _pytest.logging import LogCaptureHandler, _remove_ansi_escape_sequences
+
+
+class FluffLogHandler(LogCaptureHandler):
+    """A modified LogCaptureHandler which also exposes some helper functions.
+
+    The aim is to mimic some of the methods available on caplog.
+
+    See:
+    https://docs.pytest.org/en/7.1.x/_modules/_pytest/logging.html
+    """
+
+    @property
+    def text(self) -> str:
+        """The formatted log text."""
+        return _remove_ansi_escape_sequences(self.stream.getvalue())
+
+
+@contextmanager
+def fluff_log_catcher(level: int, logger_name: str) -> FluffLogHandler:
+    """Context manager that sets the level for capturing of logs.
+
+    After the end of the 'with' statement the level is restored to its
+    original value.
+
+    Args:
+        level (int): The lowest logging level to capture.
+        logger_name (str): The name of the logger to capture.
+    """
+    assert logger_name.startswith(
+        "sqlfluff"
+    ), "This should only be used with a SQLFluff logger."
+    logger = logging.getLogger(logger_name)
+    handler = FluffLogHandler()
+    orig_level = logger.level
+    logger.setLevel(level)
+    logger.addHandler(handler)
+    try:
+        yield handler
+    finally:
+        logger.setLevel(orig_level)
+        logger.removeHandler(handler)

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -25,6 +25,7 @@ from sqlfluff.core.linter.runner import get_runner
 import sqlfluff.core.linter as linter
 from sqlfluff.core.parser import GreedyUntil, Ref
 from sqlfluff.core.templaters import TemplatedFile
+from sqlfluff.utils.testing.logging import fluff_log_catcher
 
 
 class DummyLintError(SQLBaseError):
@@ -943,7 +944,7 @@ def test_delayed_exception():
         de.reraise()
 
 
-def test__attempt_to_change_templater_warning(caplog):
+def test__attempt_to_change_templater_warning():
     """Test warning when changing templater in .sqlfluff file in subdirectory."""
     initial_config = FluffConfig(
         configs={"core": {"templater": "jinja", "dialect": "ansi"}}
@@ -952,20 +953,14 @@ def test__attempt_to_change_templater_warning(caplog):
     updated_config = FluffConfig(
         configs={"core": {"templater": "python", "dialect": "ansi"}}
     )
-    logger = logging.getLogger("sqlfluff")
-    original_propagate_value = logger.propagate
-    try:
-        logger.propagate = True
-        with caplog.at_level(logging.WARNING, logger="sqlfluff.linter"):
-            lntr.render_string(
-                in_str="select * from table",
-                fname="test.sql",
-                config=updated_config,
-                encoding="utf-8",
-            )
-        assert "Attempt to set templater to " in caplog.text
-    finally:
-        logger.propagate = original_propagate_value
+    with fluff_log_catcher(logging.WARNING, "sqlfluff.linter") as caplog:
+        lntr.render_string(
+            in_str="select * from table",
+            fname="test.sql",
+            config=updated_config,
+            encoding="utf-8",
+        )
+    assert "Attempt to set templater to " in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This resolves #1146.

Based on pytest's own github issues, it seems wise to just implement a single workaround which simplifies existing tests. This moves all of the log handling into a context manager so that all the complexity is in one place, in a way that works well for users.