### PR TITLE
fix: #4787 BigQuery allow spaces in object references

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1266,7 +1266,10 @@ class TableReferenceSegment(ObjectReferenceSegment):
             Ref("JoinLikeClauseGrammar"),
             BracketedSegment,
         ),
-        allow_gaps=False,
+        # BigQuery allows whitespaces between the `.` of a table refrencex.
+        # Keeping the explicit `allow_gaps=True` here to
+        # make the distinction to other dialects clear.
+        allow_gaps=True,
     )
 
     def iter_raw_references(self):

--- a/test/fixtures/linter/autofix/bigquery/003_templating/after.sql
+++ b/test/fixtures/linter/autofix/bigquery/003_templating/after.sql
@@ -15,13 +15,12 @@ SELECT
     {% endfor %}
 FROM
 {% for action in considered_actions %}
-    {% if loop.first %}
-        {{action}}_raw_effect_sizes
-    {% else %}
+        {% if loop.first %}
+        {{action}}_raw_effect_sizes    {% else %}
     JOIN
         {{action}}_raw_effect_sizes
-        USING
+            USING
             ({{corr_states}})
-    {% endif %}
-{% endfor %}
+{% endif %}
+        {% endfor %}
 CROSS JOIN action_states

--- a/test/fixtures/linter/autofix/bigquery/004_templating/after.sql
+++ b/test/fixtures/linter/autofix/bigquery/004_templating/after.sql
@@ -49,15 +49,14 @@ new_raw_effect_sizes AS (
         {% endfor %}
     FROM
     {% for action in considered_actions %}
-        {% if loop.first %}
-            {{action}}_raw_effect_sizes
-        {% else %}
+                {% if loop.first %}
+            {{action}}_raw_effect_sizes    {% else %}
         JOIN
             {{action}}_raw_effect_sizes
-            USING
+                USING
                 ({{corr_states}})
-        {% endif %}
-    {% endfor %}
+    {% endif %}
+            {% endfor %}
 ),
 
 imputed_effect_sizes AS (

--- a/test/fixtures/linter/autofix/bigquery/006_fix_ignore_templating/after.sql
+++ b/test/fixtures/linter/autofix/bigquery/006_fix_ignore_templating/after.sql
@@ -10,8 +10,7 @@ SELECT * EXCEPT ({% include query %}) FROM
                 )
                 AS rnk
             {% if context_columns | default("abc") == "abc" %}
-            FROM tbl1
-            {% endif %}
+            FROM tbl1    {% endif %}
         INNER JOIN tbl2
             ON
                 tbl1.the_name = tbl2.the_name

--- a/test/fixtures/rules/std_rule_cases/LT01-operators.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-operators.yml
@@ -106,6 +106,36 @@ test_pass_placeholder_spacing:
         AND TRUE
     ;
 
+fail_bigquery_simple_whitespaces_in_object_reference:
+  # BigQuery allows spaces in object references.
+  # This tests that queries with spaces in object refereces prase and
+  # fix to the canonical object reference without spaces/.
+  fail_str: SELECT * FROM project    .    dataset    .    table
+  fix_str: SELECT * FROM project.dataset.table
+  configs:
+    core:
+      dialect: bigquery
+
+fail_bigquery_complex_whitespaces_in_object_reference:
+  # BigQuery allows spaces in object references.
+  # This tests that queries with spaces in object refereces prase and
+  # fix to the canonical object reference without spaces/.
+  fail_str: |-
+    SELECT * FROM project
+         .
+
+
+
+             dataset    .
+
+
+
+             table
+  fix_str: SELECT * FROM project.dataset.table
+  configs:
+    core:
+      dialect: bigquery
+
 fail_bigquery_whitespaces_in_function_reference:
   fail_str: SELECT dataset    .    AddFourAndDivide(5, 10)
   fix_str: SELECT dataset.AddFourAndDivide(5, 10)

--- a/test/fixtures/rules/std_rule_cases/LT01-operators.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-operators.yml
@@ -124,11 +124,7 @@ fail_bigquery_complex_whitespaces_in_object_reference:
     SELECT * FROM project
          .
 
-
-
              dataset    .
-
-
 
              table
   fix_str: SELECT * FROM project.dataset.table


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Resolves: #4787 

BigQuery allows whitespaces in object references. However, currently SQL that "utilize" this currently don't parse. This PR tries resolve this and allow spaces (at least) in table references.

Unfortunately, this seem to entirely break to logic around templated areas. I will add a (temporary) [commit](https://github.com/sqlfluff/sqlfluff/pull/4796/commits/d8f08a23abd8cabb25d96208a6963e4663b7ca64) to this branch that demonstrate this (by making the corresponding tests pass). I'm not really sure, how this should be addressed, so looking forward to get some hints/guidance.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?

Currently, yes. It entirely breaks the logic around templates areas, see above.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
