### PR TITLE
Treatment of null literals. #5099

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -400,6 +400,7 @@ ansi_dialect.add(
     # NullSegment is defined separately to the keyword, so we can give it a different
     # type
     NullLiteralSegment=StringParser("null", LiteralKeywordSegment, type="null_literal"),
+    NanLiteralSegment=StringParser("nan", LiteralKeywordSegment, type="null_literal"),
     TrueSegment=StringParser("true", LiteralKeywordSegment, type="boolean_literal"),
     FalseSegment=StringParser("false", LiteralKeywordSegment, type="boolean_literal"),
     # We use a GRAMMAR here not a Segment. Otherwise, we get an unnecessary layer
@@ -488,8 +489,8 @@ ansi_dialect.add(
     IfNotExistsGrammar=Sequence("IF", "NOT", "EXISTS"),
     LikeGrammar=OneOf("LIKE", "RLIKE", "ILIKE"),
     IsClauseGrammar=OneOf(
-        "NULL",
-        "NAN",
+        Ref("NullLiteralSegment"),
+        Ref("NanLiteralSegment"),
         Ref("BooleanLiteralGrammar"),
     ),
     SelectClauseSegmentGrammar=Sequence(

--- a/test/fixtures/dialects/ansi/create_table_column_constraint.yml
+++ b/test/fixtures/dialects/ansi/create_table_column_constraint.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 63b85c70e580cbb8521d6485449c04eba626e93d2f7e68c5fdcdf4d0c39e9279
+_hash: bb5ab21c6366260a274d74adaa1ddd3577f6f3cfb09290ad9f5eb9f2560f0933
 file:
 - statement:
     create_table_statement:
@@ -61,7 +61,7 @@ file:
                   naked_identifier: age
               - keyword: IS
               - keyword: NOT
-              - keyword: 'NULL'
+              - null_literal: 'NULL'
               end_bracket: )
       - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/ansi/create_view_a.yml
+++ b/test/fixtures/dialects/ansi/create_view_a.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d89e1e2f0206acdec249f40c648a70e713a07262aeb3dfee828991e121b792bf
+_hash: 828d3386d75173425688561ed663eaed5b254a2b06a3288cafd28f329128f049
 file:
 - statement:
     create_view_statement:
@@ -88,12 +88,12 @@ file:
                 where_clause:
                   keyword: WHERE
                   expression:
-                  - column_reference:
+                    column_reference:
                     - naked_identifier: da
                     - dot: .
                     - naked_identifier: current_appt_id
-                  - keyword: IS
-                  - keyword: 'NULL'
+                    keyword: IS
+                    null_literal: 'NULL'
               end_bracket: )
           select_statement:
             select_clause:

--- a/test/fixtures/dialects/ansi/select_d.yml
+++ b/test/fixtures/dialects/ansi/select_d.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9ccacef4fdcb6ffd6f41791b17b754fa59ceb65826a63fbe43dfcace76f09087
+_hash: d954262ab58fdf0d7eaec4c6fcec951e8ff789a701dc1acaabe5e7f8ac66d675
 file:
   statement:
     select_statement:
@@ -30,7 +30,7 @@ file:
             naked_identifier: col_a
         - keyword: IS
         - keyword: NOT
-        - keyword: 'NULL'
+        - null_literal: 'NULL'
         - binary_operator: AND
         - column_reference:
             naked_identifier: col_b

--- a/test/fixtures/dialects/athena/select_filter.yml
+++ b/test/fixtures/dialects/athena/select_filter.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3ce1960064878f554ec38c21008d429dadfab54d4103c548b97dc79020a5c74f
+_hash: b5c07fcfa9add39719d29df5f870aa2e6441447fd3ea11fa25d5dd77eac0ca9e
 file:
 - statement:
     select_statement:
@@ -120,6 +120,6 @@ file:
                   naked_identifier: x
               - keyword: IS
               - keyword: NOT
-              - keyword: 'NULL'
+              - null_literal: 'NULL'
             - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/athena/select_map_function.yml
+++ b/test/fixtures/dialects/athena/select_map_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1abe1b4ebaac883e5732f0f6422bbb001f44fd562b9a834fec52ecb40e785427
+_hash: 99a237d11640a33fbd36edc57ed22013a69bc9c5c6a030f1b033c6a739c55df0
 file:
 - statement:
     select_statement:
@@ -181,7 +181,7 @@ file:
                   naked_identifier: v
               - keyword: IS
               - keyword: NOT
-              - keyword: 'NULL'
+              - null_literal: 'NULL'
             - end_bracket: )
 - statement_terminator: ;
 - statement:

--- a/test/fixtures/dialects/athena/select_reduce.yml
+++ b/test/fixtures/dialects/athena/select_reduce.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: feb95eedec538fb26ced4e00655755b22b368d8bd2dc4ad12e3460e80692ec73
+_hash: 1df9cb1b41eb49646c10bbaa02cc3ead9ec6607066d1234d89d89f0eea4774f5
 file:
 - statement:
     select_statement:
