### PR TITLE
Add support for PG CREATE/ALTER/DROP PUBLICATION stmts

### DIFF
--- a/test/fixtures/dialects/postgres/postgres_alter_publication.sql
+++ b/test/fixtures/dialects/postgres/postgres_alter_publication.sql
@@ -1,0 +1,33 @@
+-- More thorough testing of the PublicationObjectsSegment is in postgres_create_publication.sql.
+
+ALTER PUBLICATION abc ADD TABLE def;
+
+ALTER PUBLICATION abc ADD TABLE def, TABLE ghi;
+
+ALTER PUBLICATION abc ADD TABLE def, ghi*, ONLY jkl, ONLY (mno);
+
+ALTER PUBLICATION abc SET TABLE def, ghi, TABLES IN SCHEMA y, z, CURRENT_SCHEMA;
+
+ALTER PUBLICATION abc SET (publish = 'insert,update', publish_via_partition_root = TRUE);
+
+ALTER PUBLICATION abc OWNER TO bob;
+
+ALTER PUBLICATION abc OWNER TO CURRENT_ROLE;
+
+ALTER PUBLICATION abc OWNER TO CURRENT_USER;
+
+ALTER PUBLICATION abc OWNER TO SESSION_USER;
+
+ALTER PUBLICATION abc RENAME TO def;
+
+-- examples from https://www.postgresql.org/docs/15/sql-alterpublication.html
+
+ALTER PUBLICATION noinsert SET (publish = 'update, delete');
+
+ALTER PUBLICATION mypublication ADD TABLE users (user_id, firstname), departments;
+
+ALTER PUBLICATION mypublication SET TABLE users (user_id, firstname, lastname), TABLE departments;
+
+ALTER PUBLICATION sales_publication ADD TABLES IN SCHEMA marketing, sales;
+
+ALTER PUBLICATION production_publication ADD TABLE users, departments, TABLES IN SCHEMA production;

