### PR TITLE
Redshift: Support SELECT INTO

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2649,7 +2649,7 @@ class QualifyClauseSegment(BaseSegment):
     )
 
 
-class SelectStatementSegment(ansi.SelectStatementSegment):
+class SelectStatementSegment(postgres.SelectStatementSegment):
     """A snowflake `SELECT` statement including optional Qualify.
 
     https://docs.aws.amazon.com/redshift/latest/dg/r_QUALIFY_clause.html
@@ -2666,7 +2666,7 @@ class SelectStatementSegment(ansi.SelectStatementSegment):
         terminator=Ref("SetOperatorSegment"),
     )
 
-    parse_grammar = ansi.SelectStatementSegment.parse_grammar.copy(
+    parse_grammar = postgres.SelectStatementSegment.parse_grammar.copy(
         insert=[Ref("QualifyClauseSegment", optional=True)],
         before=Ref("OrderByClauseSegment", optional=True),
     )

--- a/test/fixtures/dialects/redshift/select_into.sql
+++ b/test/fixtures/dialects/redshift/select_into.sql
@@ -1,0 +1,8 @@
+select * into newevent from event;
+
+select username, lastname, sum(pricepaid-commission) as profit
+into temp table profits
+from sales, users
+where sales.sellerid=users.userid
+group by 1, 2
+order by 3 desc;

--- a/test/fixtures/dialects/redshift/select_into.yml
+++ b/test/fixtures/dialects/redshift/select_into.yml
@@ -1,0 +1,99 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 458e0eb72d649723778066a6cebd98c64ba6230b9853f9119f7603f2e5a79776
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      into_clause:
+        keyword: into
+        table_reference:
+          naked_identifier: newevent
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: event
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: select
+      - select_clause_element:
+          column_reference:
+            naked_identifier: username
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: lastname
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: sum
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: pricepaid
+              - binary_operator: '-'
+              - column_reference:
+                  naked_identifier: commission
+              end_bracket: )
+          alias_expression:
+            keyword: as
+            naked_identifier: profit
+      into_clause:
+      - keyword: into
+      - keyword: temp
+      - keyword: table
+      - table_reference:
+          naked_identifier: profits
+      from_clause:
+      - keyword: from
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: sales
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: users
+      where_clause:
+        keyword: where
+        expression:
+        - column_reference:
+          - naked_identifier: sales
+          - dot: .
+          - naked_identifier: sellerid
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: users
+          - dot: .
+          - naked_identifier: userid
+      groupby_clause:
+      - keyword: group
+      - keyword: by
+      - numeric_literal: '1'
+      - comma: ','
+      - numeric_literal: '2'
+      orderby_clause:
+      - keyword: order
+      - keyword: by
+      - numeric_literal: '3'
+      - keyword: desc
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

fixes #5158 

v2.1.4 implicitly supports Redshift SELECT INTO statements. It breaks when Qualify Clause support was introduced by re-writting SelectStatementSegment inheriting from ansi.SelectStatementSegment.

In this PR, we change it to inherit from postgres.SelectStatementSegment. 

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
