### PR TITLE
Add support for non-quoted file paths in SparkSQL

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -150,6 +150,17 @@ sparksql_dialect.insert_lexer_matchers(
     ],
     before="code",
 )
+sparksql_dialect.insert_lexer_matchers(
+     [
+        RegexLexer(
+            "file_literal",
+            r"[a-zA-z0-9]*:?([a-zA-Z0-9\-_\.]*(\/|\\))+([a-zA-Z0-9\-_\.]*(:|\?|=|&))*[a-zA-Z0-9\-_\.]*\.?[a-z]*",
+            CodeSegment,
+            segment_kwargs={"type": "file_literal"},
+        ),
+     ],
+     before="newline",
+)
 
 # Set the bare functions
 sparksql_dialect.sets("bare_functions").clear()
@@ -383,6 +394,9 @@ sparksql_dialect.replace(
 )
 
 sparksql_dialect.add(
+    FileLiteralSegment=OneOf(
+        TypedParser("file_literal", ansi.LiteralSegment, type="file_literal"),
+    ),
     BackQuotedIdentifierSegment=TypedParser(
         "back_quote",
         ansi.IdentifierSegment,
@@ -2009,7 +2023,10 @@ class AddJarSegment(BaseSegment):
     match_grammar = Sequence(
         "ADD",
         Ref("JarKeywordSegment"),
-        AnyNumberOf(Ref("QuotedLiteralSegment")),
+        AnyNumberOf(
+            Ref("QuotedLiteralSegment"),
+            Ref("FileLiteralSegment"),
+            ),
     )
 
 

--- a/test/fixtures/dialects/sparksql/add_jar.sql
+++ b/test/fixtures/dialects/sparksql/add_jar.sql
@@ -14,5 +14,11 @@ ADD JAR "ivy://group:module:version?transitive=true";
 
 ADD JAR "ivy://group:module:version?exclude=group:module&transitive=true";
 
--- NB: Non-quoted paths are not supported in SQLFluff currently
---ADD JAR /tmp/test.jar;
+ADD JAR ivy://group:module:version?exclude=group:module&transitive=true;
+
+ADD JAR /path/to/some.jar;
+
+ADD JAR path/to/some.jar;
+
+-- NB: Non-quoted paths do not currently support whitespaces
+-- e.g. /path to/some.jar

--- a/test/fixtures/dialects/sparksql/add_jar.yml
+++ b/test/fixtures/dialects/sparksql/add_jar.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a475a17704b1a019947ed3dc476aefbd6e7175ac51ea0b22a019485c01986fa3
+_hash: ec5b3da97e77d139b6ece515f533bdc85539c29d328a2139b90521b290270a46
 file:
 - statement:
     add_jar_statement:
@@ -53,4 +53,22 @@ file:
       keyword: ADD
       file_keyword: JAR
       quoted_literal: '"ivy://group:module:version?exclude=group:module&transitive=true"'
+- statement_terminator: ;
+- statement:
+    add_jar_statement:
+      keyword: ADD
+      file_keyword: JAR
+      file_literal: ivy://group:module:version?exclude=group:module&transitive=true
+- statement_terminator: ;
+- statement:
+    add_jar_statement:
+      keyword: ADD
+      file_keyword: JAR
+      file_literal: /path/to/some.jar
+- statement_terminator: ;
+- statement:
+    add_jar_statement:
+      keyword: ADD
+      file_keyword: JAR
+      file_literal: path/to/some.jar
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

This change adds a new `file_literal` lexer matcher in the SparkSQL dialect that can be used to parse non-quoted file paths. 

This enables more comprehensive support of SparkSQL statements such as `ADD JAR`. As displayed in the documentation (https://spark.apache.org/docs/latest/sql-ref-syntax-aux-resource-mgmt-add-jar.html), non-quoted file paths are officially supported. 

`test/fixtures/dialects/sparksql/add_jar.sql` has been updated to reflect this new support. 

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