--- a/test/fixtures/dialects/postgres/postgres_alter_publication.yml
+++ b/test/fixtures/dialects/postgres/postgres_alter_publication.yml
@@ -1,0 +1,287 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: d0869a907d27f2854738d222ae3e5632ae9deb9ff5d1ad52b04419a7f0bc8fb7
+file:
+- statement:
+    alter_publication_statement:
+    - keyword: ALTER
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: ADD
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: def
+- statement_terminator: ;
+- statement:
+    alter_publication_statement:
+    - keyword: ALTER
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: ADD
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: def
+    - comma: ','
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: ghi
+- statement_terminator: ;
+- statement:
+    alter_publication_statement:
+    - keyword: ALTER
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: ADD
+    - publication_objects:
+      - keyword: TABLE
+      - publication_table:
+          table_reference:
+            naked_identifier: def
+      - comma: ','
+      - publication_table:
+          table_reference:
+            naked_identifier: ghi
+          star: '*'
+      - comma: ','
+      - publication_table:
+          keyword: ONLY
+          table_reference:
+            naked_identifier: jkl
+      - comma: ','
+      - publication_table:
+          keyword: ONLY
+          bracketed:
+            start_bracket: (
+            table_reference:
+              naked_identifier: mno
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_publication_statement:
+    - keyword: ALTER
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: SET
+    - publication_objects:
+      - keyword: TABLE
+      - publication_table:
+          table_reference:
+            naked_identifier: def
+      - comma: ','
+      - publication_table:
+          table_reference:
+            naked_identifier: ghi
+    - comma: ','
+    - publication_objects:
+      - keyword: TABLES
+      - keyword: IN
+      - keyword: SCHEMA
+      - schema_reference:
+          naked_identifier: y
+      - comma: ','
+      - schema_reference:
+          naked_identifier: z
+      - comma: ','
+      - keyword: CURRENT_SCHEMA
+- statement_terminator: ;
+- statement:
+    alter_publication_statement:
+    - keyword: ALTER
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: SET
+    - definition_parameters:
+        bracketed:
+        - start_bracket: (
+        - definition_parameter:
+            parameter: publish
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'insert,update'"
+        - comma: ','
+        - definition_parameter:
+            parameter: publish_via_partition_root
+            comparison_operator:
+              raw_comparison_operator: '='
+            boolean_literal: 'TRUE'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_publication_statement:
+    - keyword: ALTER
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: OWNER
+    - keyword: TO
+    - role_reference:
+        naked_identifier: bob
+- statement_terminator: ;
+- statement:
+    alter_publication_statement:
+    - keyword: ALTER
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: OWNER
+    - keyword: TO
+    - keyword: CURRENT_ROLE
+- statement_terminator: ;
+- statement:
+    alter_publication_statement:
+    - keyword: ALTER
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: OWNER
+    - keyword: TO
+    - keyword: CURRENT_USER
+- statement_terminator: ;
+- statement:
+    alter_publication_statement:
+    - keyword: ALTER
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: OWNER
+    - keyword: TO
+    - keyword: SESSION_USER
+- statement_terminator: ;
+- statement:
+    alter_publication_statement:
+    - keyword: ALTER
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: RENAME
+    - keyword: TO
+    - publication_reference:
+        naked_identifier: def
+- statement_terminator: ;
+- statement:
+    alter_publication_statement:
+    - keyword: ALTER
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: noinsert
+    - keyword: SET
+    - definition_parameters:
+        bracketed:
+          start_bracket: (
+          definition_parameter:
+            parameter: publish
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'update, delete'"
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_publication_statement:
+    - keyword: ALTER
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: mypublication
+    - keyword: ADD
+    - publication_objects:
+      - keyword: TABLE
+      - publication_table:
+          table_reference:
+            naked_identifier: users
+          bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: user_id
+          - comma: ','
+          - column_reference:
+              naked_identifier: firstname
+          - end_bracket: )
+      - comma: ','
+      - publication_table:
+          table_reference:
+            naked_identifier: departments
+- statement_terminator: ;
+- statement:
+    alter_publication_statement:
+    - keyword: ALTER
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: mypublication
+    - keyword: SET
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: users
+          bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: user_id
+          - comma: ','
+          - column_reference:
+              naked_identifier: firstname
+          - comma: ','
+          - column_reference:
+              naked_identifier: lastname
+          - end_bracket: )
+    - comma: ','
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: departments
+- statement_terminator: ;
+- statement:
+    alter_publication_statement:
+    - keyword: ALTER
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: sales_publication
+    - keyword: ADD
+    - publication_objects:
+      - keyword: TABLES
+      - keyword: IN
+      - keyword: SCHEMA
+      - schema_reference:
+          naked_identifier: marketing
+      - comma: ','
+      - schema_reference:
+          naked_identifier: sales
+- statement_terminator: ;
+- statement:
+    alter_publication_statement:
+    - keyword: ALTER
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: production_publication
+    - keyword: ADD
+    - publication_objects:
+      - keyword: TABLE
+      - publication_table:
+          table_reference:
+            naked_identifier: users
+      - comma: ','
+      - publication_table:
+          table_reference:
+            naked_identifier: departments
+    - comma: ','
+    - publication_objects:
+      - keyword: TABLES
+      - keyword: IN
+      - keyword: SCHEMA
+      - schema_reference:
+          naked_identifier: production
+- statement_terminator: ;

--- a/test/fixtures/dialects/postgres/postgres_create_publication.sql
+++ b/test/fixtures/dialects/postgres/postgres_create_publication.sql
@@ -1,0 +1,56 @@
+CREATE PUBLICATION abc;
+
+CREATE PUBLICATION abc FOR ALL TABLES;
+
+CREATE PUBLICATION abc FOR TABLE def;
+
+CREATE PUBLICATION abc FOR TABLE def, sch.ghi;
+
+CREATE PUBLICATION abc FOR TABLE def, TABLE sch.ghi;
+
+CREATE PUBLICATION abc FOR TABLE def*;
+
+CREATE PUBLICATION abc FOR
+    TABLE a,
+    TABLE aa, ab, ac,
+    TABLE ONLY b,
+    TABLE c*,
+    TABLE ca*, cb*,
+    TABLE ONLY (d),
+    TABLE e (col1),
+    TABLE f (col2, col3),
+    TABLE g* (col4, col5),
+    TABLE h WHERE (col6 > col7),
+    TABLE i (col8, col9) WHERE (col10 > col11),
+    TABLES IN SCHEMA j,
+    TABLES IN SCHEMA k,
+    TABLES IN SCHEMA CURRENT_SCHEMA, l, m,
+    TABLES IN SCHEMA n, o, p;
+
+CREATE PUBLICATION abc FOR TABLE a, b
+    WITH (publish = 'insert,update', publish_via_partition_root = TRUE);
+
+CREATE PUBLICATION abc FOR TABLE a, b
+    WITH (publish_via_partition_root = TRUE);
+
+CREATE PUBLICATION abc FOR TABLE a, b
+    WITH (publish = 'insert,update');
+
+CREATE PUBLICATION abc WITH (publish = 'insert,update');
+
+-- examples from https://www.postgresql.org/docs/15/sql-createpublication.html
+
+CREATE PUBLICATION mypublication FOR TABLE users, departments;
+
+CREATE PUBLICATION active_departments FOR TABLE departments WHERE (active IS TRUE);
+
+CREATE PUBLICATION alltables FOR ALL TABLES;
+
+CREATE PUBLICATION insert_only FOR TABLE mydata
+    WITH (publish = 'insert');
+
+CREATE PUBLICATION production_publication FOR TABLE users, departments, TABLES IN SCHEMA production;
+
+CREATE PUBLICATION sales_publication FOR TABLES IN SCHEMA marketing, sales;
+
+CREATE PUBLICATION users_filtered FOR TABLE users (user_id, firstname);

--- a/test/fixtures/dialects/postgres/postgres_create_publication.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_publication.yml
@@ -1,0 +1,513 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: a7de98561d58869c1d81ef7d786e9638e59c5c65507f96ed495eba88dae55f85
+file:
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: FOR
+    - keyword: ALL
+    - keyword: TABLES
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: FOR
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: def
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: FOR
+    - publication_objects:
+      - keyword: TABLE
+      - publication_table:
+          table_reference:
+            naked_identifier: def
+      - comma: ','
+      - publication_table:
+          table_reference:
+          - naked_identifier: sch
+          - dot: .
+          - naked_identifier: ghi
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: FOR
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: def
+    - comma: ','
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+          - naked_identifier: sch
+          - dot: .
+          - naked_identifier: ghi
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: FOR
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: def
+          star: '*'
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: FOR
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: a
+    - comma: ','
+    - publication_objects:
+      - keyword: TABLE
+      - publication_table:
+          table_reference:
+            naked_identifier: aa
+      - comma: ','
+      - publication_table:
+          table_reference:
+            naked_identifier: ab
+      - comma: ','
+      - publication_table:
+          table_reference:
+            naked_identifier: ac
+    - comma: ','
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          keyword: ONLY
+          table_reference:
+            naked_identifier: b
+    - comma: ','
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: c
+          star: '*'
+    - comma: ','
+    - publication_objects:
+      - keyword: TABLE
+      - publication_table:
+          table_reference:
+            naked_identifier: ca
+          star: '*'
+      - comma: ','
+      - publication_table:
+          table_reference:
+            naked_identifier: cb
+          star: '*'
+    - comma: ','
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          keyword: ONLY
+          bracketed:
+            start_bracket: (
+            table_reference:
+              naked_identifier: d
+            end_bracket: )
+    - comma: ','
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: e
+          bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: col1
+            end_bracket: )
+    - comma: ','
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: f
+          bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: col2
+          - comma: ','
+          - column_reference:
+              naked_identifier: col3
+          - end_bracket: )
+    - comma: ','
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: g
+          star: '*'
+          bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: col4
+          - comma: ','
+          - column_reference:
+              naked_identifier: col5
+          - end_bracket: )
+    - comma: ','
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: h
+          keyword: WHERE
+          bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: col6
+            - comparison_operator:
+                raw_comparison_operator: '>'
+            - column_reference:
+                naked_identifier: col7
+            end_bracket: )
+    - comma: ','
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+        - table_reference:
+            naked_identifier: i
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: col8
+          - comma: ','
+          - column_reference:
+              naked_identifier: col9
+          - end_bracket: )
+        - keyword: WHERE
+        - bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: col10
+            - comparison_operator:
+                raw_comparison_operator: '>'
+            - column_reference:
+                naked_identifier: col11
+            end_bracket: )
+    - comma: ','
+    - publication_objects:
+      - keyword: TABLES
+      - keyword: IN
+      - keyword: SCHEMA
+      - schema_reference:
+          naked_identifier: j
+    - comma: ','
+    - publication_objects:
+      - keyword: TABLES
+      - keyword: IN
+      - keyword: SCHEMA
+      - schema_reference:
+          naked_identifier: k
+    - comma: ','
+    - publication_objects:
+      - keyword: TABLES
+      - keyword: IN
+      - keyword: SCHEMA
+      - keyword: CURRENT_SCHEMA
+      - comma: ','
+      - schema_reference:
+          naked_identifier: l
+      - comma: ','
+      - schema_reference:
+          naked_identifier: m
+    - comma: ','
+    - publication_objects:
+      - keyword: TABLES
+      - keyword: IN
+      - keyword: SCHEMA
+      - schema_reference:
+          naked_identifier: n
+      - comma: ','
+      - schema_reference:
+          naked_identifier: o
+      - comma: ','
+      - schema_reference:
+          naked_identifier: p
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: FOR
+    - publication_objects:
+      - keyword: TABLE
+      - publication_table:
+          table_reference:
+            naked_identifier: a
+      - comma: ','
+      - publication_table:
+          table_reference:
+            naked_identifier: b
+    - keyword: WITH
+    - definition_parameters:
+        bracketed:
+        - start_bracket: (
+        - definition_parameter:
+            parameter: publish
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'insert,update'"
+        - comma: ','
+        - definition_parameter:
+            parameter: publish_via_partition_root
+            comparison_operator:
+              raw_comparison_operator: '='
+            boolean_literal: 'TRUE'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: FOR
+    - publication_objects:
+      - keyword: TABLE
+      - publication_table:
+          table_reference:
+            naked_identifier: a
+      - comma: ','
+      - publication_table:
+          table_reference:
+            naked_identifier: b
+    - keyword: WITH
+    - definition_parameters:
+        bracketed:
+          start_bracket: (
+          definition_parameter:
+            parameter: publish_via_partition_root
+            comparison_operator:
+              raw_comparison_operator: '='
+            boolean_literal: 'TRUE'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: FOR
+    - publication_objects:
+      - keyword: TABLE
+      - publication_table:
+          table_reference:
+            naked_identifier: a
+      - comma: ','
+      - publication_table:
+          table_reference:
+            naked_identifier: b
+    - keyword: WITH
+    - definition_parameters:
+        bracketed:
+          start_bracket: (
+          definition_parameter:
+            parameter: publish
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'insert,update'"
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: WITH
+    - definition_parameters:
+        bracketed:
+          start_bracket: (
+          definition_parameter:
+            parameter: publish
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'insert,update'"
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: mypublication
+    - keyword: FOR
+    - publication_objects:
+      - keyword: TABLE
+      - publication_table:
+          table_reference:
+            naked_identifier: users
+      - comma: ','
+      - publication_table:
+          table_reference:
+            naked_identifier: departments
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: active_departments
+    - keyword: FOR
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: departments
+          keyword: WHERE
+          bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: active
+              keyword: IS
+              boolean_literal: 'TRUE'
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: alltables
+    - keyword: FOR
+    - keyword: ALL
+    - keyword: TABLES
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: insert_only
+    - keyword: FOR
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: mydata
+    - keyword: WITH
+    - definition_parameters:
+        bracketed:
+          start_bracket: (
+          definition_parameter:
+            parameter: publish
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'insert'"
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: production_publication
+    - keyword: FOR
+    - publication_objects:
+      - keyword: TABLE
+      - publication_table:
+          table_reference:
+            naked_identifier: users
+      - comma: ','
+      - publication_table:
+          table_reference:
+            naked_identifier: departments
+    - comma: ','
+    - publication_objects:
+      - keyword: TABLES
+      - keyword: IN
+      - keyword: SCHEMA
+      - schema_reference:
+          naked_identifier: production
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: sales_publication
+    - keyword: FOR
+    - publication_objects:
+      - keyword: TABLES
+      - keyword: IN
+      - keyword: SCHEMA
+      - schema_reference:
+          naked_identifier: marketing
+      - comma: ','
+      - schema_reference:
+          naked_identifier: sales
+- statement_terminator: ;
+- statement:
+    create_publication_statement:
+    - keyword: CREATE
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: users_filtered
+    - keyword: FOR
+    - publication_objects:
+        keyword: TABLE
+        publication_table:
+          table_reference:
+            naked_identifier: users
+          bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: user_id
+          - comma: ','
+          - column_reference:
+              naked_identifier: firstname
+          - end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/postgres/postgres_drop_publication.sql
+++ b/test/fixtures/dialects/postgres/postgres_drop_publication.sql
@@ -1,0 +1,35 @@
+-- Test no trailing keyword with combinations of:
+--  * IF EXISTS
+--  * One publication vs multiple publications.
+
+DROP PUBLICATION abc;
+
+DROP PUBLICATION "abc";
+
+DROP PUBLICATION IF EXISTS abc;
+
+DROP PUBLICATION abc, "def", ghi;
+
+DROP PUBLICATION IF EXISTS abc, def, ghi;
+
+-- Test CASCADE trailing keyword
+
+DROP PUBLICATION abc CASCADE;
+
+DROP PUBLICATION IF EXISTS abc CASCADE;
+
+DROP PUBLICATION abc, def, ghi CASCADE;
+
+DROP PUBLICATION IF EXISTS abc, def, ghi CASCADE;
+
+
+-- Test RESTRICT trailing keyword
+
+DROP PUBLICATION abc RESTRICT;
+
+DROP PUBLICATION IF EXISTS abc RESTRICT;
+
+DROP PUBLICATION abc, def, ghi RESTRICT;
+
+DROP PUBLICATION IF EXISTS abc, def, ghi RESTRICT;
+

--- a/test/fixtures/dialects/postgres/postgres_drop_publication.yml
+++ b/test/fixtures/dialects/postgres/postgres_drop_publication.yml
@@ -1,0 +1,154 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 41225e922471bc8b5fb87ee6f2ac4199f7c7a5f29a52dd5dee1d99fdd1e16485
+file:
+- statement:
+    drop_publication_statement:
+    - keyword: DROP
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    drop_publication_statement:
+    - keyword: DROP
+    - keyword: PUBLICATION
+    - publication_reference:
+        quoted_identifier: '"abc"'
+- statement_terminator: ;
+- statement:
+    drop_publication_statement:
+    - keyword: DROP
+    - keyword: PUBLICATION
+    - keyword: IF
+    - keyword: EXISTS
+    - publication_reference:
+        naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    drop_publication_statement:
+    - keyword: DROP
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - comma: ','
+    - publication_reference:
+        quoted_identifier: '"def"'
+    - comma: ','
+    - publication_reference:
+        naked_identifier: ghi
+- statement_terminator: ;
+- statement:
+    drop_publication_statement:
+    - keyword: DROP
+    - keyword: PUBLICATION
+    - keyword: IF
+    - keyword: EXISTS
+    - publication_reference:
+        naked_identifier: abc
+    - comma: ','
+    - publication_reference:
+        naked_identifier: def
+    - comma: ','
+    - publication_reference:
+        naked_identifier: ghi
+- statement_terminator: ;
+- statement:
+    drop_publication_statement:
+    - keyword: DROP
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: CASCADE
+- statement_terminator: ;
+- statement:
+    drop_publication_statement:
+    - keyword: DROP
+    - keyword: PUBLICATION
+    - keyword: IF
+    - keyword: EXISTS
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: CASCADE
+- statement_terminator: ;
+- statement:
+    drop_publication_statement:
+    - keyword: DROP
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - comma: ','
+    - publication_reference:
+        naked_identifier: def
+    - comma: ','
+    - publication_reference:
+        naked_identifier: ghi
+    - keyword: CASCADE
+- statement_terminator: ;
+- statement:
+    drop_publication_statement:
+    - keyword: DROP
+    - keyword: PUBLICATION
+    - keyword: IF
+    - keyword: EXISTS
+    - publication_reference:
+        naked_identifier: abc
+    - comma: ','
+    - publication_reference:
+        naked_identifier: def
+    - comma: ','
+    - publication_reference:
+        naked_identifier: ghi
+    - keyword: CASCADE
+- statement_terminator: ;
+- statement:
+    drop_publication_statement:
+    - keyword: DROP
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: RESTRICT
+- statement_terminator: ;
+- statement:
+    drop_publication_statement:
+    - keyword: DROP
+    - keyword: PUBLICATION
+    - keyword: IF
+    - keyword: EXISTS
+    - publication_reference:
+        naked_identifier: abc
+    - keyword: RESTRICT
+- statement_terminator: ;
+- statement:
+    drop_publication_statement:
+    - keyword: DROP
+    - keyword: PUBLICATION
+    - publication_reference:
+        naked_identifier: abc
+    - comma: ','
+    - publication_reference:
+        naked_identifier: def
+    - comma: ','
+    - publication_reference:
+        naked_identifier: ghi
+    - keyword: RESTRICT
+- statement_terminator: ;
+- statement:
+    drop_publication_statement:
+    - keyword: DROP
+    - keyword: PUBLICATION
+    - keyword: IF
+    - keyword: EXISTS
+    - publication_reference:
+        naked_identifier: abc
+    - comma: ','
+    - publication_reference:
+        naked_identifier: def
+    - comma: ','
+    - publication_reference:
+        naked_identifier: ghi
+    - keyword: RESTRICT
+- statement_terminator: ;


### PR DESCRIPTION
This commit adds support for the CREATE/ALTER/DROP PUBLICATION statements in PostgreSQL 15.  It someone closely-ish follows the upstream PG grammar in gram.y.  Notable deviations include:

1.  The upstream grammar has the concept of continuation objects in the CREATE statement, where "b" is a continuation statement in "TABLE a, b, TABLE c".  It's assumed that "b" is a table by looking at the previous object, "TABLE a".

    I think it will be easier to use this tree if we instead group the related objects under a parent PublicationObjectsSegment node.

2.  The ATLER PUBLICATION ... OWNER TO statement is a bit messy in that I reproduced the CURRENT_ROLE, CURRENT_USER, SESSION_USER as is seen elsewhere in this file.  However, the upstream grammar defines a RoleSpec which is used in many different places.

    An area of future improvement could be to refactor this grammar and use a shared role spec everywhere similar to what the upstream grammar does.  In fact, I think these keywords are in the ANSI standard, so it really should be an improvement made to the ANSI dialect...


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
