### PR TITLE
Remove matches_target_tuples (#3873)

### DIFF
--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -968,41 +968,6 @@ class BaseRule(metaclass=RuleMetaclass):
         return None
 
     @staticmethod
-    def matches_target_tuples(
-        seg: BaseSegment,
-        target_tuples: List[Tuple[str, str]],
-        parent: Optional[BaseSegment] = None,
-    ):
-        """Does the given segment match any of the given type tuples?"""
-        if seg.raw_upper in [
-            elem[1] for elem in target_tuples if elem[0] == "raw_upper"
-        ]:
-            return True  # pragma: no cover
-        elif seg.is_type(*[elem[1] for elem in target_tuples if elem[0] == "type"]):
-            return True
-        # For parent type checks, there's a higher risk of getting an incorrect
-        # segment, so we add some additional guards. We also only check keywords
-        # as for other types we can check directly rather than using parent
-        elif (
-            not seg.is_meta
-            and not seg.is_comment
-            and not seg.is_templated
-            and not seg.is_whitespace
-            and isinstance(seg, RawSegment)
-            and len(seg.raw) > 0
-            and seg.is_type("keyword")
-            and parent
-            and parent.is_type(
-                *[elem[1] for elem in target_tuples if elem[0] == "parenttype"]
-            )
-        ):
-            # TODO: This clause is much less used post crawler migration.
-            # Consider whether this should be removed once that migration
-            # is complete.
-            return True  # pragma: no cover
-        return False
-
-    @staticmethod
     def discard_unsafe_fixes(
         lint_result: LintResult, templated_file: Optional[TemplatedFile]
     ):

--- a/src/sqlfluff/rules/aliasing/AL01.py
+++ b/src/sqlfluff/rules/aliasing/AL01.py
@@ -45,10 +45,10 @@ class Rule_AL01(BaseRule):
     crawl_behaviour = SegmentSeekerCrawler({"alias_expression"}, provide_raw_stack=True)
     is_fix_compatible = True
 
-    _target_elems: List[Tuple[str, str]] = [
-        ("type", "from_expression_element"),
-        ("type", "merge_statement"),
-    ]
+    _target_parent_types: Tuple[str, ...] = (
+        "from_expression_element",
+        "merge_statement",
+    )
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Implicit aliasing of table/column not allowed. Use explicit `AS` clause.
@@ -60,7 +60,7 @@ class Rule_AL01(BaseRule):
         self.aliasing: str
 
         assert context.segment.is_type("alias_expression")
-        if self.matches_target_tuples(context.parent_stack[-1], self._target_elems):
+        if context.parent_stack[-1].is_type(*self._target_parent_types):
             if any(e.raw_upper == "AS" for e in context.segment.segments):
                 if self.aliasing == "implicit":
                     if context.segment.segments[0].raw_upper == "AS":

--- a/src/sqlfluff/rules/aliasing/AL02.py
+++ b/src/sqlfluff/rules/aliasing/AL02.py
@@ -40,9 +40,7 @@ class Rule_AL02(Rule_AL01):
     config_keywords = ["aliasing"]
     # NB: crawl_behaviour is the same as Rule AL01
 
-    _target_parent_types = (
-        "select_clause_element",
-    )
+    _target_parent_types = ("select_clause_element",)
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         # T-SQL supports alternative alias expressions for AL02

--- a/src/sqlfluff/rules/aliasing/AL02.py
+++ b/src/sqlfluff/rules/aliasing/AL02.py
@@ -40,9 +40,9 @@ class Rule_AL02(Rule_AL01):
     config_keywords = ["aliasing"]
     # NB: crawl_behaviour is the same as Rule AL01
 
-    _target_elems = [
-        ("type", "select_clause_element"),
-    ]
+    _target_parent_types = (
+        "select_clause_element",
+    )
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         # T-SQL supports alternative alias expressions for AL02

--- a/src/sqlfluff/rules/capitalisation/CP03.py
+++ b/src/sqlfluff/rules/capitalisation/CP03.py
@@ -40,7 +40,9 @@ class Rule_CP03(Rule_CP01):
     crawl_behaviour = SegmentSeekerCrawler(
         {"function_name_identifier", "bare_function"}
     )
-    _exclude_elements: List[Tuple[str, str]] = []
+    _exclude_types = ()
+    _exclude_parent_types = ()
+
     config_keywords = [
         "extended_capitalisation_policy",
         "ignore_words",

--- a/src/sqlfluff/rules/capitalisation/CP04.py
+++ b/src/sqlfluff/rules/capitalisation/CP04.py
@@ -53,5 +53,6 @@ class Rule_CP04(Rule_CP01):
     is_fix_compatible = True
 
     crawl_behaviour = SegmentSeekerCrawler({"null_literal", "boolean_literal"})
-    _exclude_elements: List[Tuple[str, str]] = []
+    _exclude_types = ()
+    _exclude_parent_types = ()
     _description_elem = "Boolean/null literals"

--- a/src/sqlfluff/rules/capitalisation/CP05.py
+++ b/src/sqlfluff/rules/capitalisation/CP05.py
@@ -50,13 +50,8 @@ class Rule_CP05(Rule_CP01):
             "data_type",
         }
     )
-    _target_elems: List[Tuple[str, str]] = [
-        ("parenttype", "data_type"),
-        ("parenttype", "datetime_type_identifier"),
-        ("parenttype", "primitive_type"),
-        ("type", "data_type_identifier"),
-    ]
-    _exclude_elements: List[Tuple[str, str]] = []
+    _exclude_types = ()
+    _exclude_parent_types = ()
     config_keywords = [
         "extended_capitalisation_policy",
         "ignore_words",
@@ -65,20 +60,13 @@ class Rule_CP05(Rule_CP01):
     _description_elem = "Datatypes"
 
     def _eval(self, context: RuleContext) -> List[LintResult]:
-        """Inconsistent capitalisation of keywords.
+        """Inconsistent capitalisation of datatypes.
 
         We use the `memory` feature here to keep track of cases known to be
-        INconsistent with what we've seen so far as well as the top choice
+        Inconsistent with what we've seen so far as well as the top choice
         for what the possible case is.
 
         """
-        # Skip if not an element of the specified type/name
-        parent: Optional[BaseSegment] = (
-            context.parent_stack[-1] if context.parent_stack else None
-        )
-        if self.matches_target_tuples(context.segment, self._exclude_elements, parent):
-            return [LintResult(memory=context.memory)]  # pragma: no cover
-
         results = []
         # For some of these segments we want to run the code on
         if context.segment.is_type(
@@ -95,10 +83,12 @@ class Rule_CP05(Rule_CP01):
                 if res:
                     results.append(res)
 
+        # NOTE: Given the dialect structure we can assume the targets have a parent.
+        parent: BaseSegment = context.parent_stack[-1]
         # Don't process it if it's likely to have been processed by the parent.
-        if context.segment.is_type("data_type_identifier") and not context.parent_stack[
-            -1
-        ].is_type("primitive_type", "datetime_type_identifier", "data_type"):
+        if context.segment.is_type("data_type_identifier") and not parent.is_type(
+            "primitive_type", "datetime_type_identifier", "data_type"
+        ):
             results.append(
                 self._handle_segment(context.segment, context.memory)
             )  # pragma: no cover


### PR DESCRIPTION
This resolves #3873.

Brought up in reviewing the rule crawler work, we identified that `BaseSegment.matches_target_tuples()` was an overly complicated (and arguably too _powerful_) method that could/should be replaced.

This removes the last references to it and replaces those instances with much simpler calls.