### PR TITLE
MyPy on errors, helpers, markers & context + remove ParseContext.denylist

### DIFF
--- a/src/sqlfluff/core/parser/helpers.py
+++ b/src/sqlfluff/core/parser/helpers.py
@@ -14,7 +14,9 @@ def join_segments_raw(segments: Tuple["BaseSegment", ...]) -> str:
     return "".join(s.raw for s in segments)
 
 
-def join_segments_raw_curtailed(segments: Tuple["BaseSegment", ...], length=20) -> str:
+def join_segments_raw_curtailed(
+    segments: Tuple["BaseSegment", ...], length: int = 20
+) -> str:
     """Make a string up to a certain length from an iterable of segments."""
     return curtail_string(join_segments_raw(segments), length=length)
 
@@ -64,7 +66,7 @@ def trim_non_code_segments(
     return segments[:pre_idx], segments[pre_idx:post_idx], segments[post_idx:]
 
 
-def iter_indices(seq: List, val: Any) -> Iterator[int]:
+def iter_indices(seq: List[Any], val: Any) -> Iterator[int]:
     """Iterate all indices in a list that val occurs at.
 
     Args:

--- a/src/sqlfluff/core/parser/markers.py
+++ b/src/sqlfluff/core/parser/markers.py
@@ -50,16 +50,16 @@ class PositionMarker:
     def __str__(self) -> str:
         return self.to_source_string()
 
-    def __gt__(self, other) -> bool:
+    def __gt__(self, other: "PositionMarker") -> bool:
         return self.working_loc > other.working_loc  # pragma: no cover TODO?
 
-    def __lt__(self, other) -> bool:
+    def __lt__(self, other: "PositionMarker") -> bool:
         return self.working_loc < other.working_loc  # pragma: no cover TODO?
 
-    def __ge__(self, other) -> bool:
+    def __ge__(self, other: "PositionMarker") -> bool:
         return self.working_loc >= other.working_loc  # pragma: no cover TODO?
 
-    def __le__(self, other) -> bool:
+    def __le__(self, other: "PositionMarker") -> bool:
         return self.working_loc <= other.working_loc  # pragma: no cover TODO?
 
     @property
@@ -81,7 +81,7 @@ class PositionMarker:
         source_point: int,
         templated_point: int,
         templated_file: "TemplatedFile",
-        **kwargs,
+        **kwargs: int,  # kwargs can only contain working_line positions
     ) -> "PositionMarker":
         """Convenience method for creating point markers."""
         return cls(
@@ -96,7 +96,7 @@ class PositionMarker:
         cls,
         start_point_marker: "PositionMarker",
         end_point_marker: "PositionMarker",
-    ):
+    ) -> "PositionMarker":
         """Construct a position marker from the section between two points."""
         return cls(
             slice(
@@ -118,7 +118,7 @@ class PositionMarker:
         )
 
     @classmethod
-    def from_child_markers(cls, *markers) -> "PositionMarker":
+    def from_child_markers(cls, *markers: "PositionMarker") -> "PositionMarker":
         """Create a parent marker from it's children."""
         source_slice = slice(
             min(m.source_slice.start for m in markers),

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1206,10 +1206,6 @@ class BaseSegment(metaclass=SegmentMetaclass):
         provided which will override any existing parse grammar
         on the segment.
         """
-        # Clear the denylist cache so avoid missteps
-        if parse_context:
-            parse_context.denylist.clear()
-
         # the parse_depth and recurse kwargs control how deep we will recurse for
         # testing.
         if not self.segments:  # pragma: no cover TODO?


### PR DESCRIPTION
This makes progress on adding more mypy type annotations.

In the process I did some testing on the `denylist` in `ParseContext`, and found that now that we've implemented more effective caching in #4576, this older mechanism for caching is an unecessary overhead.

It was poorly covered in the test suite and I've done testing on large files and performance is slightly better without it now.