### PR TITLE
Fix #4453: Snowflake semi-stuctured casts in CV11

### DIFF
--- a/src/sqlfluff/rules/convention/CV11.py
+++ b/src/sqlfluff/rules/convention/CV11.py
@@ -1,6 +1,6 @@
 """Implementation of Rule CV11."""
 
-from typing import Optional, List
+from typing import Optional, List, Iterable
 
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
@@ -81,22 +81,26 @@ class Rule_CV11(BaseRule):
     @staticmethod
     def _cast_fix_list(
         context: RuleContext,
-        cast_arg_1: BaseSegment,
+        cast_arg_1: Iterable[BaseSegment],
         cast_arg_2: BaseSegment,
         later_types: Optional[Segments] = None,
     ) -> List[LintFix]:
         """Generate list of fixes to convert CONVERT and ShorthandCast to CAST."""
         # Add cast and opening parenthesis.
-        edits = [
-            KeywordSegment("cast"),
-            SymbolSegment("(", type="start_bracket"),
-            cast_arg_1,
-            WhitespaceSegment(),
-            KeywordSegment("as"),
-            WhitespaceSegment(),
-            cast_arg_2,
-            SymbolSegment(")", type="end_bracket"),
-        ]
+        edits = (
+            [
+                KeywordSegment("cast"),
+                SymbolSegment("(", type="start_bracket"),
+            ]
+            + list(cast_arg_1)
+            + [
+                WhitespaceSegment(),
+                KeywordSegment("as"),
+                WhitespaceSegment(),
+                cast_arg_2,
+                SymbolSegment(")", type="end_bracket"),
+            ]
+        )
 
         if later_types:
             pre_edits: List[BaseSegment] = [
@@ -250,7 +254,7 @@ class Rule_CV11(BaseRule):
 
                     fixes = self._cast_fix_list(
                         context,
-                        convert_content[1],
+                        [convert_content[1]],
                         convert_content[0],
                     )
                 elif current_type_casting_style == "shorthand":
@@ -262,7 +266,7 @@ class Rule_CV11(BaseRule):
                     print(previous_skipped)
                     fixes = self._cast_fix_list(
                         context,
-                        expression_datatype_segment[0],
+                        [expression_datatype_segment[0]],
                         expression_datatype_segment[1],
                         # We can have multiple shorthandcast e.g 1::int::text
                         # in that case, we need to introduce nested CAST()
@@ -349,19 +353,25 @@ class Rule_CV11(BaseRule):
 
                     fixes = self._cast_fix_list(
                         context,
-                        convert_content[1],
+                        [convert_content[1]],
                         convert_content[0],
                     )
                 elif current_type_casting_style == "shorthand":
                     expression_datatype_segment = self._get_children(
                         functional_context.segment
                     )
+
+                    for data_type_idx, seg in enumerate(expression_datatype_segment):
+                        if seg.is_type("data_type"):
+                            break
+
                     fixes = self._cast_fix_list(
                         context,
-                        expression_datatype_segment[0],
-                        expression_datatype_segment[1],
-                        expression_datatype_segment[2:],
+                        expression_datatype_segment[:data_type_idx],
+                        expression_datatype_segment[data_type_idx],
+                        expression_datatype_segment[data_type_idx + 1 :],
                     )
+                    self.logger.warning("FIXES: %s", fixes)
             elif self.preferred_type_casting_style == "convert":
                 if current_type_casting_style == "cast":
                     cast_content = self._get_children(

--- a/src/sqlfluff/rules/convention/CV11.py
+++ b/src/sqlfluff/rules/convention/CV11.py
@@ -371,7 +371,7 @@ class Rule_CV11(BaseRule):
                         expression_datatype_segment[data_type_idx],
                         expression_datatype_segment[data_type_idx + 1 :],
                     )
-                    self.logger.warning("FIXES: %s", fixes)
+
             elif self.preferred_type_casting_style == "convert":
                 if current_type_casting_style == "cast":
                     cast_content = self._get_children(

--- a/src/sqlfluff/rules/convention/CV11.py
+++ b/src/sqlfluff/rules/convention/CV11.py
@@ -402,24 +402,12 @@ class Rule_CV11(BaseRule):
                         convert_content[1],
                         convert_content[0],
                     )
-            if convert_content and len(convert_content) > 2:
-                return LintResult(
-                    anchor=context.segment,
-                    memory=context.memory,
-                    description=(
-                        "Used type casting style is different from"
-                        " the preferred type casting style."
-                    ),
-                )
-            elif cast_content and len(cast_content) > 2:
-                return LintResult(
-                    anchor=context.segment,
-                    memory=context.memory,
-                    description=(
-                        "Used type casting style is different from"
-                        " the preferred type casting style."
-                    ),
-                )
+
+            # Don't fix if there's too much content.
+            if (convert_content and len(convert_content) > 2) or (
+                cast_content and len(cast_content) > 2
+            ):
+                fixes = []
 
             return LintResult(
                 anchor=context.segment,

--- a/test/fixtures/rules/std_rule_cases/CV11.yml
+++ b/test/fixtures/rules/std_rule_cases/CV11.yml
@@ -323,7 +323,6 @@ test_pass_when_dialect_is_teradata:
     core:
       dialect: teradata
 
-
 test_fail_parenthesize_expression_when_config_shorthand_from_cast:
   fail_str: |
     select
@@ -340,7 +339,6 @@ test_fail_parenthesize_expression_when_config_shorthand_from_cast:
       convention.casting_style:
         preferred_type_casting_style: shorthand
 
-
 test_fail_parenthesize_expression_when_config_shorthand_from_convert:
   fail_str: |
     select
@@ -356,3 +354,15 @@ test_fail_parenthesize_expression_when_config_shorthand_from_convert:
     rules:
       convention.casting_style:
         preferred_type_casting_style: shorthand
+
+test_fail_parenthesize_expression_when_config_shorthand_from_convert:
+  fail_str: |
+    SELECT (TRIM(value:Longitude::VARCHAR))::DOUBLE AS longitude
+  fix_str: |
+    SELECT CAST(TRIM(CAST(value:Longitude AS varchar) AS DOUBLE) as longitude
+  configs:
+    core:
+      dialect: snowflake
+    rules:
+      convention.casting_style:
+        preferred_type_casting_style: cast

--- a/test/fixtures/rules/std_rule_cases/CV11.yml
+++ b/test/fixtures/rules/std_rule_cases/CV11.yml
@@ -355,7 +355,7 @@ test_fail_parenthesize_expression_when_config_shorthand_from_convert:
       convention.casting_style:
         preferred_type_casting_style: shorthand
 
-test_fail_parenthesize_expression_when_config_shorthand_from_convert:
+test_fail_snowflake_semi_structured_cast_4453:
   # https://github.com/sqlfluff/sqlfluff/issues/4453
   fail_str: |
     select (trim(value:Longitude::varchar))::double as longitude;

--- a/test/fixtures/rules/std_rule_cases/CV11.yml
+++ b/test/fixtures/rules/std_rule_cases/CV11.yml
@@ -356,10 +356,13 @@ test_fail_parenthesize_expression_when_config_shorthand_from_convert:
         preferred_type_casting_style: shorthand
 
 test_fail_parenthesize_expression_when_config_shorthand_from_convert:
+  # https://github.com/sqlfluff/sqlfluff/issues/4453
   fail_str: |
-    SELECT (TRIM(value:Longitude::VARCHAR))::DOUBLE AS longitude
+    select (trim(value:Longitude::varchar))::double as longitude;
+    select col:a.b:c::varchar as bar;
   fix_str: |
-    SELECT CAST(TRIM(CAST(value:Longitude AS varchar) AS DOUBLE) as longitude
+    select cast((trim(cast(value:Longitude as varchar))) as double) as longitude;
+    select cast(col:a.b:c as varchar) as bar;
   configs:
     core:
       dialect: snowflake


### PR DESCRIPTION
This resolves #4453. The algorithm in `CV11` didn't account for the parse structure of semi-structured accessing. This extends the handling to deal more robustly with that.