### PR TITLE
Select Crawler Refactor: Part 1

### DIFF
--- a/src/sqlfluff/rules/ambiguous/AM07.py
+++ b/src/sqlfluff/rules/ambiguous/AM07.py
@@ -152,19 +152,13 @@ class Rule_AM07(BaseRule):
             # , attempt to resolve wildcard to a list of
             # select targets that can be counted
             if selectable.get_wildcard_info():
-                # to start, get a list of all of the ctes in the parent
-                # stack to check whether they resolve to wildcards
-
-                select_crawler = SelectCrawler(
-                    selectable.selectable,
-                    context.dialect,
-                    parent_stack=context.parent_stack,
-                ).query_tree
-                assert select_crawler
+                # We already stepped up to a WITH statement in the outer _eval
+                # so if we need to use it we already have access to any CTEs
+                # which we might reference.
                 assert crawler.query_tree
                 select_list = self.__resolve_wildcard(
                     context,
-                    select_crawler,
+                    crawler.query_tree,
                     [],
                 )
 

--- a/src/sqlfluff/rules/structure/ST03.py
+++ b/src/sqlfluff/rules/structure/ST03.py
@@ -46,7 +46,7 @@ class Rule_ST03(BaseRule):
     name = "structure.unused_cte"
     aliases = ("L045",)
     groups = ("all", "core", "structure")
-    crawl_behaviour = SegmentSeekerCrawler({"statement"})
+    crawl_behaviour = SegmentSeekerCrawler({"with_compound_statement"})
 
     @classmethod
     def _find_all_ctes(cls, query: Query) -> Iterator[Query]:
@@ -66,7 +66,7 @@ class Rule_ST03(BaseRule):
 
     def _eval(self, context: RuleContext) -> EvalResultType:
         result = []
-        crawler = SelectCrawler(context.segment, context.dialect)
+        crawler = SelectCrawler.from_root(context.segment, context.dialect)
         if crawler.query_tree:
             # Begin analysis at the final, outer query (key=None).
             queries_with_ctes = list(self._find_all_ctes(crawler.query_tree))

--- a/src/sqlfluff/rules/structure/ST03.py
+++ b/src/sqlfluff/rules/structure/ST03.py
@@ -1,8 +1,6 @@
 """Implementation of Rule ST03."""
-from typing import Iterator
-
 from sqlfluff.core.rules import BaseRule, EvalResultType, LintResult, RuleContext
-from sqlfluff.utils.analysis.select_crawler import Query, SelectCrawler
+from sqlfluff.utils.analysis.select_crawler import SelectCrawler
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 
 

--- a/src/sqlfluff/utils/analysis/select_crawler.py
+++ b/src/sqlfluff/utils/analysis/select_crawler.py
@@ -238,7 +238,6 @@ class SelectCrawler:
         dialect: Dialect,
         parent: Optional[Query] = None,
         query_class: Type = Query,
-        parent_stack: Optional[Tuple[BaseSegment, ...]] = None,
     ):
         self.dialect: Dialect = dialect
         # "query_class" allows users of the class to customize/extend the
@@ -252,7 +251,7 @@ class SelectCrawler:
         # so we can pop "query_stack" when those segments complete processing.
         pop_queries_for = []
 
-        def append_query(query, parent_stack) -> None:
+        def append_query(query) -> None:
             """Bookkeeping when a new Query is created."""
             if query_stack:
                 query.parent = query_stack[-1]
@@ -260,16 +259,7 @@ class SelectCrawler:
             query_stack.append(query)
             if len(query_stack) == 1 and self.query_tree is None:
                 self.query_tree = query_stack[0]
-                # if parent stack is submitted as argument, crawl query to
-                # create parent relationships
-                if parent_stack:
-                    parent_segment = parent_stack[-1]
-                    parent_stack = parent_stack[: len(parent_stack) - 1]
-                    self.query_tree.parent = SelectCrawler.get_parent_query(
-                        parent_segment, dialect, parent_stack
-                    )
-                else:
-                    self.query_tree.parent = parent
+                self.query_tree.parent = parent
             pop_queries_for.append(path[-1])
 
         def finish_segment() -> None:
