### PR TITLE
Rethink test segregation in CI

### DIFF
--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -58,6 +58,14 @@ jobs:
       if: ${{ !inputs.coverage }}
       run: tox -e py${{ steps.py_version.outputs.PYVERSION }} -- -n 2 test -m "${{ inputs.marks }}"
 
+    - name: Rename coverage files with suffix
+      # NOTE: We do this because we're using the same tox environment for multiple
+      # test jobs and we need to make sure that their coverage files don't collide.s
+      if: ${{ !inputs.coverage }}
+      run: |
+        COVSUFFIX=$(echo "${{ inputs.marks }}" | sed -e 's/ /-/g')
+        for file in .coverage.*; do mv "$file" "$file.$COVSUFFIX"; done;
+
     - name: Coveralls Parallel (coveralls)
       uses: coverallsapp/github-action@master
       if: ${{ inputs.coverage }}

--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Rename coverage files with suffix
       # NOTE: We do this because we're using the same tox environment for multiple
       # test jobs and we need to make sure that their coverage files don't collide.s
-      if: ${{ !inputs.coverage }}
+      if: ${{ inputs.coverage }}
       run: |
         COVSUFFIX=$(echo "${{ inputs.marks }}" | sed -e 's/ /-/g')
         for file in .coverage.*; do mv "$file" "$file.$COVSUFFIX"; done;

--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -17,6 +17,10 @@ on:
       python-version:
         required: true
         type: string
+      marks:
+        required: false
+        type: string
+        default: "not integration"
       coverage:
         required: false
         type: boolean
@@ -43,16 +47,16 @@ jobs:
     - name: Parse Python Version
       id: py_version
       run: |
-        PYVERSION=$(echo "${{ matrix.python-version }}" | sed -e 's/\.//g')
+        PYVERSION=$(echo "${{ inputs.python-version }}" | sed -e 's/\.//g')
         echo "PYVERSION=$PYVERSION" >> $GITHUB_OUTPUT
 
     - name: Run the tests (with coverage)
       if: ${{ inputs.coverage }}
-      run: tox -e py${{ steps.py_version.outputs.PYVERSION }} -- --cov=sqlfluff -n 2 test
+      run: tox -e py${{ steps.py_version.outputs.PYVERSION }} -- --cov=sqlfluff -n 2 test -m "${{ inputs.marks }}"
 
     - name: Run the tests (without coverage)
       if: ${{ !inputs.coverage }}
-      run: tox -e py${{ steps.py_version.outputs.PYVERSION }} -- -n 2 test
+      run: tox -e py${{ steps.py_version.outputs.PYVERSION }} -- -n 2 test -m "${{ inputs.marks }}"
 
     - name: Coveralls Parallel (coveralls)
       uses: coverallsapp/github-action@master

--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -50,13 +50,21 @@ jobs:
         PYVERSION=$(echo "${{ inputs.python-version }}" | sed -e 's/\.//g')
         echo "PYVERSION=$PYVERSION" >> $GITHUB_OUTPUT
 
+    # Run test process (with or without coverage).
+    # Arguments after the "--" are passed through to pytest:
+    #   --cov=...       The library to include in coverage reporting.
+    #   -n 2            Runs with two parallel processes.
+    #   test            The path to detect tests within.
+    #   -m ...          The pytest marks to filter tests.
+    #   --durations=16  Displays the 16 slowest runs to help with performance debugging.
     - name: Run the tests (with coverage)
+      # NOTE: We have a separate job for coverage reporting because
+      # it impacts performance and slows the test suite significantly.
       if: ${{ inputs.coverage }}
-      run: tox -e py${{ steps.py_version.outputs.PYVERSION }} -- --cov=sqlfluff -n 2 test -m "${{ inputs.marks }}"
-
+      run: tox -e py${{ steps.py_version.outputs.PYVERSION }} -- --cov=sqlfluff -n 2 test -m "${{ inputs.marks }}" --durations=16
     - name: Run the tests (without coverage)
       if: ${{ !inputs.coverage }}
