### PR TITLE
docs(templater): Refactor templater configuration docs

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -448,7 +448,7 @@ For example, if passed the following *.sql* file:
 Jinja templater
 ^^^^^^^^^^^^^^^
 
-The Jinja template uses Jinja2_ to render templates.
+The Jinja templater uses Jinja2_ to render templates.
 
 .. _Jinja2: https://jinja.palletsprojects.com/
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -454,11 +454,29 @@ The Jinja template uses Jinja2_ to render templates.
 
 There are multiple, complementary ways of configuring the Jinja templater.
 
-- Reading variables and Jinja macros from config, see
-  `Complex Jinja Variable Templating`_ and
-  `Jinja Macro Templating (from config)`_
-- Loading macros from a path, see `Jinja Macro Templating (from file)`_
-- Using a library, see `Library Templating`_
+- Reading variables and Jinja macros directly from the SQLFLuff config file
+- Loading macros from a path
+- Using a library
+
+.. list-table:: Overview of Jinja templater's configuration options
+   :header-rows: 1
+
+   * - Configuration
+     - Variables
+     - Macros
+     - Documentation
+   * - Config file
+     - ✅
+     - ✅
+     - `Complex Jinja Variable Templating`_ and `Jinja Macro Templating (from config)`_
+   * - Macro Path
+     - ❌
+     - ✅
+     - `Jinja Macro Templating (from file)`_
+   * - Library
+     - ✅
+     - ✅
+     - `Library Templating`_
 
 For example, a snippet from a :code:`.sqlfluff` file that uses all config
 options:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -455,13 +455,13 @@ options:
     load_macros_from_path = my_macros
     library_path = sqlfluff_libs
 
-   [sqlfluff:templater:jinja:context]
-   my_list = ['a', 'b', 'c']
-   MY_LIST = ("d", "e", "f")
-   my_where_dict = {"field_1": 1, "field_2": 2}
+    [sqlfluff:templater:jinja:context]
+    my_list = ['a', 'b', 'c']
+    MY_LIST = ("d", "e", "f")
+    my_where_dict = {"field_1": 1, "field_2": 2}
 
