### PR TITLE
Support hive set syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -622,6 +622,7 @@ class SetStatementSegment(BaseSegment):
 
     https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Commands
     """
+
     type = "set_statement"
 
     match_grammar = Sequence(

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -617,6 +617,36 @@ class TruncateStatementSegment(BaseSegment):
     )
 
 
+class SetStatementSegment(BaseSegment):
+    """A `SET` statement.
+
+    https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Commands
+    """
+    type = "set_statement"
+
+    match_grammar = Sequence(
+        "SET",
+        OneOf(
+            # set -v
+            Sequence(
+                StringParser("-", SymbolSegment, type="option_indicator"),
+                StringParser("v", CodeSegment, type="option"),
+            ),
+            # set key = value
+            Sequence(
+                Delimited(
+                    Ref("ParameterNameSegment"),
+                    delimiter=OneOf(Ref("DotSegment"), Ref("ColonSegment")),
+                    allow_gaps=False,
+                ),
+                Ref("RawEqualsSegment"),
+                Ref("LiteralGrammar"),
+            ),
+            optional=True,
+        ),
+    )
+
+
 class StatementSegment(ansi.StatementSegment):
     """Overriding StatementSegment to allow for additional segment parsing."""
 
@@ -625,6 +655,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("AlterDatabaseStatementSegment"),
             Ref("MsckRepairTableStatementSegment"),
             Ref("MsckTableStatementSegment"),
+            Ref("SetStatementSegment"),
         ],
         remove=[
             Ref("TransactionStatementSegment"),

--- a/test/fixtures/dialects/hive/set.sql
+++ b/test/fixtures/dialects/hive/set.sql
@@ -1,0 +1,6 @@
+set;
+set -v;
+set foo = 2;
+set foo = 'bar';
+set hivevar:cat="Chloe";
+set mapreduce.reduce.memory.mb=12000;

--- a/test/fixtures/dialects/hive/set.yml
+++ b/test/fixtures/dialects/hive/set.yml
@@ -1,0 +1,53 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 28480208516434a2a38f62344f144b1d65f61ea882e57490b7748bc787c69081
+file:
+- statement:
+    set_statement:
+      keyword: set
+- statement_terminator: ;
+- statement:
+    set_statement:
+      keyword: set
+      option_indicator: '-'
+      option: v
+- statement_terminator: ;
+- statement:
+    set_statement:
+      keyword: set
+      parameter: foo
+      raw_comparison_operator: '='
+      numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    set_statement:
+      keyword: set
+      parameter: foo
+      raw_comparison_operator: '='
+      quoted_literal: "'bar'"
+- statement_terminator: ;
+- statement:
+    set_statement:
+    - keyword: set
+    - parameter: hivevar
+    - colon: ':'
+    - parameter: cat
+    - raw_comparison_operator: '='
+    - quoted_literal: '"Chloe"'
+- statement_terminator: ;
+- statement:
+    set_statement:
+    - keyword: set
+    - parameter: mapreduce
+    - dot: .
+    - parameter: reduce
+    - dot: .
+    - parameter: memory
+    - dot: .
+    - parameter: mb
+    - raw_comparison_operator: '='
+    - numeric_literal: '12000'
+- statement_terminator: ;


### PR DESCRIPTION
This resolves #3560 and resolves #1768. Two quite old issues. My parsing structure for the `set -v` command is perhaps a little non-standard, but I think the implications of that are small and we can always clean it up later if anyone builds on this work.