### PR TITLE
fix: correct macos/osx config file location

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -127,8 +127,8 @@ steps overriding those from earlier:
 0. *[...and this one doesn't really count]* There's a default config as
    part of the SQLFluff package. You can find this below, in the
    :ref:`defaultconfig` section.
-1. It will look in the user's os-specific app config directory. On OSX this is
-   `~/Library/Preferences/sqlfluff`, Unix is `~/.config/sqlfluff`, Windows is
+1. It will look in the user's os-specific app config directory.
+   On macOS and Unix this is `~/.config/sqlfluff`, Windows is
    `<home>\\AppData\\Local\\sqlfluff\\sqlfluff`, for any of the filenames
    above in the main :ref:`config` section. If multiple are present, they will
    *patch*/*override* each other in the order above.


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Use linux style xdg on mac (#955) had introduced a change where macOS config files no longer use the `~/Library/.. ` config directory and instead prefers the linux variant. The documentation was not updated, however.

This PR seeks to amend that.

### Are there any other side effects of this change that we should be aware of?
No. This is only a documentation fix.
