### PR TITLE
Consistent indentation in `MERGE` `INSERT` clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2732,9 +2732,7 @@ class MergeInsertClauseSegment(BaseSegment):
         Indent,
         Ref("BracketedColumnReferenceListGrammar", optional=True),
         Dedent,
-        Indent,
         Ref("ValuesClauseSegment", optional=True),
-        Dedent,
     )
 
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1925,9 +1925,7 @@ class MergeInsertClauseSegment(ansi.MergeInsertClauseSegment):
             Indent,
             Ref("BracketedColumnReferenceListGrammar", optional=True),
             Dedent,
-            Indent,
             Ref("ValuesClauseSegment", optional=True),
-            Dedent,
         ),
         Sequence("INSERT", "ROW"),
     )

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -1837,16 +1837,10 @@ class MergeInsertClauseSegment(BaseSegment):
     type = "merge_insert_clause"
     match_grammar = Sequence(
         "INSERT",
-        Ref("BracketedColumnReferenceListGrammar", optional=True),
-        "VALUES",
-        Bracketed(
-            Delimited(
-                OneOf(
-                    "DEFAULT",
-                    Ref("ExpressionSegment"),
-                ),
-            )
-        ),
+        Indent,
+        Ref("BracketedColumnReferenceListGrammar"),
+        Dedent,
+        Ref("ValuesClauseSegment", optional=True),
         Ref("WhereClauseSegment", optional=True),
     )
 

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -1838,7 +1838,7 @@ class MergeInsertClauseSegment(BaseSegment):
     match_grammar = Sequence(
         "INSERT",
         Indent,
-        Ref("BracketedColumnReferenceListGrammar"),
+        Ref("BracketedColumnReferenceListGrammar", optional=True),
         Dedent,
         Ref("ValuesClauseSegment", optional=True),
         Ref("WhereClauseSegment", optional=True),

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -5801,7 +5801,7 @@ class MergeInsertClauseSegment(ansi.MergeInsertClauseSegment):
     match_grammar = Sequence(
         "INSERT",
         Indent,
-        Ref("BracketedColumnReferenceListGrammar"),
+        Ref("BracketedColumnReferenceListGrammar", optional=True),
         Dedent,
         Ref("ValuesClauseSegment", optional=True),
         Ref("WhereClauseSegment", optional=True),

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -5800,16 +5800,10 @@ class MergeInsertClauseSegment(ansi.MergeInsertClauseSegment):
 
     match_grammar = Sequence(
         "INSERT",
-        Ref("BracketedColumnReferenceListGrammar", optional=True),
-        "VALUES",
-        Bracketed(
-            Delimited(
-                OneOf(
-                    "DEFAULT",
-                    Ref("ExpressionSegment"),
-                ),
-            )
-        ),
+        Indent,
+        Ref("BracketedColumnReferenceListGrammar"),
+        Dedent,
+        Ref("ValuesClauseSegment", optional=True),
         Ref("WhereClauseSegment", optional=True),
     )
 

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -2810,9 +2810,7 @@ class MergeInsertClauseSegment(ansi.MergeInsertClauseSegment):
                 Indent,
                 Ref("BracketedColumnReferenceListGrammar"),
                 Dedent,
-                Indent,
                 Ref("ValuesClauseSegment"),
-                Dedent,
             ),
         ),
     )

--- a/test/fixtures/dialects/exasol/MergeStatement.yml
+++ b/test/fixtures/dialects/exasol/MergeStatement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cf69f6048a644afca395a0752a97e0e6780fb56107cf14f96e1ff0e2fe09cd20
+_hash: 2d927806faa8c9349e523b0471fd1654957ff55219f34e5aafa17bb1588c8352
 file:
 - statement:
     merge_statement:
@@ -81,25 +81,26 @@ file:
         - keyword: MATCHED
         - keyword: THEN
         - merge_insert_clause:
