### PR TITLE
Fix #2865 (AL05 exception for Redshift Semi-structured)

### DIFF
--- a/src/sqlfluff/rules/aliasing/AL05.py
+++ b/src/sqlfluff/rules/aliasing/AL05.py
@@ -83,6 +83,28 @@ class Rule_AL05(BaseRule):
         query: AL05Query = cast(AL05Query, crawler.query_tree)
         self._analyze_table_aliases(query, context.dialect)
 
+        if context.dialect.name == "redshift":
+            # Redshift supports un-nesting using aliases.
+            # Detect that situation and ignore.
+            # https://docs.aws.amazon.com/redshift/latest/dg/query-super.html#unnest
+
+            # Do any references refer to aliases in the same list?
+            references = set()
+            aliases = set()
+
+            for alias in query.aliases:
+                aliases.add(alias.ref_str)
+                for seg in alias.object_reference.segments:
+                    if seg.is_type("identifier"):
+                        references.add(seg.raw)
+
+            # If there's any overlap between aliases and reference
+            if aliases.intersection(references):
+                self.logger.debug(
+                    "Overlapping references found. Assuming redshift semi-structured."
+                )
+                return None
+
         alias: AliasInfo
         for alias in query.aliases:
             # Skip alias if it's required (some dialects require aliases for

--- a/test/fixtures/rules/std_rule_cases/AL05.yml
+++ b/test/fixtures/rules/std_rule_cases/AL05.yml
@@ -337,3 +337,16 @@ test_pass_derived_query_requires_alias_3:
         )
         SELECT * FROM foo
     ) AS a
+
+test_pass_bigquery_nested_inner_join:
+  # Redshift _requires_ aliasing when doing semi-structured operations.
+  # https://docs.aws.amazon.com/redshift/latest/dg/query-super.html#unnest
+  # The logic here should be that if references _overlap_ (i.e. some
+  # aliases refer to other tables in the same FROM clause).
+  pass_str: |
+    SELECT tt.resource_id
+    FROM top_table AS tt
+    , tt.nested_column AS co
+  configs:
+    core:
+      dialect: redshift


### PR DESCRIPTION
This resolves #2865. As mentioned in the original issue, redshift _requires_ [the use of aliases](https://docs.aws.amazon.com/redshift/latest/dg/query-super.html#unnest), so in the case that it looks like someone is doing that - I've added an exception to the rule.