### PR TITLE
Fix: Small typo in error message

### DIFF
--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -374,7 +374,7 @@ class DbtTemplater(JinjaTemplater):
             return None, [
                 SQLTemplaterError(
                     "dbt tried to connect to the database and failed: you could use "
-                    "'execute' to skip the database calls. See"
+                    "'execute' to skip the database calls. See "
                     "https://docs.getdbt.com/reference/dbt-jinja-functions/execute/ "
                     f"Error: {e.msg}",
                     fatal=True,


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

There is a small typo in a error message, 2 words appear without space in the middle. This is just adding that space. See attached image:

![imagen](https://user-images.githubusercontent.com/32640454/234534671-2c6ef7ef-e250-4bc0-a4ce-eb23ac17de8e.png)


### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
