### PR TITLE
`terminator` > `terminators` on Delimited grammar

### DIFF
--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -205,7 +205,7 @@ class OneOf(AnyNumberOf):
         self,
         *args: Union[MatchableType, str],
         exclude: Optional[MatchableType] = None,
-        terminators: Optional[SequenceType[MatchableType]] = None,
+        terminators: Optional[SequenceType[Union[MatchableType, str]]] = None,
         reset_terminators: bool = False,
         allow_gaps: bool = True,
         optional: bool = False,

--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -27,7 +27,7 @@ class AnyNumberOf(BaseGrammar):
         min_times: int = 0,
         max_times_per_element: Optional[int] = None,
         exclude: Optional[MatchableType] = None,
-        terminators: Optional[SequenceType[MatchableType]] = None,
+        terminators: Optional[SequenceType[Union[MatchableType, str]]] = None,
         reset_terminators: bool = False,
         allow_gaps: bool = True,
         optional: bool = False,
@@ -41,7 +41,9 @@ class AnyNumberOf(BaseGrammar):
         # The intent here is that if we match something, and then the _next_
         # item is one of these, we can safely conclude it's a "total" match.
         # In those cases, we return early without considering more options.
-        self.terminators = terminators
+        self.terminators: SequenceType[MatchableType] = [
+            self._resolve_ref(t) for t in terminators or []
+        ]
         self.reset_terminators = reset_terminators
         super().__init__(
             *args,

--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -1,6 +1,6 @@
 """Definitions for Grammar."""
 
-from typing import Optional, Tuple, Union, Sequence
+from typing import Optional, Sequence, Tuple, Union
 
 from tqdm import tqdm
 

--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -111,6 +111,9 @@ class Delimited(OneOf):
         terminated = False
 
         delimiter_matchers = [self.delimiter]
+        # TODO: We should also be able to add the `parse_context.terminators`
+        # here but that currently presents issues in several dialects. That
+        # will need to be resolved in future.
         terminator_matchers = list(self.terminators)
 
         # If gaps aren't allowed, a gap (or non-code segment), acts like a terminator.

--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -1,6 +1,6 @@
 """Definitions for Grammar."""
 
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, Sequence
 
 from tqdm import tqdm
 
@@ -38,9 +38,8 @@ class Delimited(OneOf):
         *args: Union[MatchableType, str],
         delimiter: Union[MatchableType, str] = Ref("CommaSegment"),
         allow_trailing: bool = False,
-        # NOTE: Other grammars support terminators (plural)
-        # TODO: Align these to be the same eventually.
-        terminator: Optional[Union[MatchableType, str]] = None,
+        terminators: Optional[Sequence[Union[MatchableType, str]]] = None,
+        reset_terminators: bool = False,
         min_delimiters: Optional[int] = None,
         bracket_pairs_set: str = "bracket_pairs",
         allow_gaps: bool = True,
@@ -52,11 +51,12 @@ class Delimited(OneOf):
         self.bracket_pairs_set = bracket_pairs_set
         self.delimiter = self._resolve_ref(delimiter)
         self.allow_trailing = allow_trailing
-        self.terminator = self._resolve_ref(terminator)
         # Setting min delimiters means we have to match at least this number
         self.min_delimiters = min_delimiters
         super().__init__(
             *args,
+            terminators=terminators,
+            reset_terminators=reset_terminators,
             allow_gaps=allow_gaps,
             optional=optional,
             ephemeral_name=ephemeral_name,
@@ -111,10 +111,8 @@ class Delimited(OneOf):
         terminated = False
 
         delimiter_matchers = [self.delimiter]
-        terminator_matchers = []
+        terminator_matchers = list(self.terminators)
 
-        if self.terminator:
-            terminator_matchers.append(self.terminator)
         # If gaps aren't allowed, a gap (or non-code segment), acts like a terminator.
         if not self.allow_gaps:
             terminator_matchers.append(NonCodeMatcher())
@@ -155,6 +153,7 @@ class Delimited(OneOf):
             with parse_context.deeper_match(
                 name="Delimited",
                 push_terminators=[] if seeking_delimiter else delimiter_matchers,
+                clear_terminators=self.reset_terminators,
             ) as ctx:
                 match, _ = self._longest_trimmed_match(
                     segments=seg_content,

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -984,7 +984,7 @@ class ObjectReferenceSegment(BaseSegment):
     match_grammar: Matchable = Delimited(
         Ref("SingleIdentifierGrammar"),
         delimiter=Ref("ObjectReferenceDelimiterGrammar"),
-        terminator=Ref("ObjectReferenceTerminatorGrammar"),
+        terminators=[Ref("ObjectReferenceTerminatorGrammar")],
         allow_gaps=False,
     )
 
@@ -1116,7 +1116,7 @@ class CollationReferenceSegment(ObjectReferenceSegment):
         Delimited(
             Ref("SingleIdentifierGrammar"),
             delimiter=Ref("ObjectReferenceDelimiterGrammar"),
-            terminator=Ref("ObjectReferenceTerminatorGrammar"),
+            terminators=[Ref("ObjectReferenceTerminatorGrammar")],
             allow_gaps=False,
         ),
     )
@@ -2371,7 +2371,7 @@ class OrderByClauseSegment(BaseSegment):
                 # for now.
                 Sequence("NULLS", OneOf("FIRST", "LAST"), optional=True),
             ),
-            terminator=OneOf(Ref.keyword("LIMIT"), Ref("FrameClauseUnitGrammar")),
+            terminators=["LIMIT", Ref("FrameClauseUnitGrammar")],
         ),
         Dedent,
     )
