### PR TITLE
RF05 BigQuery empty identifier bug

### DIFF
--- a/src/sqlfluff/rules/references/RF05.py
+++ b/src/sqlfluff/rules/references/RF05.py
@@ -129,7 +129,7 @@ class Rule_RF05(BaseRule):
                 and context.parent_stack
                 and context.parent_stack[-1].is_type("table_reference")
             ):
-                if identifier[-1] == "*":
+                if identifier and identifier[-1] == "*":
                     identifier = identifier[:-1]
                 identifier = identifier.replace(".", "")
 


### PR DESCRIPTION
### Brief summary of the change made
Fixes the following (redacted) error report, seen in VSCode:
```
CRITICAL   [RF05] Applying rule RF05 to 'XXXXX.sql' threw an Exception: string index out of range 
Traceback (most recent call last):
  File "/XXXXX/sqlfluff/lib/python3.11/site-packages/sqlfluff/core/rules/base.py", line 796, in crawl
    res = self._eval(context=context)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/XXXXX/sqlfluff/lib/python3.11/site-packages/sqlfluff/rules/references/RF05.py", line 132, in _eval
    if identifier[-1] == "*":
       ~~~~~~~~~~^^^^
IndexError: string index out of range
```

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [Y] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
