### PR TITLE
Add strict typing to the templating tracer

### DIFF
--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -2,7 +2,7 @@
 
 import logging
 from bisect import bisect_left
-from typing import Dict, Iterator, List, Tuple, Optional, NamedTuple, Iterable
+from typing import Dict, Iterator, List, Tuple, Optional, NamedTuple, Iterable, Any
 from sqlfluff.core.config import FluffConfig
 from sqlfluff.core.errors import SQLFluffSkipFile
 from sqlfluff.core.slice_helpers import zero_slice
@@ -203,7 +203,7 @@ class TemplatedFile:
                 )
 
     @classmethod
-    def from_string(cls, raw) -> "TemplatedFile":
+    def from_string(cls, raw: str) -> "TemplatedFile":
         """Create TemplatedFile from a string."""
         return cls(source_str=raw, fname="<string>")
 
@@ -465,7 +465,7 @@ class RawTemplater:
     name = "raw"
     templater_selector = "templater"
 
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Dict[str, Any]) -> None:
         """Placeholder init function.
 
         Here we should load any initial config found in the root directory. The init
@@ -512,13 +512,13 @@ class RawTemplater:
         """
         return TemplatedFile(in_str, fname=fname), []
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: Any) -> bool:
         """Return true if `other` is of the same class as this one.
 
         NB: This is useful in comparing configs.
         """
         return isinstance(other, self.__class__)
 
-    def config_pairs(self) -> list:
+    def config_pairs(self) -> List[Tuple[str, str]]:
         """Returns info about the given templater for output by the cli."""
         return [("templater", self.name)]

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -104,7 +104,7 @@ class JinjaTracer:
             else:
                 # E.g. "00000000000000000000000000000002 a < 10". The characters
                 # after the slice ID are executable code from raw_str.
-                alt_id, slice_length = m_id.group(0), len(p[len(m_id.group(0)) + 1:])
+                alt_id, slice_length = m_id.group(0), len(p[len(m_id.group(0)) + 1 :])
 
             target_slice_idx = self.find_slice_index(alt_id)
             target_inside_block = self.raw_slice_info[
@@ -143,9 +143,7 @@ class JinjaTracer:
             )
         return raw_slices_search_result[0]
 
-    def move_to_slice(
-        self, target_slice_idx: int, target_slice_length: int
-    ) -> None:
+    def move_to_slice(self, target_slice_idx: int, target_slice_length: int) -> None:
         """Given a template location, walk execution to that point."""
         while self.program_counter < len(self.raw_sliced):
             self.record_trace(
@@ -174,7 +172,10 @@ class JinjaTracer:
                 self.program_counter = candidates[0]
 
     def record_trace(
-        self, target_slice_length: int, slice_idx: Optional[int] = None, slice_type: Optional[str] = None
+        self,
+        target_slice_length: int,
+        slice_idx: Optional[int] = None,
+        slice_type: Optional[str] = None,
     ) -> None:
         """Add the specified (default: current) location to the trace."""
         if slice_idx is None:
@@ -478,7 +479,10 @@ class JinjaAnalyzer:
         )
 
     def track_templated(
-        self, m_open: regex.Match[str], m_close: regex.Match[str], tag_contents: List[str]
+        self,
+        m_open: regex.Match[str],
+        m_close: regex.Match[str],
+        tag_contents: List[str],
     ) -> RawSliceInfo:
         """Compute tracking info for Jinja templated region, e.g. {{ foo }}."""
         unique_alternate_id = self.next_slice_id()
@@ -493,7 +497,10 @@ class JinjaAnalyzer:
         return self.make_raw_slice_info(unique_alternate_id, alternate_code)
 
     def track_call(
-        self, m_open: regex.Match[str], m_close: regex.Match[str], tag_contents: List[str]
+        self,
+        m_open: regex.Match[str],
+        m_close: regex.Match[str],
+        tag_contents: List[str],
     ) -> RawSliceInfo:
         """Set up tracking for "{% call ... %}"."""
         unique_alternate_id = self.next_slice_id()

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -3,6 +3,9 @@
 This is a newer slicing algorithm that handles cases heuristic.py does not.
 """
 
+# Import annotations for py 3.7 to allow `regex.Match[str]`
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 import logging
 import regex


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Relatively trivial PR to add strict typing to the templating tracer, and some of templating base. Small change, but yielding the work as I'm unlikely to progress more in the next week

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
