### PR TITLE
Make implicit indents visible in the parse tree

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -253,6 +253,8 @@ class BaseSegment(metaclass=SegmentMetaclass):
     # What other kwargs need to be copied when applying fixes.
     additional_kwargs: List[str] = []
     pos_marker: Optional[PositionMarker]
+    # _preface_modifier used in ._preface()
+    _preface_modifier: str = ""
 
     def __init__(
         self,
@@ -837,7 +839,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
         """Returns the preamble to any logging."""
         padded_type = "{padding}{modifier}{type}".format(
             padding=" " * (ident * tabsize),
-            modifier="[META] " if self.is_meta else "",
+            modifier=self._preface_modifier,
             type=self.get_type() + ":",
         )
         preface = "{pos:20}|{padded_type:60}  {suffix}".format(

--- a/src/sqlfluff/core/parser/segments/meta.py
+++ b/src/sqlfluff/core/parser/segments/meta.py
@@ -22,6 +22,7 @@ class MetaSegment(RawSegment):
     # closed on the same line.
     is_implicit = False
     is_meta = True
+    _preface_modifier = "[META] "
 
     def __init__(
         self,
@@ -122,6 +123,7 @@ class ImplicitIndent(Indent):
             AND b
     """
 
+    _preface_modifier = "[META] (implicit) "
     is_implicit = True
 
 


### PR DESCRIPTION
I found this while looking into #4559. Debugging implicit indents is hard because they're not obvious in the parse tree. This addresses that by making them more visible.

This change should really only affect logging - so I haven't included extensive tests.