### PR TITLE
Data type spacing

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -153,8 +153,8 @@ spacing_within = touch
 [sqlfluff:layout:type:struct_type]
 spacing_within = touch:inline
 
-[sqlfluff:layout:type:data_type]
-spacing_within = touch:inline
+[sqlfluff:layout:type:bracketed_arguments]
+spacing_before = touch:inline
 
 [sqlfluff:layout:type:typed_struct_literal]
 spacing_within = touch

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -166,6 +166,9 @@ spacing_before = touch:inline
 [sqlfluff:layout:type:array_accessor]
 spacing_before = touch:inline
 
+[sqlfluff:layout:type:colon]
+spacing_before = touch
+
 [sqlfluff:layout:type:comment]
 spacing_before = any
 spacing_after = any

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -881,17 +881,14 @@ class TimeZoneGrammar(BaseSegment):
 
 class BracketedArguments(BaseSegment):
     """A series of bracketed arguments.
-    
+
     e.g. the bracketed part of numeric(1, 3)
     """
 
     type = "bracketed_arguments"
     match_grammar = Bracketed(
         # The brackets might be empty for some cases...
-        Delimited(
-            Ref("LiteralGrammar"),
-            optional=True
-        ),
+        Delimited(Ref("LiteralGrammar"), optional=True),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -879,6 +879,22 @@ class TimeZoneGrammar(BaseSegment):
     )
 
 
+class BracketedArguments(BaseSegment):
+    """A series of bracketed arguments.
+    
+    e.g. the bracketed part of numeric(1, 3)
+    """
+
+    type = "bracketed_arguments"
+    match_grammar = Bracketed(
+        # The brackets might be empty for some cases...
+        Delimited(
+            Ref("LiteralGrammar"),
+            optional=True
+        ),
+    )
+
+
 class DatatypeSegment(BaseSegment):
     """A data type segment.
 
@@ -915,15 +931,8 @@ class DatatypeSegment(BaseSegment):
                     allow_gaps=False,
                 ),
             ),
-            Bracketed(
-                OneOf(
-                    Delimited(Ref("ExpressionSegment")),
-                    # The brackets might be empty for some cases...
-                    optional=True,
-                ),
-                # There may be no brackets for some data types
-                optional=True,
-            ),
+            # There may be no brackets for some data types
+            Ref("BracketedArguments", optional=True),
             OneOf(
                 "UNSIGNED",  # UNSIGNED MySQL
                 Ref("CharCharacterSetGrammar"),

--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -318,29 +318,8 @@ class PrimitiveTypeSegment(BaseSegment):
         "FLOAT",  # used in DDL
         "REAL",  # used "in SQL functions like SELECT CAST"
         Sequence(
-            "DECIMAL",
-            Bracketed(
-                Ref("NumericLiteralSegment"),
-                Sequence(
-                    Ref("CommaSegment"),
-                    Ref("NumericLiteralSegment"),
-                    optional=True,
-                ),
-            ),
-        ),
-        Sequence(
-            "CHAR",
-            Bracketed(
-                Ref("NumericLiteralSegment"),
-                optional=True,
-            ),
-        ),
-        Sequence(
-            "VARCHAR",
-            Bracketed(
-                Ref("NumericLiteralSegment"),
-                optional=True,
-            ),
+            OneOf("DECIMAL", "CHAR", "VARCHAR"),
+            Ref("BracketedArguments", optional=True),
         ),
         "STRING",
         "BINARY",

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1026,7 +1026,7 @@ class DatatypeSegment(ansi.DatatypeSegment):
         Sequence(
             Ref("DatatypeIdentifierSegment"),  # Simple type
             # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#parameterized_data_types
-            Bracketed(Delimited(Ref("NumericLiteralSegment")), optional=True),
+            Ref("BracketedArguments", optional=True),
         ),
         Sequence("ANY", "TYPE"),  # SQL UDFs can specify this "type"
         Ref("ArrayTypeSegment"),

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -101,13 +101,12 @@ clickhouse_dialect.add(
 )
 
 
-class BracketedArguments(BaseSegment):
+class BracketedArguments(ansi.BracketedArguments):
     """A series of bracketed arguments.
 
     e.g. the bracketed part of numeric(1, 3)
     """
 
-    type = "bracketed_arguments"
     match_grammar = Bracketed(
         Delimited(
             OneOf(

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -101,6 +101,26 @@ clickhouse_dialect.add(
 )
 
 
+class BracketedArguments(BaseSegment):
+    """A series of bracketed arguments.
+
+    e.g. the bracketed part of numeric(1, 3)
+    """
+
+    type = "bracketed_arguments"
+    match_grammar = Bracketed(
+        Delimited(
+            OneOf(
+                # Dataypes like Nullable allow optional datatypes here.
+                Ref("DatatypeIdentifierSegment"),
+                Ref("NumericLiteralSegment"),
+            ),
+            # The brackets might be empty for some cases...
+            optional=True,
+        ),
+    )
+
+
 class JoinClauseSegment(ansi.JoinClauseSegment):
     """Any number of join clauses, including the `JOIN` keyword.
 

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -1000,17 +1000,14 @@ class ColumnDatatypeSegment(BaseSegment):
 
 class BracketedArguments(BaseSegment):
     """A series of bracketed arguments.
-    
+
     e.g. the bracketed part of numeric(1, 3)
     """
 
     type = "bracketed_arguments"
     match_grammar = Bracketed(
         # The brackets might be empty for some cases...
-        Delimited(
-            Ref("NumericLiteralSegment"),
-            optional=True
-        ),
+        Delimited(Ref("NumericLiteralSegment"), optional=True),
         # In exasol, some types offer on optional MAX
         # qualifier of BIT, BYTE or CHAR
         OneOf("BIT", "BYTE", "CHAR", optional=True),

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -998,13 +998,12 @@ class ColumnDatatypeSegment(BaseSegment):
     )
 
 
-class BracketedArguments(BaseSegment):
+class BracketedArguments(ansi.BracketedArguments):
     """A series of bracketed arguments.
 
     e.g. the bracketed part of numeric(1, 3)
     """
 
-    type = "bracketed_arguments"
     match_grammar = Bracketed(
         # The brackets might be empty for some cases...
         Delimited(Ref("NumericLiteralSegment"), optional=True),

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -998,6 +998,25 @@ class ColumnDatatypeSegment(BaseSegment):
     )
 
 
+class BracketedArguments(BaseSegment):
+    """A series of bracketed arguments.
+    
+    e.g. the bracketed part of numeric(1, 3)
+    """
+
+    type = "bracketed_arguments"
+    match_grammar = Bracketed(
+        # The brackets might be empty for some cases...
+        Delimited(
+            Ref("NumericLiteralSegment"),
+            optional=True
+        ),
+        # In exasol, some types offer on optional MAX
+        # qualifier of BIT, BYTE or CHAR
+        OneOf("BIT", "BYTE", "CHAR", optional=True),
+    )
+
+
 class DatatypeSegment(BaseSegment):
     """A data type segment.
 
@@ -1012,12 +1031,7 @@ class DatatypeSegment(BaseSegment):
         # Numeric Data Types
         Sequence(
             OneOf("DECIMAL", "DEC", "NUMBER", "NUMERIC"),
-            Bracketed(
-                Delimited(
-                    Ref("NumericLiteralSegment"),
-                ),
-                optional=True,
-            ),
+            Ref("BracketedArguments", optional=True),
         ),
         "BIGINT",
         Sequence("DOUBLE", Ref.keyword("PRECISION", optional=True)),
@@ -1038,29 +1052,25 @@ class DatatypeSegment(BaseSegment):
         Sequence(
             "INTERVAL",
             "YEAR",
-            Bracketed(Ref("NumericLiteralSegment"), optional=True),
+            Ref("BracketedArguments", optional=True),
             "TO",
             "MONTH",
         ),
         Sequence(
             "INTERVAL",
             "DAY",
-            Bracketed(Ref("NumericLiteralSegment"), optional=True),
+            Ref("BracketedArguments", optional=True),
             "TO",
             "SECOND",
-            Bracketed(Ref("NumericLiteralSegment"), optional=True),
+            Ref("BracketedArguments", optional=True),
         ),
         Sequence(
             "GEOMETRY",
-            Bracketed(Ref("NumericLiteralSegment"), optional=True),
+            Ref("BracketedArguments", optional=True),
         ),
         Sequence(
             "HASHTYPE",
-            Bracketed(
-                Ref("NumericLiteralSegment"),
-                OneOf("BIT", "BYTE", optional=True),
-                optional=True,
-            ),
+            Ref("BracketedArguments", optional=True),
         ),
         Sequence(
             OneOf(
@@ -1073,23 +1083,19 @@ class DatatypeSegment(BaseSegment):
                         "NVARCHAR",
                         "NVARCHAR2",
                     ),
-                    Bracketed(
-                        Ref("NumericLiteralSegment"),
-                        OneOf("CHAR", "BYTE", optional=True),
-                        optional=True,
-                    ),
+                    Ref("BracketedArguments", optional=True),
                 ),
                 Sequence("LONG", "VARCHAR"),
                 Sequence(
                     "CHARACTER",
                     Sequence(
                         OneOf(Sequence("LARGE", "OBJECT"), "VARYING", optional=True),
-                        Bracketed(Ref("NumericLiteralSegment"), optional=True),
+                        Ref("BracketedArguments", optional=True),
                     ),
                 ),
                 Sequence(
                     "CLOB",
-                    Bracketed(Ref("NumericLiteralSegment"), optional=True),
+                    Ref("BracketedArguments", optional=True),
                 ),
             ),
             Ref("CharCharacterSetGrammar", optional=True),

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -472,12 +472,7 @@ class PrimitiveTypeSegment(BaseSegment):
         "TIMESTAMP",
         Sequence(
             OneOf("DECIMAL", "DEC", "NUMERIC"),
-            Bracketed(
-                Ref("NumericLiteralSegment"),
-                Ref("CommaSegment"),
-                Ref("NumericLiteralSegment"),
-                optional=True,
-            ),
+            Ref("BracketedArguments", optional=True),
         ),
         "DATE",
         "VARCHAR",

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -255,7 +255,7 @@ class StructTypeSchemaSegment(BaseSegment):
     match_grammar = Bracketed(
         Delimited(
             Sequence(
-                Ref("NakedIdentifierSegment"),
+                Ref("SingleIdentifierGrammar"),
                 Ref("ColonSegment"),
                 Ref("DatatypeSegment"),
                 Ref("CommentGrammar", optional=True),

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -118,7 +118,7 @@ postgres_dialect.insert_lexer_matchers(
             r"[bBxX]'[0-9a-fA-F]*'",
             CodeSegment,
             segment_kwargs={"type": "bit_string_literal"},
-        )
+        ),
     ],
     before="like_operator",
 )

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -111,6 +111,14 @@ postgres_dialect.insert_lexer_matchers(
             segment_kwargs={"type": "json_operator"},
         ),
         StringLexer("at", "@", CodeSegment),
+        # https://www.postgresql.org/docs/current/sql-syntax-lexical.html
+        RegexLexer(
+            "bit_string_literal",
+            # binary (e.g. b'1001') or hex (e.g. X'1FF')
+            r"[bBxX]'[0-9a-fA-F]*'",
+            CodeSegment,
+            segment_kwargs={"type": "bit_string_literal"},
+        )
     ],
     before="like_operator",
 )
@@ -305,6 +313,21 @@ postgres_dialect.replace(
                 Ref("MultilineConcatenateDelimiterGrammar"),
                 TypedParser(
                     "single_quote",
+                    ansi.LiteralSegment,
+                    type="quoted_literal",
+                ),
+            ),
+        ),
+        Sequence(
+            TypedParser(
+                "bit_string_literal",
+                ansi.LiteralSegment,
+                type="quoted_literal",
+            ),
+            AnyNumberOf(
+                Ref("MultilineConcatenateDelimiterGrammar"),
+                TypedParser(
+                    "bit_string_literal",
                     ansi.LiteralSegment,
                     type="quoted_literal",
                 ),
@@ -629,15 +652,12 @@ class DatatypeSegment(ansi.DatatypeSegment):
                     # numeric types [(precision)]
                     Sequence(
                         OneOf("FLOAT"),
-                        Bracketed(Ref("NumericLiteralSegment"), optional=True),
+                        Ref("BracketedArguments", optional=True),
                     ),
                     # numeric types [precision ["," scale])]
                     Sequence(
                         OneOf("DECIMAL", "NUMERIC"),
-                        Bracketed(
-                            Delimited(Ref("NumericLiteralSegment")),
-                            optional=True,
-                        ),
+                        Ref("BracketedArguments", optional=True),
                     ),
                     # monetary type
                     "MONEY",
@@ -650,7 +670,7 @@ class DatatypeSegment(ansi.DatatypeSegment):
                                 Sequence("CHARACTER", "VARYING"),
                                 "VARCHAR",
                             ),
-                            Bracketed(Ref("NumericLiteralSegment"), optional=True),
+                            Ref("BracketedArguments", optional=True),
                         ),
                         "TEXT",
                     ),
@@ -668,10 +688,7 @@ class DatatypeSegment(ansi.DatatypeSegment):
                     Sequence(
                         "BIT",
                         OneOf("VARYING", optional=True),
-                        Bracketed(
-                            Ref("NumericLiteralSegment"),
-                            optional=True,
-                        ),
+                        Ref("BracketedArguments", optional=True),
                     ),
                     # uuid type
                     "UUID",

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -332,6 +332,27 @@ class DateTimeTypeIdentifier(BaseSegment):
     )
 
 
+class BracketedArguments(BaseSegment):
+    """A series of bracketed arguments.
+    
+    e.g. the bracketed part of numeric(1, 3)
+    """
+
+    type = "bracketed_arguments"
+    match_grammar = Bracketed(
+        # The brackets might be empty for some cases...
+        Delimited(
+            OneOf(
+                Ref("LiteralGrammar"),
+                # In redshift, character types offer on optional MAX
+                # keyword in their parameters.
+                "MAX",
+            ),
+            optional=True
+        ),
+    )
+
+
 class DatatypeSegment(BaseSegment):
     """A data type segment.
 
@@ -358,10 +379,7 @@ class DatatypeSegment(BaseSegment):
         # numeric types [precision ["," scale])]
         Sequence(
             OneOf("DECIMAL", "NUMERIC"),
-            Bracketed(
-                Delimited(Ref("NumericLiteralSegment")),
-                optional=True,
-            ),
+            Ref("BracketedArguments", optional=True),
         ),
         # character types
         OneOf(
@@ -374,13 +392,7 @@ class DatatypeSegment(BaseSegment):
                     Sequence("CHARACTER", "VARYING"),
                     "NVARCHAR",
                 ),
-                Bracketed(
-                    OneOf(
-                        Ref("NumericLiteralSegment"),
-                        "MAX",
-                    ),
-                    optional=True,
-                ),
+                Ref("BracketedArguments", optional=True),
             ),
             "BPCHAR",
             "TEXT",
@@ -404,10 +416,7 @@ class DatatypeSegment(BaseSegment):
                 "VARBINARY",
                 Sequence("BINARY", "VARYING"),
             ),
-            Bracketed(
-                Ref("NumericLiteralSegment"),
-                optional=True,
-            ),
+            Ref("BracketedArguments", optional=True),
         ),
         "ANYELEMENT",
     )

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -334,7 +334,7 @@ class DateTimeTypeIdentifier(BaseSegment):
 
 class BracketedArguments(BaseSegment):
     """A series of bracketed arguments.
-    
+
     e.g. the bracketed part of numeric(1, 3)
     """
 
@@ -348,7 +348,7 @@ class BracketedArguments(BaseSegment):
                 # keyword in their parameters.
                 "MAX",
             ),
-            optional=True
+            optional=True,
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -332,13 +332,12 @@ class DateTimeTypeIdentifier(BaseSegment):
     )
 
 
-class BracketedArguments(BaseSegment):
+class BracketedArguments(ansi.BracketedArguments):
     """A series of bracketed arguments.
 
     e.g. the bracketed part of numeric(1, 3)
     """
 
