### PR TITLE
Capitalization rules ignore templated code only if configured to

### DIFF
--- a/src/sqlfluff/rules/capitalisation/CP05.py
+++ b/src/sqlfluff/rules/capitalisation/CP05.py
@@ -83,7 +83,7 @@ class Rule_CP05(Rule_CP01):
                     "symbol", "identifier", "quoted_literal"
                 ) or not seg.is_type("raw"):
                     continue
-                res = self._handle_segment(seg, context.memory)
+                res = self._handle_segment(seg, context)
                 if res:
                     results.append(res)
 
@@ -94,7 +94,7 @@ class Rule_CP05(Rule_CP01):
             "primitive_type", "datetime_type_identifier", "data_type"
         ):
             results.append(
-                self._handle_segment(context.segment, context.memory)
+                self._handle_segment(context.segment, context)
             )  # pragma: no cover
 
         return results

--- a/test/fixtures/rules/std_rule_cases/CP01.yml
+++ b/test/fixtures/rules/std_rule_cases/CP01.yml
@@ -122,11 +122,27 @@ test_pass_ignore_words_complex:
         capitalisation_policy: upper
         ignore_words_regex: (^Se|^Fr)
 
-test_pass_ignore_templated_code:
+test_pass_ignore_templated_code_true:
   pass_str: |
     {{ "select" }} a
     FROM foo
     WHERE 1
+  configs:
+    core:
+      ignore_templated_areas: true
+
+test_fail_ignore_templated_code_false:
+  fail_str: |
+    {{ "select" }} a
+    FROM foo
+    WHERE 1
+  fix_str: |
+    {{ "select" }} a
+    from foo
+    where 1
+  configs:
+    core:
+      ignore_templated_areas: false
 
 test_fail_snowflake_group_by_cube:
   fail_str: |

--- a/test/fixtures/rules/std_rule_cases/CP03.yml
+++ b/test/fixtures/rules/std_rule_cases/CP03.yml
@@ -54,11 +54,27 @@ test_pass_ignore_word:
       capitalisation.functions:
         ignore_words: min
 
-test_pass_ignore_templated_code:
+test_pass_ignore_templated_code_true:
   pass_str: |
     SELECT
         {{ "greatest(a, b)" }},
         GREATEST(i, j)
+  configs:
+    core:
+      ignore_templated_areas: true
+
+test_fail_ignore_templated_code_false:
+  fail_str: |
+    SELECT
+        {{ "greatest(a, b)" }},
+        GREATEST(i, j)
+  fix_str: |
+    SELECT
+        {{ "greatest(a, b)" }},
+        greatest(i, j)
+  configs:
+    core:
+      ignore_templated_areas: false
 
 test_pass_func_name_templated_literal_mix:
   # Issue 3022. This was actually a bug in BaseSegment.iter_patches().


### PR DESCRIPTION
The pull request at https://github.com/sqlfluff/sqlfluff/pull/2566 made sense for users who set ignore_templated_areas to true because those macros are not under their control.  However, if a user is writing their own macros and would like to lint those, that commit made the capitalization rules completely unusable.

For example, the following code in a single file would not trigger any violations, even if ignore_templated_areas is set to false:

    {% macro abc() %}
        sElEcT a, B fRoM abc;
    {% endmacro %}
    {{ abc() }}

That is... a surprising result...

This commit will now only skip templated areas if we are actually configured to do that.  Hopefully this will allow their use in templated areas if desired, while still avoiding false positives when we ignore template areas as the previous commit had aimed to fix.


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
