### PR TITLE
Remove configurable `enforce_whitespace_preceding_terminator`

### DIFF
--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -1009,7 +1009,7 @@ class Ref(BaseGrammar):
 
     def __repr__(self) -> str:
         return "<Ref: {}{}>".format(
-            ", ".join(str(self._elements)), " [opt]" if self.is_optional() else ""
+            str(self._ref), " [opt]" if self.is_optional() else ""
         )
 
     @match_wrapper(v_level=4)  # Log less for Ref

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1748,7 +1748,6 @@ class SelectClauseSegment(BaseSegment):
             Ref("SetOperatorSegment"),
             "FETCH",
         ],
-        enforce_whitespace_preceding_terminator=True,
     )
 
     parse_grammar: Matchable = Ref("SelectClauseSegmentGrammar")
@@ -2656,7 +2655,6 @@ class UnorderedSelectStatementSegment(BaseSegment):
             Ref("OrderByClauseSegment"),
             Ref("LimitClauseSegment"),
         ],
-        enforce_whitespace_preceding_terminator=True,
     )
 
     parse_grammar: Matchable = Sequence(
@@ -2690,7 +2688,6 @@ class SelectStatementSegment(BaseSegment):
             Ref("WithNoSchemaBindingClauseSegment"),
             Ref("WithDataClauseSegment"),
         ],
-        enforce_whitespace_preceding_terminator=True,
     )
 
     # Inherit most of the parse grammar from the original.
@@ -3642,12 +3639,11 @@ class SetClauseListSegment(BaseSegment):
     match_grammar: Matchable = Sequence(
         "SET",
         Indent,
-        OneOf(
+        Ref("SetClauseSegment"),
+        # set clause
+        AnyNumberOf(
+            Ref("CommaSegment"),
             Ref("SetClauseSegment"),
-            # set clause
-            AnyNumberOf(
-                Delimited(Ref("SetClauseSegment")),
-            ),
         ),
         Dedent,
     )

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -334,7 +334,6 @@ class UnorderedSelectStatementSegment(BaseSegment):
             Ref("OrderByClauseSegment"),
             Ref("LimitClauseSegment"),
         ],
-        enforce_whitespace_preceding_terminator=True,
     )
 
     parse_grammar = Sequence(
@@ -382,7 +381,6 @@ class SelectStatementSegment(BaseSegment):
             Ref("WithDataClauseSegment"),
             Ref("CommentClauseSegment"),  # within CREATE TABLE / VIEW statements
         ],
-        enforce_whitespace_preceding_terminator=True,
     )
 
     # Inherit most of the parse grammar from the original.
@@ -3223,7 +3221,6 @@ class ScriptContentSegment(BaseSegment):
     type = "script_content"
     match_grammar = GreedyUntil(
         Ref("FunctionScriptTerminatorSegment"),
-        enforce_whitespace_preceding_terminator=False,
     )
 
 
@@ -3471,7 +3468,6 @@ class SelectClauseElementSegment(ansi.SelectClauseElementSegment):
     # Important to split elements before parsing, otherwise debugging is really hard.
     match_grammar = GreedyUntil(  # type: ignore
         Ref("SelectClauseElementTerminatorGrammar"),
-        enforce_whitespace_preceding_terminator=False,
     )
 
     parse_grammar = OneOf(

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1445,7 +1445,6 @@ class SelectClauseSegment(ansi.SelectClauseSegment):
             Sequence("WITH", Ref.keyword("NO", optional=True), "DATA"),
             Ref("WithCheckOptionSegment"),
         ],
-        enforce_whitespace_preceding_terminator=True,
     )
     parse_grammar = ansi.SelectClauseSegment.parse_grammar
 
@@ -4871,17 +4870,22 @@ class SetClauseSegment(BaseSegment):
                 ),
                 Ref("EqualsSegment"),
                 Bracketed(
-                    Delimited(
-                        Sequence(
-                            OneOf(
-                                Ref("LiteralGrammar"),
-                                Ref("BareFunctionSegment"),
-                                Ref("FunctionSegment"),
-                                Ref("ColumnReferenceSegment"),
-                                Ref("ExpressionSegment"),
-                                "DEFAULT",
+                    OneOf(
+                        # Potentially a bracketed SELECT
+                        Ref("SelectableGrammar"),
+                        # Or a delimited list of literals
+                        Delimited(
+                            Sequence(
+                                OneOf(
+                                    Ref("LiteralGrammar"),
+                                    Ref("BareFunctionSegment"),
+                                    Ref("FunctionSegment"),
+                                    Ref("ColumnReferenceSegment"),
+                                    Ref("ExpressionSegment"),
+                                    "DEFAULT",
+                                ),
+                                AnyNumberOf(Ref("ShorthandCastSegment")),
                             ),
-                            AnyNumberOf(Ref("ShorthandCastSegment")),
                         ),
                     ),
                 ),

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -3209,7 +3209,6 @@ class SelectClauseSegment(BaseSegment):
             "LIMIT",
             "OVERLAPS",
         ],
-        enforce_whitespace_preceding_terminator=True,
     )
 
     parse_grammar: Matchable = Ref("SelectClauseSegmentGrammar")

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -853,7 +853,6 @@ class SelectClauseSegment(ansi.SelectClauseSegment):
             "LIMIT",
             Ref("SetOperatorSegment"),
         ],