@@ -258,10 +258,10 @@ file:
                   bracketed:
                   - start_bracket: (
                   - expression:
-                    - column_reference:
+                      column_reference:
                         naked_identifier: x
-                    - keyword: IS
-                    - keyword: 'NULL'
+                      keyword: IS
+                      null_literal: 'NULL'
                   - comma: ','
                   - expression:
                       column_reference:

--- a/test/fixtures/dialects/bigquery/literals_with_data_type_and_quoted.yml
+++ b/test/fixtures/dialects/bigquery/literals_with_data_type_and_quoted.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ff269329cbe6bf6e5e14f89f553cfaebd5bb9116cbe9190e30a50c077bc3e1ac
+_hash: 086599cb9d8417775d7067ee02c60261b7c4311d5d6defd43db83ebff6bfd85d
 file:
 - statement:
     select_statement:
@@ -382,7 +382,7 @@ file:
           - quoted_literal: "'{}'"
           - keyword: IS
           - keyword: NOT
-          - keyword: 'NULL'
+          - null_literal: 'NULL'
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -405,5 +405,5 @@ file:
           - quoted_literal: '"{}"'
           - keyword: IS
           - keyword: NOT
-          - keyword: 'NULL'
+          - null_literal: 'NULL'
 - statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/select_if.yml
+++ b/test/fixtures/dialects/bigquery/select_if.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 125abd1f84366271677a502bf8200380d0d52a3ecb5009f497b421ccaff8a845
+_hash: 1f65beb4a183a9fc16750f7bfb5a7b7b9e358759377992c1dfd9cd4994fa30a1
 file:
   statement:
     select_statement:
@@ -159,7 +159,7 @@ file:
             naked_identifier: vary
         - keyword: IS
         - keyword: NOT
-        - keyword: 'NULL'
+        - null_literal: 'NULL'
       orderby_clause:
       - keyword: ORDER
       - keyword: BY

--- a/test/fixtures/dialects/bigquery/select_quoting.yml
+++ b/test/fixtures/dialects/bigquery/select_quoting.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6b18f8f2e19d129016f96cf2116f4ba99aacb48fe9f4f493191853f93077824b
+_hash: 4ba156700ef9c14dc259c25e20cbcbdcedfd8f81987dc381bfe990ea77be5651
 file:
   statement:
     select_statement:
@@ -31,9 +31,9 @@ file:
         - column_reference:
             naked_identifier: list_id
         - keyword: IS
-        - keyword: 'NULL'
+        - null_literal: 'NULL'
         - binary_operator: OR
         - column_reference:
             naked_identifier: user_id
         - keyword: IS
-        - keyword: 'NULL'
+        - null_literal: 'NULL'

--- a/test/fixtures/dialects/mysql/json.yml
+++ b/test/fixtures/dialects/mysql/json.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9b17d892b48a3a78b3429441b8c1d3d077c39bf8bd5272563efa6545adfd40f6
+_hash: aaeefa5bec93b6c2a4cbd0bf9e96bdae0c96464e96a5fbd0071299cffc6cc1d3
 file:
 - statement:
     create_table_statement:
@@ -160,10 +160,10 @@ file:
       where_clause:
         keyword: WHERE
         expression:
-        - column_reference:
+          column_reference:
             naked_identifier: sentence
             column_path_operator: ->
             json_path: '"$.mascot"'
-        - keyword: IS
-        - keyword: 'NULL'
+          keyword: IS
+          null_literal: 'NULL'
 - statement_terminator: ;

--- a/test/fixtures/dialects/mysql/update.yml
+++ b/test/fixtures/dialects/mysql/update.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e97422c5a174d58b5638ee735094162724c01779876f33efb13089dcad90e6a2
+_hash: b7d7ef20a92e8be5f1d1d78915f1a19312436821e2173a1450e3838d0c73dcf9
 file:
 - statement:
     update_statement:
@@ -450,10 +450,10 @@ file:
       where_clause:
         keyword: where
         expression:
-        - column_reference:
+          column_reference:
           - naked_identifier: a
           - dot: .
           - naked_identifier: type
-        - keyword: is
-        - keyword: 'null'
+          keyword: is
+          null_literal: 'null'
 - statement_terminator: ;

--- a/test/fixtures/dialects/postgres/create_view.yml
+++ b/test/fixtures/dialects/postgres/create_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9a2ca7e9622364bfcd6336dc851fcdf843de8e1e49728862276719068eb61b5c
+_hash: 75ecad5fbe335560df4e2eb042a1f1a6e4ead7fb50e681f3004acf18f06cdd1e
 file:
 - statement:
     create_view_statement:
@@ -570,10 +570,10 @@ file:
           where_clause:
             keyword: WHERE
             expression:
-            - column_reference:
+              column_reference:
                 quoted_identifier: '"parent_id"'
-            - keyword: IS
-            - keyword: 'NULL'
+              keyword: IS
+              null_literal: 'NULL'
       - set_operator:
         - keyword: UNION
         - keyword: ALL

--- a/test/fixtures/dialects/postgres/null_filters.yml
+++ b/test/fixtures/dialects/postgres/null_filters.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1b26ead6a431fd6f9c3f727271035493f6fc0bc7eb2cc7d9913fbe518449496e
+_hash: f926ecc8538c230076c465d10eb56e484cf41d078050822760485b810841eb15
 file:
   statement:
     select_statement:
@@ -11,10 +11,10 @@ file:
       - keyword: SELECT
       - select_clause_element:
           expression:
-          - column_reference:
+            column_reference:
               naked_identifier: nullable_field
-          - keyword: IS
-          - keyword: 'NULL'
+            keyword: IS
+            null_literal: 'NULL'
           alias_expression:
             keyword: as
             naked_identifier: standard_is_null
@@ -34,7 +34,7 @@ file:
               naked_identifier: nullable_field
           - keyword: IS
           - keyword: NOT
-          - keyword: 'NULL'
+          - null_literal: 'NULL'
           alias_expression:
             keyword: as
             naked_identifier: standard_not_null
@@ -60,7 +60,7 @@ file:
         - column_reference:
             naked_identifier: nullable_field
         - keyword: IS
-        - keyword: 'NULL'
+        - null_literal: 'NULL'
         - binary_operator: OR
         - column_reference:
             naked_identifier: nullable_field
@@ -70,7 +70,7 @@ file:
             naked_identifier: nullable_field
         - keyword: IS
         - keyword: NOT
-        - keyword: 'NULL'
+        - null_literal: 'NULL'
         - binary_operator: OR
         - column_reference:
             naked_identifier: nullable_field

--- a/test/fixtures/dialects/redshift/super_data_type.yml
+++ b/test/fixtures/dialects/redshift/super_data_type.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 31c74742bdbfe78090a70c670b8e3a37fc326fef68bc13b500016ab1315688b2
+_hash: b1ad1348e7f28ff11211e11d120f56e880fc3d3b822ef6a6009b6ed0ecefb301
 file:
 - statement:
     select_statement:
@@ -77,7 +77,7 @@ file:
             naked_identifier: o_orderkey
         - keyword: IS
         - keyword: NOT
-        - keyword: 'NULL'
+        - null_literal: 'NULL'
 - statement_terminator: ;
 - statement:
     select_statement:

--- a/test/fixtures/dialects/snowflake/create_view.yml
+++ b/test/fixtures/dialects/snowflake/create_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a69ce064c023ff9e4040809653a3ac91201fb1e84a074f9518a2ddd096038517
+_hash: ddbf5f2d24bc7e37e3fec26d6145c5453334948627a94bff776d63464b9d8b08
 file:
 - statement:
     create_view_statement:
@@ -406,12 +406,12 @@ file:
                 where_clause:
                   keyword: WHERE
                   expression:
-                  - column_reference:
+                    column_reference:
                     - naked_identifier: da
                     - dot: .
                     - naked_identifier: current_appt_id
-                  - keyword: IS
-                  - keyword: 'NULL'
+                    keyword: IS
+                    null_literal: 'NULL'
               end_bracket: )
           select_statement:
             select_clause:

