### PR TITLE
Less copying in the ParseContext

### DIFF
--- a/src/sqlfluff/core/parser/context.py
+++ b/src/sqlfluff/core/parser/context.py
@@ -214,12 +214,18 @@ class ParseContext:
         return self.recurse > 1 or self.recurse is True
 
     @contextmanager
-    def matching_segment(self, name: str, clear_terminators=False, push_terminators=None) -> "ParseContext":
+    def matching_segment(
+        self,
+        name: str,
+        clear_terminators: bool = False,
+        push_terminators: Optional[List["ExpandedDialectElementType"]] = None,
+    ) -> "ParseContext":
         """Set the name of the current matching segment.
 
         NB: We don't reset the match depth here.
         """
         old_name = self.match_segment
+        self.match_segment = name
         _freeze_terminators = []
         if self.terminators:
             _freeze_terminators = self.terminators.copy()

--- a/src/sqlfluff/core/parser/context.py
+++ b/src/sqlfluff/core/parser/context.py
@@ -172,12 +172,13 @@ class ParseContext:
         push_terminators: Optional[List["ExpandedDialectElementType"]] = None,
     ):
         _appended = 0
-        # COPY FOR NOW (HAS TO FOR THE HACK)
-        _terminators = (
-            self.terminators.copy()
-        )  # Retain a reference to the original list.
+        _terminators = self.terminators  # Retain a reference to the original list.
         if clear_terminators:
-            self.terminators = push_terminators if push_terminators else []
+            # NOTE: It's really important that we .copy() on the way in, because
+            # we don't know what else has a reference to the input list, and
+            # we rely a lot in this code on having full control over the
+            # list of terminators.
+            self.terminators = push_terminators.copy() if push_terminators else []
         elif push_terminators:
             # Yes, inefficient for now.
             for terminator in push_terminators:
@@ -215,8 +216,6 @@ class ParseContext:
         try:
             yield self
         finally:
-            if not clear_terminators and push_terminators and not _append:
-                self.terminators = _terms  ## THIS MAKES IT WORK (BUT IT SHOULDN'T) HACK
             self._reset_terminators(
                 _append, _terms, clear_terminators=clear_terminators
             )

--- a/src/sqlfluff/core/parser/context.py
+++ b/src/sqlfluff/core/parser/context.py
@@ -189,10 +189,14 @@ class ParseContext:
         """Clear up the context."""
         pass
 
-    def deeper_match(self) -> "ParseContext":
+    def deeper_match(self, clear_terminators=False, push_terminators=None) -> "ParseContext":
         """Return a copy with an incremented match depth."""
         ctx = self._copy()
         ctx.match_depth += 1
+        if clear_terminators:
+            ctx.clear_terminators()
+        if push_terminators:
+            ctx.push_terminators(push_terminators)
         return ctx
 
     def deeper_parse(self) -> "ParseContext":
@@ -210,13 +214,17 @@ class ParseContext:
         """Return True if allowed to recurse."""
         return self.recurse > 1 or self.recurse is True
 
-    def matching_segment(self, name: str) -> "ParseContext":
+    def matching_segment(self, name: str, clear_terminators=False, push_terminators=None) -> "ParseContext":
         """Set the name of the current matching segment.
 
         NB: We don't reset the match depth here.
         """
         ctx = self._copy()
         ctx.match_segment = name
