### PR TITLE
Security option for library path

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -11,7 +11,9 @@ must be done via a file, because it otherwise gets slightly complicated.
 For details of what's available on the command line check out
 the :ref:`cliref`.
 
-Configuration files
+.. _`config-files`:
+
+Configuration Files
 -------------------
 
 For file based configuration *SQLFluff* will look for the following
@@ -655,6 +657,8 @@ projects. In particular it provides mock objects for:
 
 .. _`dbt`: https://www.getdbt.com/
 .. _`github`: https://www.github.com/sqlfluff/sqlfluff
+
+.. _jinja_library_templating:
 
 Library Templating
 """"""""""""""""""

--- a/docs/source/production.rst
+++ b/docs/source/production.rst
@@ -31,8 +31,8 @@ tool functions in a secure environment.
    be able to access and edit the :ref:`config-files`. It's important to note
    that because of :ref:`in_file_config`, that users who can edit SQL files
    which are designed to be linted, will also have access to the vast majority
-   of any configuration options available in :ref:`config-files`. This means that
-   there is minimal additional protection from restricting access to
+   of any configuration options available in :ref:`config-files`. This means
+   that there is minimal additional protection from restricting access to
    :ref:`config-files` for users who already have access to edit the linting
    target files (as described above).
 
@@ -61,7 +61,7 @@ tool functions in a secure environment.
       :language: python
 
 .. _`Jinja2 SandboxedEnvironment`: https://jinja.palletsprojects.com/en/3.0.x/sandbox/#jinja2.sandbox.SandboxedEnvironment
-.. _`dbt run_query macro`: https://docs.getdbt.com/reference/dbt-jinja-functions/run_query 
+.. _`dbt run_query macro`: https://docs.getdbt.com/reference/dbt-jinja-functions/run_query
 
 Using SQLFluff on a whole sql codebase
 --------------------------------------
@@ -89,15 +89,15 @@ build for a one-line SQL change shouldn't encourage the developer to fix lots
 of unrelated quality issues.
 
 To support this use case, SQLFluff integrates with a quality checking tool
-called ``diff-quality``. By running SQLFluff using ``diff-quality`` (rather than
-running it directly), you can limit the the output to the new or modified SQL
-in the branch (aka pull request or PR) containing the proposed changes.
+called ``diff-quality``. By running SQLFluff using ``diff-quality`` (rather
+than running it directly), you can limit the the output to the new or modified
+SQL in the branch (aka pull request or PR) containing the proposed changes.
 
 Currently, ``diff-quality`` requires that you are using ``git`` for version
 control.
 
-NOTE: Installing SQLFluff automatically installs the ``diff_cover`` package that
-provides the ``diff-quality`` tool.
+NOTE: Installing SQLFluff automatically installs the ``diff_cover`` package
+that provides the ``diff-quality`` tool.
 
 Adding ``diff-quality`` to your builds
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -142,7 +142,8 @@ such as:
 * Generating HTML reports
 * Controlling which branch to compare against (i.e. to determine new/changed
   lines). The default is `origin/master`.
-* Configuring ``diff-quality`` to return an error code if the quality is too low
+* Configuring ``diff-quality`` to return an error code if the quality is
+  too low.
 * Troubleshooting
 
 .. _using-pre-commit:

--- a/docs/source/production.rst
+++ b/docs/source/production.rst
@@ -1,8 +1,67 @@
-Production Usage
-================
+.. _production-use:
+
+Production Usage & Security
+===========================
 
 SQLFluff is designed to be used both as a utility for developers but also to
 be part of `CI/CD`_ pipelines.
