### PR TITLE
Tests for unparsable sections

### DIFF
--- a/test/dialects/unparsable_test.py
+++ b/test/dialects/unparsable_test.py
@@ -1,11 +1,10 @@
 """Test the behaviour of the unparsable routines."""
 
-import logging
 from typing import Any, Optional
 
 import pytest
 
-from sqlfluff.core import FluffConfig, Linter
+from sqlfluff.core import FluffConfig
 from sqlfluff.core.parser import BaseSegment, Lexer, RawSegment
 from sqlfluff.core.parser.context import ParseContext
 

--- a/test/dialects/unparsable_test.py
+++ b/test/dialects/unparsable_test.py
@@ -1,12 +1,12 @@
 """Test the behaviour of the unparsable routines."""
 
-import pytest
 import logging
+from typing import Any, Optional
 
-from typing import Optional, Any
+import pytest
 
 from sqlfluff.core import FluffConfig, Linter
-from sqlfluff.core.parser import Lexer, BaseSegment, RawSegment
+from sqlfluff.core.parser import BaseSegment, Lexer, RawSegment
 from sqlfluff.core.parser.context import ParseContext
 
 
@@ -38,12 +38,10 @@ from sqlfluff.core.parser.context import ParseContext
                                                 "select_clause_element",
                                                 (("numeric_literal", "1"),),
                                             ),
+                                            ("whitespace", " "),
                                             (
                                                 "unparsable",
-                                                (
-                                                    ("whitespace", " "),
-                                                    ("numeric_literal", "1"),
-                                                ),
+                                                (("numeric_literal", "1"),),
                                             ),
                                         ),
                                     ),
@@ -67,14 +65,66 @@ from sqlfluff.core.parser.context import ParseContext
                         "select_clause_element",
                         (("numeric_literal", "1"),),
                     ),
