### PR TITLE
Fix #4540: Untaken indents evaluation order.

### DIFF
--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2024,3 +2024,23 @@ test_pass_issue_4582:
     /* Single line comment 2 */
     inner join b
         on a.id = b.id
+
+test_pass_issue_4540:
+  # https://github.com/sqlfluff/sqlfluff/issues/4540
+  pass_str: |
+    with cte as (
+        select a
+        from b
+        qualify row_number() over (
+            partition by a
+        ) = 1
+    )
+
+    select a
+    from cte
+    qualify row_number() over (
+        partition by a
+    ) = 1;
+  configs:
+    core:
+      dialect: snowflake


### PR DESCRIPTION
I think the part of code which I've covered here is now getting pretty mature, so this bug was a little hard to pinpoint - but I think the crux is that we should evaluate untaken indents _outward in_ (i.e. backwards) rather than forwards. This means that the right priority is given in locating potential indents to force. This resolves #4540 .