### PR TITLE
Remove three RegexParsers

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -230,7 +230,10 @@ ansi_dialect.set_lexer_matchers(
         StringLexer("crly_bracket_close", "}", CodeSegment),
         StringLexer("colon", ":", CodeSegment),
         StringLexer("semicolon", ";", CodeSegment),
-        RegexLexer("code", r"[0-9a-zA-Z_]+", CodeSegment),
+        # This is the "fallback" lexer for anything else which looks like SQL.
+        RegexLexer(
+            "code", r"[0-9a-zA-Z_]+", CodeSegment, segment_kwargs={"type": "code"}
+        ),
     ]
 )
 
@@ -350,12 +353,9 @@ ansi_dialect.add(
             anti_template=r"^(" + r"|".join(dialect.sets("reserved_keywords")) + r")$",
         )
     ),
-    VersionIdentifierSegment=RegexParser(r"[A-Z0-9_.]*", IdentifierSegment),
     ParameterNameSegment=RegexParser(r"[A-Z][A-Z0-9_]*", CodeSegment, type="parameter"),
-    FunctionNameIdentifierSegment=RegexParser(
-        r"[A-Z_][A-Z0-9_]*",
-        CodeSegment,
-        type="function_name_identifier",
+    FunctionNameIdentifierSegment=TypedParser(
+        "code", CodeSegment, type="function_name_identifier"
     ),
     # Maybe data types should be more restrictive?
     DatatypeIdentifierSegment=SegmentGenerator(

--- a/src/sqlfluff/dialects/dialect_db2.py
+++ b/src/sqlfluff/dialects/dialect_db2.py
@@ -87,7 +87,9 @@ db2_dialect.patch_lexer_matchers(
             segment_kwargs={"type": "double_quote"},
         ),
         # In Db2, a field could have a # pound/hash sign
-        RegexLexer("code", r"[0-9a-zA-Z_#]+", CodeSegment),
+        RegexLexer(
+            "code", r"[0-9a-zA-Z_#]+", CodeSegment, segment_kwargs={"type": "code"}
+        ),
     ]
 )
 

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -174,7 +174,12 @@ postgres_dialect.patch_lexer_matchers(
             CodeSegment,
             segment_kwargs={"type": "double_quote"},
         ),
-        RegexLexer("code", r"[0-9a-zA-Z_]+[0-9a-zA-Z_$]*", CodeSegment, segment_kwargs={"type": "code"}),
+        RegexLexer(
+            "code",
+            r"[0-9a-zA-Z_]+[0-9a-zA-Z_$]*",
+            CodeSegment,
+            segment_kwargs={"type": "code"},
+        ),
     ]
 )
 

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -252,7 +252,6 @@ postgres_dialect.add(
         ansi.IdentifierSegment,
         type="naked_identifier_all",
     ),
-    VersionIdentifierSegment=RegexParser(r"[A-Z0-9_.]*", ansi.IdentifierSegment),
     SingleIdentifierFullGrammar=OneOf(
         Ref("NakedIdentifierSegment"),
         Ref("QuotedIdentifierSegment"),
@@ -2065,6 +2064,37 @@ class AlterTableActionSegment(BaseSegment):
                 "NOTHING",
             ),
         ),
+    )
+
+
+class VersionIdentifierSegment(BaseSegment):
+    """A reference to an version."""
+
+    type = "version_identifier"
+    # match grammar (don't allow whitespace)
+    match_grammar: Matchable = Sequence(
+        OneOf(
+            Ref("QuotedLiteralSegment"),
+            Ref("NumericLiteralSegment"),
+            Ref("NakedIdentifierSegment"),
+        ),
+        AnyNumberOf(
+            OneOf(
+                # Literals might follow literals if these literals
+                # begin with a "." e.g. 1.2.3.4
+                Ref("NumericLiteralSegment"),
+                Sequence(
+                    Ref("DotSegment"),
+                    OneOf(
+                        Ref("NumericLiteralSegment"),
+                        Ref("NakedIdentifierSegment"),
+                    ),
+                    allow_gaps=False,
+                ),
+            ),
+            allow_gaps=False,
+        ),
+        allow_gaps=False,
     )
 
 

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -174,7 +174,7 @@ postgres_dialect.patch_lexer_matchers(
             CodeSegment,
             segment_kwargs={"type": "double_quote"},
         ),
-        RegexLexer("code", r"[0-9a-zA-Z_]+[0-9a-zA-Z_$]*", CodeSegment),
+        RegexLexer("code", r"[0-9a-zA-Z_]+[0-9a-zA-Z_$]*", CodeSegment, segment_kwargs={"type": "code"}),
     ]
 )
 
@@ -242,11 +242,12 @@ postgres_dialect.add(
         Ref("MultilineConcatenateNewline"), min_times=1, allow_gaps=False
     ),
     # Add a Full equivalent which also allow keywords