+
+.. _security:
+
+Security Considerations
+-----------------------
+
+A full list of `Security Advisories is available on GitHub <https://github.com/sqlfluff/sqlfluff/security/advisories>`_.
+
+Given the context of how SQLFluff is designed to be used, there are three
+different tiers of access which users may have access to manipulate how the
+tool functions in a secure environment.
+
+#. *Users may have edit access to the SQL code which is being linted*. While
+   SQLFluff does not execute the SQL itself, in the process of the
+   :ref:`templating step <templater>` (in particular via jinja or dbt),
+   certain macros may have the ability to execute arbitrary SQL code (e.g.
+   the `dbt run_query macro`_). For the Jinja templater, SQLFluff uses the
+   `Jinja2 SandboxedEnvironment`_ to limit the execution on unsafe code. When
+   looking to further secure this situation, see below for ways to limit the
+   ability of users to import other libraries.
+
+#. *Users may have edit access to the SQLFluff :ref:`config-files`*. In some
+   (perhaps, many) environments, the users who can edit SQL files may also
+   be able to access and edit the :ref:`config-files`. It's important to note
+   that because of :ref:`in_file_config`, that users who can edit SQL files
+   which are designed to be linted, will also have access to the vast majority
+   of any configuration options available in :ref:`config-files`. This means that
+   there is minimal additional protection from restricting access to
+   :ref:`config-files` for users who already have access to edit the linting
+   target files (as described above).
+
+#. *Users may have access to change how SQLFluff is invoked*. SQLFluff can
+   be invoked either as a command line too or via the python API. Typically
+   the method is fixed for a given application. When thinking about how to
+   restrict the ability of users to call unsecure code, SQLFluff aims to
+   provide options at the point of invocation. In particular, as described
+   above, the primary risk vector for SQLFluff is the macro environment
+   as described in :ref:`templateconfig`. To restrict users being able to
+   bring arbitrary python methods into sqlfluff via the ``library_path``
+   configuration value (see :ref:`jinja_library_templating`), we recommend
+   that for secure environments you override this config value either by
+   providing an ``override`` option to the :class:`FluffConfig` object if
+   using the Python API or via the ``--library-path`` CLI option:
+
+   To disable this option entirely via the CLI:
+
+   .. code-block:: bash
+
+      $ sqlfluff lint my_path --library-path none
+
+   To disable this option entirely via the python API:
+
+   .. literalinclude:: ../../examples/04_config_overrides.py
+      :language: python
+
+.. _`Jinja2 SandboxedEnvironment`: https://jinja.palletsprojects.com/en/3.0.x/sandbox/#jinja2.sandbox.SandboxedEnvironment
+.. _`dbt run_query macro`: https://docs.getdbt.com/reference/dbt-jinja-functions/run_query 
 
 Using SQLFluff on a whole sql codebase
 --------------------------------------
@@ -21,8 +80,8 @@ more.
 
 .. _diff-quality:
 
-Using SQLFluff on changes using `diff-quality`
-----------------------------------------------
+Using SQLFluff on changes using ``diff-quality``
+------------------------------------------------
 
 For projects with large amounts of (potentially imperfect) SQL code, the full
 SQLFluff output could be very large, which can be distracting -- perhaps the CI
@@ -30,25 +89,25 @@ build for a one-line SQL change shouldn't encourage the developer to fix lots
 of unrelated quality issues.
 
 To support this use case, SQLFluff integrates with a quality checking tool
