### PR TITLE
Refactor AM07

### DIFF
--- a/src/sqlfluff/rules/ambiguous/AM07.py
+++ b/src/sqlfluff/rules/ambiguous/AM07.py
@@ -1,5 +1,5 @@
 """Implementation of Rule AM07."""
-from typing import Any, List, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
@@ -127,7 +127,6 @@ class Rule_AM07(BaseRule):
             cte = root_query.lookup_cte(cte_name)
             if cte:
                 _cols, _resolved = self.__resolve_wild_query(cte)
-                # select_list += t
                 num_cols += _cols
                 resolved = resolved and _resolved
             else:
@@ -193,6 +192,7 @@ class Rule_AM07(BaseRule):
         # NOTE: Backward slice to work outward.
         for parent in context.parent_stack[::-1]:
             if parent.is_type("with_compound_statement"):
+                # If it is, work from there instead.
                 root = parent
                 break
 

--- a/src/sqlfluff/rules/ambiguous/AM07.py
+++ b/src/sqlfluff/rules/ambiguous/AM07.py
@@ -57,7 +57,6 @@ class Rule_AM07(BaseRule):
 
     def __resolve_wildcard(
         self,
-        context: RuleContext,
         query: Query,
     ) -> List[Any]:
         """Attempt to resolve the wildcard to a list of selectables."""
@@ -90,26 +89,19 @@ class Rule_AM07(BaseRule):
                                         # TODO: This clause isn't covered in the tests. Without better
                                         # documentation I can't remove it yet because I dont' understand
                                         # what it's trying to do.
-                                        targets += self.__resolve_wildcard(
-                                            context,
-                                            cte,
-                                        )
+                                        targets += self.__resolve_wildcard(cte)
                                     else:
                                         targets.append(wildcard)
                                         # if select_info_target is not a string
                                         # , process as a subquery
                                 else:
                                     targets += self.__resolve_wildcard(
-                                        context,
-                                        select_info_target,
+                                        select_info_target
                                     )
                             else:
                                 cte = query.lookup_cte(wildcard_table)
                                 if cte:
-                                    targets += self.__resolve_wildcard(
-                                        context,
-                                        cte,
-                                    )
+                                    targets += self.__resolve_wildcard(cte)
                                 else:
                                     targets.append(wildcard)
                     # if there is no table specified, it is likely a subquery
@@ -119,10 +111,7 @@ class Rule_AM07(BaseRule):
                         )
                         for o in query_list:
                             if isinstance(o, Query):
-                                targets += self.__resolve_wildcard(
-                                    context,
-                                    o,
-                                )
+                                targets += self.__resolve_wildcard(o)
                                 return targets
             else:
                 assert selectable.select_info
@@ -132,7 +121,7 @@ class Rule_AM07(BaseRule):
 
         return targets
 
-    def _get_select_target_counts(self, context: RuleContext, crawler: SelectCrawler):
+    def _get_select_target_counts(self, crawler: SelectCrawler):
         """Given a set expression, get the number of select targets in each query."""
         select_list = None
         select_target_counts = set()
@@ -156,7 +145,6 @@ class Rule_AM07(BaseRule):
             # If the set query contains a wildcard, attempt to resolve it to a list of
             # select targets that can be counted.
             select_list = self.__resolve_wildcard(
-                context,
                 crawler.query_tree,
             )
 
