### PR TITLE
fix: sparksql lateral view parse tree for multiple column alias

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -1940,9 +1940,20 @@ class LateralViewClauseSegment(BaseSegment):
         "VIEW",
         Ref.keyword("OUTER", optional=True),
         Ref("FunctionSegment"),
-        # This allows for a table name to precede the alias expression.
-        Ref("SingleIdentifierGrammar", optional=True),
-        Ref("AliasExpressionSegment", optional=True),
+        OneOf(
+            Sequence(
+                Ref("SingleIdentifierGrammar"),
+                Sequence(
+                    Ref.keyword("AS", optional=True),
+                    Delimited(Ref("SingleIdentifierGrammar")),
+                    optional=True,
+                ),
+            ),
+            Sequence(
+                Ref.keyword("AS", optional=True),
+                Delimited(Ref("SingleIdentifierGrammar")),
+            ),
+        ),
         Dedent,
     )
 

--- a/test/fixtures/dialects/sparksql/select_from_lateral_view.sql
+++ b/test/fixtures/dialects/sparksql/select_from_lateral_view.sql
@@ -41,6 +41,28 @@ FROM person
     LATERAL VIEW OUTER EXPLODE(ARRAY()) tbl_name AS c_age;
 
 SELECT
+    id,
+    name,
+    age,
+    class,
+    address,
+    time,
+    c_age
+FROM person
+    LATERAL VIEW OUTER EXPLODE(ARRAY()) tbl_name c_age;
+
+SELECT
+    id,
+    name,
+    age,
+    class,
+    address,
+    time,
+    c_age
+FROM person
+    LATERAL VIEW OUTER EXPLODE(ARRAY()) c_age;
+
+SELECT
     person.id,
     exploded_people.name,
     exploded_people.age,
@@ -63,3 +85,19 @@ SELECT
     exploded_people.state
 FROM person AS p
     LATERAL VIEW INLINE(array_of_structs) exploded_people;
+
+SELECT
+    p.id,
+    exploded_people.name,
+    exploded_people.age,
+    exploded_people.state
+FROM person AS p
+    LATERAL VIEW INLINE(array_of_structs) exploded_people name, age, state;
+
+SELECT
+    p.id,
+    exploded_people.name,
+    exploded_people.age,
+    exploded_people.state
+FROM person AS p
+    LATERAL VIEW INLINE(array_of_structs) AS name, age, state;

--- a/test/fixtures/dialects/sparksql/select_from_lateral_view.yml
+++ b/test/fixtures/dialects/sparksql/select_from_lateral_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 34f23d4c7afcdc323487d4e2ab4b5569cff274159a3fb975871040e659dc898e
+_hash: d2478eb1ff7c9737cdf83e4a4ea9f34b9b5d72181fde839634c86d58a0a54f8e
 file:
 - statement:
     select_statement:
@@ -65,9 +65,8 @@ file:
                       - end_bracket: )
                   end_bracket: )
             - naked_identifier: tbl_name
-            - alias_expression:
-                keyword: AS
-                naked_identifier: c_age
+            - keyword: AS
+            - naked_identifier: c_age
           - lateral_view_clause:
             - keyword: LATERAL
             - keyword: VIEW
@@ -89,9 +88,8 @@ file:
                           numeric_literal: '80'
                       - end_bracket: )
                   end_bracket: )
-            - alias_expression:
-                keyword: AS
-                naked_identifier: d_age
+            - keyword: AS
+            - naked_identifier: d_age
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -140,9 +138,8 @@ file:
                           numeric_literal: '60'
                       - end_bracket: )
                   end_bracket: )
-            - alias_expression:
-                keyword: AS
-                naked_identifier: c_age
+            - keyword: AS
+            - naked_identifier: c_age
           - lateral_view_clause:
             - keyword: LATERAL
             - keyword: VIEW
@@ -164,9 +161,8 @@ file:
                           numeric_literal: '80'
                       - end_bracket: )
                   end_bracket: )
-            - alias_expression:
-                keyword: AS
-                naked_identifier: d_age
+            - keyword: AS
+            - naked_identifier: d_age
       groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -228,9 +224,8 @@ file:
                         end_bracket: )
                   end_bracket: )
             - naked_identifier: tbl_name
-            - alias_expression:
-                keyword: AS
-                naked_identifier: c_age
+            - keyword: AS
+            - naked_identifier: c_age
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -288,9 +283,123 @@ file:
                         end_bracket: )
                   end_bracket: )
             - naked_identifier: tbl_name