-      run: tox -e py${{ steps.py_version.outputs.PYVERSION }} -- -n 2 test -m "${{ inputs.marks }}"
+      run: tox -e py${{ steps.py_version.outputs.PYVERSION }} -- -n 2 test -m "${{ inputs.marks }}" --durations=16
 
     - name: Rename coverage files with suffix
       # NOTE: We do this because we're using the same tox environment for multiple

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -109,6 +109,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # We test coverage here for some parsing routines.
+      coverage: true
     uses: ./.github/workflows/ci-test-python.yml
     with:
       python-version: "3.11"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -96,8 +96,7 @@ jobs:
     secrets:
       gh_token: ${{ secrets.github_token }}
 
-  # This lints all our dialect fixtures to check rules can handle a variety
-  # of SQL and don't error out badly.
+  # This runs the bulk of the dialect _parsing_ tests.
   #
   # It's run as a separate job as takes longer than the CI jobs and allows
   # them to be rerun separately if GitHub Actions or Coverage is experiencing
@@ -114,10 +113,15 @@ jobs:
     with:
       python-version: "3.11"
       marks: "parse_suite"
-      coverage: true
     secrets:
       gh_token: ${{ secrets.github_token }}
-  
+
+  # This lints all our dialect fixtures to check rules can handle a variety
+  # of SQL and don't error out badly.
+  #
+  # It's run as a separate job as takes longer than the CI jobs and allows
+  # them to be rerun separately if GitHub Actions or Coverage is experiencing
+  # issues.
   dialects_fix:
     name: Dialect fixing
     strategy:
@@ -132,7 +136,7 @@ jobs:
       marks: "fix_suite"
     secrets:
       gh_token: ${{ secrets.github_token }}
-  
+
   # This lints all our rules fixtures to check rules.
   #
   # It's run as a separate job as takes longer than the CI jobs and allows

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -109,12 +109,12 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      # We test coverage here for some parsing routines.
-      coverage: true
     uses: ./.github/workflows/ci-test-python.yml
     with:
       python-version: "3.11"
       marks: "parse_suite"
+      # We test coverage here for some parsing routines.
+      coverage: true
     secrets:
       gh_token: ${{ secrets.github_token }}
 
@@ -340,14 +340,14 @@ jobs:
     needs: [python-version-tests-cov, dbt-tests-cov, python-windows-tests, dialects_parse, rules]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
       - run: python -m pip install --upgrade coverage[toml]
 
       - name: Download coverage data.
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: coverage-data
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -109,6 +109,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # We test coverage here for some parsing routines.
+      coverage: true
     uses: ./.github/workflows/ci-test-python.yml
     with:
       python-version: "3.11"
@@ -338,14 +340,14 @@ jobs:
     needs: [python-version-tests-cov, dbt-tests-cov, python-windows-tests, dialects_parse, rules]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
       - run: python -m pip install --upgrade coverage[toml]
 
       - name: Download coverage data.
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: coverage-data
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -251,7 +251,7 @@ jobs:
       # working dir on D drive which causes problems.
       run: |
         mkdir temp_pytest
-        python -m tox -e winpy -- --cov=sqlfluff -n 2 test
+        python -m tox -e winpy -- --cov=sqlfluff -n 2 test -m "not integration"
     - name: Upload coverage data (github)
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -109,8 +109,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      # We test coverage here for some parsing routines.
-      coverage: true
     uses: ./.github/workflows/ci-test-python.yml
     with:
       python-version: "3.11"
@@ -340,14 +338,14 @@ jobs:
     needs: [python-version-tests-cov, dbt-tests-cov, python-windows-tests, dialects_parse, rules]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v2
         with:
           python-version: "3.10"
 
       - run: python -m pip install --upgrade coverage[toml]
 
       - name: Download coverage data.
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v2
         with:
           name: coverage-data
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -103,77 +103,56 @@ jobs:
   # them to be rerun separately if GitHub Actions or Coverage is experiencing
   # issues.
   dialects_parse:
