### PR TITLE
Fix #2855: (Tech debt: check consistency in TemplatedFile init)

### DIFF
--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -120,7 +120,6 @@ class TemplatedFile:
         templated_str: Optional[str] = None,
         sliced_file: Optional[List[TemplatedFileSlice]] = None,
         raw_sliced: Optional[List[RawFileSlice]] = None,
-        check_consistency=True,
     ):
         """Initialise the TemplatedFile.
 
@@ -152,50 +151,48 @@ class TemplatedFile:
         self._source_newlines = list(iter_indices_of_newlines(self.source_str))
         self._templated_newlines = list(iter_indices_of_newlines(self.templated_str))
 
-        # NOTE: The "check_consistency" flag should always be True when using
-        # SQLFluff in real life. This flag was only added because some legacy
-        # templater tests in test/core/templaters/jinja_test.py use hardcoded
-        # test data with issues that will trigger errors here. It would be cool
-        # to fix that data someday. I (Barry H.) started looking into it, but
-        # it was much trickier than I expected, because bits of the same data
-        # are shared across multiple tests.
-        if check_consistency:
-            # Sanity check raw string and slices.
-            pos = 0
-            rfs: RawFileSlice
-            for idx, rfs in enumerate(self.raw_sliced):
-                assert rfs.source_idx == pos
-                pos += len(rfs.raw)
-            assert pos == len(self.source_str)
+        # Consistency check raw string and slices.
+        pos = 0
+        rfs: RawFileSlice
+        for rfs in self.raw_sliced:
+            assert rfs.source_idx == pos, (
+                "TemplatedFile. Consistency fail on running source length"
+                f": {pos} != {rfs.source_idx}"
+            )
+            pos += len(rfs.raw)
+        assert pos == len(self.source_str), (
+            "TemplatedFile. Consistency fail on total source length"
+            f": {pos} != {len(self.source_str)}"
+        )
 
-            # Sanity check templated string and slices.
-            previous_slice = None
-            tfs: Optional[TemplatedFileSlice] = None
-            for idx, tfs in enumerate(self.sliced_file):
-                if previous_slice:
-                    if tfs.templated_slice.start != previous_slice.templated_slice.stop:
-                        raise SQLFluffSkipFile(  # pragma: no cover
-                            "Templated slices found to be non-contiguous. "
-                            f"{tfs.templated_slice} (starting"
-                            f" {self.templated_str[tfs.templated_slice]!r})"
-                            f" does not follow {previous_slice.templated_slice} "
-                            "(starting "
-                            f"{self.templated_str[previous_slice.templated_slice]!r}"
-                            ")"
-                        )
-                else:
-                    if tfs.templated_slice.start != 0:
-                        raise SQLFluffSkipFile(  # pragma: no cover
-                            "First Templated slice not started at index 0 "
-                            f"(found slice {tfs.templated_slice})"
-                        )
-                previous_slice = tfs
-            if self.sliced_file and templated_str is not None:
-                if tfs.templated_slice.stop != len(templated_str):
+        # Consistency check templated string and slices.
+        previous_slice = None
+        tfs: Optional[TemplatedFileSlice] = None
+        for tfs in self.sliced_file:
+            if previous_slice:
+                if tfs.templated_slice.start != previous_slice.templated_slice.stop:
                     raise SQLFluffSkipFile(  # pragma: no cover
-                        "Length of templated file mismatch with final slice: "
-                        f"{len(templated_str)} != {tfs.templated_slice.stop}."
+                        "Templated slices found to be non-contiguous. "
+                        f"{tfs.templated_slice} (starting"
+                        f" {self.templated_str[tfs.templated_slice]!r})"
+                        f" does not follow {previous_slice.templated_slice} "
+                        "(starting "
+                        f"{self.templated_str[previous_slice.templated_slice]!r}"
+                        ")"
                     )
+            else:
+                if tfs.templated_slice.start != 0:
+                    raise SQLFluffSkipFile(  # pragma: no cover
+                        "First Templated slice not started at index 0 "
+                        f"(found slice {tfs.templated_slice})"
+                    )
+            previous_slice = tfs
+        if self.sliced_file and templated_str is not None:
+            if tfs.templated_slice.stop != len(templated_str):
+                raise SQLFluffSkipFile(  # pragma: no cover
+                    "Length of templated file mismatch with final slice: "
+                    f"{len(templated_str)} != {tfs.templated_slice.stop}."
+                )
 
     @classmethod
     def from_string(cls, raw):

--- a/test/core/templaters/base_test.py
+++ b/test/core/templaters/base_test.py
@@ -37,7 +37,7 @@ def test__templater_raw():
 
 
 SIMPLE_SOURCE_STR = "01234\n6789{{foo}}fo\nbarss"
-SIMPLE_TEMPLATED_STR = "01234\n6789x\nfo\nbarfss"
+SIMPLE_TEMPLATED_STR = "01234\n6789x\nfo\nbarss"
 SIMPLE_SLICED_FILE = [
     TemplatedFileSlice(*args)
     for args in [
@@ -134,7 +134,6 @@ def test__templated_file_get_line_pos_of_char_pos(
         templated_str=templated_str,
         sliced_file=file_slices,
         fname="test",
-        check_consistency=False,
     )
     res_line_no, res_line_pos = file.get_line_pos_of_char_pos(in_charpos)
     assert res_line_no == out_line_no
@@ -280,15 +279,20 @@ def test__templated_file_templated_slice_to_source_slice(
     in_slice, out_slice, is_literal, file_slices, raw_slices
 ):
     """Test TemplatedFile.templated_slice_to_source_slice."""
+    raw_sliced = [
+        rs if isinstance(rs, RawFileSlice) else RawFileSlice(*rs) for rs in raw_slices
+    ]
+    # Construct the source_str from the raw slices. We're not testing
+    # correct construction in these tests - we're testing what we can
+    # do with it once constructed.
+    source_str = ""
+    for raw_slice in raw_sliced:
+        source_str += raw_slice.raw
     file = TemplatedFile(
-        source_str="Dummy String",
+        source_str=source_str,
         sliced_file=file_slices,
-        raw_sliced=[
-            rs if isinstance(rs, RawFileSlice) else RawFileSlice(*rs)
-            for rs in raw_slices
-        ],
+        raw_sliced=raw_sliced,
         fname="test",
-        check_consistency=False,
     )
     source_slice = file.templated_slice_to_source_slice(in_slice)
     literal_test = file.is_source_slice_literal(source_slice)
@@ -301,28 +305,26 @@ def test__templated_file_templated_slice_to_source_slice(
         # Comment example
         (
             TemplatedFile(
-                source_str="a" * 20,
+                source_str=("a" * 10) + "{# b #}" + ("a" * 10),
                 fname="test",
                 raw_sliced=[
                     RawFileSlice("a" * 10, "literal", 0),
                     RawFileSlice("{# b #}", "comment", 10),
                     RawFileSlice("a" * 10, "literal", 17),
                 ],
-                check_consistency=False,
             ),
             [RawFileSlice("{# b #}", "comment", 10)],
         ),
         # Template tags aren't source only.
         (
             TemplatedFile(
-                source_str="aaabbbaaa",
+                source_str=r"aaa{{ b }}aaa",
                 fname="test",
                 raw_sliced=[
                     RawFileSlice("aaa", "literal", 0),
                     RawFileSlice("{{ b }}", "templated", 3),
-                    RawFileSlice("aaa", "literal", 6),
+                    RawFileSlice("aaa", "literal", 10),
                 ],
-                check_consistency=False,
             ),
             [],
         ),


### PR DESCRIPTION
This resolves #2855. There was an unnecessary flag to cover some misshapen test cases which I've fixed here. It's a low risk PR because only really covers the test suite and not the core codebase.