### PR TITLE
Keep out zero length keywords

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -101,6 +101,14 @@ class Dialect:
             self._sets[label] = set()
         return self._sets[label]
 
+    def update_keywords_set_from_multiline_string(
+        self, set_label: str, values: str
+    ) -> None:
+        """Special function to update a keywords set from a multi-line string."""
+        self.sets(set_label).update(
+            [n.strip().upper() for n in values.strip().split("\n")]
+        )
+
     def copy_as(self, name):
         """Copy this dialect and create a new one with a different name.
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -262,12 +262,11 @@ ansi_dialect.sets("datetime_units").update(
 ansi_dialect.sets("date_part_function_name").update(["DATEADD"])
 
 # Set Keywords
-ansi_dialect.sets("unreserved_keywords").update(
-    [n.strip().upper() for n in ansi_unreserved_keywords.split("\n")]
+ansi_dialect.update_keywords_set_from_multiline_string(
+    "unreserved_keywords", ansi_unreserved_keywords
 )
-
-ansi_dialect.sets("reserved_keywords").update(
-    [n.strip().upper() for n in ansi_reserved_keywords.split("\n")]
+ansi_dialect.update_keywords_set_from_multiline_string(
+    "reserved_keywords", ansi_reserved_keywords
 )
 
 # Bracket pairs (a set of tuples).

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -248,13 +248,13 @@ bigquery_dialect.replace(
 
 # Set Keywords
 bigquery_dialect.sets("unreserved_keywords").clear()
-bigquery_dialect.sets("unreserved_keywords").update(
-    [n.strip().upper() for n in bigquery_unreserved_keywords.split("\n")]
+bigquery_dialect.update_keywords_set_from_multiline_string(
+    "unreserved_keywords", bigquery_unreserved_keywords
 )
 
 bigquery_dialect.sets("reserved_keywords").clear()
-bigquery_dialect.sets("reserved_keywords").update(
-    [n.strip().upper() for n in bigquery_reserved_keywords.split("\n")]
+bigquery_dialect.update_keywords_set_from_multiline_string(
+    "reserved_keywords", bigquery_reserved_keywords
 )
 
 # Add additional datetime units

--- a/src/sqlfluff/dialects/dialect_materialize.py
+++ b/src/sqlfluff/dialects/dialect_materialize.py
@@ -24,13 +24,13 @@ from sqlfluff.dialects.dialect_materialize_keywords import (
 postgres_dialect = load_raw_dialect("postgres")
 
 materialize_dialect = postgres_dialect.copy_as("materialize")
-materialize_dialect.sets("unreserved_keywords").update(
-    [n.strip().upper() for n in materialize_unreserved_keywords.split("\n")]
+materialize_dialect.update_keywords_set_from_multiline_string(
+    "unreserved_keywords", materialize_unreserved_keywords
 )
 
 materialize_dialect.sets("reserved_keywords").clear()
-materialize_dialect.sets("reserved_keywords").update(
-    [n.strip().upper() for n in materialize_reserved_keywords.split("\n")]
+materialize_dialect.update_keywords_set_from_multiline_string(
+    "reserved_keywords", materialize_reserved_keywords
 )
 
 

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -94,13 +94,13 @@ mysql_dialect.insert_lexer_matchers(
 # Set Keywords
 # Do not clear inherited unreserved ansi keywords. Too many are needed to parse well.
 # Just add MySQL unreserved keywords.
-mysql_dialect.sets("unreserved_keywords").update(
-    [n.strip().upper() for n in mysql_unreserved_keywords.split("\n")]
+mysql_dialect.update_keywords_set_from_multiline_string(
+    "unreserved_keywords", mysql_unreserved_keywords
 )
 
 mysql_dialect.sets("reserved_keywords").clear()
-mysql_dialect.sets("reserved_keywords").update(
-    [n.strip().upper() for n in mysql_reserved_keywords.split("\n")]
+mysql_dialect.update_keywords_set_from_multiline_string(
+    "reserved_keywords", mysql_reserved_keywords
 )
 
 # Remove these reserved keywords to avoid issue in interval.sql

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -35,13 +35,13 @@ redshift_dialect = postgres_dialect.copy_as("redshift")
 
 # Set Keywords
 redshift_dialect.sets("unreserved_keywords").clear()
-redshift_dialect.sets("unreserved_keywords").update(
-    [n.strip().upper() for n in redshift_unreserved_keywords.split("\n")]
+redshift_dialect.update_keywords_set_from_multiline_string(
+    "unreserved_keywords", redshift_unreserved_keywords
 )
 
 redshift_dialect.sets("reserved_keywords").clear()
-redshift_dialect.sets("reserved_keywords").update(
-    [n.strip().upper() for n in redshift_reserved_keywords.split("\n")]
+redshift_dialect.update_keywords_set_from_multiline_string(
+    "reserved_keywords", redshift_reserved_keywords
 )
 
 redshift_dialect.sets("bare_functions").clear()

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -649,13 +649,13 @@ snowflake_dialect.replace(
 
 # Add all Snowflake keywords
 snowflake_dialect.sets("unreserved_keywords").clear()
-snowflake_dialect.sets("unreserved_keywords").update(
-    [n.strip().upper() for n in snowflake_unreserved_keywords.split("\n")]
+snowflake_dialect.update_keywords_set_from_multiline_string(
+    "unreserved_keywords", snowflake_unreserved_keywords
 )
 
 snowflake_dialect.sets("reserved_keywords").clear()
-snowflake_dialect.sets("reserved_keywords").update(
-    [n.strip().upper() for n in snowflake_reserved_keywords.split("\n")]
+snowflake_dialect.update_keywords_set_from_multiline_string(
+    "reserved_keywords", snowflake_reserved_keywords
 )
 
 # Add datetime units and their aliases from


### PR DESCRIPTION
Keep out the zero length keyword.  Their inclusion is due to the fact
that some keywords are specified in multiline strings, and the trailing
newline results in an empty string.

I think their inclusion is almost certainly accidental, so this code
strips the input string before we split it in order to avoid that
problem.

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