-    runs-on: ubuntu-latest
     name: Dialect parsing
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-    - name: Install dependencies
-      run: |
-        pip install tox
-        pip install .
-    - name: Run the tests
-      run: |
-        tox -e dialects_parse -- -n 2 test
-
+    strategy:
+      matrix:
+        python-version: [ '3.11' ]
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/ci-test-python.yml
+    with:
+      python-version: "3.11"
+      marks: "parse_suite"
+      coverage: true
+    secrets:
+      gh_token: ${{ secrets.github_token }}
+  
   dialects_fix:
-    runs-on: ubuntu-latest
     name: Dialect fixing
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-    - name: Install dependencies
-      run: |
-        pip install tox
-        pip install .
-    - name: Run the tests
-      run: |
-        tox -e dialects_fix -- -n 2 test
-
+    strategy:
+      matrix:
+        python-version: [ '3.11' ]
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/ci-test-python.yml
+    with:
+      python-version: "3.11"
+      marks: "fix_suite"
+    secrets:
+      gh_token: ${{ secrets.github_token }}
+  
   # This lints all our rules fixtures to check rules.
   #
   # It's run as a separate job as takes longer than the CI jobs and allows
   # them to be rerun separately if GitHub Actions or Coverage is experiencing
   # issues.
   rules:
-    runs-on: ubuntu-latest
     name: Rule yaml test cases
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-    - name: Install dependencies
-      run: |
-        pip install tox
-        pip install .
-    - name: Run the tests
-      run: |
-        tox -e rules -- -n 2 test
-
-    - name: Coveralls Parallel (coveralls)
-      uses: coverallsapp/github-action@master
-      if: ${{ inputs.coverage }}
-      with:
-        path-to-lcov: coverage.lcov
-        github-token: ${{ secrets.gh_token }}
-        flag-name: run-${{ inputs.python-version }}
-        parallel: true
-
-    - name: Upload coverage data (github)
-      uses: actions/upload-artifact@v3
-      if: ${{ inputs.coverage }}
-      with:
-        name: coverage-data
-        path: ".coverage.*"
-        if-no-files-found: ignore
+    strategy:
+      matrix:
+        python-version: [ '3.11' ]
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/ci-test-python.yml
+    with:
+      python-version: "3.11"
+      marks: "rules_suite"
+      coverage: true
+    secrets:
+      gh_token: ${{ secrets.github_token }}
 
   other-tests:
     runs-on: ubuntu-latest
@@ -340,7 +319,7 @@ jobs:
 
   coveralls_finish:
     name: Finalise coveralls.
-    needs: [python-version-tests-cov, dbt-tests-cov, python-windows-tests]
+    needs: [python-version-tests-cov, dbt-tests-cov, python-windows-tests, dialects_parse, rules]
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
@@ -352,7 +331,7 @@ jobs:
   coverage_check:
     name: Combine & check 100% coverage.
     runs-on: ubuntu-latest
-    needs: [python-version-tests-cov, dbt-tests-cov, python-windows-tests]
+    needs: [python-version-tests-cov, dbt-tests-cov, python-windows-tests, dialects_parse, rules]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v2

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -102,7 +102,7 @@ jobs:
   # It's run as a separate job as takes longer than the CI jobs and allows
   # them to be rerun separately if GitHub Actions or Coverage is experiencing
   # issues.
-  parser:
+  dialects_parse:
     runs-on: ubuntu-latest
     name: Dialect parsing and fixing
     steps:
@@ -117,7 +117,24 @@ jobs:
         pip install .
     - name: Run the tests
       run: |
