### PR TITLE
fix{dialect-snowflake}:Execute Task

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1011,6 +1011,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("CreateDatabaseFromShareStatementSegment"),
             Ref("AlterRoleStatementSegment"),
             Ref("AlterStorageIntegrationSegment"),
+            Ref("ExecuteTaskClauseSegment"),
         ],
         remove=[
             Ref("CreateIndexStatementSegment"),
@@ -5770,6 +5771,24 @@ class AlterTaskUnsetClauseSegment(BaseSegment):
     match_grammar = Sequence(
         "UNSET",
         Delimited(Ref("ParameterNameSegment")),
+    )
+
+
+class ExecuteTaskClauseSegment(BaseSegment):
+    """Snowflake's EXECUTE TASK clause.
+
+    ```
+        EXECUTE TASK <name>
+    ```
+
+    https://docs.snowflake.com/en/sql-reference/sql/execute-task
+    """
+
+    type = "execute_task_clause"
+    match_grammar = Sequence(
+        "EXECUTE",
+        "TASK",
+        Ref("ParameterNameSegment"),
     )
 
 

--- a/test/fixtures/dialects/snowflake/snowflake_execute_task.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_execute_task.sql
@@ -1,0 +1,1 @@
+EXECUTE TASK my_task;

--- a/test/fixtures/dialects/snowflake/snowflake_execute_task.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_execute_task.yml
@@ -1,0 +1,13 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 0059fba6a20ac46c320a7282d451301142de29d00a8cdf9b5aaeef45fbc4b4c4
+file:
+  statement:
+    execute_task_clause:
+    - keyword: EXECUTE
+    - keyword: TASK
+    - parameter: my_task
+  statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

All the use of `EXECUTE TASK <name>` when using Snowflake.

https://docs.snowflake.com/en/sql-reference/sql/execute-task#syntax


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.
