### PR TITLE
Free up pydocstyle again

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,7 @@
 # code linting and formatting
 flake8
 flake8-docstrings
-pydocstyle<6.2.0, >=6.2.2  # See: https://github.com/PyCQA/pydocstyle/issues/618
+pydocstyle!=6.2.0, !=6.2.1  # See: https://github.com/PyCQA/pydocstyle/issues/618
 black>=22.1.0
 flake8-black>=0.2.4
 ruff

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,7 @@
 # code linting and formatting
 flake8
 flake8-docstrings
-pydocstyle<6.2.0  # See: https://github.com/PyCQA/pydocstyle/issues/618
+pydocstyle<6.2.0, >=6.2.2  # See: https://github.com/PyCQA/pydocstyle/issues/618
 black>=22.1.0
 flake8-black>=0.2.4
 ruff


### PR DESCRIPTION
In #4225 we pinned `pydocstyle` to pre `6.2.0` because of https://github.com/PyCQA/pydocstyle/issues/618. Now that's resolved we can allow later versions again.