### PR TITLE
fixing limit handling for bracketed arithmathic operations

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2479,9 +2479,24 @@ class LimitClauseSegment(BaseSegment):
     match_grammar: Matchable = Sequence(
         "LIMIT",
         Indent,
-        Ref("NumericLiteralSegment"),
+        OptionallyBracketed(
+            OneOf(
+                # Allow a number by itself OR
+                Ref("NumericLiteralSegment"),
+                # An arbitrary expression
+                Ref("ExpressionSegment"),
+            )
+        ),
         OneOf(
-            Sequence("OFFSET", Ref("NumericLiteralSegment")),
+            Sequence(
+                "OFFSET",
+                OneOf(
+                    # Allow a number by itself OR
+                    Ref("NumericLiteralSegment"),
+                    # An arbitrary expression
+                    Ref("ExpressionSegment"),
+                ),
+            ),
             Sequence(
                 Ref("CommaSegment"),
                 Ref("NumericLiteralSegment"),

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2485,6 +2485,7 @@ class LimitClauseSegment(BaseSegment):
                 Ref("NumericLiteralSegment"),
                 # An arbitrary expression
                 Ref("ExpressionSegment"),
+                "ALL"
             )
         ),
         OneOf(

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2485,7 +2485,7 @@ class LimitClauseSegment(BaseSegment):
                 Ref("NumericLiteralSegment"),
                 # An arbitrary expression
                 Ref("ExpressionSegment"),
-                "ALL"
+                "ALL",
             )
         ),
         OneOf(

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1429,6 +1429,58 @@ class SelectStatementSegment(ansi.SelectStatementSegment):
     )
 
 
+class LimitClauseSegment(BaseSegment):
+    """A `LIMIT` clause like in `SELECT`."""
+
+    type = "limit_clause"
+    match_grammar: Matchable = Sequence(
+        "LIMIT",
+        Indent,
+        OneOf(
+            OptionallyBracketed(
+                Sequence(
+                    # Allow a number by itself OR
+                    Ref("NumericLiteralSegment"),
+                    # Arithmetic operations followed by a number any number of times
+                    AnyNumberOf(
+                        Sequence(
+                            Ref("ArithmeticBinaryOperatorGrammar"),
+                            Ref("NumericLiteralSegment"),
+                        ),
+                        optional=True,
+                    ),
+                )
+            ),
+            "ALL",
+        ),
+        OneOf(
+            Sequence(
+                "OFFSET",
+                OptionallyBracketed(
+                    Sequence(
+                        # Allow a number by itself OR
+                        Ref("NumericLiteralSegment"),
+                        # Arithmetic operations followed by a number any number of times
+                        AnyNumberOf(
+                            Sequence(
+                                Ref("ArithmeticBinaryOperatorGrammar"),
+                                Ref("NumericLiteralSegment"),
+                            ),
+                            optional=True,
+                        ),
+                    )
+                ),
+            ),
+            Sequence(
+                Ref("CommaSegment"),
+                Ref("NumericLiteralSegment"),
+            ),
+            optional=True,
+        ),
+        Dedent,
+    )
+
+
 class SelectClauseSegment(ansi.SelectClauseSegment):
     """Overrides ANSI to allow INTO as a terminator."""
 

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1429,58 +1429,6 @@ class SelectStatementSegment(ansi.SelectStatementSegment):
     )
 
 
-class LimitClauseSegment(BaseSegment):
-    """A `LIMIT` clause like in `SELECT`."""
-
-    type = "limit_clause"
-    match_grammar: Matchable = Sequence(
-        "LIMIT",
-        Indent,
-        OneOf(
-            OptionallyBracketed(
-                Sequence(
-                    # Allow a number by itself OR
-                    Ref("NumericLiteralSegment"),
-                    # Arithmetic operations followed by a number any number of times
-                    AnyNumberOf(
-                        Sequence(
-                            Ref("ArithmeticBinaryOperatorGrammar"),
-                            Ref("NumericLiteralSegment"),
-                        ),
-                        optional=True,
-                    ),
-                )
-            ),
-            "ALL",
-        ),
-        OneOf(
-            Sequence(
-                "OFFSET",
-                OptionallyBracketed(
-                    Sequence(
-                        # Allow a number by itself OR
-                        Ref("NumericLiteralSegment"),
-                        # Arithmetic operations followed by a number any number of times
-                        AnyNumberOf(
-                            Sequence(
-                                Ref("ArithmeticBinaryOperatorGrammar"),
-                                Ref("NumericLiteralSegment"),
-                            ),
-                            optional=True,
-                        ),
-                    )
-                ),
-            ),
-            Sequence(
-                Ref("CommaSegment"),
-                Ref("NumericLiteralSegment"),
-            ),
-            optional=True,
-        ),
-        Dedent,
-    )
-
-
 class SelectClauseSegment(ansi.SelectClauseSegment):
     """Overrides ANSI to allow INTO as a terminator."""
 