@@ -2440,7 +2440,7 @@ class GroupingExpressionList(BaseSegment):
                 Ref("ExpressionSegment"),
                 Bracketed(),  # Allows empty parentheses
             ),
-            terminator=Ref("GroupByClauseTerminatorGrammar"),
+            terminators=[Ref("GroupByClauseTerminatorGrammar")],
         ),
         Dedent,
     )
@@ -2482,7 +2482,7 @@ class GroupByClauseSegment(BaseSegment):
                         # Can `GROUP BY coalesce(col, 1)`
                         Ref("ExpressionSegment"),
                     ),
-                    terminator=Ref("GroupByClauseTerminatorGrammar"),
+                    terminators=[Ref("GroupByClauseTerminatorGrammar")],
                 ),
                 Dedent,
             ),
@@ -2791,7 +2791,7 @@ class WithCompoundStatementSegment(BaseSegment):
         Conditional(Indent, indented_ctes=True),
         Delimited(
             Ref("CTEDefinitionSegment"),
-            terminator=Ref.keyword("SELECT"),
+            terminators=["SELECT"],
         ),
         Conditional(Dedent, indented_ctes=True),
         OneOf(
@@ -3510,7 +3510,7 @@ class AccessStatementSegment(BaseSegment):
                     Ref("FunctionNameSegment"),
                     Ref("FunctionParameterListGrammar", optional=True),
                 ),
-                terminator=OneOf("TO", "FROM"),
+                terminators=["TO", "FROM"],
             ),
         ),
         Sequence("LARGE", "OBJECT", Ref("NumericLiteralSegment")),
@@ -3525,7 +3525,7 @@ class AccessStatementSegment(BaseSegment):
                 Sequence(
                     Delimited(
                         OneOf(_global_permissions, _permissions),
-                        terminator="ON",
+                        terminators=["ON"],
                     ),
                     "ON",
                     _objects,
@@ -3567,7 +3567,7 @@ class AccessStatementSegment(BaseSegment):
                 Sequence(
                     Delimited(
                         OneOf(_global_permissions, _permissions),
-                        terminator="ON",
+                        terminators=["ON"],
                     ),
                     "ON",
                     _objects,
@@ -4188,11 +4188,11 @@ class CreateTriggerStatementSegment(BaseSegment):
                 "OF",
                 Delimited(
                     Ref("ColumnReferenceSegment"),
-                    terminator=OneOf("OR", "ON"),
+                    terminators=["OR", "ON"],
                 ),
             ),
             delimiter="OR",
-            terminator="ON",
+            terminators=["ON"],
         ),
         "ON",
         Ref("TableReferenceSegment"),

--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -673,13 +673,13 @@ class GroupByClauseSegment(ansi.GroupByClauseSegment):
                 Ref("NumericLiteralSegment"),  # Can `GROUP BY 1`
                 Ref("ExpressionSegment"),  # Can `GROUP BY coalesce(col, 1)`
             ),
