### PR TITLE
Remove Codecov from CI

### DIFF
--- a/.github/workflows/ci-test-dbt.yml
+++ b/.github/workflows/ci-test-dbt.yml
@@ -70,14 +70,6 @@ jobs:
       if: ${{ !inputs.coverage }}
       run: tox -e ${{ inputs.dbt-version }} -- plugins/sqlfluff-templater-dbt
 
-    - name: Upload Coverage (codecov)
-      uses: codecov/codecov-action@v3
-      if: ${{ inputs.coverage }}
-      with:
-        # Public token to allow coverage from forks to work.
-        token: fd44b020-c716-4f72-b5f3-03fa20119956
-        files: ./coverage.xml
-
     - name: Coveralls Parallel (coveralls)
       uses: coverallsapp/github-action@master
       if: ${{ inputs.coverage }}

--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -54,14 +54,6 @@ jobs:
       if: ${{ !inputs.coverage }}
       run: tox -e py${{ steps.py_version.outputs.PYVERSION }} -- -n 2 test
 
-    - name: Upload Coverage (codecov)
-      uses: codecov/codecov-action@v3
-      if: ${{ inputs.coverage }}
-      with:
-        # Public token to allow coverage from forks to work.
-        token: fd44b020-c716-4f72-b5f3-03fa20119956
-        files: ./coverage.xml
-
     - name: Coveralls Parallel (coveralls)
       uses: coverallsapp/github-action@master
       if: ${{ inputs.coverage }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -213,12 +213,6 @@ jobs:
       run: |
         mkdir temp_pytest
         python -m tox -e winpy -- --cov=sqlfluff -n 2 test
-    - name: Upload Coverage Report
-      uses: codecov/codecov-action@v3
-      with:
-        # Public token to allow coverage from forks to work.
-        token: fd44b020-c716-4f72-b5f3-03fa20119956
-        files: ./coverage.xml
     - name: Upload coverage data (github)
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
This removes codecov from our CI pipeline. It's no longer necessary.

#4532 means we've got coverage checks in GithubActions now.
Coveralls is a good enough interface to dig into any coverage misses (and there's an uploaded html report anyway).