--- a/test/fixtures/dialects/postgres/limit_clause.sql
+++ b/test/fixtures/dialects/postgres/limit_clause.sql
@@ -1,0 +1,18 @@
+SELECT col_a
+FROM test_table
+LIMIT 2 * 5 * 10 OFFSET (5 + 10);
+
+
+SELECT col_a
+FROM test_table
+LIMIT (10 / 10) OFFSET 10 - 5;
+
+
+SELECT col_a
+FROM test_table
+LIMIT 100;
+
+
+SELECT col_a
+FROM test_table
+LIMIT ALL;

--- a/test/fixtures/dialects/postgres/limit_clause.yml
+++ b/test/fixtures/dialects/postgres/limit_clause.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3b24a3308aabbcfdefa94e098926ad788a8d4d09191f4c12c856d0a575839579
+_hash: c001065984213084c6197e3e7c67ef167e71f952c7aff6a88f0a4be14228046d
 file:
 - statement:
     select_statement:
@@ -21,18 +21,21 @@ file:
                 naked_identifier: test_table
       limit_clause:
       - keyword: LIMIT
-      - numeric_literal: '2'
-      - binary_operator: '*'
-      - numeric_literal: '5'
-      - binary_operator: '*'
-      - numeric_literal: '10'
-      - keyword: OFFSET
-      - bracketed:
-        - start_bracket: (
+      - expression:
+        - numeric_literal: '2'
+        - binary_operator: '*'
         - numeric_literal: '5'
-        - binary_operator: +
+        - binary_operator: '*'
         - numeric_literal: '10'
-        - end_bracket: )
+      - keyword: OFFSET
+      - expression:
+          bracketed:
+            start_bracket: (
+            expression:
+            - numeric_literal: '5'
+            - binary_operator: +
+            - numeric_literal: '10'
+            end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -51,15 +54,17 @@ file:
       limit_clause:
       - keyword: LIMIT
       - bracketed:
-        - start_bracket: (
-        - numeric_literal: '10'
-        - binary_operator: /
-        - numeric_literal: '10'
-        - end_bracket: )
+          start_bracket: (
+          expression:
+          - numeric_literal: '10'
+          - binary_operator: /
+          - numeric_literal: '10'
+          end_bracket: )
       - keyword: OFFSET
-      - numeric_literal: '10'
-      - binary_operator: '-'
-      - numeric_literal: '5'
+      - expression:
+        - numeric_literal: '10'
+        - binary_operator: '-'
+        - numeric_literal: '5'
 - statement_terminator: ;
 - statement:
     select_statement:

--- a/test/fixtures/dialects/postgres/limit_clause.yml
+++ b/test/fixtures/dialects/postgres/limit_clause.yml
@@ -1,0 +1,99 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 3b24a3308aabbcfdefa94e098926ad788a8d4d09191f4c12c856d0a575839579
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col_a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+      limit_clause:
+      - keyword: LIMIT
+      - numeric_literal: '2'
+      - binary_operator: '*'
+      - numeric_literal: '5'
+      - binary_operator: '*'
+      - numeric_literal: '10'
+      - keyword: OFFSET
+      - bracketed:
+        - start_bracket: (
+        - numeric_literal: '5'
+        - binary_operator: +
+        - numeric_literal: '10'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col_a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+      limit_clause:
+      - keyword: LIMIT
+      - bracketed:
+        - start_bracket: (
+        - numeric_literal: '10'
+        - binary_operator: /
+        - numeric_literal: '10'
+        - end_bracket: )
+      - keyword: OFFSET
+      - numeric_literal: '10'
+      - binary_operator: '-'
+      - numeric_literal: '5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col_a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+      limit_clause:
+        keyword: LIMIT
+        numeric_literal: '100'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col_a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+      limit_clause:
+      - keyword: LIMIT
+      - keyword: ALL
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

Adding logic to fix issue [#4938 ](https://github.com/sqlfluff/sqlfluff/issues/4938).

Handles cases for postgres well.

File now parses:

example.sql

```
SELECT col_a
FROM test_table
LIMIT 2 * 5 * 10 OFFSET (5 + 10);


SELECT col_a
FROM test_table
LIMIT ALL OFFSET 10 - 5;
```


```
% sqlfluff lint --dialect postgres example.sql
All Finished 📜 🎉!                    
```


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
