### PR TITLE
Warn on unused `noqa` directives

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -359,6 +359,12 @@ def lint_options(f: Callable) -> Callable:
             "future releases without warning."
         ),
     )(f)
+    f = click.option(
+        "--warn-unused-ignores",
+        is_flag=True,
+        default=False,
+        help="Warn about unneeded '-- noqa:' comments.",
+    )(f)
     return f
 
 
@@ -392,10 +398,18 @@ def get_config(
                 )
             )
             sys.exit(EXIT_ERROR)
+
     from_root_kwargs = {}
     if "require_dialect" in kwargs:
         from_root_kwargs["require_dialect"] = kwargs.pop("require_dialect")
+
     library_path = kwargs.pop("library_path", None)
+
+    if not kwargs.get("warn_unused_ignores", True):
+        # If it's present AND True, then keep it, otherwise remove this so
+        # that we default to the root config.
+        del kwargs["warn_unused_ignores"]
+
     # Instantiate a config object (filtering out the nulls)
     overrides = {k: kwargs[k] for k in kwargs if kwargs[k] is not None}
     if library_path is not None:

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -250,7 +250,11 @@ class OutputStreamFormatter:
         return str_buffer
 
     def dispatch_file_violations(
-        self, fname: str, linted_file: LintedFile, only_fixable: bool
+        self,
+        fname: str,
+        linted_file: LintedFile,
+        only_fixable: bool,
+        warn_unused_ignores: bool,
     ) -> None:
         """Dispatch any violations found in a file."""
         if self.verbosity < 0:
@@ -258,7 +262,9 @@ class OutputStreamFormatter:
         s = self._format_file_violations(
             fname,
             linted_file.get_violations(
-                fixable=True if only_fixable else None, filter_warning=False
+                fixable=True if only_fixable else None,
+                filter_warning=False,
+                warn_unused_ignores=warn_unused_ignores,
             ),
         )
         self._dispatch(s)

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -23,6 +23,8 @@ ignore = None
 # Warn only for rule codes (one of more rule codes, seperated by commas: e.g. LT01,LT02)
 # Also works for templating and parsing errors by using TMP or PRS
 warnings = None
+# Whether to warn about unneeded '-- noqa:' comments.
+warn_unused_ignores = False
 # Ignore linting errors found within sections of code coming directly from
 # templated code (e.g. from within Jinja curly braces. Note that it does not
 # ignore errors from literal code found within template loops.

--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -19,11 +19,18 @@ class SQLBaseError(ValueError):
         ignore=False,
         fatal=False,
         warning=False,
+        # TODO: REVISIT WHETHER THIS IS A GOOD IDEA
+        description=None,
+        code=None,
         **kwargs
     ) -> None:
         self.fatal = fatal
         self.ignore = ignore
         self.warning = warning
+        if description:
+            self.description = description
+        if code:
+            self._code = code
         if pos:
             self.line_no, self.line_pos = pos.source_position()
         else:

--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -19,18 +19,11 @@ class SQLBaseError(ValueError):
         ignore=False,
         fatal=False,
         warning=False,
-        # TODO: REVISIT WHETHER THIS IS A GOOD IDEA
-        description=None,
-        code=None,
         **kwargs
     ) -> None:
         self.fatal = fatal
         self.ignore = ignore
         self.warning = warning
-        if description:
-            self.description = description
-        if code:
-            self._code = code
         if pos:
             self.line_no, self.line_pos = pos.source_position()
         else:
@@ -232,6 +225,20 @@ class SQLLintError(SQLBaseError):
             len(self.fixes),
             self.description,
         )
+
+
+class SQLUnusedNoQaWarning(SQLBaseError):
+    """A warning about an unused noqa directive."""
+
+    _code = "NOQA"
+    _identifier = "noqa"
+
+    def __init__(self, *args, description=None, **kwargs) -> None:
+        # Should have a description.
+        self.description = description
+        # Always a warning.
+        kwargs["warning"] = True
+        super().__init__(*args, **kwargs)
 
 
 class SQLFluffUserError(ValueError):

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -167,18 +167,7 @@ class LintedFile(NamedTuple):
             violations = [v for v in violations if not v.warning]
         # Add warnings for unneeded noqa if applicable
         if warn_unused_ignores and not filter_warning and self.ignore_mask:
