### PR TITLE
Use the new CollationReferenceSegment everywhere

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1074,6 +1074,20 @@ class CollationReferenceSegment(ObjectReferenceSegment):
     """A reference to a collation."""
 
     type = "collation_reference"
+    # Some dialects like PostgreSQL want an identifier only, and quoted
+    # literals aren't allowed.  Other dialects like Snowflake only accept
+    # a quoted string literal.  We'll be a little overly-permissive and
+    # accept either... it shouldn't be too greedy since this segment generally
+    # occurs only in a Sequence after the "COLLATE" keyword.
+    match_grammar: Matchable = OneOf(
+        Ref("QuotedLiteralSegment"),
+        Delimited(
+            Ref("SingleIdentifierGrammar"),
+            delimiter=Ref("ObjectReferenceDelimiterGrammar"),
+            terminator=Ref("ObjectReferenceTerminatorGrammar"),
+            allow_gaps=False,
+        ),
+    )
 
 
 class RoleReferenceSegment(ObjectReferenceSegment):

--- a/src/sqlfluff/dialects/dialect_greenplum.py
+++ b/src/sqlfluff/dialects/dialect_greenplum.py
@@ -61,7 +61,7 @@ class CreateTableStatementSegment(postgres.CreateTableStatementSegment):
                                         Ref("ColumnConstraintSegment"),
                                         Sequence(
                                             "COLLATE",
-                                            Ref("ObjectReferenceSegment"),
+                                            Ref("CollationReferenceSegment"),
                                         ),
                                     ),
                                 ),
@@ -135,7 +135,7 @@ class CreateTableStatementSegment(postgres.CreateTableStatementSegment):
                                 AnyNumberOf(
                                     Sequence(
                                         "COLLATE",
-                                        Ref("QuotedLiteralSegment"),
+                                        Ref("CollationReferenceSegment"),
                                         optional=True,
                                     ),
                                     Ref("ParameterNameSegment", optional=True),

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -659,7 +659,7 @@ class ColumnConstraintSegment(ansi.ColumnConstraintSegment):
     match_grammar: Matchable = OneOf(
         ansi.ColumnConstraintSegment.match_grammar,
         Sequence("CHARACTER", "SET", Ref("NakedIdentifierSegment")),
-        Sequence("COLLATE", Ref("NakedIdentifierSegment")),
+        Sequence("COLLATE", Ref("CollationReferenceSegment")),
     )
 
 
@@ -2605,7 +2605,7 @@ class CreateOptionSegment(BaseSegment):
             Sequence(
                 "COLLATE",
                 Ref("EqualsSegment", optional=True),
-                Ref("NakedIdentifierSegment"),
+                Ref("CollationReferenceSegment"),
             ),
             Sequence(
                 "ENCRYPTION",
@@ -2651,7 +2651,7 @@ class AlterOptionSegment(BaseSegment):
                 Ref.keyword("DEFAULT", optional=True),
                 "COLLATE",
                 Ref("EqualsSegment", optional=True),
-                Ref("NakedIdentifierSegment"),
+                Ref("CollationReferenceSegment"),
             ),
             Sequence(
                 Ref.keyword("DEFAULT", optional=True),

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1766,7 +1766,7 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
                                         Ref("ColumnConstraintSegment"),
                                         Sequence(
                                             "COLLATE",
-                                            Ref("ObjectReferenceSegment"),
+                                            Ref("CollationReferenceSegment"),
                                         ),
                                     ),
                                 ),
