### PR TITLE
Snowflake: Optional quotes for `create user` statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -3564,27 +3564,42 @@ class CreateUserSegment(BaseSegment):
             Sequence(
                 "LOGIN_NAME",
                 Ref("EqualsSegment"),
-                Ref("ObjectReferenceSegment"),
+                OneOf(
+                    Ref("ObjectReferenceSegment"),
+                    Ref("QuotedLiteralSegment"),
+                ),
             ),
             Sequence(
                 "DISPLAY_NAME",
                 Ref("EqualsSegment"),
-                Ref("ObjectReferenceSegment"),
+                OneOf(
+                    Ref("ObjectReferenceSegment"),
+                    Ref("QuotedLiteralSegment"),
+                ),
             ),
             Sequence(
                 "FIRST_NAME",
                 Ref("EqualsSegment"),
-                Ref("ObjectReferenceSegment"),
+                OneOf(
+                    Ref("ObjectReferenceSegment"),
+                    Ref("QuotedLiteralSegment"),
+                ),
             ),
             Sequence(
                 "MIDDLE_NAME",
                 Ref("EqualsSegment"),
-                Ref("ObjectReferenceSegment"),
+                OneOf(
+                    Ref("ObjectReferenceSegment"),
+                    Ref("QuotedLiteralSegment"),
+                ),
             ),
             Sequence(
                 "LAST_NAME",
                 Ref("EqualsSegment"),
-                Ref("ObjectReferenceSegment"),
+                OneOf(
+                    Ref("ObjectReferenceSegment"),
+                    Ref("QuotedLiteralSegment"),
+                ),
             ),
             Sequence(
                 "EMAIL",
@@ -3614,17 +3629,26 @@ class CreateUserSegment(BaseSegment):
             Sequence(
                 "DEFAULT_WAREHOUSE",
                 Ref("EqualsSegment"),
-                Ref("ObjectReferenceSegment"),
+                OneOf(
+                    Ref("ObjectReferenceSegment"),
+                    Ref("QuotedLiteralSegment"),
+                ),
             ),
             Sequence(
                 "DEFAULT_NAMESPACE",
                 Ref("EqualsSegment"),
-                Ref("ObjectReferenceSegment"),
+                OneOf(
+                    Ref("ObjectReferenceSegment"),
+                    Ref("QuotedLiteralSegment"),
+                ),
             ),
             Sequence(
                 "DEFAULT_ROLE",
                 Ref("EqualsSegment"),
-                Ref("ObjectReferenceSegment"),
+                OneOf(
+                    Ref("ObjectReferenceSegment"),
+                    Ref("QuotedLiteralSegment"),
+                ),
             ),
             Sequence(
                 "DEFAULT_SECONDARY_ROLES",

--- a/test/fixtures/dialects/snowflake/snowflake_create_user.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_create_user.sql
@@ -1,5 +1,24 @@
-create user user1 
-    password='abc123' 
-    default_role = myrole 
-    default_secondary_roles = ('ALL') 
+create user user1
+    password='abc123'
+    default_role = myrole
+    display_name = user1
+    login_name = my_login_name
+    first_name = User1
+    middle_name = abc
+    last_name = Test1
+    default_warehouse = my_default_warehouse
+    default_namespace = my_default_namespace
+    default_secondary_roles = ('ALL')
     must_change_password = true;
+
+create user user2
+    password='abc123'
+    default_role = 'myrole'
+    display_name = 'user 2'
+    login_name = 'test login name'
+    first_name = 'User'
+    middle_name = 'abc'
+    last_name = 'test2'
+    default_warehouse = 'my_default_warehouse'
+    default_namespace = 'my_default_namespace'
+    must_change_password = false;

--- a/test/fixtures/dialects/snowflake/snowflake_create_user.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_create_user.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9e874fb7a01a7da4a354be907ed5b30ab5acf5f1ba5daa20a0e8ed75e200ed50
+_hash: 22283b573b8035fbf38494b02509411ee71d9b5493e78f1c4c88b09998ca16e8
 file:
-  statement:
+- statement:
     create_user_statement:
     - keyword: create
     - keyword: user
@@ -20,6 +20,41 @@ file:
         raw_comparison_operator: '='
     - object_reference:
         naked_identifier: myrole
+    - keyword: display_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: user1
+    - keyword: login_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: my_login_name
+    - keyword: first_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: User1
+    - keyword: middle_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: abc
+    - keyword: last_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: Test1
+    - keyword: default_warehouse
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: my_default_warehouse
+    - keyword: default_namespace
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: my_default_namespace
     - keyword: default_secondary_roles
     - comparison_operator:
         raw_comparison_operator: '='
@@ -31,4 +66,51 @@ file:
     - comparison_operator:
         raw_comparison_operator: '='
     - boolean_literal: 'true'
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: create
+    - keyword: user
+    - object_reference:
+        naked_identifier: user2
+    - keyword: password
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'abc123'"
+    - keyword: default_role
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'myrole'"
+    - keyword: display_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'user 2'"
+    - keyword: login_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'test login name'"
+    - keyword: first_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'User'"
+    - keyword: middle_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'abc'"
+    - keyword: last_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'test2'"
+    - keyword: default_warehouse
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'my_default_warehouse'"
+    - keyword: default_namespace
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'my_default_namespace'"
+    - keyword: must_change_password
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'false'
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
In Snowflake, some of the properties of `create user` statement can have single quotes, but they are not accepted by SQLFluff right now. This PR aims to allow them.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
