### PR TITLE
BigQuery: Fix null assignment in options segment

### DIFF
--- a/src/sqlfluff/rules/convention/CV05.py
+++ b/src/sqlfluff/rules/convention/CV05.py
@@ -52,7 +52,7 @@ class Rule_CV05(BaseRule):
 
         # Allow assignments in SET clauses
         if len(context.parent_stack) >= 2 and context.parent_stack[-2].is_type(
-            "set_clause_list", "execute_script_statement"
+            "set_clause_list", "execute_script_statement", "options_segment"
         ):
             return None
 

--- a/test/fixtures/dialects/bigquery/alter_table_set_options.sql
+++ b/test/fixtures/dialects/bigquery/alter_table_set_options.sql
@@ -3,3 +3,7 @@ SET OPTIONS (
   expiration_timestamp=TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 7 DAY),
   description="Table that expires seven days from now"
 );
+
+ALTER TABLE table
+SET OPTIONS (expiration_timestamp = NULL)
+;

--- a/test/fixtures/dialects/bigquery/alter_table_set_options.yml
+++ b/test/fixtures/dialects/bigquery/alter_table_set_options.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8fdd85c59b24e91ef35e4ddf2d3e4bb3ff60efa127707cefe561182621c360ca
+_hash: 337e774718873b99a59ccc416f8dfd887b30f51835c7bc1af3b10649192a557d
 file:
-  statement:
+- statement:
     alter_table_statement:
     - keyword: ALTER
     - keyword: TABLE
@@ -47,4 +47,21 @@ file:
             raw_comparison_operator: '='
         - quoted_literal: '"Table that expires seven days from now"'
         - end_bracket: )
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table
+    - keyword: SET
+    - options_segment:
+        keyword: OPTIONS
+        bracketed:
+          start_bracket: (
+          parameter: expiration_timestamp
+          comparison_operator:
+            raw_comparison_operator: '='
+          null_literal: 'NULL'
+          end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/CV05.yml
+++ b/test/fixtures/rules/std_rule_cases/CV05.yml
@@ -77,6 +77,15 @@ test_set_clause:
     UPDATE table1 SET col = NULL
     WHERE col = ""
 
+test_bigquery_set_options:
+  pass_str: |
+    ALTER TABLE table
+    SET OPTIONS (expiration_timestamp = NULL)
+    ;
+  configs:
+    core:
+      dialect: bigquery
+
 test_tsql_exec_clause:
   pass_str: |
     exec something


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Closes https://github.com/sqlfluff/sqlfluff/issues/4644

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
