### PR TITLE
Resolve #4484 (issues with indented_joins indents)

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1489,13 +1489,11 @@ class FromExpressionSegment(BaseSegment):
             Ref("MLTableExpressionSegment"),
             Ref("FromExpressionElementSegment"),
         ),
-        # TODO: Revisit this to make sure it's sensible.
-        Conditional(Dedent, indented_joins=False),
+        Dedent,
+        Conditional(Indent, indented_joins=True),
         AnyNumberOf(
             Sequence(
-                Conditional(Indent, indented_joins=True),
                 OneOf(Ref("JoinClauseSegment"), Ref("JoinLikeClauseGrammar")),
-                Conditional(Dedent, indented_joins=True),
             ),
             optional=True,
         ),

--- a/test/dialects/ansi_test.py
+++ b/test/dialects/ansi_test.py
@@ -192,12 +192,12 @@ def test__dialect__ansi_is_whitespace():
 @pytest.mark.parametrize(
     "sql_string, indented_joins, meta_loc",
     [
-        ("select field_1 from my_table as alias_1", True, (1, 5, 8, 14, 15)),
+        ("select field_1 from my_table as alias_1", True, (1, 5, 8, 14, 15, 16, 17)),
         ("select field_1 from my_table as alias_1", False, (1, 5, 8, 14, 15)),
         (
             "select field_1 from my_table as alias_1 join foo using (field_1)",
             True,
-            (1, 5, 8, 15, 17, 21, 22, 24, 27, 29, 31, 32, 33, 34, 35),
+            (1, 5, 8, 15, 16, 18, 22, 23, 25, 28, 30, 32, 33, 34, 35),
         ),
         (
             "select field_1 from my_table as alias_1 join foo using (field_1)",

--- a/test/fixtures/dialects/mysql/explain.yml
+++ b/test/fixtures/dialects/mysql/explain.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a1fbac192cf02d98f28a924f4b894fce63a8c73ecd867e5eea4d56c1fa6f49da
+_hash: 3628780103c71c5a4e04ea5423c51580c32bcd022b3659fce570c05bae3a63cd
 file:
 - statement:
     explain_statement:
@@ -19,11 +19,8 @@ file:
       keyword: explain
       update_statement:
         keyword: update
-        from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: tbl
+        table_reference:
+          naked_identifier: tbl
         set_clause_list:
           keyword: set
           set_clause:

--- a/test/fixtures/dialects/mysql/quoted_literal.yml
+++ b/test/fixtures/dialects/mysql/quoted_literal.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2f87d8252b0b31dabebfcb159b1a7833cc00684b7aaa53286c32683fcceaaba2
+_hash: ad88d0ef3cc10c070f32053dbaea0a7d788e8f01ef4ea30ac820784eb76cc4f6
 file:
 - statement:
     select_statement:
@@ -166,11 +166,8 @@ file:
 - statement:
     update_statement:
       keyword: UPDATE
-      from_expression:
-        from_expression_element:
-          table_expression:
-            table_reference:
-              naked_identifier: table1
+      table_reference:
+        naked_identifier: table1
       set_clause_list:
         keyword: SET
         set_clause:
@@ -183,11 +180,8 @@ file:
 - statement:
     update_statement:
       keyword: UPDATE
-      from_expression:
-        from_expression_element:
-          table_expression:
-            table_reference:
-              naked_identifier: table1
+      table_reference:
+        naked_identifier: table1
       set_clause_list:
         keyword: SET
         set_clause:

--- a/test/fixtures/dialects/mysql/update.yml
+++ b/test/fixtures/dialects/mysql/update.yml
@@ -3,16 +3,13 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e929b61b11d4ebbe7dcba4df45f5ee2d5e92b28ec812fd6032b7076f1ec4c3c2
+_hash: e97422c5a174d58b5638ee735094162724c01779876f33efb13089dcad90e6a2
 file:
 - statement:
     update_statement:
       keyword: UPDATE
-      from_expression:
-        from_expression_element:
-          table_expression:
-            table_reference:
-              naked_identifier: t1
+      table_reference:
+        naked_identifier: t1
       set_clause_list:
         keyword: SET
         set_clause:
@@ -29,11 +26,8 @@ file:
 - statement:
     update_statement:
       keyword: UPDATE
-      from_expression:
-        from_expression_element:
-          table_expression:
-            table_reference:
-              naked_identifier: t1
+      table_reference:
+        naked_identifier: t1
       set_clause_list:
       - keyword: SET
       - set_clause:
@@ -57,16 +51,13 @@ file:
 - statement_terminator: ;
 - statement:
     update_statement:
-      keyword: UPDATE
-      table_reference:
+    - keyword: UPDATE
+    - table_reference:
         naked_identifier: items
-      comma: ','
-      from_expression:
-        from_expression_element:
-          table_expression:
-            table_reference:
-              naked_identifier: month
-      set_clause_list:
+    - comma: ','
+    - table_reference:
+        naked_identifier: month
+    - set_clause_list:
         keyword: SET
         set_clause:
         - column_reference:
@@ -79,7 +70,7 @@ file:
           - naked_identifier: month
           - dot: .
           - naked_identifier: price
-      where_clause:
+    - where_clause:
         keyword: WHERE
         expression:
         - column_reference:
@@ -96,11 +87,8 @@ file:
 - statement:
     update_statement:
       keyword: UPDATE
-      from_expression:
-        from_expression_element:
-          table_expression:
-            table_reference:
-              naked_identifier: t
+      table_reference:
+        naked_identifier: t
       set_clause_list:
         keyword: SET
         set_clause:
@@ -123,11 +111,8 @@ file:
 - statement:
     update_statement:
       keyword: UPDATE
-      from_expression:
-        from_expression_element:
-          table_expression:
-            table_reference:
-              naked_identifier: items
+      table_reference:
+        naked_identifier: items
       set_clause_list:
         keyword: SET
         set_clause:
@@ -373,11 +358,8 @@ file:
     update_statement:
     - keyword: UPDATE
     - keyword: LOW_PRIORITY
-    - from_expression:
-        from_expression_element:
-          table_expression:
-            table_reference:
-              naked_identifier: foo
+    - table_reference:
+        naked_identifier: foo
     - set_clause_list:
         keyword: SET
         set_clause:
@@ -392,16 +374,13 @@ file:
 - statement_terminator: ;
 - statement:
     update_statement:
-      keyword: UPDATE
-      table_reference:
+    - keyword: UPDATE
+    - table_reference:
         naked_identifier: a
-      comma: ','
-      from_expression:
-        from_expression_element:
-          table_expression:
-            table_reference:
-              naked_identifier: b
-      set_clause_list:
+    - comma: ','
+    - table_reference:
+        naked_identifier: b
+    - set_clause_list:
         keyword: SET
         set_clause:
         - column_reference:
@@ -414,7 +393,7 @@ file:
           - naked_identifier: b
           - dot: .
           - naked_identifier: name
-      where_clause:
+    - where_clause:
         keyword: WHERE
         expression:
         - column_reference:

--- a/test/fixtures/dialects/mysql/variable_assignment.yml
+++ b/test/fixtures/dialects/mysql/variable_assignment.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: afaf7d13bb288b44720e378bce9b97f290a3d003ca4bc17e02440b6b1438ba95
+_hash: bb42313b72d36da00df4839494e6e7357c200742df78c658ddbbbe051746a937
 file:
 - statement:
     select_statement:
@@ -48,11 +48,8 @@ file:
 - statement:
     update_statement:
       keyword: UPDATE
-      from_expression:
-        from_expression_element:
-          table_expression:
-            table_reference:
-              naked_identifier: t1
+      table_reference:
+        naked_identifier: t1
       set_clause_list:
         keyword: SET
         set_clause:

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -1814,3 +1814,27 @@ test_fix_untaken_positive_4433:
             TRUE
     )
     ;
+
+test_implicit_case_4542:
+  # https://github.com/sqlfluff/sqlfluff/issues/4542
+  pass_str: |
+    select
+        a,
+        case when b is null then 0 else 1 end as c
+    from my_table;
+  configs:
+    indentation:
+      allow_implicit_indents: true
+
+test_indented_joins_4484:
+  # https://github.com/sqlfluff/sqlfluff/issues/4484
+  pass_str: |
+    select *
+    from table_1
+        inner join table_2
+            on table_1.key = table_2.key
+        inner join table_3
+            on table_2.key = table_3.key
+  configs:
+    indentation:
+      indented_joins: true

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -1815,17 +1815,6 @@ test_fix_untaken_positive_4433:
     )
     ;
 
-test_implicit_case_4542:
-  # https://github.com/sqlfluff/sqlfluff/issues/4542
-  pass_str: |
-    select
-        a,
-        case when b is null then 0 else 1 end as c
-    from my_table;
-  configs:
-    indentation:
-      allow_implicit_indents: true
-
 test_indented_joins_4484:
   # https://github.com/sqlfluff/sqlfluff/issues/4484
   pass_str: |


### PR DESCRIPTION
This resolves #4484. We don't have good test coverage of `indented_joins`, this adds a test case and also fixes the indents - they were _far_ too complicated (and wrong).