### PR TITLE
Fix for multiprocessing warnings.

### DIFF
--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -20,6 +20,7 @@ from typing import Callable, List, Tuple, Iterator
 from sqlfluff.core import FluffConfig, Linter
 from sqlfluff.core.errors import SQLFluffSkipFile
 from sqlfluff.core.linter import LintedFile, RenderedFile
+from sqlfluff.core.plugin.host import is_main_process
 
 linter_logger: logging.Logger = logging.getLogger("sqlfluff.linter")
 
@@ -179,6 +180,12 @@ class ParallelRunner(BaseRunner):
         # in the main thread.
         except Exception as e:
             return DelayedException(e, fname=fname)
+
+    @classmethod
+    def _init_global(cls, config) -> None:  # pragma: no cover
+        """For the parallel runners indicate that we're not in the main thread."""
+        is_main_process.set(False)
+        super()._init_global(config)
 
     @classmethod
     def _create_pool(cls, *args, **kwargs):

--- a/src/sqlfluff/core/plugin/host.py
+++ b/src/sqlfluff/core/plugin/host.py
@@ -15,6 +15,10 @@ from sqlfluff.core.plugin import plugin_base_name, project_name
 
 _plugin_manager = ContextVar("_plugin_manager", default=None)
 plugins_loaded = ContextVar("plugins_loaded", default=False)
+# NOTE: The is_main_process context var is defined here, but
+# we rely on each parallel runner (found in `runner.py`) to
+# maintain the value of this variable.
+is_main_process = ContextVar("is_main_process", default=True)
 
 
 def get_plugin_manager() -> pluggy.PluginManager:


### PR DESCRIPTION
This resolves another issue created by #5020 .

When running in a multiprocessing configuration, the error about import order was flagging unnecessarily. This further restricts that validation so that it only happens in the main process.