### PR TITLE
Use terminators in BaseExpression

### DIFF
--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -25,6 +25,10 @@ class AnyNumberOf(BaseGrammar):
         self.max_times_per_element = kwargs.pop("max_times_per_element", None)
         # Any patterns to _prevent_ a match.
         self.exclude = kwargs.pop("exclude", None)
+        # The intent here is that if we match something, and then the _next_
+        # item is one of these, we can safely conclude it's a "total" match.
+        # In those cases, we return early without considering more options.
+        self.terminators = kwargs.pop("terminators", None)
         super().__init__(*args, **kwargs)
 
     @cached_method_for_parse_context
@@ -150,6 +154,7 @@ class AnyNumberOf(BaseGrammar):
                 available_options,
                 parse_context=ctx,
                 trim_noncode=False,
+                terminators=self.terminators,
             )
 
         return match, matched_option

--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -242,6 +242,10 @@ class BaseGrammar(Matchable):
                     best_match = res_match, matcher
                     best_match_length = res_match.trimmed_matched_length
 
+                    # If we've got a terminator next, it's an opportunity to
+                    # end earlier, and claim an effectively "complete" match.
+                    # NOTE: This means that by specifying terminators, we can
+                    # significantly increase performance.
                     if terminators:
                         _, segs, _ = trim_non_code_segments(
                             best_match[0].unmatched_segments

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -581,14 +581,18 @@ ansi_dialect.add(
     BaseExpressionElementGrammar=OneOf(
         Ref("LiteralGrammar"),
         Ref("BareFunctionSegment"),
+        Ref("ColumnReferenceSegment"),
         Ref("IntervalExpressionSegment"),
         Ref("FunctionSegment"),
-        Ref("ColumnReferenceSegment"),
         Ref("ExpressionSegment"),
         Sequence(
             Ref("DatatypeSegment"),
             Ref("LiteralGrammar"),
         ),
+        terminators=[
+            Ref("CommaSegment"),
+            Ref("AliasExpressionSegment"),
+        ]
     ),
     FilterClauseGrammar=Sequence(
         "FILTER", Bracketed(Sequence("WHERE", Ref("ExpressionSegment")))

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -589,6 +589,12 @@ ansi_dialect.add(
             Ref("DatatypeSegment"),
             Ref("LiteralGrammar"),
         ),
+        # These terminators allow better performance by giving a signal
+        # of a likely complete match if they come after a match. For
+        # example "123," only needs to match against the LiteralGrammar
+        # and because a comma follows, never be matched against
+        # ExpressionSegment or FunctionSegment, which are both much
+        # more complicated.
         terminators=[
             Ref("CommaSegment"),
             # TODO: We can almost certainly add a few more here, but for

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -581,9 +581,9 @@ ansi_dialect.add(
     BaseExpressionElementGrammar=OneOf(
         Ref("LiteralGrammar"),
         Ref("BareFunctionSegment"),
-        Ref("ColumnReferenceSegment"),
         Ref("IntervalExpressionSegment"),
         Ref("FunctionSegment"),
+        Ref("ColumnReferenceSegment"),
         Ref("ExpressionSegment"),
         Sequence(
             Ref("DatatypeSegment"),

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -591,8 +591,10 @@ ansi_dialect.add(
         ),
         terminators=[
             Ref("CommaSegment"),
-            Ref("AliasExpressionSegment"),
-        ]
+            # TODO: We can almost certainly add a few more here, but for
+            # now, the most reliable (and impactful) is the comma.
+            # Others could include some variant on AliasExpressionSegment.
+        ],
     ),
     FilterClauseGrammar=Sequence(
         "FILTER", Bracketed(Sequence("WHERE", Ref("ExpressionSegment")))


### PR DESCRIPTION
On heavily nested expressions, being able to shortcut when a "long enough" match is found helps significantly. On combination with #4576, this has a very significant effect on heavily nested files.

It's a slightly dialled back version of what I think could be achieved, but it's a step in the right direction and does have some impact already.