### PR TITLE
fix{dialect-snowflake}:Alter Table Column Set/Unset Tag

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1730,7 +1730,22 @@ class AlterTableTableColumnActionSegment(BaseSegment):
                             "MASKING",
                             "POLICY",
                         ),
-                        # @TODO: Set/Unset TAG support
+                        Sequence(
+                            "COLUMN",
+                            Ref("ColumnReferenceSegment"),
+                            "SET",
+                            "TAG",
+                            Ref("TagReferenceSegment"),
+                            Ref("EqualsSegment"),
+                            Ref("QuotedLiteralSegment"),
+                        ),
+                        Sequence(
+                            "COLUMN",
+                            Ref("ColumnReferenceSegment"),
+                            "UNSET",
+                            "TAG",
+                            Ref("TagReferenceSegment"),
+                        ),
                     ),
                 ),
             ),

--- a/test/fixtures/dialects/snowflake/snowflake_alter_table_column.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_table_column.sql
@@ -63,6 +63,11 @@ alter table empl_info modify
   , column empl_dob unset masking policy
 ;
 
+--- Set Tag
+ALTER TABLE my_table MODIFY COLUMN my_column SET TAG my_tag = 'tagged';
+
+--- Unset Tag
+ALTER TABLE my_table MODIFY COLUMN my_column UNSET TAG my_tag;
 
 -- Drop column
 ALTER TABLE empl_info DROP COLUMN my_column;

--- a/test/fixtures/dialects/snowflake/snowflake_alter_table_column.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_alter_table_column.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9807fdbeb3a8025069b187ca234e3a42b40ac4c1250900bd6b73abb75c721f41
+_hash: a661d921f72d807ed26fa97225e83c40b6e705e975a7fe0622e259a0999323e8
 file:
 - statement:
     alter_table_statement:
@@ -515,6 +515,41 @@ file:
       - keyword: unset
       - keyword: masking
       - keyword: policy
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: my_table
+    - alter_table_table_column_action:
+      - keyword: MODIFY
+      - keyword: COLUMN
+      - column_reference:
+          naked_identifier: my_column
+      - keyword: SET
+      - keyword: TAG
+      - tag_reference:
+          naked_identifier: my_tag
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'tagged'"
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: my_table
+    - alter_table_table_column_action:
+      - keyword: MODIFY
+      - keyword: COLUMN
+      - column_reference:
+          naked_identifier: my_column
+      - keyword: UNSET
+      - keyword: TAG
+      - tag_reference:
+          naked_identifier: my_tag
 - statement_terminator: ;
 - statement:
     alter_table_statement:


### PR DESCRIPTION
### Brief summary of the change made

Allows Snowflake `ALTER TABLE ALTER COLUMN` statements to set and unset tags.

Syntax: https://docs.snowflake.com/en/sql-reference/sql/alter-table-column

### Pull Request checklist
- [ X] Please confirm you have completed any of the necessary steps below.

