### PR TITLE
Make SQLFluff compatible with DBT 1.5

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -72,7 +72,7 @@ jobs:
       gh_token: ${{ secrets.github_token }}
 
   dbt-tests-cov:
-    name: dbt 1.4 Plugin Tests
+    name: dbt 1.5 Plugin Tests
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -79,7 +79,7 @@ jobs:
     uses: ./.github/workflows/ci-test-dbt.yml
     with:
       python-version: "3.10"
-      dbt-version: "dbt140"
+      dbt-version: "dbt150"
       coverage: true
     secrets:
       gh_token: ${{ secrets.github_token }}
@@ -290,7 +290,7 @@ jobs:
       # Do not set explicitly temp dir for dbt as causes problems
       # None of these test need temp dir set
       run: |
-        python -m tox -e dbt140-winpy -- plugins/sqlfluff-templater-dbt
+        python -m tox -e dbt150-winpy -- plugins/sqlfluff-templater-dbt
 
   pip-test-pull-request:
     # Test that using pip install works as we've missed

--- a/constraints/dbt140-winpy.txt
+++ b/constraints/dbt140-winpy.txt
@@ -1,3 +1,0 @@
-dbt-core~=1.4
-dbt-postgres~=1.4
-markupsafe<=2.0.1

--- a/constraints/dbt140.txt
+++ b/constraints/dbt140.txt
@@ -1,2 +1,0 @@
-dbt-core~=1.4
-dbt-postgres~=1.4

--- a/constraints/dbt150-winpy.txt
+++ b/constraints/dbt150-winpy.txt
@@ -1,0 +1,3 @@
+dbt-core~=1.5
+dbt-postgres~=1.5
+markupsafe<=2.0.1

--- a/constraints/dbt150.txt
+++ b/constraints/dbt150.txt
@@ -1,0 +1,2 @@
+dbt-core~=1.5
+dbt-postgres~=1.5

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -246,8 +246,8 @@ class DbtTemplater(JinjaTemplater):
         return str(cli_vars) if cli_vars else "{}"
 
     def _get_threads(self) -> int:
-        threads = int(self.sqlfluff_config.get_section("processes")) or 1
-        return threads
+        threads = self.sqlfluff_config.get_section("processes")
+        return int(threads) if threads else 1
 
     def sequence_files(
         self, fnames: List[str], config=None, formatter=None

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -97,21 +97,14 @@ class DbtTemplater(JinjaTemplater):
     @cached_property
     def dbt_config(self):
         """Loads the dbt config."""
-        # Here, we read flags.PROFILE_DIR directly, prior to calling
-        # set_from_args(). Apparently, set_from_args() sets PROFILES_DIR
-        # to a lowercase version of the value, and the profile wouldn't be
-        # found if the directory name contained uppercase letters. This fix
-        # was suggested and described here:
-        # https://github.com/sqlfluff/sqlfluff/issues/2253#issuecomment-1018722979
-        user_config = read_user_config(flags.PROFILES_DIR)
         flags.set_from_args(
             DbtConfigArgs(
                 project_dir=self.project_dir,
                 profiles_dir=self.profiles_dir,
                 profile=self._get_profile(),
                 vars=self._get_cli_vars(),
+                target=self._get_target(),
             ),
-            user_config,
         )
         self.dbt_config = DbtRuntimeConfig.from_args(
             DbtConfigArgs(

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -10,7 +10,6 @@ from typing import List, Optional, Iterator, Tuple, Any, Dict, Deque
 from dataclasses import dataclass
 
 from dbt.version import get_installed_version
-from dbt.config import read_user_config
 from dbt.config.runtime import RuntimeConfig as DbtRuntimeConfig
 from dbt.adapters.factory import register_adapter, get_adapter
 from dbt.compilation import Compiler as DbtCompiler

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -107,6 +107,7 @@ class DbtTemplater(JinjaTemplater):
             ),
         )
         self.dbt_config = DbtRuntimeConfig.from_args(
+            "",
             DbtConfigArgs(
                 project_dir=self.project_dir,
                 profiles_dir=self.profiles_dir,

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -66,7 +66,7 @@ class DbtConfigArgs:
     profile: Optional[str] = None
     target: Optional[str] = None
     threads: int = 1
-    vars: str = ""
+    vars: dict = None
 
 
 class DbtTemplater(JinjaTemplater):
@@ -243,7 +243,7 @@ class DbtTemplater(JinjaTemplater):
             (self.templater_selector, self.name, "context")
         )
 
-        return str(cli_vars) if cli_vars else None
+        return cli_vars if cli_vars else dict()
 
     def _get_threads(self) -> int:
         threads = self.sqlfluff_config.get_section("processes")

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -246,8 +246,7 @@ class DbtTemplater(JinjaTemplater):
         return cli_vars if cli_vars else dict()
 
     def _get_threads(self) -> int:
-        threads = self.sqlfluff_config.get_section("processes")
-        return int(threads) if threads else 1
+        return 1
 
     def sequence_files(
         self, fnames: List[str], config=None, formatter=None

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -98,6 +98,7 @@ class DbtTemplater(JinjaTemplater):
     def dbt_config(self):
         """Loads the dbt config."""
         flags.set_from_args(
+            "",
             DbtConfigArgs(
                 project_dir=self.project_dir,
                 profiles_dir=self.profiles_dir,
@@ -107,7 +108,6 @@ class DbtTemplater(JinjaTemplater):
             ),
         )
         self.dbt_config = DbtRuntimeConfig.from_args(
-            "",
             DbtConfigArgs(
                 project_dir=self.project_dir,
                 profiles_dir=self.profiles_dir,

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -66,6 +66,7 @@ class DbtConfigArgs:
     profile: Optional[str] = None
     target: Optional[str] = None
     threads: int = 1
+    single_threaded: bool = False
     vars: dict = None
 
 

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -243,7 +243,7 @@ class DbtTemplater(JinjaTemplater):
             (self.templater_selector, self.name, "context")
         )
 
-        return str(cli_vars) if cli_vars else "{}"
+        return str(cli_vars) if cli_vars else None
 
     def _get_threads(self) -> int:
         threads = self.sqlfluff_config.get_section("processes")

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -66,7 +66,7 @@ class DbtConfigArgs:
     target: Optional[str] = None
     threads: int = 1
     single_threaded: bool = False
-    vars: Dict = None
+    vars: Optional[Dict] = None
 
 
 class DbtTemplater(JinjaTemplater):
@@ -103,7 +103,7 @@ class DbtTemplater(JinjaTemplater):
                 profiles_dir=self.profiles_dir,
                 profile=self._get_profile(),
                 vars=self._get_cli_vars(),
-                threads=self._get_threads(),
+                threads=1,
             ),
             None,
         )
@@ -114,7 +114,7 @@ class DbtTemplater(JinjaTemplater):
                 profile=self._get_profile(),
                 target=self._get_target(),
                 vars=self._get_cli_vars(),
-                threads=self._get_threads(),
+                threads=1,
             )
         )
         register_adapter(self.dbt_config)
@@ -243,10 +243,7 @@ class DbtTemplater(JinjaTemplater):
             (self.templater_selector, self.name, "context")
         )
 
-        return cli_vars if cli_vars else dict()
-
-    def _get_threads(self) -> int:
-        return 1
+        return cli_vars if cli_vars else {}
 
     def sequence_files(
         self, fnames: List[str], config=None, formatter=None

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -238,7 +238,7 @@ class DbtTemplater(JinjaTemplater):
             (self.templater_selector, self.name, "target")
         )
 
-    def _get_cli_vars(self) -> str:
+    def _get_cli_vars(self) -> dict:
         cli_vars = self.sqlfluff_config.get_section(
             (self.templater_selector, self.name, "context")
         )

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -97,13 +97,6 @@ class DbtTemplater(JinjaTemplater):
     @cached_property
     def dbt_config(self):
         """Loads the dbt config."""
