### PR TITLE
Correct BigQuery WINDOW parsing

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2362,8 +2362,11 @@ class NamedWindowExpressionSegment(BaseSegment):
     match_grammar: Matchable = Sequence(
         Ref("SingleIdentifierGrammar"),  # Window name
         "AS",
-        Bracketed(
-            Ref("WindowSpecificationSegment"),
+        OneOf(
+            Ref("SingleIdentifierGrammar"),  # Window name
+            Bracketed(
+                Ref("WindowSpecificationSegment"),
+            ),
         ),
     )
 
@@ -2419,7 +2422,6 @@ class UnorderedSelectStatementSegment(BaseSegment):
             Ref("WithDataClauseSegment"),
             Ref("OrderByClauseSegment"),
             Ref("LimitClauseSegment"),
-            Ref("NamedWindowSegment"),
         ),
         enforce_whitespace_preceding_terminator=True,
     )
@@ -2434,6 +2436,7 @@ class UnorderedSelectStatementSegment(BaseSegment):
         Ref("GroupByClauseSegment", optional=True),
         Ref("HavingClauseSegment", optional=True),
         Ref("OverlapsClauseSegment", optional=True),
+        Ref("NamedWindowSegment", optional=True),
     )
 
 

--- a/test/fixtures/dialects/bigquery/select_with_window.sql
+++ b/test/fixtures/dialects/bigquery/select_with_window.sql
@@ -1,0 +1,36 @@
+SELECT item, purchases, category, LAST_VALUE(item)
+  OVER (item_window) AS most_popular
+FROM Produce
+WINDOW item_window AS (
+  PARTITION BY category
+  ORDER BY purchases
+  ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING);
+
+SELECT item, purchases, category, LAST_VALUE(item)
+  OVER (d) AS most_popular
+FROM Produce
+WINDOW
+  a AS (PARTITION BY category),
+  b AS (a ORDER BY purchases),
+  c AS (b ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING),
+  d AS (c);
+
+SELECT item, purchases, category, LAST_VALUE(item)
+  OVER (c ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING) AS most_popular
+FROM Produce
+WINDOW
+  a AS (PARTITION BY category),
+  b AS (a ORDER BY purchases),
+  c AS b;
+
+select
+    *
+    , max(x) over (window_z) as max_x_over_z
+from raw_data_1
+window window_z as (partition by z)
+union all
+select
+    *
+    , max(x) over (window_z) as max_x_over_z
+from raw_data_2
+window window_z as (partition by z);

--- a/test/fixtures/dialects/bigquery/select_with_window.yml
+++ b/test/fixtures/dialects/bigquery/select_with_window.yml
@@ -1,0 +1,370 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 078f423fe0fa8ac12ea0aa72af5d13b5f50c251898e1cb1408e33805226f6a01
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: item
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: purchases
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: category
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LAST_VALUE
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: item
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  naked_identifier: item_window
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: most_popular
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: Produce
+      named_window:
+        keyword: WINDOW
+        named_window_expression:
+          naked_identifier: item_window
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              partitionby_clause:
+              - keyword: PARTITION
+              - keyword: BY
+              - expression:
+                  column_reference:
+                    naked_identifier: category
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: purchases
+              frame_clause:
+              - keyword: ROWS
+              - keyword: BETWEEN
+              - numeric_literal: '2'
+              - keyword: PRECEDING
+              - keyword: AND
+              - numeric_literal: '2'
+              - keyword: FOLLOWING
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: item
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: purchases
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: category
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LAST_VALUE
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: item
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  naked_identifier: d
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: most_popular
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: Produce
+      named_window:
+      - keyword: WINDOW
+      - named_window_expression:
+          naked_identifier: a
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              partitionby_clause:
+              - keyword: PARTITION
+              - keyword: BY
+              - expression:
+                  column_reference:
+                    naked_identifier: category
+            end_bracket: )
+      - comma: ','
+      - named_window_expression:
+          naked_identifier: b
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              naked_identifier: a
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: purchases
+            end_bracket: )
+      - comma: ','
+      - named_window_expression:
+          naked_identifier: c
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              naked_identifier: b
+              frame_clause:
+              - keyword: ROWS
+              - keyword: BETWEEN
+              - numeric_literal: '2'
+              - keyword: PRECEDING
+              - keyword: AND
+              - numeric_literal: '2'
+              - keyword: FOLLOWING
+            end_bracket: )
+      - comma: ','
+      - named_window_expression:
+          naked_identifier: d
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              naked_identifier: c
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: item
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: purchases
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: category
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LAST_VALUE
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: item
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  naked_identifier: c
+                  frame_clause:
+                  - keyword: ROWS
+                  - keyword: BETWEEN
+                  - numeric_literal: '2'
+                  - keyword: PRECEDING
+                  - keyword: AND
+                  - numeric_literal: '2'
+                  - keyword: FOLLOWING
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: most_popular
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: Produce
+      named_window:
+      - keyword: WINDOW
+      - named_window_expression:
+          naked_identifier: a
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              partitionby_clause:
+              - keyword: PARTITION
+              - keyword: BY
+              - expression:
+                  column_reference:
+                    naked_identifier: category
+            end_bracket: )
+      - comma: ','
+      - named_window_expression:
+          naked_identifier: b
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              naked_identifier: a
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: purchases
+            end_bracket: )
+      - comma: ','
+      - named_window_expression:
+        - naked_identifier: c
+        - keyword: AS
+        - naked_identifier: b
+- statement_terminator: ;
+- statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: max
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: x
+                end_bracket: )
+              over_clause:
+                keyword: over
+                bracketed:
+                  start_bracket: (
+                  window_specification:
+                    naked_identifier: window_z
+                  end_bracket: )
+            alias_expression:
+              keyword: as
+              naked_identifier: max_x_over_z
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: raw_data_1
+        named_window:
+          keyword: window
+          named_window_expression:
+            naked_identifier: window_z
+            keyword: as
+            bracketed:
+              start_bracket: (
+              window_specification:
+                partitionby_clause:
+                - keyword: partition
+                - keyword: by
+                - expression:
+                    column_reference:
+                      naked_identifier: z
+              end_bracket: )
+    - set_operator:
+      - keyword: union
+      - keyword: all
+    - select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: max
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: x
+                end_bracket: )
+              over_clause:
+                keyword: over
+                bracketed:
+                  start_bracket: (
+                  window_specification:
+                    naked_identifier: window_z
+                  end_bracket: )
+            alias_expression:
+              keyword: as
+              naked_identifier: max_x_over_z
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: raw_data_2
+        named_window:
+          keyword: window
+          named_window_expression:
+            naked_identifier: window_z
+            keyword: as
+            bracketed:
+              start_bracket: (
+              window_specification:
+                partitionby_clause:
+                - keyword: partition
+                - keyword: by
+                - expression:
+                    column_reference:
+                      naked_identifier: z
+              end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #4496 

### Are there any other side effects of this change that we should be aware of?
I also added support for named windows so all the BigQuery WINDOW examples parse

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
