### PR TITLE
Don't do newline conversion on write

### DIFF
--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -590,6 +590,7 @@ class LintedFile(NamedTuple):
         with tempfile.NamedTemporaryFile(
             mode="w",
             encoding=encoding,
+            newline='',  # NOTE: No newline conversion. Write as read.
             prefix=basename,
             dir=dirname,
             suffix=os.path.splitext(output_path)[1],


### PR DESCRIPTION
I ran into an issue while linting a large chunk of our project where some windows encoded files (using `\r\n`) would end up with doubled newlines. This was because the newlines were being converted on write. This ensures no conversion is done.

I'm not sure how to get a good test case around this - any suggestions welcome. Otherwise I'll suggest merging this without a test case.