### PR TITLE
--bench output with rule timings

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -677,7 +677,9 @@ def lint(
         timing_summary = result.timing_summary()
         for step in timing_summary:
             click.echo(f"=== {step} ===")
-            click.echo(formatter.cli_table(timing_summary[step].items()))
+            click.echo(
+                formatter.cli_table(timing_summary[step].items(), cols=3, col_width=20)
+            )
 
     if not nofail:
         if not non_human_output:
@@ -846,7 +848,9 @@ def _paths_fix(
         timing_summary = result.timing_summary()
         for step in timing_summary:
             click.echo(f"=== {step} ===")
-            click.echo(formatter.cli_table(timing_summary[step].items()))
+            click.echo(
+                formatter.cli_table(timing_summary[step].items(), cols=3, col_width=20)
+            )
 
     if show_lint_violations:
         click.echo("==== lint for unfixable violations ====")

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -10,6 +10,7 @@ import logging
 import shutil
 import stat
 import tempfile
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -42,11 +43,26 @@ linter_logger: logging.Logger = logging.getLogger("sqlfluff.linter")
 
 @dataclass
 class FileTimings:
+    """A dataclass for holding the timings information for a file."""
+
     step_timings: Dict[str, float]
     # NOTE: Because rules may run more than once for any
     # given file we record each run and then we can post
     # process this as we wish later.
     rule_timings: List[Tuple[str, str, float]]
+
+    def get_rule_timing_dict(self) -> Dict[str, float]:
+        """Generate a summary to total time in each rule.
+
+        This is primarily for csv export.
+        """
+        total_times: Dict[str, float] = defaultdict(float)
+
+        for code, _, time in self.rule_timings:
+            total_times[code] += time
+
+        # Return as plain dict
+        return dict(total_times.items())
 
 
 class LintedFile(NamedTuple):

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -10,6 +10,7 @@ import logging
 import shutil
 import stat
 import tempfile
+from dataclasses import dataclass
 from typing import (
     Any,
     Iterable,
@@ -20,6 +21,7 @@ from typing import (
     Union,
     cast,
     Type,
+    Dict,
 )
 
 from sqlfluff.core.errors import (
@@ -38,12 +40,21 @@ from sqlfluff.core.linter.common import NoQaDirective
 linter_logger: logging.Logger = logging.getLogger("sqlfluff.linter")
 
 
+@dataclass
+class FileTimings:
+    step_timings: Dict[str, float]
+    # NOTE: Because rules may run more than once for any
+    # given file we record each run and then we can post
+    # process this as we wish later.
+    rule_timings: List[Tuple[str, str, float]]
+
+
 class LintedFile(NamedTuple):
     """A class to store the idea of a linted file."""
 
     path: str
     violations: List[SQLBaseError]
-    time_dict: dict
+    timings: FileTimings
     tree: Optional[BaseSegment]
     ignore_mask: List[NoQaDirective]
     templated_file: TemplatedFile

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -54,7 +54,7 @@ class LintedFile(NamedTuple):
 
     path: str
     violations: List[SQLBaseError]
-    timings: FileTimings
+    timings: Optional[FileTimings]
     tree: Optional[BaseSegment]
     ignore_mask: List[NoQaDirective]
     templated_file: TemplatedFile

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -691,7 +691,7 @@ class Linter:
                     # Reason: When the linter hits the loop limit, the file is often
                     # messy, e.g. some of the fixes were applied repeatedly, possibly
                     # other weird things. We don't want the user to see this junk!
-                    return save_tree, initial_linting_errors, ignore_buff
+                    return save_tree, initial_linting_errors, ignore_buff, rule_timings
 
         if config.get("ignore_templated_areas", default=True):
             initial_linting_errors = cls.remove_templated_errors(initial_linting_errors)

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -54,6 +54,7 @@ from sqlfluff.core.linter.linting_result import LintingResult
 
 
 WalkableType = Iterable[Tuple[str, Optional[List[str]], List[str]]]
+RuleTimingsType = List[Tuple[str, str, float]]
 
 # Instantiate the linter logger
 linter_logger: logging.Logger = logging.getLogger("sqlfluff.linter")
@@ -491,7 +492,7 @@ class Linter:
         fname: Optional[str] = None,
         templated_file: Optional[TemplatedFile] = None,
         formatter: Any = None,
-    ) -> Tuple[BaseSegment, List[SQLBaseError], List[NoQaDirective]]:
+    ) -> Tuple[BaseSegment, List[SQLBaseError], List[NoQaDirective], RuleTimingsType]:
         """Lint and optionally fix a tree object."""
         # Keep track of the linting errors on the very first linter pass. The
         # list of issues output by "lint" and "fix" only includes issues present
@@ -503,7 +504,7 @@ class Linter:
         # Keep a set of previous versions to catch infinite loops.
         previous_versions: Set[Tuple[str, Tuple[SourceFix, ...]]] = {(tree.raw, ())}
         # Keep a buffer for recording rule timings.
-        rule_timings: List[Tuple[str, str, float]] = []
+        rule_timings: RuleTimingsType = []
 
         # If we are fixing then we want to loop up to the runaway_limit, otherwise just
         # once for linting.

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -22,7 +22,7 @@ from sqlfluff.core.errors import (
     SQLTemplaterError,
 )
 
-from sqlfluff.core.timing import TimingSummary
+from sqlfluff.core.timing import TimingSummary, RuleTimingSummary
 
 # Classes needed only for type checking
 from sqlfluff.core.parser.segments.base import BaseSegment
@@ -145,10 +145,12 @@ class LintingResult:
     def timing_summary(self) -> Dict[str, Dict[str, float]]:
         """Return a timing summary."""
         timing = TimingSummary()
+        rules_timing = RuleTimingSummary()
         for dir in self.paths:
             for file in dir.files:
-                timing.add(file.time_dict)
-        return timing.summary()
+                timing.add(file.timings.step_timings)
+                rules_timing.add(file.timings.rule_timings)
+        return {**timing.summary(), **rules_timing.summary()}
 
     def persist_timing_records(self, filename):
         """Persist the timing records as a csv to external analysis."""

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -148,8 +148,9 @@ class LintingResult:
         rules_timing = RuleTimingSummary()
         for dir in self.paths:
             for file in dir.files:
-                timing.add(file.timings.step_timings)
-                rules_timing.add(file.timings.rule_timings)
+                if file.timings:
+                    timing.add(file.timings.step_timings)
+                    rules_timing.add(file.timings.rule_timings)
         return {**timing.summary(), **rules_timing.summary()}
 
     def persist_timing_records(self, filename):

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -193,7 +193,7 @@ class LintingResult:
                                 if file.tree
                                 else ""
                             ),
-                            **file.time_dict,
+                            **file.timings.step_timings,
                         }
                     )
 