-    NakedIdentifierFullSegment=RegexParser(
-        r"[A-Z_][A-Z0-9_]*",
+    NakedIdentifierFullSegment=TypedParser(
+        "code",
         ansi.IdentifierSegment,
         type="naked_identifier_all",
     ),
+    VersionIdentifierSegment=RegexParser(r"[A-Z0-9_.]*", ansi.IdentifierSegment),
     SingleIdentifierFullGrammar=OneOf(
         Ref("NakedIdentifierSegment"),
         Ref("QuotedIdentifierSegment"),

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -192,7 +192,12 @@ redshift_dialect.replace(
 redshift_dialect.patch_lexer_matchers(
     [
         # add optional leading # to code for temporary tables
-        RegexLexer("code", r"#?[0-9a-zA-Z_]+[0-9a-zA-Z_$]*", CodeSegment, segment_kwargs={"type": "code"}),
+        RegexLexer(
+            "code",
+            r"#?[0-9a-zA-Z_]+[0-9a-zA-Z_$]*",
+            CodeSegment,
+            segment_kwargs={"type": "code"},
+        ),
     ]
 )
 

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -192,7 +192,7 @@ redshift_dialect.replace(
 redshift_dialect.patch_lexer_matchers(
     [
         # add optional leading # to code for temporary tables
-        RegexLexer("code", r"#?[0-9a-zA-Z_]+[0-9a-zA-Z_$]*", CodeSegment),
+        RegexLexer("code", r"#?[0-9a-zA-Z_]+[0-9a-zA-Z_$]*", CodeSegment, segment_kwargs={"type": "code"}),
     ]
 )
 

--- a/test/fixtures/dialects/exasol/AlterTableDistributePartition.yml
+++ b/test/fixtures/dialects/exasol/AlterTableDistributePartition.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 45da3e37ea8947db3458800b70ff413f4f91f92fc0b62d6df43b7f9611fc1d9e
+_hash: 143f272ccdb4017c7171fe3e38109963c67a2871f50313aad6815ea0c0c4a379
 file:
 - statement:
     alter_table_statement:
@@ -62,10 +62,10 @@ file:
         - comma: ','
         - column_reference:
             naked_identifier: DISTRIBUTE
-        - raw: BY
-        - raw: shop_id
+        - code: BY
+        - code: shop_id
         - comma: ','
-        - raw: branch_no
+        - code: branch_no
 - statement_terminator: ;
 - statement:
     alter_table_statement:

--- a/test/fixtures/dialects/exasol/CreateAdapterScriptStatement.yml
+++ b/test/fixtures/dialects/exasol/CreateAdapterScriptStatement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a05ded87cb8d9924b2553b00150ec636801eedd3ee900f8302035e191f68027d
+_hash: 21c681be1b651e921ff550b0fda29a63c79586371144328c69c414204140cd26
 file:
 - statement:
     create_adapter_script:
@@ -16,10 +16,10 @@ file:
     - keyword: AS
     - script_content:
       - raw: '%'
-      - raw: jar
-      - raw: hive_jdbc_adapter
+      - code: jar
+      - code: hive_jdbc_adapter
       - raw: .
-      - raw: jar
+      - code: jar
       - raw: ;
 - function_script_terminator: /
 - statement:
@@ -36,14 +36,14 @@ file:
       - naked_identifier: adapter_dummy
     - keyword: AS
     - script_content:
-      - raw: def
-      - raw: adapter_call
+      - code: def
+      - code: adapter_call
       - bracketed:
           start_bracket: (
-          raw: in_json
+          code: in_json
           end_bracket: )
       - raw: ':'
-      - raw: return
+      - code: return
       - double_quote: '"BLABLA"'
 - function_script_terminator: /
 - statement:
@@ -60,13 +60,13 @@ file:
       - naked_identifier: adapter_dummy
     - keyword: AS
     - script_content:
-      - raw: function
-      - raw: adapter_call
+      - code: function
+      - code: adapter_call
       - bracketed:
           start_bracket: (
-          raw: in_json
+          code: in_json
           end_bracket: )
       - raw: ':'
-      - raw: return
+      - code: return
       - single_quote: "'BLABLA'"
 - function_script_terminator: /

--- a/test/fixtures/dialects/exasol/CreateLuaScriptBracket.yml
+++ b/test/fixtures/dialects/exasol/CreateLuaScriptBracket.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8fba3a9ad0d049673ca3be918a13aaf02bd6e1cfde411d727ec673f140da6859
+_hash: 5849678931aab62be6c402719b44bf6c15d605858133f49b435e6cd5c6a69f57
 file:
   statement:
     create_scripting_lua_script:
@@ -20,23 +20,23 @@ file:
     - keyword: ROWCOUNT
     - keyword: AS
     - script_content:
-      - raw: local
-      - raw: _stmt
+      - code: local
+      - code: _stmt
       - raw: '='
       - raw: '[[SOME ASSIGNMENT WITH OPEN BRACKET ( ]]'
-      - raw: x
+      - code: x
       - raw: '='
       - numeric_literal: '1'
-      - raw: local
-      - raw: _stmt
+      - code: local
+      - code: _stmt
       - raw: '='
-      - raw: _stmt
+      - code: _stmt
       - range_operator: ..
       - raw: '[[ ) ]]'
-      - raw: local
-      - raw: _nsted
+      - code: local
+      - code: _nsted
       - raw: '='
       - raw: '[=[one ([[two]] one]=]'
-      - raw: return
+      - code: return
       - numeric_literal: '1'
   function_script_terminator: /

--- a/test/fixtures/dialects/exasol/CreatePythonScalarScript.yml
+++ b/test/fixtures/dialects/exasol/CreatePythonScalarScript.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: af169dbaf70811431a7c01120ab5baae8f5ad5efbff01f193b718b53d07d27a6
+_hash: 70cadc1549c0161178ee90989a721583de3c3d84a038e36ab0c299c2fbb0a25a
 file:
   statement:
     create_udf_script:
@@ -69,32 +69,32 @@ file:
           \    e.g.:\n    SELECT MYSCHEMA.MYPYTHONSCRIPT(\n            '[{\""
       - raw: '@lang'
       - double_quote: '":"'
-      - raw: de
+      - code: de
       - raw: '-'
-      - raw: DE
+      - code: DE
       - double_quote: '","'
       - raw: $
       - double_quote: '":"'
-      - raw: Krztxt
+      - code: Krztxt
       - double_quote: '"}, {"'
       - raw: '@lang'
       - double_quote: '":"'
-      - raw: en
+      - code: en
       - raw: '-'
-      - raw: GB
+      - code: GB
       - double_quote: '","'
       - raw: $
       - double_quote: '":"'
-      - raw: Shrttxt
+      - code: Shrttxt
       - double_quote: "\"}]',\n            '@lang',\n            '$'\n        );\n\
           \ ====================================================================*/\n\
           \"\"\""
-      - raw: def
-      - raw: run
+      - code: def
+      - code: run
       - bracketed:
           start_bracket: (
-          raw: ctx
+          code: ctx
           end_bracket: )
       - raw: ':'
-      - raw: pass
+      - code: pass
   function_script_terminator: /

--- a/test/fixtures/dialects/exasol/CreateScriptingLuaScriptStatement1.yml
+++ b/test/fixtures/dialects/exasol/CreateScriptingLuaScriptStatement1.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4dc08e0d689650d94babb10a98c0f26362fbb1b310d599db7af0ad5b134df2f3
+_hash: c6b3b602f42644ffabb641a6b69638725223a8bdc883138162c62d81270aa72f
 file:
 - statement:
     create_scripting_lua_script:
@@ -18,7 +18,7 @@ file:
       - naked_identifier: hello
     - keyword: AS
     - script_content:
-        raw: return
+        code: return
         single_quote: "'HELLO'"
 - function_script_terminator: /
 - statement:
@@ -34,6 +34,6 @@ file:
       - naked_identifier: world
     - keyword: AS
     - script_content:
-        raw: return
+        code: return
         single_quote: "'WORLD'"
 - function_script_terminator: /

--- a/test/fixtures/dialects/exasol/CreateScriptingLuaScriptStatement2.yml
+++ b/test/fixtures/dialects/exasol/CreateScriptingLuaScriptStatement2.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 812f438105868e17820fc25d3e4b129bd7c83a3f0079fb30e5dea880498a1d56
+_hash: ac623c18e014b92b3b4fe3853fefff9fab178547864151bd583341e180cceb3b
 file:
   statement:
     create_scripting_lua_script:
@@ -21,6 +21,6 @@ file:
         end_bracket: )
     - keyword: AS
     - script_content:
-        raw: return
+        code: return
         single_quote: "'HELLO'"
   function_script_terminator: /

--- a/test/fixtures/dialects/exasol/CreateScriptingLuaScriptStatement3.yml
+++ b/test/fixtures/dialects/exasol/CreateScriptingLuaScriptStatement3.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 187c7880e639ffcad489e0a8a61fe7b67afdfed0aec79426ca1666ff4e0d039d
+_hash: 661aa876a8c58d47fd402f71ddf9df1cacc9b4c1b942a198feaa54eb880592f6
 file:
   statement:
     create_scripting_lua_script:
@@ -21,39 +21,39 @@ file:
       - end_bracket: )
     - keyword: AS
     - script_content:
-      - raw: import
+      - code: import
       - bracketed:
           start_bracket: (
           single_quote: "'function_lib'"
           end_bracket: )
-      - raw: lowest
+      - code: lowest
       - comma: ','
-      - raw: highest
+      - code: highest
       - raw: '='
-      - raw: function_lib
+      - code: function_lib
       - raw: .
-      - raw: min_max
+      - code: min_max
       - bracketed:
         - start_bracket: (
-        - raw: param1
+        - code: param1
         - comma: ','
-        - raw: param2
+        - code: param2
         - comma: ','
-        - raw: param3
+        - code: param3
         - end_bracket: )
-      - raw: query
+      - code: query
       - bracketed:
         - start_bracket: (
         - raw: '[[INSERT INTO t VALUES (:x, :y)]]'
         - comma: ','
         - start_curly_bracket: '{'
-        - raw: x
+        - code: x
         - raw: '='
-        - raw: lowest
+        - code: lowest
         - comma: ','
-        - raw: y
+        - code: y
         - raw: '='
-        - raw: highest
+        - code: highest
         - end_curly_bracket: '}'
         - end_bracket: )
   function_script_terminator: /

--- a/test/fixtures/dialects/exasol/CreateUDFScriptDotSyntax.yml
+++ b/test/fixtures/dialects/exasol/CreateUDFScriptDotSyntax.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fe6a0de1e7a84e6391aa1e748d0ba80606bb3b51c01ec820b0527d508f4a258e
+_hash: 2328598c88243090b7270d3bdf4abfc8ec62e8968f0c29868df6e1a25dd96655
 file:
   statement:
     create_udf_script:
@@ -25,20 +25,20 @@ file:
           end_bracket: )
     - keyword: AS
     - script_content:
-      - raw: def
-      - raw: run
+      - code: def
+      - code: run
       - bracketed:
           start_bracket: (
-          raw: ctx
+          code: ctx
           end_bracket: )
       - raw: ':'
-      - raw: ctx
+      - code: ctx
       - raw: .
-      - raw: emit
+      - code: emit
       - bracketed:
         - start_bracket: (
-        - raw: 'True'
+        - code: 'True'
         - comma: ','
-        - raw: 'False'
+        - code: 'False'
         - end_bracket: )
   function_script_terminator: /

--- a/test/fixtures/dialects/exasol/CreateUDFScriptStatement1.yml
+++ b/test/fixtures/dialects/exasol/CreateUDFScriptStatement1.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 46272d132a2fa57493194874d7f88c52519771bec51ef821e1c31bbb33d4afb4
+_hash: a1731e61d1110ed23395aab516655bdfc035804b79aa6e109dc032043c38700a
 file:
 - statement:
     create_udf_script:
@@ -35,44 +35,44 @@ file:
         keyword: DOUBLE
     - keyword: AS
     - script_content:
-      - raw: function
-      - raw: run
+      - code: function
+      - code: run
       - bracketed:
           start_bracket: (
-          raw: ctx
+          code: ctx
           end_bracket: )
-      - raw: if
-      - raw: ctx
+      - code: if
+      - code: ctx
       - raw: .
-      - raw: a
+      - code: a
       - raw: '='
       - raw: '='
-      - raw: nil
-      - raw: or
-      - raw: ctx
+      - code: nil
+      - code: or
+      - code: ctx
       - raw: .
-      - raw: b
+      - code: b
       - raw: '='
       - raw: '='
-      - raw: nil
-      - raw: then
-      - raw: return
-      - raw: 'NULL'
-      - raw: end
-      - raw: return
+      - code: nil
+      - code: then
+      - code: return
+      - code: 'NULL'
+      - code: end
+      - code: return
       - bracketed:
         - start_bracket: (
-        - raw: ctx
+        - code: ctx
         - raw: .
-        - raw: a
+        - code: a
         - raw: +
-        - raw: ctx
+        - code: ctx
         - raw: .
-        - raw: b
+        - code: b
         - end_bracket: )
       - raw: /
       - numeric_literal: '2'
-      - raw: end
+      - code: end
 - function_script_terminator: /
 - statement:
     create_udf_script:
@@ -104,47 +104,47 @@ file:
         keyword: DOUBLE
     - keyword: AS
     - script_content:
-      - raw: function
-      - raw: run
+      - code: function
+      - code: run
       - bracketed:
           start_bracket: (
-          raw: ctx
+          code: ctx
           end_bracket: )
-      - raw: if
-      - raw: ctx
+      - code: if
+      - code: ctx
       - raw: .
-      - raw: a
+      - code: a
       - raw: '='
       - raw: '='
-      - raw: nil
-      - raw: or
-      - raw: ctx
+      - code: nil
+      - code: or
+      - code: ctx
       - raw: .
-      - raw: b
+      - code: b
       - raw: '='
       - raw: '='
-      - raw: nil
-      - raw: then
-      - raw: return
-      - raw: 'NULL'
-      - raw: end
-      - raw: x
+      - code: nil
+      - code: then
+      - code: return
+      - code: 'NULL'
+      - code: end
+      - code: x
       - raw: '='
       - numeric_literal: '10'
       - raw: /
       - numeric_literal: '2'
-      - raw: return
+      - code: return
       - bracketed:
         - start_bracket: (
-        - raw: ctx
+        - code: ctx
         - raw: .
-        - raw: a
+        - code: a
         - raw: +
-        - raw: ctx
+        - code: ctx
         - raw: .
-        - raw: b
+        - code: b
         - end_bracket: )
       - raw: /
       - numeric_literal: '2'
-      - raw: end
+      - code: end
 - function_script_terminator: /

--- a/test/fixtures/dialects/exasol/CreateUDFScriptStatement2.yml
+++ b/test/fixtures/dialects/exasol/CreateUDFScriptStatement2.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 40be04105289e8ce8061c7fad43e925e3692a7a1d0b3f79ba39e9209f69a0c75
+_hash: 817327c1c70904715f4d2304fc74a2cfc8a95e8e279203b30f08bc4e08337296
 file:
   statement:
     create_udf_script:
@@ -41,50 +41,50 @@ file:
           end_bracket: )
     - keyword: AS
     - script_content:
-      - raw: function
-      - raw: run
+      - code: function
+      - code: run
       - bracketed:
           start_bracket: (
-          raw: ctx
+          code: ctx
           end_bracket: )
-      - raw: local
-      - raw: word
+      - code: local
+      - code: word
       - raw: '='
-      - raw: ctx
+      - code: ctx
       - raw: .
-      - raw: w
-      - raw: if
+      - code: w
+      - code: if
       - bracketed:
         - start_bracket: (
-        - raw: word
+        - code: word
         - like_operator: '~'
         - raw: '='
-        - raw: 'null'
+        - code: 'null'
         - end_bracket: )
-      - raw: then
-      - raw: for
-      - raw: i
-      - raw: in
-      - raw: unicode
+      - code: then
+      - code: for
+      - code: i
+      - code: in
+      - code: unicode
       - raw: .
-      - raw: utf8
+      - code: utf8
       - raw: .
-      - raw: gmatch
+      - code: gmatch
       - bracketed:
           start_bracket: (
-          raw: word
+          code: word
           comma: ','
           single_quote: "'([%w%p]+)'"
           end_bracket: )
-      - raw: do
-      - raw: ctx
+      - code: do
+      - code: ctx
       - raw: .
-      - raw: emit
+      - code: emit
       - bracketed:
           start_bracket: (
-          raw: i
+          code: i
           end_bracket: )
-      - raw: end
-      - raw: end
-      - raw: end
+      - code: end
+      - code: end
+      - code: end
   function_script_terminator: /

--- a/test/fixtures/dialects/exasol/CreateUDFScriptStatement3.yml
+++ b/test/fixtures/dialects/exasol/CreateUDFScriptStatement3.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b7b362ba5c75e1cbb8085d85603dd790a88a88556769e7657142f83a9827c91e
+_hash: 30ca3566a9d1f58588b8995fd797b318f9ed602597266f8c1ca27ddcf6316191
 file:
   statement:
     create_udf_script:
@@ -25,12 +25,12 @@ file:
         keyword: INT
     - keyword: AS
     - script_content:
-      - raw: def
-      - raw: helloWorld
+      - code: def
+      - code: helloWorld
       - bracketed:
           start_bracket: (
           end_bracket: )
       - raw: ':'
-      - raw: return
+      - code: return
       - double_quote: '"Hello Python3 World!"'
   function_script_terminator: /

--- a/test/fixtures/dialects/exasol/CreateUDFScriptStatement4.yml
+++ b/test/fixtures/dialects/exasol/CreateUDFScriptStatement4.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 205e694478b52c2ebb744d5573cddbc130bc1f58635e2083a2887106d1544107
+_hash: 43864218bc65bd6350e9e855ee29ffa86b6e79868b89368ac9081f07e2c942f4
 file:
   statement:
     create_udf_script:
@@ -30,26 +30,26 @@ file:
             end_bracket: )
     - keyword: AS
     - script_content:
