### PR TITLE
Add support to oracle's listagg function

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -104,56 +104,10 @@ oracle_dialect.replace(
         Ref("FilterClauseGrammar"),
         Ref("OverClauseSegment", optional=True),
     ),
-    FunctionContentsGrammar=AnyNumberOf(
-        Ref("ExpressionSegment"),
-        # A Cast-like function
-        Sequence(Ref("ExpressionSegment"), "AS", Ref("DatatypeSegment")),
-        # Trim function
-        Sequence(
-            Ref("TrimParametersGrammar"),
-            Ref("ExpressionSegment", optional=True, exclude=Ref.keyword("FROM")),
-            "FROM",
-            Ref("ExpressionSegment"),
-        ),
-        # An extract-like or substring-like function
-        Sequence(
-            OneOf(Ref("DatetimeUnitSegment"), Ref("ExpressionSegment")),
-            "FROM",
-            Ref("ExpressionSegment"),
-        ),
-        Sequence(
-            # Allow an optional distinct keyword here.
-            Ref.keyword("DISTINCT", optional=True),
-            OneOf(
-                # Most functions will be using the delimited route
-                # but for COUNT(*) or similar we allow the star segment
-                # here.
-                Ref("StarSegment"),
-                Delimited(Ref("FunctionContentsExpressionGrammar")),
-            ),
-        ),
-        Ref(
-            "OrderByClauseSegment"
-        ),  # used by string_agg (postgres), group_concat (exasol),listagg (snowflake)..
-        Sequence(Ref.keyword("SEPARATOR"), Ref("LiteralGrammar")),
-        # like a function call: POSITION ( 'QL' IN 'SQL')
-        Sequence(
-            OneOf(
-                Ref("QuotedLiteralSegment"),
-                Ref("SingleIdentifierGrammar"),
-                Ref("ColumnReferenceSegment"),
-            ),
-            "IN",
-            OneOf(
-                Ref("QuotedLiteralSegment"),
-                Ref("SingleIdentifierGrammar"),
-                Ref("ColumnReferenceSegment"),
-            ),
-        ),
-        Ref("IgnoreRespectNullsGrammar"),
-        Ref("IndexColumnDefinitionSegment"),
-        Ref("EmptyStructLiteralSegment"),
-        Ref("ListaggOverflowClauseSegment"),
+    FunctionContentsGrammar=ansi_dialect.get_grammar("FunctionContentsGrammar").copy(
+        insert=[
+            Ref("ListaggOverflowClauseSegment"),
+        ]
     ),
 )
 

--- a/test/fixtures/dialects/oracle/within_group.sql
+++ b/test/fixtures/dialects/oracle/within_group.sql
@@ -1,0 +1,27 @@
+--https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/LISTAGG.html#GUID-B6E50D8E-F467-425B-9436-F7F8BF38D466
+
+SELECT LISTAGG(last_name, '; ')
+         WITHIN GROUP (ORDER BY hire_date, last_name) "Emp_list",
+       MIN(hire_date) "Earliest"
+  FROM employees
+  WHERE department_id = 30;
+
+SELECT department_id "Dept.",
+       LISTAGG(last_name, '; ') WITHIN GROUP (ORDER BY hire_date) "Employees"
+  FROM employees
+  GROUP BY department_id
+  ORDER BY department_id;
+
+SELECT department_id "Dept.",
+       LISTAGG(last_name, '; ' ON OVERFLOW TRUNCATE '...')
+               WITHIN GROUP (ORDER BY hire_date) "Employees"
+  FROM employees
+  GROUP BY department_id
+  ORDER BY department_id;
+
+SELECT department_id "Dept", hire_date "Date", last_name "Name",
+       LISTAGG(last_name, '; ') WITHIN GROUP (ORDER BY hire_date, last_name)
+         OVER (PARTITION BY department_id) as "Emp_list"
+  FROM employees
+  WHERE hire_date < '01-SEP-2003'
+  ORDER BY "Dept", "Date", "Name";

