### PR TITLE
Fix issue with macros triggering LT01

### DIFF
--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -120,6 +120,11 @@ def process_spacing(
         # If it's a newline, react accordingly.
         # NOTE: This should only trigger on literal newlines.
         elif seg.is_type("newline", "end_of_file"):
+            if seg.pos_marker and not seg.pos_marker.is_literal():
+                last_whitespace = []
+                reflow_logger.debug("    Skipping templated newline: %s", seg)
+                continue
+
             # Are we stripping newlines?
             if strip_newlines and seg.is_type("newline"):
                 reflow_logger.debug("    Stripping newline: %s", seg)

--- a/test/fixtures/rules/std_rule_cases/LT01-trailing.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-trailing.yml
@@ -21,3 +21,20 @@ test_pass_trailing_whitespace_before_template_code:
 test_fail_trailing_whitespace_and_whitespace_control:
   fail_str: "{%- set temp = 'temp' -%}\n\nSELECT\n    1, \n    2,\n"
   fix_str: "{%- set temp = 'temp' -%}\n\nSELECT\n    1,\n    2,\n"
+
+test_pass_macro_trailing:
+  pass_str: |
+    {% macro foo(bar) %}
+        {{bar}}
+    {% endmacro %}
+
+    with base as (
+        select
+            a,
+            b,
+            {{ foo(1) }} as c
+        from tblb
+    )
+
+    select *
+    from tbl


### PR DESCRIPTION
Found an issue in testing where some macros would trigger LT01 unnecessarily. This was because of incorrect handling of templated newlines. This fixes that.