### PR TITLE
TSQL: support for `DROP EXTERNAL TABLE`

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -595,6 +595,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("SqlcmdCommandSegment"),
             Ref("CreateExternalFileFormat"),
             Ref("CreateExternalTableStatementSegment"),
+            Ref("DropExternalTableStatementSegment"),
         ],
         remove=[
             Ref("CreateModelStatementSegment"),
@@ -5596,4 +5597,19 @@ class CreateRoleStatementSegment(ansi.CreateRoleStatementSegment):
             Ref("RoleReferenceSegment"),
             optional=True,
         ),
+    )
+
+
+class DropExternalTableStatementSegment(BaseSegment):
+    """A `DROP EXTERNAL TABLE ...` statement.
+
+    https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-external-table-transact-sql
+    """
+
+    type = "drop_external_table_statement"
+    match_grammar = Sequence(
+        "DROP",
+        "EXTERNAL",
+        "TABLE",
+        Ref("TableReferenceSegment"),
     )

--- a/test/fixtures/dialects/tsql/drop_external_table.sql
+++ b/test/fixtures/dialects/tsql/drop_external_table.sql
@@ -1,0 +1,7 @@
+/*
+https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-external-table-transact-sql?view=sql-server-ver16#examples
+*/
+
+DROP EXTERNAL TABLE SalesPerson;
+DROP EXTERNAL TABLE dbo.SalesPerson;
+DROP EXTERNAL TABLE EasternDivision.dbo.SalesPerson;

--- a/test/fixtures/dialects/tsql/drop_external_table.yml
+++ b/test/fixtures/dialects/tsql/drop_external_table.yml
@@ -1,0 +1,38 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 7d546bbd3f07452542aa466df7d6a782e74f556f200487bafe3bf1a8c3af2dc3
+file:
+  batch:
+  - statement:
+      drop_external_table_statement:
+      - keyword: DROP
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: SalesPerson
+  - statement_terminator: ;
+  - statement:
+      drop_external_table_statement:
+      - keyword: DROP
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: SalesPerson
+  - statement_terminator: ;
+  - statement:
+      drop_external_table_statement:
+      - keyword: DROP
+      - keyword: EXTERNAL
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: EasternDivision
+        - dot: .
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: SalesPerson
+  - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
`fixes #4918`, introduces support for `DROP EXTERNAL TABLE` in TSQL

### Are there any other side effects of this change that we should be aware of?
no

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
