### PR TITLE
Remove the majority of greedy matchers

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1390,12 +1390,7 @@ class PartitionClauseSegment(BaseSegment):
     """A `PARTITION BY` for window functions."""
 
     type = "partitionby_clause"
-    match_grammar: Matchable = StartsWith(
-        "PARTITION",
-        terminator=OneOf(Sequence("ORDER", "BY"), Ref("FrameClauseUnitGrammar")),
-        enforce_whitespace_preceding_terminator=True,
-    )
-    parse_grammar: Optional[Matchable] = Sequence(
+    match_grammar: Matchable = Sequence(
         "PARTITION",
         "BY",
         Indent,
@@ -1443,6 +1438,7 @@ class FromExpressionElementSegment(BaseSegment):
         Ref(
             "AliasExpressionSegment",
             exclude=OneOf(
+                Ref("FromClauseTerminatorGrammar"),
                 Ref("SamplingExpressionSegment"),
                 Ref("JoinLikeClauseGrammar"),
             ),
@@ -1805,12 +1801,7 @@ class FromClauseSegment(BaseSegment):
     """
 
     type = "from_clause"
-    match_grammar: Matchable = StartsWith(
-        "FROM",
-        terminator=Ref("FromClauseTerminatorGrammar"),
-        enforce_whitespace_preceding_terminator=True,
-    )
-    parse_grammar: Optional[Matchable] = Sequence(
+    match_grammar: Matchable = Sequence(
         "FROM",
         Delimited(
             Ref("FromExpressionSegment"),
@@ -2228,12 +2219,7 @@ class WhereClauseSegment(BaseSegment):
     """A `WHERE` clause like in `SELECT` or `INSERT`."""
 
     type = "where_clause"
-    match_grammar: Matchable = StartsWith(
-        "WHERE",
-        terminator=Ref("WhereClauseTerminatorGrammar"),
-        enforce_whitespace_preceding_terminator=True,
-    )
-    parse_grammar: Optional[Matchable] = Sequence(
+    match_grammar: Matchable = Sequence(
         "WHERE",
         # NOTE: The indent here is implicit to allow
         # constructions like:
@@ -2253,11 +2239,7 @@ class OrderByClauseSegment(BaseSegment):
     """A `ORDER BY` clause like in `SELECT`."""
 
     type = "orderby_clause"
-    match_grammar: Matchable = StartsWith(
-        Sequence("ORDER", "BY"),
-        terminator=Ref("OrderByClauseTerminators"),
-    )
-    parse_grammar: Optional[Matchable] = Sequence(
+    match_grammar: Matchable = Sequence(
         "ORDER",
         "BY",
         Indent,
@@ -2287,13 +2269,7 @@ class GroupByClauseSegment(BaseSegment):
 
     type = "groupby_clause"
 
-    match_grammar: Matchable = StartsWith(
-        Sequence("GROUP", "BY"),
-        terminator=Ref("GroupByClauseTerminatorGrammar"),
-        enforce_whitespace_preceding_terminator=True,
-    )
-
-    parse_grammar: Optional[Matchable] = Sequence(
+    match_grammar: Matchable = Sequence(
         "GROUP",
         "BY",
         Indent,
@@ -2315,12 +2291,7 @@ class HavingClauseSegment(BaseSegment):
     """A `HAVING` clause like in `SELECT`."""
 
     type = "having_clause"
-    match_grammar: Matchable = StartsWith(
-        "HAVING",
-        terminator=Ref("HavingClauseTerminatorGrammar"),
-        enforce_whitespace_preceding_terminator=True,
-    )
-    parse_grammar: Optional[Matchable] = Sequence(
+    match_grammar: Matchable = Sequence(
         "HAVING",
         ImplicitIndent,
         OptionallyBracketed(Ref("ExpressionSegment")),

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -28,7 +28,6 @@ from sqlfluff.core.parser import (
     RegexParser,
     SegmentGenerator,
     Sequence,
-    StartsWith,
     StringLexer,
     StringParser,
     SymbolSegment,
@@ -332,13 +331,7 @@ class QualifyClauseSegment(BaseSegment):
     """A `QUALIFY` clause like in `SELECT`."""
 
     type = "qualify_clause"
-    match_grammar = StartsWith(
-        "QUALIFY",
-        terminator=OneOf("WINDOW", "ORDER", "LIMIT"),
-        enforce_whitespace_preceding_terminator=True,
-    )
-
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "QUALIFY",
         Indent,
         OptionallyBracketed(Ref("ExpressionSegment")),
@@ -518,10 +511,7 @@ class ForInStatementSegment(BaseSegment):
     """
 
     type = "for_in_statement"
-    match_grammar = StartsWith(
-        "FOR", terminator=Sequence("END", "FOR"), include_terminator=True
-    )
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "FOR",
         Ref("SingleIdentifierGrammar"),
         "IN",
@@ -563,10 +553,7 @@ class RepeatStatementSegment(BaseSegment):
     """
 
     type = "repeat_statement"
-    match_grammar = StartsWith(
-        "REPEAT", terminator=Sequence("END", "REPEAT"), include_terminator=True
-    )
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "REPEAT",
         Indent,
         Ref("RepeatStatementsSegment"),
@@ -604,10 +591,7 @@ class IfStatementSegment(BaseSegment):
     """
 
     type = "if_statement"
-    match_grammar = StartsWith(
-        "IF", terminator=Sequence("END", "IF"), include_terminator=True
-    )
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "IF",
         Ref("ExpressionSegment"),
         "THEN",
@@ -662,10 +646,7 @@ class LoopStatementSegment(BaseSegment):
     """
 
     type = "loop_statement"
-    match_grammar = StartsWith(
-        "LOOP", terminator=Sequence("END", "LOOP"), include_terminator=True
-    )
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "LOOP",
         Indent,
         Ref("LoopStatementsSegment"),
@@ -698,10 +679,7 @@ class WhileStatementSegment(BaseSegment):
     """
 
     type = "while_statement"
-    match_grammar = StartsWith(
-        "WHILE", terminator=Sequence("END", "WHILE"), include_terminator=True
-    )
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "WHILE",
         Ref("ExpressionSegment"),
         "DO",
@@ -1375,12 +1353,7 @@ class PartitionBySegment(BaseSegment):
     """PARTITION BY partition_expression."""
 
     type = "partition_by_segment"
-    match_grammar = StartsWith(
-        "PARTITION",
-        terminator=OneOf("CLUSTER", "OPTIONS", "AS", Ref("DelimiterGrammar")),
-        enforce_whitespace_preceding_terminator=True,
-    )
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "PARTITION",
         "BY",
         Ref("ExpressionSegment"),
@@ -1391,12 +1364,7 @@ class ClusterBySegment(BaseSegment):
     """CLUSTER BY clustering_column_list."""
 
     type = "cluster_by_segment"
-    match_grammar = StartsWith(
-        "CLUSTER",
-        terminator=OneOf("OPTIONS", "AS", Ref("DelimiterGrammar")),
-        enforce_whitespace_preceding_terminator=True,
-    )
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "CLUSTER",
         "BY",
         Delimited(Ref("ExpressionSegment")),

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -273,6 +273,7 @@ class FromExpressionElementSegment(ansi.FromExpressionElementSegment):
         Ref(
             "AliasExpressionSegment",
             exclude=OneOf(
+                Ref("FromClauseTerminatorGrammar"),
                 Ref("SamplingExpressionSegment"),
                 Ref("JoinLikeClauseGrammar"),
                 "FINAL",

--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -3,8 +3,6 @@
 https://duckdb.org/docs/
 """
 
-from typing import Optional
-
 from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.dialects import dialect_ansi as ansi
 from sqlfluff.core.parser import (

--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -16,7 +16,6 @@ from sqlfluff.core.parser import (
     OneOf,
     Ref,
     Sequence,
-    StartsWith,
 )
 
 postgres_dialect = load_raw_dialect("postgres")
@@ -72,12 +71,7 @@ class SelectClauseElementSegment(ansi.SelectClauseElementSegment):
 class OrderByClauseSegment(ansi.OrderByClauseSegment):
     """A `ORDER BY` clause like in `SELECT`."""
 
-    match_grammar: Matchable = StartsWith(
-        Sequence("ORDER", "BY"),
-        terminator=Ref("OrderByClauseTerminators"),
-    )
-
-    parse_grammar: Optional[Matchable] = Sequence(
+    match_grammar: Matchable = Sequence(
         "ORDER",
         "BY",
         Indent,
@@ -93,7 +87,7 @@ class OrderByClauseSegment(ansi.OrderByClauseSegment):
                 Sequence("NULLS", OneOf("FIRST", "LAST"), optional=True),
             ),
             allow_trailing=True,
-            terminator=OneOf(Ref.keyword("LIMIT"), Ref("FrameClauseUnitGrammar")),
+            terminator=Ref("OrderByClauseTerminators"),
         ),
         Dedent,
     )
@@ -102,13 +96,7 @@ class OrderByClauseSegment(ansi.OrderByClauseSegment):
 class GroupByClauseSegment(ansi.GroupByClauseSegment):
     """A `GROUP BY` clause like in `SELECT`."""
 
-    match_grammar: Matchable = StartsWith(
-        Sequence("GROUP", "BY"),
-        terminator=Ref("GroupByClauseTerminatorGrammar"),
-        enforce_whitespace_preceding_terminator=True,
-    )
-
-    parse_grammar: Optional[Matchable] = Sequence(
+    match_grammar: Matchable = Sequence(
         "GROUP",
         "BY",
         Indent,

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -16,7 +16,6 @@ from sqlfluff.core.parser import (
     OptionallyBracketed,
     RegexParser,
     Matchable,
-    StartsWith,
     Indent,
     Dedent,
 )
@@ -947,21 +946,6 @@ class SetExpressionSegment(ansi.SetExpressionSegment):
     )
 
 
-class PartitionClauseSegment(ansi.PartitionClauseSegment):
-    """Overriding SetExpressionSegment to allow for additional segment parsing."""
-
-    match_grammar = ansi.PartitionClauseSegment.match_grammar.copy()
-    match_grammar.terminator = match_grammar.terminator.copy(  # type: ignore
-        insert=[
-            Sequence("CLUSTER", "BY"),
-            Sequence("DISTRIBUTE", "BY"),
-            Sequence("SORT", "BY"),
-        ],
-        before=Ref("FrameClauseUnitGrammar"),
-    )
-    parse_grammar = ansi.PartitionClauseSegment.parse_grammar
-
-
 class OrderByClauseSegment(ansi.OrderByClauseSegment):
     """A `ORDER BY` clause like in `SELECT`."""
 
@@ -978,18 +962,13 @@ class OrderByClauseSegment(ansi.OrderByClauseSegment):
         Ref("FrameClauseUnitGrammar"),
         "SEPARATOR",
     )
-    parse_grammar = ansi.OrderByClauseSegment.parse_grammar
 
 
 class ClusterByClauseSegment(ansi.OrderByClauseSegment):
     """A `CLUSTER BY` clause like in `SELECT`."""
 
     type = "clusterby_clause"
-    match_grammar: Matchable = StartsWith(
-        Sequence("CLUSTER", "BY"),
-        terminator=ansi.OrderByClauseSegment.match_grammar.terminator,  # type: ignore
-    )
-    parse_grammar: Optional[Matchable] = Sequence(
+    match_grammar: Matchable = Sequence(
         "CLUSTER",
         "BY",
         Indent,
@@ -1011,20 +990,7 @@ class DistributeByClauseSegment(ansi.OrderByClauseSegment):
     """A `DISTRIBUTE BY` clause like in `SELECT`."""
 
     type = "distributeby_clause"
-    match_grammar: Matchable = StartsWith(
-        Sequence("DISTRIBUTE", "BY"),
-        terminator=OneOf(
-            "SORT",
-            "LIMIT",
-            "HAVING",
-            "QUALIFY",
-            # For window functions
-            "WINDOW",
-            Ref("FrameClauseUnitGrammar"),
-            "SEPARATOR",
-        ),
-    )
-    parse_grammar: Optional[Matchable] = Sequence(
+    match_grammar: Matchable = Sequence(
         "DISTRIBUTE",
         "BY",
         Indent,
@@ -1037,7 +1003,14 @@ class DistributeByClauseSegment(ansi.OrderByClauseSegment):
                 ),
             ),
             terminator=OneOf(
-                Ref.keyword("LIMIT"), Ref("FrameClauseUnitGrammar"), Ref.keyword("SORT")
+                "SORT",
+                "LIMIT",
+                "HAVING",
+                "QUALIFY",
+                # For window functions
+                "WINDOW",
+                Ref("FrameClauseUnitGrammar"),
+                "SEPARATOR",
             ),
         ),
         Dedent,
@@ -1048,11 +1021,7 @@ class SortByClauseSegment(ansi.OrderByClauseSegment):
     """A `SORT BY` clause like in `SELECT`."""
 
     type = "sortby_clause"
-    match_grammar: Matchable = StartsWith(
-        Sequence("SORT", "BY"),
-        terminator=ansi.OrderByClauseSegment.match_grammar.terminator,  # type: ignore
-    )
-    parse_grammar: Optional[Matchable] = Sequence(
+    match_grammar: Matchable = Sequence(
         "SORT",
         "BY",
         Indent,

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -1,5 +1,4 @@
 """The Hive dialect."""
-from typing import Optional
 
 from sqlfluff.core.parser import (
     AnyNumberOf,

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -608,12 +608,7 @@ class DeleteUsingClauseSegment(BaseSegment):
     """A `USING` clause froma `DELETE` Statement`."""
 
     type = "using_clause"
-    match_grammar = StartsWith(
-        "USING",
-        terminator=Ref("FromClauseTerminatorGrammar"),
-        enforce_whitespace_preceding_terminator=True,
-    )
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "USING",
         Delimited(
             Ref("FromExpressionSegment"),

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1462,18 +1462,7 @@ class CubeRollupClauseSegment(BaseSegment):
     """
 
     type = "cube_rollup_clause"
-    match_grammar = StartsWith(
-        OneOf("CUBE", "ROLLUP"),
-        terminator=OneOf(
-            "HAVING",
-            "QUALIFY",
-            Sequence("ORDER", "BY"),
-            "LIMIT",
-            "WINDOW",
-            Ref("SetOperatorSegment"),
-        ),
-    )
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         OneOf("CUBE", "ROLLUP"),
         Bracketed(
             Ref("GroupingExpressionList"),
@@ -1488,18 +1477,7 @@ class GroupingSetsClauseSegment(BaseSegment):
     """
 
     type = "grouping_sets_clause"
-    match_grammar = StartsWith(
-        Sequence("GROUPING", "SETS"),
-        terminator=OneOf(
-            "HAVING",
-            "QUALIFY",
-            Sequence("ORDER", "BY"),
-            "LIMIT",
-            "WINDOW",
-            Ref("SetOperatorSegment"),
-        ),
-    )
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "GROUPING",
         "SETS",
         Bracketed(
@@ -1528,19 +1506,7 @@ class GroupByClauseSegment(BaseSegment):
     """A `GROUP BY` clause like in `SELECT`."""
 
     type = "groupby_clause"
-    match_grammar = StartsWith(
-        Sequence("GROUP", "BY"),
-        terminator=OneOf(
-            Sequence("ORDER", "BY"),
-            "LIMIT",
-            "HAVING",
-            "QUALIFY",
-            "WINDOW",
-            Ref("SetOperatorSegment"),
-        ),
-        enforce_whitespace_preceding_terminator=True,
-    )
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "GROUP",
         "BY",
         Indent,

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2508,8 +2508,7 @@ class FunctionSegment(ansi.FunctionSegment):
 class FromClauseSegment(ansi.FromClauseSegment):
     """Slightly modified version which allows for using brackets for content of FROM."""
 
-    match_grammar = ansi.FromClauseSegment.match_grammar
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "FROM",
         Delimited(
             OptionallyBracketed(Ref("FromExpressionSegment")),

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -828,12 +828,7 @@ class GroupByClauseSegment(ansi.GroupByClauseSegment):
     https://docs.snowflake.com/en/sql-reference/constructs/group-by.html
     """
 
-    match_grammar: Matchable = StartsWith(
-        Sequence("GROUP", "BY"),
-        terminator=Ref("GroupByClauseTerminatorGrammar"),
-        enforce_whitespace_preceding_terminator=True,
-    )
-    parse_grammar: Optional[Matchable] = Sequence(
+    match_grammar: Matchable = Sequence(
         "GROUP",
         "BY",
         Indent,
@@ -1093,6 +1088,7 @@ class FromExpressionElementSegment(ansi.FromExpressionElementSegment):
         Ref(
             "AliasExpressionSegment",
             exclude=OneOf(
+                Ref("FromClauseTerminatorGrammar"),
                 Ref("SamplingExpressionSegment"),
                 Ref("ChangesClauseSegment"),
                 Ref("JoinLikeClauseGrammar"),
@@ -1398,16 +1394,7 @@ class QualifyClauseSegment(BaseSegment):
     """
 
     type = "qualify_clause"
-    match_grammar = StartsWith(
-        "QUALIFY",
-        terminator=OneOf(
-            Sequence("ORDER", "BY"),
-            "LIMIT",
-            "FETCH",
-            "OFFSET",
-        ),
-    )
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "QUALIFY",
         Indent,
         OneOf(
@@ -6277,8 +6264,7 @@ class OrderByClauseSegment(ansi.OrderByClauseSegment):
     https://docs.snowflake.com/en/sql-reference/constructs/order-by.html
     """
 
-    match_grammar = ansi.OrderByClauseSegment.match_grammar.copy()
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "ORDER",
         "BY",
         Indent,

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -4,7 +4,6 @@ Inherits from ANSI.
 
 Based on https://docs.snowflake.com/en/sql-reference-commands.html
 """
-from typing import Optional
 
 from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -696,8 +696,7 @@ class FromUpdateClauseSegment(BaseSegment):
     """A `FROM` clause like in `SELECT` but terminated by SET."""
 
     type = "from_in_update_clause"
-    match_grammar = StartsWith("FROM", terminator=Ref.keyword("SET"))
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "FROM",
         Delimited(
             # Optional old school delimited joins
@@ -745,12 +744,7 @@ class QualifyClauseSegment(BaseSegment):
     """A `QUALIFY` clause like in `SELECT`."""
 
     type = "qualify_clause"
-    match_grammar = StartsWith(
-        "QUALIFY",
-        terminator=OneOf(Sequence("ORDER", "BY"), "LIMIT", "QUALIFY", "WINDOW"),
-        enforce_whitespace_preceding_terminator=True,
-    )
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "QUALIFY",
         Indent,
         OptionallyBracketed(Ref("ExpressionSegment")),

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -430,7 +430,6 @@ tsql_dialect.replace(
     ),
     FromClauseTerminatorGrammar=OneOf(
         "WHERE",
-        "LIMIT",
         Sequence("GROUP", "BY"),
         Sequence("ORDER", "BY"),
         "HAVING",

--- a/test/fixtures/dialects/exasol/AlterTableDistributePartition.yml
+++ b/test/fixtures/dialects/exasol/AlterTableDistributePartition.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 143f272ccdb4017c7171fe3e38109963c67a2871f50313aad6815ea0c0c4a379
+_hash: 70378d3650e57431fc47fb48dc6e68eae04241f3a5e101bc929d22134e967574
 file:
 - statement:
     alter_table_statement:
@@ -60,12 +60,13 @@ file:
         - column_reference:
             naked_identifier: order_date
         - comma: ','
+        - keyword: DISTRIBUTE
+        - keyword: BY
         - column_reference:
-            naked_identifier: DISTRIBUTE
-        - code: BY
-        - code: shop_id
+            naked_identifier: shop_id
         - comma: ','
-        - code: branch_no
+        - column_reference:
+            naked_identifier: branch_no
 - statement_terminator: ;
 - statement:
     alter_table_statement:

--- a/test/fixtures/templater/jinja_l_metas/001.yml
+++ b/test/fixtures/templater/jinja_l_metas/001.yml
@@ -42,8 +42,8 @@ file:
                       - dot: .
                       - naked_identifier: SNAPSHOT_DAILY
                   dedent: ''
-            - newline: "\n"
-            - whitespace: '    '
+              - newline: "\n"
+              - whitespace: '    '
             - where_clause:
                 keyword: WHERE
                 indent: ''

--- a/test/fixtures/templater/jinja_l_metas/009.yml
+++ b/test/fixtures/templater/jinja_l_metas/009.yml
@@ -19,19 +19,19 @@ file:
     - newline: "\n"
     - dedent: ""
     - from_clause:
-        keyword: FROM
-        whitespace: ' '
-        from_expression:
+      - keyword: FROM
+      - whitespace: ' '
+      - from_expression:
           indent: ""
           from_expression_element:
             table_expression:
               table_reference:
                 naked_identifier: a
           dedent: ""
-    - newline: "\n"
-    - dedent: ""
-    - placeholder: '{% endif %}'
-    - newline: "\n"
+      - newline: "\n"
+      - dedent: ""
+      - placeholder: '{% endif %}'
+      - newline: "\n"
     - limit_clause:
         keyword: LIMIT
         indent: ""


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Greedy matchers are less performant than their non-greedy equivalent. they're also more prone to over-matching. This PR removes most uses of StartsWith() - with a view to deprecate in the medium term. Of all of these changes, only one change has happened to the parse fixtures - and it's an improvement! There are a few StartsWith instances left, these have proven tricker to excise, so I figured I'd spin them off into a separate PR.

This also speeds up parsing of some of my large files by 5-10%

### Are there any other side effects of this change that we should be aware of?
It changes the parse tree position of some trailing whitespace. But this is due to an inconsistency between GreedyMatch and Sequence. GreedyMatch discards trailing whitespace, Sequence does not. Either are fine, but we should be consistent - and hopefully, we should be able to remove GreedyMatch soon

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
