### PR TITLE
Snowflake dialect: Add support for comment clause in the create warehouse statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -3586,6 +3586,7 @@ class CreateStatementSegment(BaseSegment):
             Sequence("WITH", optional=True),
             AnyNumberOf(
                 Ref("WarehouseObjectPropertiesSegment"),
+                Ref("CommentEqualsClauseSegment"),
                 Ref("WarehouseObjectParamsSegment"),
             ),
             Ref("TagBracketedEqualsSegment", optional=True),

--- a/test/fixtures/dialects/snowflake/snowflake_create_warehouse.sql
+++ b/test/fixtures/dialects/snowflake/snowflake_create_warehouse.sql
@@ -2,3 +2,4 @@ create or replace warehouse my_wh with warehouse_size='X-LARGE';
 create or replace warehouse my_wh warehouse_size=large initially_suspended=true;
 create warehouse if not exists LOAD_WH warehouse_size='medium';
 create warehouse if not exists LOAD_WH warehouse_size='medium' warehouse_type = standard;
+create warehouse my_wh warehouse_size = 'medium' comment = 'comment' auto_suspend = 60;

--- a/test/fixtures/dialects/snowflake/snowflake_create_warehouse.yml
+++ b/test/fixtures/dialects/snowflake/snowflake_create_warehouse.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6259c7aba5c90889d66b59c9f1b82fac66e9a85f32a3c7bfb2a7b6bf834da60e
+_hash: dd89532d265e4eb040d5a3d7556e1b6a400f53621522df236934489c30dd6db2
 file:
 - statement:
     create_statement:
@@ -71,4 +71,26 @@ file:
       - comparison_operator:
           raw_comparison_operator: '='
       - keyword: standard
+- statement_terminator: ;
+- statement:
+    create_statement:
+    - keyword: create
+    - keyword: warehouse
+    - object_reference:
+        naked_identifier: my_wh
+    - warehouse_object_properties:
+        keyword: warehouse_size
+        comparison_operator:
+          raw_comparison_operator: '='
+        warehouse_size: "'medium'"
+    - comment_equals_clause:
+        keyword: comment
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'comment'"
+    - warehouse_object_properties:
+        keyword: auto_suspend
+        comparison_operator:
+          raw_comparison_operator: '='
+        numeric_literal: '60'
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #4793 

Just adds the comment clause to the create warehouse statement, I did as it is done in the [alter warehouse](https://github.com/sqlfluff/sqlfluff/blob/720ab7f7f165858d70e6fbb3ebf67a31a3149d59/src/sqlfluff/dialects/dialect_snowflake.py#L1921) statement. 

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
