### PR TITLE
Snowflake: Stop ever-increasing indent in CREATE USER

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -3672,6 +3672,7 @@ class CreateUserSegment(BaseSegment):
             ),
             Ref("CommentEqualsClauseSegment"),
         ),
+        Dedent,
     )
 
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Adding the corresponding Dedent. Omitting this makes SQLFluff to keep increasing indent for every subsequent command by 1 every time it encounters a CREATE USER clause:

```sql
CREATE USER IF NOT EXISTS my_user
  MUST_CHANGE_PASSWORD = true;

  GRANT ROLE sysadmin TO USER my_user;

  CREATE USER IF NOT EXISTS another_user
    MUST_CHANGE_PASSWORD = true;

    GRANT ROLE sysadmin TO USER another_user;

```

### Are there any other side effects of this change that we should be aware of?

None

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
