### PR TITLE
SparkSQL: Fix file literal lexing

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -156,7 +156,8 @@ sparksql_dialect.insert_lexer_matchers(
             "file_literal",
             (
                 r"[a-zA-z0-9]*:?([a-zA-Z0-9\-_\.]*(\/|\\))+"
-                r"([a-zA-Z0-9\-_\.]*(:|\?|=|&))*[a-zA-Z0-9\-_\.]*\.?[a-z]*"
+                r"((([a-zA-Z0-9\-_\.]*(:|\?|=|&)[a-zA-Z0-9\-_\.]*)+)"
+                r"|([a-zA-Z0-9\-_\.]*\.[a-z]*))"
             ),
             CodeSegment,
             segment_kwargs={"type": "file_literal"},

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -155,7 +155,7 @@ sparksql_dialect.insert_lexer_matchers(
         RegexLexer(
             "file_literal",
             (
-                r"[a-zA-z0-9]*:?([a-zA-Z0-9\-_\.]*(\/|\\))+"
+                r"[a-zA-Z0-9]*:?([a-zA-Z0-9\-_\.]*(\/|\\)){2,}"
                 r"((([a-zA-Z0-9\-_\.]*(:|\?|=|&)[a-zA-Z0-9\-_\.]*)+)"
                 r"|([a-zA-Z0-9\-_\.]*\.[a-z]+))"
             ),

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -157,7 +157,7 @@ sparksql_dialect.insert_lexer_matchers(
             (
                 r"[a-zA-z0-9]*:?([a-zA-Z0-9\-_\.]*(\/|\\))+"
                 r"((([a-zA-Z0-9\-_\.]*(:|\?|=|&)[a-zA-Z0-9\-_\.]*)+)"
-                r"|([a-zA-Z0-9\-_\.]*\.[a-z]*))"
+                r"|([a-zA-Z0-9\-_\.]*\.[a-z]+))"
             ),
             CodeSegment,
             segment_kwargs={"type": "file_literal"},

--- a/test/fixtures/dialects/sparksql/add_jar.sql
+++ b/test/fixtures/dialects/sparksql/add_jar.sql
@@ -20,5 +20,7 @@ ADD JAR /path/to/some.jar;
 
 ADD JAR path/to/some.jar;
 
+ADD JAR ivy://path/to/some.jar;
+
 -- NB: Non-quoted paths do not currently support whitespaces
 -- e.g. /path to/some.jar

--- a/test/fixtures/dialects/sparksql/add_jar.yml
+++ b/test/fixtures/dialects/sparksql/add_jar.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ec5b3da97e77d139b6ece515f533bdc85539c29d328a2139b90521b290270a46
+_hash: b7ba37b07b7588c894e6ad680fafcb954a373185f6623e703546834c8ad6990c
 file:
 - statement:
     add_jar_statement:
@@ -71,4 +71,10 @@ file:
       keyword: ADD
       file_keyword: JAR
       file_literal: path/to/some.jar
+- statement_terminator: ;
+- statement:
+    add_jar_statement:
+      keyword: ADD
+      file_keyword: JAR
+      file_literal: ivy://path/to/some.jar
 - statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/select_order_by.sql
+++ b/test/fixtures/dialects/sparksql/select_order_by.sql
@@ -28,3 +28,9 @@ SELECT
     name,
     age
 FROM person ORDER BY name ASC, age DESC;
+
+-- Sort rows using complex expression.
+SELECT
+    name,
+    age
+FROM person ORDER BY SUM(age)/SUM(age) DESC;

--- a/test/fixtures/dialects/sparksql/select_order_by.yml
+++ b/test/fixtures/dialects/sparksql/select_order_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b11da34ea5ce77f3558ddbbcbb649e3306d390d2aed7d81d5b05365afae9f44a
+_hash: afe247b8f1ce7f10f95249deb215a501e36fbb4ffc6ff751bb1d93eed2b84c2d
 file:
 - statement:
     select_statement:
@@ -134,5 +134,48 @@ file:
       - comma: ','
       - column_reference:
           naked_identifier: age
+      - keyword: DESC
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: age
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - expression:
+        - function:
+            function_name:
+              function_name_identifier: SUM
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: age
+              end_bracket: )
+        - binary_operator: /
+        - function:
+            function_name:
+              function_name_identifier: SUM
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: age
+              end_bracket: )
       - keyword: DESC
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
This change fixes a bug with the `file_literal` regex. Previously literals such as `/word` would be considered a file. This is an issue because literals such as `/sum` were being lexed as a file literal rather than part of an expression. 

Now the `file_literal` regex requires that the file end with either a file extension or url parameters. 

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
