### PR TITLE
SparkSQL: Support ALTER TABLE SET LOCATION without partition spec

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -1095,7 +1095,7 @@ class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
             ),
             # ALTER TABLE - CHANGE FILE LOCATION
             Sequence(
-                Ref("PartitionSpecGrammar"),
+                Ref("PartitionSpecGrammar", optional=True),
                 "SET",
                 Ref("LocationGrammar"),
             ),

--- a/test/fixtures/dialects/sparksql/alter_table.sql
+++ b/test/fixtures/dialects/sparksql/alter_table.sql
@@ -55,6 +55,9 @@ ALTER TABLE Loc_Orc SET FILEFORMAT ORC;
 ALTER TABLE P1 PARTITION (Month = 2, Day = 2) SET FILEFORMAT PARQUET;
 
 -- Change the file Location
+ALTER TABLE Dbx.Tab1
+SET LOCATION '/path/to/part/ways';
+
 ALTER TABLE Dbx.Tab1 PARTITION (A = '1', B = '2')
 SET LOCATION '/path/to/part/ways';
 

--- a/test/fixtures/dialects/sparksql/alter_table.yml
+++ b/test/fixtures/dialects/sparksql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c679500066519765699ca6c686706ac93d11997dd1e5ce0f3d09ecb47289e11c
+_hash: 950e623eb6f1dbd551933c652330e5fda4c2049c80cad313a2f6d4898bf4d7b7
 file:
 - statement:
     alter_table_statement:
@@ -334,6 +334,18 @@ file:
     - keyword: FILEFORMAT
     - data_source_format:
         keyword: PARQUET
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: Dbx
+      - dot: .
+      - naked_identifier: Tab1
+    - keyword: SET
+    - keyword: LOCATION
+    - quoted_literal: "'/path/to/part/ways'"
 - statement_terminator: ;
 - statement:
     alter_table_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #5166 

making PartitionSpecGrammar optional in ALTER TABLE SET LOCATION based on https://spark.apache.org/docs/latest/sql-ref-syntax-ddl-alter-table.html

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
