### PR TITLE
Fix compatibility with dbt 1.5.2+

### DIFF
--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -22,8 +22,10 @@ from dbt.cli.resolvers import default_profiles_dir
 # On the 1.5.x branch this was between 1.5.1 and 1.5.2
 try:
     from dbt.task.contextvars import cv_project_root
-except ImportError:
-    cv_project_root = None
+except ImportError:  # pragma: no cover
+    # This path _is used_ on 1.5.1, but our test suite doesn't cover
+    # that case.
+    cv_project_root = None  
 
 try:
     from dbt.exceptions import (

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -25,7 +25,7 @@ try:
 except ImportError:  # pragma: no cover
     # This path _is used_ on 1.5.1, but our test suite doesn't cover
     # that case.
-    cv_project_root = None  
+    cv_project_root = None
 
 try:
     from dbt.exceptions import (


### PR DESCRIPTION
This resolves the compatibility issues with dbt 1.5.2 onwards due to https://github.com/dbt-labs/dbt-core/pull/7949. For those versions onward we need to manually inject the `project_root` into the context before calling any of the methods that require it.

Also removes an old path handling clause which was resolved in 2022.