### PR TITLE
Add support for dropping multiple views with PostgreSQL

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -2635,6 +2635,22 @@ class AlterViewStatementSegment(BaseSegment):
     )
 
 
+class DropViewStatementSegment(ansi.DropViewStatementSegment):
+    """A `DROP VIEW` statement.
+
+    https://www.postgresql.org/docs/15/sql-dropview.html
+    https://github.com/postgres/postgres/blob/4380c2509d51febad34e1fac0cfaeb98aaa716c5/src/backend/parser/gram.y#L6698-L6719
+    """
+
+    match_grammar: Matchable = Sequence(
+        "DROP",
+        "VIEW",
+        Ref("IfExistsGrammar", optional=True),
+        Delimited(Ref("TableReferenceSegment")),
+        Ref("DropBehaviorGrammar", optional=True),
+    )
+
+
 class CreateDatabaseStatementSegment(ansi.CreateDatabaseStatementSegment):
     """A `CREATE DATABASE` statement.
 

--- a/test/fixtures/dialects/postgres/postgres_drop_view.sql
+++ b/test/fixtures/dialects/postgres/postgres_drop_view.sql
@@ -1,0 +1,30 @@
+DROP VIEW abc;
+
+DROP VIEW "abc";
+
+DROP VIEW IF EXISTS abc;
+
+DROP VIEW abc, "def", ghi;
+
+DROP VIEW IF EXISTS abc, def, ghi;
+
+-- Test CASCADE trailing keyword
+
+DROP VIEW abc CASCADE;
+
+DROP VIEW IF EXISTS abc CASCADE;
+
+DROP VIEW abc, def, ghi CASCADE;
+
+DROP VIEW IF EXISTS abc, def, ghi CASCADE;
+
+
+-- Test RESTRICT trailing keyword
+
+DROP VIEW abc RESTRICT;
+
+DROP VIEW IF EXISTS abc RESTRICT;
+
+DROP VIEW abc, def, ghi RESTRICT;
+
+DROP VIEW IF EXISTS abc, def, ghi RESTRICT;

--- a/test/fixtures/dialects/postgres/postgres_drop_view.yml
+++ b/test/fixtures/dialects/postgres/postgres_drop_view.yml
@@ -1,0 +1,154 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 36b7a96e8518c113ef9d614a8b704ce02aa976d1b69949a8e9f68c287ded1420
+file:
+- statement:
+    drop_view_statement:
+    - keyword: DROP
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    drop_view_statement:
+    - keyword: DROP
+    - keyword: VIEW
+    - table_reference:
+        quoted_identifier: '"abc"'
+- statement_terminator: ;
+- statement:
+    drop_view_statement:
+    - keyword: DROP
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    drop_view_statement:
+    - keyword: DROP
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: abc
+    - comma: ','
+    - table_reference:
+        quoted_identifier: '"def"'
+    - comma: ','
+    - table_reference:
+        naked_identifier: ghi
+- statement_terminator: ;
+- statement:
+    drop_view_statement:
+    - keyword: DROP
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: abc
+    - comma: ','
+    - table_reference:
+        naked_identifier: def
+    - comma: ','
+    - table_reference:
+        naked_identifier: ghi
+- statement_terminator: ;
+- statement:
+    drop_view_statement:
+    - keyword: DROP
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: abc
+    - keyword: CASCADE
+- statement_terminator: ;
+- statement:
+    drop_view_statement:
+    - keyword: DROP
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: abc
+    - keyword: CASCADE
+- statement_terminator: ;
+- statement:
+    drop_view_statement:
+    - keyword: DROP
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: abc
+    - comma: ','
+    - table_reference:
+        naked_identifier: def
+    - comma: ','
+    - table_reference:
+        naked_identifier: ghi
+    - keyword: CASCADE
+- statement_terminator: ;
+- statement:
+    drop_view_statement:
+    - keyword: DROP
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: abc
+    - comma: ','
+    - table_reference:
+        naked_identifier: def
+    - comma: ','
+    - table_reference:
+        naked_identifier: ghi
+    - keyword: CASCADE
+- statement_terminator: ;
+- statement:
+    drop_view_statement:
+    - keyword: DROP
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: abc
+    - keyword: RESTRICT
+- statement_terminator: ;
+- statement:
+    drop_view_statement:
+    - keyword: DROP
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: abc
+    - keyword: RESTRICT
+- statement_terminator: ;
+- statement:
+    drop_view_statement:
+    - keyword: DROP
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: abc
+    - comma: ','
+    - table_reference:
+        naked_identifier: def
+    - comma: ','
+    - table_reference:
+        naked_identifier: ghi
+    - keyword: RESTRICT
+- statement_terminator: ;
+- statement:
+    drop_view_statement:
+    - keyword: DROP
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: abc
+    - comma: ','
+    - table_reference:
+        naked_identifier: def
+    - comma: ','
+    - table_reference:
+        naked_identifier: ghi
+    - keyword: RESTRICT
+- statement_terminator: ;


### PR DESCRIPTION
DROP statement in ANSI SQL does not support dropping multiple views at a time, but PostgreSQL does.


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
