### PR TITLE
Remove broken 'fork me' banner from docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,8 +94,8 @@ html_theme_options = {
     "touch_icon": "images/sqlfluff-sm2-sq.png",
     "github_user": "sqlfluff",
     "github_repo": "sqlfluff",
-    # GitHub Fork button
-    "github_banner": True,
+    # GitHub Fork button (points at a broken link, so disabling it)
+    "github_banner": False,
     # GitHub star button
     "github_type": "star",
     # Use `"true"` instead of `True` for counting GitHub star, see https://ghbtns.com


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Closes https://github.com/sqlfluff/sqlfluff/issues/4987

Hits a dead link: https://github.com/sphinx-doc/alabaster/blob/7a9df17b6366c96baba6bf5e14f9b6ff6bf7defa/alabaster/layout.html#L104

### Are there any other side effects of this change that we should be aware of?
I'm too lazy to find a replacement. It's probably just fine to drop off this banner.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
