### PR TITLE
SparkSQL: Add using and options clause to create view statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -516,6 +516,7 @@ sparksql_dialect.add(
         # NB: JDBC is part of DataSourceV2 but not included
         # there since there are no significant syntax changes
         "JDBC",
+        Ref("ObjectReferenceSegment"), # This allows for formats such as org.apache.spark.sql.jdbc
     ),
     TimestampAsOfGrammar=Sequence(
         "TIMESTAMP",
@@ -1175,10 +1176,15 @@ class CreateViewStatementSegment(ansi.CreateViewStatementSegment):
             ),
             optional=True,
         ),
+        Sequence("USING", Ref("DataSourceFormatGrammar"), optional=True),
+        Ref("OptionsGrammar", optional=True),
         Ref("CommentGrammar", optional=True),
         Ref("TablePropertiesGrammar", optional=True),
-        "AS",
-        OptionallyBracketed(Ref("SelectableGrammar")),
+        Sequence(
+            "AS",
+            OptionallyBracketed(Ref("SelectableGrammar")),
+            optional=True
+        ),
         Ref("WithNoSchemaBindingClauseSegment", optional=True),
     )
 

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -516,7 +516,9 @@ sparksql_dialect.add(
         # NB: JDBC is part of DataSourceV2 but not included
         # there since there are no significant syntax changes
         "JDBC",
-        Ref("ObjectReferenceSegment"), # This allows for formats such as org.apache.spark.sql.jdbc
+        Ref(
+            "ObjectReferenceSegment"
+        ),  # This allows for formats such as org.apache.spark.sql.jdbc
     ),
     TimestampAsOfGrammar=Sequence(
         "TIMESTAMP",
@@ -1180,11 +1182,7 @@ class CreateViewStatementSegment(ansi.CreateViewStatementSegment):
         Ref("OptionsGrammar", optional=True),
         Ref("CommentGrammar", optional=True),
         Ref("TablePropertiesGrammar", optional=True),
-        Sequence(
-            "AS",
-            OptionallyBracketed(Ref("SelectableGrammar")),
-            optional=True
-        ),
+        Sequence("AS", OptionallyBracketed(Ref("SelectableGrammar")), optional=True),
         Ref("WithNoSchemaBindingClauseSegment", optional=True),
     )
 

--- a/test/fixtures/dialects/sparksql/create_view.sql
+++ b/test/fixtures/dialects/sparksql/create_view.sql
@@ -15,3 +15,12 @@ SELECT * from experienced_employee limit 2 ;
 -- Replace the implementation of `simple_udf`
 CREATE OR REPLACE VIEW experienced_employee_rep AS
 SELECT * from experienced_employee limit 2 ;
+
+CREATE TEMPORARY VIEW pulse_article_search_data
+    USING org.apache.spark.sql.jdbc
+    OPTIONS (
+  url "jdbc:postgresql:dbserver",
+  dbtable "schema.tablename",
+  user 'username',
+  password 'password'
+)

--- a/test/fixtures/dialects/sparksql/create_view.yml
+++ b/test/fixtures/dialects/sparksql/create_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b2533ee6f925cd7b21d6150acbe56fdae6a2b46b2654f08c08bf26b7efa7d16d
+_hash: 5d856330a613894ea00025a26e34b8d9021766b487b251c89e1db9e02771cbc9
 file:
 - statement:
     create_view_statement:
@@ -139,3 +139,40 @@ file:
           keyword: limit
           numeric_literal: '2'
 - statement_terminator: ;
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: TEMPORARY
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: pulse_article_search_data
+    - keyword: USING
+    - object_reference:
+      - naked_identifier: org
+      - dot: .
+      - naked_identifier: apache
+      - dot: .
+      - naked_identifier: spark
+      - dot: .
+      - naked_identifier: sql
+      - dot: .
+      - naked_identifier: jdbc
+    - keyword: OPTIONS
+    - bracketed:
+      - start_bracket: (
+      - property_name_identifier:
+          properties_naked_identifier: url
+      - quoted_literal: '"jdbc:postgresql:dbserver"'
+      - comma: ','
+      - property_name_identifier:
+          properties_naked_identifier: dbtable
+      - quoted_literal: '"schema.tablename"'
+      - comma: ','
+      - property_name_identifier:
+          properties_naked_identifier: user
+      - quoted_literal: "'username'"
+      - comma: ','
+      - property_name_identifier:
+          properties_naked_identifier: password
+      - quoted_literal: "'password'"
+      - end_bracket: )


### PR DESCRIPTION
### Brief summary of the change made
This change adds support for `USING` and `OPTIONS` clauses within `CREATE VIEW` statements. This is done to reflect spark sql documentation: 
https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html

As evident on the bottom of this page, these are officially supported in `CREATE VIEW` statements. 

A test case has been added to `test/fixtures/dialects/sparksql/create_view.sql` to test this new support.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
