### PR TITLE
Resolve implicit indent issues when catching negative indents

### DIFF
--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -1043,6 +1043,15 @@ def _lint_line_untaken_negative_indents(
         # Is line break, or positive indent?
         if ip.is_line_break or ip.indent_impulse >= 0:
             continue
+
+        # When using implicit indents, we may find untaken negatives which
+        # aren't shallower than the line they're on. This is because they
+        # were implicit on the way up and so not included in `untaken_indents`.
+        # To catch them we also check that we're shallower than the start of
+        # of the line.
+        if ip.initial_indent_balance > indent_line.opening_balance():
+            continue   
+
         # It's negative, is it untaken? In the case of a multi-dedent
         # they must _all_ be untaken to take this route.
         covered_indents = set(

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -1050,7 +1050,7 @@ def _lint_line_untaken_negative_indents(
         # To catch them we also check that we're shallower than the start of
         # of the line.
         if ip.initial_indent_balance > indent_line.opening_balance():
-            continue   
+            continue
 
         # It's negative, is it untaken? In the case of a multi-dedent
         # they must _all_ be untaken to take this route.

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -1814,3 +1814,14 @@ test_fix_untaken_positive_4433:
             TRUE
     )
     ;
+
+test_implicit_case_4542:
+  # https://github.com/sqlfluff/sqlfluff/issues/4542
+  pass_str: |
+    select
+        a,
+        case when b is null then 0 else 1 end as c
+    from my_table;
+  configs:
+    indentation:
+      allow_implicit_indents: true


### PR DESCRIPTION
This resolves #4542 .

When checking for negative indents we rely on knowing all the "untaken indents" accurately. An implicit indent isn't _untaken_, but it's also not in the indent balance. We can catch this scenario by checking that a negative indent can only be caught if we go below the starting indent of the line.