### PR TITLE
strict mypy: match_wrapper & match_logging

### DIFF
--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -307,7 +307,7 @@ class BaseGrammar(Matchable):
                 )
             else:
                 # Match fresh if no cache hit
-                res_match = matcher.match(segments, parse_context=parse_context)
+                res_match = matcher.match(segments, parse_context)
                 # Cache it for later to for performance.
                 parse_context.put_parse_cache(loc_key, matcher_key, res_match)
 
@@ -347,7 +347,7 @@ class BaseGrammar(Matchable):
                         )
                         for terminator in terminators:
                             terminator_match: MatchResult = terminator.match(
-                                segs, parse_context=parse_context
+                                segs, parse_context
                             )
 
                             if terminator_match.matched_segments:
@@ -944,7 +944,7 @@ class Ref(BaseGrammar):
                 ctx.clear_terminators()
             if self.terminators:
                 ctx.push_terminators(self.terminators)
-            resp = elem.match(segments=segments, parse_context=ctx)
+            resp = elem.match(segments, ctx)
 
         return resp
 

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -142,7 +142,7 @@ class Sequence(BaseGrammar):
                         break
                     # Then if it _is_ active. Match against it.
                     with parse_context.deeper_match() as ctx:
-                        meta_match = elem.match(unmatched_segments, parse_context=ctx)
+                        meta_match = elem.match(unmatched_segments, ctx)
                     # Did it match and leave the unmatched portion the same?
                     if (
                         meta_match
@@ -414,7 +414,7 @@ class Bracketed(Sequence):
         with parse_context.deeper_match() as ctx:
             # Within the brackets, clear any inherited terminators.
             ctx.clear_terminators()
-            content_match = super().match(content_segs, parse_context=ctx)
+            content_match = super().match(content_segs, ctx)
 
         # We require a complete match for the content (hopefully for obvious reasons)
         if content_match.is_complete():

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -58,7 +58,9 @@ def _all_remaining_metas(
             if e.is_enabled(parse_context):
                 meta_match = e.match(tuple(), parse_context)
                 if meta_match:
-                    return_segments += meta_match.matched_segments
+                    return_segments += cast(
+                        Tuple[MetaSegment, ...], meta_match.matched_segments
+                    )
             continue
         elif not isinstance(e, Matchable) and e.is_meta:
             indent_seg = cast(Type[MetaSegment], e)
@@ -147,7 +149,9 @@ class Sequence(BaseGrammar):
                         and meta_match.unmatched_segments == unmatched_segments
                     ):
                         # If it did, it's just returned a new meta, keep it.
-                        new_metas = meta_match.matched_segments
+                        new_metas = cast(
+                            Tuple[MetaSegment, ...], meta_match.matched_segments
+                        )
 
                 # Do we have a new meta?
                 if new_metas:

--- a/src/sqlfluff/core/parser/match_logging.py
+++ b/src/sqlfluff/core/parser/match_logging.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Tuple, TYPE_CHECKING
 from sqlfluff.core.parser.helpers import join_segments_raw_curtailed
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from sqlfluff.core.parser.context import ParseContext
     from sqlfluff.core.parser import BaseSegment
 

--- a/src/sqlfluff/core/parser/match_logging.py
+++ b/src/sqlfluff/core/parser/match_logging.py
@@ -1,6 +1,12 @@
 """Classes to help with match logging."""
 
+import logging
+from typing import Any, Tuple, TYPE_CHECKING
 from sqlfluff.core.parser.helpers import join_segments_raw_curtailed
+
+if TYPE_CHECKING:
+    from sqlfluff.core.parser.context import ParseContext
+    from sqlfluff.core.parser import BaseSegment
 
 
 class LateLoggingObject:
@@ -12,7 +18,7 @@ class LateLoggingObject:
 
     __slots__ = "v_level", "logger", "msg"
 
-    def __init__(self, logger, msg, v_level=3) -> None:
+    def __init__(self, logger: logging.Logger, msg: str, v_level: int = 3) -> None:
         self.v_level = v_level
         self.logger = logger
         self.msg = msg
@@ -44,7 +50,15 @@ class ParseMatchLogObject(LateLoggingObject):
         "kwargs",
     ]
 
