### PR TITLE
New Rule: AL08 - column aliases must be unique

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -303,9 +303,6 @@ max_alias_length = None
 # We suggest instead using aliasing.length (AL06) in most cases.
 force_enable = False
 
-[sqlfluff:rules:aliasing.unique.column]
-case_sensitive = False
-
 [sqlfluff:rules:convention.select_trailing_comma]
 # Trailing commas
 select_clause_trailing_comma = forbid

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -303,6 +303,9 @@ max_alias_length = None
 # We suggest instead using aliasing.length (AL06) in most cases.
 force_enable = False
 
+[sqlfluff:rules:aliasing.unique.column]
+case_sensitive = False
+
 [sqlfluff:rules:convention.select_trailing_comma]
 # Trailing commas
 select_clause_trailing_comma = forbid

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -7,8 +7,9 @@ This mapping is used to validate rule config inputs, as well
 as document rule configuration.
 """
 
-from sqlfluff.core.plugin.host import get_plugin_manager
 from typing import Any, Dict
+
+from sqlfluff.core.plugin.host import get_plugin_manager
 
 STANDARD_CONFIG_INFO_DICT: Dict[str, Dict[str, Any]] = {
     "tab_space_size": {
@@ -45,10 +46,6 @@ STANDARD_CONFIG_INFO_DICT: Dict[str, Dict[str, Any]] = {
         "definition": (
             "Run this rule even for dialects where this rule is disabled by default."
         ),
-    },
-    "case_sensitive": {
-        "validation": [True, False],
-        "definition": ("Whether this rule is case sensitive or not."),
     },
     "unquoted_identifiers_policy": {
         "validation": ["all", "aliases", "column_aliases"],

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -46,6 +46,10 @@ STANDARD_CONFIG_INFO_DICT: Dict[str, Dict[str, Any]] = {
             "Run this rule even for dialects where this rule is disabled by default."
         ),
     },
+    "case_sensitive": {
+        "validation": [True, False],
+        "definition": ("Whether this rule is case sensitive or not."),
+    },
     "unquoted_identifiers_policy": {
         "validation": ["all", "aliases", "column_aliases"],
         "definition": "Types of unquoted identifiers to flag violations for.",

--- a/src/sqlfluff/rules/aliasing/AL08.py
+++ b/src/sqlfluff/rules/aliasing/AL08.py
@@ -69,7 +69,6 @@ class Rule_AL08(BaseRule):
         `_lint_references_and_aliases` method.
         """
         self.case_sensitive: bool
-        self.logger.warning(f"CONFIG: {self.case_sensitive}")
         assert context.segment.is_type("select_clause")
 
         used_aliases: Dict[str, BaseSegment] = {}
@@ -103,7 +102,6 @@ class Rule_AL08(BaseRule):
             _key = column_alias.raw if self.case_sensitive else column_alias.raw_upper
             # Strip any quote tokens
             _key = _key.strip("\"'`")
-            self.logger.warning(f"KEY: {_key}")
             # Otherwise check whether it's been used before
             if _key in used_aliases:
                 # It has.

--- a/src/sqlfluff/rules/aliasing/AL08.py
+++ b/src/sqlfluff/rules/aliasing/AL08.py
@@ -1,0 +1,118 @@
+"""Implementation of Rule AL08."""
+
+from typing import Optional, Tuple, Dict
+from sqlfluff.core.parser import BaseSegment
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext, EvalResultType
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+
+class Rule_AL08(BaseRule):
+    """Column aliases should be unique within each clause.
+
+    Reusing column aliases is very likely a coding error.
+
+    **Anti-pattern**
+
+    In this example, the alias ``foo`` is reused for two different columns:
+
+    .. code-block:: sql
+
+        SELECT
+            a as foo,
+            b as foo
+        FROM tbl;
+
+        -- This can also happen when referencing the same column
+        -- column twice, or aliasing an expression to the same
+        -- name as a column:
+
+        SELECT
+            foo,
+            foo,
+            a as foo
+        FROM tbl;
+
+    **Best practice**
+
+    Make all columns have a unique alias.
+
+    .. code-block:: sql
+
+        SELECT
+            a as foo,
+            b as bar
+        FROM tbl;
+
+        -- Avoid also using the same column twice unless aliased:
+
+        SELECT
+            foo as foo1,
+            foo as foo2,
+            a as foo3
+        FROM tbl;
+
+    """
+
+    name = "aliasing.unique.column"
+    aliases = ()
+    groups: Tuple[str, ...] = ("all", "core", "aliasing", "aliasing.unique")
+    crawl_behaviour = SegmentSeekerCrawler({"select_clause"})
+
+    def _eval(self, context: RuleContext) -> EvalResultType:
+        """Get References and Aliases and allow linting.
+
+        This rule covers a lot of potential cases of odd usages of
+        references, see the code for each of the potential cases.
+
+        Subclasses of this rule should override the
+        `_lint_references_and_aliases` method.
+        """
+        assert context.segment.is_type("select_clause")
+
+        used_aliases: Dict[str, BaseSegment] = {}
+        violations = []
+
+        # Work through each of the elements
+        for clause_element in context.segment.get_children("select_clause_element"):
+            # Is there an alias expression?
+            alias_expression = clause_element.get_child("alias_expression")
+            column_alias: Optional[BaseSegment] = None
+            if alias_expression:
+                # Get the alias (it will be the next code element after AS)
+                seg: Optional[BaseSegment] = None
+                for seg in alias_expression.segments:
+                    if not seg or not seg.is_code or seg.raw_upper == "AS":
+                        continue
+                    break
+                assert seg
+                column_alias = seg
+            # No alias, the only other thing we'll track are column references.
+            else:
+                column_reference = clause_element.get_child("column_reference")
+                if column_reference:
+                    column_alias = column_reference
+
+            # If we don't have an alias to work with, just skip this element
+            if not column_alias:
+                continue
+
+            # Otherwise check whether it's been used before
+            if column_alias.raw in used_aliases:
+                # It has.
+                previous = used_aliases[column_alias.raw]
+                assert previous.pos_marker
+                violations.append(
+                    LintResult(
+                        anchor=column_alias,
+                        description=(
+                            "Reuse of column alias "
+                            f"{column_alias.raw!r} from line "
+                            f"{previous.pos_marker.line_no}."
+                        ),
+                    )
+                )
+            else:
+                # It's not, save it to check against others.
+                used_aliases[column_alias.raw] = clause_element
+
+        return violations