-            violations += [
-                SQLBaseError(
-                    line_no=ignore.line_no,
-                    line_pos=0,
-                    warning=True,
-                    description="Unused NOQA",
-                    code="NOQA",
-                )
-                for ignore in self.ignore_mask._ignore_list
-                if not ignore.used
-                # TODO: This should be in the ignore_mask
-            ]
+            violations += self.ignore_mask.generate_warnings_for_unused()
         return violations
 
     def num_violations(self, **kwargs) -> int:

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -641,7 +641,10 @@ class Linter:
         # This is the main command line output from linting.
         if formatter:
             formatter.dispatch_file_violations(
-                parsed.fname, linted_file, only_fixable=fix
+                parsed.fname,
+                linted_file,
+                only_fixable=fix,
+                warn_unused_ignores=parsed.config.get("warn_unused_ignores"),
             )
 
         # Safety flag for unset dialects

--- a/src/sqlfluff/core/linter/noqa.py
+++ b/src/sqlfluff/core/linter/noqa.py
@@ -301,3 +301,17 @@ class IgnoreMask:
         )
         violations = self._ignore_masked_violations_line_range(violations, ignore_range)
         return violations
+
+    def generate_warnings_for_unused(self) -> List[SQLBaseError]:
+        """Generates warnings for any unused NoQaDirectives."""
+        return [
+            SQLBaseError(
+                line_no=ignore.line_no,
+                line_pos=0,
+                warning=True,
+                description="Unused NOQA",
+                code="NOQA",
+            )
+            for ignore in self._ignore_list
+            if not ignore.used
+        ]

--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -153,7 +153,12 @@ class ParallelRunner(BaseRunner):
                         # It's a LintedDir.
                         if self.linter.formatter:
                             self.linter.formatter.dispatch_file_violations(
-                                lint_result.path, lint_result, only_fixable=fix
+                                lint_result.path,
+                                lint_result,
+                                only_fixable=fix,
+                                warn_unused_ignores=self.linter.config.get(
+                                    "warn_unused_ignores"
+                                ),
                             )
                         yield lint_result
             except KeyboardInterrupt:  # pragma: no cover

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1698,7 +1698,7 @@ def test_cli_encoding(encoding, method, expect_success, tmpdir):
 
 
 def test_cli_no_disable_noqa_flag():