+        if clear_terminators:
+            ctx.clear_terminators()
+        if push_terminators:
+            ctx.push_terminators(push_terminators)
         return ctx
 
     def check_parse_cache(

--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -164,11 +164,9 @@ class AnyNumberOf(BaseGrammar):
         if not available_options:
             return MatchResult.from_unmatched(segments), None
 
-        with parse_context.deeper_match() as ctx:
-            if self.reset_terminators:
-                ctx.clear_terminators()
-            if self.terminators:
-                ctx.push_terminators(self.terminators)
+        with parse_context.deeper_match(
+            clear_terminators=self.reset_terminators, push_terminators=self.terminators
+        ) as ctx:
             match, matched_option = self._longest_trimmed_match(
                 segments,
                 available_options,

--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -927,23 +927,20 @@ class Ref(BaseGrammar):
         # First if we have an *exclude* option, we should check that
         # which would prevent the rest of this grammar from matching.
         if self.exclude:
-            with parse_context.deeper_match() as ctx:
-                # NOTE: Not covered because `exclude` and `teminators` aren't
-                # currently used together in any dialect.
-                if self.reset_terminators:  # pragma: no cover
-                    ctx.clear_terminators()
-                if self.terminators:  # pragma: no cover
-                    ctx.push_terminators(self.terminators)
+            with parse_context.deeper_match(
+                clear_terminators=self.reset_terminators,
+                push_terminators=self.terminators,
+            ) as ctx:
                 if self.exclude.match(segments, parse_context=ctx):
                     return MatchResult.from_unmatched(segments)
 
         # Match against that. NB We're not incrementing the match_depth here.
         # References shouldn't really count as a depth of match.
-        with parse_context.matching_segment(self._get_ref()) as ctx:
-            if self.reset_terminators:
-                ctx.clear_terminators()
-            if self.terminators:
-                ctx.push_terminators(self.terminators)
+        with parse_context.matching_segment(
+            self._get_ref(),
+            clear_terminators=self.reset_terminators,
+            push_terminators=self.terminators,
+        ) as ctx:
             resp = elem.match(segments, ctx)
 
         return resp

--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -266,7 +266,7 @@ class BaseGrammar(Matchable):
             parse_context.increment("ltm_calls_w_ctx_terms")
             terminators = parse_context.terminators
         else:
-            terminators = []
+            terminators = ()
 
         # Have we been passed an empty list?
         if len(segments) == 0:  # pragma: no cover

--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -150,9 +150,12 @@ class Delimited(OneOf):
                         )
                         break
 
-                with parse_context.deeper_match() as ctx:
-                    if delimiter_matchers and elements != delimiter_matchers:
-                        ctx.push_terminators(delimiter_matchers)
+                _push_terminators = []
+                if delimiter_matchers and elements != delimiter_matchers:
+                    _push_terminators = delimiter_matchers
+                with parse_context.deeper_match(
+                    push_terminators=_push_terminators
+                ) as ctx:
                     match, _ = self._longest_trimmed_match(
                         segments=seg_content,
                         matchers=elements,

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -356,10 +356,9 @@ class Bracketed(Sequence):
                 # Can't find the opening bracket. No Match.
                 return MatchResult.from_unmatched(segments)
 
-            # Look for the closing bracket
-            with parse_context.deeper_match() as ctx:
-                # Within the brackets, clear any inherited terminators.
-                ctx.clear_terminators()
+            # Look for the closing bracket.
+            # Within the brackets, clear any inherited terminators.
+            with parse_context.deeper_match(clear_terminators=True) as ctx:
                 content_segs, end_match, _ = self._bracket_sensitive_look_ahead_match(
                     segments=seg_buff,
                     matchers=[end_bracket],
@@ -410,10 +409,8 @@ class Bracketed(Sequence):
                 return MatchResult.from_unmatched(segments)
 
         # Match the content using super. Sequence will interpret the content of the
-        # elements.
-        with parse_context.deeper_match() as ctx:
-            # Within the brackets, clear any inherited terminators.
-            ctx.clear_terminators()
+        # elements. Within the brackets, clear any inherited terminators.
+        with parse_context.deeper_match(clear_terminators=True) as ctx:
             content_match = super().match(content_segs, ctx)
 
         # We require a complete match for the content (hopefully for obvious reasons)

--- a/src/sqlfluff/core/parser/matchable.py
+++ b/src/sqlfluff/core/parser/matchable.py
@@ -13,6 +13,9 @@ if TYPE_CHECKING:  # pragma: no cover
 class Matchable(ABC):
     """A base object defining the matching interface."""
 
+    # Matchables are expected to have a type
+    type: Optional[str]
+
     @abstractmethod
     def is_optional(self) -> bool:
         """Return whether this element is optional."""

--- a/src/sqlfluff/core/parser/parser.py
+++ b/src/sqlfluff/core/parser/parser.py
@@ -2,7 +2,7 @@
 
 from typing import Optional, Sequence, TYPE_CHECKING
 
-from sqlfluff.core.parser.context import RootParseContext
+from sqlfluff.core.parser.context import ParseContext
 from sqlfluff.core.config import FluffConfig
 
 if TYPE_CHECKING:
@@ -36,29 +36,32 @@ class Parser:
         root_segment = self.RootSegment(segments=segments, fname=fname)
         # Call .parse() on that segment
 
-        with RootParseContext.from_config(config=self.config, recurse=recurse) as ctx:
-            parsed = root_segment.parse(parse_context=ctx)
+        # NOTE: This is the only time we use the parse context not in the
+        # context of a context manager. That's because it's the initial
+        # instantiation.
+        ctx = ParseContext.from_config(config=self.config, recurse=recurse)
+        parsed = root_segment.parse(parse_context=ctx)
 
-            if parse_statistics:  # pragma: no cover
-                # NOTE: We use ctx.logger.warning here to output the statistics.
-                # It's not particularly beautiful, but for the users who do utilise
-                # this functionality, I don't think they mind. ¯\_(ツ)_/¯
-                # In the future, this clause might become unnecessary.
-                ctx.logger.warning("==== Parse Statistics ====")
-                for key in ctx.parse_stats:
-                    if key == "next_counts":
-                        continue
-                    ctx.logger.warning(f"{key}: {ctx.parse_stats[key]}")
-                ctx.logger.warning("## Tokens following un-terminated matches")
-                ctx.logger.warning(
-                    "Adding terminator clauses to catch these may improve performance."
-                )
-                for key, val in sorted(
-                    ctx.parse_stats["next_counts"].items(),
-                    reverse=True,
-                    key=lambda item: item[1],
-                ):
-                    ctx.logger.warning(f"{val}: {key!r}")
-                ctx.logger.warning("==== End Parse Statistics ====")
+        if parse_statistics:  # pragma: no cover
+            # NOTE: We use ctx.logger.warning here to output the statistics.
+            # It's not particularly beautiful, but for the users who do utilise
+            # this functionality, I don't think they mind. ¯\_(ツ)_/¯
+            # In the future, this clause might become unnecessary.
+            ctx.logger.warning("==== Parse Statistics ====")
+            for key in ctx.parse_stats:
+                if key == "next_counts":
+                    continue
+                ctx.logger.warning(f"{key}: {ctx.parse_stats[key]}")
+            ctx.logger.warning("## Tokens following un-terminated matches")
+            ctx.logger.warning(
+                "Adding terminator clauses to catch these may improve performance."
+            )
+            for key, val in sorted(
+                ctx.parse_stats["next_counts"].items(),
+                reverse=True,
+                key=lambda item: item[1],
+            ):
+                ctx.logger.warning(f"{val}: {key!r}")
+            ctx.logger.warning("==== End Parse Statistics ====")
 
         return parsed

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1734,7 +1734,7 @@ class BracketedSegment(BaseSegment):
             )
             if persistent
         ]
-        simple_raws = set()
+        simple_raws: Set[str] = set()
         for ref in start_brackets:
             bracket_simple = parse_context.dialect.ref(ref).simple(
                 parse_context, crumbs=crumbs

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -38,7 +38,6 @@ from sqlfluff.core.string_helpers import (
     curtail_string,
 )
 
-from sqlfluff.core.parser.context import RootParseContext
 from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.match_logging import parse_match_logging
 from sqlfluff.core.parser.match_wrapper import match_wrapper
@@ -1497,28 +1496,27 @@ class BaseSegment(metaclass=SegmentMetaclass):
 
     def _validate_segment_after_fixes(self, rule_code, dialect, fixes_applied, segment):
         """Checks correctness of new segment against match or parse grammar."""
-        root_parse_context = RootParseContext(dialect=dialect)
-        with root_parse_context as parse_context:
-            try:
-                # :HACK: Calling parse() corrupts the segment 'r'
-                # in some cases, e.g. adding additional Dedent child
-                # segments. Here, we work around this by calling
-                # parse() on a "backup copy" of the segment.
-                r_copy = deepcopy(segment)
-                for seg in r_copy.segments:
-                    seg.pos_marker = replace(
-                        seg.pos_marker,
-                        templated_file=self.pos_marker.templated_file,
-                    )
-                r_copy.parse(parse_context)
-            except ValueError:  # pragma: no cover
-                self._log_apply_fixes_check_issue(
-                    "After %s fixes were applied, segment %r failed the "
-                    "parse() check. Fixes: %r",
-                    rule_code,
-                    r_copy,
-                    fixes_applied,
+        ctx = ParseContext(dialect=dialect)
+        try:
+            # :HACK: Calling parse() corrupts the segment 'r'
+            # in some cases, e.g. adding additional Dedent child
+            # segments. Here, we work around this by calling
+            # parse() on a "backup copy" of the segment.
+            r_copy = deepcopy(segment)
+            for seg in r_copy.segments:
+                seg.pos_marker = replace(
+                    seg.pos_marker,
+                    templated_file=self.pos_marker.templated_file,
                 )
+            r_copy.parse(ctx)
+        except ValueError:  # pragma: no cover
+            self._log_apply_fixes_check_issue(
+                "After %s fixes were applied, segment %r failed the "
+                "parse() check. Fixes: %r",
+                rule_code,
+                r_copy,
+                fixes_applied,
+            )
 
     @staticmethod
     def _log_apply_fixes_check_issue(message, *args) -> None:  # pragma: no cover

--- a/test/core/parser/parse_test.py
+++ b/test/core/parser/parse_test.py
@@ -5,7 +5,7 @@ from sqlfluff.core.errors import SQLParseError
 from sqlfluff.core.linter.linter import Linter
 
 from sqlfluff.core.parser import BaseSegment, KeywordSegment, Anything, StringParser
-from sqlfluff.core.parser.context import RootParseContext
+from sqlfluff.core.parser.context import ParseContext
 
 BarKeyword = StringParser("bar", KeywordSegment)
 
@@ -20,49 +20,49 @@ class BasicSegment(BaseSegment):
 
 def test__parser__parse_match(seg_list):
     """Test match method on a real segment."""
-    with RootParseContext(dialect=None) as ctx:
-        # This should match and have consumed everything, which should
-        # now be part of a BasicSegment.
-        m = BasicSegment.match(seg_list[:1], parse_context=ctx)
-        assert m
-        assert len(m.matched_segments) == 1
-        assert isinstance(m.matched_segments[0], BasicSegment)
-        assert m.matched_segments[0].segments[0].type == "raw"
+    ctx = ParseContext(dialect=None)
+    # This should match and have consumed everything, which should
+    # now be part of a BasicSegment.
+    m = BasicSegment.match(seg_list[:1], parse_context=ctx)
+    assert m
+    assert len(m.matched_segments) == 1
+    assert isinstance(m.matched_segments[0], BasicSegment)
+    assert m.matched_segments[0].segments[0].type == "raw"
 
 
 def test__parser__parse_parse(seg_list, caplog):
     """Test parse method on a real segment."""
-    with RootParseContext(dialect=None) as ctx:
-        # Match the segment, and get the inner segment
-        seg = BasicSegment.match(seg_list[:1], parse_context=ctx).matched_segments[0]
-        # Remind ourselves that this should be an unparsed BasicSegment
-        assert isinstance(seg, BasicSegment)
+    ctx = ParseContext(dialect=None)
+    # Match the segment, and get the inner segment
+    seg = BasicSegment.match(seg_list[:1], parse_context=ctx).matched_segments[0]
+    # Remind ourselves that this should be an unparsed BasicSegment
+    assert isinstance(seg, BasicSegment)
 
-        # Now parse that segment, with debugging because this is
-        # where we'll need to debug if things fail.
-        with caplog.at_level(logging.DEBUG):
-            res = seg.parse(parse_context=ctx)
-        # Check it's still a BasicSegment
-        assert isinstance(res, BasicSegment)
-        # Check that we now have a keyword inside
-        assert isinstance(res.segments[0], KeywordSegment)
+    # Now parse that segment, with debugging because this is
+    # where we'll need to debug if things fail.
+    with caplog.at_level(logging.DEBUG):
+        res = seg.parse(parse_context=ctx)
+    # Check it's still a BasicSegment
+    assert isinstance(res, BasicSegment)
+    # Check that we now have a keyword inside
+    assert isinstance(res.segments[0], KeywordSegment)
 
 
 def test__parser__parse_expand(seg_list):
     """Test expand method on a real segment."""
-    with RootParseContext(dialect=None) as ctx:
-        # Match the segment, and get the matched segments
-        segments = BasicSegment.match(seg_list[:1], parse_context=ctx).matched_segments
-        # Remind ourselves that this should be tuple containing a BasicSegment
-        assert isinstance(segments[0], BasicSegment)
+    ctx = ParseContext(dialect=None)
+    # Match the segment, and get the matched segments
+    segments = BasicSegment.match(seg_list[:1], parse_context=ctx).matched_segments
+    # Remind ourselves that this should be tuple containing a BasicSegment
+    assert isinstance(segments[0], BasicSegment)
 
-        # Now expand those segments, using the base class version (not that it should
-        # matter)
-        res = BasicSegment.expand(segments, parse_context=ctx)
-        # Check we get an iterable containing a BasicSegment
-        assert isinstance(res[0], BasicSegment)
-        # Check that we now have a keyword inside
-        assert isinstance(res[0].segments[0], KeywordSegment)
+    # Now expand those segments, using the base class version (not that it should
+    # matter)
+    res = BasicSegment.expand(segments, parse_context=ctx)
+    # Check we get an iterable containing a BasicSegment
+    assert isinstance(res[0], BasicSegment)
+    # Check that we now have a keyword inside
+    assert isinstance(res[0].segments[0], KeywordSegment)
 
 
 def test__parser__parse_error():

--- a/test/core/parser/parser_test.py
+++ b/test/core/parser/parser_test.py
@@ -4,25 +4,25 @@ from sqlfluff.core.parser import (
     KeywordSegment,
     MultiStringParser,
 )
-from sqlfluff.core.parser.context import RootParseContext
+from sqlfluff.core.parser.context import ParseContext
 
 
 def test__parser__multistringparser__match(generate_test_segments):
     """Test the MultiStringParser matchable."""
     parser = MultiStringParser(["foo", "bar"], KeywordSegment)
-    with RootParseContext(dialect=None) as ctx:
-        # Check directly
-        seg_list = generate_test_segments(["foo", "fo"])
-        # Matches when it should
-        assert parser.match(seg_list[:1], parse_context=ctx).matched_segments == (
-            KeywordSegment("foo", seg_list[0].pos_marker),
-        )
-        # Doesn't match when it shouldn't
-        assert parser.match(seg_list[1:], parse_context=ctx).matched_segments == tuple()
+    ctx = ParseContext(dialect=None)
+    # Check directly
+    seg_list = generate_test_segments(["foo", "fo"])
+    # Matches when it should
+    assert parser.match(seg_list[:1], parse_context=ctx).matched_segments == (
+        KeywordSegment("foo", seg_list[0].pos_marker),
+    )
+    # Doesn't match when it shouldn't
+    assert parser.match(seg_list[1:], parse_context=ctx).matched_segments == tuple()
 
 
 def test__parser__multistringparser__simple():
     """Test the MultiStringParser matchable."""
     parser = MultiStringParser(["foo", "bar"], KeywordSegment)
-    with RootParseContext(dialect=None) as ctx:
-        assert parser.simple(ctx)
+    ctx = ParseContext(dialect=None)
+    assert parser.simple(ctx)

--- a/test/core/parser/segments_base_test.py
+++ b/test/core/parser/segments_base_test.py
@@ -10,7 +10,7 @@ from sqlfluff.core.parser import (
 )
 from sqlfluff.core.parser.segments.base import PathStep
 from sqlfluff.core.templaters import TemplatedFile
-from sqlfluff.core.parser.context import RootParseContext
+from sqlfluff.core.parser.context import ParseContext
 from sqlfluff.core.rules.base import LintFix
 
 
@@ -182,9 +182,10 @@ def test__parser__base_segments_base(raw_seg_list, fresh_ansi_dialect):
         base_seg.pos_marker.end_point_marker()
         == raw_seg_list[-1].pos_marker.end_point_marker()
     )
-    with RootParseContext(dialect=fresh_ansi_dialect) as ctx:
-        # Expand and given we don't have a grammar we should get the same thing
-        assert base_seg.parse(parse_context=ctx) == base_seg
+
+    ctx = ParseContext(dialect=fresh_ansi_dialect)
+    # Expand and given we don't have a grammar we should get the same thing
+    assert base_seg.parse(parse_context=ctx) == base_seg
     # Check that we correctly reconstruct the raw
     assert base_seg.raw == "foobar.barfoo"
     # Check tuple

--- a/test/core/parser/segments_common_test.py
+++ b/test/core/parser/segments_common_test.py
@@ -3,7 +3,7 @@
 import pytest
 
 from sqlfluff.core.parser import KeywordSegment, StringParser
-from sqlfluff.core.parser.context import RootParseContext
+from sqlfluff.core.parser.context import ParseContext
 from sqlfluff.core.parser.segments import EphemeralSegment
 from sqlfluff.core.parser.segments.base import UnparsableSegment
 
@@ -20,25 +20,25 @@ def test__parser__core_keyword(raw_seg_list):
     FooKeyword = StringParser("foo", KeywordSegment, type="bar")
     # Check it looks as expected
     assert FooKeyword.template.upper() == "FOO"
-    with RootParseContext(dialect=None) as ctx:
-        # Match it against a list and check it doesn't match
-        assert not FooKeyword.match(raw_seg_list, parse_context=ctx)
-        # Match it against a the first element and check it doesn't match
-        assert not FooKeyword.match(raw_seg_list[0], parse_context=ctx)
-        # Match it against a the first element as a list and check it doesn't match
-        assert not FooKeyword.match([raw_seg_list[0]], parse_context=ctx)
-        # Match it against the final element (returns tuple)
-        m = FooKeyword.match(raw_seg_list[1], parse_context=ctx)
-        assert m
-        assert m.matched_segments[0].raw == "foo"
-        assert isinstance(m.matched_segments[0], KeywordSegment)
-        # Match it against the final element as a list
-        assert FooKeyword.match([raw_seg_list[1]], parse_context=ctx)
-        # Match it against a list slice and check it still works
-        assert FooKeyword.match(raw_seg_list[1:], parse_context=ctx)
-        # Check that the types work right. Importantly that the "bar"
-        # type makes it in.
-        assert m.matched_segments[0].class_types == {"base", "keyword", "raw", "bar"}
+    ctx = ParseContext(dialect=None)
+    # Match it against a list and check it doesn't match
+    assert not FooKeyword.match(raw_seg_list, parse_context=ctx)
+    # Match it against a the first element and check it doesn't match
+    assert not FooKeyword.match(raw_seg_list[0], parse_context=ctx)
+    # Match it against a the first element as a list and check it doesn't match
+    assert not FooKeyword.match([raw_seg_list[0]], parse_context=ctx)
+    # Match it against the final element (returns tuple)
+    m = FooKeyword.match(raw_seg_list[1], parse_context=ctx)
+    assert m
+    assert m.matched_segments[0].raw == "foo"
+    assert isinstance(m.matched_segments[0], KeywordSegment)
+    # Match it against the final element as a list
+    assert FooKeyword.match([raw_seg_list[1]], parse_context=ctx)
+    # Match it against a list slice and check it still works
+    assert FooKeyword.match(raw_seg_list[1:], parse_context=ctx)
+    # Check that the types work right. Importantly that the "bar"
+    # type makes it in.
+    assert m.matched_segments[0].class_types == {"base", "keyword", "raw", "bar"}
 
 
 def test__parser__core_ephemeral_segment(raw_seg_list):
@@ -53,13 +53,13 @@ def test__parser__core_ephemeral_segment(raw_seg_list):
         ephemeral_name="foo",
     )
 
-    with RootParseContext(dialect=None) as ctx:
-        # Parse it and make sure we don't get an EphemeralSegment back
-        res = ephemeral_segment.parse(ctx)
-        assert isinstance(res, tuple)
-        elem = res[0]
-        assert not isinstance(elem, EphemeralSegment)
-        assert isinstance(elem, KeywordSegment)
+    ctx = ParseContext(dialect=None)
+    # Parse it and make sure we don't get an EphemeralSegment back
+    res = ephemeral_segment.parse(ctx)
+    assert isinstance(res, tuple)
+    elem = res[0]
+    assert not isinstance(elem, EphemeralSegment)
+    assert isinstance(elem, KeywordSegment)
 
 
 def test__parser__core_ephemeral_unparsable(raw_seg_list):
@@ -74,12 +74,12 @@ def test__parser__core_ephemeral_unparsable(raw_seg_list):
         ephemeral_name="foo",
     )
 
