### PR TITLE
Add support for PG SET ROLE / RESET ROLE

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -4125,6 +4125,8 @@ class SetStatementSegment(BaseSegment):
     """Set Statement.
 
     As specified in https://www.postgresql.org/docs/14/sql-set.html
+    Also: https://www.postgresql.org/docs/15/sql-set-role.html (still a VariableSetStmt)
+    https://github.com/postgres/postgres/blob/4380c2509d51febad34e1fac0cfaeb98aaa716c5/src/backend/parser/gram.y#L1584
     """
 
     type = "set_statement"
@@ -4145,6 +4147,7 @@ class SetStatementSegment(BaseSegment):
                 "TIME", "ZONE", OneOf(Ref("QuotedLiteralSegment"), "LOCAL", "DEFAULT")
             ),
             Sequence("SCHEMA", Ref("QuotedLiteralSegment")),
+            Sequence("ROLE", OneOf("NONE", Ref("RoleReferenceSegment"))),
         ),
     )
 
@@ -4358,12 +4361,13 @@ class ResetStatementSegment(BaseSegment):
     """A `RESET` statement.
 
     As Specified in https://www.postgresql.org/docs/14/sql-reset.html
+    Also, RESET ROLE from: https://www.postgresql.org/docs/15/sql-set-role.html
     """
 
     type = "reset_statement"
     match_grammar = Sequence(
         "RESET",
-        OneOf("ALL", Ref("ParameterNameSegment")),
+        OneOf("ALL", "ROLE", Ref("ParameterNameSegment")),
     )
 
 

--- a/test/fixtures/dialects/postgres/postgres_reset.sql
+++ b/test/fixtures/dialects/postgres/postgres_reset.sql
@@ -1,2 +1,3 @@
 RESET timezone;
 RESET ALL;
+RESET ROLE;

--- a/test/fixtures/dialects/postgres/postgres_reset.yml
+++ b/test/fixtures/dialects/postgres/postgres_reset.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e9e279911916c47d20deb5cce0ef040ce5e573f71b5044dc43b3a1f3b64bbc23
+_hash: f0addcc750a516055a2f60b81c5fb1476adfddf3f5c7ddbcf08ed68ea56d9872
 file:
 - statement:
     reset_statement:
@@ -14,4 +14,9 @@ file:
     reset_statement:
     - keyword: RESET
     - keyword: ALL
+- statement_terminator: ;
+- statement:
+    reset_statement:
+    - keyword: RESET
+    - keyword: ROLE
 - statement_terminator: ;

--- a/test/fixtures/dialects/postgres/postgres_set.sql
+++ b/test/fixtures/dialects/postgres/postgres_set.sql
@@ -8,3 +8,6 @@ SET TIME ZONE LOCAL;
 SET TIME ZONE DEFAULT;
 SET SCHEMA  'my_schema';
 SET SCHEMA  'public';
+SET ROLE my_role;
+SET ROLE "my role";
+SET ROLE NONE;

--- a/test/fixtures/dialects/postgres/postgres_set.yml
+++ b/test/fixtures/dialects/postgres/postgres_set.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e966e9d3dfde5f1921fb58fdf6dbe47e1c53e66e733dfb9f1c2baf27f619c448
+_hash: 41363cce6c6ddbe60469ac35341d52b0ca93d33eb94c4e5d5b4254701f896f46
 file:
 - statement:
     set_statement:
@@ -81,4 +81,24 @@ file:
     - keyword: SET
     - keyword: SCHEMA
     - quoted_literal: "'public'"
+- statement_terminator: ;
+- statement:
+    set_statement:
+    - keyword: SET
+    - keyword: ROLE
+    - role_reference:
+        naked_identifier: my_role
+- statement_terminator: ;
+- statement:
+    set_statement:
+    - keyword: SET
+    - keyword: ROLE
+    - role_reference:
+        quoted_identifier: '"my role"'
+- statement_terminator: ;
+- statement:
+    set_statement:
+    - keyword: SET
+    - keyword: ROLE
+    - keyword: NONE
 - statement_terminator: ;


### PR DESCRIPTION
Not much to say beyond what's in the title.

From https://www.postgresql.org/docs/15/sql-set-role.html

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
