### PR TITLE
Simplify and fix PG array accessor segment & support expressions

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -567,11 +567,11 @@ class ArrayAccessorSegment(ansi.ArrayAccessorSegment):
 
     match_grammar = Bracketed(
         OneOf(
-            OneOf(
-                Ref("QualifiedNumericLiteralSegment"),
-                Ref("NumericLiteralSegment"),
-                Ref("ExpressionSegment"),
-            ),
+            # These three are for a single element access: [n]
+            Ref("QualifiedNumericLiteralSegment"),
+            Ref("NumericLiteralSegment"),
+            Ref("ExpressionSegment"),
+            # This is for slice access: [n:m], [:m], [n:], and [:]
             Sequence(
                 OneOf(
                     Ref("QualifiedNumericLiteralSegment"),

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -565,44 +565,30 @@ class ArrayAccessorSegment(ansi.ArrayAccessorSegment):
     numbers on either side of the slice segment are optional.
     """
 
-    match_grammar = Sequence(
-        AnyNumberOf(
-            Bracketed(
-                Sequence(
-                    OneOf(
-                        OneOf(
-                            Ref("QualifiedNumericLiteralSegment"),
-                            Ref("NumericLiteralSegment"),
-                        ),
-                        Sequence(
-                            OneOf(
-                                Ref("QualifiedNumericLiteralSegment"),
-                                Ref("NumericLiteralSegment"),
-                                optional=True,
-                            ),
-                            Ref("SliceSegment"),
-                            OneOf(
-                                Ref("QualifiedNumericLiteralSegment"),
-                                Ref("NumericLiteralSegment"),
-                            ),
-                        ),
-                        Sequence(
-                            OneOf(
-                                Ref("QualifiedNumericLiteralSegment"),
-                                Ref("NumericLiteralSegment"),
-                            ),
-                            Ref("SliceSegment"),
-                            OneOf(
-                                Ref("QualifiedNumericLiteralSegment"),
-                                Ref("NumericLiteralSegment"),
-                                optional=True,
-                            ),
-                        ),
-                    ),
+    match_grammar = Bracketed(
+        OneOf(
+            OneOf(
+                Ref("QualifiedNumericLiteralSegment"),
+                Ref("NumericLiteralSegment"),
+                Ref("ExpressionSegment"),
+            ),
+            Sequence(
+                OneOf(
+                    Ref("QualifiedNumericLiteralSegment"),
+                    Ref("NumericLiteralSegment"),
+                    Ref("ExpressionSegment"),
+                    optional=True,
                 ),
-                bracket_type="square",
-            )
-        )
+                Ref("SliceSegment"),
+                OneOf(
+                    Ref("QualifiedNumericLiteralSegment"),
+                    Ref("NumericLiteralSegment"),
+                    Ref("ExpressionSegment"),
+                    optional=True,
+                ),
+            ),
+        ),
+        bracket_type="square",
     )
 
 

--- a/test/fixtures/dialects/postgres/postgres_array.sql
+++ b/test/fixtures/dialects/postgres/postgres_array.sql
@@ -53,4 +53,10 @@ SELECT SUM(CASE
         ELSE 0
         END
     ) * (MAX(ARRAY[id, vertical]))[2]
-FROM direction_with_vertical_change
+FROM direction_with_vertical_change;
+
+-- More advanced cases with expressions and missing slice start/end when accessing
+
+SELECT a[:], b[:1], c[2:], d[2:3];
+
+SELECT a[1+2:3+4], b[5+6];

--- a/test/fixtures/dialects/postgres/postgres_array.yml
+++ b/test/fixtures/dialects/postgres/postgres_array.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 15d2a03d75017e771f8b71e06ded7c07f89a71e982ebf9a51c64dc5269297299
+_hash: fa7d0f6f980261224b84a16686a50389be1004eb1a613794a20222205208f836
 file:
 - statement:
     select_statement:
@@ -307,14 +307,15 @@ file:
         keyword: SELECT
         select_clause_element:
           expression:
-            column_reference:
+          - column_reference:
               naked_identifier: schedule
-            array_accessor:
+          - array_accessor:
             - start_square_bracket: '['
             - numeric_literal: '1'
             - slice: ':'
             - numeric_literal: '2'
             - end_square_bracket: ']'
+          - array_accessor:
             - start_square_bracket: '['
             - numeric_literal: '1'
             - slice: ':'
@@ -531,40 +532,44 @@ file:
       - keyword: SELECT
       - select_clause_element:
           expression:
-            column_reference:
+          - column_reference:
               naked_identifier: f1
-            array_accessor:
-            - start_square_bracket: '['
-            - numeric_literal: '1'
-            - end_square_bracket: ']'
-            - start_square_bracket: '['
-            - numeric_literal:
+          - array_accessor:
+              start_square_bracket: '['
+              numeric_literal: '1'
+              end_square_bracket: ']'
+          - array_accessor:
+              start_square_bracket: '['
+              numeric_literal:
                 sign_indicator: '-'
                 numeric_literal: '2'
-            - end_square_bracket: ']'
-            - start_square_bracket: '['
-            - numeric_literal: '3'
-            - end_square_bracket: ']'
+              end_square_bracket: ']'
+          - array_accessor:
+              start_square_bracket: '['
+              numeric_literal: '3'
+              end_square_bracket: ']'
           alias_expression:
             keyword: AS
             naked_identifier: e1
       - comma: ','
       - select_clause_element:
           expression:
-            column_reference:
+          - column_reference:
               naked_identifier: f1
-            array_accessor:
-            - start_square_bracket: '['
-            - numeric_literal: '1'
-            - end_square_bracket: ']'
-            - start_square_bracket: '['
-            - numeric_literal:
+          - array_accessor:
+              start_square_bracket: '['
+              numeric_literal: '1'
+              end_square_bracket: ']'
+          - array_accessor:
+              start_square_bracket: '['
+              numeric_literal:
                 sign_indicator: '-'
                 numeric_literal: '1'
-            - end_square_bracket: ']'
-            - start_square_bracket: '['
-            - numeric_literal: '5'
-            - end_square_bracket: ']'
+              end_square_bracket: ']'
+          - array_accessor:
+              start_square_bracket: '['
+              numeric_literal: '5'
+              end_square_bracket: ']'
           alias_expression:
             keyword: AS
             naked_identifier: e2
@@ -661,3 +666,81 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: direction_with_vertical_change
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+            column_reference:
+              naked_identifier: a
+            array_accessor:
+              start_square_bracket: '['
+              slice: ':'
+              end_square_bracket: ']'
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              naked_identifier: b
+            array_accessor:
+              start_square_bracket: '['
+              slice: ':'
+              numeric_literal: '1'
+              end_square_bracket: ']'
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              naked_identifier: c
+            array_accessor:
+              start_square_bracket: '['
+              numeric_literal: '2'
+              slice: ':'
+              end_square_bracket: ']'
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              naked_identifier: d
+            array_accessor:
+            - start_square_bracket: '['
+            - numeric_literal: '2'
+            - slice: ':'
+            - numeric_literal: '3'
+            - end_square_bracket: ']'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+            column_reference:
+              naked_identifier: a
+            array_accessor:
+            - start_square_bracket: '['
+            - expression:
+              - numeric_literal: '1'
+              - binary_operator: +
+              - numeric_literal: '2'
+            - slice: ':'
+            - expression:
+              - numeric_literal: '3'
+              - binary_operator: +
+              - numeric_literal: '4'
+            - end_square_bracket: ']'
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+              naked_identifier: b
+            array_accessor:
+              start_square_bracket: '['
+              expression:
+              - numeric_literal: '5'
+              - binary_operator: +
+              - numeric_literal: '6'
+              end_square_bracket: ']'
+- statement_terminator: ;


### PR DESCRIPTION
PG array access with a slice is quite simple:

https://github.com/postgres/postgres/blob/4380c2509d51febad34e1fac0cfaeb98aaa716c5/src/backend/parser/gram.y#L16392-L16409

            | '[' a_expr ']'
            | '[' opt_slice_bound ':' opt_slice_bound ']'

    opt_slice_bound:
            a_expr
            | /*EMPTY*/

The existing code has a few problems:

1.  It does not allow for an access like "[:]".
2.  It does not support expressions.
3.  It has too many layers of matchers.  There is already an Accessor_Grammar that has AnyNumberOf these accessors, so we don't need another outer AnyNumberOf here.  We also don't need a Sequence containing a single OneOf.

These are all easy enough to fix.


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #4336 

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
