### PR TITLE
Address #1630: Optionally move comments after long line

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -68,6 +68,11 @@ template_blocks_indent = True
 # This is a comma seperated list of elements to skip
 # indentation edits to.
 skip_indentation_in = script_content
+# If comments are found at the end of long lines, we default to moving
+# them to the line _before_ their current location as the convention is
+# that a comment precedes the line it describes. However if you prefer
+# comments moved _after_, this configuration setting can be set to "after".
+trailing_comments = before
 
 # Layout configuration
 # See https://docs.sqlfluff.com/en/stable/layout.html#configuring-layout-and-spacing

--- a/src/sqlfluff/utils/reflow/config.py
+++ b/src/sqlfluff/utils/reflow/config.py
@@ -66,6 +66,7 @@ class ReflowConfig:
     hanging_indents: bool = False
     skip_indentation_in: FrozenSet[str] = frozenset()
     allow_implicit_indents: bool = False
+    trailing_comments: str = "before"
 
     @classmethod
     def from_dict(cls, config_dict: ConfigDictType, **kwargs):
@@ -100,6 +101,7 @@ class ReflowConfig:
             allow_implicit_indents=config.get(
                 "allow_implicit_indents", ["indentation"]
             ),
+            trailing_comments=config.get("trailing_comments", ["indentation"]),
         )
 
     def get_block_config(

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -1647,6 +1647,7 @@ def lint_line_length(
     single_indent: str,
     line_length_limit: int,
     allow_implicit_indents: bool = False,
+    trailing_comments: str = "before",
 ) -> Tuple[ReflowSequenceType, List[LintResult]]:
     """Lint the sequence to lines over the configured length.
 
@@ -1783,6 +1784,7 @@ def lint_line_length(
                     current_indent,
                     line_length_limit,
                     last_indent_idx,
+                    trailing_comments=trailing_comments,
                 )
 
             # Then check for cases where we have no other options.

--- a/src/sqlfluff/utils/reflow/sequence.py
+++ b/src/sqlfluff/utils/reflow/sequence.py
@@ -613,6 +613,7 @@ class ReflowSequence:
             single_indent=single_indent,
             line_length_limit=self.reflow_config.max_line_length,
             allow_implicit_indents=self.reflow_config.allow_implicit_indents,
+            trailing_comments=self.reflow_config.trailing_comments,
         )
 
         return ReflowSequence(

--- a/test/fixtures/rules/std_rule_cases/LT05.yml
+++ b/test/fixtures/rules/std_rule_cases/LT05.yml
@@ -10,11 +10,20 @@ test_pass_line_too_long_config_override:
 test_fail_line_too_long_with_comments_1:
   # Check we move comments correctly
   fail_str: "SELECT 1 -- Some Comment\n"
-
   fix_str: "-- Some Comment\nSELECT 1\n"
   configs:
     core:
       max_line_length: 18
+
+test_fail_line_too_long_with_comments_1_after:
+  # Check we move comments correctly
+  fail_str: "SELECT 1 -- Some Comment\n"
+  fix_str: "SELECT 1\n-- Some Comment\n"
+  configs:
+    core:
+      max_line_length: 18
+    indentation:
+      trailing_comments: after
 
 test_fail_line_too_long_with_comments_1_no_newline:
   # Check we move comments correctly, and that it


### PR DESCRIPTION
This resolves #1630 . It's also a good opportunity to add a little more modularity and clean up some duplicated code in `lint_line_length()`. This extracts the routines for moving a trailing comment into `_fix_long_line_with_comment()` and also adds a configuration flag to that method to optionally move comments _after_ rather than _before_ the line they're currently on.