### PR TITLE
SQLite: Support CreateTrigger

### DIFF
--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -368,25 +368,6 @@ class ColumnConstraintSegment(ansi.ColumnConstraintSegment):
     )
 
 
-class SelectClauseSegment(ansi.SelectClauseSegment):
-    """A group of elements in a select target statement."""
-
-    type = "select_clause"
-    match_grammar: Matchable = StartsWith(
-        "SELECT",
-        terminator=OneOf(
-            "FROM",
-            "WHERE",
-            Sequence("ORDER", "BY"),
-            "LIMIT",
-            Ref("SetOperatorSegment"),
-        ),
-        enforce_whitespace_preceding_terminator=True,
-    )
-
-    parse_grammar: Matchable = Ref("SelectClauseSegmentGrammar")
-
-
 class TableConstraintSegment(ansi.TableConstraintSegment):
     """Overriding TableConstraintSegment to allow for additional segment parsing."""
 

--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -18,6 +18,7 @@ from sqlfluff.core.parser import (
     AnyNumberOf,
     Anything,
     StartsWith,
+    Dedent,
 )
 from sqlfluff.dialects import dialect_ansi as ansi
 from sqlfluff.dialects.dialect_sqlite_keywords import (
@@ -490,12 +491,108 @@ class PragmaStatementSegment(BaseSegment):
     )
 
 
+class CreateTriggerStatementSegment(ansi.CreateTriggerStatementSegment):
+    """Create Trigger Statement.
+
+    https://www.sqlite.org/lang_createtrigger.html
+    """
+
+    type = "create_trigger"
+
+    match_grammar: Matchable = Sequence(
+        "CREATE",
+        Ref("TemporaryGrammar", optional=True),
+        "TRIGGER",
+        Ref("IfNotExistsGrammar", optional=True),
+        Ref("TriggerReferenceSegment"),
+        OneOf("BEFORE", "AFTER", Sequence("INSTEAD", "OF"), optional=True),
+        OneOf(
+            "DELETE",
+            "INSERT",
+            Sequence(
+                "UPDATE",
+                Sequence(
+                    "OF",
+                    Delimited(
+                        Ref("ColumnReferenceSegment"),
+                    ),
+                    optional=True,
+                ),
+            ),
+        ),
+        "ON",
+        Ref("TableReferenceSegment"),
+        Sequence("FOR", "EACH", "ROW", optional=True),
+        Sequence("WHEN", Bracketed(Ref("ExpressionSegment")), optional=True),
+        "BEGIN",
+        Delimited(
+            Ref("UpdateStatementSegment"),
+            Ref("InsertStatementSegment"),
+            Ref("DeleteStatementSegment"),
+            Ref("SelectableGrammar"),
+            delimiter=AnyNumberOf(Ref("DelimiterGrammar"), min_times=1),
+            allow_gaps=True,
+            allow_trailing=True,
+        ),
+        "END",
+    )
+
+
+class SelectClauseSegment(BaseSegment):
+    """A group of elements in a select target statement.
+
+    Overriding ANSI to remove StartsWith logic which assumes statements have been
+    delimited
+    """
+
+    type = "select_clause"
+    match_grammar = Ref("SelectClauseSegmentGrammar")
+
+
+class UnorderedSelectStatementSegment(BaseSegment):
+    """A `SELECT` statement without any ORDER clauses or later.
+
+    Replaces (without overriding) ANSI to remove Greedy Matcher
+    """
+
+    type = "select_statement"
+
+    match_grammar = Sequence(
+        Ref("SelectClauseSegment"),
+        # Dedent for the indent in the select clause.
+        # It's here so that it can come AFTER any whitespace.
+        Dedent,
+        Ref("FromClauseSegment", optional=True),
+        Ref("WhereClauseSegment", optional=True),
+        Ref("GroupByClauseSegment", optional=True),
+        Ref("HavingClauseSegment", optional=True),
+        Ref("OverlapsClauseSegment", optional=True),
+        Ref("NamedWindowSegment", optional=True),
+    )
+
+
+class SelectStatementSegment(BaseSegment):
+    """A `SELECT` statement.
+
+    Replaces (without overriding) ANSI to remove Greedy Matcher
+    """
+
+    type = "select_statement"
+    # Remove the Limit and Window statements from ANSI
+    match_grammar = UnorderedSelectStatementSegment.match_grammar.copy(
+        insert=[
+            Ref("OrderByClauseSegment", optional=True),
+            Ref("FetchClauseSegment", optional=True),
+            Ref("LimitClauseSegment", optional=True),
+            Ref("NamedWindowSegment", optional=True),
+        ]
+    )
+
+
 class StatementSegment(ansi.StatementSegment):
     """Overriding StatementSegment to allow for additional segment parsing."""
 