-    def __init__(self, parse_context, grammar, func, msg, v_level=3, **kwargs) -> None:
+    def __init__(
+        self,
+        parse_context: "ParseContext",
+        grammar: str,
+        func: str,
+        msg: str,
+        v_level: int = 3,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(v_level=v_level, logger=parse_context.logger, msg=msg)
         self.context = parse_context
         self.grammar = grammar
@@ -71,7 +85,14 @@ class ParseMatchLogObject(LateLoggingObject):
         return s
 
 
-def parse_match_logging(grammar, func, msg, parse_context, v_level=3, **kwargs) -> None:
+def parse_match_logging(
+    grammar: str,
+    func: str,
+    msg: str,
+    parse_context: "ParseContext",
+    v_level: int = 3,
+    **kwargs: Any,
+) -> None:
     """Log in a particular consistent format for use while matching."""
     # Make a late bound log object so we only do the string manipulation when we need
     # to.
@@ -87,7 +108,7 @@ class LateBoundJoinSegmentsCurtailed:
     until actually required by the logger.
     """
 
-    def __init__(self, segments) -> None:
+    def __init__(self, segments: Tuple["BaseSegment", ...]) -> None:
         self.segments = segments
 
     def __str__(self) -> str:

--- a/src/sqlfluff/core/parser/match_wrapper.py
+++ b/src/sqlfluff/core/parser/match_wrapper.py
@@ -11,8 +11,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from sqlfluff.core.parser import BaseSegment
 
 
-MatchFuncType = Callable[..., MatchResult]
-# MatchFuncType = Callable[[Any, Tuple[Any, ...], ParseContext], MatchResult]
+MatchFuncType = Callable[[Any, Tuple["BaseSegment", ...], ParseContext], MatchResult]
 
 
 class WrapParseMatchLogObject(ParseMatchLogObject):
@@ -62,7 +61,7 @@ def match_wrapper(v_level: int = 3) -> Callable[[MatchFuncType], MatchFuncType]:
         ) -> MatchResult:
             """A wrapper on the match function to do some basic validation."""
             # Do the match
-            m = func(self_cls, segments, parse_context=parse_context)
+            m = func(self_cls, segments, parse_context)
 
             name = getattr(self_cls, "__name__", self_cls.__class__.__name__)
 

--- a/src/sqlfluff/core/parser/match_wrapper.py
+++ b/src/sqlfluff/core/parser/match_wrapper.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from sqlfluff.core.parser import BaseSegment
 
 
-MatchFuncType = Callable[[Any, Tuple["BaseSegment", ...], ParseContext], MatchResult]
+MatchFuncType = Callable[[Any, Tuple["BaseSegment", ...], "ParseContext"], MatchResult]
 
 
 class WrapParseMatchLogObject(ParseMatchLogObject):

--- a/src/sqlfluff/core/parser/match_wrapper.py
+++ b/src/sqlfluff/core/parser/match_wrapper.py
@@ -1,8 +1,18 @@
 """Defined the `match_wrapper` which adds validation and logging to match methods."""
 
+from typing import Any, Callable, Tuple, TYPE_CHECKING
+
 from sqlfluff.core.parser.match_logging import ParseMatchLogObject
 from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.helpers import join_segments_raw_curtailed
+
+if TYPE_CHECKING:  # pragma: no cover
+    from sqlfluff.core.parser.context import ParseContext
+    from sqlfluff.core.parser import BaseSegment
+
+
+MatchFuncType = Callable[..., MatchResult]
+# MatchFuncType = Callable[[Any, Tuple[Any, ...], ParseContext], MatchResult]
 
 
 class WrapParseMatchLogObject(ParseMatchLogObject):
@@ -11,7 +21,9 @@ class WrapParseMatchLogObject(ParseMatchLogObject):
     This defers some of the specialist handling to later.
     """
 
-    def __init__(self, match, segments, **kwargs) -> None:
+    def __init__(
+        self, match: MatchResult, segments: Tuple["BaseSegment", ...], **kwargs: Any
+    ) -> None:
         self.match = match
         self.segments = segments
         super().__init__(msg="OUT", match=match, **kwargs)
@@ -25,7 +37,7 @@ class WrapParseMatchLogObject(ParseMatchLogObject):
         return super().__str__()
 
 
-def match_wrapper(v_level=3):
+def match_wrapper(v_level: int = 3) -> Callable[[MatchFuncType], MatchFuncType]:
     """Wraps a .match() method to add validation and logging.
 
     This is designed to be used as follows:
@@ -40,10 +52,14 @@ def match_wrapper(v_level=3):
     Segment based match routines.
     """
 
-    def inner_match_wrapper(func):
+    def inner_match_wrapper(func: MatchFuncType) -> MatchFuncType:
         """Decorate a match function."""
 
-        def wrapped_match_method(self_cls, segments: tuple, parse_context):
+        def wrapped_match_method(
+            self_cls: Any,
+            segments: Tuple["BaseSegment", ...],
+            parse_context: "ParseContext",
+        ) -> MatchResult:
             """A wrapper on the match function to do some basic validation."""
             # Do the match
             m = func(self_cls, segments, parse_context=parse_context)

--- a/src/sqlfluff/core/parser/segments/meta.py
+++ b/src/sqlfluff/core/parser/segments/meta.py
@@ -3,6 +3,7 @@
 from uuid import UUID
 
 from sqlfluff.core.parser.markers import PositionMarker
+from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.match_wrapper import match_wrapper
 from sqlfluff.core.parser.segments.raw import RawSegment, SourceFix
 from sqlfluff.core.parser.context import ParseContext
@@ -55,7 +56,7 @@ class MetaSegment(RawSegment):
 
     @classmethod
     @match_wrapper()
-    def match(cls, segments, parse_context) -> NotImplementedError:  # pragma: no cover
+    def match(cls, segments, parse_context) -> MatchResult:  # pragma: no cover
         """This will never be called. If it is then we're using it wrong."""
         raise NotImplementedError(
             "{} has no match method, it should only be used in a Sequence!".format(


### PR DESCRIPTION
Strict mypy for `match_wrapper.py` and `match_logging.py`. This is a relatively minimal PR. There's a larger version of this which would include `ephemeral.py` too, but that's a much bigger change.