-          - keyword: INSERT
-          - keyword: VALUES
-          - bracketed:
-            - start_bracket: (
-            - expression:
-                column_reference:
-                - naked_identifier: U
-                - dot: .
-                - naked_identifier: name
-            - comma: ','
-            - expression:
-                column_reference:
-                - naked_identifier: U
-                - dot: .
-                - naked_identifier: salary
-            - comma: ','
-            - expression:
-                bare_function: CURRENT_DATE
-            - end_bracket: )
+            keyword: INSERT
+            values_clause:
+              keyword: VALUES
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                  - naked_identifier: U
+                  - dot: .
+                  - naked_identifier: name
+              - comma: ','
+              - expression:
+                  column_reference:
+                  - naked_identifier: U
+                  - dot: .
+                  - naked_identifier: salary
+              - comma: ','
+              - expression:
+                  bare_function: CURRENT_DATE
+              - end_bracket: )
 - statement_terminator: ;
 - statement:
     merge_statement:
@@ -196,19 +197,20 @@ file:
         - keyword: MATCHED
         - keyword: THEN
         - merge_insert_clause:
-          - keyword: INSERT
-          - keyword: VALUES
-          - bracketed:
-            - start_bracket: (
-            - expression:
-                numeric_literal: '1'
-            - comma: ','
-            - expression:
-                numeric_literal: '2'
-            - comma: ','
-            - expression:
-                numeric_literal: '3'
-            - end_bracket: )
+            keyword: INSERT
+            values_clause:
+              keyword: VALUES
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  numeric_literal: '1'
+              - comma: ','
+              - expression:
+                  numeric_literal: '2'
+              - comma: ','
+              - expression:
+                  numeric_literal: '3'
+              - end_bracket: )
         merge_when_matched_clause:
         - keyword: WHEN
         - keyword: MATCHED

--- a/test/fixtures/dialects/snowflake/snowflake_merge_into.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_merge_into.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7b602a6619c523b8402544ee5be40c4a95fb1bbfec9d9cc16c842ea40846cb50
+_hash: 4fc9381cf19925291a0cb4b9a028ac88f1518d8d63395677b1d2a1cbfdd6da1a
 file:
 - statement:
     alter_table_statement:
@@ -144,16 +144,17 @@ file:
             numeric_literal: '1'
         - keyword: then
         - merge_insert_clause:
-          - keyword: insert
-          - bracketed:
+            keyword: insert
+            bracketed:
               start_bracket: (
               column_reference:
                 naked_identifier: marked
               end_bracket: )
-          - keyword: values
-          - bracketed:
-              start_bracket: (
-              expression:
-                numeric_literal: '1'
-              end_bracket: )
+            values_clause:
+              keyword: values
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '1'
+                end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -1886,3 +1886,36 @@ test_configure_no_indent_before_then_4589:
       dialect: ansi
     indentation:
       indented_then: false
+
+test_bigquery_insert_statement_values_clause:
+  pass_str: |
+    INSERT dataset.inventory (product, quantity)
+    VALUES("top load washer", 10);
+  configs:
+    core:
+      dialect: bigquery
+
+test_bigquery_merge_statement_values_clause:
+  fail_str: |
+    MERGE dataset.detailedinventory AS t
+    USING dataset.inventory AS s
+        ON t.product = s.product
+    WHEN NOT MATCHED AND quantity < 20 THEN
+        INSERT (product, quantity, supply_constrained)
+            VALUES (product, quantity, TRUE)
+    WHEN NOT MATCHED THEN
+        INSERT (product, quantity, supply_constrained)
+            VALUES (product, quantity, FALSE);
+  fix_str: |
+    MERGE dataset.detailedinventory AS t
+    USING dataset.inventory AS s
+        ON t.product = s.product
+    WHEN NOT MATCHED AND quantity < 20 THEN
+        INSERT (product, quantity, supply_constrained)
+        VALUES (product, quantity, TRUE)
+    WHEN NOT MATCHED THEN
+        INSERT (product, quantity, supply_constrained)
+        VALUES (product, quantity, FALSE);
+  configs:
+    core:
+      dialect: bigquery


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Makes progress on #4232 

This is a first attempt to clean up and unionize the different `MergeInsertClauseSegment` of dialects.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- [x] Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- [ ] Added appropriate documentation for the change.
- [x] Created GitHub issues for any relevant followup/future enhancements if appropriate.
