### PR TITLE
Mark `is_alias_required` as a private class so it doesn't appear in docs

### DIFF
--- a/src/sqlfluff/rules/aliasing/AL05.py
+++ b/src/sqlfluff/rules/aliasing/AL05.py
@@ -87,7 +87,7 @@ class Rule_AL05(BaseRule):
         for alias in query.aliases:
             # Skip alias if it's required (some dialects require aliases for
             # VALUES clauses).
-            if alias.from_expression_element and self.is_alias_required(
+            if alias.from_expression_element and self._is_alias_required(
                 alias.from_expression_element, context.dialect.name
             ):
                 continue
@@ -98,7 +98,7 @@ class Rule_AL05(BaseRule):
         return violations or None
 
     @classmethod
-    def is_alias_required(
+    def _is_alias_required(
         cls, from_expression_element: BaseSegment, dialect_name: str
     ) -> bool:
         """Given an alias, is it REQUIRED to be present?


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fixes this:

![image](https://user-images.githubusercontent.com/10931297/230086890-bb37063e-3c90-419e-b663-ca8b6e371b93.png)

### Are there any other side effects of this change that we should be aware of?

Don't think so but would like @alanmcruickshank to review to confirm if this was intentional.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
