### PR TITLE
Inroduce `SAFE` prefix segment

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -824,7 +824,10 @@ class NormalizeFunctionNameSegment(BaseSegment):
 
 
 class FunctionNameSegment(ansi.FunctionNameSegment):
-    """Function name, including any prefix bits, e.g. project, schema or SAFE keyword."""
+    """Describes the name of a function.
+
+    This includes any prefix bits, e.g. project, schema or SAFE keyword.to
+    """
 
     match_grammar: Matchable = Sequence(
         # Project name, schema identifier, etc.

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -823,30 +823,17 @@ class NormalizeFunctionNameSegment(BaseSegment):
     )
 
 
-class SafePrefixSegment(BaseSegment):
-    """SAFE prefix to a function name.
-
-    BigQuery Function names can be prefixed by the keyword SAFE to
-    return NULL instead of error.
-    https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-reference#safe_prefix
-    """
-
-    type = "safe_prefix"
-    match_grammar: Matchable = Sequence("SAFE", Ref("DotSegment"), allow_gaps=False)
-
-
 class FunctionNameSegment(ansi.FunctionNameSegment):
-    """Function name, including any prefix bits, e.g. project or schema."""
+    """Function name, including any prefix bits, e.g. project, schema or SAFE keyword."""
 
     match_grammar: Matchable = Sequence(
-        # BigQuery Function names can be prefixed by the keyword SAFE to
-        # return NULL instead of error.
-        # https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-reference#safe_prefix
-        Ref("SafePrefixSegment", optional=True),
         # Project name, schema identifier, etc.
         AnyNumberOf(
             Sequence(
-                Ref("SingleIdentifierGrammar"),
+                # BigQuery Function names can be prefixed by the keyword SAFE to
+                # return NULL instead of error.
+                # https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-reference#safe_prefix
+                OneOf("SAFE", Ref("SingleIdentifierGrammar")),
                 Ref("DotSegment"),
             ),
         ),

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -826,7 +826,7 @@ class NormalizeFunctionNameSegment(BaseSegment):
 class FunctionNameSegment(ansi.FunctionNameSegment):
     """Describes the name of a function.
 
-    This includes any prefix bits, e.g. project, schema or SAFE keyword.to
+    This includes any prefix bits, e.g. project, schema or the SAFE keyword.
     """
 
     match_grammar: Matchable = Sequence(

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -823,6 +823,42 @@ class NormalizeFunctionNameSegment(BaseSegment):
     )
 
 
+class SafePrefixSegment(BaseSegment):
+    """SAFE prefix to a function name.
+
+    BigQuery Function names can be prefixed by the keyword SAFE to
+    return NULL instead of error.
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-reference#safe_prefix
+    """
+
+    type = "safe_prefix"
+    match_grammar: Matchable = Sequence("SAFE", Ref("DotSegment"), allow_gaps=False)
+
+
+class FunctionNameSegment(ansi.FunctionNameSegment):
+    """Function name, including any prefix bits, e.g. project or schema."""
+
+    match_grammar: Matchable = Sequence(
+        # BigQuery Function names can be prefixed by the keyword SAFE to
+        # return NULL instead of error.
+        # https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-reference#safe_prefix
+        Ref("SafePrefixSegment", optional=True),
+        # Project name, schema identifier, etc.
+        AnyNumberOf(
+            Sequence(
+                Ref("SingleIdentifierGrammar"),
+                Ref("DotSegment"),
+            ),
+        ),
+        # Base function name
+        OneOf(
+            Ref("FunctionNameIdentifierSegment"),
+            Ref("QuotedIdentifierSegment"),
+        ),
+        allow_gaps=False,
+    )
+
+
 class FunctionSegment(ansi.FunctionSegment):
     """A scalar or aggregate function.
 
@@ -833,10 +869,6 @@ class FunctionSegment(ansi.FunctionSegment):
     """
 
     match_grammar = Sequence(
-        # BigQuery Function names can be prefixed by the keyword SAFE to
-        # return NULL instead of error.
-        # https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-reference#safe_prefix
-        Sequence("SAFE", Ref("DotSegment"), optional=True),
         OneOf(
             Sequence(
                 # BigQuery EXTRACT allows optional TimeZone

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -845,7 +845,10 @@ class FunctionNameSegment(ansi.FunctionNameSegment):
             Ref("FunctionNameIdentifierSegment"),
             Ref("QuotedIdentifierSegment"),
         ),
-        allow_gaps=False,
+        # BigQuery allows whitespaces between the `.` of a function refrence or
+        # SAFE prefix. Keeping the explicit `allow_gaps=True` here to
+        # make the distinction from `ansi.FunctionNameSegment` clear.
+        allow_gaps=True,
     )
 
 

--- a/test/fixtures/dialects/bigquery/select_safe_function.yml
+++ b/test/fixtures/dialects/bigquery/select_safe_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a66cbb9b8d7674401c007061994343386589e0a5e08deecc11397949a96efde1
+_hash: c327efdefc75a67358bfe575fc204aafa358fb0c29e1d53fc54bcfeb8b0f5f8d
 file:
   statement:
     select_statement:
@@ -17,9 +17,10 @@ file:
       - comma: ','
       - select_clause_element:
           function:
-            keyword: SAFE
-            dot: .
             function_name:
+              safe_prefix:
+                keyword: SAFE
+                dot: .
               function_name_identifier: SUBSTR
             bracketed:
             - start_bracket: (
@@ -40,9 +41,10 @@ file:
       - comma: ','
       - select_clause_element:
           function:
-            keyword: SAFE
-            dot: .
             function_name:
+              safe_prefix:
+                keyword: SAFE
+                dot: .
               function_name_identifier: DATEADD
             bracketed:
             - start_bracket: (
@@ -59,9 +61,10 @@ file:
       - comma: ','
       - select_clause_element:
           function:
-            keyword: SAFE
-            dot: .
             function_name:
+              safe_prefix:
+                keyword: SAFE
+                dot: .
               function_name_identifier: MY_FUNCTION
             bracketed:
               start_bracket: (

--- a/test/fixtures/dialects/bigquery/select_safe_function.yml
+++ b/test/fixtures/dialects/bigquery/select_safe_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c327efdefc75a67358bfe575fc204aafa358fb0c29e1d53fc54bcfeb8b0f5f8d
+_hash: 5fe16a4415d2a3b7ec104bed1c9356c9068b4b78320b56a4e4815db0251c448f
 file:
   statement:
     select_statement:
@@ -18,9 +18,8 @@ file:
       - select_clause_element:
           function:
             function_name:
-              safe_prefix:
-                keyword: SAFE
-                dot: .
+              keyword: SAFE
+              dot: .
               function_name_identifier: SUBSTR
             bracketed:
             - start_bracket: (
@@ -42,9 +41,8 @@ file:
       - select_clause_element:
           function:
             function_name:
-              safe_prefix:
-                keyword: SAFE
-                dot: .
+              keyword: SAFE
+              dot: .
               function_name_identifier: DATEADD
             bracketed:
             - start_bracket: (
@@ -62,9 +60,8 @@ file:
       - select_clause_element:
           function:
             function_name:
-              safe_prefix:
-                keyword: SAFE
-                dot: .
+              keyword: SAFE
+              dot: .
               function_name_identifier: MY_FUNCTION
             bracketed:
               start_bracket: (

--- a/test/fixtures/rules/std_rule_cases/LT01-operators.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-operators.yml
@@ -106,9 +106,26 @@ test_pass_placeholder_spacing:
         AND TRUE
     ;
 
+fail_bigquery_whitespaces_in_function_reference:
+  fail_str: SELECT dataset    .    AddFourAndDivide(5, 10)
+  fix_str: SELECT dataset.AddFourAndDivide(5, 10)
+  configs:
+    core:
+      dialect: bigquery
+
 pass_bigquery_safe_prefix_function:
   # SAFE prefix to function calls should not fail
   pass_str: SELECT SAFE.STRING(JSON '1')
+  configs:
+    core:
+      dialect: bigquery
+
+fail_bigquery_safe_prefix_function:
+  # Check that additional whitespaces introduced by
+  # https://github.com/sqlfluff/sqlfluff/issues/4645
+  # get fixed.
+  fail_str: SELECT SAFE . STRING(JSON '1')
+  fix_str: SELECT SAFE.STRING(JSON '1')
   configs:
     core:
       dialect: bigquery

--- a/test/fixtures/rules/std_rule_cases/LT01-operators.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-operators.yml
@@ -105,3 +105,10 @@ test_pass_placeholder_spacing:
         {% endif %}
         AND TRUE
     ;
+
+pass_bigquery_safe_prefix_function:
+  # SAFE prefix to function calls should not fail
+  pass_str: SELECT SAFE.STRING(JSON '1')
+  configs:
+    core:
+      dialect: bigquery


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Makes progress in: https://github.com/sqlfluff/sqlfluff/issues/4645

The idea here is to introduce a BigQuery specific `SafePrefixSegment` to better control the whitespacing within the function call. This

- **does** resolve the whitespace issue between `dot` and `function_name`
- **does not** resolve the whitespace issue between `SAFE` and `dot`

**Open Question:**

It's not clear to me why this still happens

```
"Expected single whitespace between 'SAFE' keyword and dot '.'."
```

Shouldn't

```
Sequence("SAFE", Ref("DotSegment"), allow_gaps=False)
```

prevent exactly that?


### Are there any other side effects of this change that we should be aware of?

No


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
