### PR TITLE
Simple API config and examples

### DIFF
--- a/examples/05_simple_api_config.py
+++ b/examples/05_simple_api_config.py
@@ -10,17 +10,17 @@ from sqlfluff.core import Linter, FluffConfig
 sqlfluff.fix("SELECT  1", dialect="bigquery")
 
 # 2. Providing the path to a config file
-sqlfluff.fix("SELECT  1", config_path="../test/fixtures/.sqlfluff")
+sqlfluff.fix("SELECT  1", config_path="test/fixtures/.sqlfluff")
 
 # 3. Providing a preconfigured FluffConfig object.
 # NOTE: This is the way of configuring SQLFluff which will give the most control.
 
 # 3a. FluffConfig objects can be created directly from a dictionary of values.
-config = FluffConfig(configs={"core": {"dialect", "bigquery"}})
+config = FluffConfig(configs={"core": {"dialect": "bigquery"}})
 # 3b. FluffConfig objects can be created from a config file in a string.
 config = FluffConfig.from_string("[sqlfluff]\ndialect=bigquery\n")
 # 3c. FluffConfig objects can be created from a path containing a config file.
-config = FluffConfig.from_path("../test/fixtures/")
+config = FluffConfig.from_path("test/fixtures/")
 # 3c. FluffConfig objects can be from keyword arguments
 config = FluffConfig.from_kwargs(dialect="bigquery", rules=["LT01"])
 
@@ -39,4 +39,5 @@ linter = Linter(config=config)
 
 lint_result = linter.lint_string("SELECT  1", fix=True)
 fixed_string = lint_result.fix_string()
-assert fixed_string == "SELECT 1\n"
+# NOTE: The "True" element shows that fixing was a success.
+assert fixed_string == ("SELECT 1", True)

--- a/examples/05_simple_api_config.py
+++ b/examples/05_simple_api_config.py
@@ -1,7 +1,9 @@
 """An example to show a few ways of configuring the API."""
 
 import sqlfluff
+from sqlfluff.core import Linter, FluffConfig
 
+# #######################################
 # The simple API can be configured in three ways.
 
 # 1. Limited keyword arguments
@@ -12,7 +14,6 @@ sqlfluff.fix("SELECT  1", config_path="../test/fixtures/.sqlfluff")
 
 # 3. Providing a preconfigured FluffConfig object.
 # NOTE: This is the way of configuring SQLFluff which will give the most control.
-from sqlfluff.core import FluffConfig
 
 # 3a. FluffConfig objects can be created directly from a dictionary of values.
 config = FluffConfig(configs={"core": {"dialect", "bigquery"}})
@@ -26,12 +27,12 @@ config = FluffConfig.from_kwargs(dialect="bigquery", rules=["LT01"])
 # The FluffConfig is then provided via a config argument.
 sqlfluff.fix("SELECT  1", config=config)
 
+
+# #######################################
 # The core API is always configured using a FluffConfig object.
 
-from sqlfluff.core import Linter
-
-# When instantiating a Linter (or Parser), a FluffConfig must be provided on instantiation.
-# See above for details on how to create a FluffConfig.
+# When instantiating a Linter (or Parser), a FluffConfig must be provided
+# on instantiation. See above for details on how to create a FluffConfig.
 linter = Linter(config=config)
 
 # The provided config will then be used in any operations.

--- a/examples/05_simple_api_config.py
+++ b/examples/05_simple_api_config.py
@@ -1,0 +1,41 @@
+"""An example to show a few ways of configuring the API."""
+
+import sqlfluff
+
+# The simple API can be configured in three ways.
+
+# 1. Limited keyword arguments
+sqlfluff.fix("SELECT  1", dialect="bigquery")
+
+# 2. Providing the path to a config file
+sqlfluff.fix("SELECT  1", config_path="../test/fixtures/.sqlfluff")
+
+# 3. Providing a preconfigured FluffConfig object.
+# NOTE: This is the way of configuring SQLFluff which will give the most control.
+from sqlfluff.core import FluffConfig
+
+# 3a. FluffConfig objects can be created directly from a dictionary of values.
+config = FluffConfig(configs={"core": {"dialect", "bigquery"}})
+# 3b. FluffConfig objects can be created from a config file in a string.
+config = FluffConfig.from_string("[sqlfluff]\ndialect=bigquery\n")
+# 3c. FluffConfig objects can be created from a path containing a config file.
+config = FluffConfig.from_path("../test/fixtures/")
+# 3c. FluffConfig objects can be from keyword arguments
+config = FluffConfig.from_kwargs(dialect="bigquery", rules=["LT01"])
+
+# The FluffConfig is then provided via a config argument.
+sqlfluff.fix("SELECT  1", config=config)
+
+# The core API is always configured using a FluffConfig object.
+
+from sqlfluff.core import Linter
+
+# When instantiating a Linter (or Parser), a FluffConfig must be provided on instantiation.
+# See above for details on how to create a FluffConfig.
+linter = Linter(config=config)
+
+# The provided config will then be used in any operations.
+
+lint_result = linter.lint_string("SELECT  1", fix=True)
+fixed_string = lint_result.fix_string()
+assert fixed_string == "SELECT 1\n"

