### PR TITLE
Allow persist timing on `fix` too.

### DIFF
--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -502,7 +502,7 @@ def test__cli__command_lint_parse(command):
         # Format with --persist-timing
         (
             (
-                fix,
+                cli_format,
                 [
                     "--fixed-suffix",
                     "_fix",

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -499,6 +499,20 @@ def test__cli__command_lint_parse(command):
             ),
             0,
         ),
+        # Format with --persist-timing
+        (
+            (
+                fix,
+                [
+                    "--fixed-suffix",
+                    "_fix",
+                    "test/fixtures/linter/whitespace_errors.sql",
+                    "--persist-timing",
+                    "test.csv",
+                ],
+            ),
+            0,
+        ),
         # Format (specifying rules)
         (
             (


### PR DESCRIPTION
In the current release `--persist-timing` only works on `lint`. This adds it to `fix` too (and also `format` in the process).