### PR TITLE
Grammar .copy() assert no unexpected kwargs

### DIFF
--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -913,6 +913,7 @@ class BaseGrammar(Matchable):
                 Elements are searched for individually.
 
         """
+        assert not kwargs, f"Unexpected kwargs to .copy(): {kwargs}"
         # Copy only the *grammar* elements. The rest comes through
         # as is because they should just be classes rather than
         # instances.

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -1,31 +1,30 @@
 """The Hive dialect."""
 
+from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
     AnyNumberOf,
     BaseSegment,
-    Sequence,
-    Ref,
-    OneOf,
     Bracketed,
-    Delimited,
-    TypedParser,
-    Nothing,
-    SymbolSegment,
-    StringParser,
-    OptionallyBracketed,
-    RegexParser,
-    Matchable,
-    Indent,
     Dedent,
+    Delimited,
+    Indent,
+    Matchable,
+    Nothing,
+    OneOf,
+    OptionallyBracketed,
+    Ref,
+    RegexParser,
+    Sequence,
+    StringParser,
+    SymbolSegment,
+    TypedParser,
 )
-
-from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser.segments.raw import CodeSegment, KeywordSegment
+from sqlfluff.dialects import dialect_ansi as ansi
 from sqlfluff.dialects.dialect_hive_keywords import (
     RESERVED_KEYWORDS,
     UNRESERVED_KEYWORDS,
 )
-from sqlfluff.dialects import dialect_ansi as ansi
 
 ansi_dialect = load_raw_dialect("ansi")
 hive_dialect = ansi_dialect.copy_as("hive")
@@ -422,7 +421,7 @@ class FromExpressionElementSegment(ansi.FromExpressionElementSegment):
         insert=[
             AnyNumberOf(Ref("LateralViewClauseSegment")),
         ],
-        after=Ref("SamplingExpressionSegment"),
+        before=Ref("PostTableExpressionGrammar", optional=True),
     )
 
 


### PR DESCRIPTION
While we can do need an arbitrary `**kwargs` argument to the grammar `.copy()` method, we never validate that for any given grammar, that we only pass appropriate values. This method is only called on import of grammars and so I think some validation is necessary.

In particular, I found an example where in the `hive` dialect we were passing an unused kwarg which was being silently ignored.

This adds an `assert` into the base `.copy()` method, and then fixes the one place where that assert was being violated.

NOTE: Most of the lines of code changed here are actually just `isort` running on the hive dialect. The rest of the changes are pretty minimal.