-        enforce_whitespace_preceding_terminator=True,
     )
     parse_grammar = ansi.SelectClauseSegment.parse_grammar
 

--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -228,7 +228,6 @@ class SelectClauseSegment(ansi.SelectClauseSegment):
             Ref("SetOperatorSegment"),
             "FETCH",
         ],
-        enforce_whitespace_preceding_terminator=True,
     )
     parse_grammar = ansi.SelectClauseSegment.parse_grammar
 

--- a/test/core/parser/grammar/grammar_other_test.py
+++ b/test/core/parser/grammar/grammar_other_test.py
@@ -29,18 +29,19 @@ def test__parser__grammar_startswith_a():
 @pytest.mark.parametrize(
     "include_terminator,match_length",
     [
-        (False, 3),
-        # NB: In this case we still shouldn't match the trailing whitespace.
-        (True, 4),
+        # NOTE: this case shouldn't include the whitespace between "bar" and "foo".
+        (False, 1),
+        # ...and in this case it _should_.
+        (True, 3),
     ],
 )
 def test__parser__grammar_startswith_b(
     include_terminator, match_length, seg_list, fresh_ansi_dialect, caplog
 ):
     """Test the StartsWith grammar with a terminator (included & excluded)."""
-    baar = StringParser("baar", KeywordSegment)
+    foo = StringParser("foo", KeywordSegment)
     bar = StringParser("bar", KeywordSegment)
-    grammar = StartsWith(bar, terminators=[baar], include_terminator=include_terminator)
+    grammar = StartsWith(bar, terminators=[foo], include_terminator=include_terminator)
     ctx = ParseContext(dialect=fresh_ansi_dialect)
     with caplog.at_level(logging.DEBUG, logger="sqlfluff.parser"):
         m = grammar.match(seg_list, parse_context=ctx)
