### PR TITLE
.simple() matching for TypedMatcher

### DIFF
--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -119,7 +119,6 @@ class AnyNumberOf(BaseGrammar):
                 available_options.append(opt)
                 matched_simple += 1
                 matched = True
-                break
 
             if not matched:
                 # Ditch this option, the simple match has failed

--- a/src/sqlfluff/core/parser/grammar/greedy.py
+++ b/src/sqlfluff/core/parser/grammar/greedy.py
@@ -1,7 +1,5 @@
 """GreedyUntil and StartsWith Grammars."""
 
-from typing import Optional, List
-
 from sqlfluff.core.parser.helpers import trim_non_code_segments
 from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.match_wrapper import match_wrapper

--- a/src/sqlfluff/core/parser/grammar/greedy.py
+++ b/src/sqlfluff/core/parser/grammar/greedy.py
@@ -170,7 +170,7 @@ class StartsWith(GreedyUntil):
         super().__init__(*args, **kwargs)
 
     @cached_method_for_parse_context
-    def simple(self, parse_context: ParseContext, crumbs=None) -> Optional[List[str]]:
+    def simple(self, parse_context: ParseContext, crumbs=None):
         """Does this matcher support a uppercase hash matching route?
 
         `StartsWith` is simple, if the thing it starts with is also simple.

--- a/src/sqlfluff/core/parser/grammar/noncode.py
+++ b/src/sqlfluff/core/parser/grammar/noncode.py
@@ -15,7 +15,7 @@ from sqlfluff.core.parser.context import ParseContext
 class NonCodeMatcher(Matchable):
     """An object which behaves like a matcher to match non-code."""
 
-    def simple(self, parse_context: ParseContext, crumbs=None) -> Optional[List[str]]:
+    def simple(self, parse_context: ParseContext, crumbs=None):
         """This element doesn't work with simple."""
         return None
 

--- a/src/sqlfluff/core/parser/grammar/noncode.py
+++ b/src/sqlfluff/core/parser/grammar/noncode.py
@@ -4,8 +4,6 @@ This is a stub of a grammar, intended for use entirely as a
 terminator or similar alongside other matchers.
 """
 
-from typing import Optional, List
-
 from sqlfluff.core.parser.match_wrapper import match_wrapper
 from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.matchable import Matchable

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -1,6 +1,6 @@
 """Sequence and Bracketed Grammars."""
 
-from typing import Optional, List, Tuple, cast
+from typing import Tuple, cast
 
 from sqlfluff.core.errors import SQLParseError
 

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -30,24 +30,26 @@ class Sequence(BaseGrammar):
     test_env = getenv("SQLFLUFF_TESTENV", "")
 
     @cached_method_for_parse_context
-    def simple(self, parse_context: ParseContext, crumbs=None) -> Optional[List[str]]:
+    def simple(self, parse_context: ParseContext, crumbs=None):
         """Does this matcher support a uppercase hash matching route?
 
         Sequence does provide this, as long as the *first* non-optional
         element does, *AND* and optional elements which preceded it also do.
         """
-        simple_buff = []
+        simple_raws = set()
+        simple_types = set()
         for opt in self._elements:
             simple = opt.simple(parse_context=parse_context, crumbs=crumbs)
             if not simple:
                 return None
-            simple_buff += simple
+            simple_raws.update(simple[0])
+            simple_types.update(simple[1])
 
             if not opt.is_optional():
                 # We found our first non-optional element!
-                return simple_buff
+                return frozenset(simple_raws), frozenset(simple_types)
         # If *all* elements are optional AND simple, I guess it's also simple.
-        return simple_buff
+        return frozenset(simple_raws), frozenset(simple_types)
 
     @match_wrapper()
     @allow_ephemeral
@@ -217,7 +219,7 @@ class Bracketed(Sequence):
         super().__init__(*args, **kwargs)
 
     @cached_method_for_parse_context
-    def simple(self, parse_context: ParseContext, crumbs=None) -> Optional[List[str]]:
+    def simple(self, parse_context: ParseContext, crumbs=None):
         """Does this matcher support a uppercase hash matching route?
 
         Bracketed does this easily, we just look for the bracket.

--- a/src/sqlfluff/core/parser/matchable.py
+++ b/src/sqlfluff/core/parser/matchable.py
@@ -2,7 +2,7 @@
 
 import copy
 from abc import ABC, abstractmethod
-from typing import List, Optional, Tuple, TYPE_CHECKING, FrozenSet
+from typing import Optional, Tuple, TYPE_CHECKING, FrozenSet
 
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/src/sqlfluff/core/parser/matchable.py
+++ b/src/sqlfluff/core/parser/matchable.py
@@ -2,7 +2,7 @@
 
 import copy
 from abc import ABC, abstractmethod