-    type = "bracketed_arguments"
     match_grammar = Bracketed(
         # The brackets might be empty for some cases...
         Delimited(

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -749,16 +749,19 @@ class PrimitiveTypeSegment(BaseSegment):
 
 class ArrayTypeSegment(hive.ArrayTypeSegment):
     """ARRAY type as per hive"""
+
     pass
 
 
 class StructTypeSegment(hive.StructTypeSegment):
     """STRUCT type as per hive"""
+
     pass
 
 
 class StructTypeSchemaSegment(hive.StructTypeSchemaSegment):
     """STRUCT type schema as per hive"""
+
     pass
 
 

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -748,19 +748,19 @@ class PrimitiveTypeSegment(BaseSegment):
 
 
 class ArrayTypeSegment(hive.ArrayTypeSegment):
-    """ARRAY type as per hive"""
+    """ARRAY type as per hive."""
 
     pass
 
 
 class StructTypeSegment(hive.StructTypeSegment):
-    """STRUCT type as per hive"""
+    """STRUCT type as per hive."""
 
     pass
 
 
 class StructTypeSchemaSegment(hive.StructTypeSchemaSegment):
-    """STRUCT type schema as per hive"""
+    """STRUCT type schema as per hive."""
 
     pass
 

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -739,24 +739,30 @@ class PrimitiveTypeSegment(BaseSegment):
         "TIMESTAMP",
         "STRING",
         Sequence(
-            OneOf("CHAR", "CHARACTER", "VARCHAR"),
-            Bracketed(Ref("NumericLiteralSegment"), optional=True),
+            OneOf("CHAR", "CHARACTER", "VARCHAR", "DECIMAL", "DEC", "NUMERIC"),
+            Ref("BracketedArguments", optional=True),
         ),
         "BINARY",
-        Sequence(
-            OneOf("DECIMAL", "DEC", "NUMERIC"),
-            Bracketed(
-                Ref("NumericLiteralSegment"),
-                Ref("CommaSegment"),
-                Ref("NumericLiteralSegment"),
-                optional=True,
-            ),
-        ),
         "INTERVAL",
     )
 
 
-class DatatypeSegment(PrimitiveTypeSegment):
+class ArrayTypeSegment(hive.ArrayTypeSegment):
+    """ARRAY type as per hive"""
+    pass
+
+
+class StructTypeSegment(hive.StructTypeSegment):
+    """STRUCT type as per hive"""
+    pass
+
+
+class StructTypeSchemaSegment(hive.StructTypeSchemaSegment):
+    """STRUCT type schema as per hive"""
+    pass
+
+
+class DatatypeSegment(BaseSegment):
     """Spark SQL Data types.
 
     https://spark.apache.org/docs/latest/sql-ref-datatypes.html
@@ -765,14 +771,7 @@ class DatatypeSegment(PrimitiveTypeSegment):
     type = "data_type"
     match_grammar = OneOf(
         Ref("PrimitiveTypeSegment"),
-        Sequence(
-            "ARRAY",
-            Bracketed(
-                Ref("DatatypeSegment"),
-                bracket_pairs_set="angle_bracket_pairs",
-                bracket_type="angle",
-            ),
-        ),
+        Ref("ArrayTypeSegment"),
         Sequence(
             "MAP",
             Bracketed(
@@ -785,23 +784,7 @@ class DatatypeSegment(PrimitiveTypeSegment):
                 bracket_type="angle",
             ),
         ),
-        Sequence(
-            "STRUCT",
-            Bracketed(
-                # CommentGrammar here is valid Spark SQL
-                # even though its not stored in Sparks Catalog
-                Delimited(
-                    Sequence(
-                        Ref("SingleIdentifierGrammar"),
-                        Ref("ColonSegment"),
-                        Ref("DatatypeSegment"),
-                        Ref("CommentGrammar", optional=True),
-                    ),
-                ),
-                bracket_pairs_set="angle_bracket_pairs",
-                bracket_type="angle",
-            ),
-        ),
+        Ref("StructTypeSegment"),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -263,15 +263,7 @@ class DatatypeSegment(ansi.DatatypeSegment):
                 ),
                 Ref("DatatypeIdentifierSegment"),
             ),
-            Bracketed(
-                OneOf(
-                    Delimited(Ref("ExpressionSegment")),
-                    # The brackets might be empty for some cases...
-                    optional=True,
-                ),
-                # There may be no brackets for some data types
-                optional=True,
-            ),
+            Ref("BracketedArguments", optional=True),
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_sqlite_keywords.py
+++ b/src/sqlfluff/dialects/dialect_sqlite_keywords.py
@@ -175,6 +175,7 @@ UNRESERVED_KEYWORDS = [
     "CLOB",
     "BLOB",
     "REAL",
+    "BIG",
     "DOUBLE",
     "PRECISION",
     "FLOAT",

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -380,6 +380,7 @@ class DatatypeSegment(ansi.DatatypeSegment):
 
     match_grammar = Sequence(
         Ref("DatatypeIdentifierSegment"),
+        Ref("BracketedArguments", optional=True),
         Bracketed(
             OneOf(
                 Delimited(Ref("ExpressionSegment")),

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1859,7 +1859,7 @@ class GoStatementSegment(BaseSegment):
 
 class BracketedArguments(BaseSegment):
     """A series of bracketed arguments.
-    
+
     e.g. the bracketed part of numeric(1, 3)
     """
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1857,13 +1857,12 @@ class GoStatementSegment(BaseSegment):
     match_grammar = Ref.keyword("GO")
 
 
-class BracketedArguments(BaseSegment):
+class BracketedArguments(ansi.BracketedArguments):
     """A series of bracketed arguments.
 
     e.g. the bracketed part of numeric(1, 3)
     """
 
-    type = "bracketed_arguments"
     match_grammar = Bracketed(
         Delimited(
             OneOf(

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1857,6 +1857,27 @@ class GoStatementSegment(BaseSegment):
     match_grammar = Ref.keyword("GO")
 
 
+class BracketedArguments(BaseSegment):
+    """A series of bracketed arguments.
+    
+    e.g. the bracketed part of numeric(1, 3)
+    """
+
+    type = "bracketed_arguments"
+    match_grammar = Bracketed(
+        # The brackets might be empty for some cases...
+        Delimited(
+            OneOf(
+                # TSQL allows optional MAX in some data types
+                "MAX",
+                Delimited(Ref("ExpressionSegment")),
+                # The brackets might be empty for some cases...
+                optional=True,
+            ),
+        ),
+    )
+
+
 class DatatypeSegment(BaseSegment):
     """A data type segment.
 
@@ -1878,16 +1899,7 @@ class DatatypeSegment(BaseSegment):
         ),
         # Stop Gap until explicit Data Types as only relevent for character
         Ref.keyword("VARYING", optional=True),
-        Bracketed(
-            OneOf(
-                "MAX",
-                Delimited(Ref("ExpressionSegment")),
-                # The brackets might be empty for some cases...
-                optional=True,
-            ),
-            # There may be no brackets for some data types
-            optional=True,
-        ),
+        Ref("BracketedArguments", optional=True),
         Ref("CharCharacterSetGrammar", optional=True),
     )
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1865,15 +1865,14 @@ class BracketedArguments(BaseSegment):
 
     type = "bracketed_arguments"
     match_grammar = Bracketed(
-        # The brackets might be empty for some cases...
         Delimited(
             OneOf(
                 # TSQL allows optional MAX in some data types
                 "MAX",
-                Delimited(Ref("ExpressionSegment")),
-                # The brackets might be empty for some cases...
-                optional=True,
+                Ref("ExpressionSegment"),
             ),
+            # The brackets might be empty for some cases...
+            optional=True,
         ),
     )
 

--- a/test/fixtures/dialects/ansi/ansi_cast_with_whitespaces.yml
+++ b/test/fixtures/dialects/ansi/ansi_cast_with_whitespaces.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 16bffa5df2ab1ccf240d9e0f886e0892fb7653fec079027c2e0957b8dda7bc09
+_hash: 98901f41139ba11863745752a671f49b443c94a77a7fd6ece89c6f40ffb33aff
 file:
 - statement:
     select_statement:
@@ -137,11 +137,11 @@ file:
               casting_operator: '::'
               data_type:
                 data_type_identifier: VARCHAR
-                bracketed:
-                  start_bracket: (
-                  expression:
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
                     numeric_literal: '512'
-                  end_bracket: )
+                    end_bracket: )
       from_clause:
         keyword: FROM
         from_expression:
@@ -231,11 +231,11 @@ file:
                   casting_operator: '::'
                   data_type:
                     data_type_identifier: VARCHAR
-                    bracketed:
-                      start_bracket: (
-                      expression:
+                    bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
                         numeric_literal: '512'
-                      end_bracket: )
+                        end_bracket: )
               - comparison_operator:
                   raw_comparison_operator: '='
               - cast_expression:
@@ -246,11 +246,11 @@ file:
                   casting_operator: '::'
                   data_type:
                     data_type_identifier: VARCHAR
-                    bracketed:
-                      start_bracket: (
-                      expression:
+                    bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
                         numeric_literal: '512'
-                      end_bracket: )
+                        end_bracket: )
       where_clause:
         keyword: WHERE
         expression:

--- a/test/fixtures/dialects/ansi/create_table_column_comment.yml
+++ b/test/fixtures/dialects/ansi/create_table_column_comment.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f750b63c91a2ba7f4d2f5925dc63e4e39a07723ce9d01242e01b4991c4634bde
+_hash: b4f5a4ef29cb9b0822653e329beb20cb29f4b504edf94d688056a0039b317f4c
 file:
   statement:
     create_table_statement:
@@ -17,11 +17,11 @@ file:
           naked_identifier: id
           data_type:
             data_type_identifier: VARCHAR
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '100'
-              end_bracket: )
+                end_bracket: )
           column_constraint_segment:
             comment_clause:
               keyword: COMMENT

--- a/test/fixtures/dialects/ansi/create_table_column_constraint.yml
+++ b/test/fixtures/dialects/ansi/create_table_column_constraint.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e0482f0f2f6480c796b00f793b89ddd654365fbf4f741719eff8fea05625c9da
+_hash: 63b85c70e580cbb8521d6485449c04eba626e93d2f7e68c5fdcdf4d0c39e9279
 file:
 - statement:
     create_table_statement:
@@ -85,11 +85,11 @@ file:
           naked_identifier: LastName
           data_type:
             data_type_identifier: varchar
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '255'
-              end_bracket: )
+                end_bracket: )
           column_constraint_segment:
           - keyword: NOT
           - keyword: 'NULL'
@@ -98,11 +98,11 @@ file:
           naked_identifier: FirstName
           data_type:
             data_type_identifier: varchar
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '255'
-              end_bracket: )
+                end_bracket: )
       - comma: ','
       - column_definition:
           naked_identifier: Age
@@ -113,11 +113,11 @@ file:
           naked_identifier: City
           data_type:
             data_type_identifier: varchar
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '255'
-              end_bracket: )
+                end_bracket: )
       - comma: ','
       - column_definition:
           naked_identifier: CONSTRAINT

--- a/test/fixtures/dialects/ansi/create_table_table_comment.yml
+++ b/test/fixtures/dialects/ansi/create_table_table_comment.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0f17c9e8db507f2549f422e942881114771ad24fe496b15ddd4eb4827a48103b
+_hash: da6f038cd44a46433364b3711dd06159873265fb4432c8c90053a97068b9b4b6
 file:
   statement:
     create_table_statement:
@@ -17,11 +17,11 @@ file:
           naked_identifier: id
           data_type:
             data_type_identifier: VARCHAR
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '100'
-              end_bracket: )
+                end_bracket: )
         end_bracket: )
     - comment_clause:
         keyword: COMMENT

--- a/test/fixtures/dialects/ansi/create_table_varchar.yml
+++ b/test/fixtures/dialects/ansi/create_table_varchar.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d832e3cb263c7f053601b9bf1e85b500e2293228827efd8d1da15bda68a06994
+_hash: ddbfbeee0227954476881c7b0236fdc0ca7fa47d1401c2911ed5508aff69f55f
 file:
   statement:
     create_table_statement:
@@ -17,9 +17,9 @@ file:
           naked_identifier: id
           data_type:
             data_type_identifier: VARCHAR
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '100'
-              end_bracket: )
+                end_bracket: )
         end_bracket: )

--- a/test/fixtures/dialects/athena/create_struct_table.yml
+++ b/test/fixtures/dialects/athena/create_struct_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 83dd94e5079631bf1bc7d5abce6bbffad6f7717340bb7f857b3cd96048df7f97
+_hash: 38d98df551428927f3dfbb68de7c816f03dfbd3cc494a3b07241c92db86247fe
 file:
 - statement:
     create_table_statement:
@@ -25,10 +25,11 @@ file:
               - data_type:
                   primitive_type:
                     keyword: varchar
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '10'
-                      end_bracket: )
+                    bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
+                        numeric_literal: '10'
+                        end_bracket: )
               - comma: ','
               - naked_identifier: age
               - colon: ':'
@@ -76,10 +77,11 @@ file:
                   - data_type:
                       primitive_type:
                         keyword: VARCHAR
-                        bracketed:
-                          start_bracket: (
-                          numeric_literal: '10'
-                          end_bracket: )
+                        bracketed_arguments:
+                          bracketed:
+                            start_bracket: (
+                            numeric_literal: '10'
+                            end_bracket: )
                   - comma: ','
                   - naked_identifier: age
                   - data_type:

--- a/test/fixtures/dialects/bigquery/declare_variable.yml
+++ b/test/fixtures/dialects/bigquery/declare_variable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0854d63975062f8193290e2ec7cfee33038b33404ad8ce59bb6cb165d20e4c7e
+_hash: 5b2050e76f6e2498f1fbdbe605abe116b14b2f43edfb1b5108fe2258010e715b
 file:
 - statement:
     declare_segment:
@@ -46,10 +46,11 @@ file:
       naked_identifier: var6
       data_type:
         data_type_identifier: string
-        bracketed:
-          start_bracket: (
-          numeric_literal: '10'
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            numeric_literal: '10'
+            end_bracket: )
 - statement_terminator: ;
 - statement:
     declare_segment:
@@ -57,12 +58,13 @@ file:
       naked_identifier: var7
       data_type:
         data_type_identifier: numeric
-        bracketed:
-        - start_bracket: (
-        - numeric_literal: '5'
-        - comma: ','
-        - numeric_literal: '2'
-        - end_bracket: )
+        bracketed_arguments:
+          bracketed:
+          - start_bracket: (
+          - numeric_literal: '5'
+          - comma: ','
+          - numeric_literal: '2'
+          - end_bracket: )
 - statement_terminator: ;
 - statement:
     declare_segment:
@@ -126,10 +128,11 @@ file:
           start_angle_bracket: <
           data_type:
             data_type_identifier: string
-            bracketed:
-              start_bracket: (
-              numeric_literal: '10'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '10'
+                end_bracket: )
           end_angle_bracket: '>'
 - statement_terminator: ;
 - statement:
@@ -235,18 +238,20 @@ file:
           - parameter: f1
           - data_type:
               data_type_identifier: string
-              bracketed:
-                start_bracket: (
-                numeric_literal: '10'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
           - comma: ','
           - parameter: f2
           - data_type:
               data_type_identifier: string
-              bracketed:
-                start_bracket: (
-                numeric_literal: '10'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '10'
+                  end_bracket: )
           - end_angle_bracket: '>'
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/clickhouse/create_table.yml
+++ b/test/fixtures/dialects/clickhouse/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8e1c3bbca74a1db024b87f5c5657fb94c22cdc895cd6716d8708f832a3c4e768
+_hash: 202c38edd25795f71b9e328b40440188d0fba28ab37bf7fa65f28a4759eb22c7
 file:
 - statement:
     create_table_statement:
@@ -477,12 +477,11 @@ file:
           naked_identifier: s
           data_type:
             data_type_identifier: Nullable
-            bracketed:
-              start_bracket: (
-              expression:
-                column_reference:
-                  naked_identifier: String
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                data_type_identifier: String
+                end_bracket: )
       - end_bracket: )
     - engine:
       - keyword: ENGINE

--- a/test/fixtures/dialects/db2/create_table_field_name_with_pound_sign.yml
+++ b/test/fixtures/dialects/db2/create_table_field_name_with_pound_sign.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 10f3b4f58d751b37ee4aa9a901fdea77a7ec0175e149f9288a0168cf1462fdf5
+_hash: 13105ac0dbc90718b62d6e22bace4ccb56603dbc9629cffda3add9014a2307a1
 file:
   statement:
     create_table_statement:
@@ -17,39 +17,36 @@ file:
           naked_identifier: my_field_1#
           data_type:
             data_type_identifier: decimal
-            bracketed:
-            - start_bracket: (
-            - expression:
-                numeric_literal: '2'
-            - comma: ','
-            - expression:
-                numeric_literal: '0'
-            - end_bracket: )
+            bracketed_arguments:
+              bracketed:
+              - start_bracket: (
+              - numeric_literal: '2'
+              - comma: ','
+              - numeric_literal: '0'
+              - end_bracket: )
       - comma: ','
       - column_definition:
           naked_identifier: '#my_field_1'
           data_type:
             data_type_identifier: decimal
-            bracketed:
-            - start_bracket: (
-            - expression:
-                numeric_literal: '2'
-            - comma: ','
-            - expression:
-                numeric_literal: '0'
-            - end_bracket: )
+            bracketed_arguments:
+              bracketed:
+              - start_bracket: (
+              - numeric_literal: '2'
+              - comma: ','
+              - numeric_literal: '0'
+              - end_bracket: )
       - comma: ','
       - column_definition:
           naked_identifier: '#'
           data_type:
             data_type_identifier: decimal
-            bracketed:
-            - start_bracket: (
-            - expression:
-                numeric_literal: '2'
-            - comma: ','
-            - expression:
-                numeric_literal: '0'
-            - end_bracket: )
+            bracketed_arguments:
+              bracketed:
+              - start_bracket: (
+              - numeric_literal: '2'
+              - comma: ','
+              - numeric_literal: '0'
+              - end_bracket: )
       - end_bracket: )
   statement_terminator: ;

