### PR TITLE
Postgres datatype spacing issues

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -148,6 +148,9 @@ spacing_within = touch
 [sqlfluff:layout:type:struct_type]
 spacing_within = touch:inline
 
+[sqlfluff:layout:type:data_type]
+spacing_within = touch:inline
+
 [sqlfluff:layout:type:typed_struct_literal]
 spacing_within = touch
 

--- a/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -327,3 +327,8 @@ test_pass_bigquery_specific_struct_access:
   configs:
     core:
       dialect: bigquery
+
+test_postgres_datatype:
+  # https://github.com/sqlfluff/sqlfluff/issues/4521
+  pass_str: |
+    select 1::NUMERIC(3, 1)


### PR DESCRIPTION
This resolves #4521 . The more specific data types have already had a similar treatment.

There's a small chance that this could create issues with some more exotic datatypes - but nothing in the current test suite, and if there are - then we should adjust those specific cases similar to what was done in #4511 .