### PR TITLE
Remove the internal cProfiler option

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -13,10 +13,6 @@ import yaml
 
 import click
 
-# For the profiler
-import pstats
-from io import StringIO
-
 # To enable colour cross platform
 import colorama
 from tqdm import tqdm
@@ -1187,9 +1183,6 @@ def quoted_presenter(dumper, data):
     ),
 )
 @click.option(
-    "--profiler", is_flag=True, help="Set this flag to engage the python profiler."
-)
-@click.option(
     "--parse-statistics",
     is_flag=True,
     help=(
@@ -1211,7 +1204,6 @@ def parse(
     include_meta: bool,
     format: str,
     write_output: Optional[str],
-    profiler: bool,
     bench: bool,
     nofail: bool,
     logger: Optional[logging.Logger] = None,
@@ -1249,18 +1241,6 @@ def parse(
         logger=logger,
         stderr_output=non_human_output,
     )
-
-    # TODO: do this better
-
-    if profiler:
-        # Set up the profiler if required
-        try:
-            import cProfile
-        except ImportError:  # pragma: no cover
-            click.echo("The cProfiler is not available on your platform.")
-            sys.exit(EXIT_ERROR)
-        pr = cProfile.Profile()
-        pr.enable()
 
     t0 = time.monotonic()
 
@@ -1319,14 +1299,6 @@ def parse(
 
         # Dump the output to stdout or to file as appropriate.
         dump_file_payload(write_output, file_output)
-    if profiler:
-        pr.disable()
-        profiler_buffer = StringIO()
-        ps = pstats.Stats(pr, stream=profiler_buffer).sort_stats("cumulative")
-        ps.print_stats()
-        click.echo("==== profiler stats ====")
-        # Only print the first 50 lines of it
-        click.echo("\n".join(profiler_buffer.getvalue().split("\n")[:50]))
 
     if violations_count > 0 and not nofail:
         sys.exit(EXIT_FAIL)  # pragma: no cover

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -346,8 +346,7 @@ def test__cli__command_render_stdin():
         (parse, ["-n", "test/fixtures/cli/passing_b.sql", "--format", "yaml"]),
         # Check parsing with no output (used mostly for testing)
         (parse, ["-n", "test/fixtures/cli/passing_b.sql", "--format", "none"]),
-        # Check the profiler and benching commands
-        (parse, ["-n", "test/fixtures/cli/passing_b.sql", "--profiler"]),
+        # Check the benching commands
         (parse, ["-n", "test/fixtures/cli/passing_b.sql", "--bench"]),
         (
             lint,


### PR DESCRIPTION
The internal `--profiler` option on `sqlfluff parse` is both too specific and also too blunt to be useful. I've been increasingly not using it, and instead reverting to running external profiling commands.

I think we might need something _instead_ of this, but it's probably not baked into the CLI, and instead is likely to be a more granular view focussed around specific steps in the process.

Until then - I think it's the right time to say bye bye to this CLI option as part of the next minor release.