### PR TITLE
Github Action Deprecations

### DIFF
--- a/.github/workflows/ci-test-dbt.yml
+++ b/.github/workflows/ci-test-dbt.yml
@@ -80,7 +80,7 @@ jobs:
         parallel: true
 
     - name: Upload coverage data (github)
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ inputs.coverage }}
       with:
         name: coverage-data

--- a/.github/workflows/ci-test-dbt.yml
+++ b/.github/workflows/ci-test-dbt.yml
@@ -55,7 +55,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -64,7 +64,7 @@ jobs:
         parallel: true
 
     - name: Upload coverage data (github)
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ inputs.coverage }}
       with:
         name: coverage-data

--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.11'
     - name: Install dependencies
@@ -108,7 +108,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.11'
     - name: Install dependencies
@@ -128,7 +128,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.11'
     - name: Install dependencies
@@ -144,7 +144,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.11
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.11'
     - name: Install dependencies
@@ -170,7 +170,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.11'
     - name: Install dependencies
@@ -195,7 +195,7 @@ jobs:
         git config --global core.eol lf
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: List Env
@@ -238,7 +238,7 @@ jobs:
         git config --global core.eol lf
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Install dependencies
@@ -259,7 +259,7 @@ jobs:
     name: pip install tests
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.11'
     - uses: actions/checkout@v3

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -214,7 +214,7 @@ jobs:
         mkdir temp_pytest
         python -m tox -e winpy -- --cov=sqlfluff -n 2 test
     - name: Upload coverage data (github)
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: coverage-data
         path: ".coverage.*"
@@ -317,7 +317,7 @@ jobs:
           python -m coverage report --fail-under=100
 
       - name: Upload HTML report if check failed.
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: html-report
           path: htmlcov

--- a/.github/workflows/create-release-pull-request.yaml
+++ b/.github/workflows/create-release-pull-request.yaml
@@ -23,7 +23,7 @@ jobs:
             fi
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: '3.11'
 

--- a/.github/workflows/publish-dbt-templater-release-to-pypi.yaml
+++ b/.github/workflows/publish-dbt-templater-release-to-pypi.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
 

--- a/.github/workflows/publish-sqlfluff-release-to-pypi.yaml
+++ b/.github/workflows/publish-sqlfluff-release-to-pypi.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
 


### PR DESCRIPTION
We're getting warnings in the Github Actions flows because of deprecated releases. This updates:
- `actions/upload-artifact` from `v2` to `v3`
- `actions/setup-python` from `v3` to `v4`

That should silence the warnings. The methods we use on each appear to be unchanged in both cases.