### PR TITLE
Add the CREATE/DROP CAST statements to ANSI and PG

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -3442,6 +3442,60 @@ class SetClauseSegment(BaseSegment):
     )
 
 
+class CreateCastStatementSegment(BaseSegment):
+    """A `CREATE CAST` statement.
+
+    https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#_11_63_user_defined_cast_definition
+    """
+
+    type = "create_cast_statement"
+
+    match_grammar: Matchable = Sequence(
+        "CREATE",
+        "CAST",
+        Bracketed(
+            Ref("DatatypeSegment"),
+            "AS",
+            Ref("DatatypeSegment"),
+        ),
+        "WITH",
+        Ref.keyword("SPECIFIC", optional=True),
+        OneOf(
+            "ROUTINE",
+            "FUNCTION",
+            "PROCEDURE",
+            Sequence(
+                OneOf("INSTANCE", "STATIC", "CONSTRUCTOR", optional=True),
+                "METHOD",
+            ),
+        ),
+        Ref("FunctionNameSegment"),
+        Ref("FunctionParameterListGrammar", optional=True),
+        Sequence("FOR", Ref("ObjectReferenceSegment"), optional=True),
+        Sequence("AS", "ASSIGNMENT", optional=True),
+    )
+
+
+class DropCastStatementSegment(BaseSegment):
+    """A `DROP CAST` statement.
+
+    https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#_11_64_drop_user_defined_cast_statement
+    """
+
+    type = "drop_cast_statement"
+
+    match_grammar: Matchable = Sequence(
+        "DROP",
+        "CAST",
+        Bracketed(
+            Ref("DatatypeSegment"),
+            "AS",
+            Ref("DatatypeSegment"),
+        ),
+        Ref("DropBehaviorGrammar", optional=True),
+    )
+
+
 class FunctionDefinitionGrammar(BaseSegment):
     """This is the body of a `CREATE FUNCTION AS` statement."""
 
@@ -3663,6 +3717,8 @@ class StatementSegment(BaseSegment):
         Ref("CreateViewStatementSegment"),
         Ref("DeleteStatementSegment"),
         Ref("UpdateStatementSegment"),
+        Ref("CreateCastStatementSegment"),
+        Ref("DropCastStatementSegment"),
         Ref("CreateFunctionStatementSegment"),
         Ref("DropFunctionStatementSegment"),
         Ref("CreateModelStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -772,6 +772,59 @@ class DefinitionParametersSegment(BaseSegment):
     )
 
 
