### PR TITLE
Add additional flags to `sqlfluff` invocations in pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,6 @@
 - id: sqlfluff-lint
   name: sqlfluff-lint
+  # Set `--processes 0` to use maximum parallelism
   entry: sqlfluff lint --processes 0
   language: python
   description: "Lints sql files with `SQLFluff`"
@@ -9,9 +10,12 @@
 
 - id: sqlfluff-fix
   name: sqlfluff-fix
-  # Needs to use "--force" to disable confirmation
-  # By default all the rules are applied
-  entry: sqlfluff fix --show-lint-violations --force --processes 0
+  # Set a couple of default flags:
+  #  - `--force` to disable confirmation
+  #  - `--show-lint-violations` shows issues to not require running `sqlfluff lint`
+  #  - `--processes 0` to use maximum parallelism
+  # By default, this hook applies all rules.
+  entry: sqlfluff fix --force --show-lint-violations --processes 0
   language: python
   description: "Fixes sql lint errors with `SQLFluff`"
   types: [sql]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,8 @@
 - id: sqlfluff-lint
   name: sqlfluff-lint
-  entry: sqlfluff lint
+  entry: sqlfluff lint --processes 0
   language: python
-  description: 'Lints sql files with `SQLFluff`'
+  description: "Lints sql files with `SQLFluff`"
   types: [sql]
   require_serial: true
   additional_dependencies: []
@@ -11,9 +11,9 @@
   name: sqlfluff-fix
   # Needs to use "--force" to disable confirmation
   # By default all the rules are applied
-  entry: sqlfluff fix --force
+  entry: sqlfluff fix --show-lint-violations --force --processes 0
   language: python
-  description: 'Fixes sql lint errors with `SQLFluff`'
+  description: "Fixes sql lint errors with `SQLFluff`"
   types: [sql]
   require_serial: true
   additional_dependencies: []


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

This PR updates the pre-commit hook configuration and adds the following flags to the pre-commit hooks that SQLFluff provides:

- `--processes 0` for both `lint` and `fix`: Parallelizing the operations is likely always desired to speed up the pre-commit hooks.
- `--show-lint-violations` for `fix`: If not specified, issues that cannot be fixed automatically will need to be identified by manually running `sqlfluff lint`.



### Are there any other side effects of this change that we should be aware of?

n/a


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