--- a/test/fixtures/dialects/sparksql/databricks_dlt_constraint.yml
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_constraint.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fd300f1b1bc9dccbe8ecd3468cbdbbdca0735b35f2d8d32cd5cde71a1ab936dd
+_hash: fc0702d568526354356fa9c90e28d354993cea13d9ac764cc10acfa08bfa3c50
 file:
 - statement:
     constraint_statement:
@@ -34,13 +34,13 @@ file:
             naked_identifier: current_page_id
         - keyword: IS
         - keyword: NOT
-        - keyword: 'NULL'
+        - null_literal: 'NULL'
         - binary_operator: AND
         - column_reference:
             naked_identifier: current_page_title
         - keyword: IS
         - keyword: NOT
-        - keyword: 'NULL'
+        - null_literal: 'NULL'
         end_bracket: )
     - keyword: 'ON'
     - keyword: VIOLATION

--- a/test/fixtures/dialects/sparksql/select_from_where_clause.yml
+++ b/test/fixtures/dialects/sparksql/select_from_where_clause.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f80fb596f8f8960dbd91f35c34a72819d16df7ead3a4fab481a439cd14e54ddf
+_hash: 3544556730f04d72062eb7ec28274e358afa322a87613e945abdc49c46934198
 file:
 - statement:
     select_statement:
@@ -252,7 +252,7 @@ file:
                   - dot: .
                   - naked_identifier: age
                 - keyword: IS
-                - keyword: 'NULL'
+                - null_literal: 'NULL'
             end_bracket: )
 - statement_terminator: ;
 - statement:


### PR DESCRIPTION
This resolves #5099 .

Treatment of null literals was inconsistent, specifically in `IS`/`IS NOT` expressions where null literals were being parsed as keywords. This resolves that.