-    """Test that unset --disable_noqa flag respects inline noqa comments."""
+    """Test that unset --disable-noqa flag respects inline noqa comments."""
     invoke_assert_code(
         ret_code=0,
         args=[
@@ -1709,7 +1709,7 @@ def test_cli_no_disable_noqa_flag():
 
 
 def test_cli_disable_noqa_flag():
-    """Test that --disable_noqa flag ignores inline noqa comments."""
+    """Test that --disable-noqa flag ignores inline noqa comments."""
     result = invoke_assert_code(
         ret_code=1,
         args=[
@@ -1723,7 +1723,26 @@ def test_cli_disable_noqa_flag():
     raw_output = repr(result.output)
 
     # Linting error is raised even though it is inline ignored.
-    assert r"L:   5 | P:  11 | CP01 |" in raw_output
+    assert r"L:   6 | P:  11 | CP01 |" in raw_output
+
+
+def test_cli_warn_unused_noqa_flag():
+    """Test that --warn-unused-ignores flag works."""
+    result = invoke_assert_code(
+        # Return value should still be success.
+        ret_code=0,
+        args=[
+            lint,
+            [
+                "test/fixtures/cli/disable_noqa_test.sql",
+                "--warn-unused-ignores",
+            ],
+        ],
+    )
+    raw_output = repr(result.output)
+
+    # Warning shown.
+    assert r"L:   5 | P:  18 | NOQA | WARNING: Unused noqa: 'noqa: CP01'" in raw_output
 
 
 def test_cli_get_default_config():

--- a/test/core/linter/noqa_test.py
+++ b/test/core/linter/noqa_test.py
@@ -145,13 +145,13 @@ def test_parse_noqa_no_dups():
             [dict(comment="noqa: enable=LT01", line_no=1)],
             [DummyLintError(1)],
             [0],
-            [],  # TODO
+            [],
         ],
         [
             [dict(comment="noqa: disable=LT01", line_no=1)],
             [DummyLintError(1)],
             [],
-            [],  # TODO
+            [0],
         ],
         [
             [
@@ -160,7 +160,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(1)],
             [0],
-            [],  # TODO
+            [],  # The disable wasn't used, neither was the enable.
         ],
         [
             [
@@ -169,7 +169,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(2)],
             [],
-            [],  # TODO
+            [0, 1],  # Both were used.
         ],
         [
             [
@@ -178,7 +178,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(3)],
             [],
-            [],  # TODO
+            [0, 1],  # Both were used.
         ],
         [
             [
@@ -187,7 +187,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(4)],
             [0],
-            [],  # TODO
+            [1],  # The enable was matched, but the disable wasn't used.
         ],
         [
             [
@@ -196,7 +196,12 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(1)],
             [0],
-            [],  # TODO
+            # TODO: This is an odd edge case, where we drop out in our
+            # evaluation too early so see whether the "enable" is ever
+            # matched. In this case _both_ are effectively unused, because
+            # we never evaluate the last one. For a first pass I think this
+            # might be an acceptable edge case.
+            [],
         ],
         [
             [
@@ -205,7 +210,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(2)],
             [],
-            [],  # TODO
+            [0, 1],  # Both were used.
         ],
         [
             [
@@ -214,7 +219,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(3)],
             [],
-            [],  # TODO
+            [0, 1],  # Both were used.
         ],
         [
             [
@@ -223,7 +228,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(4)],
             [0],
-            [],  # TODO
+            [1],  # The enable was matched, but the disable wasn't used.
         ],
         [
             [
@@ -237,7 +242,7 @@ def test_parse_noqa_no_dups():
                 DummyLintError(4, code="LT02"),
             ],
             [1, 2, 3],
-            [],  # TODO
+            [0, 1],  # The enable matched. The disable also matched rules.
         ],
         [
             [
@@ -251,7 +256,7 @@ def test_parse_noqa_no_dups():
                 DummyLintError(4, code="LT02"),
             ],
             [2],
-            [],  # TODO
+            [0, 1],  # The enable matched the disable. The disable also matched
         ],
         [
             [
@@ -262,7 +267,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(1)],
             [0],
-            [],  # TODO
+            [],
         ],
         [
             [
@@ -280,7 +285,7 @@ def test_parse_noqa_no_dups():
                 DummyLintError(2),
             ],
             [0, 1],
-            [],  # TODO
+            [],  # Neither used because wrong code.
         ],
         [
             [
@@ -293,7 +298,20 @@ def test_parse_noqa_no_dups():
                 DummyLintError(1),
             ],
             [0],
-            [],  # TODO
+            [],  # Neither used because wrong code.
+        ],
+        [
+            [
+                dict(
+                    comment="Inline comment before inline ignore -- noqa: LT*",
+                    line_no=1,
+                ),
+            ],
+            [
+                DummyLintError(1),
+            ],
+            [],
+            [0],  # Matched indirectly
         ],
     ],
     ids=[
@@ -315,7 +333,8 @@ def test_parse_noqa_no_dups():
         "4_violations_two_types_disable_all_enable_specific",
         "1_violations_comment_inline_ignore",
         "2_violations_comment_inline_ignore",
-        "1_violations_comment_inline_glob_ignore",
+        "1_violations_comment_inline_glob_ignore_unmatch",
+        "1_violations_comment_inline_glob_ignore_match",
     ],
 )
 def test_linted_file_ignore_masked_violations(

--- a/test/core/linter/noqa_test.py
+++ b/test/core/linter/noqa_test.py
@@ -113,7 +113,7 @@ def test_parse_noqa_no_dups():
 
 
 @pytest.mark.parametrize(
-    "noqa,violations,expected",
+    "noqa,violations,expected,used_noqas",
     [
         [
             [],
@@ -121,31 +121,37 @@ def test_parse_noqa_no_dups():
             [
                 0,
             ],
+            [],
         ],
         [
             [dict(comment="noqa: LT01", line_no=1)],
             [DummyLintError(1)],
             [],
+            [0],
         ],
         [
             [dict(comment="noqa: LT01", line_no=2)],
             [DummyLintError(1)],
             [0],
+            [],
         ],
         [
             [dict(comment="noqa: LT02", line_no=1)],
             [DummyLintError(1)],
             [0],
+            [],
         ],
         [
             [dict(comment="noqa: enable=LT01", line_no=1)],
             [DummyLintError(1)],
             [0],
+            [],  # TODO
         ],
         [
             [dict(comment="noqa: disable=LT01", line_no=1)],
             [DummyLintError(1)],
             [],
+            [],  # TODO
         ],
         [
             [
@@ -154,6 +160,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(1)],
             [0],
+            [],  # TODO
         ],
         [
             [
@@ -162,6 +169,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(2)],
             [],
+            [],  # TODO
         ],
         [
             [
@@ -170,6 +178,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(3)],
             [],
+            [],  # TODO
         ],
         [
             [
@@ -178,6 +187,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(4)],
             [0],
+            [],  # TODO
         ],
         [
             [
@@ -186,6 +196,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(1)],
             [0],
+            [],  # TODO
         ],
         [
             [
@@ -194,6 +205,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(2)],
             [],
+            [],  # TODO
         ],
         [
             [
@@ -202,6 +214,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(3)],
             [],
+            [],  # TODO
         ],
         [
             [
@@ -210,6 +223,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(4)],
             [0],
+            [],  # TODO
         ],
         [
             [
@@ -223,6 +237,7 @@ def test_parse_noqa_no_dups():
                 DummyLintError(4, code="LT02"),
             ],
             [1, 2, 3],
+            [],  # TODO
         ],
         [
             [
@@ -236,6 +251,7 @@ def test_parse_noqa_no_dups():
                 DummyLintError(4, code="LT02"),
             ],
             [2],
+            [],  # TODO
         ],
         [
             [
@@ -246,6 +262,7 @@ def test_parse_noqa_no_dups():
             ],
             [DummyLintError(1)],
             [0],
+            [],  # TODO
         ],
         [
             [
@@ -263,6 +280,7 @@ def test_parse_noqa_no_dups():
                 DummyLintError(2),
             ],
             [0, 1],
+            [],  # TODO
         ],
         [
             [
@@ -275,6 +293,7 @@ def test_parse_noqa_no_dups():
                 DummyLintError(1),
             ],
             [0],
+            [],  # TODO
         ],
     ],
     ids=[
@@ -300,7 +319,7 @@ def test_parse_noqa_no_dups():
     ],
 )
 def test_linted_file_ignore_masked_violations(
-    noqa: dict, violations: List[SQLBaseError], expected
+    noqa: dict, violations: List[SQLBaseError], expected, used_noqas
 ):
     """Test that _ignore_masked_violations() correctly filters violations."""
     ignore_mask = [
@@ -309,6 +328,10 @@ def test_linted_file_ignore_masked_violations(
     result = IgnoreMask(ignore_mask).ignore_masked_violations(violations)
     expected_violations = [v for i, v in enumerate(violations) if i in expected]
     assert expected_violations == result
+    # Check whether "used" evaluation works
+    expected_used = [ignore_mask[i] for i, _ in enumerate(noqa) if i in used_noqas]
+    actually_used = [i for i in ignore_mask if i.used]
+    assert actually_used == expected_used
 
 
 def test_linter_noqa():

--- a/test/fixtures/cli/disable_noqa_test.sql
+++ b/test/fixtures/cli/disable_noqa_test.sql
@@ -1,6 +1,7 @@
 -- Test to verify that --disable-noqa CLI option
 -- allows for inline noqa comments to be ignored.
+-- NOTE: two noqas so that we can also test --warn-unused-ignores
 SELECT
-    col_a AS a,
+    col_a AS a,  --noqa: CP01
     col_b as b  --noqa: CP01
 FROM t;


### PR DESCRIPTION
This resolves #2337 (an oldie). I've tried to mirror the `mypy` syntax as closely as possible.

My algorithm for what counts as "used" has a few loopholes in it, but I think they're manageable for now (e.g. We count an `enable` as _used_ when it successfully re-enables something disabled by a `disable` - but this only evaluation happens if we get close enough to it in the file (usually because there was an error within the span, or after it. If we never get there, we never evaluate it and _both_ the enable and disable will be deemed unnecessary).

The new test case in `commands_test.py` is probably the best place to see what the effect of this is.

@tunetheweb I know you had views on the original PR here so would be curious for your review on this one. 