### PR TITLE
:white_check_mark: Add strict typing for errors module

### DIFF
--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -47,11 +47,12 @@ class SQLBaseError(ValueError):
             self.line_pos = line_pos
         super().__init__(self.desc())
 
-    def __reduce__(self):  # pragma: no cover
+    def __reduce__(
+        self,
+    ) -> Tuple[type["SQLBaseError"], Tuple[Any, ...]]:  # pragma: no cover
         """Prepare the SQLBaseError for pickling."""
         return type(self), (
             self.description,
-            self.pos,
             self.line_no,
             self.line_pos,
             self.ignore,
@@ -177,7 +178,9 @@ class SQLParseError(SQLBaseError):
             line_pos=line_pos,
         )
 
-    def __reduce__(self):  # pragma: no cover
+    def __reduce__(
+        self,
+    ) -> Tuple[type["SQLParseError"], Tuple[Any, ...]]:  # pragma: no cover
         """Prepare the SQLParseError for pickling."""
         return type(self), (self.description, self.segment, self.line_no, self.line_pos)
 
@@ -213,7 +216,9 @@ class SQLLintError(SQLBaseError):
             description=description, pos=segment.pos_marker if segment else None
         )
 
-    def __reduce__(self):  # pragma: no cover
+    def __reduce__(
+        self,
+    ) -> Tuple[type["SQLLintError"], Tuple[Any, ...]]:  # pragma: no cover
         """Prepare the SQLLintError for pickling."""
         return type(self), (self.description, self.segment, self.rule, self.fixes)
 

--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -53,6 +53,7 @@ class SQLBaseError(ValueError):
         """Prepare the SQLBaseError for pickling."""
         return type(self), (
             self.description,
+            None,
             self.line_no,
             self.line_pos,
             self.ignore,

--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -10,7 +10,7 @@ tracking.
 
 https://stackoverflow.com/questions/49715881/how-to-pickle-inherited-exceptions
 """
-from typing import Optional, Tuple, Any, List, Dict, Union, TYPE_CHECKING
+from typing import Optional, Tuple, Any, List, Dict, Type, Union, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from sqlfluff.core.parser import PositionMarker, BaseSegment
@@ -49,7 +49,7 @@ class SQLBaseError(ValueError):
 
     def __reduce__(
         self,
-    ) -> Tuple[type["SQLBaseError"], Tuple[Any, ...]]:  # pragma: no cover
+    ) -> Tuple[Type["SQLBaseError"], Tuple[Any, ...]]:  # pragma: no cover
         """Prepare the SQLBaseError for pickling."""
         return type(self), (
             self.description,
@@ -181,7 +181,7 @@ class SQLParseError(SQLBaseError):
 
     def __reduce__(
         self,
-    ) -> Tuple[type["SQLParseError"], Tuple[Any, ...]]:  # pragma: no cover
+    ) -> Tuple[Type["SQLParseError"], Tuple[Any, ...]]:  # pragma: no cover
         """Prepare the SQLParseError for pickling."""
         return type(self), (self.description, self.segment, self.line_no, self.line_pos)
 
@@ -219,7 +219,7 @@ class SQLLintError(SQLBaseError):
 
     def __reduce__(
         self,
-    ) -> Tuple[type["SQLLintError"], Tuple[Any, ...]]:  # pragma: no cover
+    ) -> Tuple[Type["SQLLintError"], Tuple[Any, ...]]:  # pragma: no cover
         """Prepare the SQLLintError for pickling."""
         return type(self), (self.description, self.segment, self.rule, self.fixes)
 


### PR DESCRIPTION
Squashing a small one here 😁 

I needed to use `Tuple[Any, ...]` for typing `__reduce__` since everything is a subclass of  `SQLBaseError` and `mypy` didn't like us having different return values for inherited methods

I also this that `mypy` helped us find a bug -- the `__reduce__` for `SQLBaseError` was referencing `self.pos` which doesn't exist. I replaced it here with `None` which seems appropriate