### PR TITLE
Better error message for missing keywords

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -268,7 +268,7 @@ class Dialect:
                         name, self.name
                     )
                 )
-        elif name.endswith("KeywordSegment"):
+        elif name.endswith("KeywordSegment"):  # pragma: no cover
             keyword = name[0:-14]
             keyword_tip = (
                 "\n\nThe syntax in the query is not (yet?) supported. Try to"
@@ -289,7 +289,7 @@ class Dialect:
                     )
                 )
             )
-        else:
+        else:  # pragma: no cover
             raise RuntimeError(
                 (
                     "Grammar refers to "


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

As discussed in https://github.com/sqlfluff/sqlfluff/issues/4600#issuecomment-1486812789 (and in multiple other places), when a piece of SQL syntax is not supported we often end up trying other Segments and Grammar paths that perhaps are not supported in that particular dialect but that are inherited from the base ANSI dialect.

If this uses a Keyword that is not defined you get this sort of unhelpful output:

```
WARNING    Unable to lint test.sql due to an internal error. Please report this as an issue with your query's contents and stacktrace below!
To hide this warning, add the failing file to .sqlfluffignore
Traceback (most recent call last):
  File "/Users/barrypollard/sources/sqlfluff/src/sqlfluff/core/linter/runner.py", line 108, in run
    yield partial()
...
Lots more lines like this
...
  File "/Users/barrypollard/sources/sqlfluff/src/sqlfluff/core/parser/grammar/base.py", line 815, in simple
    return self._get_elem(dialect=parse_context.dialect).simple(
  File "/Users/barrypollard/sources/sqlfluff/src/sqlfluff/core/parser/grammar/base.py", line 843, in _get_elem
    return dialect.ref(self._get_ref())
  File "/Users/barrypollard/sources/sqlfluff/src/sqlfluff/core/dialects/base.py", line 280, in ref
    raise SyntaxWarning(
SyntaxWarning: Grammar refers to 'Respect' which was not found in the sqlite dialect. Perhaps specify the keyword? https://github.com/sqlfluff/sqlfluff/wiki/Contributing-Dialect-Changes#keywords
```

This is unhelpful for two reasons:
1) The stack trace is huge, scary looking, and ultimately completely unhelpful for this particular error.
2) In this case we have ended up in a Segment that uses the `RESPECT` keyword but that is not defined in this dialect and hence that is the error that shows. However, more often than not, the actual problem is that the syntax is just not supported by SQLFluff and so you ended up in a Segment you shouldn't have. So the fact that the `RESPECT` keyword is not defined in this dialect is not the real error.

This PR proposes turning off the tracebook in this case and also putting a more helpful error message:

```
WARNING    Unable to lint test.sql due to an internal error. Please report this as an issue with your query's contents and stacktrace below!
To hide this warning, add the failing file to .sqlfluffignore
RuntimeError: Grammar refers to the 'Respect' keyword which was not found in the sqlite dialect.

The syntax in the query is not (yet?) supported. Try to narrow down your query to a minimal, reproducible case and raise an issue on GitHub.

Or, even better, see this guide on how to help contribute keyword and/or dialect updates:
https://github.com/sqlfluff/sqlfluff/wiki/Contributing-Dialect-Changes#keywords
```

That's quite verbose, but hopefully explains it better.

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
