### PR TITLE
Adding optional sequence block for columns parsing in Snowflake external tables

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -4613,6 +4613,7 @@ class CreateExternalTableSegment(BaseSegment):
                         Sequence(
                             Ref("ExpressionSegment"),
                             Ref("TableConstraintSegment", optional=True),
+                            Sequence(Ref.keyword("NOT", optional=True), "NULL", optional=True)
                         )
                     ),
                 )

--- a/test/fixtures/dialects/snowflake/create_external_table.sql
+++ b/test/fixtures/dialects/snowflake/create_external_table.sql
@@ -9,7 +9,7 @@ create or replace external table "_p08"
     pattern='.*[.]parquet.*';
 
 CREATE EXTERNAL TABLE EXTERNAL_TABLES.TRIPS(
-  tripduration integer as try_cast(VALUE:c1::varchar as integer),
+  tripduration integer as try_cast(VALUE:c1::varchar as integer) not null,
   starttime timestamp as try_cast(VALUE:c2::varchar as timestamp),
   stoptime timestamp as try_cast(VALUE:c3::varchar as timestamp),
   start_station_id integer as try_cast(VALUE:c4::varchar as integer),

--- a/test/fixtures/dialects/snowflake/create_external_table.yml
+++ b/test/fixtures/dialects/snowflake/create_external_table.yml
@@ -106,6 +106,8 @@ file:
               data_type:
                 data_type_identifier: integer
               end_bracket: )
+      - keyword: not
+      - keyword: 'null'
       - comma: ','
       - naked_identifier: starttime
       - data_type:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX ` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
`fixes #5156 `
This PR fixes parsing error mentioned in the issue


### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
