### PR TITLE
Fix LT01 spacing check in templated areas

### DIFF
--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -113,14 +113,8 @@ def process_spacing(
 
     # Loop through the existing segments looking for spacing.
     for seg in segment_buffer:
-        # If it has a position marker, but it's not literal, then
-        # it's a templated element and so we shouldn't consider it
-        # here.
-        if seg.pos_marker and not seg.pos_marker.is_literal():
-            continue
-
         # If it's whitespace, store it.
-        elif seg.is_type("whitespace"):
+        if seg.is_type("whitespace"):
             last_whitespace.append(seg)
 
         # If it's a newline, react accordingly.

--- a/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
@@ -4,12 +4,25 @@ test_pass_parenthesis_block_isolated:
   pass_str: |
     SELECT * FROM (SELECT 1 AS C1) AS T1;
 
+test_pass_parenthesis_block_isolated_template:
+  pass_str: |
+    {{ 'SELECT * FROM (SELECT 1 AS C1) AS T1;' }}
+  configs:
+    core:
+      ignore_templated_areas: false
 
-test_pass_parenthesis_block_not_isolated:
+test_fail_parenthesis_block_not_isolated:
   fail_str: |
     SELECT * FROM(SELECT 1 AS C1)AS T1;
   fix_str: |
     SELECT * FROM (SELECT 1 AS C1) AS T1;
+
+test_fail_parenthesis_block_not_isolated_templated:
+  fail_str: |
+    {{ 'SELECT * FROM(SELECT 1 AS C1)AS T1;' }}
+  configs:
+    core:
+      ignore_templated_areas: false
 
 test_pass_parenthesis_function:
   pass_str: |

--- a/test/fixtures/rules/std_rule_cases/LT01-commas.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-commas.yml
@@ -4,8 +4,22 @@ test_fail_whitespace_before_comma:
   fail_str: SELECT 1 ,4
   fix_str: SELECT 1, 4
 
+test_fail_whitespace_before_comma_template:
+  fail_str: |
+    {{ 'SELECT 1 ,4' }}
+  configs:
+    core:
+      ignore_templated_areas: false
+
 test_pass_single_whitespace_after_comma:
   pass_str: SELECT 1, 4
+
+test_pass_single_whitespace_after_comma_template:
+  pass_str: |
+    {{ 'SELECT 1, 4' }}
+  configs:
+    core:
+      ignore_templated_areas: false
 
 test_fail_multiple_whitespace_after_comma:
   fail_str: SELECT 1,   4

--- a/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-excessive.yml
@@ -3,9 +3,23 @@ rule: LT01
 test_basic:
   pass_str: SELECT 1
 
+test_basic_template:
+  pass_str: |
+    {{ 'SELECT 1' }}
+  configs:
+    core:
+      ignore_templated_areas: false
+
 test_basic_fix:
   fail_str: SELECT     1
   fix_str: SELECT 1
+
+test_basic_fail_template:
+  fail_str: |
+    {{ 'SELECT     1' }}
+  configs:
+    core:
+      ignore_templated_areas: false
 
 test_simple_fix:
   fail_str: |


### PR DESCRIPTION
When both the LT01 rule is on, and ignore_templated_areas is False, the LT01 rule yields a large number of false positives.  For example, a template like this:

    {{ 'SELECT 1;' }}

would fail with a false positive error like this, if you run with ignore_templated_areas set to false:

    L:   1 | P:   1 | LT01 | Expected single whitespace between 'SELECT'
        keyword and numeric literal. [layout.spacing]

In respace.py, the original "if" block that bypasses template segments was added recently in:

https://github.com/sqlfluff/sqlfluff/commit/0b1f2aab2ac5eceeae5c38b049d3b8e40c338ab7

That commit was mainly focused on indentation.  I'm not sure why the change in rescape.py was made... but deleting it doesn't cause any test cases to fail, and it helps my new test cases pass.


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

This probably makes progress on issue #4641, I am not sure.  It definitely makes progress on my own test cases.

### Are there any other side effects of this change that we should be aware of?

This code is very hairy and unfamiliar to me, and I'm relying on existing test cases to ensure I'm not breaking something.  I could very easily be doing something wrong here...

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