--- a/test/fixtures/dialects/oracle/within_group.yml
+++ b/test/fixtures/dialects/oracle/within_group.yml
@@ -1,0 +1,273 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 4ada825227950ee63592765397f58f0d03f157219fd5fa98ffd93b963c93fe48
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LISTAGG
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  naked_identifier: last_name
+            - comma: ','
+            - expression:
+                quoted_literal: "'; '"
+            - end_bracket: )
+            withingroup_clause:
+            - keyword: WITHIN
+            - keyword: GROUP
+            - bracketed:
+                start_bracket: (
+                orderby_clause:
+                - keyword: ORDER
+                - keyword: BY
+                - column_reference:
+                    naked_identifier: hire_date
+                - comma: ','
+                - column_reference:
+                    naked_identifier: last_name
+                end_bracket: )
+          alias_expression:
+            quoted_identifier: '"Emp_list"'
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: MIN
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: hire_date
+              end_bracket: )
+          alias_expression:
+            quoted_identifier: '"Earliest"'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: employees
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: department_id
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '30'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: department_id
+          alias_expression:
+            quoted_identifier: '"Dept."'
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LISTAGG
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  naked_identifier: last_name
+            - comma: ','
+            - expression:
+                quoted_literal: "'; '"
+            - end_bracket: )
+            withingroup_clause:
+            - keyword: WITHIN
+            - keyword: GROUP
+            - bracketed:
+                start_bracket: (
+                orderby_clause:
+                - keyword: ORDER
+                - keyword: BY
+                - column_reference:
+                    naked_identifier: hire_date
+                end_bracket: )
+          alias_expression:
+            quoted_identifier: '"Employees"'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: employees
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: department_id
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: department_id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: department_id
+          alias_expression:
+            quoted_identifier: '"Dept."'
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LISTAGG
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  naked_identifier: last_name
+            - comma: ','
+            - expression:
+                quoted_literal: "'; '"
+            - listagg_overflow_clause:
+              - keyword: 'ON'
+              - keyword: OVERFLOW
+              - keyword: TRUNCATE
+              - quoted_identifier: "'...'"
+            - end_bracket: )
+            withingroup_clause:
+            - keyword: WITHIN
+            - keyword: GROUP
+            - bracketed:
+                start_bracket: (
+                orderby_clause:
+                - keyword: ORDER
+                - keyword: BY
+                - column_reference:
+                    naked_identifier: hire_date
+                end_bracket: )
+          alias_expression:
+            quoted_identifier: '"Employees"'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: employees
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: department_id
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: department_id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: department_id
+          alias_expression:
+            quoted_identifier: '"Dept"'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: hire_date
+          alias_expression:
+            quoted_identifier: '"Date"'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: last_name
+          alias_expression:
+            quoted_identifier: '"Name"'
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LISTAGG
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  naked_identifier: last_name
+            - comma: ','
+            - expression:
+                quoted_literal: "'; '"
+            - end_bracket: )
+            withingroup_clause:
+            - keyword: WITHIN
+            - keyword: GROUP
+            - bracketed:
+                start_bracket: (
+                orderby_clause:
+                - keyword: ORDER
+                - keyword: BY
+                - column_reference:
+                    naked_identifier: hire_date
+                - comma: ','
+                - column_reference:
+                    naked_identifier: last_name
+                end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: department_id
+                end_bracket: )
+          alias_expression:
+            keyword: as
+            quoted_identifier: '"Emp_list"'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: employees
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: hire_date
+          comparison_operator:
+            raw_comparison_operator: <
+          quoted_literal: "'01-SEP-2003'"
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          quoted_identifier: '"Dept"'
+      - comma: ','
+      - column_reference:
+          quoted_identifier: '"Date"'
+      - comma: ','
+      - column_reference:
+          quoted_identifier: '"Name"'
+- statement_terminator: ;


### PR DESCRIPTION
Closes #4145

Also add support to "on overflow" clause.
Tests taken from the  examples in [Oracle documentation](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/LISTAGG.html#GUID-B6E50D8E-F467-425B-9436-F7F8BF38D466)

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
