### PR TITLE
Adding support to ALTER TABLE with RENAME COLUMN on MySQL dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -1312,6 +1312,13 @@ class AlterTableStatementSegment(BaseSegment):
                             "TO",
                             Ref("IndexReferenceSegment"),
                         ),
+                        # Rename column
+                        Sequence(
+                            "COLUMN",
+                            Ref("ColumnReferenceSegment"),
+                            "TO",
+                            Ref("ColumnReferenceSegment"),
+                        ),
                     ),
                 ),
                 # Enable/Disable updating nonunique indexes

--- a/test/fixtures/dialects/mysql/alter_table.sql
+++ b/test/fixtures/dialects/mysql/alter_table.sql
@@ -9,6 +9,8 @@ ALTER TABLE `user` RENAME AS `users`;
 
 ALTER TABLE `users` RENAME `user`;
 
+ALTER TABLE `users` RENAME COLUMN `col_1` TO `del_col_1`;
+
 ALTER TABLE `users`
 CHANGE COLUMN `birthday` `date_of_birth` INT(11) NULL DEFAULT NULL;
 

--- a/test/fixtures/dialects/mysql/alter_table.yml
+++ b/test/fixtures/dialects/mysql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 395b48c34e9c2652d61220b12abffe11f67b90929ebf2faa8b053406caf530ea
+_hash: 489b5b234cbbe7ccacafe280af88a7bfdbbd81aa960a90796d97e796928e7f2a
 file:
 - statement:
     alter_table_statement:
@@ -60,6 +60,20 @@ file:
     - keyword: RENAME
     - table_reference:
         quoted_identifier: '`user`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`users`'
+    - keyword: RENAME
+    - keyword: COLUMN
+    - column_reference:
+        quoted_identifier: '`col_1`'
+    - keyword: TO
+    - column_reference:
+        quoted_identifier: '`del_col_1`'
 - statement_terminator: ;
 - statement:
     alter_table_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->



<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Addin support to RENAME COLUMN whe using ALTER TABLE, which is supported by MySQL which the doc can be checked here: https://dev.mysql.com/doc/refman/8.0/en/alter-table.html
fixes #4947 

### Are there any other side effects of this change that we should be aware of?
No side effect expected, syntax is fully supported by MySQL and MariaDB.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
