### PR TITLE
Correct Snowflake `CROSS JOIN` syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1092,6 +1092,7 @@ class FromExpressionElementSegment(ansi.FromExpressionElementSegment):
                 Ref("SamplingExpressionSegment"),
                 Ref("ChangesClauseSegment"),
                 Ref("JoinLikeClauseGrammar"),
+                "CROSS",
             ),
             optional=True,
         ),

--- a/test/fixtures/dialects/snowflake/select.sql
+++ b/test/fixtures/dialects/snowflake/select.sql
@@ -10,3 +10,7 @@ SELECT
     customer_id,
     TRIM(value:cross) AS cross
 FROM my_table;
+
+SELECT
+    customer_id
+FROM my_table cross join my_table2;

--- a/test/fixtures/dialects/snowflake/select.yml
+++ b/test/fixtures/dialects/snowflake/select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 49a872e61785eff065e6b7a9a3dde70cf2378bd406649775919119a551334817
+_hash: d10a05e1154523702380484f2ad9a65b7e909134045efeb252c034eee4560446
 file:
 - statement:
     select_statement:
@@ -96,4 +96,26 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: my_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: customer_id
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+          join_clause:
+          - keyword: cross
+          - keyword: join
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: my_table2
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Better fix for #4968 

The [snowflake keyword snytax](https://docs.snowflake.com/en/sql-reference/reserved-keywords) says this about `CROSS`:

```
Cannot be used as table name or alias in a FROM clause.
```

So looks like it can be used as a column name as requested by #4968 and implemented in #4975.

This PR excludes it from table aliases only.


### Are there any other side effects of this change that we should be aware of?
No more than original fix :-)

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
