### PR TITLE
Jinja templater: treat "import" and "from" as templated

### DIFF
--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -523,7 +523,8 @@ class JinjaAnalyzer:
         # :TRICKY: Syntactically, the Jinja {% include %} directive looks like
         # a block, but its behavior is basically syntactic sugar for
         # {{ open("somefile).read() }}. Thus, treat it as templated code.
-        if tag_name == "include":
+        # It's a similar situation with {% import %} and {% from ... import %}.
+        if tag_name in ["include", "import", "from"]:
             block_type = "templated"
         elif tag_name.startswith("end"):
             block_type = "block_end"

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -1059,6 +1059,18 @@ SELECT 1
             ],
         ),
         (
+            # Tests Jinja "import" directive.
+            """{% import 'echo.sql' as echo %}
+
+SELECT 1
+""",
+            None,
+            [
+                ("templated", slice(0, 31, None), slice(0, 0, None)),
+                ("literal", slice(31, 42, None), slice(0, 11, None)),
+            ],
+        ),
+        (
             # Tests Jinja "from import" directive..
             """{% from 'echo.sql' import echo %}
 {% from 'echoecho.sql' import echoecho %}
@@ -1069,9 +1081,9 @@ SELECT
 """,
             None,
             [
-                ("block_start", slice(0, 33, None), slice(0, 0, None)),
+                ("templated", slice(0, 33, None), slice(0, 0, None)),
                 ("literal", slice(33, 34, None), slice(0, 1, None)),
-                ("block_start", slice(34, 75, None), slice(1, 1, None)),
+                ("templated", slice(34, 75, None), slice(1, 1, None)),
                 ("literal", slice(75, 88, None), slice(1, 14, None)),
                 ("templated", slice(88, 105, None), slice(14, 19, None)),
                 ("literal", slice(105, 111, None), slice(19, 25, None)),


### PR DESCRIPTION
The "import" and "from" Jinja directives are currently treated as of type "block_start".  This (unsurprisingly) leads to this error:

    Indent balance test failed for 'demo.sql'. Template indents will not be linted for this file.

And then template indentation rules don't work correctly any more.  So we see errors like:

```
L:   5 | P:   1 | LT02 | Line should not be indented.
                       | [layout.indent]
```

on code like:
```
{% import 'echo.sql' as echo %}
{% if True %}
    SELECT 1;
{% endif %}
```

even though template_blocks_indent is still on.

This commit fixes the problem by treating those directives as simple "templated" types, similar to how the "include" type already is.


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