-      - raw: l
+      - code: l
       - raw: '='
-      - raw: exa
+      - code: exa
       - raw: .
-      - raw: import_script
+      - code: import_script
       - bracketed:
           start_bracket: (
           single_quote: "'LIB.MYLIB'"
           end_bracket: )
-      - raw: def
-      - raw: run
+      - code: def
+      - code: run
       - bracketed:
           start_bracket: (
-          raw: ctx
+          code: ctx
           end_bracket: )
       - raw: ':'
-      - raw: return
-      - raw: l
+      - code: return
+      - code: l
       - raw: .
-      - raw: helloWorld
+      - code: helloWorld
       - bracketed:
           start_bracket: (
           end_bracket: )

--- a/test/fixtures/dialects/exasol/CreateUDFScriptStatement5.yml
+++ b/test/fixtures/dialects/exasol/CreateUDFScriptStatement5.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 01e6305be5ca477b02d496851528cb3120e744490c203d04bb9c32c007685d22
+_hash: 516b99c05cfd78c9be40a0abc907b247f8acd0357f0512e5ac520936284a06eb
 file:
   statement:
     create_udf_script:
@@ -30,17 +30,17 @@ file:
             end_bracket: )
     - keyword: AS
     - script_content:
-      - raw: class
-      - raw: MYLIB
+      - code: class
+      - code: MYLIB
       - start_curly_bracket: '{'
-      - raw: static
-      - raw: String
-      - raw: helloWorld
+      - code: static
+      - code: String
+      - code: helloWorld
       - bracketed:
           start_bracket: (
           end_bracket: )
       - start_curly_bracket: '{'
