### PR TITLE
Add CHAR VARYING data type for PG

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -676,6 +676,10 @@ class DatatypeSegment(ansi.DatatypeSegment):
                         Sequence(
                             OneOf(
                                 "CHAR",
+                                # CHAR VARYING is not documented, but it's
+                                # in the real grammar:
+                                # https://github.com/postgres/postgres/blob/4380c2509d51febad34e1fac0cfaeb98aaa716c5/src/backend/parser/gram.y#L14262
+                                Sequence("CHAR", "VARYING"),
                                 "CHARACTER",
                                 Sequence("CHARACTER", "VARYING"),
                                 "VARCHAR",

--- a/test/fixtures/dialects/postgres/postgres_create_table.sql
+++ b/test/fixtures/dialects/postgres/postgres_create_table.sql
@@ -33,7 +33,8 @@ CREATE TABLE distributors (
 
 CREATE TABLE distributors (
     did     integer CHECK (did > 100),
-    name    varchar(40)
+    name    varchar(40),
+    long_varying char varying(100)
 );
 
 CREATE TABLE distributors (

--- a/test/fixtures/dialects/postgres/postgres_create_table.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2dd44090101b8062ac76859e45d0e246a9950d7ea475d1ee2f4b67bdd5618c58
+_hash: f0fa7d4338ee61822f792ec5b099fe417e1ee503024a4477fd2b07dba08faac8
 file:
 - statement:
     create_table_statement:
@@ -101,6 +101,17 @@ file:
             bracketed:
               start_bracket: (
               numeric_literal: '40'
+              end_bracket: )
+      - comma: ','
+      - column_reference:
+          naked_identifier: long_varying
+      - data_type:
+        - keyword: char
+        - keyword: varying
+        - bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '100'
               end_bracket: )
       - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
The online documentation omits CHAR VARYING as a possible type. However, the grammar lets you do it.


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
