### PR TITLE
RF01 & recursive_crawl improvements

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1145,17 +1145,29 @@ class BaseSegment(metaclass=SegmentMetaclass):
             recurse_into: :obj:`bool`: When an element of type "seg_type" is
                 found, whether to recurse into it.
             no_recursive_seg_type: obj: `str`: a type of segment
-                not to recurse further into.
+                not to recurse further into. It is highly recommended
+                to set this argument where possible, as it can significantly
+                narrow the search pattern.
         """
-        # Check this segment
+        # Check whether the types we're looking for are in this segment
+        # at all. If not, exit early.
+        if not self.descendant_type_set.intersection(*seg_type):
+            return
+
+        # Assuming there is a segment to be found, first check self.
         if self.is_type(*seg_type):
             match = True
             yield self
         else:
             match = False
+
+        # Then handle any recursion.
         if recurse_into or not match:
-            # Recurse
             for seg in self.segments:
+                # Don't recurse if the segment is of a type we shouldn't
+                # recurse into.
+                # NOTE: Setting no_recursive_seg_type can significantly
+                # improve performance in many cases.
                 if not seg.is_type(no_recursive_seg_type):
                     yield from seg.recursive_crawl(
                         *seg_type,

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1149,17 +1149,17 @@ class BaseSegment(metaclass=SegmentMetaclass):
                 to set this argument where possible, as it can significantly
                 narrow the search pattern.
         """
-        # Check whether the types we're looking for are in this segment
-        # at all. If not, exit early.
-        if not self.descendant_type_set.intersection(*seg_type):
-            return
-
         # Assuming there is a segment to be found, first check self.
         if self.is_type(*seg_type):
             match = True
             yield self
         else:
             match = False
+
+        # Check whether the types we're looking for are in this segment
+        # at all. If not, exit early.
+        if not self.descendant_type_set.intersection(seg_type):
+            return
 
         # Then handle any recursion.
         if recurse_into or not match:

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1136,7 +1136,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
         *seg_type: str,
         recurse_into: bool = True,
         no_recursive_seg_type: Optional[str] = None,
-    ):
+    ) -> Iterator[BaseSegment]:
         """Recursively crawl for segments of a given type.
 
         Args:
@@ -1159,7 +1159,8 @@ class BaseSegment(metaclass=SegmentMetaclass):
         # Check whether the types we're looking for are in this segment
         # at all. If not, exit early.
         if not self.descendant_type_set.intersection(seg_type):
-            return
+            # Terminate iteration.
+            return None
 
         # Then handle any recursion.
         if recurse_into or not match:

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1136,7 +1136,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
         *seg_type: str,
         recurse_into: bool = True,
         no_recursive_seg_type: Optional[str] = None,
-    ) -> Iterator[BaseSegment]:
+    ):
         """Recursively crawl for segments of a given type.
 
         Args:

--- a/src/sqlfluff/rules/references/RF01.py
+++ b/src/sqlfluff/rules/references/RF01.py
@@ -81,7 +81,7 @@ class Rule_RF01(BaseRule):
         "sparksql",
     ]
 
-    def _eval(self, context: RuleContext) -> EvalResultType:
+    def _eval(self, context: RuleContext) -> List[LintResult]:
         # Config type hints
         self.force_enable: bool
 
@@ -89,10 +89,10 @@ class Rule_RF01(BaseRule):
             context.dialect.name in self._dialects_disabled_by_default
             and not self.force_enable
         ):
-            return LintResult()
+            return []
 
         if FunctionalContext(context).parent_stack.any(sp.is_type(*_START_TYPES)):
-            return LintResult()
+            return []
 
         violations: List[LintResult] = []
         dml_target_table: Optional[Tuple[str, ...]] = None
@@ -115,7 +115,7 @@ class Rule_RF01(BaseRule):
             self._analyze_table_references(
                 query, dml_target_table, context.dialect, violations
             )
-        return violations or None
+        return violations
 
     @classmethod
     def _alias_info_as_tuples(cls, alias_info: AliasInfo) -> List[Tuple[str, ...]]:

--- a/src/sqlfluff/rules/references/RF01.py
+++ b/src/sqlfluff/rules/references/RF01.py
@@ -12,7 +12,6 @@ from sqlfluff.core.rules import (
     BaseRule,
     LintResult,
     RuleContext,
-    EvalResultType,
 )
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.utils.functional import sp, FunctionalContext

--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -532,15 +532,17 @@ def _create_table_ref(table_name: str, dialect: Dialect) -> TableExpressionSegme
 
 def _get_case_preference(root_select: Segments):
     # First get the segment itself so we have access to the generator
-    _root_segment = root_select.get()
+    root_segment = root_select.get()
+    assert root_segment, "Root SELECT not found."
     # Get the first item of the recursive crawl.
     first_keyword = next(
-        _root_segment.recursive_crawl(
+        root_segment.recursive_crawl(
             "keyword",
             recurse_into=False,
         ),
         None,
     )
+    assert first_keyword, "Keyword not found."
     # Get case preference based on the case of that keyword.
     if first_keyword.raw.islower():
         return "LOWER"

--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -531,13 +531,19 @@ def _create_table_ref(table_name: str, dialect: Dialect) -> TableExpressionSegme
 
 
 def _get_case_preference(root_select: Segments):
-    first_keyword = root_select.recursive_crawl(
-        "keyword",
-        recurse_into=False,
-    ).first()[0]
-    if first_keyword.raw[0].islower():
+    # First get the segment itself so we have access to the generator
+    _root_segment = root_select.get()
+    # Get the first item of the recursive crawl.
+    first_keyword = next(
+        _root_segment.recursive_crawl(
+            "keyword",
+            recurse_into=False,
+        ),
+        None,
+    )
+    # Get case preference based on the case of that keyword.
+    if first_keyword.raw.islower():
         return "LOWER"
-
     return "UPPER"
 
 


### PR DESCRIPTION
This is a fairly small PR, aimed at improving performance of RF01.

Includes one syntax simplification in RF01 (which is trivial), but more importantly updating the `.recursive_crawl()` method to filter based on the same type sets we now use in rule crawling.

Early testing suggests this more than halves the time spent in RF01 in long queries. Across a blended project the impact is more like 10%. Similar gains on ST05.