### PR TITLE
Don't force newlines before commas

### DIFF
--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -1083,7 +1083,7 @@ def _lint_line_untaken_negative_indents(
         # NOTE: This could potentially lead to a weird situation if two
         # statements are already on the same line. That's a bug to solve later.
         if elements[ip.idx + 1 :] and elements[ip.idx + 1].class_types.intersection(
-            {"statement_terminator", "comma"}
+            ("statement_terminator", "comma")
         ):
             reflow_logger.debug(
                 "    Detected missing -ve line break @ line %s, before "
@@ -1816,6 +1816,16 @@ def lint_line_length(
                     )
                     if indent_stats.trough < 0:
                         new_indent = current_indent
+                        # NOTE: If we're about to insert a dedent before a
+                        # comma or semicolon ... don't. They are a bit special
+                        # in being allowed to trail.
+                        if elements[e_idx + 1].class_types.intersection(
+                            ("statement_terminator", "comma")
+                        ):
+                            reflow_logger.debug(
+                                "    Skipping dedent before comma or semicolon."
+                            )
+                            continue
                     else:
                         new_indent = desired_indent
 

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -1082,13 +1082,12 @@ def _lint_line_untaken_negative_indents(
         # more configurable.
         # NOTE: This could potentially lead to a weird situation if two
         # statements are already on the same line. That's a bug to solve later.
-        if (
-            elements[ip.idx + 1 :]
-            and "statement_terminator" in elements[ip.idx + 1].class_types
+        if elements[ip.idx + 1 :] and elements[ip.idx + 1].class_types.intersection(
+            {"statement_terminator", "comma"}
         ):
             reflow_logger.debug(
                 "    Detected missing -ve line break @ line %s, before "
-                "semicolon. Ignoring...",
+                "semicolon or comma. Ignoring...",
                 elements[ip.idx + 1].segments[0].pos_marker.working_line_no,
             )
             continue


### PR DESCRIPTION
Found this while investigating #4033. Commas behave similarly to semicolons in that we should allow them to trail (unless the leading/trailing comma rule decides to move them). I'm raising this as a draft to check for knock-on effects.