--- a/test/fixtures/dialects/exasol/AlterTableColumn.yml
+++ b/test/fixtures/dialects/exasol/AlterTableColumn.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 830de392062d8919d6406b638f6a147ab37532248dd51fec82eaf3a04c3689c9
+_hash: 2b5949c81506c6ef3ba0649f65e32fd812eb7682e6080c9e181520ba389c9635
 file:
 - statement:
     alter_table_statement:
@@ -23,12 +23,13 @@ file:
               naked_identifier: new_dec
               data_type:
                 keyword: DECIMAL
-                bracketed:
-                - start_bracket: (
-                - numeric_literal: '18'
-                - comma: ','
-                - numeric_literal: '0'
-                - end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '18'
+                  - comma: ','
+                  - numeric_literal: '0'
+                  - end_bracket: )
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -46,10 +47,11 @@ file:
                 naked_identifier: new_char
                 data_type:
                   keyword: CHAR
-                  bracketed:
-                    start_bracket: (
-                    numeric_literal: '10'
-                    end_bracket: )
+                  bracketed_arguments:
+                    bracketed:
+                      start_bracket: (
+                      numeric_literal: '10'
+                      end_bracket: )
               column_constraint_segment:
                 keyword: DEFAULT
                 quoted_literal: "'some text'"
@@ -94,12 +96,13 @@ file:
             naked_identifier: i
             data_type:
               keyword: DECIMAL
-              bracketed:
-              - start_bracket: (
-              - numeric_literal: '10'
-              - comma: ','
-              - numeric_literal: '2'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - numeric_literal: '10'
+                - comma: ','
+                - numeric_literal: '2'
+                - end_bracket: )
             end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -116,10 +119,11 @@ file:
             naked_identifier: j
             data_type:
               keyword: VARCHAR
-              bracketed:
-                start_bracket: (
-                numeric_literal: '5'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '5'
+                  end_bracket: )
             column_constraint_segment:
               keyword: DEFAULT
               quoted_literal: "'text'"

--- a/test/fixtures/dialects/exasol/CreateFunctionStatement.yml
+++ b/test/fixtures/dialects/exasol/CreateFunctionStatement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2e5f4282870203bb218cfe9656c1475a83f328312317f4a6c17f56643b3e2a27
+_hash: f33f127aa0ec656ffa63587a2620ba4bdcbca0870d610d867b8b656a567b6784
 file:
 - statement:
     create_function_statement:
@@ -26,10 +26,11 @@ file:
     - keyword: RETURN
     - data_type:
         keyword: VARCHAR
-        bracketed:
-          start_bracket: (
-          numeric_literal: '10'
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            numeric_literal: '10'
+            end_bracket: )
     - keyword: AS
     - variable: res
     - data_type:
@@ -79,10 +80,11 @@ file:
     - keyword: RETURN
     - data_type:
         keyword: VARCHAR
-        bracketed:
-          start_bracket: (
-          numeric_literal: '10'
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            numeric_literal: '10'
+            end_bracket: )
     - keyword: AS
     - variable: res
     - data_type:
@@ -126,10 +128,11 @@ file:
     - keyword: RETURN
     - data_type:
         keyword: VARCHAR
-        bracketed:
-          start_bracket: (
-          numeric_literal: '10'
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            numeric_literal: '10'
+            end_bracket: )
     - keyword: AS
     - variable: res
     - data_type:
@@ -183,10 +186,11 @@ file:
     - keyword: RETURN
     - data_type:
         keyword: VARCHAR
-        bracketed:
-          start_bracket: (
-          numeric_literal: '10'
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            numeric_literal: '10'
+            end_bracket: )
     - keyword: AS
     - variable: res
     - data_type:
@@ -221,10 +225,11 @@ file:
     - keyword: RETURN
     - data_type:
         keyword: VARCHAR
-        bracketed:
-          start_bracket: (
-          numeric_literal: '10'
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            numeric_literal: '10'
+            end_bracket: )
     - keyword: AS
     - variable: res
     - data_type:
@@ -307,10 +312,11 @@ file:
     - keyword: RETURN
     - data_type:
         keyword: VARCHAR
-        bracketed:
-          start_bracket: (
-          numeric_literal: '10'
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            numeric_literal: '10'
+            end_bracket: )
     - keyword: AS
     - variable: res
     - data_type:
@@ -364,10 +370,11 @@ file:
     - keyword: RETURN
     - data_type:
         keyword: VARCHAR
-        bracketed:
-          start_bracket: (
-          numeric_literal: '10'
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            numeric_literal: '10'
+            end_bracket: )
     - keyword: AS
     - variable: res
     - data_type:
@@ -420,10 +427,11 @@ file:
     - keyword: RETURN
     - data_type:
         keyword: VARCHAR
-        bracketed:
-          start_bracket: (
-          numeric_literal: '10'
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            numeric_literal: '10'
+            end_bracket: )
     - keyword: AS
     - variable: res
     - data_type:
@@ -488,34 +496,38 @@ file:
       - naked_identifier: p1
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '6'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '6'
+              end_bracket: )
       - comma: ','
       - naked_identifier: p2
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '10'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '10'
+              end_bracket: )
       - end_bracket: )
     - keyword: RETURN
     - data_type:
         keyword: VARCHAR
-        bracketed:
-          start_bracket: (
-          numeric_literal: '20'
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            numeric_literal: '20'
+            end_bracket: )
     - keyword: IS
     - variable: res
     - data_type:
         keyword: VARCHAR
-        bracketed:
-          start_bracket: (
-          numeric_literal: '20'
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            numeric_literal: '20'
+            end_bracket: )
     - statement_terminator: ;
     - keyword: BEGIN
     - function_body:

--- a/test/fixtures/dialects/exasol/CreatePythonScalarScript.yml
+++ b/test/fixtures/dialects/exasol/CreatePythonScalarScript.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bc371af29b8f949369fa476a81b009cf89d025b40ba61cda52e3b086c09e6c10
+_hash: af169dbaf70811431a7c01120ab5baae8f5ad5efbff01f193b718b53d07d27a6
 file:
   statement:
     create_udf_script:
@@ -23,28 +23,31 @@ file:
           naked_identifier: JSON_STR
           data_type:
             keyword: VARCHAR
-            bracketed:
-              start_bracket: (
-              numeric_literal: '2000000'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '2000000'
+                end_bracket: )
       - comma: ','
       - column_datatype_definition:
           naked_identifier: LANGUAGE_KEY
           data_type:
             keyword: VARCHAR
-            bracketed:
-              start_bracket: (
-              numeric_literal: '50'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '50'
+                end_bracket: )
       - comma: ','
       - column_datatype_definition:
           naked_identifier: TXT_KEY
           data_type:
             keyword: VARCHAR
-            bracketed:
-              start_bracket: (
-              numeric_literal: '50'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '50'
+                end_bracket: )
       - end_bracket: )
     - emits_segment:
         keyword: EMITS
@@ -54,10 +57,11 @@ file:
             naked_identifier: X
             data_type:
               keyword: VARCHAR
-              bracketed:
-                start_bracket: (
-                numeric_literal: '2000000'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '2000000'
+                  end_bracket: )
           end_bracket: )
     - keyword: AS
     - script_content:

--- a/test/fixtures/dialects/exasol/CreateTableStatement.yml
+++ b/test/fixtures/dialects/exasol/CreateTableStatement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0e42fd85a50adbe93a29b3dd9037595c4f09a3a7a5c67c84eebd2daa2369f7cd
+_hash: 899769991a0703ecd90c18a7162dc7f624521b1cebf46d87f2d18368c7461560
 file:
 - statement:
     create_table_statement:
@@ -21,10 +21,11 @@ file:
               naked_identifier: a
               data_type:
               - keyword: VARCHAR
-              - bracketed:
-                  start_bracket: (
-                  numeric_literal: '20'
-                  end_bracket: )
+              - bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '20'
+                    end_bracket: )
               - keyword: UTF8
       - comma: ','
       - table_content_definition:
@@ -33,12 +34,13 @@ file:
               naked_identifier: b
               data_type:
                 keyword: DECIMAL
-                bracketed:
-                - start_bracket: (
-                - numeric_literal: '24'
-                - comma: ','
-                - numeric_literal: '4'
-                - end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '24'
+                  - comma: ','
+                  - numeric_literal: '4'
+                  - end_bracket: )
             column_constraint_segment:
               table_constraint_definition:
               - keyword: NOT
@@ -288,10 +290,11 @@ file:
               naked_identifier: country
               data_type:
                 keyword: VARCHAR
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '40'
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '40'
+                    end_bracket: )
       - comma: ','
       - table_content_definition:
           table_constraint_definition:
@@ -360,10 +363,11 @@ file:
               naked_identifier: b
               data_type:
                 keyword: VARCHAR
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '20'
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '20'
+                    end_bracket: )
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -385,12 +389,13 @@ file:
               naked_identifier: ID
               data_type:
                 keyword: DECIMAL
-                bracketed:
-                - start_bracket: (
-                - numeric_literal: '18'
-                - comma: ','
-                - numeric_literal: '0'
-                - end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '18'
+                  - comma: ','
+                  - numeric_literal: '0'
+                  - end_bracket: )
             column_constraint_segment:
               keyword: IDENTITY
               table_constraint_definition:
@@ -424,12 +429,13 @@ file:
               naked_identifier: ID
               data_type:
                 keyword: DECIMAL
-                bracketed:
-                - start_bracket: (
-                - numeric_literal: '18'
-                - comma: ','
-                - numeric_literal: '0'
-                - end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '18'
+                  - comma: ','
+                  - numeric_literal: '0'
+                  - end_bracket: )
       - comma: ','
       - table_content_definition:
           column_definition:
@@ -437,10 +443,11 @@ file:
               naked_identifier: C1
               data_type:
                 keyword: CHAR
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '1'
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '1'
+                    end_bracket: )
       - comma: ','
       - table_content_definition:
           table_constraint_definition:
@@ -470,12 +477,13 @@ file:
               naked_identifier: ID
               data_type:
                 keyword: DECIMAL
-                bracketed:
-                - start_bracket: (
-                - numeric_literal: '18'
-                - comma: ','
-                - numeric_literal: '0'
-                - end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '18'
+                  - comma: ','
+                  - numeric_literal: '0'
+                  - end_bracket: )
       - comma: ','
       - table_content_definition:
           column_definition:
@@ -483,10 +491,11 @@ file:
               naked_identifier: C1
               data_type:
                 keyword: CHAR
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '1'
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '1'
+                    end_bracket: )
       - comma: ','
       - table_content_definition:
           table_constraint_definition:
@@ -517,10 +526,11 @@ file:
               naked_identifier: C1
               data_type:
                 keyword: CHAR
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '1'
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '1'
+                    end_bracket: )
             column_constraint_segment:
               table_constraint_definition:
               - keyword: CONSTRAINT

--- a/test/fixtures/dialects/exasol/CreateUDFScriptStatement2.yml
+++ b/test/fixtures/dialects/exasol/CreateUDFScriptStatement2.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 86052bc2315a44a9fcd00b91f5e2755f4fc19b6d90681003caecde2fc5efaa43
+_hash: 40be04105289e8ce8061c7fad43e925e3692a7a1d0b3f79ba39e9209f69a0c75
 file:
   statement:
     create_udf_script:
@@ -19,10 +19,11 @@ file:
           naked_identifier: w
           data_type:
             keyword: varchar
-            bracketed:
-              start_bracket: (
-              numeric_literal: '10000'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '10000'
+                end_bracket: )
         end_bracket: )
     - emits_segment:
         keyword: EMITS
@@ -32,10 +33,11 @@ file:
             naked_identifier: words
             data_type:
               keyword: varchar
-              bracketed:
-                start_bracket: (
-                numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '100'
+                  end_bracket: )
           end_bracket: )
     - keyword: AS
     - script_content:

--- a/test/fixtures/dialects/exasol/CreateUDFScriptStatement4.yml
+++ b/test/fixtures/dialects/exasol/CreateUDFScriptStatement4.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4052e3a94919da01eaac14af07687ab6822cc1c2429e9c9adaae17eaa401b7b7
+_hash: 205e694478b52c2ebb744d5573cddbc130bc1f58635e2083a2887106d1544107
 file:
   statement:
     create_udf_script:
@@ -23,10 +23,11 @@ file:
     - keyword: RETURNS
     - data_type:
         keyword: VARCHAR
-        bracketed:
-          start_bracket: (
-          numeric_literal: '2000'
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            numeric_literal: '2000'
+            end_bracket: )
     - keyword: AS
     - script_content:
       - raw: l

--- a/test/fixtures/dialects/exasol/CreateUDFScriptStatement5.yml
+++ b/test/fixtures/dialects/exasol/CreateUDFScriptStatement5.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7ee18c4b7ed0dcd5468b9d8f25df98314ea7d2afa636921faadab1f8f650f7f4
+_hash: 01e6305be5ca477b02d496851528cb3120e744490c203d04bb9c32c007685d22
 file:
   statement:
     create_udf_script:
@@ -23,10 +23,11 @@ file:
     - keyword: RETURNS
     - data_type:
         keyword: VARCHAR
-        bracketed:
-          start_bracket: (
-          numeric_literal: '2000'
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            numeric_literal: '2000'
+            end_bracket: )
     - keyword: AS
     - script_content:
       - raw: class

--- a/test/fixtures/dialects/exasol/DataTypeTest.yml
+++ b/test/fixtures/dialects/exasol/DataTypeTest.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f3784e1b3ce39b615798a7d2d7404069755635626ee4eaa2404fc106f68475a1
+_hash: 1145859a4e145cf9c986fec7cf06740385f18279926d2013bca49b17377c8f26
 file:
 - statement:
     create_table_statement:
@@ -35,10 +35,11 @@ file:
               naked_identifier: c1
               data_type:
                 keyword: DECIMAL
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '10'
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '10'
+                    end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -55,12 +56,13 @@ file:
               naked_identifier: c1
               data_type:
                 keyword: DECIMAL
-                bracketed:
-                - start_bracket: (
-                - numeric_literal: '10'
-                - comma: ','
-                - numeric_literal: '2'
-                - end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '10'
+                  - comma: ','
+                  - numeric_literal: '2'
+                  - end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -77,12 +79,13 @@ file:
               naked_identifier: c1
               data_type:
                 keyword: DEC
-                bracketed:
-                - start_bracket: (
-                - numeric_literal: '10'
-                - comma: ','
-                - numeric_literal: '2'
-                - end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '10'
+                  - comma: ','
+                  - numeric_literal: '2'
+                  - end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -99,10 +102,11 @@ file:
               naked_identifier: c1
               data_type:
                 keyword: NUMERIC
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '10'
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '10'
+                    end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -119,12 +123,13 @@ file:
               naked_identifier: c1
               data_type:
                 keyword: NUMBER
-                bracketed:
-                - start_bracket: (
-                - numeric_literal: '10'
-                - comma: ','
-                - numeric_literal: '2'
-                - end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '10'
+                  - comma: ','
+                  - numeric_literal: '2'
+                  - end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -387,10 +392,11 @@ file:
               data_type:
               - keyword: INTERVAL
               - keyword: YEAR
-              - bracketed:
-                  start_bracket: (
-                  numeric_literal: '1'
-                  end_bracket: )
+              - bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '1'
+                    end_bracket: )
               - keyword: TO
               - keyword: MONTH
         end_bracket: )
@@ -410,16 +416,18 @@ file:
               data_type:
               - keyword: INTERVAL
               - keyword: DAY
-              - bracketed:
-                  start_bracket: (
-                  numeric_literal: '2'
-                  end_bracket: )
+              - bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '2'
+                    end_bracket: )
               - keyword: TO
               - keyword: SECOND
-              - bracketed:
-                  start_bracket: (
-                  numeric_literal: '1'
-                  end_bracket: )
+              - bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '1'
+                    end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -436,10 +444,11 @@ file:
               naked_identifier: c1
               data_type:
                 keyword: GEOMETRY
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '1000'
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '1000'
+                    end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -472,11 +481,12 @@ file:
               naked_identifier: c1
               data_type:
                 keyword: HASHTYPE
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '8'
-                  keyword: BYTE
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '8'
+                    keyword: BYTE
+                    end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -493,11 +503,12 @@ file:
               naked_identifier: c1
               data_type:
                 keyword: HASHTYPE
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '8'
-                  keyword: BIT
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '8'
+                    keyword: BIT
+                    end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -514,10 +525,11 @@ file:
               naked_identifier: c1
               data_type:
                 keyword: CHAR
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '1'
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '1'
+                    end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -535,10 +547,11 @@ file:
               data_type:
               - keyword: CHAR
               - keyword: VARYING
-              - bracketed:
-                  start_bracket: (
-                  numeric_literal: '1'
-                  end_bracket: )
+              - bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '1'
+                    end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -555,11 +568,12 @@ file:
               naked_identifier: c1
               data_type:
                 keyword: VARCHAR
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '2000'
-                  keyword: CHAR
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '2000'
+                    keyword: CHAR
+                    end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -576,10 +590,11 @@ file:
               naked_identifier: c1
               data_type:
                 keyword: VARCHAR2
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '2000'
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '2000'
+                    end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -596,11 +611,12 @@ file:
               naked_identifier: c1
               data_type:
                 keyword: VARCHAR
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '2000'
-                  keyword: BYTE
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '2000'
+                    keyword: BYTE
+                    end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -636,10 +652,11 @@ file:
               - keyword: CHARACTER
               - keyword: LARGE
               - keyword: OBJECT
