### PR TITLE
Update funding yaml to use github sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -12,4 +12,7 @@
 # as a donation toward infrastructure and hosting costs, or to enable
 # maintainers to spend more time on the project.
 
-custom: https://flattr.com/@alanmcruickshank
+# For more details on how this money is used, see the GitHub sponsor
+# page for sqlfluff at https://github.com/sponsors/sqlfluff.
+
+github: sqlfluff


### PR DESCRIPTION
Flattr seems to be retiring their platform for funding, and github sponsorship is much more fully featured. Adding link here - ditto to the org page in separate PR.