-            - alias_expression:
-                keyword: AS
-                naked_identifier: c_age
+            - keyword: AS
+            - naked_identifier: c_age
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: class
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: address
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: time
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: c_age
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+            lateral_view_clause:
+            - keyword: LATERAL
+            - keyword: VIEW
+            - keyword: OUTER
+            - function:
+                function_name:
+                  function_name_identifier: EXPLODE
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    function:
+                      function_name:
+                        function_name_identifier: ARRAY
+                      bracketed:
+                        start_bracket: (
+                        end_bracket: )
+                  end_bracket: )
+            - naked_identifier: tbl_name
+            - naked_identifier: c_age
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: class
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: address
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: time
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: c_age
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+            lateral_view_clause:
+            - keyword: LATERAL
+            - keyword: VIEW
+            - keyword: OUTER
+            - function:
+                function_name:
+                  function_name_identifier: EXPLODE
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    function:
+                      function_name:
+                        function_name_identifier: ARRAY
+                      bracketed:
+                        start_bracket: (
+                        end_bracket: )
+                  end_bracket: )
+            - naked_identifier: c_age
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -320,8 +429,8 @@ file:
           - dot: .
           - naked_identifier: state
       from_clause:
-      - keyword: FROM
-      - from_expression:
+        keyword: FROM
+        from_expression:
           from_expression_element:
             table_expression:
               table_reference:
@@ -339,87 +448,12 @@ file:
                       naked_identifier: array_of_structs
                   end_bracket: )
             - naked_identifier: exploded_people
-            - alias_expression:
-                keyword: AS
-                naked_identifier: name
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: age
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: state
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-      - keyword: SELECT
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: p
-          - dot: .
-          - naked_identifier: id
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: exploded_people
-          - dot: .
-          - naked_identifier: name
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: exploded_people
-          - dot: .
-          - naked_identifier: age
-      - comma: ','
-      - select_clause_element:
-          column_reference:
-          - naked_identifier: exploded_people
-          - dot: .
-          - naked_identifier: state
-      from_clause:
-      - keyword: FROM
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: person
-            alias_expression:
-              keyword: AS
-              naked_identifier: p
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: INLINE
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    column_reference:
-                      naked_identifier: array_of_structs
-                  end_bracket: )
-            - naked_identifier: exploded_people
-            - alias_expression:
-                keyword: AS
-                naked_identifier: name
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: age
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: state
+            - keyword: AS
+            - naked_identifier: name
+            - comma: ','
+            - naked_identifier: age
+            - comma: ','
+            - naked_identifier: state
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -471,4 +505,173 @@ file:
                       naked_identifier: array_of_structs
                   end_bracket: )
             - naked_identifier: exploded_people
+            - keyword: AS
+            - naked_identifier: name
+            - comma: ','
+            - naked_identifier: age
+            - comma: ','
+            - naked_identifier: state
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: p
+          - dot: .
+          - naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: state
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+            alias_expression:
+              keyword: AS
+              naked_identifier: p
+            lateral_view_clause:
+            - keyword: LATERAL
+            - keyword: VIEW
+            - function:
+                function_name:
+                  function_name_identifier: INLINE
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: array_of_structs
+                  end_bracket: )
+            - naked_identifier: exploded_people
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: p
+          - dot: .
+          - naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: state
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+            alias_expression:
+              keyword: AS
+              naked_identifier: p
+            lateral_view_clause:
+            - keyword: LATERAL
+            - keyword: VIEW
+            - function:
+                function_name:
+                  function_name_identifier: INLINE
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: array_of_structs
+                  end_bracket: )
+            - naked_identifier: exploded_people
+            - naked_identifier: name
+            - comma: ','
+            - naked_identifier: age
+            - comma: ','
+            - naked_identifier: state
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: p
+          - dot: .
+          - naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: state
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+            alias_expression:
+              keyword: AS
+              naked_identifier: p
+            lateral_view_clause:
+            - keyword: LATERAL
+            - keyword: VIEW
+            - function:
+                function_name:
+                  function_name_identifier: INLINE
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: array_of_structs
+                  end_bracket: )
+            - keyword: AS
+            - naked_identifier: name
+            - comma: ','
+            - naked_identifier: age
+            - comma: ','
+            - naked_identifier: state
 - statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/select_lateral_view_supported_tvf.yml
+++ b/test/fixtures/dialects/sparksql/select_lateral_view_supported_tvf.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0174a44ebf919b68b3717938814bd471de9b0122e36ec569fd4c553d9fd48707
+_hash: 178acfd014cf9b8b0815c26e4b85e0121265e0f2aa05a2f1146a3c8f60f91449
 file:
 - statement:
     select_statement:
@@ -96,9 +96,8 @@ file:
                           numeric_literal: '4'
                       - end_bracket: )
                   end_bracket: )