-called `diff-quality`. By running SQLFluff using `diff-quality` (rather than
+called ``diff-quality``. By running SQLFluff using ``diff-quality`` (rather than
 running it directly), you can limit the the output to the new or modified SQL
 in the branch (aka pull request or PR) containing the proposed changes.
 
 Currently, ``diff-quality`` requires that you are using ``git`` for version
 control.
 
-NOTE: Installing SQLFluff automatically installs the `diff_cover` package that
-provides the `diff-quality` tool.
+NOTE: Installing SQLFluff automatically installs the ``diff_cover`` package that
+provides the ``diff-quality`` tool.
 
-Adding `diff-quality` to your builds
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Adding ``diff-quality`` to your builds
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In your CI build script:
 
 1. Set the current working directory to the ``git`` repository containing the
 SQL code to be checked.
 
-2. Run `diff-quality`, specifying SQLFluff as the underlying tool:
+2. Run ``diff-quality``, specifying SQLFluff as the underlying tool:
 
 .. code-block:: text
 
@@ -72,18 +131,18 @@ The output will look something like:
     -------------
 
 These messages are basically the same as those provided directly by SQLFluff,
-although the format is a little different. Note that `diff-quality` only lists
+although the format is a little different. Note that ``diff-quality`` only lists
 the line _numbers_, not the character position. If you need the character
 position, you will need to run SQLFluff directly.
 
-For more information on `diff-quality`, see the
+For more information on ``diff-quality``, see the
 `documentation <https://diff-cover.readthedocs.io/en/latest/>`_. It covers topics
 such as:
 
 * Generating HTML reports
 * Controlling which branch to compare against (i.e. to determine new/changed
   lines). The default is `origin/master`.
-* Configuring `diff-quality` to return an error code if the quality is too low
+* Configuring ``diff-quality`` to return an error code if the quality is too low
 * Troubleshooting
 
 .. _using-pre-commit:

--- a/examples/04_config_overrides.py
+++ b/examples/04_config_overrides.py
@@ -2,7 +2,7 @@
 
 from sqlfluff.core import Linter, FluffConfig
 
-sql = "SELECT 1"
+sql = "SELECT 1\n"
 
 
 config = FluffConfig(

--- a/examples/04_config_overrides.py
+++ b/examples/04_config_overrides.py
@@ -6,12 +6,12 @@ sql = "SELECT 1\n"
 
 
 config = FluffConfig(
-    configs={
-        "core": {"dialect": "snowflake"},
+    overrides={
+        "dialect": "snowflake",
         # NOTE: We explicitly set the string "none" here rather
         # than a None literal so that it overrides any config
         # set by any config files in the path.
-        "templater": {"library_path": "none"},
+        "library_path": "none",
     }
 )
 

--- a/examples/04_config_overrides.py
+++ b/examples/04_config_overrides.py
@@ -1,17 +1,17 @@
 """This is an example of providing config overrides."""
 
-from sqlfluff.core import Lexer, Parser, Linter, FluffConfig
+from sqlfluff.core import Linter, FluffConfig
 
 sql = "SELECT 1"
 
 
 config = FluffConfig(
-    overrides={
-        "dialect": "snowflake",
+    configs={
+        "core": {"dialect": "snowflake"},
         # NOTE: We explicitly set the string "none" here rather
         # than a None literal so that it overrides any config
         # set by any config files in the path.
-        "templater": {"library_path": "none"}
+        "templater": {"library_path": "none"},
     }
 )
 

--- a/examples/04_config_overrides.py
+++ b/examples/04_config_overrides.py
@@ -1,0 +1,20 @@
+"""This is an example of providing config overrides."""
+
+from sqlfluff.core import Lexer, Parser, Linter, FluffConfig
+
+sql = "SELECT 1"
+
+
+config = FluffConfig(
+    overrides={
+        "dialect": "snowflake",
+        # NOTE: We explicitly set the string "none" here rather
+        # than a None literal so that it overrides any config
+        # set by any config files in the path.
+        "templater": {"library_path": "none"}
+    }
+)
+
+linted_file = Linter(config=config).lint_string(sql)
+
+assert linted_file.get_violations() == []

--- a/src/sqlfluff/cli/click_deprecated_option.py
+++ b/src/sqlfluff/cli/click_deprecated_option.py
@@ -92,7 +92,7 @@ class DeprecatedOptionsCommand(click.Command):
             finally:
                 del frame
 
-            if opt in deprecated:  # type: ignore
+            if opt in deprecated:
                 msg = (
                     f"DeprecationWarning: The option {opt!r} is deprecated, "
                     f"use {preferred!r}."

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -392,6 +392,7 @@ def get_config(
     from_root_kwargs = {}
     if "require_dialect" in kwargs:
         from_root_kwargs["require_dialect"] = kwargs.pop("require_dialect")
+    library_path = None
     if "library_path" in kwargs:
         library_path = kwargs.pop("library_path")
     # Instantiate a config object (filtering out the nulls)

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -392,9 +392,7 @@ def get_config(
     from_root_kwargs = {}
     if "require_dialect" in kwargs:
         from_root_kwargs["require_dialect"] = kwargs.pop("require_dialect")
-    library_path = None
-    if "library_path" in kwargs:
-        library_path = kwargs.pop("library_path")
+    library_path = kwargs.pop("library_path", None)
     # Instantiate a config object (filtering out the nulls)
     overrides = {k: kwargs[k] for k in kwargs if kwargs[k] is not None}
     if library_path is not None:

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -309,6 +309,16 @@ def core_options(f: Callable) -> Callable:
         default=None,
         help="Set this flag to ignore inline noqa comments.",
     )(f)
+    f = click.option(
+        "--library-path",
+        default=None,
+        help=(
+            "Override the `library_path` value from the [sqlfluff:templater:jinja]"
+            " configuration value. Set this to 'none' to disable entirely."
+            " This overrides any values set by users in configuration files or"
+            " inline directives."
+        ),
+    )(f)
     return f
 
 
@@ -382,8 +392,18 @@ def get_config(
     from_root_kwargs = {}
     if "require_dialect" in kwargs:
         from_root_kwargs["require_dialect"] = kwargs.pop("require_dialect")
+    if "library_path" in kwargs:
+        library_path = kwargs.pop("library_path")
     # Instantiate a config object (filtering out the nulls)
     overrides = {k: kwargs[k] for k in kwargs if kwargs[k] is not None}
+    if library_path is not None:
+        # Check for a null value
+        if library_path.lower() == "none":
+            library_path = None
+        # Make sure there's a dict there.
+        overrides["templater"] = overrides["templater"] or {}
+        # Set the global override
+        overrides["templater"]["library_path"] = library_path
     try:
         return FluffConfig.from_root(
             extra_config_path=extra_config_path,

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -400,7 +400,7 @@ def get_config(
     if library_path is not None:
         # Check for a null value
         if library_path.lower() == "none":
-            library_path = None
+            library_path = None  # Set an explicit None value.
         # Make sure there's a dict there.
         overrides["templater"] = overrides["templater"] or {}
         # Set the global override

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -401,10 +401,8 @@ def get_config(
         # Check for a null value
         if library_path.lower() == "none":
             library_path = None  # Set an explicit None value.
-        # Make sure there's a dict there.
-        overrides["templater"] = overrides["templater"] or {}
         # Set the global override
-        overrides["templater"]["library_path"] = library_path
+        overrides["library_path"] = library_path
     try:
         return FluffConfig.from_root(
             extra_config_path=extra_config_path,

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -133,9 +133,7 @@ class JinjaTemplater(PythonTemplater):
         # If a more global library_path is set, let that take precedence.
         library_path = config.get_section(
             (self.templater_selector, "library_path")
-        ) or config.get_section(
-            (self.templater_selector, self.name, "library_path")
-        )
+        ) or config.get_section((self.templater_selector, self.name, "library_path"))
         if not library_path:
             return {}
 

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -131,9 +131,7 @@ class JinjaTemplater(PythonTemplater):
 
     def _extract_libraries_from_config(self, config):
         # If a more global library_path is set, let that take precedence.
-        library_path = config.get_section(
-            (self.templater_selector, "library_path")
-        ) or config.get_section((self.templater_selector, self.name, "library_path"))
+        library_path = config.get("library_path") or config.get_section((self.templater_selector, self.name, "library_path"))
         if not library_path:
             return {}
 

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -130,7 +130,10 @@ class JinjaTemplater(PythonTemplater):
         return macro_ctx
 
     def _extract_libraries_from_config(self, config):
+        # If a more global library_path is set, let that take precedence.
         library_path = config.get_section(
+            (self.templater_selector, "library_path")
+        ) or config.get_section(
             (self.templater_selector, self.name, "library_path")
         )
         if not library_path:

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -131,7 +131,9 @@ class JinjaTemplater(PythonTemplater):
 
     def _extract_libraries_from_config(self, config):
         # If a more global library_path is set, let that take precedence.
-        library_path = config.get("library_path") or config.get_section((self.templater_selector, self.name, "library_path"))
+        library_path = config.get("library_path") or config.get_section(
+            (self.templater_selector, self.name, "library_path")
+        )
         if not library_path:
             return {}
 

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -545,6 +545,33 @@ def test__cli__command_lint_parse(command):
             ),
             1,
         ),
+        # Test overriding library path when it doesn't cause an issue
+        (
+            (
+                lint,
+                [
+                    "test/fixtures/cli/passing_b.sql",
+                    "--library-path",
+                    "none"
+                ],
+            ),
+            0,
+        ),
+        # Test overriding library path when it DOES cause an issue
+        # (because macros won't be found).
+        (
+            (
+                # Render because that's the step where the issue will
+                # occur. 
+                render,
+                [
+                    "test/fixtures/templater/jinja_r_library_in_macro/jinja.sql"
+                    "--library-path",
+                    "none"
+                ],
+            ),
+            1,
+        ),
         # Test render fail
         (
             (

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -549,11 +549,7 @@ def test__cli__command_lint_parse(command):
         (
             (
                 lint,
-                [
-                    "test/fixtures/cli/passing_b.sql",
-                    "--library-path",
-                    "none"
-                ],
+                ["test/fixtures/cli/passing_b.sql", "--library-path", "none"],
             ),
             0,
         ),
@@ -562,12 +558,12 @@ def test__cli__command_lint_parse(command):
         (
             (
                 # Render because that's the step where the issue will
-                # occur. 
+                # occur.
                 render,
                 [
                     "test/fixtures/templater/jinja_r_library_in_macro/jinja.sql"
                     "--library-path",
-                    "none"
+                    "none",
                 ],
             ),
             1,

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -549,7 +549,7 @@ def test__cli__command_lint_parse(command):
         (
             (
                 lint,
-                ["test/fixtures/cli/passing_b.sql", "--library-path", "none"],
+                ["test/fixtures/cli/passing_a.sql", "--library-path", "none"],
             ),
             0,
         ),
@@ -561,7 +561,7 @@ def test__cli__command_lint_parse(command):
                 # occur.
                 render,
                 [
-                    "test/fixtures/templater/jinja_r_library_in_macro/jinja.sql"
+                    "test/fixtures/templater/jinja_r_library_in_macro/jinja.sql",
                     "--library-path",
                     "none",
                 ],

--- a/test/fixtures/templater/jinja_m_libraries_module/.sqlfluff
+++ b/test/fixtures/templater/jinja_m_libraries_module/.sqlfluff
@@ -1,3 +1,3 @@
-[sqlfluff:templater]
-# Test setting the library_path via the global setting (not via just jinja)
+[sqlfluff]
+# Test setting the library_path via the global setting (not via jinja config)
 library_path=libs

--- a/test/fixtures/templater/jinja_m_libraries_module/.sqlfluff
+++ b/test/fixtures/templater/jinja_m_libraries_module/.sqlfluff
@@ -1,2 +1,3 @@
-[sqlfluff:templater:jinja]
+[sqlfluff:templater]
+# Test setting the library_path via the global setting (not via just jinja)
 library_path=libs


### PR DESCRIPTION
This resolves a potential security risk, and also adds a bunch of documentation to cover it.

It enables a CLI option to override the `library_path` option in the templater to prevent unsecured code being called.