### PR TITLE
Fix #4807: LT02 & LT12 issues with empty files.

### DIFF
--- a/src/sqlfluff/rules/layout/LT12.py
+++ b/src/sqlfluff/rules/layout/LT12.py
@@ -124,6 +124,10 @@ class Rule_LT12(BaseRule):
         # We only care about the final segment of the parse tree.
         parent_stack, segment = get_last_segment(FunctionalContext(context).segment)
         self.logger.debug("Found last segment as: %s", segment)
+        if not segment:
+            # NOTE: Edge case. If the file is totally empty, we won't find a final
+            # segment. In this case return without error.
+            return None
 
         trailing_newlines = Segments(*get_trailing_newlines(context.segment))
         trailing_literal_newlines = trailing_newlines

--- a/src/sqlfluff/utils/reflow/sequence.py
+++ b/src/sqlfluff/utils/reflow/sequence.py
@@ -106,7 +106,8 @@ class ReflowSequence:
     def _validate_reflow_sequence(elements: ReflowSequenceType):
         # An empty set of elements _is_ allowed as an edge case.
         if not elements:
-            return
+            # Return early if so
+            return None
         # Check odds and evens
         OddType = elements[0].__class__
         EvenType = ReflowPoint if OddType is ReflowBlock else ReflowBlock

--- a/src/sqlfluff/utils/reflow/sequence.py
+++ b/src/sqlfluff/utils/reflow/sequence.py
@@ -104,7 +104,9 @@ class ReflowSequence:
 
     @staticmethod
     def _validate_reflow_sequence(elements: ReflowSequenceType):
-        assert elements, "ReflowSequence has empty elements."
+        # An empty set of elements _is_ allowed as an edge case.
+        if not elements:
+            return
         # Check odds and evens
         OddType = elements[0].__class__
         EvenType = ReflowPoint if OddType is ReflowBlock else ReflowBlock

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -251,6 +251,14 @@ def test__cli__command_lint_stdin(command):
     invoke_assert_code(args=[lint, ("--dialect=ansi",) + command], cli_input=sql)
 
 
+def test__cli__command_lint_empty_stdin():
+    """Check linting an empty file raises no exceptions.
+
+    https://github.com/sqlfluff/sqlfluff/issues/4807
+    """
+    invoke_assert_code(args=[lint, ("-d", "ansi", "-")], cli_input="")
+
+
 def test__cli__command_render_stdin():
     """Check render on a simple script using stdin."""
     with open("test/fixtures/cli/passing_a.sql") as test_file:


### PR DESCRIPTION
This fixes #4807.

Two rules didn't play nice with empty files. I've added explicit handling for that scenario in LT12, and in the reflow constructor for LT02 (and other rules using reflow).