### PR TITLE
Clickhouse Dialect - Support Dollar Quoted Literals

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -36,6 +36,18 @@ clickhouse_dialect.replace(
         Ref("QuotedIdentifierSegment"),
         Ref("SingleQuotedIdentifierSegment"),
     ),
+    QuotedLiteralSegment=OneOf(
+        TypedParser(
+            "single_quote",
+            ansi.LiteralSegment,
+            type="quoted_literal"
+        ),
+        TypedParser(
+            "dollar_quote",
+            ansi.LiteralSegment,
+            type="quoted_literal",
+        ),
+    ),
 )
 
 clickhouse_dialect.insert_lexer_matchers(

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -40,7 +40,7 @@ clickhouse_dialect.replace(
         TypedParser(
             "single_quote",
             ansi.LiteralSegment,
-            type="quoted_literal"
+            type="quoted_literal",
         ),
         TypedParser(
             "dollar_quote",

--- a/test/fixtures/dialects/clickhouse/dollar_quoted_literal.sql
+++ b/test/fixtures/dialects/clickhouse/dollar_quoted_literal.sql
@@ -1,0 +1,3 @@
+SELECT * FROM foo WHERE col1 = $$bar$$;
+
+SELECT * FROM foo WHERE col1 = $baz$bar$baz$;

--- a/test/fixtures/dialects/clickhouse/dollar_quoted_literal.yml
+++ b/test/fixtures/dialects/clickhouse/dollar_quoted_literal.yml
@@ -1,0 +1,55 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: db62483fc2007d81cce45cf5cb073a25261d92065231c8344f0fbafff69db6ff
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foo
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: col1
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: $$bar$$
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foo
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: col1
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: $baz$bar$baz$
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Prior to this change, dollar quoted literals failed to parse when using the Clickhouse Dialect. 

Example (Output generated using tests in this repo):
```
Query: SELECT * FROM foo WHERE col1 = $$bar$$;
FAILED test/dialects/dialects_test.py::test__dialect__base_file_parse[clickhouse-dollar_quoted_literal.sql] - assert not [SQLParseError("Line 1, Position 29: Found unparsable section: ' = $$bar$$'"), SQLParseError("Line 3, Position 29: Found unparsable section: ' = $baz$bar$baz$'")]
FAILED test/dialects/dialects_test.py::test__dialect__base_broad_fix[clickhouse-dollar_quoted_literal.sql] - assert not [SQLParseError("Line 1, Position 29: Found unparsable section: ' = $$bar$$'"), SQLParseError("Line 3, Position 29: Found unparsable section: ' = $baz$bar$baz$'")]
FAILED test/dialects/dialects_test.py::test__dialect__base_parse_struct[clickhouse-dollar_quoted_literal.sql-True-dollar_quoted_literal.yml] - AssertionError: assert ('file', (('statement', (('select_statement', (('select_clause', (('keyword', 'SELECT'), ('select_clause_element', (('wildcard_expression', (('wildcard_identifier', (('star', '*'),)),)),)))), ('from_clause', (('keyw...
```

Example (From actual usecase)
```
Checking src/selectors/Query.sql00:01
== [Query.sql] FAIL00:02
L:  39 | P:  43 |  PRS | Line 39, Position 43: Found unparsable section:00:02
                       | '$$string$$, $$string2$$'
```


### Are there any other side effects of this change that we should be aware of?
I don't think so, all tests pass

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
