### PR TITLE
Fix untaken indent bug

### DIFF
--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -757,7 +757,11 @@ def _map_line_buffers(
                     if "placeholder" in elements[loc + 1].class_types or (
                         loc >= 1 and "placeholder" in elements[loc - 1].class_types
                     ):
-                        continue
+                        # TODO: Review whether this is really necessary. Developments
+                        # in the indentation algorithm should make this unnecessary
+                        # but I've left it in for now as a safety valve in case an
+                        # example arises where it's necessary.
+                        continue  # pragma: no cover
 
                     # If the location was in the line we're just closing. That's
                     # not a problem because it's an untaken indent which is closed

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -688,8 +688,8 @@ def _map_line_buffers(
 
         if not indent_point.is_line_break:
             # If it's not a line break, we should still check whether it's
-            # untaken to keep track of them.
-            if indent_point.indent_impulse:
+            # a positive untaken to keep track of them.
+            if indent_point.indent_impulse > 0:
                 untaken_indent_locs[
                     indent_point.initial_indent_balance + indent_point.indent_impulse
                 ] = indent_point.idx


### PR DESCRIPTION
I found this bug in the process of working through #4033. The locations of previous untaken indents we're being corrupted by _negative_ untaken dedents. They should _not_ be included in the positive untaken indent tracking.

No test cases changed at this stage. I think that's ok - and a test case to stretch them will come as part of #4033 (and now actually as part of #4564).