-            terminator=OneOf(
+            terminators=[
                 Sequence("ORDER", "BY"),
                 "LIMIT",
                 "OFFSET",
                 "HAVING",
                 Ref("SetOperatorSegment"),
-            ),
+            ],
         ),
         Dedent,
     )

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1190,7 +1190,7 @@ class ColumnReferenceSegment(ObjectReferenceSegment):
                 delimiter=OneOf(
                     Ref("DotSegment"), Sequence(Ref("DotSegment"), Ref("DotSegment"))
                 ),
-                terminator=OneOf(
+                terminators=[
                     "ON",
                     "AS",
                     "USING",
@@ -1202,7 +1202,7 @@ class ColumnReferenceSegment(ObjectReferenceSegment):
                     Ref("ColonSegment"),
                     Ref("DelimiterGrammar"),
                     BracketedSegment,
-                ),
+                ],
                 allow_gaps=False,
             ),
             allow_gaps=False,
@@ -1278,7 +1278,7 @@ class TableReferenceSegment(ObjectReferenceSegment):
         delimiter=OneOf(
             Ref("DotSegment"), Sequence(Ref("DotSegment"), Ref("DotSegment"))
         ),
-        terminator=OneOf(
+        terminators=[
             "ON",
             "AS",
             "USING",
@@ -1290,7 +1290,7 @@ class TableReferenceSegment(ObjectReferenceSegment):
             Ref("DelimiterGrammar"),
             Ref("JoinLikeClauseGrammar"),
             BracketedSegment,
-        ),
+        ],
         allow_gaps=False,
     )
 

--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -85,7 +85,7 @@ class OrderByClauseSegment(ansi.OrderByClauseSegment):
                 Sequence("NULLS", OneOf("FIRST", "LAST"), optional=True),
             ),
             allow_trailing=True,
-            terminator=Ref("OrderByClauseTerminators"),
+            terminators=[Ref("OrderByClauseTerminators")],
         ),
         Dedent,
     )
@@ -106,7 +106,7 @@ class GroupByClauseSegment(ansi.GroupByClauseSegment):
                 Ref("ExpressionSegment"),
             ),
             allow_trailing=True,
-            terminator=Ref("GroupByClauseTerminatorGrammar"),
+            terminators=[Ref("GroupByClauseTerminatorGrammar")],
         ),
         Dedent,
     )

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -162,10 +162,10 @@ exasol_dialect.add(
         "BY",
         Delimited(
             Ref("ColumnReferenceSegment"),
-            terminator=OneOf(
+            terminators=[
                 Ref("TablePartitionByGrammar"),
                 Ref("DelimiterGrammar"),
-            ),
+            ],
         ),
     ),
     TablePartitionByGrammar=Sequence(
@@ -173,10 +173,10 @@ exasol_dialect.add(
         "BY",
         Delimited(
             Ref("ColumnReferenceSegment"),
-            terminator=OneOf(
+            terminators=[
                 Ref("TableDistributeByGrammar"),
                 Ref("DelimiterGrammar"),
-            ),
+            ],
         ),
     ),
     TableConstraintEnableDisableGrammar=OneOf("ENABLE", "DISABLE"),
@@ -513,7 +513,7 @@ class ConnectByClauseSegment(BaseSegment):
             Delimited(
                 Ref("ExpressionSegment"),
                 delimiter="AND",
-                terminator="START",
+                terminators=["START"],
             ),
             Sequence("START", "WITH", Ref("ExpressionSegment"), optional=True),
         ),
@@ -548,13 +548,13 @@ class GroupByClauseSegment(BaseSegment):
                 Ref("ExpressionSegment"),
                 Bracketed(),  # Allows empty parentheses
             ),
-            terminator=OneOf(
+            terminators=[
                 Sequence("ORDER", "BY"),
                 "LIMIT",
                 "HAVING",
                 "QUALIFY",
                 Ref("SetOperatorSegment"),
-            ),
+            ],
         ),
         Dedent,
     )