-              - bracketed:
-                  start_bracket: (
-                  numeric_literal: '1000'
-                  end_bracket: )
+              - bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '1000'
+                    end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -657,10 +674,11 @@ file:
               data_type:
               - keyword: CHARACTER
               - keyword: VARYING
-              - bracketed:
-                  start_bracket: (
-                  numeric_literal: '1000'
-                  end_bracket: )
+              - bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '1000'
+                    end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -677,10 +695,11 @@ file:
               naked_identifier: c1
               data_type:
                 keyword: CLOB
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '2000'
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '2000'
+                    end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -697,10 +716,11 @@ file:
               naked_identifier: c1
               data_type:
               - keyword: CLOB
-              - bracketed:
-                  start_bracket: (
-                  numeric_literal: '2000'
-                  end_bracket: )
+              - bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '2000'
+                    end_bracket: )
               - keyword: ASCII
         end_bracket: )
 - statement_terminator: ;
@@ -718,11 +738,12 @@ file:
               naked_identifier: c1
               data_type:
               - keyword: VARCHAR
-              - bracketed:
-                  start_bracket: (
-                  numeric_literal: '2000'
-                  keyword: CHAR
-                  end_bracket: )
+              - bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '2000'
+                    keyword: CHAR
+                    end_bracket: )
               - keyword: UTF8
         end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/exasol/SelectStatement.yml
+++ b/test/fixtures/dialects/exasol/SelectStatement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 413a3e631dda3ac322923173545eb45268a3051bb70d6e94ed812fefef1b3c04
+_hash: 1d9c8d0de467df4cb21269fda3e771ddfd90848dde0ec3b60bb6dfd7782f1438
 file:
 - statement:
     select_statement:
@@ -323,10 +323,11 @@ file:
                         naked_identifier: v
                         data_type:
                           keyword: VARCHAR
-                          bracketed:
-                            start_bracket: (
-                            numeric_literal: '1'
-                            end_bracket: )
+                          bracketed_arguments:
+                            bracketed:
+                              start_bracket: (
+                              numeric_literal: '1'
+                              end_bracket: )
                     end_bracket: )
                 - import_from_clause:
                     keyword: FROM
@@ -980,19 +981,21 @@ file:
                   naked_identifier: id
                   data_type:
                     keyword: VARCHAR
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '2000'
-                      end_bracket: )
+                    bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
+                        numeric_literal: '2000'
+                        end_bracket: )
               - comma: ','
               - column_datatype_definition:
                   naked_identifier: error_column
                   data_type:
                     keyword: VARCHAR
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '2000000'
-                      end_bracket: )
+                    bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
+                        numeric_literal: '2000000'
+                        end_bracket: )
               - end_bracket: )
       from_clause:
         keyword: FROM

--- a/test/fixtures/dialects/hive/create_table_datatypes.yml
+++ b/test/fixtures/dialects/hive/create_table_datatypes.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1c0c9996996949b39b8d78939103b1432d2f93cf5744ac8016ec6b3998c4c244
+_hash: 224d06e8d35e55927c093e397084485a36d7cdf2f67f972db87effd738945841
 file:
   statement:
     create_table_statement:
@@ -38,12 +38,13 @@ file:
           data_type:
             primitive_type:
               keyword: decimal
-              bracketed:
-              - start_bracket: (
-              - numeric_literal: '10'
-              - comma: ','
-              - numeric_literal: '2'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - numeric_literal: '10'
+                - comma: ','
+                - numeric_literal: '2'
+                - end_bracket: )
       - comma: ','
       - column_definition:
           naked_identifier: col5
@@ -106,12 +107,13 @@ file:
                 - data_type:
                     primitive_type:
                       keyword: decimal
-                      bracketed:
-                      - start_bracket: (
-                      - numeric_literal: '10'
-                      - comma: ','
-                      - numeric_literal: '2'
-                      - end_bracket: )
+                      bracketed_arguments:
+                        bracketed:
+                        - start_bracket: (
+                        - numeric_literal: '10'
+                        - comma: ','
+                        - numeric_literal: '2'
+                        - end_bracket: )
                 - end_angle_bracket: '>'
               - end_angle_bracket: '>'
       - comma: ','

--- a/test/fixtures/dialects/hive/select_cast.yml
+++ b/test/fixtures/dialects/hive/select_cast.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b17a6a2dcf84705928031ae19004613bbe8fcc1fd62159c5c3460ad46461121e
+_hash: 5ffab9520bca3181f57fc2f9cd06f404e2fcf543b9939c8e11725b69357e14c6
 file:
 - statement:
     select_statement:
@@ -39,12 +39,13 @@ file:
                   - data_type:
                       primitive_type:
                         keyword: decimal
-                        bracketed:
-                        - start_bracket: (
-                        - numeric_literal: '23'
-                        - comma: ','
-                        - numeric_literal: '2'
-                        - end_bracket: )
+                        bracketed_arguments:
+                          bracketed:
+                          - start_bracket: (
+                          - numeric_literal: '23'
+                          - comma: ','
+                          - numeric_literal: '2'
+                          - end_bracket: )
                   - end_bracket: )
               end_bracket: )
       from_clause:

--- a/test/fixtures/dialects/mysql/alter_table.yml
+++ b/test/fixtures/dialects/mysql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 41fcfee6a93246aff99c4bb64693cda8eff625400fa30d5fd23e5063cf327638
+_hash: 89b6fa9346caa591ef096db64743edb72ee3152626d842a36f26194d29a66c86
 file:
 - statement:
     alter_table_statement:
@@ -17,11 +17,11 @@ file:
         quoted_identifier: '`name`'
         data_type:
           data_type_identifier: varchar
-          bracketed:
-            start_bracket: (
-            expression:
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
               numeric_literal: '255'
-            end_bracket: )
+              end_bracket: )
         column_constraint_segment:
         - keyword: NOT
         - keyword: 'NULL'
@@ -75,11 +75,11 @@ file:
       - quoted_identifier: '`date_of_birth`'
       - data_type:
           data_type_identifier: INT
-          bracketed:
-            start_bracket: (
-            expression:
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
               numeric_literal: '11'
-            end_bracket: )
+              end_bracket: )
       - column_constraint_segment:
           keyword: 'NULL'
       - column_constraint_segment:
@@ -100,11 +100,11 @@ file:
         quoted_identifier: '`date_of_birth`'
         data_type:
           data_type_identifier: INT
-          bracketed:
-            start_bracket: (
-            expression:
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
               numeric_literal: '11'
-            end_bracket: )
+              end_bracket: )
         column_constraint_segment:
         - keyword: NOT
         - keyword: 'NULL'
@@ -123,11 +123,11 @@ file:
         quoted_identifier: '`date_of_birth`'
         data_type:
           data_type_identifier: INT
-          bracketed:
-            start_bracket: (
-            expression:
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
               numeric_literal: '11'
-            end_bracket: )
+              end_bracket: )
     - keyword: FIRST
 - statement_terminator: ;
 - statement:
@@ -144,11 +144,11 @@ file:
         quoted_identifier: '`date_of_birth`'
         data_type:
           data_type_identifier: INT
-          bracketed:
-            start_bracket: (
-            expression:
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
               numeric_literal: '11'
-            end_bracket: )
+              end_bracket: )
     - keyword: AFTER
     - column_reference:
         quoted_identifier: '`name`'

--- a/test/fixtures/dialects/mysql/create_table.yml
+++ b/test/fixtures/dialects/mysql/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: aefbc327ea54f5ebca58050d3670b6029b61a43b5be55b05c2d3680fc3843bf3
+_hash: 65200fb3726083ed628137a772c5c576374ea5dc38201fb6de7193ef010378aa
 file:
   statement:
     create_table_statement:
@@ -17,22 +17,22 @@ file:
           naked_identifier: b
           data_type:
             data_type_identifier: VARCHAR
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '255'
-              end_bracket: )
+                end_bracket: )
             keyword: BINARY
       - comma: ','
       - column_definition:
         - quoted_identifier: '`id`'
         - data_type:
             data_type_identifier: int
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '11'
-              end_bracket: )
+                end_bracket: )
             keyword: unsigned
         - column_constraint_segment:
           - keyword: NOT

--- a/test/fixtures/dialects/mysql/create_table_column_charset.yml
+++ b/test/fixtures/dialects/mysql/create_table_column_charset.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d877ff3721ded5cdf94ae809105d1b8ecdb8905425ad65df255aa695f97fb89b
+_hash: 7c7aaa2edf1b20348d4e650e50d76e088af9310c66be309ecf2e0d0d9e70c60e
 file:
   statement:
     create_table_statement:
@@ -17,11 +17,11 @@ file:
         - naked_identifier: col1
         - data_type:
             data_type_identifier: VARCHAR
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '5'
-              end_bracket: )
+                end_bracket: )
         - column_constraint_segment:
           - keyword: CHARACTER
           - keyword: SET

--- a/test/fixtures/dialects/mysql/create_table_index.yml
+++ b/test/fixtures/dialects/mysql/create_table_index.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 40c32eb27d8d8dc065fe6ac0e484d6b1f9ffffaf63230c70c66d24d20c93d5da
+_hash: 239a8345bf5a129ab923e9daa7100b71b1ce4d9f17d737d949fcde022171e019
 file:
   statement:
     create_table_statement:
@@ -28,11 +28,11 @@ file:
           naked_identifier: a
           data_type:
             data_type_identifier: TEXT
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '500'
-              end_bracket: )
+                end_bracket: )
       - comma: ','
       - column_definition:
           naked_identifier: b

--- a/test/fixtures/dialects/oracle/alter_table.yml
+++ b/test/fixtures/dialects/oracle/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 97b72bf4757d9b6121f40a94df1136f6d551faa919fd929adbc68d0ef932335b
+_hash: 62e662faef165ee133558b909165aafc753074f67cdf25a3870c7f25ecc55390
 file:
 - statement:
     alter_table_statement:
@@ -34,11 +34,11 @@ file:
             naked_identifier: column_name
             data_type:
               data_type_identifier: NUMBER
-              bracketed:
-                start_bracket: (
-                expression:
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
                   numeric_literal: '18'
-                end_bracket: )
+                  end_bracket: )
           end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -53,11 +53,11 @@ file:
           naked_identifier: column_name
           data_type:
             data_type_identifier: NUMBER
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '18'
-              end_bracket: )
+                end_bracket: )
 - statement_terminator: ;
 - statement:
     alter_table_statement:

--- a/test/fixtures/dialects/postgres/postgres_alter_table.yml
+++ b/test/fixtures/dialects/postgres/postgres_alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 41dfc3fcb84393e15f3b50236490fe3e599c6ddb098c8aa1b70ecfeccf168bf1
+_hash: 866be1b451584cabb0ddf9f4f7ed9716dae714a6269a8e7a13362581c86462ff
 file:
 - statement:
     alter_table_statement:
@@ -18,10 +18,11 @@ file:
           naked_identifier: address
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '30'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '30'
+              end_bracket: )
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -62,10 +63,11 @@ file:
           naked_identifier: status
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '30'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '30'
+              end_bracket: )
       - column_constraint_segment:
           keyword: DEFAULT
           quoted_literal: "'old'"
@@ -106,10 +108,11 @@ file:
       - keyword: TYPE
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '80'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '80'
+              end_bracket: )
     - comma: ','
     - alter_table_action_segment:
       - keyword: ALTER
@@ -119,10 +122,11 @@ file:
       - keyword: TYPE
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '100'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '100'
+              end_bracket: )
 - statement_terminator: ;
 - statement:
     alter_table_statement:

--- a/test/fixtures/dialects/postgres/postgres_cast_with_whitespaces.yml
+++ b/test/fixtures/dialects/postgres/postgres_cast_with_whitespaces.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 45f6ce610eb11288932f751215ccd224f40f71b9709a919f29620b0453a0cdaf
+_hash: 8aa7f240daeacea8a3fa688ddb3fea842e1a61cbfda2ff0d93b25e749ebb126b
 file:
 - statement:
     select_statement:
@@ -138,10 +138,11 @@ file:
               casting_operator: '::'
               data_type:
                 keyword: VARCHAR
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '512'
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '512'
+                    end_bracket: )
       from_clause:
         keyword: FROM
         from_expression:
@@ -233,10 +234,11 @@ file:
                   casting_operator: '::'
                   data_type:
                     keyword: VARCHAR
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '512'
-                      end_bracket: )
+                    bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
+                        numeric_literal: '512'
+                        end_bracket: )
               - comparison_operator:
                   raw_comparison_operator: '='
               - cast_expression:
@@ -247,10 +249,11 @@ file:
                   casting_operator: '::'
                   data_type:
                     keyword: VARCHAR
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '512'
-                      end_bracket: )
+                    bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
+                        numeric_literal: '512'
+                        end_bracket: )
       where_clause:
         keyword: WHERE
         expression:

--- a/test/fixtures/dialects/postgres/postgres_create_table.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c158e3d5521d5f515b33918f3d2acbaf9305561e3f78fb82175e1c9c59c2890c
+_hash: 7880269f4bce9ff93caca9665e3b5f3aff1c424509d69405f4aac0bd39d9405a
 file:
 - statement:
     create_table_statement:
@@ -47,10 +47,11 @@ file:
           naked_identifier: name
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '40'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '40'
+              end_bracket: )
       - column_constraint_segment:
         - keyword: NOT
         - keyword: 'NULL'
@@ -96,10 +97,11 @@ file:
           naked_identifier: name
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '40'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '40'
+              end_bracket: )
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -119,10 +121,11 @@ file:
           naked_identifier: name
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '40'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '40'
+              end_bracket: )
       - comma: ','
       - table_constraint:
         - keyword: CONSTRAINT
@@ -164,10 +167,11 @@ file:
           naked_identifier: name
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '40'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '40'
+              end_bracket: )
       - comma: ','
       - table_constraint:
         - keyword: PRIMARY
@@ -199,10 +203,11 @@ file:
           naked_identifier: name
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '40'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '40'
+              end_bracket: )
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -217,10 +222,11 @@ file:
           naked_identifier: name
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '40'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '40'
+              end_bracket: )
       - column_constraint_segment:
           keyword: DEFAULT
           quoted_literal: "'Luso Films'"
@@ -273,10 +279,11 @@ file:
           naked_identifier: name
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '40'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '40'
+              end_bracket: )
       - column_constraint_segment:
         - keyword: NOT
         - keyword: 'NULL'
@@ -299,10 +306,11 @@ file:
           naked_identifier: name
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '40'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '40'
+              end_bracket: )
       - column_constraint_segment:
           keyword: UNIQUE
       - end_bracket: )
@@ -324,10 +332,11 @@ file:
           naked_identifier: name
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '40'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '40'
+              end_bracket: )
       - comma: ','
       - table_constraint:
           keyword: UNIQUE
@@ -355,10 +364,11 @@ file:
           naked_identifier: name
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '40'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '40'
+              end_bracket: )
       - comma: ','
       - table_constraint:
           keyword: UNIQUE
@@ -1224,10 +1234,11 @@ file:
       - data_type:
         - keyword: character
         - keyword: varying
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '40'
-            end_bracket: )
+        - bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '40'
+              end_bracket: )
       - column_constraint_segment:
         - keyword: NOT
         - keyword: 'NULL'

--- a/test/fixtures/dialects/postgres/postgres_datatypes.yml
+++ b/test/fixtures/dialects/postgres/postgres_datatypes.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 67fe4cda699b59e407814faa7e106c8b83eaf551895a6a36e63a45b15a8e92de
+_hash: 7cf843dbbfd1ddd3907ede58652e56d6e0a9c7446e8b623461a83834f985e330
 file:
 - statement:
     create_table_statement:
@@ -107,10 +107,11 @@ file:
           naked_identifier: b
       - data_type:
           keyword: float
