### PR TITLE
fix(dialect-clickhouse): Add materialized view statement

### DIFF
--- a/test/fixtures/dialects/clickhouse/create_materialized_view.sql
+++ b/test/fixtures/dialects/clickhouse/create_materialized_view.sql
@@ -1,0 +1,50 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS db.table_mv
+TO db.table
+AS
+    SELECT
+        column1,
+        column2
+    FROM db.table_kafka;
+
+CREATE MATERIALIZED VIEW table_mv
+TO table
+AS
+    SELECT
+        column1,
+        column2
+    FROM table_kafka;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS db.table_mv
+ON CLUSTER mycluster
+TO db.table
+AS
+    SELECT
+        column1,
+        column2
+    FROM db.table_kafka;
+
+CREATE MATERIALIZED VIEW table_mv
+TO table
+ENGINE = MergeTree()
+AS
+    SELECT
+        column1,
+        column2
+    FROM table_kafka;
+
+CREATE MATERIALIZED VIEW table_mv
+ENGINE = MergeTree()
+AS
+    SELECT
+        column1,
+        column2
+    FROM table_kafka;
+
+CREATE MATERIALIZED VIEW table_mv
+ENGINE = MergeTree()
+POPULATE
+AS
+    SELECT
+        column1,
+        column2
+    FROM table_kafka;

--- a/test/fixtures/dialects/clickhouse/create_materialized_view.yml
+++ b/test/fixtures/dialects/clickhouse/create_materialized_view.yml
@@ -1,0 +1,229 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: a5d6cd3865f0a5a4395112277b201da1a9794712fcf125b9269ef777e366bc21
+file:
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: table_mv
+    - keyword: TO
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: table
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: column1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: column2
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: db
+                - dot: .
+                - naked_identifier: table_kafka
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: table_mv
+    - keyword: TO
+    - table_reference:
+        naked_identifier: table
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: column1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: column2
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table_kafka
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: table_mv
+    - keyword: 'ON'
+    - keyword: CLUSTER
+    - expression:
+        column_reference:
+          naked_identifier: mycluster
+    - keyword: TO
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: table
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: column1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: column2
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: db
+                - dot: .
+                - naked_identifier: table_kafka
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: table_mv
+    - keyword: TO
+    - table_reference:
+        naked_identifier: table
+    - engine:
+        keyword: ENGINE
+        comparison_operator:
+          raw_comparison_operator: '='
+        engine_function:
+          function_name:
+            function_name_identifier: MergeTree
+          bracketed:
+            start_bracket: (
+            end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: column1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: column2
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table_kafka
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: table_mv
+    - engine:
+        keyword: ENGINE
+        comparison_operator:
+          raw_comparison_operator: '='
+        engine_function:
+          function_name:
+            function_name_identifier: MergeTree
+          bracketed:
+            start_bracket: (
+            end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: column1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: column2
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table_kafka
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: table_mv
+    - engine:
+        keyword: ENGINE
+        comparison_operator:
+          raw_comparison_operator: '='
+        engine_function:
+          function_name:
+            function_name_identifier: MergeTree
+          bracketed:
+            start_bracket: (
+            end_bracket: )
+    - keyword: POPULATE
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: column1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: column2
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table_kafka
+- statement_terminator: ;

--- a/test/fixtures/dialects/clickhouse/create_table.yml
+++ b/test/fixtures/dialects/clickhouse/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 202c38edd25795f71b9e328b40440188d0fba28ab37bf7fa65f28a4759eb22c7
+_hash: 70f6acdf665d02008e12fa18131d686ca8a206117c271538b8d1c82b9154e116
 file:
 - statement:
     create_table_statement:
@@ -529,20 +529,26 @@ file:
         naked_identifier: all_hits
     - keyword: 'ON'
     - keyword: CLUSTER
-    - cluster_reference:
-        naked_identifier: cluster
-    - bracketed:
-      - start_bracket: (
-      - column_definition:
-          naked_identifier: p
-          data_type:
-            data_type_identifier: Date
-      - comma: ','
-      - column_definition:
-          naked_identifier: i
-          data_type:
-            data_type_identifier: Int32
-      - end_bracket: )
+    - expression:
+        function:
+          function_name:
+            function_name_identifier: cluster
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+                naked_identifier: p
+          - expression:
+              column_reference:
+                naked_identifier: Date
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: i
+          - expression:
+              column_reference:
+                naked_identifier: Int32
+          - end_bracket: )
     - engine:
         keyword: ENGINE
         comparison_operator:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Improve the Clickhouse dialect:
- Parse `MATERIALIZED VIEW` with dedicated Statement

Also fix bugs:
- `On Cluster` statement (with `ClusterReferenceSegment` function) that blocked some tests cases
- Statement Segment management (with `StatementSegment` function) that blocked any addition o *Something*Class (as issued with `CreateMaterializedViewStatementSegment` evolution)


### Are there any other side effects of this change that we should be aware of?

No side effect.


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - ~`.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.~
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - [x] Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- ~Added appropriate documentation for the change.~
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