-        # Here, we read flags.PROFILE_DIR directly, prior to calling
-        # set_from_args(). Apparently, set_from_args() sets PROFILES_DIR
-        # to a lowercase version of the value, and the profile wouldn't be
-        # found if the directory name contained uppercase letters. This fix
-        # was suggested and described here:
-        # https://github.com/sqlfluff/sqlfluff/issues/2253#issuecomment-1018722979
-        user_config = read_user_config(flags.get_flags().PROFILES_DIR)
         flags.set_from_args(
             DbtConfigArgs(
                 project_dir=self.project_dir,
@@ -111,7 +104,7 @@ class DbtTemplater(JinjaTemplater):
                 profile=self._get_profile(),
                 vars=self._get_cli_vars(),
             ),
-            user_config,
+            user_config=None,
         )
         self.dbt_config = DbtRuntimeConfig.from_args(
             DbtConfigArgs(

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -65,7 +65,7 @@ class DbtConfigArgs:
     profiles_dir: Optional[str] = None
     profile: Optional[str] = None
     target: Optional[str] = None
-    single_threaded: bool = False
+    threads: int = 1
     vars: str = ""
 
 
@@ -103,6 +103,7 @@ class DbtTemplater(JinjaTemplater):
                 profiles_dir=self.profiles_dir,
                 profile=self._get_profile(),
                 vars=self._get_cli_vars(),
+                threads=self._get_threads(),
             ),
             user_config=None,
         )
@@ -113,6 +114,7 @@ class DbtTemplater(JinjaTemplater):
                 profile=self._get_profile(),
                 target=self._get_target(),
                 vars=self._get_cli_vars(),
+                threads=self._get_threads(),
             )
         )
         register_adapter(self.dbt_config)
@@ -242,6 +244,10 @@ class DbtTemplater(JinjaTemplater):
         )
 
         return str(cli_vars) if cli_vars else "{}"
+
+    def _get_threads(self) -> int:
+        threads = int(self.sqlfluff_config.get_section("processes")) or 1
+        return threads
 
     def sequence_files(
         self, fnames: List[str], config=None, formatter=None

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = generate-fixture-yml, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{37,38,39,310}, dbt{110,140}-py{37,38,39,310}, cov-report, bench, mypy, winpy, dbt{110,140}-winpy, yamllint
+envlist = generate-fixture-yml, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{37,38,39,310}, dbt{110,150}-py{37,38,39,310}, cov-report, bench, mypy, winpy, dbt{110,150}-winpy, yamllint
 
 [testenv]
 passenv = CI, CIRCLECI, CIRCLE_*, HOME, SQLFLUFF_BENCHMARK_API_KEY
@@ -11,14 +11,14 @@ setenv =
     COVERAGE_FILE = .coverage.{envname}
     winpy: TMPDIR = temp_pytest
     # Constrain dbt versions
-    dbt{110,140,}: PIP_CONSTRAINT=constraints/{envname}.txt
+    dbt{110,150,}: PIP_CONSTRAINT=constraints/{envname}.txt
 allowlist_externals =
     make
 pip_pre = false
 deps =
     -rrequirements_dev.txt
-    dbt{110,140,}: dbt-core
-    dbt{110,140,}: dbt-postgres
+    dbt{110,150,}: dbt-core
+    dbt{110,150,}: dbt-postgres
 # Include any other steps necessary for testing below.
 # {posargs} is there to allow us to specify specific tests, which
 # can then be invoked from tox by calling e.g.
@@ -30,7 +30,7 @@ commands =
     # number pinned to the same version number of the main sqlfluff library
     # so it _must_ be installed second in the context of a version which isn't
     # yet released (and so not available on pypi).
-    dbt{110,140,}: python -m pip install {toxinidir}/plugins/sqlfluff-templater-dbt
+    dbt{110,150,}: python -m pip install {toxinidir}/plugins/sqlfluff-templater-dbt
     # Add the example plugin.
     # NOTE: The trailing comma is important because in the github test suite
     # the python version is not specified and instead the "py" environment
@@ -38,7 +38,7 @@ commands =
     # still installs the relevant plugins.
     {py,winpy}{37,38,39,310,311,}: python -m pip install {toxinidir}/plugins/sqlfluff-plugin-example
     # For the dbt test cases install dependencies.
-    dbt{110,140,}: dbt deps --project-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project --profiles-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt
+    dbt{110,150,}: dbt deps --project-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project --profiles-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt
     # Clean up from previous tests
     python {toxinidir}/util.py clean-tests
     # Run tests


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes an issue wherein dbt.flags cannot find PROFILES_DIR.

The issue that this call used to fix seems to have been fixed in a backported change https://github.com/dbt-labs/dbt-core/commit/c952d44ec5c2506995fbad75320acbae49125d3d#diff-b99c74c2d09fa1ea054aa843fa3738bd7c9d39acb9c5b90ca920f0e1fcf38010

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
