### PR TITLE
Select Crawler Refactor: Part 2

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1051,6 +1051,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
         *seg_type: str,
         recurse_into: bool = True,
         no_recursive_seg_type: Optional[str] = None,
+        allow_self: bool = True,
     ) -> Iterator[BaseSegment]:
         """Recursively crawl for segments of a given type.
 
@@ -1059,13 +1060,15 @@ class BaseSegment(metaclass=SegmentMetaclass):
                 to look for.
             recurse_into: :obj:`bool`: When an element of type "seg_type" is
                 found, whether to recurse into it.
-            no_recursive_seg_type: obj: `str`: a type of segment
+            no_recursive_seg_type: :obj:`str`: a type of segment
                 not to recurse further into. It is highly recommended
                 to set this argument where possible, as it can significantly
                 narrow the search pattern.
+            allow_self: :obj:`bool`: Whether to allow the initial segment this
+                is called on to be one of the results.
         """
-        # Assuming there is a segment to be found, first check self.
-        if self.is_type(*seg_type):
+        # Assuming there is a segment to be found, first check self (if allowed):
+        if allow_self and self.is_type(*seg_type):
             match = True
             yield self
         else:

--- a/src/sqlfluff/utils/analysis/select_crawler.py
+++ b/src/sqlfluff/utils/analysis/select_crawler.py
@@ -177,40 +177,31 @@ class Query:
             "select_statement",
             "values_clause",
         ]
-        for event, path in SelectCrawler.visit_segments(
-            segment, recurse_into=recurse_into
+        for seg in segment.recursive_crawl(
+            *types, recurse_into=False, allow_self=False
         ):
-            seg = path[-1]
-            if event == "end" or not seg.is_type(*types):
-                continue
-
-            if seg is segment:
-                # If the starting segment itself matches the list of types we're
-                # searching for, recursive_crawl() will return it. Skip that.
-                continue
-
+            # Crawl efficiently, don't recurse here. We do that later.
+            # What do we have?
+            # 1. If it's a table reference, work out whether it's to a CTE
+            #    or to an external table.
             if seg.is_type("table_reference"):
                 if not seg.is_qualified() and lookup_cte:
                     cte = self.lookup_cte(seg.raw, pop=pop)
                     if cte:
                         # It's a CTE.
                         yield cte
-                # It's an external table.
+                # It's an external table reference.
                 yield seg.raw
+            # 2. If it's some kind of more complex expression which is still
+            #    valid in this position, generate an appropriate sub-select.
             else:
                 assert seg.is_type(
                     "set_expression", "select_statement", "values_clause"
                 )
                 found_nested_select = True
-                seg_ = Segments(*path[1:]).first(
-                    sp.is_type(
-                        "from_expression_element",
-                        "set_expression",
-                        "select_statement",
-                        "values_clause",
-                    )
-                )[0]
-                crawler = SelectCrawler(seg_, self.dialect, parent=self)
+                # Generate a subselect crawler, referencing the current query
+                # as the parent.
+                crawler = SelectCrawler(seg, self.dialect, parent=self)
                 # We know this will pass because we specified parent=self above.
                 assert crawler.query_tree
                 yield crawler.query_tree

--- a/test/fixtures/rules/std_rule_cases/RF03.yml
+++ b/test/fixtures/rules/std_rule_cases/RF03.yml
@@ -16,6 +16,8 @@ test_pass_on_tableless_table:
   pass_str: SELECT (SELECT MAX(bar) FROM tbl) + 1 AS col
 
 test_fail_single_table_mixed_qualification_of_references_subquery:
+  # NOTE: Even though there's a subquery here, we can still fix it
+  # because there is no ambiguity about which table we're referencing.
   fail_str: SELECT * FROM (SELECT my_tbl.bar, baz FROM my_tbl)
   fix_str: SELECT * FROM (SELECT my_tbl.bar, my_tbl.baz FROM my_tbl)
 
@@ -272,6 +274,9 @@ test_pass_tsql_pivot:
       dialect: tsql
 
 test_unfixable_ambiguous_reference_subquery:
+  # `field_2` could be from the outer query or the inner
+  # query (i.e. from `other_table` or `my_alias`) and because
+  # it's ambiguous we shouldn't provide a fix.
   fail_str: |
     SELECT (
         SELECT other_table.other_table_field_1


### PR DESCRIPTION
This PR follows on from #5104 .

As a next step this removes the use of `visit_segments` (which doesn't filter) and replaces it with `recursive_crawl` with much more specific filtering. That triggered some follow on issues with `RF03` which I've also addressed and tried to do that in the simplest way.

Draft for now, I might go a little further before putting it up for review...