@@ -1601,7 +1601,7 @@ class SetClauseListSegment(BaseSegment):
         Indent,
         Delimited(
             Ref("SetClauseSegment"),
-            terminator="FROM",
+            terminators=["FROM"],
         ),
         Dedent,
     )
@@ -2579,7 +2579,7 @@ class GrantRevokeSystemPrivilegesSegment(BaseSegment):
             ),
             Delimited(
                 Ref("SystemPrivilegesSegment"),
-                terminator=OneOf("TO", "FROM"),
+                terminators=["TO", "FROM"],
             ),
         ),
         OneOf("TO", "FROM"),
@@ -2597,7 +2597,7 @@ class GrantRevokeObjectPrivilegesSegment(BaseSegment):
     match_grammar = Sequence(
         OneOf(
             Sequence("ALL", Ref.keyword("PRIVILEGES", optional=True)),
-            Delimited(Ref("ObjectPrivilegesSegment"), terminator="ON"),
+            Delimited(Ref("ObjectPrivilegesSegment"), terminators=["ON"]),
         ),
         "ON",
         OneOf(
@@ -2627,7 +2627,7 @@ class GrantRevokeRolesSegment(BaseSegment):
     match_grammar = Sequence(
         OneOf(
             Sequence("ALL", "ROLES"),  # Revoke only
-            Delimited(Ref("RoleReferenceSegment"), terminator=OneOf("TO", "FROM")),
+            Delimited(Ref("RoleReferenceSegment"), terminators=["TO", "FROM"]),
         ),
         OneOf("TO", "FROM"),
         Delimited(Ref("RoleReferenceSegment")),
@@ -2644,7 +2644,7 @@ class GrantRevokeImpersonationSegment(BaseSegment):
         "ON",
         Delimited(
             Ref("SingleIdentifierGrammar"),
-            terminator=OneOf("TO", "FROM"),
+            terminators=["TO", "FROM"],
         ),
         OneOf("TO", "FROM"),
         Delimited(Ref("SingleIdentifierGrammar")),
@@ -2659,7 +2659,7 @@ class GrantRevokeConnectionSegment(BaseSegment):
         "CONNECTION",
         Delimited(
             Ref("SingleIdentifierGrammar"),
-            terminator=OneOf("TO", "FROM"),
+            terminators=["TO", "FROM"],
         ),
         OneOf("TO", "FROM"),
         Delimited(Ref("SingleIdentifierGrammar")),

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -1013,7 +1013,7 @@ class ClusterByClauseSegment(ansi.OrderByClauseSegment):
                     Ref("ExpressionSegment"),
                 ),
             ),
-            terminator=OneOf(Ref.keyword("LIMIT"), Ref("FrameClauseUnitGrammar")),
+            terminators=["LIMIT", Ref("FrameClauseUnitGrammar")],
         ),
         Dedent,
     )
@@ -1035,7 +1035,7 @@ class DistributeByClauseSegment(ansi.OrderByClauseSegment):
                     Ref("ExpressionSegment"),
                 ),
             ),
-            terminator=OneOf(
+            terminators=[
                 "SORT",
                 "LIMIT",
                 "HAVING",
@@ -1044,7 +1044,7 @@ class DistributeByClauseSegment(ansi.OrderByClauseSegment):
                 "WINDOW",
                 Ref("FrameClauseUnitGrammar"),
                 "SEPARATOR",
-            ),
+            ],
         ),
         Dedent,
     )
@@ -1068,7 +1068,7 @@ class SortByClauseSegment(ansi.OrderByClauseSegment):
                 OneOf("ASC", "DESC", optional=True),
                 Sequence("NULLS", OneOf("FIRST", "LAST"), optional=True),
             ),
