### PR TITLE
Tighten terminators on `Delimited`

### DIFF
--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -111,10 +111,13 @@ class Delimited(OneOf):
         terminated = False
 
         delimiter_matchers = [self.delimiter]
-        # TODO: We should also be able to add the `parse_context.terminators`
-        # here but that currently presents issues in several dialects. That
-        # will need to be resolved in future.
-        terminator_matchers = list(self.terminators)
+        # NOTE: If the configured delimiter is in parse_context.terminators then
+        # treat is _only_ as a delimiter and not as a terminator. This happens
+        # frequently during nested comma expressions.
+        terminator_matchers = [
+            *self.terminators,
+            *(t for t in parse_context.terminators if t not in delimiter_matchers),
+        ]
 
         # If gaps aren't allowed, a gap (or non-code segment), acts like a terminator.
         if not self.allow_gaps:

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1593,7 +1593,7 @@ class FromExpressionSegment(BaseSegment):
                 Ref("MLTableExpressionSegment"),
                 Ref("FromExpressionElementSegment"),
                 Bracketed(Ref("FromExpressionSegment")),
-                terminators=[Ref.keyword("ORDER"), Ref.keyword("GROUP")],
+                terminators=[Sequence("ORDER", "BY"), Sequence("GROUP", "BY")],
             ),
             Dedent,
             Conditional(Indent, indented_joins=True),
@@ -1602,7 +1602,7 @@ class FromExpressionSegment(BaseSegment):
                     OneOf(Ref("JoinClauseSegment"), Ref("JoinLikeClauseGrammar")),
                 ),
                 optional=True,
-                terminators=[Ref.keyword("ORDER"), Ref.keyword("GROUP")],
+                terminators=[Sequence("ORDER", "BY"), Sequence("GROUP", "BY")],
             ),
             Conditional(Dedent, indented_joins=True),
         )


### PR DESCRIPTION
Merging #5152 fixed the bug which left a loophole in #5150. This closes that loophole.

No user facing changes. This is prep for stricter unparsable controls as part of #5124.