### PR TITLE
:arrow_up: Bump mypy version in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v1.4.1
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]


### PR DESCRIPTION
Right now it errors for me on the older version of `mypy`, when I bring it up to the current version it passes just fine

