### PR TITLE
Try running tests against py312

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -61,7 +61,10 @@ jobs:
     name: Python ${{ matrix.python-version }} Tests
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        # NOTE: The most _stable_ python version should be the
+        # one with coverage. Others are tested for convenience.
+        # Pre-release versions should also be added here.
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.12' ]
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
This adds Python 3.12 to the test suite (without coverage). It's now in pre-release mode (as per this tracker: https://devguide.python.org/versions/) so it seems like a good moment to at least try it - if the tests pass, then I propose bringing it into the suite but not yet as a required test. It should become the main test on full release, which is currently due in October 23.