--- a/src/sqlfluff/core/timing.py
+++ b/src/sqlfluff/core/timing.py
@@ -1,6 +1,6 @@
 """Timing summary class."""
 
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Tuple, Set
 from collections import defaultdict
 
 
@@ -37,4 +37,39 @@ class TimingSummary:
                     "max": max(vals[step]),
                     "avg": sum(vals[step]) / len(vals[step]),
                 }
+        return summary
+
+
+class RuleTimingSummary:
+    """An object for tracking the timing of rules across many files."""
+
+    def __init__(self):
+        self._timings: List[Tuple[str, str, float]] = []
+
+    def add(self, rule_timings: List[Tuple[str, str, float]]):
+        """Add a set of rule timings."""
+        # Add records to the main list.
+        self._timings.extend(rule_timings)
+
+    def summary(self, threshold=0.5) -> Dict[str, Dict[str, float]]:
+        """Generate a summary for display."""
+        keys: Set[Tuple[str, str]] = set()
+        vals: Dict[Tuple[str, str], List[float]] = defaultdict(list)
+
+        for code, name, time in self._timings:
+            vals[(code, name)].append(time)
+            keys.add((code, name))
+
+        summary = {}
+        for code, name in sorted(keys):
+            timings = vals[(code, name)]
+            # For brevity, if the total time taken is less than
+            # `threshold`, then don't display.
+            if sum(timings) < threshold:
+                continue
+            summary[f"{code}: {name}"] = {
+                "sum (n)": f"{sum(timings):.2f} ({len(timings)})",
+                "min": min(timings),
+                "max": max(timings),
+            }
         return summary

--- a/src/sqlfluff/core/timing.py
+++ b/src/sqlfluff/core/timing.py
@@ -1,6 +1,6 @@
 """Timing summary class."""
 
-from typing import Optional, List, Dict, Tuple, Set
+from typing import Optional, List, Dict, Tuple, Set, Union
 from collections import defaultdict
 
 
@@ -43,7 +43,7 @@ class TimingSummary:
 class RuleTimingSummary:
     """An object for tracking the timing of rules across many files."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._timings: List[Tuple[str, str, float]] = []
 
     def add(self, rule_timings: List[Tuple[str, str, float]]):
@@ -51,7 +51,7 @@ class RuleTimingSummary:
         # Add records to the main list.
         self._timings.extend(rule_timings)
 
-    def summary(self, threshold=0.5) -> Dict[str, Dict[str, float]]:
+    def summary(self, threshold=0.5) -> Dict[str, Dict[str, Union[float, str]]]:
         """Generate a summary for display."""
         keys: Set[Tuple[str, str]] = set()
         vals: Dict[Tuple[str, str], List[float]] = defaultdict(list)
@@ -60,7 +60,7 @@ class RuleTimingSummary:
             vals[(code, name)].append(time)
             keys.add((code, name))
 
-        summary = {}
+        summary: Dict[str, Dict[str, Union[float, str]]] = {}
         for code, name in sorted(keys):
             timings = vals[(code, name)]
             # For brevity, if the total time taken is less than

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -535,8 +535,8 @@ def test__cli__command_lint_parse(command):
             (
                 lint,
                 [
-                    "test/fixtures/linter/autofix/bigquery004_templating/before.sql",
-                    "--bench"
+                    "test/fixtures/linter/autofix/bigquery/004_templating/before.sql",
+                    "--bench",
                 ],
             ),
             1,

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -529,6 +529,18 @@ def test__cli__command_lint_parse(command):
             ),
             1,
         ),
+        # Test a longer lint fail with --bench
+        # This tests the threshold rules clause
+        (
+            (
+                lint,
+                [
+                    "test/fixtures/linter/autofix/bigquery004_templating/before.sql",
+                    "--bench"
+                ],
+            ),
+            1,
+        ),
     ],
 )
 def test__cli__command_lint_parse_with_retcode(command, ret_code):

--- a/test/core/linter_test.py
+++ b/test/core/linter_test.py
@@ -766,7 +766,7 @@ def test_linted_file_ignore_masked_violations(
     lf = linter.LintedFile(
         path="",
         violations=violations,
-        time_dict={},
+        timings=None,
         tree=None,
         ignore_mask=ignore_mask,
         templated_file=TemplatedFile.from_string(""),


### PR DESCRIPTION
This adds more granularity to the `--bench` output so that rule timings are visible (from performance session with @WittierDinosaur). Also adds rule timings to the timing csv output for performance tuning.