### PR TITLE
Never run in multiprocessing mode with only 1 file.

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -1052,6 +1052,10 @@ class Linter:
         files_count = len(expanded_paths)
         if processes is None:
             processes = self.config.get("processes", default=1)
+        # Hard set processes to 1 if only 1 file is queued.
+        # The overhead will never be worth it with one file.
+        if files_count == 1:
+            processes = 1
 
         # to avoid circular import
         from sqlfluff.core.linter.runner import get_runner

--- a/test/core/linter/linter_test.py
+++ b/test/core/linter/linter_test.py
@@ -306,7 +306,12 @@ def test__linter__linting_parallel_thread(force_error, monkeypatch):
         dialect="ansi",
     )
     result = lntr.lint_paths(
-        ("test/fixtures/linter/comma_errors.sql",),
+        # NOTE: Lint more than one file to make sure we enabled the multithreaded
+        # code path.
+        (
+            "test/fixtures/linter/comma_errors.sql",
+            "test/fixtures/linter/whitespace_errors.sql",
+        ),
         processes=2,
     )
 


### PR DESCRIPTION
I thought I'd fixed this a while ago!

When there's only one file being processed we shouldn't invoke any of the multithreaded runners. This clause detects running on a single file and forces us to use the simple runner in that case.

No tests in this case because both options work, this is more of a performance hack.