### PR TITLE
Oracle: Add support for `$` and `#`  in identifier

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -15,6 +15,8 @@ from sqlfluff.core.parser import (
     Matchable,
     Ref,
     RegexLexer,
+    RegexParser,
+    SegmentGenerator,
     Sequence,
     StringLexer,
     StringParser,
@@ -50,6 +52,18 @@ oracle_dialect.sets("bare_functions").update(
     ]
 )
 
+
+oracle_dialect.patch_lexer_matchers(
+    [
+        RegexLexer(
+            "code",
+            r"[a-zA-Z][0-9a-zA-Z_$#]*",
+            CodeSegment,
+            segment_kwargs={"type": "code"},
+        ),
+    ]
+)
+
 oracle_dialect.insert_lexer_matchers(
     [
         RegexLexer(
@@ -76,6 +90,14 @@ oracle_dialect.replace(
         ),
         Ref.keyword("PURGE", optional=True),
         optional=True,
+    ),
+    NakedIdentifierSegment=SegmentGenerator(
+        lambda dialect: RegexParser(
+            r"[A-Z0-9_]*[A-Z][A-Z0-9_#$]*",
+            ansi.IdentifierSegment,
+            type="naked_identifier",
+            anti_template=r"^(" + r"|".join(dialect.sets("reserved_keywords")) + r")$",
+        )
     ),
 )
 

--- a/test/fixtures/dialects/oracle/create_table.sql
+++ b/test/fixtures/dialects/oracle/create_table.sql
@@ -1,0 +1,11 @@
+-- create table with # in table name
+create table tabl#e1 (c1 SMALLINT, c2 DATE);
+
+-- create table with $ in table name
+create table table1$ (c1 SMALLINT, c2 DATE);
+
+-- create table with both $ & # in table name
+create table tab#le1$ (c1 SMALLINT, c2 DATE);
+
+-- create table with $ & # in column name
+create table tab#le1$ (c#1 SMALLINT, c$2 DATE);

--- a/test/fixtures/dialects/oracle/create_table.yml
+++ b/test/fixtures/dialects/oracle/create_table.yml
@@ -1,0 +1,83 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9c5e9bc766712d02ab700df17b3bc93e54f7b06c6fad0462b9a87a9713eb30a8
+file:
+- statement:
+    create_table_statement:
+    - keyword: create
+    - keyword: table
+    - table_reference:
+        naked_identifier: tabl#e1
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: c1
+          data_type:
+            data_type_identifier: SMALLINT
+      - comma: ','
+      - column_definition:
+          naked_identifier: c2
+          data_type:
+            data_type_identifier: DATE
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: create
+    - keyword: table
+    - table_reference:
+        naked_identifier: table1$
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: c1
+          data_type:
+            data_type_identifier: SMALLINT
+      - comma: ','
+      - column_definition:
+          naked_identifier: c2
+          data_type:
+            data_type_identifier: DATE
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: create
+    - keyword: table
+    - table_reference:
+        naked_identifier: tab#le1$
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: c1
+          data_type:
+            data_type_identifier: SMALLINT
+      - comma: ','
+      - column_definition:
+          naked_identifier: c2
+          data_type:
+            data_type_identifier: DATE
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: create
+    - keyword: table
+    - table_reference:
+        naked_identifier: tab#le1$
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: c#1
+          data_type:
+            data_type_identifier: SMALLINT
+      - comma: ','
+      - column_definition:
+          naked_identifier: c$2
+          data_type:
+            data_type_identifier: DATE
+      - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Oracle: Add support for `$` and `#`  in identifier

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

fix for https://github.com/open-metadata/OpenMetadata/issues/7216