-    with RootParseContext(dialect=None) as ctx:
-        # Parse it and make sure we don't get an EphemeralSegment back
-        res = ephemeral_segment.parse(ctx)
-        assert isinstance(res, tuple)
-        elem = res[0]
-        # We should get an unparsable back.
-        assert isinstance(elem, UnparsableSegment)
-        # Check the ephemeral name comes through in the expectation.
-        assert "Expected: 'foo'" in elem.stringify()
+    ctx = ParseContext(dialect=None)
+    # Parse it and make sure we don't get an EphemeralSegment back
+    res = ephemeral_segment.parse(ctx)
+    assert isinstance(res, tuple)
+    elem = res[0]
+    # We should get an unparsable back.
+    assert isinstance(elem, UnparsableSegment)
+    # Check the ephemeral name comes through in the expectation.
+    assert "Expected: 'foo'" in elem.stringify()

--- a/test/dialects/conftest.py
+++ b/test/dialects/conftest.py
@@ -9,7 +9,7 @@ from sqlfluff.core.parser import (
     BaseSegment,
     RawSegment,
 )
-from sqlfluff.core.parser.context import RootParseContext
+from sqlfluff.core.parser.context import ParseContext
 from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.matchable import Matchable
 
@@ -62,9 +62,9 @@ def _dialect_specific_segment_parses(dialect, segmentref, raw, caplog):
     # derivatives or not.
     if isinstance(Seg, Matchable) or issubclass(Seg, RawSegment):
         print("Raw/Parser route...")
