### PR TITLE
Support `WITH ORDINALITY` clauses in Postgres

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -4798,3 +4798,23 @@ class NamedArgumentSegment(BaseSegment):
         Ref("RightArrowSegment"),
         Ref("ExpressionSegment"),
     )
+
+
+class TableExpressionSegment(ansi.TableExpressionSegment):
+    """The main table expression e.g. within a FROM clause.
+
+    Override from ANSI to allow optional WITH ORDINALITY clause
+    """
+
+    match_grammar: Matchable = OneOf(
+        Ref("ValuesClauseSegment"),
+        Ref("BareFunctionSegment"),
+        Sequence(
+            Ref("FunctionSegment"),
+            Sequence("WITH", "ORDINALITY", optional="True"),
+        ),
+        Ref("TableReferenceSegment"),
+        # Nested Selects
+        Bracketed(Ref("SelectableGrammar")),
+        Bracketed(Ref("MergeStatementSegment")),
+    )

--- a/test/fixtures/dialects/postgres/postgres_table_functions.sql
+++ b/test/fixtures/dialects/postgres/postgres_table_functions.sql
@@ -1,0 +1,7 @@
+select * from unnest(array['123', '456']);
+
+select * from unnest(array['123', '456']) as a(val, row_num);
+
+select * from unnest(array['123', '456']) with ordinality;
+
+select * from unnest(array['123', '456']) with ordinality as a(val, row_num);

--- a/test/fixtures/dialects/postgres/postgres_table_functions.yml
+++ b/test/fixtures/dialects/postgres/postgres_table_functions.yml
@@ -1,0 +1,151 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 87790be6cd29e35d6b49f004079316a4d1a8ce524ff8545019db85b2247c4b25
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: unnest
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    typed_array_literal:
+                      array_type:
+                        keyword: array
+                      array_literal:
+                      - start_square_bracket: '['
+                      - quoted_literal: "'123'"
+                      - comma: ','
+                      - quoted_literal: "'456'"
+                      - end_square_bracket: ']'
+                  end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: unnest
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    typed_array_literal:
+                      array_type:
+                        keyword: array
+                      array_literal:
+                      - start_square_bracket: '['
+                      - quoted_literal: "'123'"
+                      - comma: ','
+                      - quoted_literal: "'456'"
+                      - end_square_bracket: ']'
+                  end_bracket: )
+            alias_expression:
+              keyword: as
+              naked_identifier: a
+              bracketed:
+                start_bracket: (
+                identifier_list:
+                - naked_identifier: val
+                - comma: ','
+                - naked_identifier: row_num
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+            - function:
+                function_name:
+                  function_name_identifier: unnest
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    typed_array_literal:
+                      array_type:
+                        keyword: array
+                      array_literal:
+                      - start_square_bracket: '['
+                      - quoted_literal: "'123'"
+                      - comma: ','
+                      - quoted_literal: "'456'"
+                      - end_square_bracket: ']'
+                  end_bracket: )
+            - keyword: with
+            - keyword: ordinality
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+            - function:
+                function_name:
+                  function_name_identifier: unnest
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    typed_array_literal:
+                      array_type:
+                        keyword: array
+                      array_literal:
+                      - start_square_bracket: '['
+                      - quoted_literal: "'123'"
+                      - comma: ','
+                      - quoted_literal: "'456'"
+                      - end_square_bracket: ']'
+                  end_bracket: )
+            - keyword: with
+            - keyword: ordinality
+            alias_expression:
+              keyword: as
+              naked_identifier: a
+              bracketed:
+                start_bracket: (
+                identifier_list:
+                - naked_identifier: val
+                - comma: ','
+                - naked_identifier: row_num
+                end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fxied #3843 

### Are there any other side effects of this change that we should be aware of?
Don't think so

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
