### PR TITLE
Adding support for NOCOPY and INSTANT algorithm on CREATE INDEX on MySQL dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -804,6 +804,7 @@ class CreateIndexStatementSegment(ansi.CreateIndexStatementSegment):
     """A `CREATE INDEX` statement.
 
     https://dev.mysql.com/doc/refman/8.0/en/create-index.html
+    https://mariadb.com/kb/en/create-index/
     """
 
     match_grammar = Sequence(
@@ -820,7 +821,7 @@ class CreateIndexStatementSegment(ansi.CreateIndexStatementSegment):
             Sequence(
                 "ALGORITHM",
                 Ref("EqualsSegment", optional=True),
-                OneOf("DEFAULT", "INPLACE", "COPY"),
+                OneOf("DEFAULT", "INPLACE", "COPY", "NOCOPY", "INSTANT"),
             ),
             Sequence(
                 "LOCK",

--- a/src/sqlfluff/dialects/dialect_mysql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_mysql_keywords.py
@@ -785,4 +785,6 @@ ZONE
 mysql_unreserved_keywords += """NOW
 SHARED
 INPLACE
+NOCOPY
+INSTANT
 """

--- a/test/fixtures/dialects/mysql/create_index.sql
+++ b/test/fixtures/dialects/mysql/create_index.sql
@@ -8,5 +8,7 @@ CREATE INDEX idx ON tbl (col ASC);
 CREATE INDEX idx ON tbl (col DESC);
 CREATE INDEX part_of_name ON customer (name(10));
 CREATE INDEX idx ON tbl (col) ALGORITHM DEFAULT;
+CREATE INDEX idx ON tbl (col) ALGORITHM NOCOPY;
+CREATE INDEX idx ON tbl (col) ALGORITHM INSTANT;
 CREATE INDEX idx ON tbl (col) LOCK DEFAULT;
 CREATE INDEX idx ON tbl ((col1 + col2), (col1 - col2), col1);

--- a/test/fixtures/dialects/mysql/create_index.yml
+++ b/test/fixtures/dialects/mysql/create_index.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b32f27257ab99686db1f16498efe2ecfd3a419f47ed46444b44bb1f3bddce05e
+_hash: 5ba008b762b05319be63ea1b01262c62e054e8ba120801da8589dc396cd1fdd3
 file:
 - statement:
     create_index_statement:
@@ -171,6 +171,40 @@ file:
         end_bracket: )
     - keyword: ALGORITHM
     - keyword: DEFAULT
+- statement_terminator: ;
+- statement:
+    create_index_statement:
+    - keyword: CREATE
+    - keyword: INDEX
+    - index_reference:
+        naked_identifier: idx
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: tbl
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: col
+        end_bracket: )
+    - keyword: ALGORITHM
+    - keyword: NOCOPY
+- statement_terminator: ;
+- statement:
+    create_index_statement:
+    - keyword: CREATE
+    - keyword: INDEX
+    - index_reference:
+        naked_identifier: idx
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: tbl
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: col
+        end_bracket: )
+    - keyword: ALGORITHM
+    - keyword: INSTANT
 - statement_terminator: ;
 - statement:
     create_index_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Adding support for NOCOPY and INSTANT algorithm on CREATE INDEX on the MySQL dialect
Both algorithms are supported by MariaDB as defined in the MariaDB documentation:
https://mariadb.com/kb/en/create-index/
fixes #4864 

### Are there any other side effects of this change that we should be aware of?
No side effects are expected but these algorithms are only currently supported by MariaDB.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
  - Added appropriate documentation for the change.
  - Created GitHub issues for any relevant followup/future enhancements if appropriate.