-          bracketed:
-            start_bracket: (
-            numeric_literal: '24'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '24'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: c
@@ -145,41 +146,45 @@ file:
           naked_identifier: b
       - data_type:
           keyword: numeric
-          bracketed:
-            start_bracket: (
-            numeric_literal: '7'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '7'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: ba
       - data_type:
           keyword: decimal
-          bracketed:
-            start_bracket: (
-            numeric_literal: '7'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '7'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: c
       - data_type:
           keyword: numeric
-          bracketed:
-          - start_bracket: (
-          - numeric_literal: '7'
-          - comma: ','
-          - numeric_literal: '2'
-          - end_bracket: )
+          bracketed_arguments:
+            bracketed:
+            - start_bracket: (
+            - numeric_literal: '7'
+            - comma: ','
+            - numeric_literal: '2'
+            - end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: ca
       - data_type:
           keyword: decimal
-          bracketed:
-          - start_bracket: (
-          - numeric_literal: '7'
-          - comma: ','
-          - numeric_literal: '2'
-          - end_bracket: )
+          bracketed_arguments:
+            bracketed:
+            - start_bracket: (
+            - numeric_literal: '7'
+            - comma: ','
+            - numeric_literal: '2'
+            - end_bracket: )
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -213,10 +218,11 @@ file:
           naked_identifier: b
       - data_type:
           keyword: char
-          bracketed:
-            start_bracket: (
-            numeric_literal: '7'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '7'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: c
@@ -227,10 +233,11 @@ file:
           naked_identifier: d
       - data_type:
           keyword: character
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: e
@@ -243,19 +250,21 @@ file:
       - data_type:
         - keyword: character
         - keyword: varying
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '8'
-            end_bracket: )
+        - bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '8'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: g
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '9'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '9'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: h
@@ -520,10 +529,11 @@ file:
           naked_identifier: b
       - data_type:
           keyword: bit
-          bracketed:
-            start_bracket: (
-            numeric_literal: '3'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '3'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: c
@@ -536,10 +546,11 @@ file:
       - data_type:
         - keyword: bit
         - keyword: varying
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+        - bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/postgres/postgres_values_in_subquery.yml
+++ b/test/fixtures/dialects/postgres/postgres_values_in_subquery.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: aba2f3f0a365ff71ee9b1e4e8f15c6529a208eed45bf272d26fd63097de2c522
+_hash: 933cfd65728859ad86b8bd1b29e76c524ff542d39de19ac6cd7ec3587b4814a6
 file:
 - statement:
     with_compound_statement:
@@ -34,12 +34,13 @@ file:
                   casting_operator: '::'
                   data_type:
                     keyword: NUMERIC
-                    bracketed:
-                    - start_bracket: (
-                    - numeric_literal: '4'
-                    - comma: ','
-                    - numeric_literal: '3'
-                    - end_bracket: )
+                    bracketed_arguments:
+                      bracketed:
+                      - start_bracket: (
+                      - numeric_literal: '4'
+                      - comma: ','
+                      - numeric_literal: '3'
+                      - end_bracket: )
             - end_bracket: )
           end_bracket: )
       select_statement:

--- a/test/fixtures/dialects/redshift/redshift_alter_table.yml
+++ b/test/fixtures/dialects/redshift/redshift_alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6bc3c02fc648cb830e03576656136fbc00c666846eec82602e50eb1ab48945f2
+_hash: b358e5c9e83a669ac2d4bdf4ac461d1798190d2ff1004402370fd07685404904
 file:
 - statement:
     alter_table_statement:
@@ -97,10 +97,11 @@ file:
       - keyword: type
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '300'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '300'
+              end_bracket: )
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -130,10 +131,11 @@ file:
           naked_identifier: c2
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '16'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '16'
+              end_bracket: )
       - column_attribute_segment:
         - keyword: encode
         - keyword: lzo
@@ -142,10 +144,11 @@ file:
           naked_identifier: c3
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '32'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '32'
+              end_bracket: )
       - column_attribute_segment:
         - keyword: encode
         - keyword: zstd

--- a/test/fixtures/dialects/redshift/redshift_cast_conversion.yml
+++ b/test/fixtures/dialects/redshift/redshift_cast_conversion.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6571d63bee7a840364cfc9dcc69baad6ce37f3b03876af1532d5469fdab84aa2
+_hash: 00f304d6ee102003b6d8f10e865a978a0d8426ae757544b3c721bc29c25262db
 file:
 - statement:
     select_statement:
@@ -164,12 +164,13 @@ file:
               keyword: as
               data_type:
                 keyword: decimal
-                bracketed:
-                - start_bracket: (
-                - numeric_literal: '38'
-                - comma: ','
-                - numeric_literal: '2'
-                - end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '38'
+                  - comma: ','
+                  - numeric_literal: '2'
+                  - end_bracket: )
               end_bracket: )
       from_clause:
         keyword: from
@@ -191,12 +192,13 @@ file:
               start_bracket: (
               data_type:
                 keyword: decimal
-                bracketed:
-                - start_bracket: (
-                - numeric_literal: '38'
-                - comma: ','
-                - numeric_literal: '2'
-                - end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '38'
+                  - comma: ','
+                  - numeric_literal: '2'
+                  - end_bracket: )
               comma: ','
               expression:
                 column_reference:
@@ -222,12 +224,13 @@ file:
               casting_operator: '::'
               data_type:
                 keyword: decimal
-                bracketed:
-                - start_bracket: (
-                - numeric_literal: '38'
-                - comma: ','
-                - numeric_literal: '2'
-                - end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '38'
+                  - comma: ','
+                  - numeric_literal: '2'
+                  - end_bracket: )
       from_clause:
         keyword: from
         from_expression:

--- a/test/fixtures/dialects/redshift/redshift_cast_with_whitespaces.yml
+++ b/test/fixtures/dialects/redshift/redshift_cast_with_whitespaces.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 45f6ce610eb11288932f751215ccd224f40f71b9709a919f29620b0453a0cdaf
+_hash: 8aa7f240daeacea8a3fa688ddb3fea842e1a61cbfda2ff0d93b25e749ebb126b
 file:
 - statement:
     select_statement:
@@ -138,10 +138,11 @@ file:
               casting_operator: '::'
               data_type:
                 keyword: VARCHAR
-                bracketed:
-                  start_bracket: (
-                  numeric_literal: '512'
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '512'
+                    end_bracket: )
       from_clause:
         keyword: FROM
         from_expression:
@@ -233,10 +234,11 @@ file:
                   casting_operator: '::'
                   data_type:
                     keyword: VARCHAR
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '512'
-                      end_bracket: )
+                    bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
+                        numeric_literal: '512'
+                        end_bracket: )
               - comparison_operator:
                   raw_comparison_operator: '='
               - cast_expression:
@@ -247,10 +249,11 @@ file:
                   casting_operator: '::'
                   data_type:
                     keyword: VARCHAR
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '512'
-                      end_bracket: )
+                    bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
+                        numeric_literal: '512'
+                        end_bracket: )
       where_clause:
         keyword: WHERE
         expression:

--- a/test/fixtures/dialects/redshift/redshift_create_external_table.yml
+++ b/test/fixtures/dialects/redshift/redshift_create_external_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e726b6bf80889e1cb0aa978bee525887797e2058afecba7ee00f19572ec16d8c
+_hash: 5b6df3353f64d90fb128da7d2a5d1a94e0961673673ec9d3ad2feb1de1c6d8ff
 file:
 - statement:
     create_external_table_statement:
@@ -281,12 +281,13 @@ file:
           naked_identifier: pricepaid
       - data_type:
           keyword: decimal
-          bracketed:
-          - start_bracket: (
-          - numeric_literal: '8'
-          - comma: ','
-          - numeric_literal: '2'
-          - end_bracket: )
+          bracketed_arguments:
+            bracketed:
+            - start_bracket: (
+            - numeric_literal: '8'
+            - comma: ','
+            - numeric_literal: '2'
+            - end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: saletime
@@ -348,10 +349,11 @@ file:
           naked_identifier: event_type
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '10'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '10'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: recipientaccountid
@@ -402,21 +404,23 @@ file:
           naked_identifier: club_name
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '15'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '15'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: league_spi
       - data_type:
           keyword: decimal
-          bracketed:
-          - start_bracket: (
-          - numeric_literal: '6'
-          - comma: ','
-          - numeric_literal: '2'
-          - end_bracket: )
+          bracketed_arguments:
+            bracketed:
+            - start_bracket: (
+            - numeric_literal: '6'
+            - comma: ','
+            - numeric_literal: '2'
+            - end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: league_nspi
@@ -468,10 +472,11 @@ file:
           naked_identifier: col2
       - data_type:
           keyword: varchar
-          bracketed:
-            start_bracket: (
-            numeric_literal: '10'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '10'
+              end_bracket: )
       - end_bracket: )
     - keyword: ROW
     - keyword: FORMAT

--- a/test/fixtures/dialects/redshift/redshift_create_external_table_as.yml
+++ b/test/fixtures/dialects/redshift/redshift_create_external_table_as.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 544c9c565672cef9ac4cefe062707d7dcde10903d1403182d76c833b5526b8b9
+_hash: 5a2eac3d5e8513beb33d3032b380eb39d87c37ababa89c2006b45da8aecf0b5e
 file:
 - statement:
     create_external_table_statement:
@@ -504,10 +504,11 @@ file:
             naked_identifier: l_shipmode
         - data_type:
             keyword: varchar
-            bracketed:
-              start_bracket: (
-              numeric_literal: '24'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '24'
+                end_bracket: )
         - end_bracket: )
     - keyword: ROW
     - keyword: FORMAT

--- a/test/fixtures/dialects/redshift/redshift_create_procedure.yml
+++ b/test/fixtures/dialects/redshift/redshift_create_procedure.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 16bdf27c12ddfed8b01f70cdd28d5ef9448e8161bb52cbbb05ac2492e515ec67
+_hash: 28b9d6a0b11c121a1f22aabba6fb4737c14511348e978c8ad2a58cf98697c1d7
 file:
 - statement:
     create_procedure_statement:
@@ -23,10 +23,11 @@ file:
         - parameter: f2
         - data_type:
             keyword: varchar
-            bracketed:
-              start_bracket: (
-              numeric_literal: '20'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '20'
+                end_bracket: )
         - end_bracket: )
     - function_definition:
       - keyword: AS
@@ -60,19 +61,21 @@ file:
         - keyword: INOUT
         - data_type:
             keyword: varchar
-            bracketed:
-              start_bracket: (
-              numeric_literal: '256'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '256'
+                end_bracket: )
         - comma: ','
         - parameter: out_var
         - keyword: OUT
         - data_type:
             keyword: varchar
-            bracketed:
-              start_bracket: (
-              numeric_literal: '256'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '256'
+                end_bracket: )
         - end_bracket: )
     - function_definition:
         keyword: AS

--- a/test/fixtures/dialects/redshift/redshift_create_rls_policy.yml
+++ b/test/fixtures/dialects/redshift/redshift_create_rls_policy.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a0d9fd0e05165e340cbde4a3938407ec0f549388c1fc0cc633f0a59dd35e7075
+_hash: 4a3d668d485fa7a049937fa617411a44a32ddfe24d99dfd50558f6d64e04d58f
 file:
 - statement:
     create_rls_policy_statement:
@@ -19,10 +19,11 @@ file:
           naked_identifier: catgroup
         data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '10'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '10'
+              end_bracket: )
         end_bracket: )
     - keyword: USING
     - bracketed:
@@ -49,21 +50,23 @@ file:
           naked_identifier: foo
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '10'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '10'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: bar
       - data_type:
           keyword: DECIMAL
-          bracketed:
-          - start_bracket: (
-          - numeric_literal: '10'
-          - comma: ','
-          - numeric_literal: '2'
-          - end_bracket: )
+          bracketed_arguments:
+            bracketed:
+            - start_bracket: (
+            - numeric_literal: '10'
+            - comma: ','
+            - numeric_literal: '2'
+            - end_bracket: )
       - end_bracket: )
     - keyword: AS
     - alias_expression:

--- a/test/fixtures/dialects/redshift/redshift_create_table.yml
+++ b/test/fixtures/dialects/redshift/redshift_create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e4accb429e0edd7857ac7c2df421079bd7aa7a9ac5ed932491e9e071bfe6c227
+_hash: 7d3fe19e4caf58d383de1e5d252eb2b50348dfcb5fa8a3a0a44196995e2453ce
 file:
 - statement:
     create_table_statement:
@@ -25,10 +25,11 @@ file:
           naked_identifier: col2
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - column_constraint_segment:
         - keyword: NOT
         - keyword: 'NULL'
@@ -67,10 +68,11 @@ file:
           naked_identifier: col2
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - column_attribute_segment:
         - keyword: GENERATED
         - keyword: BY
@@ -118,46 +120,51 @@ file:
           naked_identifier: col2
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: col3
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: col4
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: col5
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: col6
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - end_bracket: )
     - table_constraint:
       - keyword: DISTKEY
@@ -200,10 +207,11 @@ file:
           naked_identifier: col2
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - column_constraint_segment:
           keyword: REFERENCES
           table_reference:
@@ -251,10 +259,11 @@ file:
           naked_identifier: col2
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - end_bracket: )
     - table_constraint:
       - keyword: DISTKEY
@@ -291,10 +300,11 @@ file:
           naked_identifier: col2
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - end_bracket: )
     - table_constraint:
       - keyword: DISTKEY
@@ -331,10 +341,11 @@ file:
           naked_identifier: col2
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - end_bracket: )
     - table_constraint:
       - keyword: DISTKEY
@@ -371,10 +382,11 @@ file:
           naked_identifier: col2
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - end_bracket: )
     - keyword: BACKUP
     - keyword: 'YES'
@@ -400,10 +412,11 @@ file:
           naked_identifier: col2
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - end_bracket: )
     - keyword: BACKUP
     - keyword: 'NO'
@@ -447,10 +460,11 @@ file:
           naked_identifier: col2
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - column_attribute_segment:
         - keyword: ENCODE
         - keyword: TEXT255
@@ -492,10 +506,11 @@ file:
           naked_identifier: col2
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - column_attribute_segment:
         - keyword: ENCODE
         - keyword: TEXT255
@@ -504,10 +519,11 @@ file:
           naked_identifier: col3
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - column_attribute_segment:
         - keyword: COLLATE
         - keyword: CASE_SENSITIVE
@@ -516,10 +532,11 @@ file:
           naked_identifier: col3
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
       - column_attribute_segment:
         - keyword: COLLATE
         - keyword: CASE_INSENSITIVE
@@ -552,10 +569,11 @@ file:
           naked_identifier: col3
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '60'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '60'
+              end_bracket: )
       - comma: ','
       - table_constraint:
           keyword: UNIQUE
@@ -610,10 +628,11 @@ file:
           naked_identifier: col3
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '60'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '60'
+              end_bracket: )
       - comma: ','
       - table_constraint:
         - keyword: PRIMARY
@@ -673,10 +692,11 @@ file:
           naked_identifier: col3
       - data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '60'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '60'
+              end_bracket: )
       - comma: ','
       - table_constraint:
         - keyword: FOREIGN
@@ -801,10 +821,11 @@ file:
           naked_identifier: col_name
         data_type:
           keyword: VARCHAR
-          bracketed:
-            start_bracket: (
-            numeric_literal: '5'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
         end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/snowflake/snowflake_alter_table_column.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_table_column.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 22878f1f16fcd23b97eeabe2abce943e02764130cdad64ba43b7353535333d37
+_hash: 9807fdbeb3a8025069b187ca234e3a42b40ac4c1250900bd6b73abb75c721f41
 file:
 - statement:
     alter_table_statement:
@@ -32,11 +32,11 @@ file:
           naked_identifier: my_column
           data_type:
             data_type_identifier: VARCHAR
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '5000'
-              end_bracket: )
+                end_bracket: )
           column_constraint_segment:
           - keyword: NOT
           - keyword: 'NULL'
@@ -352,11 +352,11 @@ file:
       - keyword: type
       - data_type:
           data_type_identifier: varchar
-          bracketed:
-            start_bracket: (
-            expression:
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
               numeric_literal: '50'
-            end_bracket: )
+              end_bracket: )
       - comma: ','
       - keyword: column
       - column_reference:

--- a/test/fixtures/dialects/snowflake/snowflake_create_function.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 943412daaab1e8723cee6db804cacb1c90e825ce86e3044dc32505f0ec78b5b6
+_hash: 0630997eb3e8b4bfb534a6524c14c7cab5a4bdd141bda2448a39df6e994d8b1d
 file:
 - statement:
     create_function_statement:
@@ -156,14 +156,13 @@ file:
           parameter: i
           data_type:
             data_type_identifier: numeric
-            bracketed:
-            - start_bracket: (
-            - expression:
-                numeric_literal: '9'
-            - comma: ','
-            - expression:
-                numeric_literal: '0'
-            - end_bracket: )
+            bracketed_arguments:
+              bracketed:
+              - start_bracket: (
+              - numeric_literal: '9'
+              - comma: ','
+              - numeric_literal: '0'
+              - end_bracket: )
           end_bracket: )
     - keyword: returns
     - data_type:

--- a/test/fixtures/dialects/snowflake/snowflake_create_procedure.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_create_procedure.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 609766cf0f7add54c181ff475b51330286da57701948ba9686bf1091661eed85
+_hash: 69630c224e7d42bd02d11e08fa7078e7b972ee4fabbb9150d5879b170ce1ee55
 file:
 - statement:
     create_procedure_statement:
@@ -75,23 +75,26 @@ file:
         - parameter: test_table
         - data_type:
             data_type_identifier: VARCHAR
-            bracketed:
-              start_bracket: (
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
         - comma: ','
         - parameter: test_col
         - data_type:
             data_type_identifier: VARCHAR
-            bracketed:
-              start_bracket: (
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
         - end_bracket: )
     - keyword: RETURNS
     - data_type:
         data_type_identifier: VARCHAR
-        bracketed:
-          start_bracket: (
-          end_bracket: )
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            end_bracket: )
     - keyword: LANGUAGE
     - keyword: JAVASCRIPT
     - keyword: AS

--- a/test/fixtures/dialects/snowflake/snowflake_create_table.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e82416b945a853194035f5f1c35d78f22b47bd50d6bd6c7902c42b4438651696
+_hash: 6253e281a173eaa117a9689da502e225a4e0257cbe8794d870bee5fc4ac9b19a
 file:
 - statement:
     create_table_statement:
@@ -462,11 +462,11 @@ file:
           naked_identifier: orderstatus
           data_type:
             data_type_identifier: varchar
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '100'
-              end_bracket: )
+                end_bracket: )
           column_constraint_segment:
             keyword: default
             null_literal: 'null'
@@ -475,11 +475,11 @@ file:
           naked_identifier: price
           data_type:
             data_type_identifier: varchar
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '255'
-              end_bracket: )
+                end_bracket: )
       - end_bracket: )
     - keyword: as
     - select_statement:
@@ -857,11 +857,11 @@ file:
           quoted_identifier: '"COL1"'
           data_type:
             data_type_identifier: varchar
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '128'
-              end_bracket: )
+                end_bracket: )
           column_constraint_segment:
           - keyword: NOT
           - keyword: 'NULL'
@@ -870,11 +870,11 @@ file:
           quoted_identifier: '"COL2"'
           data_type:
             data_type_identifier: varchar
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '128'
-              end_bracket: )
+                end_bracket: )
           column_constraint_segment:
           - keyword: NOT
           - keyword: 'NULL'

--- a/test/fixtures/dialects/snowflake/snowflake_semi_structured.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_semi_structured.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1fd11671106a0ebb0f68da3963f5a55a5fa359681839ac888c45ef3c283933b2
+_hash: bb6046b43b0d0fc5451fc777357451cd2ebbce591a7cc1d418c8e453eb99d68d
 file:
 - statement:
     select_statement:
@@ -157,14 +157,13 @@ file:
               casting_operator: '::'
               data_type:
                 data_type_identifier: NUMBER
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    numeric_literal: '10'
-                - comma: ','
-                - expression:
-                    numeric_literal: '6'
-                - end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '10'
+                  - comma: ','
+                  - numeric_literal: '6'
+                  - end_bracket: )
           alias_expression:
             keyword: AS
             naked_identifier: lat
@@ -184,14 +183,13 @@ file:
               casting_operator: '::'
               data_type:
                 data_type_identifier: NUMBER
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    numeric_literal: '10'
-                - comma: ','
-                - expression:
-                    numeric_literal: '6'
-                - end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '10'
+                  - comma: ','
+                  - numeric_literal: '6'
+                  - end_bracket: )
           alias_expression:
             keyword: AS
             naked_identifier: lng

--- a/test/fixtures/dialects/sparksql/create_table_complex_datatypes.yml
+++ b/test/fixtures/dialects/sparksql/create_table_complex_datatypes.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 51bbf5a827b5e2ba4aefdea69bee7821d3755ed83bf2761759a9ef850ac21bee
+_hash: 1811f635ec9ca83a5a5e53be4fd196d99221664219e955ca29ac13512c75b710
 file:
 - statement:
     create_table_statement:
@@ -16,202 +16,215 @@ file:
       - column_definition:
           naked_identifier: a
           data_type:
-          - keyword: STRUCT
-          - start_angle_bracket: <
-          - naked_identifier: b
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: STRING
-          - comma: ','
-          - naked_identifier: c
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: BOOLEAN
-          - end_angle_bracket: '>'
-      - comma: ','
-      - column_definition:
-          naked_identifier: d
-          data_type:
-            keyword: MAP
-            start_angle_bracket: <
-            primitive_type:
-              keyword: STRING
-            comma: ','
-            data_type:
-              primitive_type:
-                keyword: BOOLEAN
-            end_angle_bracket: '>'
-      - comma: ','
-      - column_definition:
-          naked_identifier: e
-          data_type:
-            keyword: ARRAY
-            start_angle_bracket: <
-            data_type:
-              primitive_type:
-                keyword: STRING
-            end_angle_bracket: '>'
-      - end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: CREATE
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: table_identifier
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          naked_identifier: a
-          data_type:
-          - keyword: STRUCT
-          - start_angle_bracket: <
-          - naked_identifier: b
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: STRING
-          - keyword: COMMENT
-          - quoted_literal: "'struct_comment'"
-          - comma: ','
-          - naked_identifier: c
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: BOOLEAN
-          - end_angle_bracket: '>'
-          column_constraint_segment:
-            comment_clause:
-              keyword: COMMENT
-              quoted_literal: "'col_comment'"
-      - comma: ','
-      - column_definition:
-          naked_identifier: d
-          data_type:
-            keyword: MAP
-            start_angle_bracket: <
-            primitive_type:
-              keyword: STRING
-            comma: ','
-            data_type:
-              primitive_type:
-                keyword: BOOLEAN
-            end_angle_bracket: '>'
-          column_constraint_segment:
-            comment_clause:
-              keyword: COMMENT
-              quoted_literal: "'col_comment'"
-      - comma: ','
-      - column_definition:
-          naked_identifier: e
-          data_type:
-            keyword: ARRAY
-            start_angle_bracket: <
-            data_type:
-              primitive_type:
-                keyword: STRING
-            end_angle_bracket: '>'
-          column_constraint_segment:
-            comment_clause:
-              keyword: COMMENT
-              quoted_literal: "'col_comment'"
-      - end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_table_statement:
-    - keyword: CREATE
-    - keyword: TABLE
-    - table_reference:
-        naked_identifier: table_identifier
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          naked_identifier: a
-          data_type:
-          - keyword: STRUCT
-          - start_angle_bracket: <
-          - naked_identifier: b
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: STRING
-          - comma: ','
-          - naked_identifier: c
-          - colon: ':'
-          - data_type:
-              keyword: MAP
-              start_angle_bracket: <
-              primitive_type:
-                keyword: STRING
-              comma: ','
-              data_type:
-                primitive_type:
-                  keyword: BOOLEAN
-              end_angle_bracket: '>'
-          - end_angle_bracket: '>'
-      - comma: ','
-      - column_definition:
-          naked_identifier: d
-          data_type:
-            keyword: MAP
-            start_angle_bracket: <
-            primitive_type:
-              keyword: STRING
-            comma: ','
-            data_type:
-            - keyword: STRUCT
-            - start_angle_bracket: <
-            - naked_identifier: e
-            - colon: ':'
-            - data_type:
-                primitive_type:
-                  keyword: STRING
-            - comma: ','
-            - naked_identifier: f
-            - colon: ':'
-            - data_type:
-                keyword: MAP
-                start_angle_bracket: <
-                primitive_type:
-                  keyword: STRING
-                comma: ','
-                data_type:
+            struct_type:
+              keyword: STRUCT
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: b
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: STRING
+              - comma: ','
+              - naked_identifier: c
+              - colon: ':'
+              - data_type:
                   primitive_type:
                     keyword: BOOLEAN
-                end_angle_bracket: '>'
-            - end_angle_bracket: '>'
+              - end_angle_bracket: '>'
+      - comma: ','
+      - column_definition:
+          naked_identifier: d
+          data_type:
+            keyword: MAP
+            start_angle_bracket: <
+            primitive_type:
+              keyword: STRING
+            comma: ','
+            data_type:
+              primitive_type:
+                keyword: BOOLEAN
+            end_angle_bracket: '>'
+      - comma: ','
+      - column_definition:
+          naked_identifier: e
+          data_type:
+            array_type:
+              keyword: ARRAY
+              start_angle_bracket: <
+              data_type:
+                primitive_type:
+                  keyword: STRING
+              end_angle_bracket: '>'
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table_identifier
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: a
+          data_type:
+            struct_type:
+              keyword: STRUCT
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: b
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: STRING
+              - keyword: COMMENT
+              - quoted_literal: "'struct_comment'"
+              - comma: ','
+              - naked_identifier: c
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: BOOLEAN
+              - end_angle_bracket: '>'
+          column_constraint_segment:
+            comment_clause:
+              keyword: COMMENT
+              quoted_literal: "'col_comment'"
+      - comma: ','
+      - column_definition:
+          naked_identifier: d
+          data_type:
+            keyword: MAP
+            start_angle_bracket: <
+            primitive_type:
+              keyword: STRING
+            comma: ','
+            data_type:
+              primitive_type:
+                keyword: BOOLEAN
+            end_angle_bracket: '>'
+          column_constraint_segment:
+            comment_clause:
+              keyword: COMMENT
+              quoted_literal: "'col_comment'"
+      - comma: ','
+      - column_definition:
+          naked_identifier: e
+          data_type:
+            array_type:
+              keyword: ARRAY
+              start_angle_bracket: <
+              data_type:
+                primitive_type:
+                  keyword: STRING
+              end_angle_bracket: '>'
+          column_constraint_segment:
+            comment_clause:
+              keyword: COMMENT
+              quoted_literal: "'col_comment'"
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table_identifier
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: a
+          data_type:
+            struct_type:
+              keyword: STRUCT
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: b
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: STRING
+              - comma: ','
+              - naked_identifier: c
+              - colon: ':'
+              - data_type:
+                  keyword: MAP
+                  start_angle_bracket: <
+                  primitive_type:
+                    keyword: STRING
+                  comma: ','
+                  data_type:
+                    primitive_type:
+                      keyword: BOOLEAN
+                  end_angle_bracket: '>'
+              - end_angle_bracket: '>'
+      - comma: ','
+      - column_definition:
+          naked_identifier: d
+          data_type:
+            keyword: MAP
+            start_angle_bracket: <
+            primitive_type:
+              keyword: STRING
+            comma: ','
+            data_type:
+              struct_type:
+                keyword: STRUCT
+                struct_type_schema:
+                - start_angle_bracket: <
+                - naked_identifier: e
+                - colon: ':'
+                - data_type:
+                    primitive_type:
+                      keyword: STRING
+                - comma: ','
+                - naked_identifier: f
+                - colon: ':'
+                - data_type:
+                    keyword: MAP
+                    start_angle_bracket: <
+                    primitive_type:
+                      keyword: STRING
+                    comma: ','
+                    data_type:
+                      primitive_type:
+                        keyword: BOOLEAN
+                    end_angle_bracket: '>'
+                - end_angle_bracket: '>'
             end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           naked_identifier: g
           data_type:
-            keyword: ARRAY
-            start_angle_bracket: <
-            data_type:
-            - keyword: STRUCT
-            - start_angle_bracket: <
-            - naked_identifier: h
-            - colon: ':'
-            - data_type:
-                primitive_type:
-                  keyword: STRING
-            - comma: ','
-            - naked_identifier: i
-            - colon: ':'
-            - data_type:
-                keyword: MAP
-                start_angle_bracket: <
-                primitive_type:
-                  keyword: STRING
-                comma: ','
-                data_type:
-                  primitive_type:
-                    keyword: BOOLEAN
-                end_angle_bracket: '>'
-            - end_angle_bracket: '>'
-            end_angle_bracket: '>'
+            array_type:
+              keyword: ARRAY
+              start_angle_bracket: <
+              data_type:
+                struct_type:
+                  keyword: STRUCT
+                  struct_type_schema:
+                  - start_angle_bracket: <
+                  - naked_identifier: h
+                  - colon: ':'
+                  - data_type:
+                      primitive_type:
+                        keyword: STRING
+                  - comma: ','
+                  - naked_identifier: i
+                  - colon: ':'
+                  - data_type:
+                      keyword: MAP
+                      start_angle_bracket: <
+                      primitive_type:
+                        keyword: STRING
+                      comma: ','
+                      data_type:
+                        primitive_type:
+                          keyword: BOOLEAN
+                      end_angle_bracket: '>'
+                  - end_angle_bracket: '>'
+              end_angle_bracket: '>'
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -225,20 +238,22 @@ file:
       - column_definition:
           naked_identifier: a
           data_type:
-          - keyword: STRUCT
-          - start_angle_bracket: <
-          - quoted_identifier: '`b`'
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: STRING
-          - comma: ','
-          - naked_identifier: c
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: BOOLEAN
-          - end_angle_bracket: '>'
+            struct_type:
+              keyword: STRUCT
+              struct_type_schema:
+              - start_angle_bracket: <
+              - quoted_identifier: '`b`'
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: STRING
+              - comma: ','
+              - naked_identifier: c
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: BOOLEAN
+              - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           quoted_identifier: '`d`'
@@ -256,11 +271,12 @@ file:
       - column_definition:
           naked_identifier: e
           data_type:
-            keyword: ARRAY
-            start_angle_bracket: <
-            data_type:
-              primitive_type:
-                keyword: STRING
-            end_angle_bracket: '>'
+            array_type:
+              keyword: ARRAY
+              start_angle_bracket: <
+              data_type:
+                primitive_type:
+                  keyword: STRING
+              end_angle_bracket: '>'
       - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/create_table_hiveformat.yml
+++ b/test/fixtures/dialects/sparksql/create_table_hiveformat.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8381964744a2723edcf42ca3a6389fac06143cf17b41ef1794ff592b1213f03e
+_hash: 03e4ead84f735d4f8f1c49478be446a4b63ce784fd0333578dd1b1ccc5d9d633
 file:
 - statement:
     create_table_statement:
@@ -370,12 +370,13 @@ file:
       - column_definition:
           naked_identifier: friends
           data_type:
-            keyword: ARRAY
-            start_angle_bracket: <
-            data_type:
-              primitive_type:
-                keyword: STRING
-            end_angle_bracket: '>'
+            array_type:
+              keyword: ARRAY
+              start_angle_bracket: <
+              data_type:
+                primitive_type:
+                  keyword: STRING
+              end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           naked_identifier: children
@@ -393,20 +394,22 @@ file:
       - column_definition:
           naked_identifier: address
           data_type:
-          - keyword: STRUCT
-          - start_angle_bracket: <
-          - naked_identifier: street
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: STRING
-          - comma: ','
-          - naked_identifier: city
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: STRING
-          - end_angle_bracket: '>'
+            struct_type:
+              keyword: STRUCT
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: street
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: STRING
+              - comma: ','
+              - naked_identifier: city
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: STRING
+              - end_angle_bracket: '>'
       - end_bracket: )
     - row_format_clause:
       - keyword: ROW

--- a/test/fixtures/dialects/sparksql/databricks_operator_colon_sign.yml
+++ b/test/fixtures/dialects/sparksql/databricks_operator_colon_sign.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 99110a6c45b5907ccf64930fcc76e4653b5c58bc49fb4fbeab1279ad6d07c818
+_hash: 677133458db91d62118a67dbd7c1bcf81c3606396175e5e7de01565c67b601ed
 file:
 - statement:
     select_statement:
@@ -54,12 +54,13 @@ file:
               data_type:
                 primitive_type:
                   keyword: DECIMAL
-                  bracketed:
-                  - start_bracket: (
-                  - numeric_literal: '5'
-                  - comma: ','
-                  - numeric_literal: '2'
-                  - end_bracket: )
+                  bracketed_arguments:
+                    bracketed:
+                    - start_bracket: (
+                    - numeric_literal: '5'
+                    - comma: ','
+                    - numeric_literal: '2'
+                    - end_bracket: )
       from_clause:
         keyword: FROM
         from_expression:

--- a/test/fixtures/dialects/sparksql/delta_update_table_schema.yml
+++ b/test/fixtures/dialects/sparksql/delta_update_table_schema.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 63ea3f968b4add320516f1caca79f87260d6f9e5f221ae9d11b739b4767ef2d1
+_hash: 1df824dca4c17f32f634e4d7bc9e0d4ef4bf35a94d2847f357bce6ed98793baf
 file:
 - statement:
     alter_table_statement:
@@ -354,26 +354,28 @@ file:
       - column_definition:
           naked_identifier: col_b
           data_type:
-          - keyword: STRUCT
-          - start_angle_bracket: <
-          - naked_identifier: key2
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: STRING
-          - comma: ','
-          - naked_identifier: nested
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: STRING
-          - comma: ','
-          - naked_identifier: key1
-          - colon: ':'
-          - data_type:
-              primitive_type:
-                keyword: STRING
-          - end_angle_bracket: '>'
+            struct_type:
+              keyword: STRUCT
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: key2
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: STRING
+              - comma: ','
+              - naked_identifier: nested
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: STRING
+              - comma: ','
+              - naked_identifier: key1
+              - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: STRING
+              - end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           naked_identifier: col_a

--- a/test/fixtures/dialects/teradata/create_table.yml
+++ b/test/fixtures/dialects/teradata/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9575db20580324d3eeb9919f2fdebdb2174b8b78d41d59ccfe94dffa6e31f8e9
+_hash: 3badd344b1e26c3368e9102fa001ff4302206b72fb4594f4dda4a6611a08fd32
 file:
 - statement:
     create_table_statement:
@@ -20,11 +20,11 @@ file:
             naked_identifier: Org_Unit_Code
           data_type:
             data_type_identifier: char
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '6'
-              end_bracket: )
+                end_bracket: )
           td_column_attribute_constraint:
           - keyword: character
           - keyword: set
@@ -38,11 +38,11 @@ file:
             naked_identifier: Org_Unit_Type
           data_type:
             data_type_identifier: char
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '3'
-              end_bracket: )
+                end_bracket: )
           td_column_attribute_constraint:
           - keyword: character
           - keyword: set
@@ -56,11 +56,11 @@ file:
             naked_identifier: Entity_Code
           data_type:
             data_type_identifier: varchar
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '10'
-              end_bracket: )
+                end_bracket: )
           td_column_attribute_constraint:
             keyword: uppercase
           column_constraint_segment:
