### PR TITLE
Allow comment match with preceding line

### DIFF
--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -920,7 +920,9 @@ def _deduce_line_current_indent(
     consumed from the source as by potential templating tags.
     """
     indent_seg = None
-    if last_line_break_idx:
+    if not elements[0].segments:
+        return ""
+    elif last_line_break_idx:
         indent_seg = cast(
             ReflowPoint, elements[last_line_break_idx]
         )._get_indent_segment()

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -1002,19 +1002,30 @@ def _lint_line_starting_indent(
     if current_indent == desired_starting_indent:
         return []
 
-    # Edge case: Multiline comments. If the previous line was a multiline
-    # comment and this line starts with a multiline comment, then we should
-    # only lint the indent if it's _too small_. Otherwise we risk destroying
-    # indentation which the logic here is not smart enough to handle.
-    if (
-        initial_point_idx > 0
-        and initial_point_idx < len(elements) - 1
-        and "block_comment" in elements[initial_point_idx - 1].class_types
-        and "block_comment" in elements[initial_point_idx + 1].class_types
-    ):
-        if len(current_indent) > len(desired_starting_indent):
-            reflow_logger.debug("    Indent is bigger than required. OK.")
-            return []
+    if initial_point_idx > 0 and initial_point_idx < len(elements) - 1:
+        # Edge case: Lone comments. Normally comments are anchored to the line
+        # _after_ where they come. However, if the existing location _matches_
+        # the _preceding line_, then we will allow it. It's not the "expected"
+        # location but it is allowable.
+        if "comment" in elements[initial_point_idx + 1].class_types:
+            last_indent = _deduce_line_current_indent(
+                elements, indent_points[0].last_line_break_idx
+            )
+            if len(current_indent) == len(last_indent):
+                reflow_logger.debug("    Indent matches previous line. OK.")
+                return []
+
+        # Edge case: Multiline comments. If the previous line was a multiline
+        # comment and this line starts with a multiline comment, then we should
+        # only lint the indent if it's _too small_. Otherwise we risk destroying
+        # indentation which the logic here is not smart enough to handle.
+        if (
+            "block_comment" in elements[initial_point_idx - 1].class_types
+            and "block_comment" in elements[initial_point_idx + 1].class_types
+        ):
+            if len(current_indent) > len(desired_starting_indent):
+                reflow_logger.debug("    Indent is bigger than required. OK.")
+                return []
 
     reflow_logger.debug(
         "    Correcting indent @ line %s. Existing indent: %r -> %r",

--- a/test/fixtures/linter/autofix/bigquery/001_templating/after.sql
+++ b/test/fixtures/linter/autofix/bigquery/001_templating/after.sql
@@ -1,5 +1,5 @@
 select *
 from `{{project}}.{{dataset}}.user_labels_with_probs`
 where prob_max >= {{label_prob_threshold}}
-    --- only focus on 3 segments
+--- only focus on 3 segments
     and label_str not in ('marketing_maven', 'growth_services')

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -346,12 +346,22 @@ test_pass_indented_from_with_comment:
     -- Comment
     JOIN t2 USING (user_id)
 
-test_fail_indented_from_with_comment_fix:
-  fail_str: |
+test_fail_indented_from_with_comment_alternate:
+  # This shows the alternative position of comments being allowed.
+  pass_str: |
     SELECT *
     FROM
         t1
         -- Comment
+    JOIN t2 USING (user_id)
+
+test_fail_indented_from_with_comment_fix:
+  # This shows the fix still returns to the primary location.
+  fail_str: |
+    SELECT *
+    FROM
+        t1
+            -- Comment
     JOIN t2 USING (user_id)
   fix_str: |
     SELECT *
@@ -1941,3 +1951,22 @@ test_fail_issue_4680:
         {% else %}
         col1 > 0
       {% endif %}
+
+test_pass_trailing_comment_1:
+  # NOTE: This checks that we allow the alternative placement of comments
+  pass_str: |
+    select
+        bar
+        -- comment
+    from foo
+
+test_pass_trailing_comment_2:
+  # NOTE: This checks that we allow the alternative placement of comments
+  pass_str: |
+    select
+        bar
+        /* comment
+        with
+        more
+        lines */
+    from foo


### PR DESCRIPTION
Another one found during testing against our project. IMHO I think the comment indentation rules are _too strict_ right now. While I agree that the default _fix_ anchor should be the _following_ line - if a comment currently matches the indentation of the line before, then I don't think that should trigger a linting error. This opens up that.