### PR TITLE
Nicer formatted dbt errors

### DIFF
--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -19,11 +19,13 @@ try:
     from dbt.exceptions import (
         CompilationException as DbtCompilationException,
         FailedToConnectException as DbtFailedToConnectException,
+        DbtProjectError,
     )
 except ImportError:
     from dbt.exceptions import (
         CompilationError as DbtCompilationException,
         FailedToConnectError as DbtFailedToConnectException,
+        DbtProjectError,
     )
 
 from dbt import flags
@@ -33,7 +35,7 @@ from jinja2_simple_tags import StandaloneTag
 from sqlfluff.cli.formatters import OutputStreamFormatter
 from sqlfluff.core import FluffConfig
 from sqlfluff.core.cached_property import cached_property
-from sqlfluff.core.errors import SQLTemplaterError, SQLFluffSkipFile
+from sqlfluff.core.errors import SQLTemplaterError, SQLFluffSkipFile, SQLFluffUserError
 
 from sqlfluff.core.templaters.base import TemplatedFile, large_file_check
 
@@ -149,6 +151,8 @@ class DbtTemplater(JinjaTemplater):
             # https://github.com/dbt-labs/dbt-core/issues/6055 is solved.
             os.chdir(self.project_dir)
             self.dbt_manifest = ManifestLoader.get_full_manifest(self.dbt_config)
+        except DbtProjectError as err:  # pragma: no cover
+            raise SQLFluffUserError(f"DbtProjectError: {err}")
         finally:
             os.chdir(old_cwd)
         return self.dbt_manifest


### PR DESCRIPTION
This is a very small PR, related to #3744.

It makes dbt errors slightly nicer formatted in the CL so we don't get a full tracelog. Example.

Before this PR, a profiles file error would look like this:

```
=== [dbt templater] Sorting Nodes...
ERROR      dbt_profiles_dir: C:\Users\alanc\.dbt could not be accessed. Check it exists.
Traceback (most recent call last):
  File "C:\Python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\Scripts\sqlfluff.EXE\__main__.py", line 7, in <module>
    sys.exit(cli())
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\click\core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\click\core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\click\core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\click\core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\click\core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\sqlfluff\cli\commands.py", line 604, in lint
    result = lnt.lint_paths(
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\sqlfluff\core\linter\linter.py", line 1184, in lint_paths
    for i, linted_file in enumerate(runner.run(expanded_paths, fix), start=1):
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\sqlfluff\core\linter\runner.py", line 106, in run
    for fname, partial in self.iter_partials(fnames, fix=fix):
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\sqlfluff\core\linter\runner.py", line 59, in iter_partials
    for fname, rendered in self.iter_rendered(fnames):
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\sqlfluff\core\linter\runner.py", line 42, in iter_rendered
    for fname in self.linter.templater.sequence_files(
  File "c:\users\alanc\dev\sqlfluff\plugins\sqlfluff-templater-dbt\sqlfluff_templater_dbt\templater.py", line 281, in sequence_files
    for key, node in self.dbt_manifest.nodes.items():
  File "C:\Python39\lib\functools.py", line 993, in __get__
    val = self.func(instance)
  File "c:\users\alanc\dev\sqlfluff\plugins\sqlfluff-templater-dbt\sqlfluff_templater_dbt\templater.py", line 151, in dbt_manifest
    self.dbt_manifest = ManifestLoader.get_full_manifest(self.dbt_config)
  File "C:\Python39\lib\functools.py", line 993, in __get__
    val = self.func(instance)
  File "c:\users\alanc\dev\sqlfluff\plugins\sqlfluff-templater-dbt\sqlfluff_templater_dbt\templater.py", line 114, in dbt_config
    self.dbt_config = DbtRuntimeConfig.from_args(
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\dbt\config\runtime.py", line 263, in from_args
    project, profile = cls.collect_parts(args)
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\dbt\config\runtime.py", line 207, in collect_parts
    profile = cls.collect_profile(args=args)
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\dbt\config\runtime.py", line 229, in collect_profile
    profile = cls._get_rendered_profile(args, profile_renderer, profile_name)
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\dbt\config\runtime.py", line 200, in _get_rendered_profile
    return Profile.render_from_args(args, profile_renderer, profile_name)
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\dbt\config\profile.py", line 428, in render_from_args
    return cls.from_raw_profiles(
  File "C:\Users\alanc\.virtualenvs\data_warehouse-quLENCc_\lib\site-packages\dbt\config\profile.py", line 384, in from_raw_profiles
    raise DbtProjectError("Could not find profile named '{}'".format(profile_name))
dbt.exceptions.DbtProjectError: Runtime Error
  Could not find profile named 'tails_analytics_profile'
```

After this PR, it looks like this:
```
=== [dbt templater] Sorting Nodes...

User Error: DbtProjectError: Runtime Error
  Could not find profile named 'tails_analytics_profile'
```