### PR TITLE
SparkSQL: Improve window frame bounds

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -3158,3 +3158,31 @@ class SelectClauseSegment(BaseSegment):
     )
 
     parse_grammar: Matchable = Ref("SelectClauseSegmentGrammar")
+
+
+class FrameClauseSegment(ansi.FrameClauseSegment):
+    """A frame clause for window functions.
+
+    This overrides the ansi dialect frame clause segment as the sparksql
+    frame clause allows for a more expressive frame syntax.
+    https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-window.html
+    """
+
+    type = "frame_clause"
+    #interval 6 days preceding
+    _frame_extent = OneOf(
+        Sequence("CURRENT", "ROW"),
+        Sequence(
+            OneOf(
+                Ref("NumericLiteralSegment"), 
+                "UNBOUNDED",
+                Ref("IntervalExpressionSegment"),
+                ),
+            OneOf("PRECEDING", "FOLLOWING"),
+        ),
+    )
+
+    match_grammar: Matchable = Sequence(
+        Ref("FrameClauseUnitGrammar"),
+        OneOf(_frame_extent, Sequence("BETWEEN", _frame_extent, "AND", _frame_extent)),
+    )

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -3169,15 +3169,15 @@ class FrameClauseSegment(ansi.FrameClauseSegment):
     """
 
     type = "frame_clause"
-    #interval 6 days preceding
+    # interval 6 days preceding
     _frame_extent = OneOf(
         Sequence("CURRENT", "ROW"),
         Sequence(
             OneOf(
-                Ref("NumericLiteralSegment"), 
+                Ref("NumericLiteralSegment"),
                 "UNBOUNDED",
                 Ref("IntervalExpressionSegment"),
-                ),
+            ),
             OneOf("PRECEDING", "FOLLOWING"),
         ),
     )

--- a/test/fixtures/dialects/sparksql/window_functions.sql
+++ b/test/fixtures/dialects/sparksql/window_functions.sql
@@ -112,3 +112,15 @@ SELECT
 FROM test_ignore_null AS ignore_nulls
     WINDOW w AS (ORDER BY ignore_nulls.id)
 ORDER BY ignore_nulls.id;
+
+SELECT
+    ignore_nulls.id,
+    ignore_nulls.v,
+    LEAD(ignore_nulls.v, 0) RESPECT NULLS OVER w AS v_lead,
+    LAG(ignore_nulls.v, 0) RESPECT NULLS OVER w AS v_lag,
+    NTH_VALUE(ignore_nulls.v, 2) RESPECT NULLS OVER w AS v_nth_value,
+    FIRST_VALUE(ignore_nulls.v) RESPECT NULLS OVER w AS v_first_value,
+    LAST_VALUE(ignore_nulls.v) RESPECT NULLS OVER w AS v_last_value
+FROM test_ignore_null AS ignore_nulls
+    WINDOW w AS (ORDER BY ignore_nulls.id)
+ORDER BY ignore_nulls.id;

--- a/test/fixtures/dialects/sparksql/window_functions.sql
+++ b/test/fixtures/dialects/sparksql/window_functions.sql
@@ -122,5 +122,5 @@ SELECT
     FIRST_VALUE(ignore_nulls.v) RESPECT NULLS OVER w AS v_first_value,
     LAST_VALUE(ignore_nulls.v) RESPECT NULLS OVER w AS v_last_value
 FROM test_ignore_null AS ignore_nulls
-    WINDOW w AS (ORDER BY ignore_nulls.id)
+    WINDOW w AS (ORDER BY ignore_nulls.id range between interval 6 days preceding and current row)
 ORDER BY ignore_nulls.id;

--- a/test/fixtures/dialects/sparksql/window_functions.yml
+++ b/test/fixtures/dialects/sparksql/window_functions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: edeee342ef226afa51902c974ae0074be18aba4aa6cf0819d12496f74da1c8ec
+_hash: 00bbbff73f8f9a420c42c4cdd5d98e0f36c435b97662e439e295403c96aae249
 file:
 - statement:
     select_statement:
@@ -1090,6 +1090,18 @@ file:
                       - naked_identifier: ignore_nulls
                       - dot: .
                       - naked_identifier: id
+                    frame_clause:
+                    - keyword: range
+                    - keyword: between
+                    - interval_expression:
+                        keyword: interval
+                        interval_literal:
+                          numeric_literal: '6'
+                          date_part: days
+                    - keyword: preceding
+                    - keyword: and
+                    - keyword: current
+                    - keyword: row
                   end_bracket: )
       orderby_clause:
       - keyword: ORDER

--- a/test/fixtures/dialects/sparksql/window_functions.yml
+++ b/test/fixtures/dialects/sparksql/window_functions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ee5f830c8e113fe87f49dcb120b0fe14735f8fe695a632db77f4cde8a6d003bf
+_hash: edeee342ef226afa51902c974ae0074be18aba4aa6cf0819d12496f74da1c8ec
 file:
 - statement:
     select_statement:
@@ -772,6 +772,169 @@ file:
       - keyword: BY
       - column_reference:
           naked_identifier: id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: ignore_nulls
+          - dot: .
+          - naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: ignore_nulls
+          - dot: .
+          - naked_identifier: v
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LEAD
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                - naked_identifier: ignore_nulls
+                - dot: .
+                - naked_identifier: v
+            - comma: ','
+            - expression:
+                numeric_literal: '0'
+            - end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - naked_identifier: w
+          alias_expression:
+            keyword: AS
+            naked_identifier: v_lead
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LAG
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                - naked_identifier: ignore_nulls
+                - dot: .
+                - naked_identifier: v
+            - comma: ','
+            - expression:
+                numeric_literal: '0'
+            - end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - naked_identifier: w
+          alias_expression:
+            keyword: AS
+            naked_identifier: v_lag
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: NTH_VALUE
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                - naked_identifier: ignore_nulls
+                - dot: .
+                - naked_identifier: v
+            - comma: ','
+            - expression:
+                numeric_literal: '2'
+            - end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - naked_identifier: w
+          alias_expression:
+            keyword: AS
+            naked_identifier: v_nth_value
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: FIRST_VALUE
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                - naked_identifier: ignore_nulls
+                - dot: .
+                - naked_identifier: v
+              end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - naked_identifier: w
+          alias_expression:
+            keyword: AS
+            naked_identifier: v_first_value
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LAST_VALUE
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                - naked_identifier: ignore_nulls
+                - dot: .
+                - naked_identifier: v
+              end_bracket: )
+            over_clause:
+            - keyword: RESPECT
+            - keyword: NULLS
+            - keyword: OVER
+            - naked_identifier: w
+          alias_expression:
+            keyword: AS
+            naked_identifier: v_last_value
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_ignore_null
+            alias_expression:
+              keyword: AS
+              naked_identifier: ignore_nulls
+            named_window:
+              keyword: WINDOW
+              named_window_expression:
+                naked_identifier: w
+                keyword: AS
+                bracketed:
+                  start_bracket: (
+                  window_specification:
+                    orderby_clause:
+                    - keyword: ORDER
+                    - keyword: BY
+                    - column_reference:
+                      - naked_identifier: ignore_nulls
+                      - dot: .
+                      - naked_identifier: id
+                  end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: ignore_nulls
+        - dot: .
+        - naked_identifier: id
 - statement_terminator: ;
 - statement:
     select_statement:


### PR DESCRIPTION
### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This change adds support for interval expressions within the window frame bounds in spark sql. While it isn't clear that this is supported on the official documentation. The ANTLR grammar file on the OSS displays this https://github.com/apache/spark/blob/007a42b8511b005aabdf45955e504d1f71eb1d25/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4#L1120

A test was added to `test/fixtures/dialects/sparksql/window_functions.sql`
### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