-            terminator=OneOf(Ref.keyword("LIMIT"), Ref("FrameClauseUnitGrammar")),
+            terminators=["LIMIT", Ref("FrameClauseUnitGrammar")],
         ),
         Dedent,
     )

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -637,14 +637,12 @@ class DeleteStatementSegment(BaseSegment):
         OneOf(
             Sequence(
                 "FROM",
-                Delimited(
-                    Ref("TableReferenceSegment"), terminator=Ref.keyword("USING")
-                ),
+                Delimited(Ref("TableReferenceSegment"), terminators=["USING"]),
                 Ref("DeleteUsingClauseSegment"),
                 Ref("WhereClauseSegment", optional=True),
             ),
             Sequence(
-                Delimited(Ref("TableReferenceSegment"), terminator=Ref.keyword("FROM")),
+                Delimited(Ref("TableReferenceSegment"), terminators=["FROM"]),
                 Ref("FromClauseSegment"),
                 Ref("WhereClauseSegment", optional=True),
             ),
@@ -2424,7 +2422,7 @@ class FlushStatementSegment(BaseSegment):
             Sequence(
                 "TABLES",
                 Sequence(
-                    Delimited(Ref("TableReferenceSegment"), terminator="WITH"),
+                    Delimited(Ref("TableReferenceSegment"), terminators=["WITH"]),
                     optional=True,
                 ),
                 Sequence("WITH", "READ", "LOCK", optional=True),
@@ -2432,7 +2430,7 @@ class FlushStatementSegment(BaseSegment):
             Sequence(
                 "TABLES",
                 Sequence(
-                    Delimited(Ref("TableReferenceSegment"), terminator="FOR"),
+                    Delimited(Ref("TableReferenceSegment"), terminators=["FOR"]),
                     optional=False,
                 ),
                 Sequence("FOR", "EXPORT", optional=True),

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -458,7 +458,7 @@ class TableReferenceSegment(ObjectReferenceSegment):
             Sequence(Ref("DotSegment"), Ref("DotSegment")),
             Ref("AtSignSegment"),
         ),
-        terminator=OneOf(
+        terminators=[
             "ON",
             "AS",
             "USING",
@@ -471,7 +471,7 @@ class TableReferenceSegment(ObjectReferenceSegment):
             Ref("DelimiterGrammar"),
             Ref("JoinLikeClauseGrammar"),
             BracketedSegment,
-        ),
+        ],
         allow_gaps=False,
     )
 

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1497,14 +1497,14 @@ class GroupByClauseSegment(BaseSegment):
                 Ref("ExpressionSegment"),
                 Bracketed(),  # Allows empty parentheses
             ),
-            terminator=OneOf(
+            terminators=[
                 Sequence("ORDER", "BY"),
                 "LIMIT",
                 "HAVING",
                 "QUALIFY",
                 "WINDOW",
                 Ref("SetOperatorSegment"),
-            ),
+            ],
         ),
         Dedent,
     )
@@ -2265,7 +2265,7 @@ class PublicationObjectsSegment(BaseSegment):
             "TABLE",
             Delimited(
                 Ref("PublicationTableSegment"),
-                terminator=Sequence(Ref("CommaSegment"), OneOf("TABLE", "TABLES")),
+                terminators=[Sequence(Ref("CommaSegment"), OneOf("TABLE", "TABLES"))],
             ),
         ),
         Sequence(
@@ -2274,7 +2274,7 @@ class PublicationObjectsSegment(BaseSegment):
             "SCHEMA",
             Delimited(
                 OneOf(Ref("SchemaReferenceSegment"), "CURRENT_SCHEMA"),
-                terminator=Sequence(Ref("CommaSegment"), OneOf("TABLE", "TABLES")),
+                terminators=[Sequence(Ref("CommaSegment"), OneOf("TABLE", "TABLES"))],
             ),
         ),
     )
@@ -3267,7 +3267,7 @@ class AlterDefaultPrivilegesStatementSegment(BaseSegment):
             OneOf("ROLE", "USER"),
             Delimited(
                 Ref("ObjectReferenceSegment"),
-                terminator=OneOf("IN", "GRANT", "REVOKE"),
+                terminators=["IN", "GRANT", "REVOKE"],
             ),
             optional=True,
         ),
@@ -3276,7 +3276,7 @@ class AlterDefaultPrivilegesStatementSegment(BaseSegment):
             "SCHEMA",
             Delimited(
                 Ref("SchemaReferenceSegment"),
-                terminator=OneOf("GRANT", "REVOKE"),
+                terminators=["GRANT", "REVOKE"],
             ),
             optional=True,
         ),
@@ -3307,7 +3307,7 @@ class AlterDefaultPrivilegesObjectPrivilegesSegment(BaseSegment):
             "TRUNCATE",
             "UPDATE",
             "USAGE",
