### PR TITLE
Add support for comparison operators with space in Oracle

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -720,3 +720,42 @@ class SelectStatementSegment(ansi.SelectStatementSegment):
             Ref("NamedWindowSegment", optional=True),
         ]
     )
+
+
+class GreaterThanOrEqualToSegment(ansi.CompositeComparisonOperatorSegment):
+    """Allow spaces between operators."""
+
+    match_grammar = OneOf(
+        Sequence(
+            Ref("RawGreaterThanSegment"),
+            Ref("RawEqualsSegment"),
+        ),
+        Sequence(
+            Ref("RawNotSegment"),
+            Ref("RawLessThanSegment"),
+        ),
+    )
+
+
+class LessThanOrEqualToSegment(ansi.CompositeComparisonOperatorSegment):
+    """Allow spaces between operators."""
+
+    match_grammar = OneOf(
+        Sequence(
+            Ref("RawLessThanSegment"),
+            Ref("RawEqualsSegment"),
+        ),
+        Sequence(
+            Ref("RawNotSegment"),
+            Ref("RawGreaterThanSegment"),
+        ),
+    )
+
+
+class NotEqualToSegment(ansi.CompositeComparisonOperatorSegment):
+    """Allow spaces between operators."""
+
+    match_grammar = OneOf(
+        Sequence(Ref("RawNotSegment"), Ref("RawEqualsSegment")),
+        Sequence(Ref("RawLessThanSegment"), Ref("RawGreaterThanSegment")),
+    )

--- a/test/fixtures/dialects/oracle/comparison_operators_with_space.sql
+++ b/test/fixtures/dialects/oracle/comparison_operators_with_space.sql
@@ -1,0 +1,11 @@
+select 1
+from   dual
+where  3 < = 5;
+
+select 1
+from   dual
+where  4 >  = 2;
+
+select 1
+from   dual
+where  1  !   = 3;

--- a/test/fixtures/dialects/oracle/comparison_operators_with_space.yml
+++ b/test/fixtures/dialects/oracle/comparison_operators_with_space.yml
@@ -1,0 +1,73 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 70bbe6d19831c69c75359a6098c6a2cff155fcbddf2ebfbb444909ff2e756898
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          numeric_literal: '1'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dual
+      where_clause:
+        keyword: where
+        expression:
+        - numeric_literal: '3'
+        - comparison_operator:
+          - raw_comparison_operator: <
+          - raw_comparison_operator: '='
+        - numeric_literal: '5'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          numeric_literal: '1'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dual
+      where_clause:
+        keyword: where
+        expression:
+        - numeric_literal: '4'
+        - comparison_operator:
+          - raw_comparison_operator: '>'
+          - raw_comparison_operator: '='
+        - numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          numeric_literal: '1'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dual
+      where_clause:
+        keyword: where
+        expression:
+        - numeric_literal: '1'
+        - comparison_operator:
+          - raw_comparison_operator: '!'
+          - raw_comparison_operator: '='
+        - numeric_literal: '3'
+- statement_terminator: ;


### PR DESCRIPTION
Add support for comparison operators with space in Oracle

Closes #5059 

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
