### PR TITLE
Hive: INSERT INTO without TABLE keyword

### DIFF
--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -702,7 +702,7 @@ class InsertStatementSegment(BaseSegment):
             ),
             Sequence(
                 "INTO",
-                "TABLE",
+                Ref.keyword("TABLE", optional=True),
                 Ref("TableReferenceSegment"),
                 Ref("PartitionSpecGrammar", optional=True),
                 OneOf(

--- a/test/fixtures/dialects/hive/insert_into_table.sql
+++ b/test/fixtures/dialects/hive/insert_into_table.sql
@@ -1,2 +1,5 @@
 INSERT INTO TABLE foo
 SELECT a, b FROM bar;
+
+INSERT INTO foo
+SELECT a, b FROM bar;

--- a/test/fixtures/dialects/hive/insert_into_table.yml
+++ b/test/fixtures/dialects/hive/insert_into_table.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c804de2529568ca9467775111da50bbfa85d6eae2af0e82486f72131d7205980
+_hash: 2a26381ae66bfbdbfbac6d6ec79085122f726a8b22522b87c638c76e5bc8fc68
 file:
-  statement:
+- statement:
     insert_statement:
     - keyword: INSERT
     - keyword: INTO
@@ -29,4 +29,28 @@ file:
               table_expression:
                 table_reference:
                   naked_identifier: bar
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: foo
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: bar
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Closes https://github.com/sqlfluff/sqlfluff/issues/4816

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
