### PR TITLE
Fix: Add exception to the warning & config for the BaseRule.

### DIFF
--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -580,7 +580,7 @@ class RuleMetaclass(type):
             # Except if it's the base rule, in which case we shouldn't try and
             # apply configuration _anyway_.
             pass
-        elif not plugins_loaded.get() :
+        elif not plugins_loaded.get():
             # Show a warning if a plugin has their imports set up in a suboptimal
             # way. The example plugin imports the rules in both ways, to test the
             # triggering of this warning.

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -576,7 +576,11 @@ class RuleMetaclass(type):
         # NOTE: We should only validate and add config keywords
         # into the docstring if the plugin loading methods have
         # fully completed (i.e. plugins_loaded.get() is True).
-        if not plugins_loaded.get():
+        if name == "BaseRule":
+            # Except if it's the base rule, in which case we shouldn't try and
+            # apply configuration _anyway_.
+            pass
+        elif not plugins_loaded.get() :
             # Show a warning if a plugin has their imports set up in a suboptimal
             # way. The example plugin imports the rules in both ways, to test the
             # triggering of this warning.


### PR DESCRIPTION
While building docs, the warning for rule configuration occasionally flags and that's because of the import path for the `BaseRule` (which shouldn't apply any configuration _anyway_). This provides an exception for that and explicitly _doesn't_ check for any of this when we're instantiating the `BaseRule`.