@@ -98,26 +99,22 @@ def test__parser__grammar_delimited(
 
 
 @pytest.mark.parametrize(
-    "keyword,enforce_ws,slice_len",
+    "keyword,slice_len",
     [
         # Basic testing
-        ("foo", False, 1),
+        ("foo", 1),
         # Greedy matching until the first item should return none
-        ("bar", False, 0),
-        # Greedy matching up to baar should return bar, foo...
-        ("baar", False, 3),
-        # ... except if whitespace is required to precede it
-        ("baar", True, 6),
+        ("bar", 0),
+        # NOTE: the greedy until "baar" won't match because baar is
+        # a keyword and therefore is required to have whitespace
+        # before it. In the test sequence "baar" does not.
+        # See `greedy_match()` for details.
+        ("baar", 6),
     ],
 )
-def test__parser__grammar_greedyuntil(
-    keyword, seg_list, enforce_ws, slice_len, fresh_ansi_dialect
-):
+def test__parser__grammar_greedyuntil(keyword, seg_list, slice_len, fresh_ansi_dialect):
     """Test the GreedyUntil grammar."""
-    grammar = GreedyUntil(
-        StringParser(keyword, KeywordSegment),
-        enforce_whitespace_preceding_terminator=enforce_ws,
-    )
+    grammar = GreedyUntil(StringParser(keyword, KeywordSegment))
     ctx = ParseContext(dialect=fresh_ansi_dialect)
     assert (
         grammar.match(seg_list, parse_context=ctx).matched_segments

--- a/test/fixtures/dialects/postgres/update_table.yml
+++ b/test/fixtures/dialects/postgres/update_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 320a90a2ddb68b9b8b2bd161e4460a0e99440a5564e30d9a169626c810eefd97
+_hash: 26b055849f4a57835725cace78c91ced7d84f04fea5b9cb0fcf57778b25602bd
 file:
 - statement:
     update_statement:
@@ -307,37 +307,36 @@ file:
             raw_comparison_operator: '='
         - bracketed:
             start_bracket: (
-            expression:
-              select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    column_reference:
-                      naked_identifier: first_name
-                - comma: ','
-                - select_clause_element:
-                    column_reference:
-                      naked_identifier: last_name
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: salesmen
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                  - column_reference:
-                    - naked_identifier: salesmen
-                    - dot: .
-                    - naked_identifier: id
-                  - comparison_operator:
-                      raw_comparison_operator: '='
-                  - column_reference:
-                    - naked_identifier: accounts
-                    - dot: .
-                    - naked_identifier: sales_id
+            select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: first_name
+              - comma: ','
+              - select_clause_element:
+                  column_reference:
+                    naked_identifier: last_name
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: salesmen
+              where_clause:
+                keyword: WHERE
+                expression:
+                - column_reference:
+                  - naked_identifier: salesmen
+                  - dot: .
+                  - naked_identifier: id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: accounts
+                  - dot: .
+                  - naked_identifier: sales_id
             end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -411,75 +410,74 @@ file:
             raw_comparison_operator: '='
         - bracketed:
             start_bracket: (
-            expression:
-              select_statement:
-                select_clause:
-                - keyword: SELECT
-                - select_clause_element:
-                    function:
-                      function_name:
-                        function_name_identifier: sum
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: x
-                        end_bracket: )
-                - comma: ','
-                - select_clause_element:
-                    function:
-                      function_name:
-                        function_name_identifier: sum
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: y
-                        end_bracket: )
-                - comma: ','
-                - select_clause_element:
-                    function:
-                      function_name:
-                        function_name_identifier: avg
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: x
-                        end_bracket: )
-                - comma: ','
-                - select_clause_element:
-                    function:
-                      function_name:
-                        function_name_identifier: avg
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: y
-                        end_bracket: )
-                from_clause:
-                  keyword: FROM
-                  from_expression:
-                    from_expression_element:
-                      table_expression:
-                        table_reference:
-                          naked_identifier: data
-                      alias_expression:
-                        naked_identifier: d
-                where_clause:
-                  keyword: WHERE
-                  expression:
-                  - column_reference:
-                    - naked_identifier: d
-                    - dot: .
-                    - naked_identifier: group_id
-                  - comparison_operator:
-                      raw_comparison_operator: '='
-                  - column_reference:
-                    - naked_identifier: s
-                    - dot: .
-                    - naked_identifier: group_id
+            select_statement:
+              select_clause:
+              - keyword: SELECT
+              - select_clause_element:
+                  function:
+                    function_name:
+                      function_name_identifier: sum
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: x
+                      end_bracket: )
+              - comma: ','
+              - select_clause_element:
+                  function:
+                    function_name:
+                      function_name_identifier: sum
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: y
+                      end_bracket: )
+              - comma: ','
+              - select_clause_element:
+                  function:
+                    function_name:
+                      function_name_identifier: avg
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: x
+                      end_bracket: )
+              - comma: ','
+              - select_clause_element:
+                  function:
+                    function_name:
+                      function_name_identifier: avg
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: y
+                      end_bracket: )
+              from_clause:
+                keyword: FROM
+                from_expression:
+                  from_expression_element:
+                    table_expression:
+                      table_reference:
+                        naked_identifier: data
+                    alias_expression:
+                      naked_identifier: d
+              where_clause:
+                keyword: WHERE
+                expression:
+                - column_reference:
+                  - naked_identifier: d
+                  - dot: .
+                  - naked_identifier: group_id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: s
+                  - dot: .
+                  - naked_identifier: group_id
             end_bracket: )
 - statement_terminator: ;
 - statement:


### PR DESCRIPTION
The justification for this isn't totally obvious.
- We're extending the use of terminators across dialects.
- Some terminators make sense to require whitespace before them, some don't.
- Currently this is configured on the _grammar_ (i.e. it's applied in the same way for all terminators).
- This doesn't make sense as we have more and more diverse things used as terminators.
- That means that we need a better way of controlling whether whitespace is required. That would either involve _per terminator configuration_ (which adds a lot of overhead), _OR_ we have some way of inferring whether whitespace is required based on the terminator itself.
- This PR implements the latter, inferring that if it's a _keyword_ (i.e. contains only letters), then it likely _does_ require whitespace before it (specifically the test case which highlights this is a snowflake one where `my_field:data:from:to:blah` was matching a `FROM` to terminate the clause). Symbols (like commas or semicolons) don't.

This means we can remove the current `enforce_whitespace_preceding_terminator` flag (which is a super long name anyway), but also opens the door for more flexible terminator usage across dialects.

In the process I've also fixed the `__repr__` method for `Ref` which was broken, and also un-nested the code flow a little in `greedy_match()`.

There were two locations in the grammar where I had to adjust the dialects to respond to this, both I think were incorrectly specified in the past and were just taking advantage of a loophole in their function. I think the new specs are much better. Only one parse yaml test changes as a result and it's just that the `select_statement` segments are no longer nested within `bracketed`.