-        tox -e parser -- -n 2 test
+        tox -e dialects_parse -- -n 2 test
+
+  dialects_fix:
+    runs-on: ubuntu-latest
+    name: Dialect parsing and fixing
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        pip install tox
+        pip install .
+    - name: Run the tests
+      run: |
+        tox -e dialects_fix -- -n 2 test
 
   # This lints all our rules fixtures to check rules.
   #

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -102,9 +102,9 @@ jobs:
   # It's run as a separate job as takes longer than the CI jobs and allows
   # them to be rerun separately if GitHub Actions or Coverage is experiencing
   # issues.
-  ruleslinting:
+  parser:
     runs-on: ubuntu-latest
-    name: Rules critical errors tests
+    name: Dialect parsing and fixing
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -117,7 +117,46 @@ jobs:
         pip install .
     - name: Run the tests
       run: |
-        tox -e ruleslinting -- -n 2 test
+        tox -e parser -- -n 2 test
+
+  # This lints all our rules fixtures to check rules.
+  #
+  # It's run as a separate job as takes longer than the CI jobs and allows
+  # them to be rerun separately if GitHub Actions or Coverage is experiencing
+  # issues.
+  rules:
+    runs-on: ubuntu-latest
+    name: Rule yaml test cases
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        pip install tox
+        pip install .
+    - name: Run the tests
+      run: |
+        tox -e rules -- -n 2 test
+
+    - name: Coveralls Parallel (coveralls)
+      uses: coverallsapp/github-action@master
+      if: ${{ inputs.coverage }}
+      with:
+        path-to-lcov: coverage.lcov
+        github-token: ${{ secrets.gh_token }}
+        flag-name: run-${{ inputs.python-version }}
+        parallel: true
+
+    - name: Upload coverage data (github)
+      uses: actions/upload-artifact@v3
+      if: ${{ inputs.coverage }}
+      with:
+        name: coverage-data
+        path: ".coverage.*"
+        if-no-files-found: ignore
 
   other-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -104,7 +104,7 @@ jobs:
   # issues.
   dialects_parse:
     runs-on: ubuntu-latest
-    name: Dialect parsing and fixing
+    name: Dialect parsing
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -121,7 +121,7 @@ jobs:
 
   dialects_fix:
     runs-on: ubuntu-latest
-    name: Dialect parsing and fixing
+    name: Dialect fixing
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 markers =
     dbt: Marks tests needing the "dbt" plugin (deselect with '-m "not dbt"').
-    parser_suite: Marks the suite of parsing tests across a range of dialects.
-    rules_suite: Marks the suite of rules tests. Also known as the yaml tests.
+    integration: Marks tests outside of the core suite.
+    parse_suite: Marks the suite of parsing tests across a range of dialects (part of integration).
+    fix_suite: Marks the suite of fixing tests across a range of dialects (part of integration).
+    rules_suite: Marks the suite of rules tests. Also known as the yaml tests (part of integration).

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 markers =
-    dbt: marks tests needing the "dbt" plugin (deselect with '-m "not dbt"')
-    integration_test: marks integration tests
+    dbt: Marks tests needing the "dbt" plugin (deselect with '-m "not dbt"').
+    parser_suite: Marks the suite of parsing tests across a range of dialects.
+    rules_suite: Marks the suite of rules tests. Also known as the yaml tests.

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1002,7 +1002,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
         return [item for s in self.segments for item in s.raw_segments]
 
     def iter_segments(self, expanding=None, pass_through=False):
