### PR TITLE
[EXPERIMENT]: Eliminate "parse_grammar" from parsing phase

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1206,6 +1206,9 @@ class BaseSegment(metaclass=SegmentMetaclass):
 
         # Check the Parse Grammar
         parse_grammar = parse_grammar or self.parse_grammar
+        # ####################### TEMP EXPERIMENT
+        parse_grammar = None  # Don't do parsing - check performance.
+        # ####################### TEMP EXPERIMENT
         if parse_grammar is None:
             # No parse grammar, go straight to expansion
             parse_context.logger.debug(


### PR DESCRIPTION
This is an experiment. It will definitely break a few things, but I'm curious for how much and what the potential upside might be. I'll work on this a little before deciding whether it's viable. @WittierDinosaur suggested this option a long time ago.

**Hypothesis**: I think there's a lot of duplicate work in the parser by switching between the _parsing_ and _matching_ phases. Looking at the profiler results, we're matching hundreds of thousands of times for even fairly modest files. In theory we should be able to reduce down to just the current _matching_ phase, if we are a little smarter about how we identify and handle unparsable code. This PR explores that possibility.

Initial results suggest that the performance impact could be huge. Hurdles might exist in:
- Placement of `MetaSegment` objects (hopefully easily solvable).
- Positioning of `UnparsableSegment` objects (solvable with a bit of thought - it's more a logical problem of how to infer it rather than a technical challenge). At the moment we just instantite them when a segment doesn't _parse_. I think a different solution might be when an `AnyOf` doesn't find any options which _match_? Needs more thought to work through that though.
- Some files not parsing at all? (although I'm more hopeful on this one).

Before all the recent caching work, I think this wouldn't have been viable - but I do wonder whether it now has legs.