### PR TITLE
SQLite: Fix multiple parse issues in Expression_A_Grammar

### DIFF
--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -154,81 +154,15 @@ sqlite_dialect.replace(
         ),
         Ref("IndexColumnDefinitionSegment"),
     ),
-    Expression_A_Grammar=Sequence(
-        OneOf(
-            Ref("Expression_C_Grammar"),
-            Sequence(
-                OneOf(
-                    Ref("SignedSegmentGrammar"),
-                    # Ref('TildeSegment'),
-                    Ref("NotOperatorGrammar"),
-                    # used in CONNECT BY clauses (EXASOL, Snowflake, Postgres...)
-                ),
-                Ref("Expression_C_Grammar"),
-            ),
+    # NOTE: This block was copy/pasted from dialect_ansi.py with these changes made:
+    #  - "PRIOR" keyword removed from Expression_A_Unary_Operator_Grammar
+    Expression_A_Unary_Operator_Grammar=OneOf(
+        Ref(
+            "SignedSegmentGrammar",
+            exclude=Sequence(Ref("QualifiedNumericLiteralSegment")),
         ),
-        AnyNumberOf(
-            OneOf(
-                Sequence(
-                    OneOf(
-                        Sequence(
-                            Ref.keyword("NOT", optional=True),
-                            Ref("LikeGrammar"),
-                        ),
-                        Sequence(
-                            Ref("BinaryOperatorGrammar"),
-                            Ref.keyword("NOT", optional=True),
-                        ),
-                        # We need to add a lot more here...
-                    ),
-                    Ref("Expression_C_Grammar"),
-                    Sequence(
-                        Ref.keyword("ESCAPE"),
-                        Ref("Expression_C_Grammar"),
-                        optional=True,
-                    ),
-                ),
-                Sequence(
-                    Ref.keyword("NOT", optional=True),
-                    "IN",
-                    Bracketed(
-                        OneOf(
-                            Delimited(
-                                Ref("Expression_A_Grammar"),
-                            ),
-                            Ref("SelectableGrammar"),
-                            ephemeral_name="InExpression",
-                        )
-                    ),
-                ),
-                Sequence(
-                    Ref.keyword("NOT", optional=True),
-                    "IN",
-                    Ref("FunctionSegment"),  # E.g. UNNEST()
-                ),
-                Sequence(
-                    "IS",
-                    Ref.keyword("NOT", optional=True),
-                    Ref("IsClauseGrammar"),
-                ),
-                Ref("IsNullGrammar"),
-                Ref("NotNullGrammar"),
-                Ref("CollateGrammar"),
-                Sequence(
-                    # e.g. NOT EXISTS, but other expressions could be met as
-                    # well by inverting the condition with the NOT operator
-                    "NOT",
-                    Ref("Expression_C_Grammar"),
-                ),
-                Sequence(
-                    Ref.keyword("NOT", optional=True),
-                    "BETWEEN",
-                    Ref("Expression_B_Grammar"),
-                    "AND",
-                    Ref("Expression_A_Grammar"),
-                ),
-            )
-        ),
+        Ref("TildeSegment"),
+        Ref("NotOperatorGrammar"),
     ),
 )
 

--- a/test/fixtures/dialects/sqlite/arithmetric_a.sql
+++ b/test/fixtures/dialects/sqlite/arithmetric_a.sql
@@ -1,0 +1,49 @@
+SELECT 1 + (2 * 3) >= 4 + 6+13 as val;
+
+SELECT 1 + ~(~2 * 3) >= 4 + ~6+13 as val;
+
+SELECT -1;
+
+SELECT -1 + 5;
+
+SELECT ~1;
+
+SELECT -1 + ~5;
+
+SELECT 4 & ~8 | 16;
+
+SELECT 8 + ~(3);
+
+SELECT 8 | ~ ~ ~4;
+
+SELECT 1 * -(5);
+
+SELECT 1 * -5;
+
+SELECT 1 * - - - 5;
+
+SELECT 1 * - - - (5);
+
+SELECT 1 * + + (5);
+
+SELECT 1 * - - - func(5);
+
+SELECT 1 * ~ ~ ~ func(5);
+
+SELECT 1 * +(5);
+
+SELECT 1 * +5;
+
+SELECT 1 * + + 5;
+
+SELECT FALSE AND NOT (TRUE);
+
+SELECT FALSE AND NOT NOT NOT (TRUE); -- parses middle NOT as column ref
+
+SELECT FALSE AND NOT (TRUE);
+
+SELECT FALSE AND NOT func(5);
+
+SELECT 'abc' LIKE - - 5; -- PG can parse this ok, and then fail due to data type mismatch
+
+SELECT 'abc' LIKE ~ ~ 5; -- PG can parse this ok, and then fail due to data type mismatch

--- a/test/fixtures/dialects/sqlite/arithmetric_a.yml
+++ b/test/fixtures/dialects/sqlite/arithmetric_a.yml
@@ -1,0 +1,395 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 68162fcf003cf96cc1361038a52f8a6da37d5bee87037883ce33a4f2c011cf6f
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '1'
+          - binary_operator: +
+          - bracketed:
+              start_bracket: (
+              expression:
+              - numeric_literal: '2'
+              - binary_operator: '*'
+              - numeric_literal: '3'
+              end_bracket: )
+          - comparison_operator:
+            - raw_comparison_operator: '>'
+            - raw_comparison_operator: '='
+          - numeric_literal: '4'
+          - binary_operator: +
+          - numeric_literal: '6'
+          - binary_operator: +
+          - numeric_literal: '13'
+          alias_expression:
+            keyword: as
+            naked_identifier: val
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '1'
+          - binary_operator: +
+          - tilde: '~'
+          - bracketed:
+              start_bracket: (
+              expression:
+              - tilde: '~'
+              - numeric_literal: '2'
+              - binary_operator: '*'
+              - numeric_literal: '3'
+              end_bracket: )
+          - comparison_operator:
+            - raw_comparison_operator: '>'
+            - raw_comparison_operator: '='
+          - numeric_literal: '4'
+          - binary_operator: +
+          - tilde: '~'
+          - numeric_literal: '6'
+          - binary_operator: +
+          - numeric_literal: '13'
+          alias_expression:
+            keyword: as
+            naked_identifier: val
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal:
+            sign_indicator: '-'
+            numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal:
+              sign_indicator: '-'
+              numeric_literal: '1'
+          - binary_operator: +
+          - numeric_literal: '5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            tilde: '~'
+            numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal:
+              sign_indicator: '-'
+              numeric_literal: '1'
+          - binary_operator: +
+          - tilde: '~'
+          - numeric_literal: '5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '4'
+          - binary_operator:
+              ampersand: '&'
+          - tilde: '~'
+          - numeric_literal: '8'
+          - binary_operator:
+              pipe: '|'
+          - numeric_literal: '16'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            numeric_literal: '8'
+            binary_operator: +
+            tilde: '~'
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '3'
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '8'
+          - binary_operator:
+              pipe: '|'
+          - tilde: '~'
+          - tilde: '~'
+          - tilde: '~'
+          - numeric_literal: '4'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            numeric_literal: '1'
+            binary_operator: '*'
+            sign_indicator: '-'
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '5'
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '1'
+          - binary_operator: '*'
+          - numeric_literal:
+              sign_indicator: '-'
+              numeric_literal: '5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '1'
+          - binary_operator: '*'
+          - sign_indicator: '-'
+          - sign_indicator: '-'
+          - numeric_literal:
+              sign_indicator: '-'
+              numeric_literal: '5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '1'
+          - binary_operator: '*'
+          - sign_indicator: '-'
+          - sign_indicator: '-'
+          - sign_indicator: '-'
+          - bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '5'
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '1'
+          - binary_operator: '*'
+          - sign_indicator: +
+          - sign_indicator: +
+          - bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '5'
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '1'
+          - binary_operator: '*'
+          - sign_indicator: '-'
+          - sign_indicator: '-'
+          - sign_indicator: '-'
+          - function:
+              function_name:
+                function_name_identifier: func
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '5'
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '1'
+          - binary_operator: '*'
+          - tilde: '~'
+          - tilde: '~'
+          - tilde: '~'
+          - function:
+              function_name:
+                function_name_identifier: func
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '5'
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            numeric_literal: '1'
+            binary_operator: '*'
+            sign_indicator: +
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '5'
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '1'
+          - binary_operator: '*'
+          - numeric_literal:
+              sign_indicator: +
+              numeric_literal: '5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '1'
+          - binary_operator: '*'
+          - sign_indicator: +
+          - numeric_literal:
+              sign_indicator: +
+              numeric_literal: '5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            boolean_literal: 'FALSE'
+            binary_operator: AND
+            keyword: NOT
+            bracketed:
+              start_bracket: (
+              expression:
+                boolean_literal: 'TRUE'
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - boolean_literal: 'FALSE'
+          - binary_operator: AND
+          - keyword: NOT
+          - keyword: NOT
+          - keyword: NOT
+          - bracketed:
+              start_bracket: (
+              expression:
+                boolean_literal: 'TRUE'
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            boolean_literal: 'FALSE'
+            binary_operator: AND
+            keyword: NOT
+            bracketed:
+              start_bracket: (
+              expression:
+                boolean_literal: 'TRUE'
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            boolean_literal: 'FALSE'
+            binary_operator: AND
+            keyword: NOT
+            function:
+              function_name:
+                function_name_identifier: func
+              bracketed:
+                start_bracket: (
+                expression:
+                  numeric_literal: '5'
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            quoted_literal: "'abc'"
+            keyword: LIKE
+            sign_indicator: '-'
+            numeric_literal:
+              sign_indicator: '-'
+              numeric_literal: '5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - quoted_literal: "'abc'"
+          - keyword: LIKE
+          - tilde: '~'
+          - tilde: '~'
+          - numeric_literal: '5'
+- statement_terminator: ;


### PR DESCRIPTION
This commit copies over the changes from #4717 into the SQLite grammar, since it had been copy/pasted.

The change was made by diffing the original Expression_A_Grammar from before #4717 was merged, against the current SQLite implementation. I only found the one difference being removal of "PRIOR" keyword, so I only override Expression_A_Unary_Operator_Grammar so that can be removed.

Also the tests were copied verbatim from the ANSI dialect tests.

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