+                    ("whitespace", " "),
                     # We should get a single unparsable section
                     # here at the end.
                     (
                         "unparsable",
+                        (("numeric_literal", "1"),),
+                    ),
+                ),
+            ),
+        ),
+        # This more complex example looks a little strange, but does
+        # reflect current unparsable behaviour. During future work
+        # on the parser, the structure of this result may change
+        # but it should still result in am unparsable section _within_
+        # the brackets, and not just a totally unparsable statement.
+        (
+            "SelectClauseSegment",
+            "ansi",
+            "SELECT 1 + (2 2 2)",
+            (
+                "select_clause",
+                (
+                    ("keyword", "SELECT"),
+                    ("whitespace", " "),
+                    (
+                        "select_clause_element",
                         (
-                            ("whitespace", " "),
-                            ("numeric_literal", "1"),
+                            (
+                                "expression",
+                                (
+                                    ("numeric_literal", "1"),
+                                    ("whitespace", " "),
+                                    ("binary_operator", "+"),
+                                    ("whitespace", " "),
+                                    (
+                                        "bracketed",
+                                        (
+                                            ("start_bracket", "("),
+                                            ("expression", (("numeric_literal", "2"),)),
+                                            (
+                                                "unparsable",
+                                                (
+                                                    ("whitespace", " "),
+                                                    ("numeric_literal", "2"),
+                                                    ("whitespace", " "),
+                                                    ("numeric_literal", "2"),
+                                                ),
+                                            ),
+                                            ("end_bracket", ")"),
+                                        ),
+                                    ),
+                                ),
+                            ),
                         ),
+                    ),
+                    # This is a bit odd but it reflects current
+                    # behaviour. Ideally it should not be present.
+                    (
+                        "unparsable",
+                        (),
                     ),
                 ),
             ),

--- a/test/dialects/unparsable_test.py
+++ b/test/dialects/unparsable_test.py
@@ -1,0 +1,116 @@
+"""Test the behaviour of the unparsable routines."""
+
+import pytest
+import logging
+
+from typing import Optional, Any
+
+from sqlfluff.core import FluffConfig, Linter
+from sqlfluff.core.parser import Lexer, BaseSegment, RawSegment
+from sqlfluff.core.parser.context import ParseContext
+
+
+# NOTE: Being specific on the segment ref helps to avoid crazy nesting.
+@pytest.mark.parametrize(
+    "segmentref,dialect,raw,structure",
+    [
+        (
+            # The first here makes sure all of this works from the outer
+            # segment, but for other tests we should aim to be more specific.
+            None,
+            "ansi",
+            "SELECT 1 1",
+            (
+                "file",
+                (
+                    (
+                        "statement",
+                        (
+                            (
+                                "select_statement",
+                                (
+                                    (
+                                        "select_clause",
+                                        (
+                                            ("keyword", "SELECT"),
+                                            ("whitespace", " "),
+                                            (
+                                                "select_clause_element",
+                                                (("numeric_literal", "1"),),
+                                            ),
+                                            (
+                                                "unparsable",
+                                                (
+                                                    ("whitespace", " "),
+                                                    ("numeric_literal", "1"),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        (
+            "SelectClauseSegment",
+            "ansi",
+            "SELECT 1 1",
+            (
+                "select_clause",
+                (
+                    ("keyword", "SELECT"),
+                    ("whitespace", " "),
+                    (
+                        "select_clause_element",
+                        (("numeric_literal", "1"),),
+                    ),
+                    # We should get a single unparsable section
+                    # here at the end.
+                    (
+                        "unparsable",
+                        (
+                            ("whitespace", " "),
+                            ("numeric_literal", "1"),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ],
+)
+def test_dialect_unparsable(
+    segmentref: Optional[str], dialect: str, raw: str, structure: Any
+):
+    """Test the structure of unparsables."""
+    config = FluffConfig(overrides=dict(dialect=dialect))
+
+    # Get the referenced object (if set, otherwise root)
+    if segmentref:
+        Seg = config.get("dialect_obj").ref(segmentref)
+    else:
+        Seg = config.get("dialect_obj").get_root_segment()
+    # We only allow BaseSegments as matchables in this test.
+    assert issubclass(Seg, BaseSegment)
+    assert not issubclass(Seg, RawSegment)
+
+    # Lex the raw string.
+    lex = Lexer(config=config)
+    seg_list, vs = lex.lex(raw)
+    assert not vs
+    print(seg_list)
+
+    # Construct an unparsed segment
+    seg = Seg(seg_list, pos_marker=seg_list[0].pos_marker)
+    # Perform the match (THIS IS THE MEAT OF THE TEST)
+    ctx = ParseContext.from_config(config)
+    result = seg.parse(parse_context=ctx)
+
+    print(result)
+    assert len(result) == 1
+    parsed = result[0]
+    assert isinstance(parsed, Seg)
+
+    assert parsed.to_tuple(show_raw=True) == structure

--- a/test/dialects/unparsable_test.py
+++ b/test/dialects/unparsable_test.py
@@ -149,7 +149,6 @@ def test_dialect_unparsable(
     lex = Lexer(config=config)
     seg_list, vs = lex.lex(raw)
     assert not vs
-    print(seg_list)
 
     # Construct an unparsed segment
     seg = Seg(seg_list, pos_marker=seg_list[0].pos_marker)

--- a/test/dialects/unparsable_test.py
+++ b/test/dialects/unparsable_test.py
@@ -157,7 +157,6 @@ def test_dialect_unparsable(
     ctx = ParseContext.from_config(config)
     result = seg.parse(parse_context=ctx)
 
-    print(result)
     assert len(result) == 1
     parsed = result[0]
     assert isinstance(parsed, Seg)


### PR DESCRIPTION
This is part of #5124 . Before I start changing the unparsable logic - I thought I should put some tests around the existing logic.

Not loads of tests, but this does give us enough to act as a comparison point. Ideally I'd like it to be a little more specific in future, but at the very least I don't want it to get more generic (i.e. just getting a totally unparsable statement).