### PR TITLE
Better context based tracking

### DIFF
--- a/src/sqlfluff/core/parser/context.py
+++ b/src/sqlfluff/core/parser/context.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 import logging
 import uuid
-from typing import Iterator, Optional, TYPE_CHECKING, Dict, Any, Tuple, Sequence
+from typing import Iterator, Optional, TYPE_CHECKING, Dict, Any, Tuple, Sequence, List
 
 if TYPE_CHECKING:  # pragma: no cover
     from sqlfluff.core.parser.match_result import MatchResult
@@ -72,7 +72,11 @@ class ParseContext:
         self.parse_stats: Dict[str, Any] = {"next_counts": defaultdict(int)}
         # The following attributes are only accessible via a copy
         # and not in the init method.
-        self.match_segment: Optional[str] = None
+        # NOTE: We default to the name `File` which is not
+        # particularly informative, does indicate the root segment.
+        self.match_segment: str = "File"
+        self._match_stack: List[str] = []
+        self._parse_stack: List[str] = []
         self.match_depth = 0
         self.parse_depth = 0
         # self.terminators is a tuple to afford some level of isolation
@@ -149,10 +153,26 @@ class ParseContext:
     @contextmanager
     def deeper_match(
         self,
+        name: str,
         clear_terminators: bool = False,
         push_terminators: Optional[Sequence["ExpandedDialectElementType"]] = None,
     ) -> Iterator["ParseContext"]:
-        """Increment match depth."""
+        """Increment match depth.
+
+        Args:
+            name (:obj:`str`): Name of segment we are starting to parse.
+                NOTE: This value is entirely used for tracking and logging
+                purposes.
+            clear_terminators (:obj:`bool`, optional): Whether to force
+                clear any inherited terminators. This is useful in structures
+                like brackets, where outer terminators shouldn't apply while
+                within. Terminators are stashed until we return back out of
+                this context.
+            push_terminators (:obj:`Sequence` of :obj:`Matchable`): Additional
+                terminators to add to the environment while in this context.
+        """
+        self._match_stack.append(self.match_segment)
+        self.match_segment = name
         self.match_depth += 1
         _append, _terms = self._set_terminators(clear_terminators, push_terminators)
         try:
@@ -162,11 +182,23 @@ class ParseContext:
                 _append, _terms, clear_terminators=clear_terminators
             )
             self.match_depth -= 1
+            # Reset back to old name
+            self.match_segment = self._match_stack.pop()
 
     @contextmanager
-    def deeper_parse(self) -> Iterator["ParseContext"]:
-        """Increment parse depth."""
+    def deeper_parse(self, name: str) -> Iterator["ParseContext"]:
+        """Increment parse depth.
+
+        Args:
+            name (:obj:`str`): Name of segment we are starting to parse.
+                NOTE: This value is entirely used for tracking and logging
+                purposes.
+        """
         _match_depth = self.match_depth
+        _match_stack = self._match_stack
+        self._parse_stack.append(self.match_segment)
+        self._match_stack = []  # Reset Parse Stack
+        self.match_segment = name
         self.parse_depth += 1
         self.match_depth = 0
         _append, _terms = self._set_terminators(clear_terminators=True)
@@ -180,31 +212,18 @@ class ParseContext:
             if not isinstance(self.recurse, bool):  # pragma: no cover TODO?
                 self.recurse += 1
             self._reset_terminators(_append, _terms, clear_terminators=True)
+            # Reset back to old name
+            self.match_segment = self._parse_stack.pop()
+            # And old stack
+            self._match_stack = _match_stack
+
+    def stack(self) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
+        """Return stacks as a tuples so that it can't be edited."""
+        return tuple(self._parse_stack), tuple(self._match_stack)
 
     def may_recurse(self) -> bool:
         """Return True if allowed to recurse."""
         return self.recurse > 1 or self.recurse is True