-    match_grammar = ansi.StatementSegment.match_grammar
-
-    parse_grammar: Matchable = OneOf(
+    match_grammar = OneOf(
         Ref("AlterTableStatementSegment"),
         Ref("CreateIndexStatementSegment"),
         Ref("CreateTableStatementSegment"),
@@ -514,3 +611,5 @@ class StatementSegment(ansi.StatementSegment):
         Ref("UpdateStatementSegment"),
         Bracketed(Ref("StatementSegment")),
     )
+
+    parse_grammar = match_grammar

--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -17,7 +17,6 @@ from sqlfluff.core.parser import (
     Nothing,
     AnyNumberOf,
     Anything,
-    StartsWith,
     Dedent,
 )
 from sqlfluff.dialects import dialect_ansi as ansi

--- a/test/fixtures/dialects/sqlite/create_trigger.sql
+++ b/test/fixtures/dialects/sqlite/create_trigger.sql
@@ -1,1 +1,50 @@
-CREATE TRIGGER update_customer_address UPDATE OF address ON customers;
+CREATE TRIGGER update_customer_address UPDATE OF address ON customers
+  BEGIN
+    UPDATE orders SET address = new.address WHERE customer_name = old.name;
+  END;
+
+CREATE TRIGGER cust_addr_chng
+INSTEAD OF UPDATE OF cust_addr ON customer_address
+BEGIN
+  UPDATE customer SET cust_addr=NEW.cust_addr
+   WHERE cust_id=NEW.cust_id;
+END;
+
+CREATE TRIGGER validate_email_before_insert_leads
+   BEFORE INSERT ON leads
+BEGIN
+   SELECT 1;
+END;
+
+CREATE TRIGGER log_contact_after_update
+   AFTER UPDATE ON leads
+BEGIN
+	INSERT INTO lead_logs (
+		old_id,
+		new_id,
+		old_phone,
+		new_phone,
+		old_email,
+		new_email,
+		user_action,
+		created_at
+	)
+VALUES
+	(
+		old.id,
+		new.id,
+		old.phone,
+		new.phone,
+		old.email,
+		new.email,
+		'UPDATE'
+	) ;
+END;
+
+CREATE TRIGGER aft_insert AFTER INSERT ON emp_details
+BEGIN
+INSERT INTO emp_log(emp_id,salary,edittime)
+         VALUES(NEW.employee_id,NEW.salary,current_date);
+END;
+
+

--- a/test/fixtures/dialects/sqlite/create_trigger.yml
+++ b/test/fixtures/dialects/sqlite/create_trigger.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c2944bc2a520f5fffd2769dfc50ba9c5d0fe45b03bb15fba514fafb7fd109d4a
+_hash: a6c6cd83844198daf4513a642932e69466dd2c90d887929b24e9d6577e8d120c
 file:
-  statement:
+- statement:
     create_trigger:
     - keyword: CREATE
     - keyword: TRIGGER
@@ -18,4 +18,237 @@ file:
     - keyword: 'ON'
     - table_reference:
         naked_identifier: customers
-  statement_terminator: ;
+    - keyword: BEGIN
+    - update_statement:
+        keyword: UPDATE
+        table_reference:
+          naked_identifier: orders
+        set_clause_list:
+          keyword: SET
+          set_clause:
+          - column_reference:
+              naked_identifier: address
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: new
+            - dot: .
+            - naked_identifier: address
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+              naked_identifier: customer_name
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: old
+            - dot: .
+            - naked_identifier: name
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: cust_addr_chng
+    - keyword: INSTEAD
+    - keyword: OF
+    - keyword: UPDATE
+    - keyword: OF
+    - column_reference:
+        naked_identifier: cust_addr
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: customer_address
+    - keyword: BEGIN
+    - update_statement:
+        keyword: UPDATE
+        table_reference:
+          naked_identifier: customer
+        set_clause_list:
+          keyword: SET
+          set_clause:
+          - column_reference:
+              naked_identifier: cust_addr
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: NEW
+            - dot: .
+            - naked_identifier: cust_addr
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+              naked_identifier: cust_id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: NEW
+            - dot: .
+            - naked_identifier: cust_id
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: validate_email_before_insert_leads
+    - keyword: BEFORE
+    - keyword: INSERT
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: leads
+    - keyword: BEGIN
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            numeric_literal: '1'
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: log_contact_after_update
+    - keyword: AFTER
+    - keyword: UPDATE
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: leads
+    - keyword: BEGIN
+    - insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: lead_logs
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: old_id
+        - comma: ','
+        - column_reference:
+            naked_identifier: new_id
+        - comma: ','
+        - column_reference:
+            naked_identifier: old_phone
+        - comma: ','
+        - column_reference:
+            naked_identifier: new_phone
+        - comma: ','
+        - column_reference:
+            naked_identifier: old_email
+        - comma: ','
+        - column_reference:
+            naked_identifier: new_email
+        - comma: ','
+        - column_reference:
+            naked_identifier: user_action
+        - comma: ','
+        - column_reference:
+            naked_identifier: created_at
+        - end_bracket: )
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+              - naked_identifier: old
+              - dot: .
+              - naked_identifier: id
+          - comma: ','
+          - expression:
+              column_reference:
+              - naked_identifier: new
+              - dot: .
+              - naked_identifier: id
+          - comma: ','
+          - expression:
+              column_reference:
+              - naked_identifier: old
+              - dot: .
+              - naked_identifier: phone
+          - comma: ','
+          - expression:
+              column_reference:
+              - naked_identifier: new
+              - dot: .
+              - naked_identifier: phone
+          - comma: ','
+          - expression:
+              column_reference:
+              - naked_identifier: old
+              - dot: .
+              - naked_identifier: email
+          - comma: ','
+          - expression:
+              column_reference:
+              - naked_identifier: new
+              - dot: .
+              - naked_identifier: email
+          - comma: ','
+          - expression:
+              quoted_literal: "'UPDATE'"
+          - end_bracket: )
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: aft_insert
+    - keyword: AFTER
+    - keyword: INSERT
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: emp_details
+    - keyword: BEGIN
+    - insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: emp_log
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: emp_id
+        - comma: ','
+        - column_reference:
+            naked_identifier: salary
+        - comma: ','
+        - column_reference:
+            naked_identifier: edittime
+        - end_bracket: )
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+              - naked_identifier: NEW
+              - dot: .
+              - naked_identifier: employee_id
+          - comma: ','
+          - expression:
+              column_reference:
+              - naked_identifier: NEW
+              - dot: .
+              - naked_identifier: salary
+          - comma: ','
+          - expression:
+              bare_function: current_date
+          - end_bracket: )
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
This PR gives SQLite support for CreateTrigger. In doing so, StatementSegment could no longer use the Greedy matcher, as Delimited statements can exist inside the statement. Several of the SelectStatement grammar pieces have also been displaced for the same reason. I've gathered several examples of CreateTrigger from the sqlite docs and other sources to test.

Fixes #1846 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