@@ -72,11 +72,11 @@ file:
             naked_identifier: Parent_Org_Unit_Code
           data_type:
             data_type_identifier: char
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '6'
-              end_bracket: )
+                end_bracket: )
           td_column_attribute_constraint:
           - keyword: character
           - keyword: set
@@ -90,11 +90,11 @@ file:
             naked_identifier: Parent_Org_Unit_Type
           data_type:
             data_type_identifier: char
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '3'
-              end_bracket: )
+                end_bracket: )
           td_column_attribute_constraint:
           - keyword: character
           - keyword: set
@@ -108,11 +108,11 @@ file:
             naked_identifier: Parent_Entity_Code
           data_type:
             data_type_identifier: varchar
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '10'
-              end_bracket: )
+                end_bracket: )
           td_column_attribute_constraint:
             keyword: uppercase
           column_constraint_segment:

--- a/test/fixtures/dialects/teradata/create_table_stmt.yml
+++ b/test/fixtures/dialects/teradata/create_table_stmt.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ed3990efbc92aa72a08ed29dd6371d853cb3be43fab5668e69a1a2427b9ed575
+_hash: 21981d268a2697bb67da8fb4a6c9b4aa9ef7d9545a7b04259adea592591d3f92
 file:
   statement:
     create_table_statement:
@@ -39,11 +39,11 @@ file:
             naked_identifier: FIELD1
           data_type:
             data_type_identifier: CHAR
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '9'
-              end_bracket: )
+                end_bracket: )
         end_bracket: )
     - td_table_constraint:
       - keyword: PRIMARY

--- a/test/fixtures/dialects/teradata/create_table_stmt_2.yml
+++ b/test/fixtures/dialects/teradata/create_table_stmt_2.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bd33bf070f394474732e4a74bd1808082a78a7044c40b8841b064723f31f75a5
+_hash: 8b9d1e361194f1e8fa9e08200de67e0ca3b3b581d305f7577b5c9038fe0ca3ca
 file:
   statement:
     create_table_statement:
@@ -19,11 +19,11 @@ file:
             naked_identifier: CHAR_FIELD
         - data_type:
             data_type_identifier: CHAR
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '19'
-              end_bracket: )
+                end_bracket: )
         - td_column_attribute_constraint:
           - keyword: CHARACTER
           - keyword: SET
@@ -60,14 +60,13 @@ file:
             naked_identifier: DECIMAL_FIELD
           data_type:
             data_type_identifier: DECIMAL
-            bracketed:
-            - start_bracket: (
-            - expression:
-                numeric_literal: '15'
-            - comma: ','
-            - expression:
-                numeric_literal: '2'
-            - end_bracket: )
+            bracketed_arguments:
+              bracketed:
+              - start_bracket: (
+              - numeric_literal: '15'
+              - comma: ','
+              - numeric_literal: '2'
+              - end_bracket: )
           td_column_attribute_constraint:
             keyword: COMPRESS
             bracketed:
@@ -108,11 +107,11 @@ file:
             naked_identifier: TIMESTAMP_FIELD
           data_type:
             data_type_identifier: TIMESTAMP
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '6'
-              end_bracket: )
+                end_bracket: )
           column_constraint_segment:
           - keyword: NOT
           - keyword: 'NULL'

--- a/test/fixtures/dialects/teradata/create_table_stmt_3.yml
+++ b/test/fixtures/dialects/teradata/create_table_stmt_3.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b7fbf02d7f6097837f16800fe669722f75a9d81baf345f63c6f04aa51a31fba0
+_hash: 9ffbbc697e46c5549859022966608d7c9f4296ec1962c3a455cf26707f2d873d
 file:
   statement:
     create_table_statement:
@@ -19,11 +19,11 @@ file:
             naked_identifier: DES_EVENTO
         - data_type:
             data_type_identifier: VARCHAR
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '255'
-              end_bracket: )
+                end_bracket: )
         - td_column_attribute_constraint:
           - keyword: CHARACTER
           - keyword: SET

--- a/test/fixtures/dialects/teradata/create_table_stmt_4.yml
+++ b/test/fixtures/dialects/teradata/create_table_stmt_4.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4b566ceea9d591b537356005ca503574fcfe0cdb0430c274aeb6af4f39dbdbdd
+_hash: bf62ad54c88397641a65ceae62c072d661544f2c0993695e44ea00582b7713ac
 file:
   statement:
     create_table_statement:
@@ -20,11 +20,11 @@ file:
             naked_identifier: Org_Unit_Code
           data_type:
             data_type_identifier: char
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '6'
-              end_bracket: )
+                end_bracket: )
           td_column_attribute_constraint:
           - keyword: character
           - keyword: set
@@ -38,11 +38,11 @@ file:
             naked_identifier: Org_Unit_Type
           data_type:
             data_type_identifier: char
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '3'
-              end_bracket: )
+                end_bracket: )
           td_column_attribute_constraint:
           - keyword: character
           - keyword: set
@@ -56,11 +56,11 @@ file:
             naked_identifier: Entity_Code
           data_type:
             data_type_identifier: varchar
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '10'
-              end_bracket: )
+                end_bracket: )
           td_column_attribute_constraint:
             keyword: uppercase
           column_constraint_segment:
@@ -72,11 +72,11 @@ file:
             naked_identifier: Parent_Org_Unit_Code
           data_type:
             data_type_identifier: char
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '6'
-              end_bracket: )
+                end_bracket: )
           td_column_attribute_constraint:
           - keyword: character
           - keyword: set
@@ -90,11 +90,11 @@ file:
             naked_identifier: Parent_Org_Unit_Type
           data_type:
             data_type_identifier: char
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '3'
-              end_bracket: )
+                end_bracket: )
           td_column_attribute_constraint:
           - keyword: character
           - keyword: set
@@ -108,11 +108,11 @@ file:
             naked_identifier: Parent_Entity_Code
           data_type:
             data_type_identifier: varchar
-            bracketed:
-              start_bracket: (
-              expression:
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
                 numeric_literal: '10'
-              end_bracket: )
+                end_bracket: )
           td_column_attribute_constraint:
             keyword: uppercase
           column_constraint_segment:

--- a/test/fixtures/dialects/tsql/alter_table.yml
+++ b/test/fixtures/dialects/tsql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a586045c6ed2abb30cdd526d4e0dfeeceb32daf854b0c6fbfcdb30eda6fed4c6
+_hash: 4e240e41dde1c884915f6b1bed1d5c8af6fcaa7437f9962ef42d9b1070ca6504
 file:
 - batch:
     statement:
@@ -38,11 +38,12 @@ file:
           naked_identifier: column_b
           data_type:
             data_type_identifier: VARCHAR
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '20'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '20'
+                end_bracket: )
           column_constraint_segment:
             keyword: 'NULL'
     statement_terminator: ;
@@ -81,11 +82,12 @@ file:
         - naked_identifier: column_b
         - data_type:
             data_type_identifier: VARCHAR
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '20'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '20'
+                end_bracket: )
         - column_constraint_segment:
             keyword: 'NULL'
         - column_constraint_segment:
@@ -297,11 +299,12 @@ file:
           naked_identifier: rec_number
           data_type:
             data_type_identifier: VARCHAR
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '36'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '36'
+                end_bracket: )
 - go_statement:
     keyword: GO
 - batch:

--- a/test/fixtures/dialects/tsql/cast_variable.yml
+++ b/test/fixtures/dialects/tsql/cast_variable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bc6640b52894d99c9c6bb382dcaa1de71630c65eaa51007683569191d4fa7057
+_hash: 935199c7ac89c3a42afe824da3a00b3541e19ed276476b2ef8cd50e05ab7c023
 file:
   batch:
   - statement:
@@ -69,11 +69,12 @@ file:
                 keyword: as
                 data_type:
                   data_type_identifier: datetime2
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      numeric_literal: '7'
-                    end_bracket: )
+                  bracketed_arguments:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        numeric_literal: '7'
+                      end_bracket: )
                 end_bracket: )
             alias_expression:
               keyword: as
@@ -94,10 +95,11 @@ file:
         parameter: '@sample'
         data_type:
           data_type_identifier: nvarchar
-          bracketed:
-            start_bracket: (
-            keyword: max
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              keyword: max
+              end_bracket: )
         comparison_operator:
           raw_comparison_operator: '='
         expression:
@@ -111,8 +113,9 @@ file:
               keyword: as
               data_type:
                 data_type_identifier: nvarchar
-                bracketed:
-                  start_bracket: (
-                  keyword: max
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    keyword: max
+                    end_bracket: )
               end_bracket: )

--- a/test/fixtures/dialects/tsql/convert.yml
+++ b/test/fixtures/dialects/tsql/convert.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 333083802ef106d5d7512ee256d7e2e6856582381f86e757c0738a03e997edaa
+_hash: 4473a6434c9f0ce4b91fae0d3d548d74f7374294e65e6d08f3e5d5c60f2bdd62
 file:
   batch:
     statement:
@@ -18,11 +18,12 @@ file:
                 start_bracket: (
                 data_type:
                   data_type_identifier: nvarchar
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      numeric_literal: '100'
-                    end_bracket: )
+                  bracketed_arguments:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        numeric_literal: '100'
+                      end_bracket: )
                 comma: ','
                 expression:
                   column_reference:

--- a/test/fixtures/dialects/tsql/create_function.yml
+++ b/test/fixtures/dialects/tsql/create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d2367df86b733e01c31b74fd789fa082675d68347a588e3bda401261c000de45
+_hash: 9ded27ea23a5a527e9a235ea24249e64b61d4711444cf4b648973734d3618169
 file:
 - batch:
     statement:
@@ -89,11 +89,12 @@ file:
                               keyword: as
                               data_type:
                                 data_type_identifier: CHAR
-                                bracketed:
-                                  start_bracket: (
-                                  expression:
-                                    numeric_literal: '4'
-                                  end_bracket: )
+                                bracketed_arguments:
+                                  bracketed:
+                                    start_bracket: (
+                                    expression:
+                                      numeric_literal: '4'
+                                    end_bracket: )
                               end_bracket: )
                           binary_operator: +
                           quoted_literal: "'0104'"
@@ -148,11 +149,12 @@ file:
                                   keyword: AS
                                   data_type:
                                     data_type_identifier: CHAR
-                                    bracketed:
-                                      start_bracket: (
-                                      expression:
-                                        numeric_literal: '4'
-                                      end_bracket: )
+                                    bracketed_arguments:
+                                      bracketed:
+                                        start_bracket: (
+                                        expression:
+                                          numeric_literal: '4'
+                                        end_bracket: )
                                   end_bracket: )
                             - binary_operator: +
                             - quoted_literal: "'12'"
@@ -178,11 +180,12 @@ file:
                                   keyword: AS
                                   data_type:
                                     data_type_identifier: CHAR
-                                    bracketed:
-                                      start_bracket: (
-                                      expression:
-                                        numeric_literal: '2'
-                                      end_bracket: )
+                                    bracketed_arguments:
+                                      bracketed:
+                                        start_bracket: (
+                                        expression:
+                                          numeric_literal: '2'
+                                        end_bracket: )
                                   end_bracket: )
                             end_bracket: )
                         binary_operator: +
@@ -403,10 +406,11 @@ file:
       - keyword: RETURNS
       - data_type:
           data_type_identifier: nvarchar
-          bracketed:
-            start_bracket: (
-            keyword: max
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              keyword: max
+              end_bracket: )
       - keyword: AS
       - procedure_statement:
           statement:
@@ -418,10 +422,11 @@ file:
                   parameter: '@str'
                   data_type:
                     data_type_identifier: nvarchar
-                    bracketed:
-                      start_bracket: (
-                      keyword: max
-                      end_bracket: )
+                    bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
+                        keyword: max
+                        end_bracket: )
                   comparison_operator:
                     raw_comparison_operator: '='
                   expression:

--- a/test/fixtures/dialects/tsql/create_table.yml
+++ b/test/fixtures/dialects/tsql/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9c4df4bc451697763a63f72353e16d68127913db625f1b309fd65bccac00232f
+_hash: ccc658e26d6da19c548f74249a88d58ab89cef1a54e3c532b04b3e8f49134ecc
 file:
   batch:
     statement:
@@ -20,32 +20,35 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )

--- a/test/fixtures/dialects/tsql/create_table_constraints.yml
+++ b/test/fixtures/dialects/tsql/create_table_constraints.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ae78f80d2edb04232dca076a9b908ecec860d7000e48422858ae0811b3ace7c1
+_hash: c209d12094922d427621030eedd44fc62ddf5d14b674f093b04220a29b5d32e6
 file:
 - batch:
     statement:
@@ -45,11 +45,12 @@ file:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
             column_constraint_segment:
               keyword: DEFAULT
               quoted_literal: "'mydefault'"
@@ -208,11 +209,12 @@ file:
           - quoted_identifier: '[ColumnB]'
           - data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
           - column_constraint_segment:
               keyword: FILESTREAM
           - column_constraint_segment:
@@ -230,11 +232,12 @@ file:
           - quoted_identifier: '[ColumnC]'
           - data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
           - column_constraint_segment:
               keyword: 'NULL'
           - column_constraint_segment:
@@ -246,14 +249,15 @@ file:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
             column_constraint_segment:
             - keyword: GENERATED
             - keyword: ALWAYS
@@ -266,11 +270,12 @@ file:
             quoted_identifier: '[columnE]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
             column_constraint_segment:
               encrypted_with_grammar:
               - keyword: ENCRYPTED
@@ -297,11 +302,12 @@ file:
             quoted_identifier: '[column1]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
             column_constraint_segment:
               keyword: collate
               object_reference:

--- a/test/fixtures/dialects/tsql/create_table_on_filegroup.yml
+++ b/test/fixtures/dialects/tsql/create_table_on_filegroup.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 85548d5c81e3b0d0f3b7b710c41ed57f079648a0884c028004ff292adf184f5d
+_hash: e98064d324c4b081392469410dbfab5dddbc12b258a107db6cd00d212abb8f2e
 file:
   batch:
     statement:
@@ -20,34 +20,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - on_partition_or_filegroup_statement:
           filegroup_clause:

--- a/test/fixtures/dialects/tsql/create_table_with_distribution.yml
+++ b/test/fixtures/dialects/tsql/create_table_with_distribution.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 949a316997d06d8bd81c0b45452d66cb06690d73bbbad7dfdfcc4c30a70fcd3c
+_hash: aeb7acea73d669a0a20a1a1a8280c6f23521a663b9ab9fd3c40d4c110312b983
 file:
 - batch:
     statement:
@@ -20,34 +20,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - table_distribution_index_clause:
           keyword: WITH
@@ -93,34 +96,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - table_distribution_index_clause:
           keyword: WITH
@@ -164,34 +170,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - table_distribution_index_clause:
           keyword: WITH
@@ -243,34 +252,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - table_distribution_index_clause:
           keyword: WITH
@@ -327,34 +339,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - table_distribution_index_clause:
           keyword: WITH
@@ -410,34 +425,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - table_distribution_index_clause:
           keyword: WITH

--- a/test/fixtures/dialects/tsql/create_table_with_sequence_bracketed.yml
+++ b/test/fixtures/dialects/tsql/create_table_with_sequence_bracketed.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1bd12039e6f42fc17a4d325703a2c1ec44307e77fc9a4ea4f90e0bce8f7aae2e
+_hash: bd8e5b608fd5cd901c0f50ac677f1ae452f8d065fe2abcb5f38423944df59dae
 file:
 - batch:
     statement:
@@ -114,24 +114,26 @@ file:
             naked_identifier: GMCODE
             data_type:
               data_type_identifier: VARCHAR
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             naked_identifier: AVERAGE_RNA_FLOW_PER_100000
             data_type:
               data_type_identifier: DECIMAL
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '16'
-              - comma: ','
-              - expression:
-                  numeric_literal: '2'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '16'
+                - comma: ','
+                - expression:
+                    numeric_literal: '2'
+                - end_bracket: )
             column_constraint_segment:
               keyword: 'NULL'
         - comma: ','
@@ -274,11 +276,12 @@ file:
             naked_identifier: GEMEENTE_CODE
             data_type:
               data_type_identifier: VARCHAR
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
             column_constraint_segment:
               keyword: 'NULL'
         - comma: ','
@@ -286,11 +289,12 @@ file:
             naked_identifier: GEMEENTE
             data_type:
               data_type_identifier: VARCHAR
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
             column_constraint_segment:
               keyword: 'NULL'
         - comma: ','
@@ -298,11 +302,12 @@ file:
             naked_identifier: LEEFTIJD
             data_type:
               data_type_identifier: VARCHAR
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
             column_constraint_segment:
               keyword: 'NULL'
         - comma: ','
@@ -310,11 +315,12 @@ file:
             naked_identifier: GESLACHT
             data_type:
               data_type_identifier: VARCHAR
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
             column_constraint_segment:
               keyword: 'NULL'
         - comma: ','
@@ -322,11 +328,12 @@ file:
             naked_identifier: DATUM_PEILING
             data_type:
               data_type_identifier: VARCHAR
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
             column_constraint_segment:
               keyword: 'NULL'
         - comma: ','
