### PR TITLE
Safety valve for fixes in CV03

### DIFF
--- a/src/sqlfluff/rules/convention/CV03.py
+++ b/src/sqlfluff/rules/convention/CV03.py
@@ -79,8 +79,8 @@ class Rule_CV03(BaseRule):
                                     # Not safe to fix
                                     self.logger.info(
                                         "Preventing deletion of %s, because source "
-                                        "position is the same as %s. Templated positions "
-                                        "are %s and %s.",
+                                        "position is the same as %s. Templated "
+                                        "positions are %s and %s.",
                                         last_content,
                                         seg,
                                         last_content.pos_marker.templated_position(),

--- a/src/sqlfluff/rules/convention/CV03.py
+++ b/src/sqlfluff/rules/convention/CV03.py
@@ -58,9 +58,43 @@ class Rule_CV03(BaseRule):
         if self.select_clause_trailing_comma == "forbid":
             # Is it a comma?
             if last_content.is_type("comma"):
+                # The last content is a comma. Before we try and remove it, we
+                # should check that it's safe. One edge case is that it's a trailing
+                # comma in a loop, but that if we try and remove it, we also break
+                # the previous examples. We should check that this comma doesn't
+                # share a source position with any other commas in the same select.
+
+                # If there isn't a source position, then it's safe to remove, it's
+                # a recent addition.
+                if not last_content.pos_marker:
+                    fixes = [LintFix.delete(last_content)]
+                else:
+                    comma_pos = last_content.pos_marker.source_position()
+                    for seg in context.segment.segments:
+                        if seg.is_type("comma"):
+                            if not seg.pos_marker:
+                                continue
+                            elif seg.pos_marker.source_position() == comma_pos:
+                                if seg is not last_content:
+                                    # Not safe to fix
+                                    self.logger.info(
+                                        "Preventing deletion of %s, because source "
+                                        "position is the same as %s. Templated positions "
+                                        "are %s and %s.",
+                                        last_content,
+                                        seg,
+                                        last_content.pos_marker.templated_position(),
+                                        seg.pos_marker.templated_position(),
+                                    )
+                                    fixes = []
+                                    break
+                    else:
+                        # No matching commas found. It's safe.
+                        fixes = [LintFix.delete(last_content)]
+
                 return LintResult(
                     anchor=last_content,
-                    fixes=[LintFix.delete(last_content)],
+                    fixes=fixes,
                     description="Trailing comma in select statement forbidden",
                 )
         elif self.select_clause_trailing_comma == "require":

--- a/src/sqlfluff/rules/convention/CV03.py
+++ b/src/sqlfluff/rules/convention/CV03.py
@@ -66,13 +66,13 @@ class Rule_CV03(BaseRule):
 
                 # If there isn't a source position, then it's safe to remove, it's
                 # a recent addition.
-                if not last_content.pos_marker:
+                if not last_content.pos_marker:  # pragma: no cover
                     fixes = [LintFix.delete(last_content)]
                 else:
                     comma_pos = last_content.pos_marker.source_position()
                     for seg in context.segment.segments:
                         if seg.is_type("comma"):
-                            if not seg.pos_marker:
+                            if not seg.pos_marker:  # pragma: no cover
                                 continue
                             elif seg.pos_marker.source_position() == comma_pos:
                                 if seg is not last_content:

--- a/test/fixtures/rules/std_rule_cases/CV03.yml
+++ b/test/fixtures/rules/std_rule_cases/CV03.yml
@@ -30,3 +30,28 @@ test_forbid_fail:
     rules:
       convention.select_trailing_comma:
         select_clause_trailing_comma: forbid
+
+test_fail_templated:
+  # NOTE: Check no fix, because it's not safe.
+  fail_str: |
+    SELECT
+        {% for col in ['a', 'b', 'c'] %}
+            {{col}},
+        {% endfor %}
+    FROM tbl
+  fix_str: |
+    SELECT
+        {% for col in ['a', 'b', 'c'] %}
+            {{col}},
+        {% endfor %}
+    FROM tbl
+  violations_after_fix:
+  - code: CV03
+    description: Trailing comma in select statement forbidden
+    line_no: 3
+    line_pos: 16
+    name: "convention.select_trailing_comma"
+  configs:
+    rules:
+      convention.select_trailing_comma:
+        select_clause_trailing_comma: forbid


### PR DESCRIPTION
This resolves #4681 . When a comma is in a loop - it's not safe to remove. This prevents that.