### PR TITLE
AM06 to ignore aggregate ORDER BY clauses

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1250,6 +1250,16 @@ class QualifiedNumericLiteralSegment(BaseSegment):
     )
 
 
+class AggregateOrderByClause(BaseSegment):
+    """An order by clause for an aggregate fucntion.
+
+    Defined as a class to allow a specific type for rule AM06
+    """
+
+    type = "aggregate_order_by"
+    match_grammar: Matchable = Ref("OrderByClauseSegment")
+
+
 ansi_dialect.add(
     # FunctionContentsExpressionGrammar intended as a hook to override
     # in other dialects.
@@ -1283,7 +1293,7 @@ ansi_dialect.add(
             ),
         ),
         Ref(
-            "OrderByClauseSegment"
+            "AggregateOrderByClause"
         ),  # used by string_agg (postgres), group_concat (exasol),listagg (snowflake)..
         Sequence(Ref.keyword("SEPARATOR"), Ref("LiteralGrammar")),
         # like a function call: POSITION ( 'QL' IN 'SQL')

--- a/src/sqlfluff/rules/ambiguous/AM06.py
+++ b/src/sqlfluff/rules/ambiguous/AM06.py
@@ -87,7 +87,11 @@ class Rule_AM06(BaseRule):
     crawl_behaviour = SegmentSeekerCrawler(
         {"groupby_clause", "orderby_clause", "grouping_expression_list"}
     )
-    _ignore_types: List[str] = ["withingroup_clause", "window_specification"]
+    _ignore_types: List[str] = [
+        "withingroup_clause",
+        "window_specification",
+        "aggregate_order_by",
+    ]
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
         """Inconsistent column references in GROUP BY/ORDER BY clauses."""

--- a/test/fixtures/dialects/bigquery/select_function_parameter_order_by_multiple_columns.yml
+++ b/test/fixtures/dialects/bigquery/select_function_parameter_order_by_multiple_columns.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 87f5a5df052d37110cb46046ad44bbb48dc479d0cbce6a926c08b2406322ffc0
+_hash: 369719879934cc50e9157180a6c18f02451bcd9c966bf8632f2e2621e25290af
 file:
   statement:
     select_statement:
@@ -18,14 +18,15 @@ file:
               expression:
                 column_reference:
                   naked_identifier: a
-              orderby_clause:
-              - keyword: ORDER
-              - keyword: BY
-              - column_reference:
-                  naked_identifier: b
-              - comma: ','
-              - column_reference:
-                  naked_identifier: c
+              aggregate_order_by:
+                orderby_clause:
+                - keyword: ORDER
+                - keyword: BY
+                - column_reference:
+                    naked_identifier: b
+                - comma: ','
+                - column_reference:
+                    naked_identifier: c
               end_bracket: )
       from_clause:
         keyword: FROM

--- a/test/fixtures/rules/std_rule_cases/AM06.yml
+++ b/test/fixtures/rules/std_rule_cases/AM06.yml
@@ -671,3 +671,14 @@ test_fail_groupby_rollup_sparksql:
   configs:
     core:
       dialect: sparksql
+
+test_pass_array_agg_bigquery:
+  pass_str: |
+    SELECT
+        to_json_string(array_agg(product_id order by started_at desc)) AS products
+    FROM purchased
+    GROUP by 1
+
+  configs:
+    core:
+      dialect: bigquery


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #3649 

### Are there any other side effects of this change that we should be aware of?
Shouldn't be

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