@@ -310,7 +300,7 @@ class SelectCrawler:
                             # select_statement segments, and those will be
                             # added to this Query later.
                             query = self.query_class(QueryType.Simple, dialect)
-                            append_query(query, parent_stack)
+                            append_query(query)
                         # Ignore segments under a from_expression_element.
                         # Those will be nested queries, and we're only
                         # interested in CTEs and "main" queries, i.e.
@@ -333,7 +323,7 @@ class SelectCrawler:
                                 query = self.query_class(
                                     QueryType.Simple, dialect, [selectable]
                                 )
-                                append_query(query, parent_stack)
+                                append_query(query)
                     else:
                         # We're processing a "with" statement.
                         if cte_name_segment_stack:
@@ -367,7 +357,7 @@ class SelectCrawler:
                             ] = query
                             cte_definition_segment_stack.pop()
                             cte_name_segment_stack.pop()
-                            append_query(query, parent_stack)
+                            append_query(query)
                         else:
                             # There's no CTE name, so we're probably processing
                             # the main query following a block of CTEs.
@@ -406,7 +396,7 @@ class SelectCrawler:
                         query.cte_definition_segment = cte_definition_segment_stack[-1]
                         cte_definition_segment_stack.pop()
                         cte_name_segment_stack.pop()
-                    append_query(query, parent_stack)
+                    append_query(query)
                 elif path[-1].is_type("common_table_expression"):
                     # This is a "<<cte name>> AS". Save definition segment and
                     # name for later.
@@ -454,8 +444,3 @@ class SelectCrawler:
                 yield from cls.visit_segments(seg, path, recurse_into)
         yield "end", path
         path.pop()
-
-    @classmethod
-    def get_parent_query(cls, seg, dialect, parent_stack) -> Optional[Query]:
-        """Creates a query tree from a querys parent stack to create full path."""
-        return cls(seg, dialect, parent_stack=parent_stack).query_tree

--- a/test/utils/analysis/test_select_crawler.py
+++ b/test/utils/analysis/test_select_crawler.py
@@ -189,37 +189,3 @@ join (
         "ctes": {"D": {"selectables": ["select x, z from b"]}},
         "query_type": "WithCompound",
     }
-
-
-def test_parent_select_crawler():
-    """Test to verify parent stack crawling functionality."""
-    sql = """
-        with b as (select 1 from c)
-        select * from (
-            with a as (select * from b)
-            select * from a
-            union
-            select 2 from d
-        )
-    """
-    linter = Linter(dialect="ansi")
-    parsed = linter.parse_string(sql)
-    segments = list(
-        parsed.tree.recursive_crawl(
-            "with_compound_statement",
-            "set_expression",
-            "select_statement",
-        )
-    )
-    crawler = SelectCrawler(
-        segments[-1],
-        linter.dialect,
-        parent_stack=segments[: len(segments) - 1],
-    )
-    # be able to recurse up parent stack so that functions can access
-    # ctes from any part of the stack
-    assert crawler.query_tree.parent.parent.parent.parent.as_json() == {
-        "query_type": "WithCompound",
-        "selectables": ["select * from a", "select 2 from d"],
-        "ctes": {"A": {"selectables": ["select * from b"]}},
-    }


### PR DESCRIPTION
This is a draft for now while I see how the test suite reacts.

The next big frontier for performance in linting is the `SelectCrawler`. It's very wasteful in terms of how much work it does. I'm slowly working through and pulling bits out of it, but it's going to take a few passes.

This PR:
- Modularises the test suite to make it a bit more DRY.
- Removes the `parent_stack` option to `SelectCrawler`. It was a hack and can be much better solved now that we've got fairly reliable access to the parent segment anyway.
- Removes the use of `parent_query` in AM07 but just detecting a `WITH` statement early and using that instead where we can.
- Simplifies `ST03` to use a much more minimal set of methods and avoid too much jumping around (it also uses fewer lines of code).