### PR TITLE
Remove IdentitySet

### DIFF
--- a/src/sqlfluff/core/parser/__init__.py
+++ b/src/sqlfluff/core/parser/__init__.py
@@ -15,7 +15,6 @@ from sqlfluff.core.parser.segments import (
     Dedent,
     ImplicitIndent,
     SegmentGenerator,
-    IdentitySet,
 )
 from sqlfluff.core.parser.grammar import (
     Sequence,
@@ -81,5 +80,4 @@ __all__ = (
     "RegexLexer",
     "Parser",
     "Matchable",
-    "IdentitySet",
 )

--- a/src/sqlfluff/core/parser/segments/__init__.py
+++ b/src/sqlfluff/core/parser/segments/__init__.py
@@ -5,7 +5,6 @@ from sqlfluff.core.parser.segments.base import (
     BaseFileSegment,
     UnparsableSegment,
     BracketedSegment,
-    IdentitySet,
     FixPatch,
     SourceFix,
 )
@@ -54,7 +53,6 @@ __all__ = (
     "TemplateSegment",
     "EndOfFile",
     "TemplateLoop",
-    "IdentitySet",
     "FixPatch",
     "SourceFix",
 )

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import logging
 import weakref
 from collections import defaultdict
-from collections.abc import MutableSet
 from copy import copy, deepcopy
 from dataclasses import dataclass, field, replace
 from io import StringIO
@@ -1871,46 +1870,3 @@ class BaseFileSegment(BaseSegment):
         for stmt in self.get_children("statement"):
             references |= stmt.get_table_references()
         return references
-
-
-class IdentitySet(MutableSet):
-    """Similar to built-in set(), but based on object IDENTITY.
-
-    This is often important when working with BaseSegment and other types,
-    where different object instances may compare as equal.
-
-    Copied from: https://stackoverflow.com/questions/16994307/identityset-in-python
-    """
-
-    key = id  # should return a hashable object
-
-    def __init__(self, iterable=()) -> None:
-        self.map: dict = {}  # id -> object
-        self |= iterable  # add elements from iterable to the set (union)
-
-    def __len__(self) -> int:  # Sized
-        return len(self.map)
-
-    def __iter__(self):  # Iterable
-        return self.map.values().__iter__()  # pragma: no cover
-
-    def __contains__(self, x):  # Container
-        return self.key(x) in self.map
-
-    def add(self, value):  # MutableSet
-        """Add an element."""
-        self.map[self.key(value)] = value
-
-    def update(self, value) -> None:
-        """Add elements in 'value'."""
-        for v in value:
-            self.add(v)
-
-    def discard(self, value):  # MutableSet
-        """Remove an element.  Do not raise an exception if absent."""
-        self.map.pop(self.key(value), None)  # pragma: no cover
-
-    def __repr__(self) -> str:  # pragma: no cover
-        if not self:
-            return "%s()" % (self.__class__.__name__,)
-        return "%s(%r)" % (self.__class__.__name__, list(self))

--- a/src/sqlfluff/rules/convention/CV06.py
+++ b/src/sqlfluff/rules/convention/CV06.py
@@ -2,10 +2,9 @@
 from typing import List, NamedTuple, Optional, Sequence, cast
 
 from sqlfluff.core.parser import SymbolSegment
-from sqlfluff.core.parser.segments.base import BaseSegment, IdentitySet
+from sqlfluff.core.parser.segments.base import BaseSegment
 from sqlfluff.core.parser.segments.raw import NewlineSegment, RawSegment
-
-from sqlfluff.core.rules import BaseRule, LintResult, LintFix, RuleContext
+from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import RootOnlyCrawler
 from sqlfluff.utils.functional import Segments, sp
 
@@ -287,9 +286,7 @@ class Rule_CV06(BaseRule):
             parent_segment, "create_after", anchor_segment, filter_meta=True
         )
         lintfix_fn = LintFix.create_after
-        # :TRICKY: Use IdentitySet rather than set() since
-        # different segments may compare as equal.
-        whitespace_deletion_set = IdentitySet(whitespace_deletions)
+        whitespace_deletion_set = set(whitespace_deletions)
         if anchor_segment in whitespace_deletion_set:
             # Can't delete() and create_after() the same segment. Use replace()
             # instead.

--- a/src/sqlfluff/rules/convention/CV07.py
+++ b/src/sqlfluff/rules/convention/CV07.py
@@ -1,8 +1,7 @@
 """Implementation of Rule CV07."""
 from typing import List
 
-from sqlfluff.core.parser.segments.base import IdentitySet
-from sqlfluff.core.rules import BaseRule, LintResult, LintFix, RuleContext
+from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import RootOnlyCrawler
 from sqlfluff.utils.functional import Segments, sp
 