--- a/src/sqlfluff/rules/aliasing/__init__.py
+++ b/src/sqlfluff/rules/aliasing/__init__.py
@@ -19,5 +19,15 @@ def get_rules() -> List[Type[BaseRule]]:
     from sqlfluff.rules.aliasing.AL05 import Rule_AL05
     from sqlfluff.rules.aliasing.AL06 import Rule_AL06
     from sqlfluff.rules.aliasing.AL07 import Rule_AL07
+    from sqlfluff.rules.aliasing.AL08 import Rule_AL08
 
-    return [Rule_AL01, Rule_AL02, Rule_AL03, Rule_AL04, Rule_AL05, Rule_AL06, Rule_AL07]
+    return [
+        Rule_AL01,
+        Rule_AL02,
+        Rule_AL03,
+        Rule_AL04,
+        Rule_AL05,
+        Rule_AL06,
+        Rule_AL07,
+        Rule_AL08,
+    ]

--- a/test/fixtures/rules/std_rule_cases/AL08.yml
+++ b/test/fixtures/rules/std_rule_cases/AL08.yml
@@ -1,0 +1,44 @@
+rule: AL08
+
+test_fail_references:
+  fail_str: |
+    select
+      foo,
+      foo
+
+test_fail_aliases:
+  fail_str: |
+    select
+      a as foo,
+      b as foo
+
+test_fail_alias_refs:
+  fail_str: |
+    select
+      foo,
+      b as foo,
+
+test_fail_locs:
+  fail_str: |
+    select
+      foo,
+      b as foo,
+      c as bar,
+      bar,
+      d foo,
+  violations:
+    - code: AL08
+      description: Reuse of column alias 'foo' from line 2.
+      line_no: 3
+      line_pos: 8
+      name: aliasing.unique.column
+    - code: AL08
+      description: Reuse of column alias 'bar' from line 4.
+      line_no: 5
+      line_pos: 3
+      name: aliasing.unique.column
+    - code: AL08
+      description: Reuse of column alias 'foo' from line 2.
+      line_no: 6
+      line_pos: 5
+      name: aliasing.unique.column

--- a/test/fixtures/rules/std_rule_cases/AL08.yml
+++ b/test/fixtures/rules/std_rule_cases/AL08.yml
@@ -16,7 +16,7 @@ test_fail_alias_refs:
   fail_str: |
     select
       foo,
-      b as foo,
+      b as foo
 
 test_fail_locs:
   fail_str: |
@@ -42,3 +42,29 @@ test_fail_locs:
       line_no: 6
       line_pos: 5
       name: aliasing.unique.column
+
+test_fail_alias_quoted:
+  fail_str: |
+    select
+      foo,
+      b as "foo"
+  configs:
+    core:
+      dialect: snowflake
+
+test_fail_alias_case:
+  fail_str: |
+    select
+      foo,
+      b as FOO
+
+test_pass_alias_case:
+  pass_str: |
+    select
+      foo,
+      b as FOO
+
+  configs:
+    rules:
+      aliasing.unique.column:
+        case_sensitive: true

--- a/test/fixtures/rules/std_rule_cases/AL08.yml
+++ b/test/fixtures/rules/std_rule_cases/AL08.yml
@@ -58,13 +58,17 @@ test_fail_alias_case:
       foo,
       b as FOO
 
-test_pass_alias_case:
+test_fail_qualified:
+  fail_str: |
+    select
+      a.foo
+      , b as foo
+    from a
+
+test_pass_table_names:
   pass_str: |
     select
-      foo,
-      b as FOO
-
-  configs:
-    rules:
-      aliasing.unique.column:
-        case_sensitive: true
+      a.b,
+      b.c,
+      c.d
+    from a, b, c


### PR DESCRIPTION
I've been meaning to add this for ages, strangely never been requested.

This is a new rule to catch duplicate columns. A sibling to https://docs.sqlfluff.com/en/stable/rules.html#rule-aliasing.unique.table

Optional case sensitivity which defaults to case insensitive, also quote stripping included.