@@ -1840,7 +1840,7 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
                                 AnyNumberOf(
                                     Sequence(
                                         "COLLATE",
-                                        Ref("QuotedLiteralSegment"),
+                                        Ref("CollationReferenceSegment"),
                                         optional=True,
                                     ),
                                     Ref("ParameterNameSegment", optional=True),
@@ -2027,7 +2027,7 @@ class AlterTableActionSegment(BaseSegment):
             Ref("IfNotExistsGrammar", optional=True),
             Ref("ColumnReferenceSegment"),
             Ref("DatatypeSegment"),
-            Sequence("COLLATE", Ref("QuotedLiteralSegment"), optional=True),
+            Sequence("COLLATE", Ref("CollationReferenceSegment"), optional=True),
             AnyNumberOf(Ref("ColumnConstraintSegment")),
         ),
         Sequence(
@@ -2046,7 +2046,9 @@ class AlterTableActionSegment(BaseSegment):
                     Sequence("SET", "DATA", optional=True),
                     "TYPE",
                     Ref("DatatypeSegment"),
-                    Sequence("COLLATE", Ref("QuotedLiteralSegment"), optional=True),
+                    Sequence(
+                        "COLLATE", Ref("CollationReferenceSegment"), optional=True
+                    ),
                     Sequence("USING", OneOf(Ref("ExpressionSegment")), optional=True),
                 ),
                 Sequence(
@@ -4148,7 +4150,7 @@ class ConflictTargetSegment(BaseSegment):
                         ),
                         Sequence(
                             "COLLATE",
-                            Ref("QuotedLiteralSegment"),
+                            Ref("CollationReferenceSegment"),
                             optional=True,
                         ),
                         Ref("OperationClassReferenceSegment", optional=True),
@@ -4314,7 +4316,7 @@ class CreateDomainStatementSegment(BaseSegment):
         Ref("ObjectReferenceSegment"),
         Sequence("AS", optional=True),
         Ref("DatatypeSegment"),
