### PR TITLE
Try parse caching

### DIFF
--- a/src/sqlfluff/core/parser/context.py
+++ b/src/sqlfluff/core/parser/context.py
@@ -42,6 +42,9 @@ class RootParseContext:
         self.logger = parser_logger
         # A uuid for this parse context to enable cache invalidation
         self.uuid = uuid.uuid4()
+        # A dict for parse caching. This is reset for each file,
+        # but persists for the duration of an individual file parse.
+        self._parse_cache = {}
 
     @classmethod
     def from_config(cls, config, **overrides: Dict[str, bool]) -> "RootParseContext":

--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -25,6 +25,10 @@ class AnyNumberOf(BaseGrammar):
         self.max_times_per_element = kwargs.pop("max_times_per_element", None)
         # Any patterns to _prevent_ a match.
         self.exclude = kwargs.pop("exclude", None)
+        # The intent here is that if we match something, and then the _next_
+        # item is one of these, we can safely conclude it's a "total" match.
+        # In those cases, we return early without considering more options.
+        self.terminators = kwargs.pop("terminators", None)
         super().__init__(*args, **kwargs)
 
     @cached_method_for_parse_context
@@ -150,6 +154,7 @@ class AnyNumberOf(BaseGrammar):
                 available_options,
                 parse_context=ctx,
                 trim_noncode=False,
+                terminators=self.terminators,
             )
 
         return match, matched_option

--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -3,6 +3,7 @@
 import copy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional, Union, Type, Tuple, Any
+from uuid import uuid4
 
 from sqlfluff.core.errors import SQLParseError
 from sqlfluff.core.string_helpers import curtail_string
@@ -163,6 +164,15 @@ class BaseGrammar(Matchable):
         # If this is the case, the actual segment construction happens in the
         # match_wrapper.
         self.ephemeral_name = ephemeral_name
+        # Generate a cache key
+        self._cache_key = uuid4().hex
+
+    def cache_key(self) -> str:
+        """Get the cache key for this grammar.
+
+        For grammars these are unique per-instance.
+        """
+        return self._cache_key
 
     def is_optional(self):
         """Return whether this segment is optional.
@@ -218,13 +228,40 @@ class BaseGrammar(Matchable):
         if trim_noncode:
             pre_nc, segments, post_nc = trim_non_code_segments(segments)
 
+        # Characterise this location.
+        # Initial segment raw, loc, type and length of segment series.
+        loc_key = (segments[0].raw, segments[0].pos_marker.working_loc, segments[0].get_type(), len(segments))
+
         best_match_length = 0
         # iterate at this position across all the matchers
         for matcher in matchers:
-            # MyPy seems to require a type hint here. Not quite sure why.
-            res_match: MatchResult = matcher.match(
-                segments, parse_context=parse_context
-            )
+            
+            # Need to cache against the matcher too.
+            cache_key = (loc_key, matcher.cache_key())
+
+            # Check parse cache.
+            # TODO: We shouldn't be reaching through this many private methods!!!
+            # TODO: TIDY THIS UP LATER
+            if cache_key in parse_context._root_ctx._parse_cache:
+                # If it is, reuse that one. Don't re-match.
+                res_match = parse_context._root_ctx._parse_cache[cache_key]
+                
+                # TODO: Revise this logging if it works.
+                parse_match_logging(
+                    cls.__name__,
+                    "_look_ahead_match",
+                    "CH!",
+                    parse_context=parse_context,
+                    cache_hit="TRUE - CACHE HIT",
+                )
+            else:
+                # MyPy seems to require a type hint here. Not quite sure why.
+                res_match: MatchResult = matcher.match(
+                    segments, parse_context=parse_context
+                )
+                # Cache it, in case we need it later.
+                parse_context._root_ctx._parse_cache[cache_key] = res_match
+
             if res_match.is_complete():
                 # Just return it! (WITH THE RIGHT OTHER STUFF)
                 if trim_noncode:

--- a/src/sqlfluff/core/parser/grammar/noncode.py
+++ b/src/sqlfluff/core/parser/grammar/noncode.py
@@ -23,6 +23,15 @@ class NonCodeMatcher(Matchable):
         """Not optional."""
         return False
 
+    def cache_key(self) -> str:
+        """Get the cache key for the matcher.
+
+        NOTE: In this case, this class is a bit of a singleton
+        and so we don't need a unique UUID in the same way as
+        other classes.
+        """
+        return "non-code-matcher"
+
     @match_wrapper(v_level=4)
     def match(self, segments, parse_context):
         """Match any starting non-code segments."""

--- a/src/sqlfluff/core/parser/matchable.py
+++ b/src/sqlfluff/core/parser/matchable.py
@@ -34,3 +34,12 @@ class Matchable(ABC):
     def copy(self, **kwargs) -> "Matchable":  # pragma: no cover TODO?
         """Copy this Matchable."""
         return copy.copy(self)
+
+    @abstractmethod
+    def cache_key(self) -> str:
+        """A string to use for cache keying.
+
+        This string should be unique at the parsing stage such that
+        if there has already been a match against this key for a set
+        of segments, that we can reuse that match.
+        """

--- a/src/sqlfluff/core/parser/parsers.py
+++ b/src/sqlfluff/core/parser/parsers.py
@@ -4,6 +4,7 @@ Matchable objects which return individual segments.
 """
 
 from abc import abstractmethod
+from uuid import uuid4
 import regex
 from typing import Collection, Type, Optional, List, Tuple, Union
 
@@ -32,6 +33,15 @@ class BaseParser(Matchable):
         self.type = type
         self.optional = optional
         self.segment_kwargs = segment_kwargs or {}
+        # Generate a cache key
+        self._cache_key = uuid4().hex
+
+    def cache_key(self) -> str:
+        """Get the cache key for this parser.
+
+        For parsers, they're unique per-instance.
+        """
+        return self._cache_key
 
     def is_optional(self) -> bool:
         """Return whether this element is optional."""

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -207,6 +207,10 @@ class SegmentMetaclass(type):
         here saves calculating it at runtime for each
         instance of the class.
         """
+        # Create a cache uuid on definition.
+        # We do it here so every _definition_ of a segment
+        # gets a unique UUID regardless of dialect.
+        class_dict["_cache_key"] = uuid4().hex
         class_obj = super().__new__(mcs, name, bases, class_dict)
         added_type = class_dict.get("type", None)
         class_types = {added_type} if added_type else set()
@@ -695,6 +699,14 @@ class BaseSegment(metaclass=SegmentMetaclass):
             # Other segments will either override this method, or aren't
             # simple.
             return None
+
+    @classmethod
+    def cache_key(cls) -> str:
+        """Return the cache key for this segment definition.
+
+        NOTE: The key itself is generated on _definition_ by the metaclass.
+        """
+        return cls._cache_key
 
     @classmethod
     def is_optional(cls):


### PR DESCRIPTION
This is a draft PR, which in testing on some files has _drastically_ reduced parsing time.

Part of the issue in parsing was that we were re-matching the same segments against the same matchers over and over again. This gets around that by caching results which can be reused if we try the same match again.

Draft until tests are passing.