### PR TITLE
Remove extra code escapes from release notes docs

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -152,9 +152,9 @@ Upgrading to 1.4
 This release brings several internal changes, and acts as a prelude
 to 2.0.0. In particular, the following config values have changed:
 
-* :code:`sqlfluff:rules:L007:operator_new_lines`` has been changed to
+* :code:`sqlfluff:rules:L007:operator_new_lines` has been changed to
   :code:`sqlfluff:layout:type:binary_operator:line_position`.
-* :code:`sqlfluff:rules:comma_style`` and
+* :code:`sqlfluff:rules:comma_style` and
   :code:`sqlfluff:rules:L019:comma_style` have both been consolidated
   into :code:`sqlfluff:layout:type:comma:line_position`.
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Noticed this on [the release notes page](https://docs.sqlfluff.com/en/latest/releasenotes.html#upgrading-to-1-4):

<img width="684" alt="image" src="https://github.com/sqlfluff/sqlfluff/assets/10931297/0d5fe0a6-9fe6-4ef5-8fa3-323020b8f2bf">


### Are there any other side effects of this change that we should be aware of?
Nope, simple doc update

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
