### PR TITLE
Clickhouse: Add support for [LEFT] ARRAY JOIN

### DIFF
--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -76,7 +76,9 @@ class JinjaTracer:
         trace_template = self.make_template(trace_template_str)
         trace_template_output = trace_template.render()
         # Split output by section. Each section has two possible formats.
-        trace_entries = list(regex.finditer(r"\0", trace_template_output))
+        trace_entries: List[regex.Match] = list(
+            regex.finditer(r"\0", trace_template_output)
+        )
         for match_idx, match in enumerate(trace_entries):
             pos1 = match.span()[0]
             try:

--- a/test/fixtures/dialects/clickhouse/join.sql
+++ b/test/fixtures/dialects/clickhouse/join.sql
@@ -58,3 +58,12 @@ SELECT * FROM test1 CROSS JOIN test2;
 SELECT * FROM test1 as t1 FULL ALL JOIN test2 USING ty1,ty2;
 SELECT * FROM test1 as t1 FULL JOIN test2 USING ty1,ty2;
 SELECT * FROM test1 as t1 FULL ALL OUTER JOIN test2 USING ty1,ty2;
+-- ARRAY join
+SELECT col FROM (SELECT arr FROM test1) AS t2 ARRAY JOIN arr AS col;
+SELECT col FROM (SELECT [1, 2] AS arr) AS t1 LEFT ARRAY JOIN arr AS col;
+SELECT * FROM (SELECT [1, 2] AS arr) AS t1 ARRAY JOIN arr;
+SELECT * FROM (SELECT [1, 2] AS arr) AS t1 LEFT ARRAY JOIN arr;
+SELECT * FROM (SELECT [1, 2] AS arr, [3, 4] AS arr2) AS t1 ARRAY JOIN arr, arr2;
+SELECT x, y FROM (SELECT [1, 2] AS arr, [3, 4] AS arr2) AS t1 ARRAY JOIN arr AS x, arr2 AS y;
+SELECT *,ch,cg FROM (SELECT 1) ARRAY JOIN ['1','2'] as cg, splitByChar(',','1,2') as ch;
+SELECT * FROM (SELECT [1,2] x) AS t1 ARRAY JOIN t1.*;

--- a/test/fixtures/dialects/clickhouse/join.yml
+++ b/test/fixtures/dialects/clickhouse/join.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9352ebb9eaf7ee550822c86ff44a96f1908e4b446afa8a3f26aa5c41463b2340
+_hash: 691193ed2bf48b17d52586c0663c81b562d7f2c58769fcd4349b4cb2cdb06511
 file:
 - statement:
     select_statement:
@@ -1499,4 +1499,383 @@ file:
           - naked_identifier: ty1
           - comma: ','
           - naked_identifier: ty2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      column_reference:
+                        naked_identifier: arr
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: test1
+                end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: t2
+          array_join_clause:
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+              column_reference:
+                naked_identifier: arr
+              alias_expression:
+                keyword: AS
+                naked_identifier: col
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                      alias_expression:
+                        keyword: AS
+                        naked_identifier: arr
+                end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: t1
+          array_join_clause:
+          - keyword: LEFT
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+              column_reference:
+                naked_identifier: arr
+              alias_expression:
+                keyword: AS
+                naked_identifier: col
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                      alias_expression:
+                        keyword: AS
+                        naked_identifier: arr
+                end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: t1
+          array_join_clause:
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+              column_reference:
+                naked_identifier: arr
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                      alias_expression:
+                        keyword: AS
+                        naked_identifier: arr
+                end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: t1
+          array_join_clause:
+          - keyword: LEFT
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+              column_reference:
+                naked_identifier: arr
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                      alias_expression:
+                        keyword: AS
+                        naked_identifier: arr
+                  - comma: ','
+                  - select_clause_element:
+                      array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '3'
+                      - comma: ','
+                      - numeric_literal: '4'
+                      - end_square_bracket: ']'
+                      alias_expression:
+                        keyword: AS
+                        naked_identifier: arr2
+                end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: t1
+          array_join_clause:
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+              column_reference:
+                naked_identifier: arr
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: arr2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: x
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: y
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                      alias_expression:
+                        keyword: AS
+                        naked_identifier: arr
+                  - comma: ','
+                  - select_clause_element:
+                      array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '3'
+                      - comma: ','
+                      - numeric_literal: '4'
+                      - end_square_bracket: ']'
+                      alias_expression:
+                        keyword: AS
+                        naked_identifier: arr2
+                end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: t1
+          array_join_clause:
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+              column_reference:
+                naked_identifier: arr
+              alias_expression:
+                keyword: AS
+                naked_identifier: x
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: arr2
+              alias_expression:
+                keyword: AS
+                naked_identifier: y
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: ch
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: cg
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      numeric_literal: '1'
+                end_bracket: )
+          array_join_clause:
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+              array_literal:
+              - start_square_bracket: '['
+              - quoted_literal: "'1'"
+              - comma: ','
+              - quoted_literal: "'2'"
+              - end_square_bracket: ']'
+              alias_expression:
+                keyword: as
+                naked_identifier: cg
+          - comma: ','
+          - select_clause_element:
+              function:
+                function_name:
+                  function_name_identifier: splitByChar
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    quoted_literal: "','"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'1,2'"
+                - end_bracket: )
+              alias_expression:
+                keyword: as
+                naked_identifier: ch
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                      alias_expression:
+                        naked_identifier: x
+                end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: t1
+          array_join_clause:
+          - keyword: ARRAY
+          - keyword: JOIN
+          - select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  naked_identifier: t1
+                  dot: .
+                  star: '*'
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Clickhouse: Add support for [LEFT] ARRAY JOIN

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
