### PR TITLE
Ensure Unparsable can be given position.

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1698,9 +1698,14 @@ class UnparsableSegment(BaseSegment):
     comment_separate = True
     _expected = ""
 
-    def __init__(self, segments: Tuple[BaseSegment, ...], expected: str = "") -> None:
+    def __init__(
+        self,
+        segments: Tuple[BaseSegment, ...],
+        pos_marker: Optional[PositionMarker] = None,
+        expected: str = "",
+    ) -> None:
         self._expected = expected
-        super().__init__(segments=segments)
+        super().__init__(segments=segments, pos_marker=pos_marker)
 
     def _suffix(self) -> str:
         """Return any extra output required at the end when logging.


### PR DESCRIPTION
This fixes an issue which was an oversight from some of the previous `mypy` work. If we try to apply fixes to an unparsable segment, then this fails (because we try to set position). No coverage because it's a very niche area.