### PR TITLE
Fix #4559: TSQL implicit indents on WHERE

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -16,6 +16,7 @@ from sqlfluff.core.parser import (
     Dedent,
     Delimited,
     Indent,
+    ImplicitIndent,
     Matchable,
     Nothing,
     OneOf,
@@ -851,7 +852,7 @@ class WhereClauseSegment(BaseSegment):
     type = "where_clause"
     match_grammar = Sequence(
         "WHERE",
-        Indent,
+        ImplicitIndent,
         OptionallyBracketed(Ref("ExpressionSegment")),
         Dedent,
     )

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -1838,3 +1838,15 @@ test_indented_joins_4484:
   configs:
     indentation:
       indented_joins: true
+
+test_tsql_where_implicit_4559:
+  # https://github.com/sqlfluff/sqlfluff/issues/4559
+  pass_str: |
+    SELECT t.col1
+    WHERE t.col2 = 'foo'
+        AND t.col3 = 'bar'
+  configs:
+    core:
+      dialect: tsql
+    indentation:
+      allow_implicit_indents: true


### PR DESCRIPTION
This resolves #4559. TSQL reimplements `WhereClauseSegment` (and is the only dialect to do so) and didn't use the implicit indent segment. This fixes that (and adds a test case)