### PR TITLE
Add performance shortcuts to LT03 & LT04

### DIFF
--- a/src/sqlfluff/rules/layout/LT03.py
+++ b/src/sqlfluff/rules/layout/LT03.py
@@ -106,16 +106,14 @@ class Rule_LT03(BaseRule):
 
     def _eval(self, context: RuleContext) -> List[LintResult]:
         """Operators should follow a standard for being before/after newlines.
-
-        We use the memory to keep track of whitespace up to now, and
-        whether the last code segment was an operator or not.
-        Anchor is our signal as to whether there's a problem.
-
-        We only trigger if we have an operator FOLLOWED BY a newline
-        before the next meaningful code segment.
+    
+        For the fixing routines we delegate to the reflow utils. However
+        for performance reasons we have some initial shortcuts to quickly
+        identify situations which are _ok_ to avoid the overhead of the
+        full reflow path.
         """
         # NOTE: These shortcuts assume that any newlines will be direct
-        # siblings of the comma in question. This isn't _always_ the case
+        # siblings of the operator in question. This isn't _always_ the case
         # but is true often enough to have meaningful upside from early
         # detection.
         if context.segment.is_type("comparison_operator"):

--- a/src/sqlfluff/rules/layout/LT03.py
+++ b/src/sqlfluff/rules/layout/LT03.py
@@ -130,7 +130,6 @@ class Rule_LT03(BaseRule):
             binary_positioning = context.config.get(
                 "line_position", ["layout", "type", "binary_operator"]
             )
-            self.logger.warning("FOO")
             if self._check_trail_lead_shortcut(
                 context.segment, context.parent_stack[-1], binary_positioning
             ):

--- a/src/sqlfluff/rules/layout/LT03.py
+++ b/src/sqlfluff/rules/layout/LT03.py
@@ -106,7 +106,7 @@ class Rule_LT03(BaseRule):
 
     def _eval(self, context: RuleContext) -> List[LintResult]:
         """Operators should follow a standard for being before/after newlines.
-    
+
         For the fixing routines we delegate to the reflow utils. However
         for performance reasons we have some initial shortcuts to quickly
         identify situations which are _ok_ to avoid the overhead of the


### PR DESCRIPTION
This is triggered by the early performance investigations from @WittierDinosaur . We've noticed LT04 is a culprit of slowness in some larger queries. This adds a shortcut for places where the full reflow routine isn't required. It doesn't cover all cases, but in cases that are _clearly passing_ it bypasses the need to run the full reflow routine to generate the fix.

If that has a meaningful impact, it would be fairly easy to port similar changes to the operator routines, and also add some additional clauses here to account for some other scenarios.