### PR TITLE
MySQL: Add CREATE INDEX

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -777,6 +777,37 @@ class TableConstraintSegment(BaseSegment):
     )
 
 
+class CreateIndexStatementSegment(ansi.CreateIndexStatementSegment):
+    """A `CREATE INDEX` statement.
+
+    https://dev.mysql.com/doc/refman/8.0/en/create-index.html
+    """
+
+    match_grammar = Sequence(
+        "CREATE",
+        OneOf("UNIQUE", "FULLTEXT", "SPATIAL", optional=True),
+        "INDEX",
+        Ref("IndexReferenceSegment"),
+        Ref("IndexTypeGrammar", optional=True),
+        "ON",
+        Ref("TableReferenceSegment"),
+        Ref("BracketedKeyPartListGrammar"),
+        Ref("IndexOptionsSegment", optional=True),
+        AnySetOf(
+            Sequence(
+                "ALGORITHM",
+                Ref("EqualsSegment", optional=True),
+                OneOf("DEFAULT", "INPLACE", "COPY"),
+            ),
+            Sequence(
+                "LOCK",
+                Ref("EqualsSegment", optional=True),
+                OneOf("DEFAULT", "NONE", "SHARED", "EXCLUSIVE"),
+            ),
+        ),
+    )
+
+
 class IntervalExpressionSegment(BaseSegment):
     """An interval expression segment.
 

--- a/test/fixtures/dialects/mysql/create_index.sql
+++ b/test/fixtures/dialects/mysql/create_index.sql
@@ -1,0 +1,11 @@
+CREATE INDEX idx ON tbl (col);
+CREATE UNIQUE INDEX idx ON tbl (col);
+CREATE FULLTEXT INDEX idx ON tbl (col);
+CREATE SPATIAL INDEX idx ON tbl (col);
+CREATE INDEX idx USING BTREE ON tbl (col);
+CREATE INDEX idx USING HASH ON tbl (col);
+CREATE INDEX idx ON tbl (col ASC);
+CREATE INDEX idx ON tbl (col DESC);
+CREATE INDEX part_of_name ON customer (name(10));
+CREATE INDEX idx ON tbl (col) ALGORITHM DEFAULT;
+CREATE INDEX idx ON tbl (col) LOCK DEFAULT;

--- a/test/fixtures/dialects/mysql/create_index.yml
+++ b/test/fixtures/dialects/mysql/create_index.yml
@@ -1,0 +1,191 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9003bec52fd7d526fbd647f8a2e904a0abb8a9e45da381a5fa7007b0313564ae
+file:
+- statement:
+    create_index_statement:
+    - keyword: CREATE
+    - keyword: INDEX
+    - index_reference:
+        naked_identifier: idx
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: tbl
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: col
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_index_statement:
+    - keyword: CREATE
+    - keyword: UNIQUE
+    - keyword: INDEX
+    - index_reference:
+        naked_identifier: idx
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: tbl
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: col
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_index_statement:
+    - keyword: CREATE
+    - keyword: FULLTEXT
+    - keyword: INDEX
+    - index_reference:
+        naked_identifier: idx
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: tbl
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: col
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_index_statement:
+    - keyword: CREATE
+    - keyword: SPATIAL
+    - keyword: INDEX
+    - index_reference:
+        naked_identifier: idx
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: tbl
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: col
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_index_statement:
+    - keyword: CREATE
+    - keyword: INDEX
+    - index_reference:
+        naked_identifier: idx
+    - index_type:
+      - keyword: USING
+      - keyword: BTREE
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: tbl
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: col
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_index_statement:
+    - keyword: CREATE
+    - keyword: INDEX
+    - index_reference:
+        naked_identifier: idx
+    - index_type:
+      - keyword: USING
+      - keyword: HASH
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: tbl
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: col
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_index_statement:
+    - keyword: CREATE
+    - keyword: INDEX
+    - index_reference:
+        naked_identifier: idx
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: tbl
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: col
+        keyword: ASC
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_index_statement:
+    - keyword: CREATE
+    - keyword: INDEX
+    - index_reference:
+        naked_identifier: idx
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: tbl
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: col
+        keyword: DESC
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_index_statement:
+    - keyword: CREATE
+    - keyword: INDEX
+    - index_reference:
+        naked_identifier: part_of_name
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: customer
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: name
+        bracketed:
+          start_bracket: (
+          numeric_literal: '10'
+          end_bracket: )
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_index_statement:
+    - keyword: CREATE
+    - keyword: INDEX
+    - index_reference:
+        naked_identifier: idx
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: tbl
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: col
+        end_bracket: )
+    - keyword: ALGORITHM
+    - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    create_index_statement:
+    - keyword: CREATE
+    - keyword: INDEX
+    - index_reference:
+        naked_identifier: idx
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: tbl
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: col
+        end_bracket: )
+    - keyword: LOCK
+    - keyword: DEFAULT
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Support CREATE INDEX with MySQL specific options.
https://dev.mysql.com/doc/refman/8.0/en/create-index.html

Functional Key Parts are not yet supported. I'll work on it.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
