### PR TITLE
Resolve pickling of errors #5066

### DIFF
--- a/docs/source/production.rst
+++ b/docs/source/production.rst
@@ -72,8 +72,13 @@ are found then the `exit code`_ will be 0. If violations are found then
 a non-zero code will be returned which can be interrogated to find out
 more.
 
-- At the moment all error states related to linting return *65*.
-- An error as a result of a SQLFluff internal error will return *1*.
+- An error code of ``0`` means *operation success*, *no issues found*.
+- An error code of ``1`` means *operation success*, *issues found*. For
+  example this might mean that a linting issue was found, or that one file
+  could not be parsed.
+- An error code of ``2`` means an error occurred and the operation could
+  not be completed. For example a configuration issue or an internal error
+  within SQLFluff.
 
 .. _`CI/CD`: https://en.wikipedia.org/wiki/Continuous_integration
 .. _`exit code`: https://shapeshed.com/unix-exit-codes/

--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -47,9 +47,15 @@ class SQLBaseError(ValueError):
             self.line_pos = line_pos
         super().__init__(self.desc())
 
+    def __eq__(self, other) -> bool:
+        """Errors compare equal if they are the same type and same content."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self.__dict__ == other.__dict__
+
     def __reduce__(
         self,
-    ) -> Tuple[Type["SQLBaseError"], Tuple[Any, ...]]:  # pragma: no cover
+    ) -> Tuple[Type["SQLBaseError"], Tuple[Any, ...]]:
         """Prepare the SQLBaseError for pickling."""
         return type(self), (
             self.description,
@@ -169,6 +175,9 @@ class SQLParseError(SQLBaseError):
         segment: Optional["BaseSegment"] = None,
         line_no: int = 0,
         line_pos: int = 0,
+        ignore: bool = False,
+        fatal: bool = False,
+        warning: Optional[bool] = None,
     ) -> None:
         # Store the segment on creation - we might need it later
         self.segment = segment
@@ -177,13 +186,24 @@ class SQLParseError(SQLBaseError):
             pos=segment.pos_marker if segment else None,
             line_no=line_no,
             line_pos=line_pos,
+            ignore=ignore,
+            fatal=fatal,
+            warning=warning,
         )
 
     def __reduce__(
         self,
-    ) -> Tuple[Type["SQLParseError"], Tuple[Any, ...]]:  # pragma: no cover
+    ) -> Tuple[Type["SQLParseError"], Tuple[Any, ...]]:
         """Prepare the SQLParseError for pickling."""
-        return type(self), (self.description, self.segment, self.line_no, self.line_pos)
+        return type(self), (
+            self.description,
+            self.segment,
+            self.line_no,
+            self.line_pos,
+            self.ignore,
+            self.fatal,
+            self.warning,
+        )
 
 
 class SQLLintError(SQLBaseError):
@@ -208,20 +228,34 @@ class SQLLintError(SQLBaseError):
         segment: "BaseSegment",
         rule: "BaseRule",
         fixes: Optional[List["LintFix"]] = None,
+        ignore: bool = False,
+        fatal: bool = False,
+        warning: Optional[bool] = None,
     ) -> None:
-        # Something about position, message and fix?
         self.segment = segment
         self.rule = rule
         self.fixes = fixes or []
         super().__init__(
-            description=description, pos=segment.pos_marker if segment else None
+            description=description,
+            pos=segment.pos_marker if segment else None,
+            ignore=ignore,
+            fatal=fatal,
+            warning=warning,
         )
 
     def __reduce__(
         self,
-    ) -> Tuple[Type["SQLLintError"], Tuple[Any, ...]]:  # pragma: no cover
+    ) -> Tuple[Type["SQLLintError"], Tuple[Any, ...]]:
         """Prepare the SQLLintError for pickling."""
-        return type(self), (self.description, self.segment, self.rule, self.fixes)
+        return type(self), (
+            self.description,
+            self.segment,
+            self.rule,
+            self.fixes,
+            self.ignore,
+            self.fatal,
+            self.warning,
+        )
 
     @property
     def fixable(self) -> bool:

--- a/src/sqlfluff/core/parser/markers.py
+++ b/src/sqlfluff/core/parser/markers.py
@@ -62,6 +62,11 @@ class PositionMarker:
     def __le__(self, other: "PositionMarker") -> bool:
         return self.working_loc <= other.working_loc  # pragma: no cover TODO?
 
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, PositionMarker):
+            return False
+        return self.working_loc == other.working_loc
+
     @property
     def working_loc(self) -> Tuple[int, int]:
         """Location tuple for the working position."""

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -379,6 +379,20 @@ def test__cli__command_render_stdin():
                 "test/fixtures/linter/operator_errors.sql",
             ],
         ),
+        # Check ignoring linting (multiprocess)
+        # https://github.com/sqlfluff/sqlfluff/issues/5066
+        (
+            lint,
+            [
+                "-n",
+                "--ignore",
+                "linting",
+                "-p",
+                "2",
+                "test/fixtures/linter/operator_errors.sql",
+                "test/fixtures/linter/comma_errors.sql",
+            ],
+        ),
         # Check linting works in specifying multiple rules
         (
             lint,

--- a/test/core/errors_test.py
+++ b/test/core/errors_test.py
@@ -1,0 +1,75 @@
+"""Tests pickling and unpickling of errors."""
+
+import pickle
+import pytest
+import copy
+
+from sqlfluff.core.parser import PositionMarker, RawSegment
+from sqlfluff.core.rules import BaseRule
+from sqlfluff.core.templaters import TemplatedFile
+
+from sqlfluff.core.errors import SQLBaseError, SQLLintError, SQLParseError, SQLLexError
+
+
+class Rule_T078(BaseRule):
+    """A dummy rule."""
+
+    groups = ("all",)
+
+    def _eval(self, context):
+        pass
+
+
+def assert_pickle_robust(err: SQLBaseError):
+    """Test that the class remains the same through copying and pickling."""
+    # First try copying (and make sure they still compare equal)
+    err_copy = copy.copy(err)
+    assert err_copy == err
+    # Then try picking (and make sure they also still compare equal)
+    pickled = pickle.dumps(err)
+    pickle_copy = pickle.loads(pickled)
+    assert pickle_copy == err
+
+
+@pytest.mark.parametrize(
+    "ignore",
+    [True, False],
+)
+def test__lex_error_pickle(ignore):
+    """Test lexing error pickling."""
+    template = TemplatedFile.from_string("foobar")
+    err = SQLLexError("Foo", pos=PositionMarker(slice(0, 6), slice(0, 6), template))
+    # Set ignore to true if configured.
+    # NOTE: This not copying was one of the reasons for this test.
+    err.ignore = ignore
+    assert_pickle_robust(err)
+
+
+@pytest.mark.parametrize(
+    "ignore",
+    [True, False],
+)
+def test__parse_error_pickle(ignore):
+    """Test parse error pickling."""
+    template = TemplatedFile.from_string("foobar")
+    segment = RawSegment("foobar", PositionMarker(slice(0, 6), slice(0, 6), template))
+    err = SQLParseError("Foo", segment=segment)
+    # Set ignore to true if configured.
+    # NOTE: This not copying was one of the reasons for this test.
+    err.ignore = ignore
+    assert_pickle_robust(err)
+
+
+@pytest.mark.parametrize(
+    "ignore",
+    [True, False],
+)
+def test__lint_error_pickle(ignore):
+    """Test lint error pickling."""
+    template = TemplatedFile.from_string("foobar")
+    segment = RawSegment("foobar", PositionMarker(slice(0, 6), slice(0, 6), template))
+    err = SQLLintError("Foo", segment=segment, rule=Rule_T078)
+    # Set ignore to true if configured.
+    # NOTE: This not copying was one of the reasons for this test.
+    err.ignore = ignore
+    assert_pickle_robust(err)


### PR DESCRIPTION
This was an interesting one! This resolves #5066.

The problem here was that when violations (subclassess of `SQLBaseError`) were pickled and unpickled when being passed from child processes back into the main thread (when `processes > 1`) - not all the values were set properly. Specifically in this case the `ignore` value was being reset.

The docs were also outdated 🙄 

This PR:
- Updates the docs to reflect current practice.
- Adds a CLI test case which reflects the original issue here.
- Adds a new set of test cases to cover pickling and unpickling errors.