### PR TITLE
SparkSQL: Fix Group By Clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -1815,22 +1815,33 @@ class GroupByClauseSegment(ansi.GroupByClauseSegment):
         "GROUP",
         "BY",
         Indent,
-        Delimited(
-            OneOf(
-                Ref("ColumnReferenceSegment"),
-                # Can `GROUP BY 1`
-                Ref("NumericLiteralSegment"),
-                # Can `GROUP BY coalesce(col, 1)`
-                Ref("ExpressionSegment"),
-                Ref("CubeRollupClauseSegment"),
-                Ref("GroupingSetsClauseSegment"),
+        OneOf(
+            Delimited(
+                AnyNumberOf(
+                    Ref("ColumnReferenceSegment"),
+                    # Can `GROUP BY 1`
+                    Ref("NumericLiteralSegment"),
+                    # Can `GROUP BY coalesce(col, 1)`
+                    Ref("ExpressionSegment"),
+                    Ref("CubeRollupClauseSegment"),
+                    Ref("GroupingSetsClauseSegment"),
+                    min_times=1
+                )
             ),
-            terminator=Ref("GroupByClauseTerminatorGrammar"),
+            Sequence(
+                Delimited(
+                    AnyNumberOf(
+                        Ref("ColumnReferenceSegment"),
+                        # Can `GROUP BY 1`
+                        Ref("NumericLiteralSegment"),
+                        # Can `GROUP BY coalesce(col, 1)`
+                        Ref("ExpressionSegment"),
+                        min_times=1
+                    ),
+                ),
+                Ref("WithCubeRollupClauseSegment"),
+            ),
         ),
-        # TODO: New Rule
-        #  Warn if CubeRollupClauseSegment and
-        #  WithCubeRollupClauseSegment used in same query
-        Ref("WithCubeRollupClauseSegment", optional=True),
         Dedent,
     )
 

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -1825,7 +1825,7 @@ class GroupByClauseSegment(ansi.GroupByClauseSegment):
                     Ref("ExpressionSegment"),
                     Ref("CubeRollupClauseSegment"),
                     Ref("GroupingSetsClauseSegment"),
-                    min_times=1
+                    min_times=1,
                 )
             ),
             Sequence(
@@ -1836,7 +1836,7 @@ class GroupByClauseSegment(ansi.GroupByClauseSegment):
                         Ref("NumericLiteralSegment"),
                         # Can `GROUP BY coalesce(col, 1)`
                         Ref("ExpressionSegment"),
-                        min_times=1
+                        min_times=1,
                     ),
                 ),
                 Ref("WithCubeRollupClauseSegment"),

--- a/test/fixtures/dialects/sparksql/select_group_by.sql
+++ b/test/fixtures/dialects/sparksql/select_group_by.sql
@@ -47,6 +47,14 @@ FROM dealer
 GROUP BY GROUPING SETS ((city, car_model), (city), (car_model), ())
 ORDER BY city;
 
+SELECT
+    city,
+    car_model,
+    sum(quantity) AS sum_quantity
+FROM dealer
+GROUP BY city, car_model GROUPING SETS ((city, car_model), (city), (car_model), ())
+ORDER BY city;
+
 -- Group by processing with `ROLLUP` clause.
 -- Equivalent GROUP BY GROUPING SETS ((city, car_model), (city), ())
 SELECT

--- a/test/fixtures/dialects/sparksql/select_group_by.yml
+++ b/test/fixtures/dialects/sparksql/select_group_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: dea545107ae74b4b6b065945481cf2301d6d483c6526ece7dd103b6cc8aa6eef
+_hash: 25088a45141732c93a4126dc56ebf8e3c01f1f1052f1b6114563fc57a588b3e2
 file:
 - statement:
     select_statement:
@@ -258,6 +258,87 @@ file:
       groupby_clause:
       - keyword: GROUP
       - keyword: BY
+      - grouping_sets_clause:
+        - keyword: GROUPING
+        - keyword: SETS
+        - bracketed:
+            start_bracket: (
+            grouping_expression_list:
+            - bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    naked_identifier: city
+              - comma: ','
+              - expression:
+                  column_reference:
+                    naked_identifier: car_model
+              - end_bracket: )
+            - comma: ','
+            - bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: city
+                end_bracket: )
+            - comma: ','
+            - bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: car_model
+                end_bracket: )
+            - comma: ','
+            - bracketed:
+                start_bracket: (
+                end_bracket: )
+            end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: city
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: city
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: car_model
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: sum
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: quantity
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: sum_quantity
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dealer
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: city
+      - comma: ','
+      - column_reference:
+          naked_identifier: car_model
       - grouping_sets_clause:
         - keyword: GROUPING
         - keyword: SETS


### PR DESCRIPTION
### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This change updates the `GroupByClauseSegment` to better match the definition in the open source (https://github.com/apache/spark/blob/2931993e059f5d3741fc09438b7da88ccd8d4446/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4#L600). 

One issue with the previous definition is that it didn't allow for expressions to precede grouping sets. This is now possible and a new test case has been added to `test/fixtures/dialects/sparksql/select_group_by.sql`.



### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
