### PR TITLE
Fix #4603 indent after Jinja 'do' directive

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -189,7 +189,7 @@ class Linter:
                 getattr(elem, "indent_val", 0)
                 for elem in cast(Tuple[BaseSegment, ...], tokens)
             )
-            if indent_balance != 0:
+            if indent_balance != 0:  # pragma: no cover
                 linter_logger.debug(
                     "Indent balance test failed for %r. Template indents will not be "
                     "linted for this file.",
@@ -207,7 +207,7 @@ class Linter:
                 if token.indent_val != 0:
                     # Don't allow it if we're not linting templating block indents.
                     if not templating_blocks_indent:
-                        continue
+                        continue  # pragma: no cover
             new_tokens.append(token)
 
         # Return new buffer

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -524,7 +524,7 @@ class JinjaAnalyzer:
         # a block, but its behavior is basically syntactic sugar for
         # {{ open("somefile).read() }}. Thus, treat it as templated code.
         # It's a similar situation with {% import %} and {% from ... import %}.
-        if tag_name in ["include", "import", "from"]:
+        if tag_name in ["include", "import", "from", "do"]:
             block_type = "templated"
         elif tag_name.startswith("end"):
             block_type = "block_end"

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -1092,6 +1092,23 @@ SELECT
             ],
         ),
         (
+            # Tests Jinja "do" directive. Should be treated as a
+            # templated instead of block - issue 4603.
+            """{% do true %}
+
+{% if true %}
+    select 1
+{% endif %}""",
+            None,
+            [
+                ("templated", slice(0, 13, None), slice(0, 0, None)),
+                ('literal', slice(13, 15, None), slice(0, 2, None)),
+                ("block_start", slice(15, 28, None), slice(2, 2, None)),
+                ("literal", slice(28, 42, None), slice(2, 16, None)),
+                ("block_end", slice(42, 53, None), slice(16, 16, None)),
+            ],
+        ),
+        (
             # Tests issue 2541, a bug where the {%- endfor %} was causing
             # IndexError: list index out of range.
             """{% for x in ['A', 'B'] %}

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -1102,7 +1102,7 @@ SELECT
             None,
             [
                 ("templated", slice(0, 13, None), slice(0, 0, None)),
-                ('literal', slice(13, 15, None), slice(0, 2, None)),
+                ("literal", slice(13, 15, None), slice(0, 2, None)),
                 ("block_start", slice(15, 28, None), slice(2, 2, None)),
                 ("literal", slice(28, 42, None), slice(2, 16, None)),
                 ("block_end", slice(42, 53, None), slice(16, 16, None)),


### PR DESCRIPTION
### Brief summary of the change made

Fixes #4603 

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
