### PR TITLE
CV06: don't flag files that don't have code

### DIFF
--- a/src/sqlfluff/rules/convention/CV06.py
+++ b/src/sqlfluff/rules/convention/CV06.py
@@ -322,6 +322,8 @@ class Rule_CV06(BaseRule):
             elif not segment.is_meta:
                 before_segment.append(segment)
             trigger_segment = segment
+        else:
+            return None  # File does not contain any statements
         self.logger.debug("Trigger on: %s", trigger_segment)
         self.logger.debug("Anchoring on: %s", anchor_segment)
 

--- a/test/fixtures/rules/std_rule_cases/CV06.yml
+++ b/test/fixtures/rules/std_rule_cases/CV06.yml
@@ -494,3 +494,25 @@ test_fail_templated_fix_crosses_block_boundary:
     rules:
       convention.terminator:
         require_final_semicolon: true
+
+test_pass_empty_file:
+  pass_str: ""
+
+test_pass_empty_file_with_require_final_semicolon:
+  pass_str: ""
+  configs:
+    rules:
+      convention.terminator:
+        require_final_semicolon: true
+
+test_pass_file_with_only_comments:
+  pass_str: |
+    -- just an empty file
+
+test_pass_file_with_only_comments_with_require_final_semicolon:
+  pass_str: |
+    -- just an empty file
+  configs:
+    rules:
+      convention.terminator:
+        require_final_semicolon: true


### PR DESCRIPTION
If a file contains only whitespace, comments, or other things like that, the require_final_semicolon aspect of the rule will flag it anyway.

We can exit this aspect of the rule early if there is no code found.

This fixes #4435.


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
