### PR TITLE
Re-enable dbt 1.1 & 1.2

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -87,20 +87,20 @@ jobs:
     secrets:
       gh_token: ${{ secrets.github_token }}
 
-  # dbt-tests-nocov:
-  #   name: dbt ${{ matrix.dbt-version }} Plugin Tests
-  #   strategy:
-  #     matrix:
-  #       dbt-version: [ "dbt110", "dbt120" ]
-  #   permissions:
-  #     contents: read
-  #     pull-requests: write
-  #   uses: ./.github/workflows/ci-test-dbt.yml
-  #   with:
-  #     python-version: "3.9"
-  #     dbt-version: "${{ matrix.dbt-version }}"
-  #   secrets:
-  #     gh_token: ${{ secrets.github_token }}
+  dbt-tests-nocov:
+    name: dbt ${{ matrix.dbt-version }} Plugin Tests
+    strategy:
+      matrix:
+        dbt-version: [ "dbt110", "dbt120" ]
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/ci-test-dbt.yml
+    with:
+      python-version: "3.9"
+      dbt-version: "${{ matrix.dbt-version }}"
+    secrets:
+      gh_token: ${{ secrets.github_token }}
 
   # This runs the bulk of the dialect _parsing_ tests.
   #

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -75,7 +75,7 @@ jobs:
     name: dbt ${{ matrix.dbt-version }} Plugin Tests
     strategy:
       matrix:
-        dbt-version: [ "dbt130", "dbt140", "dbt150" ]
+        dbt-version: [ "dbt110", "dbt130", "dbt140", "dbt150" ]
     permissions:
       contents: read
       pull-requests: write
@@ -91,7 +91,7 @@ jobs:
     name: dbt ${{ matrix.dbt-version }} Plugin Tests
     strategy:
       matrix:
-        dbt-version: [ "dbt110", "dbt120" ]
+        dbt-version: [ "dbt120" ]
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
This re-enables support and tests for dbt 1.1 and 1.2. It effectively selectively reverts the fixes made in #4886, which fixed support for 1.5, but broke support for 1.1 & 1.2.

Combined with #4941 and #4939, this means we should have full compatibility with dbt 1.1.0 up to the latest 1.5.2. Anything pre 1.1 doesn't compile anymore so I'm very comfortable not supporting that 😄 .

Note that I'm added `dbt110` back into the coverage group so that the clauses for 1.1 and 1.2 are covered.