### PR TITLE
Bugfix: Treat Function name properly in grants

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -3443,7 +3443,7 @@ class AccessStatementSegment(BaseSegment):
                     "IN",
                     OneOf("DATABASE", "SCHEMA"),
                 ),
-                optional = True,
+                optional=True,
             ),
             Delimited(
                 Ref("ObjectReferenceSegment"),

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -3443,10 +3443,16 @@ class AccessStatementSegment(BaseSegment):
                     "IN",
                     OneOf("DATABASE", "SCHEMA"),
                 ),
-                optional=True,
+                optional = True,
             ),
-            Delimited(Ref("ObjectReferenceSegment"), terminator=OneOf("TO", "FROM")),
-            Ref("FunctionParameterListGrammar", optional=True),
+            Delimited(
+                Ref("ObjectReferenceSegment"),
+                Sequence(
+                    Ref("FunctionNameSegment"),
+                    Ref("FunctionParameterListGrammar", optional=True),
+                ),
+                terminator=OneOf("TO", "FROM"),
+            ),
         ),
         Sequence("LARGE", "OBJECT", Ref("NumericLiteralSegment")),
     )

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -2367,8 +2367,14 @@ class AccessStatementSegment(BaseSegment):
                 ),
                 optional=True,
             ),
-            Delimited(Ref("ObjectReferenceSegment"), terminator=OneOf("TO", "FROM")),
-            Ref("FunctionParameterListGrammar", optional=True),
+            Delimited(
+                Ref("ObjectReferenceSegment"),
+                Sequence(
+                    Ref("FunctionNameSegment"),
+                    Ref("FunctionParameterListGrammar", optional=True),
+                ),
+                terminator=OneOf("TO", "FROM"),
+            ),
         ),
     )
 

--- a/test/fixtures/dialects/postgres/create_function.yml
+++ b/test/fixtures/dialects/postgres/create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a2a0f2c4bee4578f40958582525e3f84a4b19d621ce8333f1364624f3b028c98
+_hash: 763dcc4eb40c6b199824179d4cce12783cbcfddc9a1a5567d169f3df3bd298ea
 file:
 - statement:
     create_function_statement:
@@ -543,8 +543,8 @@ file:
     - keyword: ALL
     - keyword: 'ON'
     - keyword: FUNCTION
-    - object_reference:
-        naked_identifier: check_password
+    - function_name:
+        function_name_identifier: check_password
     - function_parameter_list:
         bracketed:
         - start_bracket: (
@@ -566,8 +566,8 @@ file:
     - keyword: EXECUTE
     - keyword: 'ON'
     - keyword: FUNCTION
-    - object_reference:
-        naked_identifier: check_password
+    - function_name:
+        function_name_identifier: check_password
     - function_parameter_list:
         bracketed:
         - start_bracket: (

--- a/test/fixtures/dialects/snowflake/grant_revoke.yml
+++ b/test/fixtures/dialects/snowflake/grant_revoke.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 25596156a43ae14090219ab8f410cb86b21ff7e0077e7ef54e797d975fe21c92
+_hash: aeee2f396458b254c167e80035f3da42c44feeb3cb7ace72d3ccb39f9357113e
 file:
 - statement:
     access_statement:
@@ -410,8 +410,8 @@ file:
     - keyword: privileges
     - keyword: 'on'
     - keyword: function
-    - object_reference:
-        naked_identifier: add5
+    - function_name:
+        function_name_identifier: add5
     - function_parameter_list:
         bracketed:
           start_bracket: (
@@ -550,12 +550,12 @@ file:
     - keyword: privileges
     - keyword: 'on'
     - keyword: function
-    - object_reference:
+    - function_name:
       - naked_identifier: mydb
       - dot: .
       - naked_identifier: myschema
       - dot: .
-      - naked_identifier: add5
+      - function_name_identifier: add5
     - function_parameter_list:
         bracketed:
           start_bracket: (
@@ -574,12 +574,12 @@ file:
     - keyword: privileges
     - keyword: 'on'
     - keyword: function
-    - object_reference:
+    - function_name:
       - naked_identifier: mydb
       - dot: .
       - naked_identifier: myschema
       - dot: .
-      - naked_identifier: add5
+      - function_name_identifier: add5
     - function_parameter_list:
         bracketed:
           start_bracket: (
@@ -597,12 +597,12 @@ file:
     - keyword: usage
     - keyword: 'on'
     - keyword: procedure
-    - object_reference:
+    - function_name:
       - naked_identifier: mydb
       - dot: .
       - naked_identifier: myschema
       - dot: .
-      - naked_identifier: myprocedure
+      - function_name_identifier: myprocedure
     - function_parameter_list:
         bracketed:
           start_bracket: (
@@ -851,8 +851,8 @@ file:
     - keyword: privileges
     - keyword: 'on'
     - keyword: procedure
-    - object_reference:
-        naked_identifier: clean_schema
+    - function_name:
+        function_name_identifier: clean_schema
     - function_parameter_list:
         bracketed:
           start_bracket: (
@@ -871,8 +871,8 @@ file:
     - keyword: privileges
     - keyword: 'on'
     - keyword: function
-    - object_reference:
-        naked_identifier: add5
+    - function_name:
+        function_name_identifier: add5
     - function_parameter_list:
         bracketed:
           start_bracket: (


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes a bug whereby function names in grants were treated as object references, making reflow improperly space the brackets.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