-   [sqlfluff:templater:jinja:macros]
-   a_macro_def = {% macro my_macro(n) %}{{ n }} + {{ n * 2 }}{% endmacro %}
+    [sqlfluff:templater:jinja:macros]
+    a_macro_def = {% macro my_macro(n) %}{{ n }} + {{ n * 2 }}{% endmacro %}
 
 Complex Jinja Variable Templating
 """""""""""""""""""""""""""""""""
@@ -543,7 +543,7 @@ this introduces the idea of config *blocks* which could be selectively
 overwritten by other configuration files downstream as required.
 
 Jinja Macro Templating (from file)
-""""""""""""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""""""
 
 In addition to macros specified in the config file, macros can also be
 loaded from files or folders. This is specified in the config file:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -438,9 +438,9 @@ The Jinja template uses Jinja2_ to render templates.
 
 There are multiple, complementary ways of configuring the Jinja templater.
 
-- Reading Variables and macros from config
-- Loading macros from a path.
-- Using a library
+- Reading variables and Jinja macros from config, see `Complex Jinja Variable Templating`_ and `Jinja Macro Templating (from config)`_
+- Loading macros from a path, see `Jinja Macro Templating (from file)`_
+- Using a library, see `Library Templating`_
 
 For example, a snippet from a :code:`.sqlfluff` file that uses all config
 options:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -390,6 +390,22 @@ Also, SQLFluff has an integration to use :code:`dbt` as a templater.
 
 - `dbt templater`_ (via plugin which is covered in a different section).
 
+.. note::
+
+    Templaters may not be able to generate a rendered SQL that cover
+    the entire raw file.
+
+    For example, if the raw SQL uses a :code:`{% if condition %}` block,
+    the rendered version of the template will only include either the
+    :code:`{% then %}` or the :code:`{% else %}` block (depending on the
+    provided configuration for the templater), but not both.
+
+    In this case, because SQLFluff linting can only operate on the output
+    of the templater, some areas of the raw SQL will never be seen by the
+    linter and will not be covered by lint rules.
+
+    This is functionality we hope to support in future.
+
 Generic Variable Templating
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -374,9 +374,11 @@ This is achieved by the following set of operations:
 2. SQLFluff applies the lint and fix operations to the rendered file
 3. SQLFluff backports the rule violations to the templated section of the SQL.
 
-SQLFluff may not have access to the fully operational templater.
-But instead uses a set of user-provided dummy values to render the template,
-see below.
+SQLFluff does not automatically have access to the same environment used in
+production template setup.
+This means it is necessary to either provide that environment or provide dummy
+values to effectively render the template and generate valid SQL.
+Refer to the templater sections below for details.
 
 SQLFluff natively supports the following templating engines
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -438,7 +438,9 @@ The Jinja template uses Jinja2_ to render templates.
 
 There are multiple, complementary ways of configuring the Jinja templater.
 
-- Reading variables and Jinja macros from config, see `Complex Jinja Variable Templating`_ and `Jinja Macro Templating (from config)`_
+- Reading variables and Jinja macros from config, see
+  `Complex Jinja Variable Templating`_ and
+  `Jinja Macro Templating (from config)`_
 - Loading macros from a path, see `Jinja Macro Templating (from file)`_
 - Using a library, see `Library Templating`_
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -356,18 +356,42 @@ layout: :ref:`layoutconfig`.
 
 .. _templateconfig:
 
-Jinja Templating Configuration
-------------------------------
+Templating Configuration
+------------------------
 
-When thinking about Jinja templating there are two different kinds of things
-that a user might want to fill into a templated file, *variables* and
-*functions/macros*. Currently *functions* aren't implemented in any
-of the templaters.
+This section explains how to configure templating for SQL files.
 
-Variable Templating
-^^^^^^^^^^^^^^^^^^^
+When writing SQL files, users might utilise some kind of templating.
+The SQL file itself is written with placeholders which get rendered to proper
+SQL at run time.
+This can range from very simple placeholder templating to complex Jinja
+templating.
 
-Variables are available in the *jinja*, *python* and *placeholder* templaters.
+SQLFluff supports templated sections in SQL, see :ref:`templater`.
+This is achieved by the following set of operations:
+
+1. SQLFluff pre-renders the templated SQL
+2. SQLFluff applies the lint and fix operations to the rendered file
+3. SQLFluff backports the rule violations to the templated section of the SQL.
+
+SQLFluff may not have access to the fully operational templater.
+But instead uses a set of user-provided dummy values to render the template,
+see below.
+
+SQLFluff natively supports the following templating engines
+
+- `Jinja templater`_
+- `Placeholder templater`_
+- `Python templater`_
+
+Also, SQLFluff has an integration to use :code:`dbt` as a templater.
+
+- `dbt templater`_ (via plugin which is covered in a different section).
+
+Generic Variable Templating
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Variables are available in all the templaters.
 By default the templating engine will expect variables for templating to be
 available in the config, and the templater will be look in the section
 corresponding to the context for that templater. By convention, the config for
@@ -403,8 +427,320 @@ For example, if passed the following *.sql* file:
     `SQLTemplatingError` and this will appear as a violation without
     a line number, quoting the name of the variable that couldn't be found.
 
-Placeholder templating
-^^^^^^^^^^^^^^^^^^^^^^
+Jinja templater
+^^^^^^^^^^^^^^^
+
+The Jinja template uses Jinja2_ to render templates.
+
+.. _Jinja2: https://jinja.palletsprojects.com/
+
+There are multiple, complementary ways of configuring the Jinja templater.
+
+- Reading Variables and macros from config
+- Loading macros from a path.
+- Using a library
+
+For example, a snippet from a :code:`.sqlfluff` file that uses all config
+options:
+
+.. code-block:: cfg
+
+    [sqlfluff]
+    templater = jinja
+
+    [sqlfluff:templater:jinja]
+    apply_dbt_builtins = true
+    load_macros_from_path = my_macros
+    library_path = sqlfluff_libs
+
+   [sqlfluff:templater:jinja:context]
+   my_list = ['a', 'b', 'c']
+   MY_LIST = ("d", "e", "f")
+   my_where_dict = {"field_1": 1, "field_2": 2}
+
+   [sqlfluff:templater:jinja:macros]
+   a_macro_def = {% macro my_macro(n) %}{{ n }} + {{ n * 2 }}{% endmacro %}
+
+Complex Jinja Variable Templating
+"""""""""""""""""""""""""""""""""
+
+Apart from the Generic variable templating that is supported for all
+templaters, two more advanced features of variable templating are available for
+Jinja.
+
+*case sensitivity* and *native python types*.
+Both are illustrated in the following example:
+
+.. code-block:: cfg
+
+    [sqlfluff:templater:jinja:context]
+    my_list = ['a', 'b', 'c']
+    MY_LIST = ("d", "e", "f")
+    my_where_dict = {"field_1": 1, "field_2": 2}
+
+.. code-block:: SQL+Jinja
+
+    SELECT
+        {% for elem in MY_LIST %}
+            '{{elem}}' {% if not loop.last %}||{% endif %}
+        {% endfor %} as concatenated_list
+    FROM tbl
+    WHERE
+        {% for field, value in my_where_dict.items() %}
+            {{field}} = {{value}} {% if not loop.last %}and{% endif %}
+        {% endfor %}
+
+...will render as...
+
+.. code-block:: sql
+
+    SELECT
+        'd' || 'e' || 'f' as concatenated_list
+    FROM tbl
+    WHERE
+        field_1 = 1 and field_2 = 2
+
+Note that the variable was replaced in a case sensitive way and that the
+settings in the config file were interpreted as native python types.
+
+Jinja Macro Templating (from config)
+""""""""""""""""""""""""""""""""""""
+
+Macros (which also look and feel like *functions* are available only in the
+*jinja* templater. Similar to `Generic Variable Templating`_, these are
+specified in config files, what's different in this case is how they are named.
+Similar to the *context* section above, macros are configured separately in the
+*macros* section of the config.
+Consider the following example.
+
+If passed the following *.sql* file:
+
+.. code-block:: SQL+Jinja
+
+    SELECT {{ my_macro(6) }} FROM some_table
+
+...and the following configuration in *.sqlfluff* in the same directory (note
+the tight control of whitespace):
+
+.. code-block:: cfg
+
+    [sqlfluff:templater:jinja:macros]
+    a_macro_def = {% macro my_macro(n) %}{{ n }} + {{ n * 2 }}{% endmacro %}
+
+...then before parsing, the sql will be transformed to:
+
+.. code-block:: sql
+
+    SELECT 6 + 12 FROM some_table
+
+Note that in the code block above, the variable name in the config is
+*a_macro_def*, and this isn't apparently otherwise used anywhere else.
+Broadly this is accurate, however within the configuration loader this will
+still be used to overwrite previous *values* in other config files. As such
+this introduces the idea of config *blocks* which could be selectively
+overwritten by other configuration files downstream as required.
+
+Jinja Macro Templating (from file)
+""""""""""""""""""""""""""""""""""""
+
+In addition to macros specified in the config file, macros can also be
+loaded from files or folders. This is specified in the config file:
+
+.. code-block:: cfg
+
+    [sqlfluff:templater:jinja]
+    load_macros_from_path = my_macros
+
+``load_macros_from_path`` is a comma-separated list of :code:`.sql` files or
+folders. Locations are *relative to the config file*. For example, if the
+config file above was found at :code:`/home/my_project/.sqlfluff`, then
+SQLFluff will look for macros in the folder :code:`/home/my_project/my_macros/`
+(but not subfolders). Any macros defined in the config will always take
+precedence over a macro defined in the path.
+
+* :code:`.sql` files: Macros in these files are available in every :code:`.sql`
+  file without requiring a Jinja :code:`include` or :code:`import`.
+* Folders: To use macros from the :code:`.sql` files in folders, use Jinja
+  :code:`include` or :code:`import` as explained below.
+
+**Note:** The :code:`load_macros_from_path` setting also defines the search
+path for Jinja
+`include <https://jinja.palletsprojects.com/en/3.0.x/templates/#include>`_ or
+`import <https://jinja.palletsprojects.com/en/3.0.x/templates/#import>`_.
+Unlike with macros (as noted above), subdirectories are supported. For example,
+if :code:`load_macros_from_path` is set to :code:`my_macros`, and there is a
+file :code:`my_macros/subdir/my_file.sql`, you can do:
+
+.. code-block:: jinja
+
+   {% include 'subdir/include_comment.sql' %}
+
+.. note::
+
+    Throughout the templating process **whitespace** will still be treated
+    rigorously, and this includes **newlines**. In particular you may choose
+    to provide *dummy* macros in your configuration different from the actual
+    macros used in production.
+
+    **REMEMBER:** The reason SQLFluff supports macros is to *enable* it to parse
+    templated sql without it being a blocker. It shouldn't be a requirement that
+    the *templating* is accurate - it only needs to work well enough that
+    *parsing* and *linting* are helpful.
+
+Builtin Jinja Macro Blocks
+""""""""""""""""""""""""""
+
+One of the main use cases which inspired *SQLFluff* as a project was `dbt`_.
+It uses jinja templating extensively and leads to some users maintaining large
+repositories of sql files which could potentially benefit from some linting.
+
+.. note::
+    *SQLFluff* has now a tighter integration with dbt through the "dbt" templater.
+    It is the recommended templater for dbt projects. If used, it eliminates the
+    need for the overrides described in this section.
+
+    To use the dbt templater, go to `dbt templater`_.
+
+*SQLFluff* anticipates this use case and provides some built in macro blocks
+in the `Default Configuration`_ which assist in getting started with `dbt`_
+projects. In particular it provides mock objects for:
+
+* *ref*: The mock version of this provided simply returns the model reference
+  as the name of the table. In most cases this is sufficient.
+* *config*: A regularly used macro in `dbt`_ to set configuration values. For
+  linting purposes, this makes no difference and so the provided macro simply
+  returns nothing.
+
+.. note::
+    If there are other builtin macros which would make your life easier,
+    consider submitting the idea (or even better a pull request) on `github`_.
+
+.. _`dbt`: https://www.getdbt.com/
+.. _`github`: https://www.github.com/sqlfluff/sqlfluff
+
+Library Templating
+""""""""""""""""""
+
+If using *SQLFluff* with jinja as your templater, you may have library
+function calls within your sql files that can not be templated via the
+normal macro templating mechanisms:
+
+.. code-block:: SQL+Jinja
+
+    SELECT foo, bar FROM baz {{ dbt_utils.group_by(2) }}
+
+To template these libraries, you can use the `sqlfluff:jinja:library_path`
+config option:
+
+.. code-block:: cfg
+
+    [sqlfluff:templater:jinja]
+    library_path = sqlfluff_libs
+
+This will pull in any python modules from that directory and allow sqlfluff
+to use them in templates. In the above example, you might define a file at
+`sqlfluff_libs/dbt_utils.py` as:
+
+.. code-block:: python
+
+    def group_by(n):
+        return "GROUP BY 1,2"
+
+
+If an `__init__.py` is detected, it will be loaded alongside any modules and
+submodules found within the library path.
+
+.. code-block:: SQL+Jinja
+
+   SELECT
+      {{ custom_sum('foo', 'bar') }},
+      {{ foo.bar.another_sum('foo', 'bar') }}
+   FROM
+      baz
+
+`sqlfluff_libs/__init__.py`:
+
+.. code-block:: python
+
+    def custom_sum(a: str, b: str) -> str:
+        return a + b
+
+`sqlfluff_libs/foo/__init__.py`:
+
+.. code-block:: python
+
+    # empty file
+
+`sqlfluff_libs/foo/bar.py`:
+
+.. code-block:: python
+
+     def another_sum(a: str, b: str) -> str:
+        return a + b
+
+Interaction with ``--ignore=templating``
+""""""""""""""""""""""""""""""""""""""""
+
+Ignoring Jinja templating errors provides a way for users to use SQLFluff
+while reducing or avoiding the need to spend a lot of time adding variables
+to ``[sqlfluff:templater:jinja:context]``.
+
+When ``--ignore=templating`` is enabled, the Jinja templater behaves a bit
+differently. This additional behavior is *usually* but not *always* helpful
+for making the file at least partially parsable and fixable. It definitely
+doesn’t **guarantee** that every file can be fixed, but it’s proven useful for
+some users.
+
+Here's how it works:
+
+* Within the expanded SQL, undefined variables are automatically *replaced*
+  with the corresponding string value.
+* If you do: ``{% include query %}``, and the variable ``query`` is not
+  defined, it returns a “file” containing the string ``query``.
+* If you do: ``{% include "query_file.sql" %}``, and that file does not exist
+  or you haven’t configured a setting for ``load_macros_from_path``, it
+  returns a “file” containing the text ``query_file``.
+
+For example:
+
+.. code-block:: SQL+Jinja
+
+   select {{ my_variable }}
+   from {% include "my_table.sql" %}
+
+is interpreted as:
+
+.. code-block:: sql
+
+   select my_variable
+   from my_table
+
+The values provided by the Jinja templater act *a bit* (not exactly) like a
+mixture of several types:
+
+* ``str``
+* ``int``
+* ``list``
+* Jinja's ``Undefined`` `class <https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.Undefined>`_
+
+Because the values behave like ``Undefined``, it's possible to replace them
+using Jinja's ``default()`` `filter <https://jinja.palletsprojects.com/en/3.1.x/templates/#jinja-filters.default>`_.
+For example:
+
+.. code-block:: SQL+Jinja
+
+      select {{ my_variable | default("col_a") }}
+      from my_table
+
+is interpreted as:
+
+.. code-block:: sql
+
+      select col_a
+      from my_table
+
+Placeholder templater
+^^^^^^^^^^^^^^^^^^^^^
 
 Libraries such as SQLAlchemy or Psycopg use different parameter placeholder
 styles to mark where a parameter has to be inserted in the query.
@@ -504,277 +840,13 @@ instead.
 Also consider making a pull request to the project to have your style added,
 it may be useful to other people and simplify your configuration.
 
-Complex Variable Templating
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Two more advanced features of variable templating are *case sensitivity*
-and *native python types*. Both are illustrated in the following example:
-
-.. code-block:: cfg
-
-    [sqlfluff:templater:jinja:context]
-    my_list = ['a', 'b', 'c']
-    MY_LIST = ("d", "e", "f")
-    my_where_dict = {"field_1": 1, "field_2": 2}
-
-.. code-block:: SQL+Jinja
-
-    SELECT
-        {% for elem in MY_LIST %}
-            '{{elem}}' {% if not loop.last %}||{% endif %}
-        {% endfor %} as concatenated_list
-    FROM tbl
-    WHERE
-        {% for field, value in my_where_dict.items() %}
-            {{field}} = {{value}} {% if not loop.last %}and{% endif %}
-        {% endfor %}
-
-...will render as...
-
-.. code-block:: sql
-
-    SELECT
-        'd' || 'e' || 'f' as concatenated_list
-    FROM tbl
-    WHERE
-        field_1 = 1 and field_2 = 2
-
-Note that the variable was replaced in a case sensitive way and that the
-settings in the config file were interpreted as native python types.
-
-Macro Templating
+Python templater
 ^^^^^^^^^^^^^^^^
 
-Macros (which also look and feel like *functions* are available only in the
-*jinja* templater. Similar to `Variable Templating`_, these are specified in
-config files, what's different in this case is how they are named. Similar to
-the *context* section above, macros are configured separately in the *macros*
-section of the config. Consider the following example.
+Uses native Python f-strings.
 
-If passed the following *.sql* file:
-
-.. code-block:: SQL+Jinja
-
-    SELECT {{ my_macro(6) }} FROM some_table
-
-...and the following configuration in *.sqlfluff* in the same directory (note
-the tight control of whitespace):
-
-.. code-block:: cfg
-
-    [sqlfluff:templater:jinja:macros]
-    a_macro_def = {% macro my_macro(n) %}{{ n }} + {{ n * 2 }}{% endmacro %}
-
-...then before parsing, the sql will be transformed to:
-
-.. code-block:: sql
-
-    SELECT 6 + 12 FROM some_table
-
-Note that in the code block above, the variable name in the config is
-*a_macro_def*, and this isn't apparently otherwise used anywhere else.
-Broadly this is accurate, however within the configuration loader this will
-still be used to overwrite previous *values* in other config files. As such
-this introduces the idea of config *blocks* which could be selectively
-overwritten by other configuration files downstream as required.
-
-In addition to macros specified in the config file, macros can also be
-loaded from files or folders. This is specified in the config file:
-
-.. code-block:: cfg
-
-    [sqlfluff:templater:jinja]
-    load_macros_from_path = my_macros
-
-``load_macros_from_path`` is a comma-separated list of :code:`.sql` files or
-folders. Locations are *relative to the config file*. For example, if the
-config file above was found at :code:`/home/my_project/.sqlfluff`, then
-SQLFluff will look for macros in the folder :code:`/home/my_project/my_macros/`
-(but not subfolders). Any macros defined in the config will always take
-precedence over a macro defined in the path.
-
-* :code:`.sql` files: Macros in these files are available in every :code:`.sql`
-  file without requiring a Jinja :code:`include` or :code:`import`.
-* Folders: To use macros from the :code:`.sql` files in folders, use Jinja
-  :code:`include` or :code:`import` as explained below.
-
-**Note:** The :code:`load_macros_from_path` setting also defines the search
-path for Jinja
-`include <https://jinja.palletsprojects.com/en/3.0.x/templates/#include>`_ or
-`import <https://jinja.palletsprojects.com/en/3.0.x/templates/#import>`_.
-Unlike with macros (as noted above), subdirectories are supported. For example,
-if :code:`load_macros_from_path` is set to :code:`my_macros`, and there is a
-file :code:`my_macros/subdir/my_file.sql`, you can do:
-
-.. code-block:: jinja
-
-   {% include 'subdir/include_comment.sql' %}
-
-.. note::
-
-    Throughout the templating process **whitespace** will still be treated
-    rigorously, and this includes **newlines**. In particular you may choose
-    to provide *dummy* macros in your configuration different from the actual
-    macros used in production.
-
-    **REMEMBER:** The reason SQLFluff supports macros is to *enable* it to parse
-    templated sql without it being a blocker. It shouldn't be a requirement that
-    the *templating* is accurate - it only needs to work well enough that
-    *parsing* and *linting* are helpful.
-
-Builtin Macro Blocks
-^^^^^^^^^^^^^^^^^^^^
-
-One of the main use cases which inspired *SQLFluff* as a project was `dbt`_.
-It uses jinja templating extensively and leads to some users maintaining large
-repositories of sql files which could potentially benefit from some linting.
-
-.. note::
-    *SQLFluff* has now a tighter integration with dbt through the "dbt" templater.
-    It is the recommended templater for dbt projects. If used, it eliminates the
-    need for the overrides described in this section.
-
-    To use the dbt templater, go to `dbt Project Configuration`_.
-
-*SQLFluff* anticipates this use case and provides some built in macro blocks
-in the `Default Configuration`_ which assist in getting started with `dbt`_
-projects. In particular it provides mock objects for:
-
-* *ref*: The mock version of this provided simply returns the model reference
-  as the name of the table. In most cases this is sufficient.
-* *config*: A regularly used macro in `dbt`_ to set configuration values. For
-  linting purposes, this makes no difference and so the provided macro simply
-  returns nothing.
-
-.. note::
-    If there are other builtin macros which would make your life easier,
-    consider submitting the idea (or even better a pull request) on `github`_.
-
-.. _`dbt`: https://www.getdbt.com/
-.. _`github`: https://www.github.com/sqlfluff/sqlfluff
-
-Interaction with ``--ignore=templating``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Ignoring Jinja templating errors provides a way for users to use SQLFluff
-while reducing or avoiding the need to spend a lot of time adding variables
-to ``[sqlfluff:templater:jinja:context]``.
-
-When ``--ignore=templating`` is enabled, the Jinja templater behaves a bit
-differently. This additional behavior is *usually* but not *always* helpful
-for making the file at least partially parsable and fixable. It definitely
-doesn’t **guarantee** that every file can be fixed, but it’s proven useful for
-some users.
-
-Here's how it works:
-
-* Within the expanded SQL, undefined variables are automatically *replaced*
-  with the corresponding string value.
-* If you do: ``{% include query %}``, and the variable ``query`` is not
-  defined, it returns a “file” containing the string ``query``.
-* If you do: ``{% include "query_file.sql" %}``, and that file does not exist
-  or you haven’t configured a setting for ``load_macros_from_path``, it
-  returns a “file” containing the text ``query_file``.
-
-For example:
-
-.. code-block:: SQL+Jinja
-
-   select {{ my_variable }}
-   from {% include "my_table.sql" %}
-
-is interpreted as:
-
-.. code-block:: sql
-
-   select my_variable
-   from my_table
-
-The values provided by the Jinja templater act *a bit* (not exactly) like a
-mixture of several types:
-
-* ``str``
-* ``int``
-* ``list``
-* Jinja's ``Undefined`` `class <https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.Undefined>`_
-
-Because the values behave like ``Undefined``, it's possible to replace them
-using Jinja's ``default()`` `filter <https://jinja.palletsprojects.com/en/3.1.x/templates/#jinja-filters.default>`_.
-For example:
-
-.. code-block:: SQL+Jinja
-
-      select {{ my_variable | default("col_a") }}
-      from my_table
-
-is interpreted as:
-
-.. code-block:: sql
-
-      select col_a
-      from my_table
-
-Library Templating
-^^^^^^^^^^^^^^^^^^
-
-If using *SQLFluff* for dbt with jinja as your templater, you may have library
-function calls within your sql files that can not be templated via the
-normal macro templating mechanisms:
-
-.. code-block:: SQL+Jinja
-
-    SELECT foo, bar FROM baz {{ dbt_utils.group_by(2) }}
-
-To template these libraries, you can use the `sqlfluff:jinja:library_path`
-config option:
-
-.. code-block:: cfg
-
-    [sqlfluff:templater:jinja]
-    library_path = sqlfluff_libs
-
-This will pull in any python modules from that directory and allow sqlfluff
-to use them in templates. In the above example, you might define a file at
-`sqlfluff_libs/dbt_utils.py` as:
-
-.. code-block:: python
-
-    def group_by(n):
-        return "GROUP BY 1,2"
-
-
-If an `__init__.py` is detected, it will be loaded alongside any modules and
-submodules found within the library path.
-
-.. code-block:: SQL+Jinja
-
-   SELECT
-      {{ custom_sum('foo', 'bar') }},
-      {{ foo.bar.another_sum('foo', 'bar') }}
-   FROM
-      baz
-
-`sqlfluff_libs/__init__.py`:
-
-.. code-block:: python
-
-    def custom_sum(a: str, b: str) -> str:
-        return a + b
-
-`sqlfluff_libs/foo/__init__.py`:
-
-.. code-block:: python
-
-    # empty file
-
-`sqlfluff_libs/foo/bar.py`:
-
-.. code-block:: python
-
-     def another_sum(a: str, b: str) -> str:
-        return a + b
-
-dbt Project Configuration
--------------------------
+:code:`dbt` templater
+^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
     From sqlfluff version 0.7.0 onwards, the dbt templater has been moved
@@ -823,7 +895,7 @@ Cons:
 * Runs slower
 
 Installation & Configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+""""""""""""""""""""""""""""
 
 In order to get started using *SQLFluff* with a dbt project you will
 first need to install the relevant `dbt adapter`_ for your dialect
@@ -906,7 +978,7 @@ See below configuration and its equivalent dbt command:
     dbt run --vars '{"my_variable": 1}'
 
 Known Caveats
-^^^^^^^^^^^^^
+"""""""""""""
 
 - To use the dbt templater, you must set `templater = dbt` in the `.sqlfluff`
   config file in the directory where sqlfluff is run. The templater cannot
@@ -1041,8 +1113,8 @@ linted and the sub files will also be applied within that subdirectory.
 Default Configuration
 ---------------------
 
-The default configuration is as follows, note the `Builtin Macro Blocks`_ in
-section *[sqlfluff:templater:jinja:macros]* as referred to above.
+The default configuration is as follows, note the `Builtin Jinja Macro Blocks`_
+in section *[sqlfluff:templater:jinja:macros]* as referred to above.
 
 .. note::
 

--- a/docs/source/internals.rst
+++ b/docs/source/internals.rst
@@ -17,6 +17,7 @@ At a high level, the behaviour of SQLFluff is divided into a few key stages.
 Whether calling `sqlfluff lint`, `sqlfluff fix` or `sqlfluff parse`, the
 internal flow is largely the same.
 
+.. _templater:
 
 Stage 1, the templater
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

This PR tries to improve the documentation about configuration of the various templaters.

Currently, the documentation can be a little hard to read and understand. For example

- Placeholder templater docs is a subsection to Jinja. In the middle of other Jinja documentation, which can be distracting.
- Alone from the configuration documentation It's not immediately clear which templaters exists. Users have to find the  Internals documentation to learn about available templaters.
- All available configuration options for the Jinja templater are not available at one glance.

See the current structure:

<img width="243" alt="image" src="https://user-images.githubusercontent.com/14202480/235641451-e6b2d5d8-7b69-4ffc-8818-118172366150.png">


To address these point, this PR groups all templating into a section of the configuration docs, like so

<img width="241" alt="image" src="https://user-images.githubusercontent.com/14202480/235640691-d4f3301c-cba5-4d3d-8c77-5027ba8c73cb.png">

Then, all the specifics are handled in the corresponding sections.

**Note:** I tried to leave to documentation itself, as untouched as possible. Only the general section is new. For existing ones, just changing the hierarchy levels. I'm planing to add further changes to the documentation itself, but I don't wanna mix this in here, which is focusing on the structure on the docs mainly.

### Are there any other side effects of this change that we should be aware of?

No, documentation only change.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