+class CreateCastStatementSegment(ansi.CreateCastStatementSegment):
+    """A `CREATE CAST` statement.
+
+    https://www.postgresql.org/docs/15/sql-createcast.html
+    https://github.com/postgres/postgres/blob/4380c2509d51febad34e1fac0cfaeb98aaa716c5/src/backend/parser/gram.y#L8951
+    """
+
+    match_grammar: Matchable = Sequence(
+        "CREATE",
+        "CAST",
+        Bracketed(
+            Ref("DatatypeSegment"),
+            "AS",
+            Ref("DatatypeSegment"),
+        ),
+        OneOf(
+            Sequence(
+                "WITH",
+                "FUNCTION",
+                Ref("FunctionNameSegment"),
+                Ref("FunctionParameterListGrammar", optional=True),
+            ),
+            Sequence("WITHOUT", "FUNCTION"),
+            Sequence("WITH", "INOUT"),
+        ),
+        OneOf(
+            Sequence("AS", "ASSIGNMENT", optional=True),
+            Sequence("AS", "IMPLICIT", optional=True),
+            optional=True,
+        ),
+    )
+
+
+class DropCastStatementSegment(ansi.DropCastStatementSegment):
+    """A `DROP CAST` statement.
+
+    https://www.postgresql.org/docs/15/sql-dropcast.html
+    https://github.com/postgres/postgres/blob/4380c2509d51febad34e1fac0cfaeb98aaa716c5/src/backend/parser/gram.y#L8995
+    """
+
+    match_grammar: Matchable = Sequence(
+        "DROP",
+        "CAST",
+        Sequence("IF", "EXISTS", optional=True),
+        Bracketed(
+            Ref("DatatypeSegment"),
+            "AS",
+            Ref("DatatypeSegment"),
+        ),
+        Ref("DropBehaviorGrammar", optional=True),
+    )
+
+
 class CreateFunctionStatementSegment(ansi.CreateFunctionStatementSegment):
     """A `CREATE FUNCTION` statement.
 

--- a/test/fixtures/dialects/ansi/create_cast.sql
+++ b/test/fixtures/dialects/ansi/create_cast.sql
@@ -1,0 +1,25 @@
+CREATE CAST (int AS bool) WITH FUNCTION fname;
+
+CREATE CAST (int AS bool) WITH FUNCTION fname AS ASSIGNMENT;
+
+CREATE CAST (int AS bool) WITH FUNCTION fname();
+
+CREATE CAST (int AS bool) WITH FUNCTION fname(bool);
+
+CREATE CAST (int AS bool) WITH FUNCTION sch.fname(int, bool) AS ASSIGNMENT;
+
+CREATE CAST (udt_1 AS udt_2) WITH FUNCTION fname(udt_1, udt_2) FOR udt_3;
+
+CREATE CAST (sch.udt_1 AS sch.udt_2) WITH FUNCTION sch.fname(sch.udt_1, sch.udt_2) FOR sch.udt_3;
+
+CREATE CAST (int AS bool) WITH ROUTINE fname();
+
+CREATE CAST (int AS bool) WITH PROCEDURE fname();
+
+CREATE CAST (int AS bool) WITH METHOD fname();
+
+CREATE CAST (int AS bool) WITH INSTANCE METHOD fname();
+
+CREATE CAST (int AS bool) WITH STATIC METHOD fname();
+
+CREATE CAST (int AS bool) WITH CONSTRUCTOR METHOD fname();

--- a/test/fixtures/dialects/ansi/create_cast.yml
+++ b/test/fixtures/dialects/ansi/create_cast.yml
@@ -1,0 +1,316 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 54848c7eae3e3c3c50ab04feca39d8798be72e8e24009c02366c2b4083750362
+file:
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: int
+      - keyword: AS
+      - data_type:
+          data_type_identifier: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: fname
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: int
+      - keyword: AS
+      - data_type:
+          data_type_identifier: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: fname
+    - keyword: AS
+    - keyword: ASSIGNMENT
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: int
+      - keyword: AS
+      - data_type:
+          data_type_identifier: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: int
+      - keyword: AS
+      - data_type:
+          data_type_identifier: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          data_type:
+            data_type_identifier: bool
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: int
+      - keyword: AS
+      - data_type:
+          data_type_identifier: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        naked_identifier: sch
+        dot: .
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+        - start_bracket: (
+        - data_type:
+            data_type_identifier: int
+        - comma: ','
+        - data_type:
+            data_type_identifier: bool
+        - end_bracket: )
+    - keyword: AS
+    - keyword: ASSIGNMENT
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: udt_1
+      - keyword: AS
+      - data_type:
+          data_type_identifier: udt_2
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+        - start_bracket: (
+        - data_type:
+            data_type_identifier: udt_1
+        - comma: ','
+        - data_type:
+            data_type_identifier: udt_2
+        - end_bracket: )
+    - keyword: FOR
+    - object_reference:
+        naked_identifier: udt_3
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          naked_identifier: sch
+          dot: .
+          data_type_identifier: udt_1
+      - keyword: AS
+      - data_type:
+          naked_identifier: sch
+          dot: .
+          data_type_identifier: udt_2
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        naked_identifier: sch
+        dot: .
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+        - start_bracket: (
+        - data_type:
+            naked_identifier: sch
+            dot: .
+            data_type_identifier: udt_1
+        - comma: ','
+        - data_type:
+            naked_identifier: sch
+            dot: .
+            data_type_identifier: udt_2
+        - end_bracket: )
+    - keyword: FOR
+    - object_reference:
+      - naked_identifier: sch
+      - dot: .
+      - naked_identifier: udt_3
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: int
+      - keyword: AS
+      - data_type:
+          data_type_identifier: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: ROUTINE
+    - function_name:
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: int
+      - keyword: AS
+      - data_type:
+          data_type_identifier: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: PROCEDURE
+    - function_name:
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: int
+      - keyword: AS
+      - data_type:
+          data_type_identifier: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: METHOD
+    - function_name:
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: int
+      - keyword: AS
+      - data_type:
+          data_type_identifier: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: INSTANCE
+    - keyword: METHOD
+    - function_name:
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: int
+      - keyword: AS
+      - data_type:
+          data_type_identifier: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: STATIC
+    - keyword: METHOD
+    - function_name:
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: int
+      - keyword: AS
+      - data_type:
+          data_type_identifier: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: CONSTRUCTOR
+    - keyword: METHOD
+    - function_name:
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/ansi/drop_cast.sql
+++ b/test/fixtures/dialects/ansi/drop_cast.sql
@@ -1,0 +1,9 @@
+DROP CAST (int AS bool);
+
+DROP CAST (int AS bool) RESTRICT;
+
+DROP CAST (int AS bool) CASCADE;
+
+DROP CAST (udt_1 AS udt_2);
+
+DROP CAST (sch.udt_1 AS sch.udt_2);

--- a/test/fixtures/dialects/ansi/drop_cast.yml
+++ b/test/fixtures/dialects/ansi/drop_cast.yml
@@ -1,0 +1,78 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9ab44c21d3a8f7594f50924ffe73aaf87716721475787ac5558e197378caf83c
+file:
+- statement:
+    drop_cast_statement:
+    - keyword: DROP
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: int
+      - keyword: AS
+      - data_type:
+          data_type_identifier: bool
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    drop_cast_statement:
+    - keyword: DROP
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: int
+      - keyword: AS
+      - data_type:
+          data_type_identifier: bool
+      - end_bracket: )
+    - keyword: RESTRICT
+- statement_terminator: ;
+- statement:
+    drop_cast_statement:
+    - keyword: DROP
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: int
+      - keyword: AS
+      - data_type:
+          data_type_identifier: bool
+      - end_bracket: )
+    - keyword: CASCADE
+- statement_terminator: ;
+- statement:
+    drop_cast_statement:
+    - keyword: DROP
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: udt_1
+      - keyword: AS
+      - data_type:
+          data_type_identifier: udt_2
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    drop_cast_statement:
+    - keyword: DROP
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          naked_identifier: sch
+          dot: .
+          data_type_identifier: udt_1
+      - keyword: AS
+      - data_type:
+          naked_identifier: sch
+          dot: .
+          data_type_identifier: udt_2
+      - end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/postgres/postgres_create_cast.sql
+++ b/test/fixtures/dialects/postgres/postgres_create_cast.sql
@@ -1,0 +1,24 @@
+CREATE CAST (int AS bool) WITH FUNCTION fname;
+CREATE CAST (int AS bool) WITH FUNCTION fname AS ASSIGNMENT;
+CREATE CAST (int AS bool) WITH FUNCTION fname AS IMPLICIT;
+
+CREATE CAST (int AS bool) WITH FUNCTION fname();
+CREATE CAST (int AS bool) WITH FUNCTION fname() AS ASSIGNMENT;
+CREATE CAST (int AS bool) WITH FUNCTION fname() AS IMPLICIT;
+
+CREATE CAST (int AS bool) WITH FUNCTION fname(bool);
+
+CREATE CAST (int AS bool) WITH FUNCTION sch.fname(int, bool) AS ASSIGNMENT;
+
+CREATE CAST (udt_1 AS udt_2) WITH FUNCTION fname(udt_1, udt_2);
+
+CREATE CAST (sch.udt_1 AS sch.udt_2) WITH FUNCTION sch.fname(sch.udt_1, sch.udt_2);
+
+-- PG extension for not listing an actual function:
+CREATE CAST (int AS bool) WITHOUT FUNCTION;
+CREATE CAST (int AS bool) WITHOUT FUNCTION AS ASSIGNMENT;
+CREATE CAST (int AS bool) WITHOUT FUNCTION AS IMPLICIT;
+
+CREATE CAST (int AS bool) WITH INOUT;
+CREATE CAST (int AS bool) WITH INOUT AS ASSIGNMENT;
+CREATE CAST (int AS bool) WITH INOUT AS IMPLICIT;

--- a/test/fixtures/dialects/postgres/postgres_create_cast.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_cast.yml
@@ -1,0 +1,342 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9e34d987801d78938da48d706596e4179445070e27a9b8e4a6146a28543d4c37
+file:
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: fname
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: fname
+    - keyword: AS
+    - keyword: ASSIGNMENT
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: fname
+    - keyword: AS
+    - keyword: IMPLICIT
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+    - keyword: AS
+    - keyword: ASSIGNMENT
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+    - keyword: AS
+    - keyword: IMPLICIT
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          data_type:
+            keyword: bool
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        naked_identifier: sch
+        dot: .
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+        - start_bracket: (
+        - data_type:
+            keyword: int
+        - comma: ','
+        - data_type:
+            keyword: bool
+        - end_bracket: )
+    - keyword: AS
+    - keyword: ASSIGNMENT
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: udt_1
+      - keyword: AS
+      - data_type:
+          data_type_identifier: udt_2
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+        - start_bracket: (
+        - data_type:
+            data_type_identifier: udt_1
+        - comma: ','
+        - data_type:
+            data_type_identifier: udt_2
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          naked_identifier: sch
+          dot: .
+          data_type_identifier: udt_1
+      - keyword: AS
+      - data_type:
+          naked_identifier: sch
+          dot: .
+          data_type_identifier: udt_2
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: FUNCTION
+    - function_name:
+        naked_identifier: sch
+        dot: .
+        function_name_identifier: fname
+    - function_parameter_list:
+        bracketed:
+        - start_bracket: (
+        - data_type:
+            naked_identifier: sch
+            dot: .
+            data_type_identifier: udt_1
+        - comma: ','
+        - data_type:
+            naked_identifier: sch
+            dot: .
+            data_type_identifier: udt_2
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: WITHOUT
+    - keyword: FUNCTION
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: WITHOUT
+    - keyword: FUNCTION
+    - keyword: AS
+    - keyword: ASSIGNMENT
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: WITHOUT
+    - keyword: FUNCTION
+    - keyword: AS
+    - keyword: IMPLICIT
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: INOUT
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: INOUT
+    - keyword: AS
+    - keyword: ASSIGNMENT
+- statement_terminator: ;
+- statement:
+    create_cast_statement:
+    - keyword: CREATE
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: WITH
+    - keyword: INOUT
+    - keyword: AS
+    - keyword: IMPLICIT
+- statement_terminator: ;

--- a/test/fixtures/dialects/postgres/postgres_drop_cast.sql
+++ b/test/fixtures/dialects/postgres/postgres_drop_cast.sql
@@ -1,0 +1,17 @@
+-- ANSI SQL:
+
+DROP CAST (int AS bool);
+
+DROP CAST (int AS bool) RESTRICT;
+
+DROP CAST (int AS bool) CASCADE;
+
+DROP CAST (udt_1 AS udt_2);
+
+DROP CAST (sch.udt_1 AS sch.udt_2);
+
+-- Additional PG extensions:
+
+DROP CAST IF EXISTS (int AS bool);
+DROP CAST IF EXISTS (int AS bool) RESTRICT;
+DROP CAST IF EXISTS (int AS bool) CASCADE;

--- a/test/fixtures/dialects/postgres/postgres_drop_cast.yml
+++ b/test/fixtures/dialects/postgres/postgres_drop_cast.yml
@@ -1,0 +1,125 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 797c59758187f686eabaaa295a9e2b392158e11ab37a934556cf024cf468e083
+file:
+- statement:
+    drop_cast_statement:
+    - keyword: DROP
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    drop_cast_statement:
+    - keyword: DROP
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: RESTRICT
+- statement_terminator: ;
+- statement:
+    drop_cast_statement:
+    - keyword: DROP
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: CASCADE
+- statement_terminator: ;
+- statement:
+    drop_cast_statement:
+    - keyword: DROP
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          data_type_identifier: udt_1
+      - keyword: AS
+      - data_type:
+          data_type_identifier: udt_2
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    drop_cast_statement:
+    - keyword: DROP
+    - keyword: CAST
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          naked_identifier: sch
+          dot: .
+          data_type_identifier: udt_1
+      - keyword: AS
+      - data_type:
+          naked_identifier: sch
+          dot: .
+          data_type_identifier: udt_2
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    drop_cast_statement:
+    - keyword: DROP
+    - keyword: CAST
+    - keyword: IF
+    - keyword: EXISTS
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    drop_cast_statement:
+    - keyword: DROP
+    - keyword: CAST
+    - keyword: IF
+    - keyword: EXISTS
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: RESTRICT
+- statement_terminator: ;
+- statement:
+    drop_cast_statement:
+    - keyword: DROP
+    - keyword: CAST
+    - keyword: IF
+    - keyword: EXISTS
+    - bracketed:
+      - start_bracket: (
+      - data_type:
+          keyword: int
+      - keyword: AS
+      - data_type:
+          keyword: bool
+      - end_bracket: )
+    - keyword: CASCADE
+- statement_terminator: ;


### PR DESCRIPTION
Add CREATE CAST and DROP CAST statements to the ANSI dialect, following the SQL 2016 grammar at:

https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html

Then, add the same statements to the postgres dialect, changing the grammar to follow the grammar defined at:

https://github.com/postgres/postgres/blob/4380c2509d51febad34e1fac0cfaeb98aaa716c5/src/backend/parser/gram.y

The test fixtures were validated as follows:

* ANSI statements were run through https://developer.mimer.com/sql-2016-validator/

* PG statements were parsed using my local PG 15 instance.


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