-from typing import List, Optional, Tuple, TYPE_CHECKING
+from typing import List, Optional, Tuple, TYPE_CHECKING, FrozenSet
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -20,8 +20,14 @@ class Matchable(ABC):
     @abstractmethod
     def simple(
         self, parse_context: "ParseContext", crumbs: Optional[Tuple[str, ...]] = None
-    ) -> Optional[List[str]]:
+    ) -> Optional[Tuple[FrozenSet[str], FrozenSet[str]]]:
         """Try to obtain a simple response from the matcher.
+
+        Returns:
+            None - if not simple.
+            Tuple of two sets of strings if simple. The first is a set of
+                uppercase raw strings which would match. The second is a set
+                of segment types that would match.
 
         NOTE: the crumbs kwarg is designed to be used by Ref to
         detect recursion.

--- a/src/sqlfluff/core/parser/parsers.py
+++ b/src/sqlfluff/core/parser/parsers.py
@@ -123,16 +123,13 @@ class TypedParser(BaseParser):
             **segment_kwargs,
         )
 
-    def simple(cls, parse_context: ParseContext, crumbs=None) -> Optional[List[str]]:
+    def simple(cls, parse_context: ParseContext, crumbs=None):
         """Does this matcher support a uppercase hash matching route?
 
-        TypedParser segment does NOT for now. We might need to later for efficiency.
-
-        There is a way that this *could* be enabled, by allowing *another*
-        shortcut route, to look ahead at the types of upcoming segments,
-        rather than their content.
+        TypedParser segment doesn't support matching against raw strings,
+        but it does support it against types.
         """
-        return None
+        return frozenset(), frozenset((cls.template,))
 
     def _is_first_match(self, segment: BaseSegment):
         """Return true if the type matches the target type."""
@@ -152,7 +149,7 @@ class StringParser(BaseParser):
     ):
         self.template = template.upper()
         # Create list version upfront to avoid recreating it multiple times.
-        self._simple = [self.template]
+        self._simple = frozenset((self.template,))
         super().__init__(
             raw_class=raw_class,
             type=type,
@@ -160,13 +157,13 @@ class StringParser(BaseParser):
             **segment_kwargs,
         )
 
-    def simple(self, parse_context: "ParseContext", crumbs=None) -> Optional[List[str]]:
+    def simple(self, parse_context: "ParseContext", crumbs=None):
         """Return simple options for this matcher.
 
         Because string matchers are not case sensitive we can
         just return the template here.
         """
-        return self._simple
+        return self._simple, frozenset()
 
     def _is_first_match(self, segment: BaseSegment):
         """Does the segment provided match according to the current rules."""
@@ -190,7 +187,7 @@ class MultiStringParser(BaseParser):
     ):
         self.templates = {template.upper() for template in templates}
         # Create list version upfront to avoid recreating it multiple times.
-        self._simple = list(self.templates)
+        self._simple = frozenset(self.templates)
         super().__init__(
             raw_class=raw_class,
             type=type,
@@ -198,13 +195,13 @@ class MultiStringParser(BaseParser):
             **segment_kwargs,
         )
 
-    def simple(self, parse_context: "ParseContext", crumbs=None) -> Optional[List[str]]:
+    def simple(self, parse_context: "ParseContext", crumbs=None):
         """Return simple options for this matcher.
 
         Because string matchers are not case sensitive we can
         just return the templates here.
         """
-        return self._simple
+        return self._simple, frozenset()
 
     def _is_first_match(self, segment: BaseSegment):
         """Does the segment provided match according to the current rules."""
@@ -240,7 +237,7 @@ class RegexParser(BaseParser):
             **segment_kwargs,
         )
 
-    def simple(cls, parse_context: ParseContext, crumbs=None) -> Optional[List[str]]:
+    def simple(cls, parse_context: ParseContext, crumbs=None):
         """Does this matcher support a uppercase hash matching route?
 
         Regex segment does NOT for now. We might need to later for efficiency.

--- a/src/sqlfluff/core/parser/parsers.py
+++ b/src/sqlfluff/core/parser/parsers.py
@@ -6,7 +6,7 @@ Matchable objects which return individual segments.
 from abc import abstractmethod
 from uuid import uuid4
 import regex
-from typing import Collection, Type, Optional, List, Tuple, Union
+from typing import Collection, Type, Optional, Tuple, Union
 
 from sqlfluff.core.parser.context import ParseContext
 from sqlfluff.core.parser.matchable import Matchable

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -690,7 +690,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
     # ################ CLASS METHODS
 
     @classmethod