@@ -334,11 +341,12 @@ file:
             naked_identifier: POPULATIE
             data_type:
               data_type_identifier: VARCHAR
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
             column_constraint_segment:
               keyword: 'NULL'
         - comma: ','
@@ -346,11 +354,12 @@ file:
             naked_identifier: VEILIGHEIDSREGIO_CODE
             data_type:
               data_type_identifier: VARCHAR
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
             column_constraint_segment:
               keyword: 'NULL'
         - comma: ','
@@ -358,11 +367,12 @@ file:
             naked_identifier: VEILIGHEIDSREGIO_NAAM
             data_type:
               data_type_identifier: VARCHAR
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
             column_constraint_segment:
               keyword: 'NULL'
         - comma: ','
@@ -370,11 +380,12 @@ file:
             naked_identifier: PROVINCIE_CODE
             data_type:
               data_type_identifier: VARCHAR
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
             column_constraint_segment:
               keyword: 'NULL'
         - comma: ','
@@ -382,11 +393,12 @@ file:
             naked_identifier: PROVINCIE_NAAM
             data_type:
               data_type_identifier: VARCHAR
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
             column_constraint_segment:
               keyword: 'NULL'
         - comma: ','
@@ -394,11 +406,12 @@ file:
             naked_identifier: GGD_CODE
             data_type:
               data_type_identifier: VARCHAR
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
             column_constraint_segment:
               keyword: 'NULL'
         - comma: ','
@@ -406,11 +419,12 @@ file:
             naked_identifier: GGD_NAAM
             data_type:
               data_type_identifier: VARCHAR
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
             column_constraint_segment:
               keyword: 'NULL'
         - comma: ','
@@ -559,14 +573,15 @@ file:
             naked_identifier: INFECTED_DAILY_INCREASE
             data_type:
               data_type_identifier: DECIMAL
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '16'
-              - comma: ','
-              - expression:
-                  numeric_literal: '1'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '16'
+                - comma: ','
+                - expression:
+                    numeric_literal: '1'
+                - end_bracket: )
             column_constraint_segment:
               keyword: 'NULL'
         - comma: ','
@@ -609,39 +624,42 @@ file:
             quoted_identifier: '[7D_AVERAGE_INFECTED_DAILY_INCREASE_TOTAL]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '16'
-              - comma: ','
-              - expression:
-                  numeric_literal: '2'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '16'
+                - comma: ','
+                - expression:
+                    numeric_literal: '2'
+                - end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[7D_AVERAGE_INFECTED_DAILY_INCREASE_LAG]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '16'
-              - comma: ','
-              - expression:
-                  numeric_literal: '2'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '16'
+                - comma: ','
+                - expression:
+                    numeric_literal: '2'
+                - end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[7D_AVERAGE_INFECTED_DAILY_INCREASE_ABSOLUTE]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '16'
-              - comma: ','
-              - expression:
-                  numeric_literal: '2'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '16'
+                - comma: ','
+                - expression:
+                    numeric_literal: '2'
+                - end_bracket: )
         - end_bracket: )
       - statement_terminator: ;

--- a/test/fixtures/dialects/tsql/create_table_with_trailing_comma.yml
+++ b/test/fixtures/dialects/tsql/create_table_with_trailing_comma.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2b88578420020536b87708edc25b6e03e3d68f285ad98811fb1feeeb6855847c
+_hash: 1741f41c3ad5d4387b08448fc575cf531f48835b024826f368d22069ecf693d9
 file:
   batch:
     statement:
@@ -20,10 +20,11 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
           comma: ','
           end_bracket: )

--- a/test/fixtures/dialects/tsql/create_type.yml
+++ b/test/fixtures/dialects/tsql/create_type.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a2c1c31fefcb68ff28a78b97c46dd954b01b2f37fd35e738d24f403801789768
+_hash: 1873d9ddf12a690dee729b24d8f6678ce9686f646e8321db57a10d32d349aadb
 file:
   batch:
   - statement:
@@ -20,11 +20,12 @@ file:
             naked_identifier: name
             data_type:
               data_type_identifier: nvarchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '10'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '10'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             naked_identifier: height

--- a/test/fixtures/dialects/tsql/delete.yml
+++ b/test/fixtures/dialects/tsql/delete.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f61ec5dd4a6ba9978e233cba06f0b7d6a9d3483827a18fe8f7b594c545c6224d
+_hash: 499e9012f5cb95c4d85b318e244cf97db07a0782422e2f77aa327eb635e1e8a9
 file:
 - batch:
     statement:
@@ -76,11 +76,12 @@ file:
               keyword: as
               data_type:
                 data_type_identifier: char
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    numeric_literal: '3'
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      numeric_literal: '3'
+                    end_bracket: )
               end_bracket: )
         statement_terminator: ;
 - go_statement:
@@ -552,11 +553,12 @@ file:
             naked_identifier: ProductName
             data_type:
               data_type_identifier: nvarchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '50'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '50'
+                  end_bracket: )
             column_constraint_segment:
             - keyword: NOT
             - keyword: 'NULL'

--- a/test/fixtures/dialects/tsql/execute.yml
+++ b/test/fixtures/dialects/tsql/execute.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cf4430aab8cf836129293bbc70a61d2c282e592dc39fb2cb61bbde2e2c3136b3
+_hash: 84fadab934cf174f454d0fa9b518ddb7164fa80fe55111cd14f33d8c97b93fb7
 file:
   batch:
   - statement:
@@ -206,10 +206,11 @@ file:
         parameter: '@statement'
         data_type:
           data_type_identifier: nvarchar
-          bracketed:
-            start_bracket: (
-            keyword: max
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              keyword: max
+              end_bracket: )
         comparison_operator:
           raw_comparison_operator: '='
         expression:

--- a/test/fixtures/dialects/tsql/function_default_params.yml
+++ b/test/fixtures/dialects/tsql/function_default_params.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 30609c9432def3d60a46ab44bffa6749659192dbab365b5180a19826c8fbf5e5
+_hash: d7b3e7a4024bf5794510cdb9fe85e46231c6e7f4a658d817d6396cd865f1b5b3
 file:
   batch:
     create_procedure_statement:
@@ -17,11 +17,12 @@ file:
       - parameter: '@param1'
       - data_type:
           data_type_identifier: nvarchar
-          bracketed:
-            start_bracket: (
-            expression:
-              numeric_literal: '10'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '10'
+              end_bracket: )
       - comparison_operator:
           raw_comparison_operator: '='
       - expression:

--- a/test/fixtures/dialects/tsql/hints.yml
+++ b/test/fixtures/dialects/tsql/hints.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e43dd4231a12a1515781ca109632f9fdbb660030b474b3b475f0f99735425dd0
+_hash: 6fe6077b68d1043a06174c757f1566f29133888aab96b254faa753d3b667b133
 file:
 - batch:
     statement:
@@ -82,20 +82,22 @@ file:
       - parameter: '@city_name'
       - data_type:
           data_type_identifier: NVARCHAR
-          bracketed:
-            start_bracket: (
-            expression:
-              numeric_literal: '30'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '30'
+              end_bracket: )
       - comma: ','
       - parameter: '@postal_code'
       - data_type:
           data_type_identifier: NVARCHAR
-          bracketed:
-            start_bracket: (
-            expression:
-              numeric_literal: '15'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '15'
+              end_bracket: )
     - keyword: AS
     - procedure_statement:
         statement:

--- a/test/fixtures/dialects/tsql/print.yml
+++ b/test/fixtures/dialects/tsql/print.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5da646ea7ac1fc4b9d5602093d75a4521539f0acbe14d93e17ac7b7cccd339ad
+_hash: 683357bdaa8ac0f3bc686790545ee9e82d84517b8cb80ce8b441081659f15244
 file:
   batch:
   - statement:
@@ -12,11 +12,12 @@ file:
         parameter: '@TestVal'
         data_type:
           data_type_identifier: VARCHAR
-          bracketed:
-            start_bracket: (
-            expression:
-              numeric_literal: '20'
-            end_bracket: )
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '20'
+              end_bracket: )
         comparison_operator:
           raw_comparison_operator: '='
         expression:
@@ -45,11 +46,12 @@ file:
               keyword: AS
               data_type:
                 data_type_identifier: VARCHAR
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    numeric_literal: '50'
-                  end_bracket: )
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      numeric_literal: '50'
+                    end_bracket: )
               end_bracket: )
         statement_terminator: ;
   - statement:

--- a/test/fixtures/dialects/tsql/select.yml
+++ b/test/fixtures/dialects/tsql/select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 58b14f77a31e4a4c43259e4d42b5e0a77a87be1b619e857fac329c4747b8c8e6
+_hash: 5ce6e3c7c4dc3263e4f470a51c0b7c52a2173bba1d16f2852067b0d232b40bc6
 file:
   batch:
     statement:
@@ -835,11 +835,12 @@ file:
                 data_type:
                   data_type_identifier: character
                   keyword: varying
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      numeric_literal: '1'
-                    end_bracket: )
+                  bracketed_arguments:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        numeric_literal: '1'
+                      end_bracket: )
                 end_bracket: )
         - comma: ','
         - select_clause_element:

--- a/test/fixtures/dialects/tsql/sequence.yml
+++ b/test/fixtures/dialects/tsql/sequence.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 55438b24f9c3193ab3eae96d8dc40ef8d77e87dfa87b431d31c7fce238cd8387
+_hash: e0e8fd69019db0ed39c2baf5e6e04d8015b32483129f0e256d19de7838d1a0f7
 file:
 - batch:
     statement:
@@ -35,14 +35,15 @@ file:
           keyword: AS
           data_type:
             data_type_identifier: decimal
-            bracketed:
-            - start_bracket: (
-            - expression:
-                numeric_literal: '3'
-            - comma: ','
-            - expression:
-                numeric_literal: '0'
-            - end_bracket: )
+            bracketed_arguments:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  numeric_literal: '3'
+              - comma: ','
+              - expression:
+                  numeric_literal: '0'
+              - end_bracket: )
       - create_sequence_options_segment:
         - keyword: START
         - keyword: WITH

--- a/test/fixtures/dialects/tsql/stored_procedure_single_statement.yml
+++ b/test/fixtures/dialects/tsql/stored_procedure_single_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9c8937fc2416f96d82bcc938dd539ee97a0f9325979556e8bf1d29956bfad457
+_hash: 3e7b1bb873be22b78273c31cc7f23750f41e2ccc8bcac842a2ffcccdb1027d2b
 file:
   batch:
     create_procedure_statement:
@@ -25,11 +25,12 @@ file:
         - parameter: '@Orange'
         - data_type:
             data_type_identifier: varchar
-            bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '100'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '100'
+                end_bracket: )
         - end_bracket: )
     - keyword: AS
     - procedure_statement:

--- a/test/fixtures/dialects/tsql/table_variables.yml
+++ b/test/fixtures/dialects/tsql/table_variables.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 512c12d4847dc7dbbf698c6196f18b67857899b2bfc9f15232b5fceaa093e2b1
+_hash: 862b2714c5dba3bc89677f4191a6c8ab1c6135281db59a5ba2e5b9183b80c83c
 file:
   batch:
     statement:
@@ -22,9 +22,10 @@ file:
             naked_identifier: url
             data_type:
               data_type_identifier: nvarchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - end_bracket: )

--- a/test/fixtures/dialects/tsql/temporal_tables.yml
+++ b/test/fixtures/dialects/tsql/temporal_tables.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8e2d486950fe63d6e398a60c422c187d0418ead52131beadbacb260d8ba75e8a
+_hash: d66d0d6cba86db7a5b3fea6e509b2eca5b706032e71909585ff41ae4f374dc25
 file:
 - batch:
   - statement:
@@ -135,34 +135,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - table_option_statement:
           keyword: WITH
@@ -207,34 +210,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - table_option_statement:
           keyword: WITH
@@ -265,34 +271,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - table_option_statement:
           keyword: WITH
@@ -335,34 +344,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - table_option_statement:
           keyword: WITH
@@ -411,34 +423,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - table_option_statement:
           keyword: WITH
@@ -503,34 +518,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - table_option_statement:
           keyword: WITH
@@ -569,34 +587,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - table_option_statement:
           keyword: WITH
@@ -637,34 +658,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - table_option_statement:
           keyword: WITH
@@ -730,34 +754,37 @@ file:
             quoted_identifier: '[Column B]'
             data_type:
               data_type_identifier: '[varchar]'
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnC]'
             data_type:
               data_type_identifier: varchar
-              bracketed:
-                start_bracket: (
-                expression:
-                  numeric_literal: '100'
-                end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
         - comma: ','
         - column_definition:
             quoted_identifier: '[ColumnDecimal]'
             data_type:
               data_type_identifier: decimal
-              bracketed:
-              - start_bracket: (
-              - expression:
-                  numeric_literal: '10'
-              - comma: ','
-              - expression:
-                  numeric_literal: '3'
-              - end_bracket: )
+              bracketed_arguments:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '10'
+                - comma: ','
+                - expression:
+                    numeric_literal: '3'
+                - end_bracket: )
         - end_bracket: )
       - table_option_statement:
           keyword: WITH

--- a/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -330,5 +330,16 @@ test_pass_bigquery_specific_struct_access:
 
 test_postgres_datatype:
   # https://github.com/sqlfluff/sqlfluff/issues/4521
+  # https://github.com/sqlfluff/sqlfluff/issues/4565
   pass_str: |
-    select 1::NUMERIC(3, 1)
+    select
+        1::NUMERIC(3, 1),
+        2::double precision,
+        '2020-01-01'::timestamp with time zone,
+        'foo'::character varying,
+        B'10101'::bit(3),
+        B'10101'::bit varying(3),
+        B'10101'::bit varying
+  configs:
+    core:
+      dialect: postgres

--- a/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -416,3 +416,37 @@ test_sparksql_datatype:
   configs:
     core:
       dialect: sparksql
+
+test_exasol_datatype:
+  pass_str: |
+      select
+          1::double precision,
+          1::DECIMAL(3, 1),
+          1::NUMERIC(3, 1),
+          'bar'::VARCHAR(2000 CHAR),
+          col1::INTERVAL DAY(2) TO SECOND(1)
+  configs:
+    core:
+      dialect: exasol
+
+test_teradata_datatype:
+  pass_str: |
+      select
+          1::DECIMAL(3, 1),
+          1::DEC(3, 1),
+          1::NUMERIC(3, 1),
+          'bar'::CHAR(3)
+  configs:
+    core:
+      dialect: teradata
+
+test_tsql_datatype:
+  pass_str: |
+      select
+          1::DECIMAL(3, 1),
+          1::DEC(3, 1),
+          1::NUMERIC(3, 1),
+          'bar'::character varying(3)
+  configs:
+    core:
+      dialect: tsql

--- a/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -343,3 +343,76 @@ test_postgres_datatype:
   configs:
     core:
       dialect: postgres
+
+test_redshift_datatype:
+  pass_str: |
+    select
+        1::NUMERIC(3, 1),
+        2::double precision,
+        '2020-01-01'::timestamp with time zone,
+        'foo'::character varying,
+        'foo'::character varying(MAX),
+        'foo'::character varying(255),
+        '10101'::binary varying(6)
+  configs:
+    core:
+      dialect: redshift
+
+test_bigquery_datatype:
+  pass_str: |
+      select 1::NUMERIC(3, 1)
+  configs:
+    core:
+      dialect: bigquery
+
+test_athena_datatype:
+  pass_str: |
+      select
+          1::DECIMAL(3, 1),
+          'foo'::VARCHAR(4),
+          'bar'::CHAR(3),
+          col1::STRUCT<foo: int>,
+          col2::ARRAY<int>,
+          '2020-01-01'::timestamp with time zone
+  configs:
+    core:
+      dialect: athena
+
+test_hive_datatype:
+  pass_str: |
+      select
+          1::DECIMAL(3, 1),
+          1::DEC(3, 1),
+          1::NUMERIC(3, 1),
+          col1::STRUCT<foo: int>,
+          col2::ARRAY<int>,
+          col3::ARRAY<int>[4]
+  configs:
+    core:
+      dialect: hive
+
+test_sqlite_datatype:
+  pass_str: |
+      select
+          1::double precision,
+          1::DECIMAL(10, 5),
+          1::unsigned big int,
+          'foo'::varying character(255),
+          'foo'::character(20),
+          'foo'::nvarchar(200)
+  configs:
+    core:
+      dialect: sqlite
+
+test_sparksql_datatype:
+  pass_str: |
+      select
+          1::DECIMAL(3, 1),
+          1::DEC(3, 1),
+          1::NUMERIC(3, 1),
+          'bar'::CHAR(3),
+          col1::STRUCT<foo: int>,
+          col2::ARRAY<int>
+  configs:
+    core:
+      dialect: sparksql


### PR DESCRIPTION
This one is quite involved. It fixes #4565 and reworks some of what was done in #4521.

It rethinks how we define spacing in datatypes, rather than just prohibiting spaces within datatypes (which is problematic for `double precision`), but rather defines the bracketed section of the datatype with a specific type and then saying _"don't put spaces before it"_.

In the process, I've added a bunch more tests for spacing around datatypes, covering most of the major dialects which define datatypes.