### PR TITLE
Support new rules config in toml files.

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -71,6 +71,12 @@ For example, a snippet from a :code:`pyproject.toml` file:
     [tool.sqlfluff.templater.jinja]
     apply_dbt_builtins = true
 
+    # For rule specific configuration, use dots between the names exactly
+    # as you would in .sqlfluff. In the background, SQLFluff will unpack the
+    # configuration paths accordingly. 
+    [tool.sqlfluff.rules.capitalisation.keywords]
+    capitalisation_policy = "upper"
+
 .. _`cfg file`: https://docs.python.org/3/library/configparser.html
 .. _`pyproject.toml file`: https://www.python.org/dev/peps/pep-0518/
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -73,7 +73,7 @@ For example, a snippet from a :code:`pyproject.toml` file:
 
     # For rule specific configuration, use dots between the names exactly
     # as you would in .sqlfluff. In the background, SQLFluff will unpack the
-    # configuration paths accordingly. 
+    # configuration paths accordingly.
     [tool.sqlfluff.rules.capitalisation.keywords]
     capitalisation_policy = "upper"
 

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -319,6 +319,12 @@ class ConfigLoader:
         ...     }}
         ... })
         [(('rules', 'capitalisation.keywords', 'capitalisation_policy'), 'upper')]
+
+        NOTE: Some rules make have more than one dot in their name.
+        >>> ConfigLoader._walk_toml({"rules":
+        ...     {"a": {"b": {"c": {"d": {"e": "f"}}}}}
+        ... })
+        [(('rules', 'a.b.c.d', 'e'), 'f')]
         """
         buff: List[Tuple[Tuple[str, ...], Any]] = []
         # NOTE: For the "rules" section of the sqlfluff config,

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -149,6 +149,7 @@ def test__config__load_toml():
         },
         "bar": {"foo": "foobar"},
         "fnarr": {"fnarr": {"foo": "foobar"}},
+        "rules": {"capitalisation.keywords": {"capitalisation_policy": "upper"}},
     }
 
 

--- a/test/fixtures/config/toml/pyproject.toml
+++ b/test/fixtures/config/toml/pyproject.toml
@@ -12,3 +12,6 @@ foo = "foobar"
 
 [tool.sqlfluff.fnarr.fnarr]
 foo = "foobar"
+
+[tool.sqlfluff.rules.capitalisation.keywords]
+capitalisation_policy = "upper"


### PR DESCRIPTION
This resolves #4519.

The new rules config (containing `.` characters in the rule name), conflicts with the `toml` format where we use `.` for the section separators rather than `:` (as per `.sqlfluff`).

This adds a special case in the toml parsing so that they can be interpreted in exactly the same way.