@@ -106,7 +105,7 @@ class Rule_CV07(BaseRule):
                 .reversed()
             )
             self.logger.debug("Trailing: %s", trailing)
-            lift_nodes = IdentitySet(leading + trailing)
+            lift_nodes = set(leading + trailing)
             fixes = []
             if lift_nodes:
                 fixes.append(LintFix.create_before(parent, list(leading)))

--- a/src/sqlfluff/rules/layout/LT07.py
+++ b/src/sqlfluff/rules/layout/LT07.py
@@ -1,15 +1,11 @@
 """Implementation of Rule LT07."""
 
-from sqlfluff.core.parser import (
-    IdentitySet,
-    NewlineSegment,
-)
+from typing import Optional, Set, cast
 
+from sqlfluff.core.parser import NewlineSegment, RawSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.utils.functional import sp, FunctionalContext
-
-from typing import Optional
+from sqlfluff.utils.functional import FunctionalContext, sp
 
 
 class Rule_LT07(BaseRule):
@@ -59,7 +55,7 @@ class Rule_LT07(BaseRule):
 
         # Find the end brackets for the CTE *query* (i.e. ignore optional
         # list of CTE columns).
-        cte_end_brackets = IdentitySet()
+        cte_end_brackets: Set[RawSegment] = set()
         for cte in (
             FunctionalContext(context)
             .segment.children(sp.is_type("common_table_expression"))
@@ -97,7 +93,7 @@ class Rule_LT07(BaseRule):
                     self.logger.debug("Skipping because on same line.")
                     continue
                 # Otherwise add to the ones to check.
-                cte_end_brackets.add(cte_end_bracket[0])
+                cte_end_brackets.add(cast(RawSegment, cte_end_bracket[0]))
 
         for seg in cte_end_brackets:
             contains_non_whitespace = False

--- a/src/sqlfluff/rules/layout/LT09.py
+++ b/src/sqlfluff/rules/layout/LT09.py
@@ -2,13 +2,10 @@
 
 from typing import List, NamedTuple, Optional, Sequence
 
-from sqlfluff.core.parser import WhitespaceSegment
-
-from sqlfluff.core.parser import BaseSegment, NewlineSegment
-from sqlfluff.core.parser.segments.base import IdentitySet
+from sqlfluff.core.parser import BaseSegment, NewlineSegment, WhitespaceSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.utils.functional import Segments, sp, FunctionalContext
+from sqlfluff.utils.functional import FunctionalContext, Segments, sp
 
 
 class SelectTargetsInfo(NamedTuple):
@@ -338,9 +335,7 @@ class Rule_LT09(BaseRule):
                     # :TRICKY: Below, we have a couple places where we
                     # filter to guard against deleting the same segment
                     # multiple times -- this is illegal.
-                    # :TRICKY: Use IdentitySet rather than set() since
-                    # different segments may compare as equal.
-                    all_deletes = IdentitySet(
+                    all_deletes = set(
                         fix.anchor for fix in fixes if fix.edit_type == "delete"
                     )
                     fixes_ = []

--- a/src/sqlfluff/rules/references/RF03.py
+++ b/src/sqlfluff/rules/references/RF03.py
@@ -3,7 +3,7 @@
 from typing import Iterator, List, Optional, Set
 
 from sqlfluff.core.dialects.common import AliasInfo, ColumnAliasInfo
-from sqlfluff.core.parser.segments.base import BaseSegment, IdentitySet
+from sqlfluff.core.parser.segments.base import BaseSegment
 from sqlfluff.core.parser.segments.raw import SymbolSegment
 from sqlfluff.utils.analysis.select import SelectStatementColumnsAndTables
 from sqlfluff.utils.analysis.select_crawler import Query, SelectCrawler
@@ -95,15 +95,13 @@ class Rule_RF03(BaseRule):
 
         if not FunctionalContext(context).parent_stack.any(sp.is_type(*_START_TYPES)):
             crawler = SelectCrawler(context.segment, context.dialect)
-            visited: IdentitySet = IdentitySet()
+            visited: Set = set()
             if crawler.query_tree:
                 # Recursively visit and check each query in the tree.
                 return list(self._visit_queries(crawler.query_tree, visited))
         return None
 
-    def _visit_queries(
-        self, query: Query, visited: IdentitySet
-    ) -> Iterator[LintResult]:
+    def _visit_queries(self, query: Query, visited: set) -> Iterator[LintResult]:
         select_info: Optional[SelectStatementColumnsAndTables] = None
         if query.selectables:
             select_info = query.selectables[0].select_info


### PR DESCRIPTION
Improvements to comparisons of BaseSegment (specifically the work on `__eq__`) mean that normal sets work fine for segments now. We can remove the complexity of having to maintain `IdentitySet`.

The relevant changes were probably in #5076 .