-      - raw: return
+      - code: return
       - double_quote: '"Hello Java World!"'
       - raw: ;
       - end_curly_bracket: '}'

--- a/test/fixtures/dialects/materialize/materialize_alter_statements.yml
+++ b/test/fixtures/dialects/materialize/materialize_alter_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b1dc0a14d9236681cd3e36e7e939d0338c339431e55e9c385df9b7982d895cd5
+_hash: e7697299c2d39a580ae55e20643bb8dc6b0d59571152394e3e5dfddb58f4a29c
 file:
 - statement:
     alter_connection_rotate_keys:
@@ -121,7 +121,7 @@ file:
     - object_reference:
         naked_identifier: name
     - keyword: AS
-    - raw: value
+    - code: value
 - statement_terminator: ;
 - statement:
     alter_secret_statement:
@@ -130,7 +130,7 @@ file:
     - object_reference:
         naked_identifier: name
     - keyword: AS
-    - raw: value
+    - code: value
 - statement_terminator: ;
 - statement:
     alter_source_sink_size_statement:

--- a/test/fixtures/dialects/materialize/materialize_copy_to_from_statements.yml
+++ b/test/fixtures/dialects/materialize/materialize_copy_to_from_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a34c4368d0453fcd8c9df9799107c972653582fd0b00ea2e230a4a7e47f48183
+_hash: 14a224ca214ea00272992458a67532a8f2524fa05cd154bdb5a18024bf39402f
 file:
 - statement:
     copy_to_statement:
