### PR TITLE
Rename ST09

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -383,5 +383,5 @@ wildcard_policy = single
 # By default, allow subqueries in from clauses, but not join clauses
 forbid_subquery_in = join
 
-[sqlfluff:rules:structure.first_table]
+[sqlfluff:rules:structure.join_condition_order]
 preferred_first_table_in_join_clause = earlier

--- a/src/sqlfluff/rules/structure/ST09.py
+++ b/src/sqlfluff/rules/structure/ST09.py
@@ -1,13 +1,14 @@
 """Implementation of Rule ST09."""
-from typing import Optional, Tuple, List, cast
+from typing import List, Optional, Tuple, cast
+
 from sqlfluff.core.parser.segments.raw import BaseSegment, SymbolSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.utils.functional import Segments, FunctionalContext
 from sqlfluff.dialects.dialect_ansi import (
     FromExpressionElementSegment,
     JoinClauseSegment,
 )
+from sqlfluff.utils.functional import FunctionalContext, Segments
 
 
 class Rule_ST09(BaseRule):
@@ -63,7 +64,7 @@ class Rule_ST09(BaseRule):
             and foo.b = bar.b
     """
 
-    name = "structure.first_table"
+    name = "structure.join_condition_order"
     aliases = ()
     groups: Tuple[str, ...] = ("all", "structure")
     config_keywords = ["preferred_first_table_in_join_clause"]

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -2,6 +2,7 @@
 
 import configparser
 import json
+import logging
 import os
 import pathlib
 import re
@@ -11,7 +12,6 @@ import subprocess
 import sys
 import tempfile
 import textwrap
-import logging
 from unittest.mock import MagicMock, patch
 
 import chardet
@@ -24,18 +24,18 @@ from click.testing import CliRunner
 # We import the library directly here to get the version
 import sqlfluff
 from sqlfluff.cli.commands import (
-    lint,
-    version,
-    rules,
-    fix,
     cli_format,
-    parse,
     dialects,
+    fix,
     get_config,
+    lint,
+    parse,
     render,
+    rules,
+    version,
 )
-from sqlfluff.core.rules import BaseRule, LintFix, LintResult
 from sqlfluff.core.parser.segments.raw import CommentSegment
+from sqlfluff.core.rules import BaseRule, LintFix, LintResult
 from sqlfluff.utils.testing.cli import invoke_assert_code
 
 re_ansi_escape = re.compile(r"\x1b[^m]*m")
@@ -1960,7 +1960,7 @@ multiple_expected_output = """==== finding fixable violations ====
 == [test/fixtures/linter/multiple_sql_errors.sql] FAIL
 L:  12 | P:   1 | LT02 | Expected indent of 4 spaces. [layout.indent]
 L:  40 | P:  10 | ST09 | Joins should list the table referenced earlier first.
-                       | [structure.first_table]
+                       | [structure.join_condition_order]
 ==== fixing violations ====
 2 fixable linting violations found
 Are you sure you wish to attempt to fix these? [Y/n] ...

--- a/test/fixtures/rules/std_rule_cases/ST09.yml
+++ b/test/fixtures/rules/std_rule_cases/ST09.yml
@@ -50,7 +50,7 @@ test_pass_later_table_first:
 
   configs:
     rules:
-      structure.first_table:
+      structure.join_condition_order:
         preferred_first_table_in_join_clause: later
 
 test_fail_earlier_table_first:
@@ -72,7 +72,7 @@ test_fail_earlier_table_first:
 
   configs:
     rules:
-      structure.first_table:
+      structure.join_condition_order:
         preferred_first_table_in_join_clause: later
 
 test_fail_later_table_first:


### PR DESCRIPTION
Renames the new ST09 from `structure.first_table` to `structure.join_condition_order`.