--- a/src/sqlfluff/api/simple.py
+++ b/src/sqlfluff/api/simple.py
@@ -61,6 +61,7 @@ def lint(
     dialect: str = "ansi",
     rules: Optional[List[str]] = None,
     exclude_rules: Optional[List[str]] = None,
+    config: Optional[FluffConfig] = None,
     config_path: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Lint a SQL string.
@@ -73,13 +74,16 @@ def lint(
             references to lint for. Defaults to None.
         exclude_rules (:obj:`Optional[List[str]`, optional): A list of rule
             references to avoid linting for. Defaults to None.
-        config_path (:obj:`Optional[str]`, optional): A path to a .sqlfluff config.
+        config (:obj:`Optional[FluffConfig]`, optional): A configuration object
+            to use for the operation. Defaults to None.
+        config_path (:obj:`Optional[str]`, optional): A path to a .sqlfluff config,
+            which is only used if a `config` is not already provided.
             Defaults to None.
 
     Returns:
         :obj:`List[Dict[str, Any]]` for each violation found.
     """
-    cfg = get_simple_config(
+    cfg = config or get_simple_config(
         dialect=dialect,
         rules=rules,
         exclude_rules=exclude_rules,
@@ -98,6 +102,7 @@ def fix(
     dialect: str = "ansi",
     rules: Optional[List[str]] = None,
     exclude_rules: Optional[List[str]] = None,
+    config: Optional[FluffConfig] = None,
     config_path: Optional[str] = None,
     fix_even_unparsable: Optional[bool] = None,
 ) -> str:
@@ -111,13 +116,16 @@ def fix(
             references to fix for. Defaults to None.
         exclude_rules (:obj:`Optional[List[str]`, optional): A subset of rule
             references to avoid fixing for. Defaults to None.
-        config_path (:obj:`Optional[str]`, optional): A path to a .sqlfluff config.
+        config (:obj:`Optional[FluffConfig]`, optional): A configuration object
+            to use for the operation. Defaults to None.
+        config_path (:obj:`Optional[str]`, optional): A path to a .sqlfluff config,
+            which is only used if a `config` is not already provided.
             Defaults to None.
 
     Returns:
         :obj:`str` for the fixed SQL if possible.
     """
-    cfg = get_simple_config(
+    cfg = config or get_simple_config(
         dialect=dialect,
         rules=rules,
         exclude_rules=exclude_rules,
@@ -143,6 +151,7 @@ def fix(
 def parse(
     sql: str,
     dialect: str = "ansi",
+    config: Optional[FluffConfig] = None,
     config_path: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Parse a SQL string.
@@ -151,13 +160,16 @@ def parse(
         sql (:obj:`str`): The SQL to be parsed.
         dialect (:obj:`str`, optional): A reference to the dialect of the SQL
             to be parsed. Defaults to `ansi`.
-        config_path (:obj:`Optional[str]`, optional): A path to a .sqlfluff config.
+        config (:obj:`Optional[FluffConfig]`, optional): A configuration object
+            to use for the operation. Defaults to None.
+        config_path (:obj:`Optional[str]`, optional): A path to a .sqlfluff config,
+            which is only used if a `config` is not already provided.
             Defaults to None.
 
     Returns:
         :obj:`Dict[str, Any]` JSON containing the parsed structure.
     """
-    cfg = get_simple_config(
+    cfg = config or get_simple_config(
         dialect=dialect,
         config_path=config_path,
     )


### PR DESCRIPTION
This PR enables passing a `FluffConfig` to the simple API and not just a `config_path`. I've added an example file to demonstrate the functionality.