@@ -69,8 +69,8 @@ file:
     - keyword: WITH
     - bracketed:
       - start_bracket: (
-      - raw: FORMAT
-      - raw: binary
+      - code: FORMAT
+      - code: binary
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -99,8 +99,8 @@ file:
     - keyword: WITH
     - bracketed:
       - start_bracket: (
-      - raw: FORMAT
-      - raw: binary
+      - code: FORMAT
+      - code: binary
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -134,11 +134,11 @@ file:
           start_bracket: (
           numeric_literal: '6'
           comma: ','
-          raw: 'NULL'
+          code: 'NULL'
           end_bracket: )
-      - raw: ORDER
-      - raw: BY
-      - raw: column1
+      - code: ORDER
+      - code: BY
+      - code: column1
       - end_bracket: )
     - keyword: TO
     - keyword: STDOUT
@@ -161,13 +161,13 @@ file:
     - keyword: WITH
     - bracketed:
       - start_bracket: (
-      - raw: FORMAT
-      - raw: CSV
+      - code: FORMAT
+      - code: CSV
       - comma: ','
-      - raw: DELIMITER
+      - code: DELIMITER
       - single_quote: "'!'"
       - comma: ','
-      - raw: QUOTE
+      - code: QUOTE
       - single_quote: "'!'"
       - end_bracket: )
 - statement_terminator: ;
@@ -181,7 +181,7 @@ file:
     - keyword: WITH
     - bracketed:
         start_bracket: (
-        raw: DELIMITER
+        code: DELIMITER
         single_quote: "'|'"
         end_bracket: )
 - statement_terminator: ;
@@ -194,8 +194,8 @@ file:
     - keyword: STDIN
     - bracketed:
       - start_bracket: (
-      - raw: FORMAT
-      - raw: CSV
+      - code: FORMAT
+      - code: CSV
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -207,7 +207,7 @@ file:
     - keyword: STDIN
     - bracketed:
         start_bracket: (
-        raw: DELIMITER
+        code: DELIMITER
         single_quote: "'|'"
         end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/materialize/materialize_create_cluster_replica_statements.yml
+++ b/test/fixtures/dialects/materialize/materialize_create_cluster_replica_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ba593bbf1fa0ccc9eefa05a2a5384a80c662fc635660cb22a13c748688521334
+_hash: 463be35f1c6e42bf30ab2665e71ea802e4f444715047607ee668e52eb30b6136
 file:
 - statement:
     create_cluster_statement:
@@ -14,10 +14,10 @@ file:
     - keyword: REPLICAS
     - bracketed:
         start_bracket: (
-        raw: r1
+        code: r1
         bracketed:
           start_bracket: (
-          raw: size
+          code: size
           single_quote: "'1'"
           end_bracket: )
         end_bracket: )
@@ -31,17 +31,17 @@ file:
     - keyword: REPLICAS
     - bracketed:
       - start_bracket: (
-      - raw: r1
+      - code: r1
       - bracketed:
           start_bracket: (
-          raw: size
+          code: size
           single_quote: "'1'"
           end_bracket: )
       - comma: ','
-      - raw: r2
+      - code: r2
       - bracketed:
           start_bracket: (
-          raw: size
+          code: size
           single_quote: "'1'"
           end_bracket: )
       - end_bracket: )
@@ -55,7 +55,7 @@ file:
       - naked_identifier: default
       - dot: .
       - naked_identifier: size_1
-    - raw: SIZE
+    - code: SIZE
     - single_quote: "'large'"
 - statement_terminator: ;
 - statement:
@@ -67,7 +67,7 @@ file:
       - naked_identifier: c1
       - dot: .
       - naked_identifier: r1
-    - raw: SIZE
+    - code: SIZE
     - raw: '='
     - single_quote: "'medium'"
 - statement_terminator: ;
@@ -80,11 +80,11 @@ file:
       - naked_identifier: default
       - dot: .
       - naked_identifier: replica
-    - raw: AVAILABILITY
-    - raw: ZONE
+    - code: AVAILABILITY
+    - code: ZONE
     - single_quote: "'a'"
     - comma: ','
-    - raw: AVAILABILITY
-    - raw: ZONE
+    - code: AVAILABILITY
+    - code: ZONE
     - single_quote: "'b'"
 - statement_terminator: ;

--- a/test/fixtures/dialects/materialize/materialize_create_connection_statement.yml
+++ b/test/fixtures/dialects/materialize/materialize_create_connection_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d48e57736a0884fb917150c2ddfa097d374b193e09c5eab9729c262fcdcd22f7
+_hash: 5f3d1f3a9c4277dabd7d090163feecaad34554d319d420be8d2c11cbd671a1b6
 file:
 - statement:
     create_secret_statement:
@@ -15,7 +15,7 @@ file:
     - object_reference:
         naked_identifier: name
     - keyword: AS
-    - raw: value
+    - code: value
 - statement_terminator: ;
 - statement:
     create_secret_statement:
@@ -24,7 +24,7 @@ file:
     - object_reference:
         naked_identifier: name
     - keyword: AS
-    - raw: value
+    - code: value
 - statement_terminator: ;
 - statement:
     create_connection_statement:
@@ -37,12 +37,12 @@ file:
     - keyword: PRIVATELINK
     - bracketed:
       - start_bracket: (
-      - raw: SERVICE
-      - raw: NAME
+      - code: SERVICE
+      - code: NAME
       - single_quote: "'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc'"
       - comma: ','
-      - raw: AVAILABILITY
-      - raw: ZONES
+      - code: AVAILABILITY
+      - code: ZONES
       - bracketed:
         - start_bracket: (
         - single_quote: "'use1-az1'"
@@ -63,29 +63,29 @@ file:
     - keyword: REGISTRY
     - bracketed:
       - start_bracket: (
-      - raw: URL
+      - code: URL
       - single_quote: "'https://rp-f00000bar.data.vectorized.cloud:30993'"
       - comma: ','
-      - raw: SSL
-      - raw: KEY
+      - code: SSL
+      - code: KEY
       - raw: '='
-      - raw: SECRET
-      - raw: csr_ssl_key
+      - code: SECRET
+      - code: csr_ssl_key
       - comma: ','
-      - raw: SSL
-      - raw: CERTIFICATE
+      - code: SSL
+      - code: CERTIFICATE
       - raw: '='
-      - raw: SECRET
-      - raw: csr_ssl_crt
+      - code: SECRET
+      - code: csr_ssl_crt
       - comma: ','
-      - raw: USERNAME
+      - code: USERNAME
       - raw: '='
       - single_quote: "'foo'"
       - comma: ','
-      - raw: PASSWORD
+      - code: PASSWORD
       - raw: '='
-      - raw: SECRET
-      - raw: csr_password
+      - code: SECRET
+      - code: csr_password
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -99,12 +99,12 @@ file:
     - keyword: PRIVATELINK
     - bracketed:
       - start_bracket: (
-      - raw: SERVICE
-      - raw: NAME
+      - code: SERVICE
+      - code: NAME
       - single_quote: "'com.amazonaws.vpce.us-east-1.vpce-svc-0e123abc123198abc'"
       - comma: ','
-      - raw: AVAILABILITY
-      - raw: ZONES
+      - code: AVAILABILITY
+      - code: ZONES
       - bracketed:
         - start_bracket: (
         - single_quote: "'use1-az1'"
@@ -125,12 +125,12 @@ file:
     - keyword: REGISTRY
     - bracketed:
       - start_bracket: (
-      - raw: URL
+      - code: URL
       - single_quote: "'http://my-confluent-schema-registry:8081'"
       - comma: ','
-      - raw: AWS
-      - raw: PRIVATELINK
-      - raw: privatelink_svc
+      - code: AWS
+      - code: PRIVATELINK
+      - code: privatelink_svc
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -143,20 +143,20 @@ file:
     - keyword: KAFKA
     - bracketed:
       - start_bracket: (
-      - raw: BROKER
+      - code: BROKER
       - single_quote: "'rp-f00000bar.data.vectorized.cloud:30365'"
       - comma: ','
-      - raw: SSL
-      - raw: KEY
+      - code: SSL
+      - code: KEY
       - raw: '='
-      - raw: SECRET
-      - raw: kafka_ssl_key
+      - code: SECRET
+      - code: kafka_ssl_key
       - comma: ','
-      - raw: SSL
-      - raw: CERTIFICATE
+      - code: SSL
+      - code: CERTIFICATE
       - raw: '='
-      - raw: SECRET
-      - raw: kafka_ssl_crt
+      - code: SECRET
+      - code: kafka_ssl_crt
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -169,7 +169,7 @@ file:
     - keyword: KAFKA
     - bracketed:
         start_bracket: (
-        raw: BROKERS
+        code: BROKERS
         bracketed:
         - start_bracket: (
         - single_quote: "'broker1:9092'"
@@ -188,24 +188,24 @@ file:
     - keyword: POSTGRES
     - bracketed:
       - start_bracket: (
-      - raw: HOST
+      - code: HOST
       - single_quote: "'instance.foo000.us-west-1.rds.amazonaws.com'"
       - comma: ','
-      - raw: PORT
+      - code: PORT
       - numeric_literal: '5432'
       - comma: ','
-      - raw: USER
+      - code: USER
       - single_quote: "'postgres'"
       - comma: ','
-      - raw: PASSWORD
-      - raw: SECRET
-      - raw: pgpass
+      - code: PASSWORD
+      - code: SECRET
+      - code: pgpass
       - comma: ','
-      - raw: SSL
-      - raw: MODE
+      - code: SSL
+      - code: MODE
       - single_quote: "'require'"
       - comma: ','
-      - raw: DATABASE
+      - code: DATABASE
       - single_quote: "'postgres'"
       - end_bracket: )
 - statement_terminator: ;
@@ -220,13 +220,13 @@ file:
     - keyword: TUNNEL
     - bracketed:
       - start_bracket: (
-      - raw: HOST
+      - code: HOST
       - single_quote: "'bastion-host'"
       - comma: ','
-      - raw: PORT
+      - code: PORT
       - numeric_literal: '22'
       - comma: ','
-      - raw: USER
+      - code: USER
       - single_quote: "'materialize'"
       - comma: ','
       - end_bracket: )
@@ -241,17 +241,17 @@ file:
     - keyword: POSTGRES
     - bracketed:
       - start_bracket: (
-      - raw: HOST
+      - code: HOST
       - single_quote: "'instance.foo000.us-west-1.rds.amazonaws.com'"
       - comma: ','
-      - raw: PORT
+      - code: PORT
       - numeric_literal: '5432'
       - comma: ','
-      - raw: SSH
-      - raw: TUNNEL
-      - raw: tunnel
+      - code: SSH
+      - code: TUNNEL
+      - code: tunnel
       - comma: ','
-      - raw: DATABASE
+      - code: DATABASE
       - single_quote: "'postgres'"
       - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/materialize/materialize_create_index.yml
+++ b/test/fixtures/dialects/materialize/materialize_create_index.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8eaa2c6e51a20fe64b1770caebd8acca5c4c40d22ad42be2b3919d1b829bc399
+_hash: 45c60649e71f15fc61e09c36070046f876af3cb2e9a407e1ddd2f63489875b81
 file:
 - statement:
     create_index_statement:
@@ -16,7 +16,7 @@ file:
         naked_identifier: active_customers
     - bracketed:
         start_bracket: (
-        raw: geo_id
+        code: geo_id
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -30,10 +30,10 @@ file:
         naked_identifier: active_customers
     - bracketed:
         start_bracket: (
-        raw: upper
+        code: upper
         bracketed:
           start_bracket: (
-          raw: guid
+          code: guid
           end_bracket: )
         end_bracket: )
 - statement_terminator: ;
@@ -52,6 +52,6 @@ file:
         naked_identifier: t1
     - bracketed:
         start_bracket: (
-        raw: f1
+        code: f1
         end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/materialize/materialize_create_sink_statements.yml
+++ b/test/fixtures/dialects/materialize/materialize_create_sink_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3c8ddc5e2d29bc641f89d24a14b14a3fdf1d6e695ceda407358e2d61b6321526
+_hash: 1fc428ea414b4ccb08c4c9649d3feed58070a02a1494226d32475fbd080cef7f
 file:
 - statement:
     create_sink_kafka_statement:
@@ -15,25 +15,25 @@ file:
     - object_reference:
         naked_identifier: quotes
     - keyword: INTO
-    - raw: KAFKA
-    - raw: CONNECTION
-    - raw: kafka_connection
+    - code: KAFKA
+    - code: CONNECTION
+    - code: kafka_connection
     - bracketed:
         start_bracket: (
-        raw: TOPIC
+        code: TOPIC
         single_quote: "'quotes-sink'"
         end_bracket: )
-    - raw: FORMAT
-    - raw: JSON
-    - raw: ENVELOPE
-    - raw: DEBEZIUM
-    - raw: WITH
+    - code: FORMAT
+    - code: JSON
+    - code: ENVELOPE
+    - code: DEBEZIUM
+    - code: WITH
     - bracketed:
-      - start_bracket: (
-      - raw: SIZE
-      - raw: '='
-      - single_quote: "'3xsmall'"
-      - end_bracket: )
+        start_bracket: (
+        code: SIZE
+        raw: '='
+        single_quote: "'3xsmall'"
+        end_bracket: )
 - statement_terminator: ;
 - statement:
     create_sink_kafka_statement:
@@ -45,23 +45,23 @@ file:
     - object_reference:
         naked_identifier: frank_quotes
     - keyword: INTO
-    - raw: KAFKA
-    - raw: CONNECTION
-    - raw: kafka_connection
+    - code: KAFKA
+    - code: CONNECTION
+    - code: kafka_connection
     - bracketed:
         start_bracket: (
-        raw: TOPIC
+        code: TOPIC
         single_quote: "'frank-quotes-sink'"
         end_bracket: )
-    - raw: FORMAT
-    - raw: JSON
-    - raw: ENVELOPE
-    - raw: DEBEZIUM
-    - raw: WITH
+    - code: FORMAT
+    - code: JSON
+    - code: ENVELOPE
+    - code: DEBEZIUM
+    - code: WITH
     - bracketed:
-      - start_bracket: (
-      - raw: SIZE
-      - raw: '='
-      - single_quote: "'3xsmall'"
-      - end_bracket: )
+        start_bracket: (
+        code: SIZE
+        raw: '='
+        single_quote: "'3xsmall'"
+        end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/materialize/materialize_create_source_statements.yml
+++ b/test/fixtures/dialects/materialize/materialize_create_source_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a3d984f3cf9c375c5ada88ba1c0222d93beeb3efd0f472dad53eadcc7eb54eeb
+_hash: e4637e97ea11a573f43a5e1d0a19f101f3e569164fa4f0886387efd47fb8053a
 file:
 - statement:
     create_source_kafka_statement:
@@ -18,24 +18,24 @@ file:
         naked_identifier: kafka_connection
     - bracketed:
         start_bracket: (
-        raw: TOPIC
+        code: TOPIC
         single_quote: "'test_topic'"
         end_bracket: )
     - keyword: FORMAT
-    - raw: AVRO
-    - raw: USING
-    - raw: CONFLUENT
-    - raw: SCHEMA
-    - raw: REGISTRY
-    - raw: CONNECTION
-    - raw: csr_connection
-    - raw: WITH
+    - code: AVRO
+    - code: USING
+    - code: CONFLUENT
+    - code: SCHEMA
+    - code: REGISTRY
+    - code: CONNECTION
+    - code: csr_connection
+    - code: WITH
     - bracketed:
-      - start_bracket: (
-      - raw: SIZE
-      - raw: '='
-      - single_quote: "'3xsmall'"
-      - end_bracket: )
+        start_bracket: (
+        code: SIZE
+        raw: '='
+        single_quote: "'3xsmall'"
+        end_bracket: )
 - statement_terminator: ;
 - statement:
     create_view_statement:
@@ -129,24 +129,24 @@ file:
         naked_identifier: kafka_connection
     - bracketed:
         start_bracket: (
-        raw: TOPIC
+        code: TOPIC
         single_quote: "'test_topic'"
         end_bracket: )
     - keyword: FORMAT
-    - raw: PROTOBUF
-    - raw: USING
-    - raw: CONFLUENT
-    - raw: SCHEMA
-    - raw: REGISTRY
-    - raw: CONNECTION
-    - raw: csr_connection
-    - raw: WITH
+    - code: PROTOBUF
+    - code: USING
+    - code: CONFLUENT
+    - code: SCHEMA
+    - code: REGISTRY
+    - code: CONNECTION
+    - code: csr_connection
+    - code: WITH
     - bracketed:
-      - start_bracket: (
-      - raw: SIZE
-      - raw: '='
-      - single_quote: "'3xsmall'"
-      - end_bracket: )
+        start_bracket: (
+        code: SIZE
+        raw: '='
+        single_quote: "'3xsmall'"
+        end_bracket: )
 - statement_terminator: ;
 - statement:
     create_source_kafka_statement:
@@ -161,20 +161,20 @@ file:
         naked_identifier: kafka_connection
     - bracketed:
         start_bracket: (
-        raw: TOPIC
+        code: TOPIC
         single_quote: "'test_topic'"
         end_bracket: )
     - keyword: FORMAT
-    - raw: TEXT
-    - raw: ENVELOPE
-    - raw: UPSERT
-    - raw: WITH
+    - code: TEXT
+    - code: ENVELOPE
+    - code: UPSERT
+    - code: WITH
     - bracketed:
-      - start_bracket: (
-      - raw: SIZE
-      - raw: '='
-      - single_quote: "'3xsmall'"
-      - end_bracket: )
+        start_bracket: (
+        code: SIZE
+        raw: '='
+        single_quote: "'3xsmall'"
+        end_bracket: )
 - statement_terminator: ;
 - statement:
     create_source_kafka_statement:
@@ -200,21 +200,21 @@ file:
         naked_identifier: kafka_connection
     - bracketed:
         start_bracket: (
-        raw: TOPIC
+        code: TOPIC
         single_quote: "'test_topic'"
         end_bracket: )
     - keyword: FORMAT
-    - raw: CSV
-    - raw: WITH
+    - code: CSV
+    - code: WITH
     - numeric_literal: '3'
-    - raw: COLUMNS
-    - raw: WITH
+    - code: COLUMNS
+    - code: WITH
     - bracketed:
-      - start_bracket: (
-      - raw: SIZE
-      - raw: '='
-      - single_quote: "'3xsmall'"
-      - end_bracket: )
+        start_bracket: (
+        code: SIZE
+        raw: '='
+        single_quote: "'3xsmall'"
+        end_bracket: )
 - statement_terminator: ;
 - statement:
     create_source_load_generator_statement:
@@ -231,11 +231,11 @@ file:
     - keyword: TABLES
     - keyword: WITH
     - bracketed:
-      - start_bracket: (
-      - raw: SIZE
-      - raw: '='
-      - single_quote: "'3xsmall'"
-      - end_bracket: )
+        start_bracket: (
+        code: SIZE
+        raw: '='
+        single_quote: "'3xsmall'"
+        end_bracket: )
 - statement_terminator: ;
 - statement:
     create_source_load_generator_statement:
@@ -249,8 +249,8 @@ file:
     - keyword: TPCH
     - bracketed:
       - start_bracket: (
-      - raw: SCALE
-      - raw: FACTOR
+      - code: SCALE
+      - code: FACTOR
       - numeric_literal: '1'
       - end_bracket: )
     - keyword: FOR
@@ -258,11 +258,11 @@ file:
     - keyword: TABLES
     - keyword: WITH
     - bracketed:
-      - start_bracket: (
-      - raw: SIZE
-      - raw: '='
-      - single_quote: "'3xsmall'"
-      - end_bracket: )
+        start_bracket: (
+        code: SIZE
+        raw: '='
+        single_quote: "'3xsmall'"
+        end_bracket: )
 - statement_terminator: ;
 - statement:
     create_source_load_generator_statement:
@@ -276,11 +276,11 @@ file:
     - keyword: COUNTER
     - keyword: WITH
     - bracketed:
-      - start_bracket: (
-      - raw: SIZE
-      - raw: '='
-      - single_quote: "'3xsmall'"
-      - end_bracket: )
+        start_bracket: (
+        code: SIZE
+        raw: '='
+        single_quote: "'3xsmall'"
+        end_bracket: )
 - statement_terminator: ;
 - statement:
     create_source_postgres_statement:
@@ -295,7 +295,7 @@ file:
         naked_identifier: pg_connection
     - bracketed:
         start_bracket: (
-        raw: PUBLICATION
+        code: PUBLICATION
         single_quote: "'mz_source'"
         end_bracket: )
     - keyword: FOR
@@ -303,11 +303,11 @@ file:
     - keyword: TABLES
     - keyword: WITH
     - bracketed:
-      - start_bracket: (
-      - raw: SIZE
-      - raw: '='
-      - single_quote: "'3xsmall'"
-      - end_bracket: )
+        start_bracket: (
+        code: SIZE
+        raw: '='
+        single_quote: "'3xsmall'"
+        end_bracket: )
 - statement_terminator: ;
 - statement:
     create_source_postgres_statement:
@@ -322,26 +322,26 @@ file:
         naked_identifier: pg_connection
     - bracketed:
         start_bracket: (
-        raw: PUBLICATION
+        code: PUBLICATION
         single_quote: "'mz_source'"
         end_bracket: )
     - keyword: FOR
     - keyword: TABLES
     - bracketed:
       - start_bracket: (
-      - raw: table_1
+      - code: table_1
       - comma: ','
-      - raw: table_2
-      - raw: AS
-      - raw: alias_table_2
+      - code: table_2
+      - code: AS
+      - code: alias_table_2
       - end_bracket: )
     - keyword: WITH
     - bracketed:
-      - start_bracket: (
-      - raw: SIZE
-      - raw: '='
-      - single_quote: "'3xsmall'"
-      - end_bracket: )
+        start_bracket: (
+        code: SIZE
+        raw: '='
+        single_quote: "'3xsmall'"
+        end_bracket: )
 - statement_terminator: ;
 - statement:
     create_source_postgres_statement:
@@ -356,16 +356,16 @@ file:
         naked_identifier: pg_connection
     - bracketed:
       - start_bracket: (
-      - raw: PUBLICATION
+      - code: PUBLICATION
       - single_quote: "'mz_source'"
       - comma: ','
-      - raw: TEXT
-      - raw: COLUMNS
+      - code: TEXT
+      - code: COLUMNS
       - bracketed:
         - start_bracket: (
-        - raw: table
+        - code: table
         - raw: .
-        - raw: column_of_unsupported_type
+        - code: column_of_unsupported_type
         - end_bracket: )
       - end_bracket: )
     - keyword: FOR
@@ -373,11 +373,11 @@ file:
     - keyword: TABLES
     - keyword: WITH
     - bracketed:
-      - start_bracket: (
-      - raw: SIZE
-      - raw: '='
-      - single_quote: "'3xsmall'"
-      - end_bracket: )
+        start_bracket: (
+        code: SIZE
+        raw: '='
+        single_quote: "'3xsmall'"
+        end_bracket: )
 - statement_terminator: ;
 - statement:
     create_source_postgres_statement:
@@ -392,16 +392,16 @@ file:
         naked_identifier: pg_connection
     - bracketed:
         start_bracket: (
-        raw: PUBLICATION
+        code: PUBLICATION
         single_quote: "'mz_source'"
         end_bracket: )
     - keyword: WITH
     - bracketed:
-      - start_bracket: (
-      - raw: SIZE
-      - raw: '='
-      - single_quote: "'3xsmall'"
-      - end_bracket: )
+        start_bracket: (
+        code: SIZE
+        raw: '='
+        single_quote: "'3xsmall'"
+        end_bracket: )
 - statement_terminator: ;
 - statement:
     create_type_statement:

--- a/test/fixtures/dialects/materialize/materialize_create_views.yml
+++ b/test/fixtures/dialects/materialize/materialize_create_views.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3e47162cf0ca19d94e60235647045a9bdfb752f2efa41d00991012479e329ae4
+_hash: 4be57036ad8e690e8a4c9558ca524fb6b19854e6f04ea7c17a30896b5096745b
 file:
 - statement:
     create_materialized_view_statement:
@@ -15,9 +15,9 @@ file:
       - dot: .
       - quoted_identifier: '"test"'
     - keyword: AS
-    - raw: SELECT
+    - code: SELECT
     - numeric_literal: '1'
-    - raw: AS
+    - code: AS
     - double_quote: '"id"'
 - statement_terminator: ;
 - statement:
@@ -48,11 +48,11 @@ file:
       - dot: .
       - quoted_identifier: '"test"'
     - keyword: AS
-    - raw: SELECT
+    - code: SELECT
     - single_quote: "'{\"a\": 1}'"
     - raw: '::'
-    - raw: json
-    - raw: AS
+    - code: json
+    - code: AS
     - double_quote: '"id"'
 - statement_terminator: ;
 - statement:
@@ -63,35 +63,35 @@ file:
     - object_reference:
         naked_identifier: active_customer_per_geo
     - keyword: AS
-    - raw: SELECT
-    - raw: geo
+    - code: SELECT
+    - code: geo
     - raw: .
-    - raw: name
+    - code: name
     - comma: ','
-    - raw: count
+    - code: count
     - bracketed:
         start_bracket: (
         raw: '*'
         end_bracket: )
-    - raw: FROM
-    - raw: geo_regions
-    - raw: AS
-    - raw: geo
-    - raw: JOIN
-    - raw: active_customers
-    - raw: 'ON'
-    - raw: active_customers
+    - code: FROM
+    - code: geo_regions
+    - code: AS
+    - code: geo
+    - code: JOIN
+    - code: active_customers
+    - code: 'ON'
+    - code: active_customers
     - raw: .
-    - raw: geo_id
+    - code: geo_id
     - raw: '='
-    - raw: geo
+    - code: geo
     - raw: .
-    - raw: id
-    - raw: GROUP
-    - raw: BY
-    - raw: geo
+    - code: id
+    - code: GROUP
+    - code: BY
+    - code: geo
     - raw: .
-    - raw: name
+    - code: name
 - statement_terminator: ;
 - statement:
     create_materialized_view_statement:
@@ -101,17 +101,17 @@ file:
     - object_reference:
         naked_identifier: active_customers
     - keyword: AS
-    - raw: SELECT
-    - raw: guid
+    - code: SELECT
+    - code: guid
     - comma: ','
-    - raw: geo_id
+    - code: geo_id
     - comma: ','
-    - raw: last_active_on
-    - raw: FROM
-    - raw: customer_source
-    - raw: GROUP
-    - raw: BY
-    - raw: geo_id
+    - code: last_active_on
+    - code: FROM
+    - code: customer_source
+    - code: GROUP
+    - code: BY
+    - code: geo_id
 - statement_terminator: ;
 - statement:
     create_view_statement:

--- a/test/fixtures/dialects/materialize/materialize_explain_statements.yml
+++ b/test/fixtures/dialects/materialize/materialize_explain_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9671d1e626ab3257e443b6f9a83144bdaf0a1270c3f44620d63684ede6275855
+_hash: c95b68f0e3ce20972e4b6086e90fb236dbc77e2eb7d718e4df5b4efa6158e63b
 file:
 - statement:
     explain_statement:
@@ -72,9 +72,9 @@ file:
     - keyword: WITH
     - bracketed:
       - start_bracket: (
-      - raw: arity
+      - code: arity
       - comma: ','
-      - raw: join_impls
+      - code: join_impls
       - end_bracket: )
     - keyword: VIEW
     - object_reference:
@@ -88,7 +88,7 @@ file:
     - keyword: WITH
     - bracketed:
         start_bracket: (
-        raw: arity
+        code: arity
         end_bracket: )
     - keyword: AS
     - keyword: TEXT

--- a/test/fixtures/dialects/materialize/materialize_subscribe_fetch_statements.yml
+++ b/test/fixtures/dialects/materialize/materialize_subscribe_fetch_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3d0f7e2826bb710e0a8adaf01c0f6b58df93f5ab72b5441ecb904afcbbbaf479
+_hash: 211577430ed00b854e469e247c1c35a412aa5b87ea2de4e89d4c0b1d01032d50
 file:
 - statement:
     fetch_statement:
@@ -13,11 +13,11 @@ file:
         naked_identifier: c
     - keyword: WITH
     - bracketed:
-      - start_bracket: (
-      - raw: timeout
-      - raw: '='
-      - single_quote: "'1s'"
-      - end_bracket: )
+        start_bracket: (
+        code: timeout
+        raw: '='
+        single_quote: "'1s'"
+        end_bracket: )
 - statement_terminator: ;
 - statement:
     fetch_statement:
@@ -33,8 +33,8 @@ file:
         naked_identifier: c
     - keyword: CURSOR
     - keyword: FOR
-    - raw: SUBSCRIBE
-    - raw: fetch_during_ingest
+    - code: SUBSCRIBE
+    - code: fetch_during_ingest
 - statement_terminator: ;
 - statement:
     declare_statement:
@@ -43,12 +43,12 @@ file:
         naked_identifier: c
     - keyword: CURSOR
     - keyword: FOR
-    - raw: SUBSCRIBE
+    - code: SUBSCRIBE
     - bracketed:
       - start_bracket: (
-      - raw: SELECT
+      - code: SELECT
       - raw: '*'
-      - raw: FROM
-      - raw: t1
+      - code: FROM
+      - code: t1
       - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/postgres/postgres_comment_on.yml
+++ b/test/fixtures/dialects/postgres/postgres_comment_on.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 33381b0b86302058a5674d19c7a48f20a5af530917b5185963a97a4d581aba83
+_hash: 30f7e598ee1ea2bb81c0e7000e562ff401d31fe6d8058dbf6031afe373fdc6fe
 file:
 - statement:
     comment_clause:
@@ -45,8 +45,8 @@ file:
         naked_identifier: my_aggregate
     - bracketed:
       - start_bracket: (
-      - raw: double
-      - raw: precision
+      - code: double
+      - code: precision
       - end_bracket: )
     - keyword: IS
     - quoted_literal: "'Computes sample variance'"
@@ -284,9 +284,9 @@ file:
         naked_identifier: my_proc
     - bracketed:
       - start_bracket: (
-      - raw: integer
+      - code: integer
       - comma: ','
-      - raw: integer
+      - code: integer
       - end_bracket: )
     - keyword: IS
     - quoted_literal: "'Runs a report'"
@@ -343,9 +343,9 @@ file:
         naked_identifier: my_routine
     - bracketed:
       - start_bracket: (
-      - raw: integer
+      - code: integer
       - comma: ','
-      - raw: integer
+      - code: integer
       - end_bracket: )
     - keyword: IS
     - quoted_literal: "'Runs a routine (which is a function or procedure)'"

--- a/test/fixtures/dialects/postgres/postgres_composite_types.yml
+++ b/test/fixtures/dialects/postgres/postgres_composite_types.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3b6a6b1369d1d10833d15178a6c7a131652b89a235dca285c32f963dcb730b7c
+_hash: fd4a08b86542fd0e9656247766feaeeedc6af7c222fdbc8ba378e599a3bf8867
 file:
 - statement:
     create_type_statement:
@@ -14,14 +14,14 @@ file:
     - keyword: AS
     - bracketed:
       - start_bracket: (
-      - raw: int_
-      - raw: INT4
+      - code: int_
+      - code: INT4
       - comma: ','
-      - raw: bool_
-      - raw: BOOLEAN
+      - code: bool_
+      - code: BOOLEAN
       - comma: ','
-      - raw: comment_
-      - raw: TEXT
+      - code: comment_
+      - code: TEXT
       - end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/postgres/postgres_create_extension.sql
+++ b/test/fixtures/dialects/postgres/postgres_create_extension.sql
@@ -1,11 +1,11 @@
 CREATE EXTENSION amazing_extension
     with schema schema1
-    VERSION 2.0
-    FROM 1.0;
+    VERSION 2.0.1.2
+    FROM '1.0';
 
 CREATE EXTENSION IF NOT EXISTS amazing_extension
     with schema schema1
-    VERSION 2.0
+    VERSION 1.2.3a4
     FROM 1.0;
 
 

--- a/test/fixtures/dialects/postgres/postgres_create_extension.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_extension.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ecc9699f8a881f56b241c5099433e6d13173c8537e1aa113206c93ba08b6f4ba
+_hash: b6e77e8335e52d18ec1650ced762ac2d2a692cce2b782d0f0adadfdfe8854b59
 file:
 - statement:
     create_extension_statement:
@@ -16,9 +16,13 @@ file:
     - schema_reference:
         naked_identifier: schema1
     - keyword: VERSION
-    - identifier: '2.0'
+    - version_identifier:
+      - numeric_literal: '2.0'
+      - numeric_literal: '.1'
+      - numeric_literal: '.2'
     - keyword: FROM
-    - identifier: '1.0'
+    - version_identifier:
+        quoted_literal: "'1.0'"
 - statement_terminator: ;
 - statement:
     create_extension_statement:
@@ -34,9 +38,13 @@ file:
     - schema_reference:
         naked_identifier: schema1
     - keyword: VERSION
-    - identifier: '2.0'
+    - version_identifier:
+        numeric_literal: '1.2'
+        dot: .
+        naked_identifier: 3a4
     - keyword: FROM
-    - identifier: '1.0'
+    - version_identifier:
+        numeric_literal: '1.0'
 - statement_terminator: ;
 - statement:
     drop_extension_statement:

--- a/test/fixtures/dialects/postgres/postgres_create_function.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fd7206234d3089bf40aa15d903a2a756abe694096830bbd9e25d37311ce22728
+_hash: a2a0f2c4bee4578f40958582525e3f84a4b19d621ce8333f1364624f3b028c98
 file:
 - statement:
     create_function_statement:
@@ -325,11 +325,11 @@ file:
     - keyword: AS
     - bracketed:
       - start_bracket: (
-      - raw: f1
-      - raw: int
+      - code: f1
+      - code: int
       - comma: ','
-      - raw: f2
-      - raw: text
+      - code: f2
+      - code: text
       - end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/postgres/postgres_create_table.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7880269f4bce9ff93caca9665e3b5f3aff1c424509d69405f4aac0bd39d9405a
+_hash: a76f4fb19b133a1000a4103a133ca8931376b9bc8fc7a4c14794785381e49093
 file:
 - statement:
     create_table_statement:
@@ -432,11 +432,11 @@ file:
     - keyword: AS
     - bracketed:
       - start_bracket: (
-      - raw: name
-      - raw: text
+      - code: name
+      - code: text
       - comma: ','
-      - raw: salary
-      - raw: numeric
+      - code: salary
+      - code: numeric
       - end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/postgres/postgres_create_type.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_type.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b996a018c7e24a91965a3214b8747f2cf73dbe4b540672aaab01848ffdfe7356
+_hash: 13bcdb2d8d6b13a8e0d3029166a5e129a68c54ffc57a18d5ba3e7b378366ddc8
 file:
 - statement:
     create_type_statement:
@@ -49,9 +49,9 @@ file:
     - keyword: RANGE
     - bracketed:
       - start_bracket: (
-      - raw: SUBTYPE
+      - code: SUBTYPE
       - raw: '='
-      - raw: FLOAT
+      - code: FLOAT
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -63,13 +63,13 @@ file:
     - keyword: AS
     - bracketed:
       - start_bracket: (
-      - raw: INPUT
+      - code: INPUT
       - raw: '='
-      - raw: foo
+      - code: foo
       - comma: ','
-      - raw: OUTPUT
+      - code: OUTPUT
       - raw: '='
-      - raw: bar
+      - code: bar
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -81,9 +81,9 @@ file:
     - keyword: AS
     - bracketed:
       - start_bracket: (
-      - raw: foo
-      - raw: varchar
-      - raw: collate
-      - raw: utf8
+      - code: foo
+      - code: varchar
+      - code: collate
+      - code: utf8
       - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/redshift/redshift_create_model.yml
+++ b/test/fixtures/dialects/redshift/redshift_create_model.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6513c9d67d768b6b8d8fbe2e8b8ba21236c8c4fc3b0b300c1ac0dd492f38b461
+_hash: 08b1482a19515e0e55aaa7e583f133a972bc89ed1c69182d51b5ba62e9f3b3cb
 file:
 - statement:
     create_model_statement:
@@ -85,10 +85,10 @@ file:
     - keyword: EXCEPT
     - bracketed:
       - start_bracket: (
-      - raw: NUM_ROUND
+      - code: NUM_ROUND
       - single_quote: "'100'"
       - comma: ','
-      - raw: NUM_CLASS
+      - code: NUM_CLASS
       - single_quote: "'30'"
       - end_bracket: )
     - keyword: SETTINGS
@@ -192,7 +192,7 @@ file:
     - keyword: EXCEPT
     - bracketed:
         start_bracket: (
-        raw: K
+        code: K
         single_quote: "'5'"
         end_bracket: )
     - keyword: SETTINGS

--- a/test/fixtures/dialects/teradata/create_table_stmt_3.yml
+++ b/test/fixtures/dialects/teradata/create_table_stmt_3.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9ffbbc697e46c5549859022966608d7c9f4296ec1962c3a455cf26707f2d873d
+_hash: 2a1999394771b519f4daf4b3d620f1b4ea325dac0b388b5b6486149cadff9d39
 file:
   statement:
     create_table_statement:
@@ -68,22 +68,22 @@ file:
             function_name_identifier: RANGE_N
           bracketed:
           - start_bracket: (
-          - raw: FEC_OPERACION
-          - raw: BETWEEN
-          - raw: DATE
+          - code: FEC_OPERACION
+          - code: BETWEEN
+          - code: DATE
           - single_quote: "'2007-01-01'"
-          - raw: AND
-          - raw: DATE
+          - code: AND
+          - code: DATE
           - single_quote: "'2022-01-01'"
-          - raw: EACH
-          - raw: INTERVAL
+          - code: EACH
+          - code: INTERVAL
           - single_quote: "'1'"
-          - raw: MONTH
+          - code: MONTH
           - comma: ','
-          - raw: 'NO'
-          - raw: RANGE
-          - raw: OR
-          - raw: UNKNOWN
+          - code: 'NO'
+          - code: RANGE
+          - code: OR
+          - code: UNKNOWN
           - end_bracket: )
       - keyword: INDEX
       - object_reference:


### PR DESCRIPTION
This makes a little progress on #3390.

The most substantive change here (at least as far as parse tree changes - is that the "root" matcher (`code`) now has it's own type rather than just showing up as `raw`). That means we can use it for matching using the `TypedParser` and remove a couple of the `RegexParser` usages.

The segments migrated from `RegexParser` to `TypedParser` are:
- `FunctionNameIdentifierSegment`
- `VersionIdentifierSegment`
- `NakedIdentifierFullSegment`