### PR TITLE
Allow DML queries to be selectable in CTEs on PG

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -487,6 +487,18 @@ postgres_dialect.replace(
         # Add in semi structured expressions
         Ref("SemiStructuredAccessorSegment"),
     ),
+    # PostgreSQL supports the non-standard "RETURNING" keyword, and therefore the
+    # INSERT/UPDATE/DELETE statements can also be used in subqueries.
+    NonWithSelectableGrammar=OneOf(
+        Ref("SetExpressionSegment"),
+        OptionallyBracketed(Ref("SelectStatementSegment")),
+        Ref("NonSetSelectableGrammar"),
+        # moved from NonWithNonSelectableGrammar:
+        Ref("UpdateStatementSegment"),
+        Ref("InsertStatementSegment"),
+        Ref("DeleteStatementSegment"),
+    ),
+    NonWithNonSelectableGrammar=OneOf(),
 )
 
 

--- a/test/fixtures/dialects/postgres/postgres_with.sql
+++ b/test/fixtures/dialects/postgres/postgres_with.sql
@@ -39,3 +39,19 @@ WITH RECURSIVE search_graph(id, link, data, depth) AS (
     WHERE g.id = sg.link
 ) CYCLE id SET is_cycle USING path
 SELECT * FROM search_graph;
+
+-- test that DML queries are also selectable
+WITH tbl AS (
+    INSERT INTO a VALUES (5) RETURNING *
+)
+SELECT * FROM tbl;
+
+WITH tbl AS (
+    UPDATE a SET b = 5 RETURNING *
+)
+SELECT * FROM tbl;
+
+WITH tbl AS (
+    DELETE FROM a RETURNING *
+)
+SELECT * FROM tbl;

--- a/test/fixtures/dialects/postgres/postgres_with.yml
+++ b/test/fixtures/dialects/postgres/postgres_with.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a90e3937826e06152bd3b304e9fdb8584d462c1ef71ea388d62ba57cc5fd3ce7
+_hash: 7dd7fa95cac9b0cf5224a8f2a0d007882f19ee2e7424f1339a6b0611e55df7b9
 file:
 - statement:
     with_compound_statement:
@@ -558,4 +558,111 @@ file:
               table_expression:
                 table_reference:
                   naked_identifier: search_graph
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        naked_identifier: tbl
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          insert_statement:
+          - keyword: INSERT
+          - keyword: INTO
+          - table_reference:
+              naked_identifier: a
+          - values_clause:
+              keyword: VALUES
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '5'
+                end_bracket: )
+          - keyword: RETURNING
+          - star: '*'
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tbl
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        naked_identifier: tbl
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          update_statement:
+          - keyword: UPDATE
+          - table_reference:
+              naked_identifier: a
+          - set_clause_list:
+              keyword: SET
+              set_clause:
+                column_reference:
+                  naked_identifier: b
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '5'
+          - keyword: RETURNING
+          - star: '*'
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tbl
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        naked_identifier: tbl
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          delete_statement:
+          - keyword: DELETE
+          - keyword: FROM
+          - table_reference:
+              naked_identifier: a
+          - keyword: RETURNING
+          - star: '*'
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tbl
 - statement_terminator: ;


### PR DESCRIPTION
PostgreSQL supports the non-standard RETURNING clause on a DML query, and therefore those queries can also be used in a CTE.


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
