### PR TITLE
Preserve zero-length template segments

### DIFF
--- a/src/sqlfluff/core/parser/lexer.py
+++ b/src/sqlfluff/core/parser/lexer.py
@@ -434,16 +434,15 @@ def _handle_zero_length_slice(
         # Move on
         return
 
-    # We've got a zero slice. This could be a block, unrendered templates
-    # or unrendered code (either because of loops of consumption).
-    if not is_zero_slice(tfs.source_slice):
-        yield TemplateSegment.from_slice(
-            tfs.source_slice,
-            tfs.templated_slice,
-            tfs.slice_type,
-            templated_file,
-        )
-    return
+    # Always return the slice, even if the source slice was also zero length.  Some
+    # templaters might want to pass through totally zero length slices as a way of
+    # marking locations in the middle of templated output.
+    yield TemplateSegment.from_slice(
+        tfs.source_slice,
+        tfs.templated_slice,
+        tfs.slice_type,
+        templated_file,
+    )
 
 
 def _iter_segments(


### PR DESCRIPTION
I am making a custom templater that will intentionally yield zero length slices with a special slice_type.  This is going to be used to signal to some rules information about special markers in the templated result. Unfortunately, SQLFluff strips these right out unless they are prefixed with "block".  Thus, I had to implement this fragile and hacky workaround from my templater when emitting slices:

```python
[
    TemplatedFileSlice("block_start", ...),
    TemplatedFileSlice("block_my_custom_slice_type", ...),
    TemplatedFileSlice("block_end", ...),
]
```

Prefixing the slice type with "block" was necessary to trick this line of code in lexer.py in _handle_zero_length_slice:

    if tfs.slice_type.startswith("block"):
        <snip>

The next problem was that the yield statement was failing:

    yield TemplateSegment.from_slice(...block_uuid=block_stack.top())

Since the block_stack was empty, this would crash.  Thus the final hack: first emit some fake block start/end slices to put something on the block stack, and then the custom "block" slice type in the middle.

This all seems very hacky and fragile, so I'd rather just pass through these segments as-is without going down the "block" branch of code.

This commit removes the "if" condition that excluded these segments. A new test function is also introduced that allows us to continue to add more test cases where we want to specify an exact TemplatedFile input to the lexer, rather than depending on a particular templater implementation in the test.

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?

Hopefully not?  All tests pass...

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