-        with RootParseContext.from_config(config) as ctx:
-            with caplog.at_level(logging.DEBUG):
-                parsed = Seg.match(segments=seg_list, parse_context=ctx)
+        ctx = ParseContext.from_config(config)
+        with caplog.at_level(logging.DEBUG):
+            parsed = Seg.match(segments=seg_list, parse_context=ctx)
         assert isinstance(parsed, MatchResult)
         assert len(parsed.matched_segments) == 1
         print(parsed)
@@ -75,9 +75,9 @@ def _dialect_specific_segment_parses(dialect, segmentref, raw, caplog):
         # Construct an unparsed segment
         seg = Seg(seg_list, pos_marker=seg_list[0].pos_marker)
         # Perform the match (THIS IS THE MEAT OF THE TEST)
-        with RootParseContext.from_config(config) as ctx:
-            with caplog.at_level(logging.DEBUG):
-                parsed = seg.parse(parse_context=ctx)
+        ctx = ParseContext.from_config(config)
+        with caplog.at_level(logging.DEBUG):
+            parsed = seg.parse(parse_context=ctx)
         print(parsed)
         assert isinstance(parsed, Seg)
 
@@ -102,9 +102,9 @@ def _dialect_specific_segment_not_match(dialect, segmentref, raw, caplog):
     seg_list = lex(raw, config=config)
     Seg = validate_segment(segmentref, config=config)
 
-    with RootParseContext.from_config(config) as ctx:
-        with caplog.at_level(logging.DEBUG):
-            match = Seg.match(segments=seg_list, parse_context=ctx)
+    ctx = ParseContext.from_config(config)
+    with caplog.at_level(logging.DEBUG):
+        match = Seg.match(segments=seg_list, parse_context=ctx)
 
     assert not match
 


### PR DESCRIPTION
Another possible performance improvement from the mypy work. Saves ~10% on large files.

In the ParseContext object, we made copies as we move up and down the parsing structure. This does some more "smart" management of the context (and uses `contextlib` instead) to avoid all the copying, and just use context managers properly instead. I've also consolidated the way that people interact with the context too.

At this point, the distinction between `ParseContext` and `RootParseContext` makes no sense - so I've merged the two together and simplified the whole module as a result. There is now only `ParseContext`.

I didn't manage _total_ isolation, so I still do some tuple manipulation to add some safety, because getting lists to play nice was too hard.