### PR TITLE
Redshift: Support with no schema binding

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2516,6 +2516,27 @@ class FromClauseSegment(ansi.FromClauseSegment):
     )
 
 
+class CreateViewStatementSegment(BaseSegment):
+    """A `CREATE VIEW` statement."""
+
+    type = "create_view_statement"
+    # https://crate.io/docs/sql-99/en/latest/chapters/18.html#create-view-statement
+    # https://dev.mysql.com/doc/refman/8.0/en/create-view.html
+    # https://www.postgresql.org/docs/12/sql-createview.html
+    match_grammar: Matchable = Sequence(
+        "CREATE",
+        Ref("OrReplaceGrammar", optional=True),
+        "VIEW",
+        Ref("IfNotExistsGrammar", optional=True),
+        Ref("TableReferenceSegment"),
+        # Optional list of column names
+        Ref("BracketedColumnReferenceListGrammar", optional=True),
+        "AS",
+        OptionallyBracketed(Ref("SelectableGrammar")),
+        Ref("WithNoSchemaBindingClauseSegment", optional=True),
+    )
+
+
 class CreateExternalFunctionStatementSegment(BaseSegment):
     """A `CREATE EXTERNAL FUNCTION` segment.
 

--- a/test/fixtures/dialects/redshift/redshift_create_view.sql
+++ b/test/fixtures/dialects/redshift/redshift_create_view.sql
@@ -1,0 +1,5 @@
+create view sales_vw as
+select * from public.sales
+union all
+select * from spectrum.sales
+with no schema binding;

--- a/test/fixtures/dialects/redshift/redshift_create_view.yml
+++ b/test/fixtures/dialects/redshift/redshift_create_view.yml
@@ -1,0 +1,56 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: f74e44d078baf289d9899d89b523de92e3b9bbbc1e17970c385f14647931d931
+file:
+  statement:
+    create_view_statement:
+    - keyword: create
+    - keyword: view
+    - table_reference:
+        naked_identifier: sales_vw
+    - keyword: as
+    - set_expression:
+      - select_statement:
+          select_clause:
+            keyword: select
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: from
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                  - naked_identifier: public
+                  - dot: .
+                  - naked_identifier: sales
+      - set_operator:
+        - keyword: union
+        - keyword: all
+      - select_statement:
+          select_clause:
+            keyword: select
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: from
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                  - naked_identifier: spectrum
+                  - dot: .
+                  - naked_identifier: sales
+    - with_no_schema_binding_clause:
+      - keyword: with
+      - keyword: 'no'
+      - keyword: schema
+      - keyword: binding
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #4806 - adds back funcitonality removed in Postgres

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
