### PR TITLE
Allow running one rule test locally

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -297,3 +297,8 @@ def test_verbosity_level(request):
     Has a verbosity level of 0
     """
     return request.config.getoption("verbose")
+
+
+def pytest_addoption(parser):
+    """Allow to run test/rules/yaml_test_cases_test.py for a specific rule_id."""
+    parser.addoption("--rule_id", action="store", default="*", help="Rule id to run")

--- a/test/rules/yaml_test_cases_test.py
+++ b/test/rules/yaml_test_cases_test.py
@@ -9,14 +9,21 @@ from sqlfluff.utils.testing.rules import (
 )
 from sqlfluff.core.config import FluffConfig
 
-ids, test_cases = load_test_cases(
-    test_cases_path=os.path.join("test/fixtures/rules/std_rule_cases", "*.yml")
-)
+
+def pytest_generate_tests(metafunc):
+    """Generate tests, optionally by rule_id."""
+    rule_id = metafunc.config.getoption("rule_id")
+    ids, test_cases = load_test_cases(
+        test_cases_path=os.path.join(
+            "test/fixtures/rules/std_rule_cases", f"{rule_id}.yml"
+        )
+    )
+    if "test_case" in metafunc.fixturenames:
+        metafunc.parametrize("test_case", test_cases, ids=ids)
 
 
 @pytest.mark.integration
 @pytest.mark.rules_suite
-@pytest.mark.parametrize("test_case", test_cases, ids=ids)
 def test__rule_test_case(test_case, caplog):
     """Run the tests."""
     with caplog.at_level(logging.DEBUG, logger="sqlfluff.rules"):


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
https://sqlfluff.slack.com/archives/C01JS7H598E/p1689011691858599?thread_ts=1689006583.842359&cid=C01JS7H598E

We can test just one rule locally if we want:

```
(.venv) gregoryfinley@Gregorys-MacBook-Pro sqlfluff % pytest -vv "test/rules/yaml_test_cases_test.py" --rule_id=AL01 
===================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.11.1, pytest-7.4.0, pluggy-1.2.0 -- /Users/gregoryfinley/.pyenv/versions/3.11.1/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/gregoryfinley/git-repos/sqlfluff
configfile: pytest.ini
collected 15 items                                                                                                                                                                            

test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_default_explicit] PASSED                                                                                        [  6%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_explicit] PASSED                                                                                                [ 13%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_implicit] PASSED                                                                                                [ 20%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_implicit_alias] PASSED                                                                                          [ 26%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_implicit_alias_space] PASSED                                                                                    [ 33%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_implicit_alias_explicit] PASSED                                                                                 [ 40%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_implicit_alias_implicit] PASSED                                                                                 [ 46%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_implicit_alias_implicit_multiple] PASSED                                                                        [ 53%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_implicit_alias_implicit_newline] PASSED                                                                         [ 60%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_default_explicit_alias_merge] PASSED                                                                            [ 66%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_explicit_alias_merge] PASSED                                                                                    [ 73%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_pass_implicit_alias_merge] PASSED                                                                                    [ 80%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_alias_expression_4492] PASSED                                                                                        [ 86%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_alias_expression_4089] PASSED                                                                                        [ 93%]
test/rules/yaml_test_cases_test.py::test__rule_test_global_config PASSED                                                                                                                [100%]

===================================================================================== 15 passed in 0.81s ======================================================================================
```

You can already just run one test case for the rule if you desired, but maybe the whole rule is easiest and you would never do this:

```
.venv) gregoryfinley@Gregorys-MacBook-Pro sqlfluff % pytest "test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_default_explicit]"  -vv

===================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.11.1, pytest-7.4.0, pluggy-1.2.0 -- /Users/gregoryfinley/.pyenv/versions/3.11.1/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/gregoryfinley/git-repos/sqlfluff
configfile: pytest.ini
collected 1 item                                                                                                                                                                              

test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_default_explicit] PASSED                                                                                        [100%]

====================================================================================== 1 passed in 0.65s ======================================================================================
```


By default, we still run everything:

```
(.venv) gregoryfinley@Gregorys-MacBook-Pro sqlfluff % pytest "test/rules/yaml_test_cases_test.py"  -vv                

===================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.11.1, pytest-7.4.0, pluggy-1.2.0 -- /Users/gregoryfinley/.pyenv/versions/3.11.1/bin/python3.11
cachedir: .pytest_cache
rootdir: /Users/gregoryfinley/git-repos/sqlfluff
configfile: pytest.ini
collected 1414 items                                                                                                                                                                          

test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_default_explicit] PASSED                                                                                        [  0%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_explicit] PASSED                                                                                                [  0%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_implicit] PASSED                                                                                                [  0%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_implicit_alias] PASSED                                                                                          [  0%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_implicit_alias_space] PASSED                                                                                    [  0%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_implicit_alias_explicit] PASSED                                                                                 [  0%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_implicit_alias_implicit] PASSED                                                                                 [  0%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_implicit_alias_implicit_multiple] PASSED                                                                        [  0%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_implicit_alias_implicit_newline] PASSED                                                                         [  0%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_default_explicit_alias_merge] PASSED                                                                            [  0%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_fail_explicit_alias_merge] PASSED                                                                                    [  0%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_pass_implicit_alias_merge] PASSED                                                                                    [  0%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_alias_expression_4492] PASSED                                                                                        [  0%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL01_test_alias_expression_4089] PASSED                                                                                        [  0%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL02_issue_561] PASSED                                                                                                         [  1%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL02_test_fail_explicit_column_default] PASSED                                                                                 [  1%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL02_test_fail_explicit_column_explicit] PASSED                                                                                [  1%]
test/rules/yaml_test_cases_test.py::test__rule_test_case[AL02_test_fail_explicit_column_implicit] PASSED                                                                                [  1%]
....
```

If this lands, I might start a "Contributing Rule Changes" wiki.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
