### PR TITLE
Move `_prune_options` within `_longest_trimmed_match`.

### DIFF
--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -1,6 +1,6 @@
 """AnyNumberOf and OneOf."""
 
-from typing import List, Optional, Tuple, Set
+from typing import List, Optional, Tuple
 
 from sqlfluff.core.parser.context import ParseContext
 from sqlfluff.core.parser.grammar.base import (
@@ -11,7 +11,6 @@ from sqlfluff.core.parser.grammar.base import (
 from sqlfluff.core.parser.grammar.types import SimpleHintType
 from sqlfluff.core.parser.grammar.sequence import Sequence, Bracketed
 from sqlfluff.core.parser.helpers import trim_non_code_segments
-from sqlfluff.core.parser.match_logging import parse_match_logging
 from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.match_wrapper import match_wrapper
 from sqlfluff.core.parser.segments import BaseSegment, allow_ephemeral
@@ -62,17 +61,6 @@ class AnyNumberOf(BaseGrammar):
         case, if min_times is zero then this is also optional.
         """
         return self.optional or self.min_times == 0
-
-    @staticmethod
-    def _first_non_whitespace(segments) -> Optional[Tuple[str, Set[str]]]:
-        """Return the upper first non-whitespace segment in the iterable."""
-        for segment in segments:
-            if segment.first_non_whitespace_segment_raw_upper:
-                return (
-                    segment.first_non_whitespace_segment_raw_upper,
-                    segment.class_types,
-                )
-        return None
 
     def _match_once(
         self, segments: Tuple[BaseSegment, ...], parse_context: ParseContext

--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -74,77 +74,6 @@ class AnyNumberOf(BaseGrammar):
                 )
         return None
 
-    def _prune_options(
-        self, segments: Tuple[BaseSegment, ...], parse_context: ParseContext
-    ) -> List[MatchableType]:
-        """Use the simple matchers to prune which options to match on."""
-        available_options = []
-        prune_buff = []
-        non_simple = 0
-        pruned_simple = 0
-        matched_simple = 0
-
-        # Find the first code element to match against.
-        first_elem = self._first_non_whitespace(segments)
-        # If we don't have an appropriate option to match against,
-        # then we should just return immediately. Nothing will match.
-        if not first_elem:
-            return self._elements
-        first_raw, first_types = first_elem
-
-        for opt in self._elements:
-            simple = opt.simple(parse_context=parse_context)
-            if simple is None:
-                # This element is not simple, we have to do a
-                # full match with it...
-                available_options.append(opt)
-                non_simple += 1
-                continue
-
-            # Otherwise we have a simple option, so let's use
-            # it for pruning.
-            simple_raws, simple_types = simple
-            matched = False
-
-            # We want to know if the first meaningful element of the str_buff
-            # matches the option, based on either simple _raw_ matching or
-            # simple _type_ matching.
-
-            # Match Raws
-            if simple_raws and first_raw in simple_raws:
-                # If we get here, it's matched the FIRST element of the string buffer.
-                available_options.append(opt)
-                matched_simple += 1
-                matched = True
-
-            # Match Types
-            if simple_types and not matched and first_types.intersection(simple_types):
-                # If we get here, it's matched the FIRST element of the string buffer.
-                available_options.append(opt)
-                matched_simple += 1
-                matched = True
-
-            if not matched:
-                # Ditch this option, the simple match has failed
-                prune_buff.append(opt)
-                pruned_simple += 1
-                continue
-
-        parse_match_logging(
-            self.__class__.__name__,
-            "match",
-            "PRN",
-            parse_context=parse_context,
-            v_level=3,
-            ns=non_simple,
-            ps=pruned_simple,
-            ms=matched_simple,
-            pruned=prune_buff,
-            opts=available_options or "ALL",
-        )
-
-        return available_options
-
     def _match_once(
         self, segments: Tuple[BaseSegment, ...], parse_context: ParseContext
     ) -> Tuple[MatchResult, Optional["MatchableType"]]:
@@ -153,23 +82,12 @@ class AnyNumberOf(BaseGrammar):
         This serves as the main body of OneOf, but also a building block
         for AnyNumberOf.
         """
-        # For efficiency, we'll be pruning options if we can
-        # based on their simpleness. this provides a short cut
-        # to return earlier if we can.
-        # `segments` may already be nested so we need to break out
-        # the raw segments within it.
-        available_options = self._prune_options(segments, parse_context=parse_context)
-
-        # If we've pruned all the options, return unmatched (with some logging).
-        if not available_options:
-            return MatchResult.from_unmatched(segments), None
-
         with parse_context.deeper_match(
             clear_terminators=self.reset_terminators, push_terminators=self.terminators
         ) as ctx:
             match, matched_option = self._longest_trimmed_match(
                 segments,
-                available_options,
+                self._elements,
                 parse_context=ctx,
                 trim_noncode=False,
             )

--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -237,6 +237,65 @@ class BaseGrammar(Matchable):
         return None
 
     @classmethod
+    def _prune_options(
+        cls,
+        options: List[MatchableType],
+        segments: Tuple[BaseSegment, ...],
+        parse_context: ParseContext,
+    ) -> List[MatchableType]:
+        """Use the simple matchers to prune which options to match on.
+
+        Works in the context of a grammar making choices between options
+        such as AnyOf or the content of Delimited.
+        """
+        available_options = []
+        prune_buff = []
+
+        # Find the first code element to match against.
+        first_segment = cls._first_non_whitespace(segments)
+        # If we don't have an appropriate option to match against,
+        # then we should just return immediately. Nothing will match.
+        if not first_segment:
+            return options
+        first_raw, first_types = first_segment
+
+        for opt in options:
+            simple = opt.simple(parse_context=parse_context)
+            if simple is None:
+                # This element is not simple, we have to do a
+                # full match with it...
+                available_options.append(opt)
+                continue
+
+            # Otherwise we have a simple option, so let's use
+            # it for pruning.
+            simple_raws, simple_types = simple
+            matched = False
+
+            # We want to know if the first meaningful element of the str_buff
+            # matches the option, based on either simple _raw_ matching or
+            # simple _type_ matching.
+
+            # Match Raws
+            if simple_raws and first_raw in simple_raws:
+                # If we get here, it's matched the FIRST element of the string buffer.
+                available_options.append(opt)
+                matched = True
+
+            # Match Types
+            if simple_types and not matched and first_types.intersection(simple_types):
+                # If we get here, it's matched the FIRST element of the string buffer.
+                available_options.append(opt)
+                matched = True
+
+            if not matched:
+                # Ditch this option, the simple match has failed
+                prune_buff.append(opt)
+                continue
+
+        return available_options
+
+    @classmethod
     def _longest_trimmed_match(
         cls,
         segments: Tuple[BaseSegment, ...],
@@ -253,9 +312,45 @@ class BaseGrammar(Matchable):
         Returns:
             `tuple` of (match_object, matcher).
 
-        NOTE: This matching method is the workhorse of the parser. It's performance
-        can be monitored using the `parse_stats` object on the context.
+        NOTE: This matching method is the workhorse of the parser. It drives the
+        functionality of the AnyOf & AnyNumberOf grammars, and therefore by extension
+        the degree of branching within the parser. It's performance can be monitored
+        using the `parse_stats` object on the context.
+
+        The things which determine the performance of this method are:
+        1. Pruning. This method uses `_prune_options()` to filter down which matchable
+           options proceed to the full matching step. Ideally only very few do and this
+           can handle the majority of the filtering.
+        2. Caching. This method uses the parse cache (`check_parse_cache` and
+           `put_parse_cache`) on the ParseContext to speed up repetitive matching
+           operations. As we make progress through a file there will often not be a
+           cached value already available, and so this cache has the greatest impact
+           within poorly optimised (or highly nested) expressions.
+        2. Terminators. By default, _all_ the options are evaluated, and then the
+           longest (the `best`) is returned. The exception to this is when the match
+           is `complete` (i.e. it matches _all_ the remaining segments), or when a
+           match is followed by a valid terminator (i.e. a segment which indicates
+           that the match is _effectively_ complete). In these latter scenarios, the
+           _first_ complete or terminated match is returned. In the ideal case, the
+           only matcher which is evaluated should be the "correct" one, and then no
+           others should be attempted.
         """
+        # Have we been passed an empty list?
+        if len(segments) == 0:  # pragma: no cover
+            return MatchResult.from_empty(), None
+        # If presented with no options, return no match
+        elif not matchers:
+            return MatchResult.from_unmatched(segments), None
+
+        # Prune available options, based on their simple representation for efficiency.
+        available_options = cls._prune_options(
+            matchers, segments, parse_context=parse_context
+        )
+
+        # If we've pruned all the options, return no match
+        if not available_options:
+            return MatchResult.from_unmatched(segments), None
+
         terminated = False
 
         parse_context.increment("ltm_calls")
@@ -267,10 +362,6 @@ class BaseGrammar(Matchable):
             terminators = parse_context.terminators
         else:
             terminators = ()
-
-        # Have we been passed an empty list?
-        if len(segments) == 0:  # pragma: no cover
-            return MatchResult.from_empty(), None
 
         # If gaps are allowed, trim the ends.
         if trim_noncode:
@@ -289,8 +380,9 @@ class BaseGrammar(Matchable):
         )
 
         best_match_length = 0
+        best_match: Optional[Tuple[MatchResult, MatchableType]] = None
         # iterate at this position across all the matchers
-        for idx, matcher in enumerate(matchers):
+        for idx, matcher in enumerate(available_options):
             # Check parse cache.
             matcher_key = matcher.cache_key()
             res_match: Optional[MatchResult] = parse_context.check_parse_cache(
@@ -336,7 +428,7 @@ class BaseGrammar(Matchable):
                     # end earlier, and claim an effectively "complete" match.
                     # NOTE: This means that by specifying terminators, we can
                     # significantly increase performance.
-                    if idx == len(matchers) - 1:
+                    if idx == len(available_options) - 1:
                         # If it's the last option - no need to check terminators.
                         # We're going to end anyway, so we can skip that step.
                         terminated = True
@@ -370,6 +462,7 @@ class BaseGrammar(Matchable):
         # If we get here, then there wasn't a complete match. If we
         # has a best_match, return that.
         if best_match_length > 0:
+            assert best_match
             # If not terminated, keep track of what the next token would
             # have been if we had been able to terminate using it.
             if not terminated:

--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -7,6 +7,7 @@ from typing import (
     List,
     Optional,
     Union,
+    Set,
     Type,
     Tuple,
     Any,
@@ -234,6 +235,17 @@ class BaseGrammar(Matchable):
         self, parse_context: ParseContext, crumbs: Optional[List[str]] = None
     ) -> SimpleHintType:
         """Does this matcher support a lowercase hash matching route?"""
+        return None
+
+    @staticmethod
+    def _first_non_whitespace(segments) -> Optional[Tuple[str, Set[str]]]:
+        """Return the upper first non-whitespace segment in the iterable."""
+        for segment in segments:
+            if segment.first_non_whitespace_segment_raw_upper:
+                return (
+                    segment.first_non_whitespace_segment_raw_upper,
+                    segment.class_types,
+                )
         return None
 
     @classmethod

--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -326,7 +326,7 @@ class BaseGrammar(Matchable):
            operations. As we make progress through a file there will often not be a
            cached value already available, and so this cache has the greatest impact
            within poorly optimised (or highly nested) expressions.
-        2. Terminators. By default, _all_ the options are evaluated, and then the
+        3. Terminators. By default, _all_ the options are evaluated, and then the
            longest (the `best`) is returned. The exception to this is when the match
            is `complete` (i.e. it matches _all_ the remaining segments), or when a
            match is followed by a valid terminator (i.e. a segment which indicates

--- a/src/sqlfluff/core/parser/match_wrapper.py
+++ b/src/sqlfluff/core/parser/match_wrapper.py
@@ -60,10 +60,16 @@ def match_wrapper(v_level: int = 3) -> Callable[[MatchFuncType], MatchFuncType]:
             parse_context: "ParseContext",
         ) -> MatchResult:
             """A wrapper on the match function to do some basic validation."""
-            # Do the match
-            m = func(self_cls, segments, parse_context)
-
             name = getattr(self_cls, "__name__", self_cls.__class__.__name__)
+
+            # Do the match
+            try:
+                m = func(self_cls, segments, parse_context)
+            except Exception as err:  # pragma: no cover
+                # NOTE: only available in python 3.11.
+                if hasattr(err, "add_note"):
+                    err.add_note(f" Within {name!r}.")
+                raise err
 
             # Validate result
             if not isinstance(m, MatchResult):  # pragma: no cover

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -4236,7 +4236,7 @@ class PathSegment(BaseSegment):
         Sequence(
             Ref("SlashSegment"),
             Delimited(
-                Ref("CodeSegment"),
+                TypedParser("code", CodeSegment, type="path_segment"),
                 delimiter=Ref("SlashSegment"),
                 allow_gaps=False,
             ),

--- a/test/fixtures/dialects/clickhouse/system_statement.yml
+++ b/test/fixtures/dialects/clickhouse/system_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4b49048c190a02edef107796677f2afd209aabb0dbc37c6beb343b9d288e6f64
+_hash: 987ac8b8f29bfe092c81571ac50c3e3a9658807051484df125a605c3893d2488
 file:
 - statement:
     select_statement:
@@ -52,9 +52,9 @@ file:
       - keyword: MODEL
       - path_segment:
         - slash: /
-        - code: model
+        - path_segment: model
         - slash: /
-        - code: path
+        - path_segment: path
 - statement_terminator: ;
 - statement:
     system_statement:
@@ -68,9 +68,9 @@ file:
         - naked_identifier: cluster_name
       - path_segment:
         - slash: /
-        - code: model
+        - path_segment: model
         - slash: /
-        - code: path
+        - path_segment: path
 - statement_terminator: ;
 - statement:
     system_statement:


### PR DESCRIPTION
Hopefully a nice small and tidy PR.

This moves the `_prune_options` method (and `_first_non_whitespace` along with it) from the `AnyOf` grammar up into `BaseGrammar`. I've also moved it _inside_ `_longest_trimmed_match()` which means it's automatically used in `Delimited` as well as `AnyOf` or `AnyNumberOf`. Performance impact should be positive, but small.

Part of this is for simplification, but I also hope to take another pass at the parse statistics to support better optimisation there, and having the pruning operation within that step should help significantly with doing that.

This led to finding an issue in the `ansi` dialect (related to some `clickhouse` statements) - so that's why I've touched one of the dialect and yaml.