### PR TITLE
Add a no-output option

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -616,6 +616,8 @@ def lint(
         file_output = json.dumps(result.as_records())
     elif format == FormatType.yaml.value:
         file_output = yaml.dump(result.as_records(), sort_keys=False)
+    elif format == FormatType.none.value:
+        file_output = ""
     elif format == FormatType.github_annotation.value:
         if annotation_level == "error":
             annotation_level = "failure"
@@ -1109,6 +1111,7 @@ def quoted_presenter(dumper, data):
             FormatType.human.value,
             FormatType.json.value,
             FormatType.yaml.value,
+            FormatType.none.value,
         ],
         case_sensitive=False,
     ),
@@ -1239,6 +1242,8 @@ def parse(
             file_output = yaml.dump(parsed_strings_dict, sort_keys=False)
         elif format == FormatType.json.value:
             file_output = json.dumps(parsed_strings_dict)
+        elif format == FormatType.none.value:
+            file_output = ""
 
         # Dump the output to stdout or to file as appropriate.
         dump_file_payload(write_output, file_output)

--- a/src/sqlfluff/core/enums.py
+++ b/src/sqlfluff/core/enums.py
@@ -12,6 +12,7 @@ class FormatType(Enum):
     yaml = "yaml"
     github_annotation = "github-annotation"
     github_annotation_native = "github-annotation-native"
+    none = "none"  # An option to return _no output_.
 
 
 class Color(Enum):

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -336,6 +336,8 @@ def test__cli__command_render_stdin():
         # Check basic parsing, with the yaml output
         (parse, ["-n", "test/fixtures/cli/passing_b.sql", "-c", "-f", "yaml"]),
         (parse, ["-n", "test/fixtures/cli/passing_b.sql", "--format", "yaml"]),
+        # Check parsing with no output (used mostly for testing)
+        (parse, ["-n", "test/fixtures/cli/passing_b.sql", "--format", "none"]),
         # Check the profiler and benching commands
         (parse, ["-n", "test/fixtures/cli/passing_b.sql", "--profiler"]),
         (parse, ["-n", "test/fixtures/cli/passing_b.sql", "--bench"]),
@@ -1213,7 +1215,7 @@ def test__cli__command_parse_serialize_from_stdin(serialize, write_file, tmp_pat
     assert result["filepath"] == "stdin"
 
 
-@pytest.mark.parametrize("serialize", ["yaml", "json"])
+@pytest.mark.parametrize("serialize", ["yaml", "json", "none"])
 @pytest.mark.parametrize(
     "sql,expected,exit_code",
     [
@@ -1268,6 +1270,8 @@ def test__cli__command_lint_serialize_from_stdin(serialize, sql, expected, exit_
         assert json.loads(result.output) == expected
     elif serialize == "yaml":
         assert yaml.safe_load(result.output) == expected
+    elif serialize == "none":
+        assert result.output == ""
     else:
         raise Exception
 
@@ -1320,7 +1324,7 @@ def test__cli__command_lint_nocolor(isatty, should_strip_ansi, capsys, tmpdir):
 
 @pytest.mark.parametrize(
     "serialize",
-    ["human", "yaml", "json", "github-annotation", "github-annotation-native"],
+    ["human", "yaml", "json", "github-annotation", "github-annotation-native", "none"],
 )
 @pytest.mark.parametrize("write_file", [None, "outfile"])
 def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_path):
@@ -1353,7 +1357,8 @@ def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_
         ret_code=1,
     )
 
-    if write_file:
+    # NOTE: The "none" serializer doesn't write a file even if specified.
+    if write_file and serialize != "none":
         with open(target_file, "r") as payload_file:
             result_payload = payload_file.read()
     else:
@@ -1368,6 +1373,8 @@ def test__cli__command_lint_serialize_multiple_files(serialize, write_file, tmp_
 
     if serialize == "human":
         assert payload_length == 23 if write_file else 32
+    elif serialize == "none":
+        assert payload_length == 1  # There will be a single newline.
     elif serialize == "json":
         result = json.loads(result_payload)
         assert len(result) == 2


### PR DESCRIPTION
While testing the parser it's sometimes useful to supress output (long output can take as long to write to stdout as the thing I'm testing!). This adds an additional `none` output which then outputs... nothing. 