### PR TITLE
Simplify rules with improvement to SegmentSeeker

### DIFF
--- a/src/sqlfluff/core/rules/crawlers.py
+++ b/src/sqlfluff/core/rules/crawlers.py
@@ -51,13 +51,22 @@ class SegmentSeekerCrawler(BaseCrawler):
     """
 
     def __init__(
-        self, types: Set[str], provide_raw_stack: bool = False, **kwargs: Any
+        self,
+        types: Set[str],
+        provide_raw_stack: bool = False,
+        allow_recurse: bool = True,
+        **kwargs: Any
     ) -> None:
         self.types = types
         # Tracking a raw stack involves a lot of tuple manipulation, so we
         # only do it when required - otherwise we skip it. Rules can explicitly
         # request it when defining their crawler.
         self.provide_raw_stack = provide_raw_stack
+        # If allow_recurse is false, then one a segment matches, none of it's
+        # children will be returned. This is useful in cases where we might have
+        # many start points, but one root segment will check any matching sub-
+        # segments in the same evaluation.
+        self.allow_recurse = allow_recurse
         super().__init__(**kwargs)
 
     def is_self_match(self, segment: BaseSegment) -> bool:
@@ -71,6 +80,7 @@ class SegmentSeekerCrawler(BaseCrawler):
         """
         # Check whether we should consider this segment _or it's children_
         # at all.
+        self_match = False
         if not self.passes_filter(context.segment):
             if self.provide_raw_stack:  # pragma: no cover
                 context.raw_stack += tuple(context.segment.raw_segments)
@@ -78,11 +88,14 @@ class SegmentSeekerCrawler(BaseCrawler):
 
         # Then check the segment itself, yield if it's a match.
         if self.is_self_match(context.segment):
+            self_match = True
             yield context
 
         # Check whether any children?
         # Abort if not - we've already yielded self.
-        if not context.segment.segments:
+        # NOTE: This same clause also works if we did match but aren't
+        # allowed to recurse.
+        if not context.segment.segments or (self_match and not self.allow_recurse):
             # Add self to raw stack first if so.
             if self.provide_raw_stack:
                 context.raw_stack += (cast(RawSegment, context.segment),)

--- a/src/sqlfluff/rules/references/RF03.py
+++ b/src/sqlfluff/rules/references/RF03.py
@@ -70,7 +70,9 @@ class Rule_RF03(BaseRule):
         "single_table_references",
         "force_enable",
     ]
-    crawl_behaviour = SegmentSeekerCrawler(set(_START_TYPES))
+    # If any of the parents would have also triggered the rule, don't fire
+    # because they will more accurately process any internal references.
+    crawl_behaviour = SegmentSeekerCrawler(set(_START_TYPES), allow_recurse=False)
     _is_struct_dialect = False
     _dialects_with_structs = ["bigquery", "hive", "redshift"]
     # This could be turned into an option
@@ -92,15 +94,12 @@ class Rule_RF03(BaseRule):
         if context.dialect.name in self._dialects_with_structs:
             self._is_struct_dialect = True
 
-        # If any of the parents would have also triggered the rule, don't fire
-        # because they will more accurately process any internal references.
-        if not any(seg.is_type(*_START_TYPES) for seg in context.parent_stack):
-            crawler = SelectCrawler(context.segment, context.dialect)
-            visited: Set = set()
-            if crawler.query_tree:
-                # Recursively visit and check each query in the tree.
-                return list(self._visit_queries(crawler.query_tree, visited))
-        return None
+        crawler = SelectCrawler(context.segment, context.dialect)
+        visited: Set = set()
+        if crawler.query_tree:
+            # Recursively visit and check each query in the tree.
+            return list(self._visit_queries(crawler.query_tree, visited))
+        return []
 
     def _iter_available_targets(self, query) -> Iterator[str]:
         """Iterate along a list of valid alias targets."""


### PR DESCRIPTION
Noticed this while working on some other rules. A couple of rules could seek more effectively rather than just rejecting segments based on their parents. This adds that simple functionality, which should reduce overheads.