### PR TITLE
Athena: Fix parsing error with aliases starting with underscore

### DIFF
--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -221,7 +221,7 @@ athena_dialect.replace(
     NakedIdentifierSegment=SegmentGenerator(
         # Generate the anti template from the set of reserved keywords
         lambda dialect: RegexParser(
-            r"([_]+|[A-Z0-9_]*[A-Z][A-Z0-9_]*)",
+            r"([A-Z0-9_]*[A-Z][A-Z0-9_]*|[_]+)",
             ansi.IdentifierSegment,
             type="naked_identifier",
             anti_template=r"^(" + r"|".join(dialect.sets("reserved_keywords")) + r")$",

--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -221,7 +221,7 @@ athena_dialect.replace(
     NakedIdentifierSegment=SegmentGenerator(
         # Generate the anti template from the set of reserved keywords
         lambda dialect: RegexParser(
-            r"([A-Z0-9_]*[A-Z][A-Z0-9_]*|[_]+)",
+            r"[A-Z0-9_]*[A-Z_][A-Z0-9_]*",
             ansi.IdentifierSegment,
             type="naked_identifier",
             anti_template=r"^(" + r"|".join(dialect.sets("reserved_keywords")) + r")$",

--- a/test/fixtures/dialects/athena/select_underscore.sql
+++ b/test/fixtures/dialects/athena/select_underscore.sql
@@ -2,6 +2,8 @@ SELECT 1 AS _;
 
 SELECT 1 AS __;
 
+SELECT 1 AS __TEST;
+
 SELECT a
 FROM (
 VALUES ('a'), ('b')

--- a/test/fixtures/dialects/athena/select_underscore.yml
+++ b/test/fixtures/dialects/athena/select_underscore.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 40356891ee431750530c54abf858185798c2811e5623e22a09be65c93258daf3
+_hash: eb8702f25cd1de35b8140b81706fbad6ffc0a8dceee1a6f48739822b96f30b03
 file:
 - statement:
     select_statement:
@@ -24,6 +24,16 @@ file:
           alias_expression:
             keyword: AS
             naked_identifier: __
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: '1'
+          alias_expression:
+            keyword: AS
+            naked_identifier: __TEST
 - statement_terminator: ;
 - statement:
     select_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fixes parsing error for Athena dialect when alias starts with underscore.

### Are there any other side effects of this change that we should be aware of?

N/A

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