-            terminator="ON",
+            terminators=["ON"],
         ),
     )
 
@@ -3362,7 +3362,7 @@ class AlterDefaultPrivilegesGrantSegment(BaseSegment):
         "TO",
         Delimited(
             Ref("AlterDefaultPrivilegesToFromRolesSegment"),
-            terminator="WITH",
+            terminators=["WITH"],
         ),
         Sequence("WITH", "GRANT", "OPTION", optional=True),
     )
@@ -3384,7 +3384,7 @@ class AlterDefaultPrivilegesRevokeSegment(BaseSegment):
         "FROM",
         Delimited(
             Ref("AlterDefaultPrivilegesToFromRolesSegment"),
-            terminator=OneOf("RESTRICT", "CASCADE"),
+            terminators=["RESTRICT", "CASCADE"],
         ),
         Ref("DropBehaviorGrammar", optional=True),
     )
@@ -3982,7 +3982,7 @@ class CreateTriggerStatementSegment(ansi.CreateTriggerStatementSegment):
                     "OF",
                     Delimited(
                         Ref("ColumnReferenceSegment"),
-                        terminator=OneOf("OR", "ON"),
+                        terminators=["OR", "ON"],
                     ),
                     optional=True,
                 ),
@@ -5192,7 +5192,7 @@ class ColumnReferenceSegment(ObjectReferenceSegment):
                 delimiter=OneOf(
                     Ref("DotSegment"), Sequence(Ref("DotSegment"), Ref("DotSegment"))
                 ),
-                terminator=OneOf(
+                terminators=[
                     "ON",
                     "AS",
                     "USING",
@@ -5205,7 +5205,7 @@ class ColumnReferenceSegment(ObjectReferenceSegment):
                     Ref("DelimiterGrammar"),
                     Ref("JoinLikeClauseGrammar"),
                     BracketedSegment,
-                ),
+                ],
                 allow_gaps=False,
             ),
             allow_gaps=False,

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -349,9 +349,15 @@ snowflake_dialect.add(
             # Can `GROUP BY coalesce(col, 1)`
             Ref("ExpressionSegment"),
         ),
-        terminator=OneOf(
-            "ORDER", "LIMIT", "FETCH", "OFFSET", "HAVING", "QUALIFY", "WINDOW"
-        ),
+        terminators=[
+            "ORDER",
+            "LIMIT",
+            "FETCH",
+            "OFFSET",
+            "HAVING",
+            "QUALIFY",
+            "WINDOW",
+        ],
     ),
     LimitLiteralGrammar=OneOf(
         Ref("NumericLiteralSegment"),
@@ -2374,7 +2380,7 @@ class AccessStatementSegment(BaseSegment):
                     Ref("FunctionNameSegment"),
                     Ref("FunctionParameterListGrammar", optional=True),
                 ),
-                terminator=OneOf("TO", "FROM"),
+                terminators=["TO", "FROM"],
             ),
         ),
     )
@@ -2387,7 +2393,7 @@ class AccessStatementSegment(BaseSegment):
                 Sequence(
                     Delimited(
                         OneOf(_global_permissions, _permissions),
-                        terminator="ON",
+                        terminators=["ON"],
                     ),
                     "ON",
                     _objects,
@@ -2429,7 +2435,7 @@ class AccessStatementSegment(BaseSegment):
                 Sequence(
                     Delimited(
                         OneOf(_global_permissions, _permissions),
-                        terminator="ON",
+                        terminators=["ON"],
                     ),
                     "ON",
                     _objects,
@@ -6350,7 +6356,7 @@ class OrderByClauseSegment(ansi.OrderByClauseSegment):
                 OneOf("ASC", "DESC", optional=True),
                 Sequence("NULLS", OneOf("FIRST", "LAST"), optional=True),
             ),
-            terminator=OneOf("LIMIT", "FETCH", "OFFSET", Ref("FrameClauseUnitGrammar")),
+            terminators=["LIMIT", "FETCH", "OFFSET", Ref("FrameClauseUnitGrammar")],
         ),
         Dedent,
     )

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -1579,14 +1579,14 @@ class ClusterByClauseSegment(BaseSegment):
                     Ref("ExpressionSegment"),
                 ),
             ),
