### PR TITLE
Add support for fetch first row(s) only in Oracle

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2551,7 +2551,7 @@ class FetchClauseSegment(BaseSegment):
             "FIRST",
             "NEXT",
         ),
-        Ref("NumericLiteralSegment"),
+        Ref("NumericLiteralSegment", optional=True),
         OneOf("ROW", "ROWS"),
         "ONLY",
     )

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -616,3 +616,19 @@ class SqlplusVariableGrammar(BaseSegment):
             Ref("ParameterNameSegment"),
         )
     )
+
+
+class FetchClauseSegment(BaseSegment):
+    """A `FETCH` clause like in `SELECT."""
+
+    type = "fetch_clause"
+    match_grammar: Matchable = Sequence(
+        "FETCH",
+        OneOf(
+            "FIRST",
+            "NEXT",
+        ),
+        Ref("NumericLiteralSegment", optional=True),
+        OneOf("ROW", "ROWS"),
+        "ONLY",
+    )

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -616,19 +616,3 @@ class SqlplusVariableGrammar(BaseSegment):
             Ref("ParameterNameSegment"),
         )
     )
-
-
-class FetchClauseSegment(BaseSegment):
-    """A `FETCH` clause like in `SELECT."""
-
-    type = "fetch_clause"
-    match_grammar: Matchable = Sequence(
-        "FETCH",
-        OneOf(
-            "FIRST",
-            "NEXT",
-        ),
-        Ref("NumericLiteralSegment", optional=True),
-        OneOf("ROW", "ROWS"),
-        "ONLY",
-    )

--- a/test/fixtures/dialects/oracle/fetch_first_row_only.sql
+++ b/test/fixtures/dialects/oracle/fetch_first_row_only.sql
@@ -1,0 +1,15 @@
+select column_name
+from   table_name
+fetch  first row only;
+
+select column_name
+from   table_name
+fetch  first rows only;
+
+select column_name
+from   table_name
+fetch  first 2 row only;
+
+select column_name
+from   table_name
+fetch  first 2 rows only;

--- a/test/fixtures/dialects/oracle/fetch_first_row_only.yml
+++ b/test/fixtures/dialects/oracle/fetch_first_row_only.yml
@@ -1,0 +1,89 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 536341383952d140b9f33fde33d846482376e3b154d8e8fd49cbd82d2ddfa34e
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          column_reference:
+            naked_identifier: column_name
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table_name
+      fetch_clause:
+      - keyword: fetch
+      - keyword: first
+      - keyword: row
+      - keyword: only
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          column_reference:
+            naked_identifier: column_name
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table_name
+      fetch_clause:
+      - keyword: fetch
+      - keyword: first
+      - keyword: rows
+      - keyword: only
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          column_reference:
+            naked_identifier: column_name
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table_name
+      fetch_clause:
+      - keyword: fetch
+      - keyword: first
+      - numeric_literal: '2'
+      - keyword: row
+      - keyword: only
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          column_reference:
+            naked_identifier: column_name
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table_name
+      fetch_clause:
+      - keyword: fetch
+      - keyword: first
+      - numeric_literal: '2'
+      - keyword: rows
+      - keyword: only
+- statement_terminator: ;


### PR DESCRIPTION
Closes #5058 

Add support for fetch first row(s) only, without specifying how many rows.
In this clause oracle fetches only 1 row.

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