@@ -194,7 +182,7 @@ class Rule_AM07(BaseRule):
         )
 
         set_segment_select_sizes, resolve_wildcard = self._get_select_target_counts(
-            context, crawler
+            crawler
         )
         self.logger.info(
             "Resolved select sizes (resolved wildcard: %s) : %s",

--- a/src/sqlfluff/rules/ambiguous/AM07.py
+++ b/src/sqlfluff/rules/ambiguous/AM07.py
@@ -60,13 +60,14 @@ class Rule_AM07(BaseRule):
     groups: Tuple[str, ...] = ("all", "ambiguous")
     crawl_behaviour = SegmentSeekerCrawler({"set_expression"}, provide_raw_stack=True)
 
-    def __resolve_wildcard(
+    def __resolve_wild_query(
         self,
         query: Query,
     ) -> List[Any]:
         """Attempt to resolve the wildcard to a list of selectables."""
         targets = []
         process_queries = query.selectables
+        resolved_wildcard = True
         # if one of the source queries for a query within the set is a
         # set expression, just use the first query. If that first query isn't
         # reflective of the others, that will be caught when that segment
@@ -78,39 +79,9 @@ class Rule_AM07(BaseRule):
         for selectable in process_queries:
             if selectable.get_wildcard_info():
                 for wildcard in selectable.get_wildcard_info():
-                    if wildcard.tables:
-                        for wildcard_table in wildcard.tables:
-                            cte_name = wildcard_table
-                            # Get the AliasInfo for the table referenced in the wildcard
-                            # expression.
-                            alias_info = selectable.find_alias(wildcard_table)
-                            # attempt to resolve alias or table name to a cte
-                            if alias_info:
-                                select_info_target = SelectCrawler.get(
-                                    query, alias_info.from_expression_element
-                                )[0]
-                                if isinstance(select_info_target, str):
-                                    cte_name = select_info_target
-                                else:
-                                    targets += self.__resolve_wildcard(
-                                        select_info_target
-                                    )
-                                    continue
-
-                            cte = query.lookup_cte(cte_name)
-                            if cte:
-                                targets += self.__resolve_wildcard(cte)
-                            else:
-                                targets.append(wildcard)
-                    # if there is no table specified, it is likely a subquery
-                    else:
-                        query_list = SelectCrawler.get(
-                            query, query.selectables[0].selectable
-                        )
-                        for o in query_list:
-                            if isinstance(o, Query):
-                                targets += self.__resolve_wildcard(o)
-                                return targets
+                    targets += self.__resolve_selectable_wildcard(
+                        wildcard, selectable, query
+                    )
             else:
                 assert selectable.select_info
                 targets.extend(
@@ -118,6 +89,46 @@ class Rule_AM07(BaseRule):
                 )
 
         return targets
+
+    def __resolve_selectable_wildcard(self, wildcard, selectable, root_query):
+        # If there is no table specified, it is likely a subquery.
+        # Handle that first.
+        if not wildcard.tables:
+            query_list = SelectCrawler.get(
+                root_query, root_query.selectables[0].selectable
+            )
+            for o in query_list:
+                if isinstance(o, Query):
+                    return self.__resolve_wild_query(o)
+            raise NotImplementedError("I DON'T KNOW HOW TO GET HERE")
+
+        # There might be multiple tables referenced in some wildcard cases.
+        # resolved_wildcard = True
+        select_list = []
+        for wildcard_table in wildcard.tables:
+            cte_name = wildcard_table
+            # Get the AliasInfo for the table referenced in the wildcard
+            # expression.
+            alias_info = selectable.find_alias(wildcard_table)
+            # attempt to resolve alias or table name to a cte
+            if alias_info:
+                select_info_target = SelectCrawler.get(
+                    root_query, alias_info.from_expression_element
+                )[0]
+                if isinstance(select_info_target, str):
+                    cte_name = select_info_target
+                else:
+                    select_list += self.__resolve_wild_query(select_info_target)
+                    continue
+
+            cte = root_query.lookup_cte(cte_name)
+            if cte:
+                select_list += self.__resolve_wild_query(cte)
+            else:
+                # Unable to resolve
+                # resolved_wildcard = False
+                select_list.append(wildcard)
+        return select_list
 
     def __resolve_selectable(
         self, selectable: Selectable, root_query: Query
@@ -128,20 +139,22 @@ class Rule_AM07(BaseRule):
         # If there's no wildcard, just count the columns and move on.
         if not wildcard_info:
             # if there is no wildcard in the query use the count of select targets
-            select_list = selectable.select_info.select_targets
             return len(selectable.select_info.select_targets), True
 
-        # If the set query contains a wildcard, attempt to resolve it to a list of
-        # select targets that can be counted.
-        select_list = self.__resolve_wildcard(
-            root_query,
-        )
+        select_list = []
+        resolved_wildcard = True
+
+        # If the set query contains on or more wildcards, attempt to resolve it to a
+        # list of select targets that can be counted.
+        for wildcard in wildcard_info:
+            select_list += self.__resolve_selectable_wildcard(
+                wildcard, selectable, root_query
+            )
 
         # get the number of resolved targets plus the total number of
         # targets minus the number of wildcards
         # if all wildcards have been resolved this adds up to the
         # total number of select targets in the query
-        resolved_wildcard = True
         for select in select_list:
             if isinstance(select, WildcardInfo):
                 resolved_wildcard = False


### PR DESCRIPTION
This is part of cleaning up the select crawlers.

As part of that I've had a bunch of issues with AM07. The original code was quite convoluted and hard to follow, in particular there was a `list` being passed around and mutated in several methods.

This clears up that rule to make it easier to work with in future. I haven't changed any of the tests and you'll note that this PR only touches one file. Specifically:

- I've removed all mutation within methods. Everything is now handled with return values.
- All returns are now fully typed, and rather than returning a `list` they return just an `int` and `bool`.
- I've removed the need to pass around as many values. In particular we were passing around a `context` and a `crawler` which weren't' necessary.
- There's more logging, and better comments.

This *looks* like a total re-write, and it basically is - but the logic flow is the same, just in a very different structure.