### PR TITLE
Make version number an argument not an option in release script.

### DIFF
--- a/.github/workflows/create-release-pull-request.yaml
+++ b/.github/workflows/create-release-pull-request.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Prepare release
         run: |
-          python util.py prepare-release --new_version_num=${{ github.event.inputs.newVersionNumber }}
+          python util.py release ${{ github.event.inputs.newVersionNumber }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ secrets.GITHUB_REPOSITORY_OWNER }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,7 +272,7 @@ need a [GitHub Personal Access Token](https://docs.github.com/en/authentication/
 source .venv/bin/activate
 export GITHUB_REPOSITORY_OWNER=sqlfluff
 export GITHUB_TOKEN=gho_xxxxxxxx # Change to your token with "repo" permissions.
-python util.py prepare-release --new_version_num=0.13.4 # Change to your release number
+python util.py release 2.0.3 # Change to your release number
 ```
 
 Below is the old list of release steps, but many are automated by the process

--- a/util.py
+++ b/util.py
@@ -121,8 +121,8 @@ def benchmark(cmd, runs, from_file):
 
 
 @cli.command()
-@click.option("--new_version_num")
-def prepare_release(new_version_num):
+@click.argument("new_version_num")
+def release(new_version_num):
     """Change version number in the cfg files."""
     api = GhApi(
         owner=os.environ["GITHUB_REPOSITORY_OWNER"],


### PR DESCRIPTION
For the release script I always have to use `--help` to remember the command and the option name. The script doesn't really work _without using the option_ however - so it seems more sensible to make it an argument so that it's always required. I think the command is also too long. This shortens things:
```bash
# from...
python util.py prepare-release --new_version_num=1.1.1
# ...to...
python util.py release 1.1.1
```

I've also updated the CI script, but I'm hoping this is easier for me to remember when kicking this off manually in future.