-    def simple(cls, parse_context: ParseContext, crumbs=None) -> Optional[List[str]]:
+    def simple(cls, parse_context: ParseContext, crumbs=None):
         """Does this matcher support an uppercase hash matching route?
 
         This should be true if the MATCH grammar is simple. Most more
@@ -1706,7 +1706,7 @@ class BracketedSegment(BaseSegment):
         super().__init__(*args, **kwargs)
 
     @classmethod
-    def simple(cls, parse_context: ParseContext, crumbs=None) -> Optional[List[str]]:
+    def simple(cls, parse_context: ParseContext, crumbs=None):
         """Simple methods for bracketed and the persistent brackets."""
         start_brackets = [
             start_bracket
@@ -1715,12 +1715,17 @@ class BracketedSegment(BaseSegment):
             )
             if persistent
         ]
-        start_simple = []
+        simple_raws = set()
         for ref in start_brackets:
-            start_simple += parse_context.dialect.ref(ref).simple(
+            bracket_simple = parse_context.dialect.ref(ref).simple(
                 parse_context, crumbs=crumbs
             )
-        return start_simple
+            assert bracket_simple, "All bracket segments must support simple."
+            assert bracket_simple[0], "All bracket segments must support raw simple."
+            # NOTE: By making this assumption we don't have to handle the "typed"
+            # simple here.
+            simple_raws.update(bracket_simple[0])
+        return frozenset(simple_raws), frozenset()
 
     @classmethod
     def match(

--- a/src/sqlfluff/core/parser/segments/meta.py
+++ b/src/sqlfluff/core/parser/segments/meta.py
@@ -65,7 +65,7 @@ class MetaSegment(RawSegment):
         )
 
     @classmethod
-    def simple(cls, parse_context: ParseContext, crumbs=None) -> Optional[List[str]]:
+    def simple(cls, parse_context: ParseContext, crumbs=None):
         """Does this matcher support an uppercase hash matching route?
 
         This should be true if the MATCH grammar is simple. Most more

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2293,16 +2293,16 @@ class LimitClauseSegment(BaseSegment):
     match_grammar: Matchable = Sequence(
         "LIMIT",
         Indent,
+        Ref("NumericLiteralSegment"),
         OneOf(
-            Ref("NumericLiteralSegment"),
             Sequence(
-                Ref("NumericLiteralSegment"), "OFFSET", Ref("NumericLiteralSegment")
+                "OFFSET", Ref("NumericLiteralSegment")
             ),
             Sequence(
-                Ref("NumericLiteralSegment"),
                 Ref("CommaSegment"),
                 Ref("NumericLiteralSegment"),
             ),
+            optional=True,
         ),
         Dedent,
     )

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2295,9 +2295,7 @@ class LimitClauseSegment(BaseSegment):
         Indent,
         Ref("NumericLiteralSegment"),
         OneOf(
-            Sequence(
-                "OFFSET", Ref("NumericLiteralSegment")
-            ),
+            Sequence("OFFSET", Ref("NumericLiteralSegment")),
             Sequence(
                 Ref("CommaSegment"),
                 Ref("NumericLiteralSegment"),

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -154,6 +154,9 @@ bigquery_dialect.add(
             Ref("ArrayLiteralSegment"),
             Ref("TupleSegment"),
             Ref("BaseExpressionElementGrammar"),
+            terminators=[
+                Ref("SemicolonSegment"),
+            ]
         ),
     ),
     ExtendedDatetimeUnitSegment=SegmentGenerator(
@@ -1322,11 +1325,10 @@ class DeclareStatementSegment(BaseSegment):
         "DECLARE",
         Delimited(Ref("SingleIdentifierFullGrammar")),
         OneOf(
-            Ref("DatatypeSegment"),
             Ref("DefaultDeclareOptionsGrammar"),
             Sequence(
                 Ref("DatatypeSegment"),
-                Ref("DefaultDeclareOptionsGrammar"),
+                Ref("DefaultDeclareOptionsGrammar", optional=True),
             ),
         ),
     )

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -156,7 +156,7 @@ bigquery_dialect.add(
             Ref("BaseExpressionElementGrammar"),
             terminators=[
                 Ref("SemicolonSegment"),
-            ]
+            ],
         ),
     ),
     ExtendedDatetimeUnitSegment=SegmentGenerator(


### PR DESCRIPTION
This relates to #3390, although probably not obviously.

`RegexMatcher` is bad, because it doesn't prune nicely using the `.simple()` route. Much of the way to get around that is through a greater use of the `TypedMatcher`, which means we can push the regex operations up into the lexer. **However**, up till now the `TypedMatcher` didn't support `simple` matching _either_. This implements that feature.

As a side effect, some of the handing for _non-simple_ matching can be removed from the base grammar - resulting in a simpler codebase. While it's still _possible_ to end up with some non-simple options (because we haven't get removed all of the `RegexMatcher` options), they now aren't actually used in any of the relevant cases. Because the aim is to remove them in the long run, instead of keeping the handling logic (_"just in case"_), I've instead asserted that all the options _are_ simple and then we'll get an error if they are used in that position. If that does happen it should be a signal for us to migrate things faster to the `TypedMatcher`.

This change on it's own I think results in a 5-10% improvement in the parsing speed. It's not massive, but every little helps, and it enables some simplification in the codebase.