-            - alias_expression:
-                keyword: AS
-                naked_identifier: c2
+            - keyword: AS
+            - naked_identifier: c2
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -143,9 +142,8 @@ file:
                           numeric_literal: '4'
                       - end_bracket: )
                   end_bracket: )
-            - alias_expression:
-                keyword: AS
-                naked_identifier: c2
+            - keyword: AS
+            - naked_identifier: c2
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -251,8 +249,8 @@ file:
           - dot: .
           - naked_identifier: b
       from_clause:
-      - keyword: FROM
-      - from_expression:
+        keyword: FROM
+        from_expression:
           from_expression_element:
             table_expression:
               table_reference:
@@ -298,15 +296,10 @@ file:
                             - end_bracket: )
                       - end_bracket: )
                   end_bracket: )
-            - alias_expression:
-                keyword: AS
-                naked_identifier: c1
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: c2
+            - keyword: AS
+            - naked_identifier: c1
+            - comma: ','
+            - naked_identifier: c2
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -324,8 +317,8 @@ file:
           - dot: .
           - naked_identifier: b
       from_clause:
-      - keyword: FROM
-      - from_expression:
+        keyword: FROM
+        from_expression:
           from_expression_element:
             table_expression:
               table_reference:
@@ -371,15 +364,10 @@ file:
                             - end_bracket: )
                       - end_bracket: )
                   end_bracket: )
-            - alias_expression:
-                keyword: AS
-                naked_identifier: c1
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: c2
+            - keyword: AS
+            - naked_identifier: c1
+            - comma: ','
+            - naked_identifier: c2
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -472,9 +460,8 @@ file:
                           numeric_literal: '20'
                       - end_bracket: )
                   end_bracket: )
-            - alias_expression:
-                keyword: AS
-                naked_identifier: c1
+            - keyword: AS
+            - naked_identifier: c1
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -519,9 +506,8 @@ file:
                           numeric_literal: '20'
                       - end_bracket: )
                   end_bracket: )
-            - alias_expression:
-                keyword: AS
-                naked_identifier: c1
+            - keyword: AS
+            - naked_identifier: c1
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -562,8 +548,8 @@ file:
           - dot: .
           - naked_identifier: b
       from_clause:
-      - keyword: FROM
-      - from_expression:
+        keyword: FROM
+        from_expression:
           from_expression_element:
             table_expression:
               table_reference:
@@ -588,15 +574,10 @@ file:
                 - expression:
                     numeric_literal: '3'
                 - end_bracket: )
-            - alias_expression:
-                keyword: AS
-                naked_identifier: c1
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: c2
+            - keyword: AS
+            - naked_identifier: c1
+            - comma: ','
+            - naked_identifier: c2
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -634,8 +615,8 @@ file:
           - dot: .
           - naked_identifier: b
       from_clause:
-      - keyword: FROM
-      - from_expression:
+        keyword: FROM
+        from_expression:
           from_expression_element:
             table_expression:
               table_reference:
@@ -657,15 +638,10 @@ file:
                 - expression:
                     quoted_literal: "'b'"
                 - end_bracket: )
-            - alias_expression:
-                keyword: AS
-                naked_identifier: c1
-      - comma: ','
-      - from_expression:
-          from_expression_element:
-            table_expression:
-              table_reference:
-                naked_identifier: c2
+            - keyword: AS
+            - naked_identifier: c1
+            - comma: ','
+            - naked_identifier: c2
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -720,7 +696,6 @@ file:
                 - expression:
                     quoted_literal: "'HOST'"
                 - end_bracket: )
-            - alias_expression:
-                keyword: AS
-                naked_identifier: c1
+            - keyword: AS
+            - naked_identifier: c1
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->
- Closes https://github.com/sqlfluff/sqlfluff/issues/4978
- Add 4 more valid sparksql lateral view test cases listed below. They not not necessarily allowed by documentation but definitely parsable and runnable. Not sure if it's a feature or bug of Spark. Let me know if you don't want explicitly test for them:

```sql
-- table alias + optional AS + column alias
LATERAL VIEW OUTER EXPLODE(ARRAY()) tbl_name c_age

-- optional table alias + optional AS + column alias
LATERAL VIEW OUTER EXPLODE(ARRAY()) c_age

-- table alias + optional AS + column aliases
LATERAL VIEW INLINE(array_of_structs) exploded_people name, age, state

-- optional table alias + AS + column aliases
LATERAL VIEW INLINE(array_of_structs) AS name, age, state
```

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.


cc @WittierDinosaur , previous editor on sparksql LateralViewClauseSegment.