### PR TITLE
TSQL: `PERIOD FOR SYSTEM_TIME` (temporal tables)

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2826,6 +2826,7 @@ class CreateTableStatementSegment(BaseSegment):
                             Ref("TableConstraintSegment"),
                             Ref("ColumnDefinitionSegment"),
                             Ref("TableIndexSegment"),
+                            Ref("PeriodSegment"),
                         ),
                         allow_trailing=True,
                     )
@@ -5137,6 +5138,26 @@ class CreateExternalDataSourceStatementSegment(BaseSegment):
                     Ref("EqualsSegment"),
                     OneOf("ON", "OFF"),
                 ),
+            ),
+        ),
+    )
+
+class PeriodSegment(BaseSegment):
+    """A `PERIOD FOR SYSTEM_TIME` for `CREATE TABLE` of temporal tables.
+    
+    https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql?view=sql-server-ver15
+    https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql?view=sql-server-ver16#generated-always-as--row--transaction_id--sequence_number----start--end---hidden---not-null-
+    """
+
+    type = "period_segment"
+    match_grammar = Sequence(
+        "PERIOD",
+        "FOR",
+        "SYSTEM_TIME",
+        Bracketed(
+            Delimited(
+                Ref("ColumnReferenceSegment"),
+                Ref("ColumnReferenceSegment"),
             ),
         ),
     )

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -5142,9 +5142,10 @@ class CreateExternalDataSourceStatementSegment(BaseSegment):
         ),
     )
 
+
 class PeriodSegment(BaseSegment):
     """A `PERIOD FOR SYSTEM_TIME` for `CREATE TABLE` of temporal tables.
-    
+
     https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql?view=sql-server-ver15
     https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql?view=sql-server-ver16#generated-always-as--row--transaction_id--sequence_number----start--end---hidden---not-null-
     """

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -404,6 +404,7 @@ UNRESERVED_KEYWORDS = [
     "PAUSED",
     "PERCENTILE_CONT",
     "PERCENTILE_DISC",
+    "PERIOD",
     "PERSISTED",
     "PRECEDING",
     "PRECISION",  # listed as reserved but functionally unreserved

--- a/test/fixtures/dialects/tsql/temporal_tables.sql
+++ b/test/fixtures/dialects/tsql/temporal_tables.sql
@@ -31,6 +31,22 @@ WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = dbo.EmployeeHistory), DURABILITY =
 ;
 GO
 
+
+-- https://learn.microsoft.com/en-us/sql/relational-databases/tables/creating-a-system-versioned-temporal-table?view=sql-server-ver16#creating-a-temporal-table-with-a-default-history-table
+CREATE TABLE Department
+(
+    DeptID INT NOT NULL PRIMARY KEY CLUSTERED
+  , DeptName VARCHAR(50) NOT NULL
+  , ManagerID INT NULL
+  , ParentDeptID INT NULL
+  , ValidFrom DATETIME2 GENERATED ALWAYS AS ROW START NOT NULL
+  , ValidTo DATETIME2 GENERATED ALWAYS AS ROW END NOT NULL
+  , PERIOD FOR SYSTEM_TIME (ValidFrom, ValidTo)
+)
+WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = dbo.DepartmentHistory))
+;
+GO
+
 CREATE TABLE [dbo].[EC DC] (
     [Column B] [varchar](100),
     [ColumnC] varchar(100),

--- a/test/fixtures/dialects/tsql/temporal_tables.yml
+++ b/test/fixtures/dialects/tsql/temporal_tables.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d66d0d6cba86db7a5b3fea6e509b2eca5b706032e71909585ff41ae4f374dc25
+_hash: bbd05ea5802b6edbcb5baf6d32bf80afd3ce4fa374f6cf87ff658b3bf31190a8
 file:
 - batch:
   - statement:
@@ -193,6 +193,118 @@ file:
           - end_bracket: )
       - statement_terminator: ;
   - statement_terminator: ;
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: Department
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+          - naked_identifier: DeptID
+          - data_type:
+              data_type_identifier: INT
+          - column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+          - column_constraint_segment:
+            - keyword: PRIMARY
+            - keyword: KEY
+            - keyword: CLUSTERED
+        - comma: ','
+        - column_definition:
+            naked_identifier: DeptName
+            data_type:
+              data_type_identifier: VARCHAR
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '50'
+                  end_bracket: )
+            column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: ManagerID
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+              keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: ParentDeptID
+            data_type:
+              data_type_identifier: INT
+            column_constraint_segment:
+              keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+          - naked_identifier: ValidFrom
+          - data_type:
+              data_type_identifier: DATETIME2
+          - column_constraint_segment:
+            - keyword: GENERATED
+            - keyword: ALWAYS
+            - keyword: AS
+            - keyword: ROW
+            - keyword: START
+          - column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+          - naked_identifier: ValidTo
+          - data_type:
+              data_type_identifier: DATETIME2
+          - column_constraint_segment:
+            - keyword: GENERATED
+            - keyword: ALWAYS
+            - keyword: AS
+            - keyword: ROW
+            - keyword: END
+          - column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - period_segment:
+          - keyword: PERIOD
+          - keyword: FOR
+          - keyword: SYSTEM_TIME
+          - bracketed:
+            - start_bracket: (
+            - column_reference:
+                naked_identifier: ValidFrom
+            - comma: ','
+            - column_reference:
+                naked_identifier: ValidTo
+            - end_bracket: )
+        - end_bracket: )
+      - table_option_statement:
+          keyword: WITH
+          bracketed:
+          - start_bracket: (
+          - keyword: SYSTEM_VERSIONING
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - keyword: 'ON'
+          - bracketed:
+              start_bracket: (
+              keyword: HISTORY_TABLE
+              comparison_operator:
+                raw_comparison_operator: '='
+              table_reference:
+              - naked_identifier: dbo
+              - dot: .
+              - naked_identifier: DepartmentHistory
+              end_bracket: )
+          - end_bracket: )
+      - statement_terminator: ;
 - go_statement:
     keyword: GO
 - batch:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Support for `PERIOD FOR SYSTEM_TIME` (temporal tables)
Follow-up for #3542
Fixes https://github.com/sqlfluff/sqlfluff/issues/3542#issuecomment-1482836223


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