-            terminator=OneOf(
+            terminators=[
                 "LIMIT",
                 "HAVING",
                 # For window functions
                 "WINDOW",
                 Ref("FrameClauseUnitGrammar"),
                 "SEPARATOR",
-            ),
+            ],
         ),
         Dedent,
     )
@@ -1615,7 +1615,7 @@ class DistributeByClauseSegment(BaseSegment):
                     Ref("ExpressionSegment"),
                 ),
             ),
-            terminator=OneOf(
+            terminators=[
                 "SORT",
                 "LIMIT",
                 "HAVING",
@@ -1623,7 +1623,7 @@ class DistributeByClauseSegment(BaseSegment):
                 "WINDOW",
                 Ref("FrameClauseUnitGrammar"),
                 "SEPARATOR",
-            ),
+            ],
         ),
         Dedent,
     )
@@ -1672,7 +1672,7 @@ class SelectHintSegment(BaseSegment):
                     # At least function should be supplied
                     min_times=1,
                 ),
-                terminator=Ref("EndHintSegment"),
+                terminators=[Ref("EndHintSegment")],
             ),
             Ref("EndHintSegment"),
         ),
@@ -1886,7 +1886,7 @@ class SortByClauseSegment(BaseSegment):
                 # sense here for now.
                 Sequence("NULLS", OneOf("FIRST", "LAST"), optional=True),
             ),
-            terminator=OneOf(
+            terminators=[
                 "LIMIT",
                 "HAVING",
                 "QUALIFY",
@@ -1894,7 +1894,7 @@ class SortByClauseSegment(BaseSegment):
                 "WINDOW",
                 Ref("FrameClauseUnitGrammar"),
                 "SEPARATOR",
-            ),
+            ],
         ),
         Dedent,
     )

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -891,7 +891,7 @@ class WithCompoundStatementSegment(BaseSegment):
         Conditional(Indent, indented_ctes=True),
         Delimited(
             Ref("CTEDefinitionSegment"),
-            terminator=Ref.keyword("SELECT"),
+            terminators=["SELECT"],
         ),
         Conditional(Dedent, indented_ctes=True),
         OneOf(
@@ -4879,7 +4879,7 @@ class AccessStatementSegment(BaseSegment):
             Sequence("ALL", _schema_object_types_plural, "IN", "SCHEMA"),
             optional=True,
         ),
-        Delimited(Ref("ObjectReferenceSegment"), terminator=OneOf("TO", "FROM")),
+        Delimited(Ref("ObjectReferenceSegment"), terminators=["TO", "FROM"]),
         Ref("FunctionParameterListGrammar", optional=True),
     )
 
@@ -4892,7 +4892,7 @@ class AccessStatementSegment(BaseSegment):
                 Sequence(
                     Delimited(
                         OneOf(_global_permissions, _permissions),
-                        terminator="ON",
+                        terminators=["ON"],
                     ),
                 ),
                 Sequence("ALL", Ref.keyword("PRIVILEGES", optional=True)),
@@ -4923,7 +4923,7 @@ class AccessStatementSegment(BaseSegment):
             OneOf(
                 Delimited(
                     OneOf(_global_permissions, _permissions),
-                    terminator="ON",
+                    terminators=["ON"],
                 ),
                 Sequence("ALL", Ref.keyword("PRIVILEGES", optional=True)),
             ),
@@ -4950,7 +4950,7 @@ class AccessStatementSegment(BaseSegment):
             OneOf(
                 Delimited(
                     OneOf(_global_permissions, _permissions),
-                    terminator="ON",
+                    terminators=["ON"],
                 ),
                 Sequence("ALL", Ref.keyword("PRIVILEGES", optional=True)),
             ),


### PR DESCRIPTION
When we introduced deeper support for terminators in the context, it highlighted a few of the older grammars which already had _some_ support for terminators but with a slightly different syntax. This updates `Delimited` to use `terminators` and not `terminator` (note the plural - it's also a list rather than a single grammar). No functionality change for now, this almost entirely just syntax. It does use the parent `terminators` attribute from `AnyOf` in the background though.

The other grammar which needs this treatment is `StartsWith`, but I'll handle that as a separate PR (because it's a more tricky beast).