-        """Iterate raw segments, optionally expanding some children."""
+        """Iterate segments, optionally expanding some children."""
         for s in self.segments:
             if expanding and s.is_type(*expanding):
                 yield from s.iter_segments(

--- a/test/dialects/dialects_test.py
+++ b/test/dialects/dialects_test.py
@@ -43,6 +43,7 @@ def lex_and_parse(config_overrides: Dict[str, Any], raw: str) -> Optional[BaseSe
     return Parser(config=config).parse(tokens)
 
 
+@pytest.mark.parser_suite
 @pytest.mark.parametrize("dialect,file", parse_success_examples)
 def test__dialect__base_file_parse(dialect, file):
     """For given test examples, check successful parsing."""
@@ -62,7 +63,7 @@ def test__dialect__base_file_parse(dialect, file):
     assert "unparsable" not in typs
 
 
-@pytest.mark.integration_test
+@pytest.mark.parser_suite
 @pytest.mark.parametrize("dialect,file", parse_success_examples)
 def test__dialect__base_broad_fix(
     dialect, file, raise_critical_errors_after_fix, caplog
@@ -78,12 +79,13 @@ def test__dialect__base_broad_fix(
         print(parsed.stringify())
 
     config = FluffConfig(overrides=config_overrides)
-    # Due to "raise_critical_errors_after_fix" fixure "fix",
+    # Due to "raise_critical_errors_after_fix" fixture "fix",
     # will now throw.
     with caplog.at_level(logging.DEBUG, logger="sqlfluff.rules"):
         Linter(config=config).lint_string(raw, fix=True)
 
 
+@pytest.mark.parser_suite
 @pytest.mark.parametrize("dialect,sqlfile,code_only,yamlfile", parse_structure_examples)
 def test__dialect__base_parse_struct(
     dialect,

--- a/test/dialects/dialects_test.py
+++ b/test/dialects/dialects_test.py
@@ -43,7 +43,8 @@ def lex_and_parse(config_overrides: Dict[str, Any], raw: str) -> Optional[BaseSe
     return Parser(config=config).parse(tokens)
 
 
-@pytest.mark.parser_suite
+@pytest.mark.integration
+@pytest.mark.parse_suite
 @pytest.mark.parametrize("dialect,file", parse_success_examples)
 def test__dialect__base_file_parse(dialect, file):
     """For given test examples, check successful parsing."""
@@ -63,7 +64,8 @@ def test__dialect__base_file_parse(dialect, file):
     assert "unparsable" not in typs
 
 
-@pytest.mark.parser_suite
+@pytest.mark.integration
+@pytest.mark.fix_suite
 @pytest.mark.parametrize("dialect,file", parse_success_examples)
 def test__dialect__base_broad_fix(
     dialect, file, raise_critical_errors_after_fix, caplog
@@ -85,7 +87,8 @@ def test__dialect__base_broad_fix(
         Linter(config=config).lint_string(raw, fix=True)
 
 
-@pytest.mark.parser_suite
+@pytest.mark.integration
+@pytest.mark.parse_suite
 @pytest.mark.parametrize("dialect,sqlfile,code_only,yamlfile", parse_structure_examples)
 def test__dialect__base_parse_struct(
     dialect,

--- a/test/dialects/dialects_test.py
+++ b/test/dialects/dialects_test.py
@@ -81,7 +81,18 @@ def test__dialect__base_file_parse(dialect, file):
 def test__dialect__base_broad_fix(
     dialect, file, raise_critical_errors_after_fix, caplog
 ):
-    """Run a full fix with all rules, in search of critical errors."""
+    """Run a full fix with all rules, in search of critical errors.
+
+    NOTE: This suite does all of the same things as the above test
+    suite (the `parse_suite`), but also runs fix. In CI, we run
+    the above tests _with_ coverage tracking, but these we run
+    _without_.
+
+    The purpose of this test is as a more stretching run through
+    a wide range of test sql examples, and the full range of rules
+    to find any potential critical errors raised by any interactions
+    between different dialects and rules.
+    """
     raw = load_file(dialect, file)
     config_overrides = dict(dialect=dialect)
 

--- a/test/rules/yaml_test_cases_test.py
+++ b/test/rules/yaml_test_cases_test.py
@@ -14,7 +14,8 @@ ids, test_cases = load_test_cases(
 )
 
 
-@pytest.mark.parser_suite
+@pytest.mark.integration
+@pytest.mark.rules_suite
 @pytest.mark.parametrize("test_case", test_cases, ids=ids)
 def test__rule_test_case(test_case, caplog):
     """Run the tests."""

--- a/test/rules/yaml_test_cases_test.py
+++ b/test/rules/yaml_test_cases_test.py
@@ -14,6 +14,7 @@ ids, test_cases = load_test_cases(
 )
 
 
+@pytest.mark.parser_suite
 @pytest.mark.parametrize("test_case", test_cases, ids=ids)
 def test__rule_test_case(test_case, caplog):
     """Run the tests."""

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands =
     # Clean up from previous tests
     python {toxinidir}/util.py clean-tests
     # Run tests
-    pytest -vv -rsfE --cov-report=lcov {posargs: {toxinidir}/test} -m "not parser_suite and not rules_suite"
+    pytest -vv -rsfE --cov-report=lcov {posargs: {toxinidir}/test} -m "not integration"
     python test/patch_lcov.py
 
 [testenv:cov-init]
@@ -80,9 +80,13 @@ commands =
     flake8
     ruff check .
 
-[testenv:parser]
+[testenv:dialects_parse]
 # Tests the parsing and fixing fixtures across all dialects (no coverage)
-commands = pytest -vv -rsfE {posargs: {toxinidir}/test} -m "parser_suite"
+commands = pytest -vv -rsfE {posargs: {toxinidir}/test} -m "parse_suite"
+
+[testenv:dialects_fix]
+# Tests the parsing and fixing fixtures across all dialects (no coverage)
+commands = pytest -vv -rsfE {posargs: {toxinidir}/test} -m "fix_suite"
 
 [testenv:rules]
 # Runs the yaml test cases for all rules (with coverage)

--- a/tox.ini
+++ b/tox.ini
@@ -151,6 +151,8 @@ testpaths = test
 
 [coverage:run]
 source = src/sqlfluff
+# Run in parallel mode so that files for different suites don't overlap.
+parallel = True
 omit =
     src/sqlfluff/__main__.py
     plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/osmosis/*.py

--- a/tox.ini
+++ b/tox.ini
@@ -151,8 +151,6 @@ testpaths = test
 
 [coverage:run]
 source = src/sqlfluff
-# Run in parallel mode so that files for different suites don't overlap.
-parallel = True
 omit =
     src/sqlfluff/__main__.py
     plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/osmosis/*.py

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands =
     # Clean up from previous tests
     python {toxinidir}/util.py clean-tests
     # Run tests
-    pytest -vv -rsfE --cov-report=xml --cov-report=lcov {posargs: {toxinidir}/test} -m "not integration_test"
+    pytest -vv -rsfE --cov-report=lcov {posargs: {toxinidir}/test} -m "not parser_suite and not rules_suite"
     python test/patch_lcov.py
 
 [testenv:cov-init]
@@ -80,8 +80,13 @@ commands =
     flake8
     ruff check .
 
-[testenv:ruleslinting]
-commands = pytest -vv -rsfE {posargs: {toxinidir}/test} -m "integration_test"
+[testenv:parser]
+# Tests the parsing and fixing fixtures across all dialects (no coverage)
+commands = pytest -vv -rsfE {posargs: {toxinidir}/test} -m "parser_suite"
+
+[testenv:rules]
+# Runs the yaml test cases for all rules (with coverage)
+commands = pytest -vv -rsfE --cov-report=lcov {posargs: {toxinidir}/test} -m "rules_suite"
 
 [testenv:doctests]
 commands = pytest -vv -rsfE --doctest-modules {posargs: {toxinidir}/src}

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands =
     # the python version is not specified and instead the "py" environment
     # is invoked. Leaving the trailing comma ensures that this environment
     # still installs the relevant plugins.
-    {py,winpy}{37,38,39,310,}: python -m pip install {toxinidir}/plugins/sqlfluff-plugin-example
+    {py,winpy}{37,38,39,310,311,}: python -m pip install {toxinidir}/plugins/sqlfluff-plugin-example
     # For the dbt test cases install dependencies.
     dbt{110,140,}: dbt deps --project-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project --profiles-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt
     # Clean up from previous tests

--- a/tox.ini
+++ b/tox.ini
@@ -168,4 +168,4 @@ source =
     D:\a\sqlfluff\sqlfluff\src\
     D:\a\sqlfluff\sqlfluff\.tox\winpy\Lib\site-packages\
     /home/runner/work/sqlfluff/sqlfluff/src/
-    /home/runner/work/sqlfluff/sqlfluff/.tox/py/lib/python*/site-packages/
+    /home/runner/work/sqlfluff/sqlfluff/.tox/*/lib/*/site-packages/

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands =
     # Clean up from previous tests
     python {toxinidir}/util.py clean-tests
     # Run tests
-    pytest -vv -rsfE --cov-report=lcov {posargs: {toxinidir}/test} -m "not integration"
+    pytest -vv -rsfE --cov-report=lcov {posargs: {toxinidir}/test}
     python test/patch_lcov.py
 
 [testenv:cov-init]
@@ -79,18 +79,6 @@ skip_install = true
 commands =
     flake8
     ruff check .
-
-[testenv:dialects_parse]
-# Tests the parsing and fixing fixtures across all dialects (no coverage)
-commands = pytest -vv -rsfE {posargs: {toxinidir}/test} -m "parse_suite"
-
-[testenv:dialects_fix]
-# Tests the parsing and fixing fixtures across all dialects (no coverage)
-commands = pytest -vv -rsfE {posargs: {toxinidir}/test} -m "fix_suite"
-
-[testenv:rules]
-# Runs the yaml test cases for all rules (with coverage)
-commands = pytest -vv -rsfE --cov-report=lcov {posargs: {toxinidir}/test} -m "rules_suite"
 
 [testenv:doctests]
 commands = pytest -vv -rsfE --doctest-modules {posargs: {toxinidir}/src}


### PR DESCRIPTION
This stems from a discussion on slack about the duration of the test suite. Previously, the longest duration was around 16 minutes. The longest parts are below, taken from this example: https://github.com/sqlfluff/sqlfluff/actions/runs/4441331387
- The python matrix tests (without coverage): 7-11mins
- Python 3.11 tests (with coverage): 13mins
- Python 3.10 windows test (with coverage): 16mins
- _"Critical errors test"_: 8mins

This PR does a few things:
- It expands the use of [pytest marks](https://docs.pytest.org/en/7.1.x/how-to/mark.html), from just the existing `integration_test` mark to:
  - A `fix_suite` mark which maps roughly to the original `integration_test` mark.
  - A `parse_suite` mark which covers the similar parsing suite for parsing structure tests and parsing/lexing success tests.
  - A `rules_suite` mark which covers the rules yaml tests.
  - An `integration` mark which also covers the above three suites.
- For the default python matrix tests, it excludes the `integration` mark, which reduces runtimes to ~2mins without coverage, ~3min for linux with coverage and ~4min for windows with coverage.
- Creates new test jobs for each of the three other suites:
  - _"Dialect parsing"_ - which covers the `parse_suite`, taking ~8mins
  - _"Rules yaml test cases"_ - which covers the `rules_suite`, taking ~4mins
  - _"Dialect fixing"_ - which covers the `fix_suite`, taking ~6mins
- Additionally, the existing _"Critical errors test"_, (now called the _"Dialect fixing"_ job), was running the `.parse()` methods twice, once in the `lex_and_parse.()` method and once in `Parser.parse()` method. A small refactor of `dialects_test.py` removes this duplication.

**The critical path of the whole CI run takes around 9mins, rather than around 17mins**. 🎉🎉

The limiting factor is the `parse_suite` (and then the coverage reporting job briefly afterwards). The next longest job is the `fix_suite` which is also very sensitive to parsing times. Reducing parsing times (@WittierDinosaur 😄 ), is the most sensible thing to reduce times further and could get us as far as 5mins (which is the runtime of the tests on the dbt templater plugin - and the next longest job).

Additionally, if merged, the `rules_suite` and `parse_suite` should be made _Required_ tests.