### PR TITLE
Sqlite: COLLATE column constraint

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2819,9 +2819,8 @@ class ColumnConstraintSegment(BaseSegment):
             Ref("ReferenceDefinitionGrammar"),  # REFERENCES reftable [ ( refcolumn) ]x
             Ref("CommentClauseSegment"),
             Sequence(
-                "COLLATE",  # https://www.sqlite.org/datatype3.html#collation
-                OneOf("BINARY", "NOCASE", "RTRIM"),
-            ),
+                "COLLATE", Ref("CollationReferenceSegment")
+            ),  # https://www.sqlite.org/datatype3.html#collation
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2818,6 +2818,10 @@ class ColumnConstraintSegment(BaseSegment):
             Ref("AutoIncrementGrammar"),
             Ref("ReferenceDefinitionGrammar"),  # REFERENCES reftable [ ( refcolumn) ]x
             Ref("CommentClauseSegment"),
+            Sequence(
+                "COLLATE",  # https://www.sqlite.org/datatype3.html#collation
+                OneOf("BINARY", "NOCASE", "RTRIM"),
+            ),
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_sqlite_keywords.py
+++ b/src/sqlfluff/dialects/dialect_sqlite_keywords.py
@@ -201,4 +201,7 @@ UNRESERVED_KEYWORDS = [
     "RESTART",
     "RESET",
     "STRICT",
+    "BINARY",
+    "NOCASE",
+    "RTRIM",
 ]

--- a/test/fixtures/dialects/sqlite/create_table.sql
+++ b/test/fixtures/dialects/sqlite/create_table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE users (
     user_id INTEGER PRIMARY KEY AUTOINCREMENT,
     username TEXT NOT NULL UNIQUE,
-    password TEXT NOT NULL,
+    password TEXT NOT NULL COLLATE NOCASE,
     email TEXT NOT NULL UNIQUE
 );

--- a/test/fixtures/dialects/sqlite/create_table.yml
+++ b/test/fixtures/dialects/sqlite/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d41b1c6f7c9e285362e2e75bbca5f6286c324a06946c837e5531684758e73b4c
+_hash: 0a94ff2d639e165e4e4981d3ea0e3d4f2750a07ed4f2c0bb2d145d5166d2c62f
 file:
   statement:
     create_table_statement:
@@ -33,12 +33,15 @@ file:
             keyword: UNIQUE
       - comma: ','
       - column_definition:
-          naked_identifier: password
-          data_type:
+        - naked_identifier: password
+        - data_type:
             data_type_identifier: TEXT
-          column_constraint_segment:
+        - column_constraint_segment:
           - keyword: NOT
           - keyword: 'NULL'
+        - column_constraint_segment:
+          - keyword: COLLATE
+          - keyword: NOCASE
       - comma: ','
       - column_definition:
         - naked_identifier: email

--- a/test/fixtures/dialects/sqlite/create_table.yml
+++ b/test/fixtures/dialects/sqlite/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0a94ff2d639e165e4e4981d3ea0e3d4f2750a07ed4f2c0bb2d145d5166d2c62f
+_hash: 8aa612e64befa74ee94085376570eed5f55511432f801989f14dc97de88dd851
 file:
   statement:
     create_table_statement:
@@ -40,8 +40,9 @@ file:
           - keyword: NOT
           - keyword: 'NULL'
         - column_constraint_segment:
-          - keyword: COLLATE
-          - keyword: NOCASE
+            keyword: COLLATE
+            collation_reference:
+              naked_identifier: NOCASE
       - comma: ','
       - column_definition:
         - naked_identifier: email


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Closes https://github.com/sqlfluff/sqlfluff/issues/4829

### Are there any other side effects of this change that we should be aware of?
Maybe could sneak into sqlite dialect directly instead of ANSI, but I felt `ColumnConstraintSegment` still has a ton of overlap so didn't want to redefine in sqlite.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