-        Sequence("COLLATE", Ref("ObjectReferenceSegment"), optional=True),
+        Sequence("COLLATE", Ref("CollationReferenceSegment"), optional=True),
         Sequence("DEFAULT", Ref("ExpressionSegment"), optional=True),
         AnyNumberOf(
             Sequence(
@@ -4949,7 +4951,7 @@ class AlterTypeStatementSegment(BaseSegment):
                     Ref("DatatypeSegment"),
                     Sequence(
                         "COLLATE",
-                        Ref("QuotedLiteralSegment"),
+                        Ref("CollationReferenceSegment"),
                         optional=True,
                     ),
                     Ref("CascadeRestrictGrammar", optional=True),
@@ -4963,7 +4965,7 @@ class AlterTypeStatementSegment(BaseSegment):
                     Ref("DatatypeSegment"),
                     Sequence(
                         "COLLATE",
-                        Ref("QuotedLiteralSegment"),
+                        Ref("CollationReferenceSegment"),
                         optional=True,
                     ),
                     Ref("CascadeRestrictGrammar", optional=True),

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -682,7 +682,7 @@ class AlterTableActionSegment(BaseSegment):
             Ref("ColumnReferenceSegment"),
             Ref("DatatypeSegment"),
             Sequence("DEFAULT", Ref("ExpressionSegment"), optional=True),
-            Sequence("COLLATE", Ref("QuotedLiteralSegment"), optional=True),
+            Sequence("COLLATE", Ref("CollationReferenceSegment"), optional=True),
             AnyNumberOf(Ref("ColumnConstraintSegment")),
         ),
         Sequence(

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -2912,7 +2912,7 @@ class ColumnConstraintSegment(ansi.ColumnConstraintSegment):
     """
 
     match_grammar = AnySetOf(
-        Sequence("COLLATE", Ref("QuotedLiteralSegment")),
+        Sequence("COLLATE", Ref("CollationReferenceSegment")),
         Sequence(
             "DEFAULT",
             OneOf(

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -275,15 +275,6 @@ tsql_dialect.add(
         Sequence(Ref.keyword("GLOBAL", optional=True), Ref("NakedIdentifierSegment")),
         Ref("ParameterNameSegment"),
     ),
-    CollationSegment=SegmentGenerator(
-        # Generate the anti template from the set of reserved keywords
-        lambda dialect: RegexParser(
-            r"[A-Z][A-Za-z0-9_]*[A-Za-z0-9_]",
-            CodeSegment,
-            type="collation",
-            anti_template=r"^(" + r"|".join(dialect.sets("reserved_keywords")) + r")$",
-        )
-    ),
     SqlcmdOperatorSegment=SegmentGenerator(
         lambda dialect: MultiStringParser(
             dialect.sets("sqlcmd_operators"),
@@ -554,7 +545,7 @@ tsql_dialect.replace(
         Ref("PivotUnpivotStatementSegment"),
         min_times=1,
     ),
-    CollateGrammar=Sequence("COLLATE", Ref("CollationSegment")),
+    CollateGrammar=Sequence("COLLATE", Ref("CollationReferenceSegment")),
 )
 
 
@@ -2150,7 +2141,7 @@ class ColumnConstraintSegment(BaseSegment):
         OneOf(
             "FILESTREAM",
             Sequence(
-                "COLLATE", Ref("ObjectReferenceSegment")
+                "COLLATE", Ref("CollationReferenceSegment")
             ),  # [COLLATE collation_name]
             "SPARSE",
             Sequence(

--- a/test/fixtures/dialects/mysql/alter_database.yml
+++ b/test/fixtures/dialects/mysql/alter_database.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1a3cf1b2d4e056df9b2f63b93f99b8927e62cb596d91f695a4775e1e7a8ba08a
+_hash: 5d0dbcc43a689f9226f66b080216e263fb9711d557ce16897b279cff342bf6d7
 file:
 - statement:
     alter_database_statement:
@@ -18,7 +18,8 @@ file:
       - naked_identifier: utf8mb4
     - alter_option_segment:
         keyword: COLLATE
-        naked_identifier: utf8mb4_0900_ai_ci
+        collation_reference:
+          naked_identifier: utf8mb4_0900_ai_ci
     - alter_option_segment:
       - keyword: DEFAULT
       - keyword: ENCRYPTION
@@ -41,7 +42,8 @@ file:
         keyword: COLLATE
         comparison_operator:
           raw_comparison_operator: '='
-        naked_identifier: utf8mb4_0900_ai_ci
+        collation_reference:
+          naked_identifier: utf8mb4_0900_ai_ci
     - alter_option_segment:
       - keyword: DEFAULT
       - keyword: ENCRYPTION
@@ -62,7 +64,8 @@ file:
       - naked_identifier: utf8mb4
     - alter_option_segment:
         keyword: COLLATE
-        naked_identifier: utf8mb4_0900_ai_ci
+        collation_reference:
+          naked_identifier: utf8mb4_0900_ai_ci
     - alter_option_segment:
       - keyword: DEFAULT
       - keyword: ENCRYPTION

--- a/test/fixtures/dialects/mysql/create_database.yml
+++ b/test/fixtures/dialects/mysql/create_database.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5142ae149abf66ce1a11d844c6ede33d1eee99401cbeda5caa778e8cb0089167
+_hash: d4ddb2e6e7c37d2270c3b4da1083779a7f7c8217fadb6566c35021d6eb462f2c
 file:
 - statement:
     create_database_statement:
@@ -35,7 +35,8 @@ file:
       - naked_identifier: utf8mb4
     - create_option_segment:
         keyword: COLLATE
-        naked_identifier: utf8mb4_0900_ai_ci
+        collation_reference:
+          naked_identifier: utf8mb4_0900_ai_ci
     - create_option_segment:
       - keyword: DEFAULT
       - keyword: ENCRYPTION
@@ -58,7 +59,8 @@ file:
         keyword: COLLATE
         comparison_operator:
           raw_comparison_operator: '='
-        naked_identifier: utf8mb4_0900_ai_ci
+        collation_reference:
+          naked_identifier: utf8mb4_0900_ai_ci
     - create_option_segment:
       - keyword: DEFAULT
       - keyword: ENCRYPTION
@@ -79,7 +81,8 @@ file:
       - naked_identifier: utf8mb4
     - create_option_segment:
         keyword: COLLATE
-        naked_identifier: utf8mb4_0900_ai_ci
+        collation_reference:
+          naked_identifier: utf8mb4_0900_ai_ci
     - create_option_segment:
       - keyword: DEFAULT
       - keyword: ENCRYPTION

--- a/test/fixtures/dialects/mysql/create_table_column_charset.yml
+++ b/test/fixtures/dialects/mysql/create_table_column_charset.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7c7aaa2edf1b20348d4e650e50d76e088af9310c66be309ecf2e0d0d9e70c60e
+_hash: f2c0b6a7781e5ac8b770f06d49f23f0556e6c70e8d26d5485bbeb6bf0f2f041c
 file:
   statement:
     create_table_statement:
@@ -28,6 +28,7 @@ file:
           - naked_identifier: latin1
         - column_constraint_segment:
             keyword: COLLATE
-            naked_identifier: latin1_german1_ci
+            collation_reference:
+              naked_identifier: latin1_german1_ci
         end_bracket: )
   statement_terminator: ;

--- a/test/fixtures/dialects/postgres/postgres_create_table.yml
+++ b/test/fixtures/dialects/postgres/postgres_create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 018c70d55089f99a37e106fa0831d6f42012e7b23f5a4ddfdc15b230df2d45a8
+_hash: f8685cf721a120ea44119298289874b95200715111592d9665c63df372b3bb83
 file:
 - statement:
     create_table_statement:
@@ -1416,7 +1416,7 @@ file:
       - column_constraint_segment:
           keyword: UNIQUE
       - keyword: COLLATE
-      - object_reference:
+      - collation_reference:
           naked_identifier: numeric
       - column_constraint_segment:
         - keyword: NOT
@@ -1435,7 +1435,7 @@ file:
       - column_constraint_segment:
           keyword: UNIQUE
       - keyword: COLLATE
-      - object_reference:
+      - collation_reference:
           naked_identifier: numeric
       - comma: ','
       - column_reference:
@@ -1443,7 +1443,7 @@ file:
       - data_type:
           keyword: text
       - keyword: COLLATE
-      - object_reference:
+      - collation_reference:
           naked_identifier: numeric
       - column_constraint_segment:
         - keyword: NOT
@@ -1500,7 +1500,7 @@ file:
         - tablespace_reference:
             naked_identifier: tblspace
       - keyword: COLLATE
-      - object_reference:
+      - collation_reference:
           naked_identifier: numeric
       - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/snowflake_create_table.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6253e281a173eaa117a9689da502e225a4e0257cbe8794d870bee5fc4ac9b19a
+_hash: 7cb60e2e1d385ed839f00c1ac77930e2b2409ff5c87e7c6561a22bef706b7a7b
 file:
 - statement:
     create_table_statement:
@@ -559,7 +559,8 @@ file:
             data_type_identifier: varchar
           column_constraint_segment:
             keyword: collate
-            quoted_literal: "'utf8'"
+            collation_reference:
+              quoted_literal: "'utf8'"
       - comma: ','
       - column_definition:
           naked_identifier: english_phrase
@@ -567,7 +568,8 @@ file:
             data_type_identifier: varchar
           column_constraint_segment:
             keyword: collate
-            quoted_literal: "'en'"
+            collation_reference:
+              quoted_literal: "'en'"
       - comma: ','
       - column_definition:
           naked_identifier: spanish_phrase
@@ -575,7 +577,8 @@ file:
             data_type_identifier: varchar
           column_constraint_segment:
             keyword: collate
-            quoted_literal: "'sp'"
+            collation_reference:
+              quoted_literal: "'sp'"
       - end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/tsql/collate.yml
+++ b/test/fixtures/dialects/tsql/collate.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6da6849d0cf0e48809d62b8bdfce5180ca01fd95df5005628ca1532711c76fca
+_hash: dca7d5478d7b46625258401d664c36b95e94cffc6a4e046d2f72e1dc54ce2b34
 file:
   batch:
   - statement:
@@ -43,7 +43,8 @@ file:
                   - dot: .
                   - naked_identifier: col
                 - keyword: COLLATE
-                - collation: Latin1_GENERAL_CS_AS
+                - collation_reference:
+                    naked_identifier: Latin1_GENERAL_CS_AS
           statement_terminator: ;
   - statement:
       select_statement:
@@ -76,7 +77,8 @@ file:
                   - dot: .
                   - naked_identifier: col
                 - keyword: COLLATE
-                - collation: Latin1_GENERAL_CS_AS
+                - collation_reference:
+                    naked_identifier: Latin1_GENERAL_CS_AS
                 - comparison_operator:
                     raw_comparison_operator: '='
                 - column_reference:
@@ -105,7 +107,8 @@ file:
             column_reference:
               naked_identifier: col
             keyword: COLLATE
-            collation: Latin1_General_CS_AS_KS_WS
+            collation_reference:
+              naked_identifier: Latin1_General_CS_AS_KS_WS
         - keyword: DESC
         statement_terminator: ;
   - statement:
@@ -117,7 +120,8 @@ file:
               column_reference:
                 naked_identifier: col
               keyword: COLLATE
-              collation: Latin1_General_CS_AS_KS_WS
+              collation_reference:
+                naked_identifier: Latin1_General_CS_AS_KS_WS
         from_clause:
           keyword: FROM
           from_expression:
@@ -135,7 +139,8 @@ file:
               column_reference:
                 naked_identifier: col
               keyword: COLLATE
-              collation: database_default
+              collation_reference:
+                naked_identifier: database_default
         from_clause:
           keyword: FROM
           from_expression:

--- a/test/fixtures/dialects/tsql/create_external_table.yml
+++ b/test/fixtures/dialects/tsql/create_external_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 674327298cc2e1ec4d6325ddb6a906d3af04bf5cc8dfb35b51693ee84ccf9a51
+_hash: 12537be730d551297489fb91ede9e13b1067815a7a5b1a94924a28445c14838a
 file:
   batch:
   - statement:
@@ -224,7 +224,7 @@ file:
               data_type_identifier: CHAR
           - column_constraint_segment:
               keyword: COLLATE
-              object_reference:
+              collation_reference:
                 naked_identifier: latin1_general_bin
           - column_constraint_segment:
             - keyword: NOT
@@ -273,7 +273,7 @@ file:
                   end_bracket: )
           - column_constraint_segment:
               keyword: COLLATE
-              object_reference:
+              collation_reference:
                 naked_identifier: latin1_general_bin
           - column_constraint_segment:
             - keyword: NOT
@@ -291,7 +291,7 @@ file:
                   end_bracket: )
           - column_constraint_segment:
               keyword: COLLATE
-              object_reference:
+              collation_reference:
                 naked_identifier: latin1_general_bin
           - column_constraint_segment:
             - keyword: NOT
@@ -323,7 +323,7 @@ file:
                   end_bracket: )
           - column_constraint_segment:
               keyword: COLLATE
-              object_reference:
+              collation_reference:
                 naked_identifier: latin1_general_bin
           - column_constraint_segment:
             - keyword: NOT

--- a/test/fixtures/dialects/tsql/create_table_constraints.yml
+++ b/test/fixtures/dialects/tsql/create_table_constraints.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c209d12094922d427621030eedd44fc62ddf5d14b674f093b04220a29b5d32e6
+_hash: 653c3331eb481f4fe465aa9aa63fb4d83bf7515eb19bd756bd6d0dfde3ba0184
 file:
 - batch:
     statement:
@@ -310,7 +310,7 @@ file:
                   end_bracket: )
             column_constraint_segment:
               keyword: collate
-              object_reference:
+              collation_reference:
                 naked_identifier: Latin1_General_BIN
         - end_bracket: )
 - go_statement:


### PR DESCRIPTION
This is the result of searching for sequences of "COLLATE" followed by some other segment type.  During this exercise, I realized that some dialects also accept string literals instead.

This commit makes the CollationReferenceSegment in the ANSI dialect a little extra permissive and accepts either an object reference or a string literal.


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
