### PR TITLE
DOC: Fix .sqlfluff example in Getting Started

### DIFF
--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -258,7 +258,7 @@ put the following content:
     [sqlfluff:indentation]
     tab_space_size = 2
 
-    [sqlfluff:rules:CP01]
+    [sqlfluff:rules:capitalisation.keywords]
     capitalisation_policy = lower
 
 Then rerun the same command as before.


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
The example `.sqlfluff` config file in the Getting Started section:
```
[sqlfluff]
dialect = ansi

[sqlfluff:indentation]
tab_space_size = 2

[sqlfluff:rules:CP01]
capitalisation_policy = lower
```
gives me these warnings when run with version 2.1.4 of sqlfluff:
```
WARNING    Rule configuration contain a section for unexpected rule 'CP01'. These values will be ignored. 
WARNING    The reference was however found as a match for rule CP01 with name 'capitalisation.keywords'. SQLFluff assumes configuration for this rule will be specified in 'sqlfluff:rules:capitalisation.keywords'
```
and the rule then appears to be ignored (the capitalisation of the keywords does not change to lowercase).

The changes fixes the example config file according to the suggestion.

### Pull Request checklist
Documentation-only change.