-
-    @contextmanager
-    def matching_segment(
-        self,
-        name: str,
-        clear_terminators: bool = False,
-        push_terminators: Optional[Sequence["ExpandedDialectElementType"]] = None,
-    ) -> Iterator["ParseContext"]:
-        """Set the name of the current matching segment.
-
-        NB: We don't reset the match depth here.
-        """
-        old_name = self.match_segment
-        self.match_segment = name
-        _append, _terms = self._set_terminators(clear_terminators, push_terminators)
-        try:
-            yield self
-        finally:
-            self._reset_terminators(_append, _terms, clear_terminators)
-            # Reset back to old name
-            self.match_segment = old_name
 
     def check_parse_cache(
         self, loc_key: Tuple[Any, ...], matcher_key: str

--- a/src/sqlfluff/core/parser/context.py
+++ b/src/sqlfluff/core/parser/context.py
@@ -217,7 +217,7 @@ class ParseContext:
             # And old stack
             self._match_stack = _match_stack
 
-    def stack(self) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
+    def stack(self) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:  # pragma: no cover
         """Return stacks as a tuples so that it can't be edited."""
         return tuple(self._parse_stack), tuple(self._match_stack)
 

--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -165,7 +165,9 @@ class AnyNumberOf(BaseGrammar):
             return MatchResult.from_unmatched(segments), None
 
         with parse_context.deeper_match(
-            clear_terminators=self.reset_terminators, push_terminators=self.terminators
+            name=self.__class__.__name__,
+            clear_terminators=self.reset_terminators,
+            push_terminators=self.terminators,
         ) as ctx:
             match, matched_option = self._longest_trimmed_match(
                 segments,
@@ -189,7 +191,9 @@ class AnyNumberOf(BaseGrammar):
         # First if we have an *exclude* option, we should check that
         # which would prevent the rest of this grammar from matching.
         if self.exclude:
-            with parse_context.deeper_match() as ctx:
+            with parse_context.deeper_match(
+                name=self.__class__.__name__ + "-Exclude"
+            ) as ctx:
                 if self.exclude.match(segments, parse_context=ctx):
                     return MatchResult.from_unmatched(segments)
 

--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -928,6 +928,7 @@ class Ref(BaseGrammar):
         # which would prevent the rest of this grammar from matching.
         if self.exclude:
             with parse_context.deeper_match(
+                name=self._get_ref() + "-Exclude",
                 clear_terminators=self.reset_terminators,
                 push_terminators=self.terminators,
             ) as ctx:
@@ -936,8 +937,8 @@ class Ref(BaseGrammar):
 
         # Match against that. NB We're not incrementing the match_depth here.
         # References shouldn't really count as a depth of match.
-        with parse_context.matching_segment(
-            self._get_ref(),
+        with parse_context.deeper_match(
+            name=self._get_ref(),
             clear_terminators=self.reset_terminators,
             push_terminators=self.terminators,
         ) as ctx:

--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -134,7 +134,7 @@ class Delimited(OneOf):
                     break
 
                 # Check whether there is a terminator before checking for content
-                with parse_context.deeper_match() as ctx:
+                with parse_context.deeper_match(name="Delimited-Term") as ctx:
                     match, _ = self._longest_trimmed_match(
                         segments=seg_content,
                         matchers=terminator_matchers,
@@ -154,7 +154,7 @@ class Delimited(OneOf):
                 if delimiter_matchers and elements != delimiter_matchers:
                     _push_terminators = delimiter_matchers
                 with parse_context.deeper_match(
-                    push_terminators=_push_terminators
+                    name="Delimited", push_terminators=_push_terminators
                 ) as ctx:
                     match, _ = self._longest_trimmed_match(
                         segments=seg_content,

--- a/src/sqlfluff/core/parser/grammar/greedy.py
+++ b/src/sqlfluff/core/parser/grammar/greedy.py
@@ -68,7 +68,7 @@ class GreedyUntil(BaseGrammar):
             return MatchResult.from_matched(segments)
 
         while True:
-            with parse_context.deeper_match() as ctx:
+            with parse_context.deeper_match(name="GreedyUntil") as ctx:
                 pre, mat, matcher = cls._bracket_sensitive_look_ahead_match(
                     seg_buff, matchers, parse_context=ctx
                 )
@@ -192,7 +192,7 @@ class StartsWith(GreedyUntil):
             # We've trying to match on a sequence of segments which contain no code.
             # That means this isn't a match.
             return MatchResult.from_unmatched(segments)  # pragma: no cover TODO?
-        with parse_context.deeper_match() as ctx:
+        with parse_context.deeper_match(name="StartsWith") as ctx:
             match = self.target.match(
                 segments=segments[first_code_idx:], parse_context=ctx
             )

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -141,7 +141,9 @@ class Sequence(BaseGrammar):
                         # If it's not active, skip it.
                         break
                     # Then if it _is_ active. Match against it.
-                    with parse_context.deeper_match() as ctx:
+                    with parse_context.deeper_match(
+                        name=f"Sequence-Meta-@{idx}"
+                    ) as ctx:
                         meta_match = elem.match(unmatched_segments, ctx)
                     # Did it match and leave the unmatched portion the same?
                     if (
@@ -188,7 +190,7 @@ class Sequence(BaseGrammar):
 
                 # We've already dealt with potential whitespace above, so carry on
                 # to matching
-                with parse_context.deeper_match() as ctx:
+                with parse_context.deeper_match(name=f"Sequence-@{idx}") as ctx:
                     elem_match = elem.match(mid_seg, parse_context=ctx)
 
                 if not elem_match.has_match():
@@ -348,7 +350,7 @@ class Bracketed(Sequence):
         # Otherwise try and match the segments directly.
         else:
             # Look for the first bracket
-            with parse_context.deeper_match() as ctx:
+            with parse_context.deeper_match(name="Bracketed-First") as ctx:
                 start_match = start_bracket.match(seg_buff, parse_context=ctx)
             if start_match:
                 seg_buff = start_match.unmatched_segments
@@ -358,7 +360,9 @@ class Bracketed(Sequence):
 
             # Look for the closing bracket.
             # Within the brackets, clear any inherited terminators.
-            with parse_context.deeper_match(clear_terminators=True) as ctx:
+            with parse_context.deeper_match(
+                name="Bracketed-End", clear_terminators=True
+            ) as ctx:
                 content_segs, end_match, _ = self._bracket_sensitive_look_ahead_match(
                     segments=seg_buff,
                     matchers=[end_bracket],
@@ -410,7 +414,9 @@ class Bracketed(Sequence):
 
         # Match the content using super. Sequence will interpret the content of the
         # elements. Within the brackets, clear any inherited terminators.
-        with parse_context.deeper_match(clear_terminators=True) as ctx:
+        with parse_context.deeper_match(
+            name="Bracketed", clear_terminators=True
+        ) as ctx:
             content_match = super().match(content_segs, ctx)
 
         # We require a complete match for the content (hopefully for obvious reasons)

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -793,7 +793,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
 
         if cls.match_grammar:
             # Call the private method
-            with parse_context.deeper_match() as ctx:
+            with parse_context.deeper_match(name=cls.__name__) as ctx:
                 m = cls.match_grammar.match(segments=segments, parse_context=ctx)
 
             if m.has_match():
@@ -1199,7 +1199,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
                     )
 
             # NOTE: No match_depth kwarg, because this is the start of the matching.
-            with parse_context.matching_segment(self.__class__.__name__) as ctx:
+            with parse_context.deeper_match(name=self.__class__.__name__) as ctx:
                 m = parse_grammar.match(segments=segments, parse_context=ctx)
 
             # Basic Validation, that we haven't dropped anything.
@@ -1256,7 +1256,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
         )
         if parse_context.may_recurse():
             parse_context.logger.debug(parse_depth_msg)
-            with parse_context.deeper_parse() as ctx:
+            with parse_context.deeper_parse(name=self.__class__.__name__) as ctx:
                 self.segments = self.expand(
                     self.segments,
                     parse_context=ctx,


### PR DESCRIPTION
Following on from #5046 , this consolidates the `.matching_segment()` method into `.deeper_match()`. In doing this, I've made the `name` option on these context managers a required argument and changed up how the `ParseContext` keeps track of location in parse tree. Specifically, we now keep track of a _stack_ of names, rather than just the top name, which would allow a better indication of _where_ we are in the parsing operation - particularly given everything else is very recursive.

It's worth noting that this location is _only_ for logging purposes, and I don't even use that output yet anywhere in this PR. The intent is that it will be more usable for diagnosing inefficient portions of dialects.

This _does_ introduce back a little more overhead into changing context, but I've attempted to be as efficient as possible - and in my testing I don't see a noticeable performance impact of doing this.