### PR TITLE
Pull terminator setting up into the base grammar

### DIFF
--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -27,7 +27,7 @@ class AnyNumberOf(BaseGrammar):
         min_times: int = 0,
         max_times_per_element: Optional[int] = None,
         exclude: Optional[MatchableType] = None,
-        terminators: Optional[SequenceType[Union[MatchableType, str]]] = None,
+        terminators: SequenceType[Union[MatchableType, str]] = (),
         reset_terminators: bool = False,
         allow_gaps: bool = True,
         optional: bool = False,
@@ -38,18 +38,13 @@ class AnyNumberOf(BaseGrammar):
         self.max_times_per_element = max_times_per_element
         # Any patterns to _prevent_ a match.
         self.exclude = exclude
-        # The intent here is that if we match something, and then the _next_
-        # item is one of these, we can safely conclude it's a "total" match.
-        # In those cases, we return early without considering more options.
-        self.terminators: SequenceType[MatchableType] = [
-            self._resolve_ref(t) for t in terminators or []
-        ]
-        self.reset_terminators = reset_terminators
         super().__init__(
             *args,
             allow_gaps=allow_gaps,
             optional=optional,
             ephemeral_name=ephemeral_name,
+            terminators=terminators,
+            reset_terminators=reset_terminators,
         )
 
     @cached_method_for_parse_context
@@ -205,7 +200,7 @@ class OneOf(AnyNumberOf):
         self,
         *args: Union[MatchableType, str],
         exclude: Optional[MatchableType] = None,
-        terminators: Optional[SequenceType[Union[MatchableType, str]]] = None,
+        terminators: SequenceType[Union[MatchableType, str]] = (),
         reset_terminators: bool = False,
         allow_gaps: bool = True,
         optional: bool = False,
@@ -235,7 +230,7 @@ class OptionallyBracketed(OneOf):
         self,
         *args: Union[MatchableType, str],
         exclude: Optional[MatchableType] = None,
-        terminators: Optional[SequenceType[MatchableType]] = None,
+        terminators: SequenceType[Union[MatchableType, str]] = (),
         reset_terminators: bool = False,
         optional: bool = False,
         ephemeral_name: Optional[str] = None,
@@ -261,7 +256,7 @@ class AnySetOf(AnyNumberOf):
         max_times: Optional[int] = None,
         min_times: int = 0,
         exclude: Optional[MatchableType] = None,
-        terminators: Optional[SequenceType[MatchableType]] = None,
+        terminators: SequenceType[Union[MatchableType, str]] = (),
         reset_terminators: bool = False,
         allow_gaps: bool = True,
         optional: bool = False,

--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -155,6 +155,8 @@ class BaseGrammar(Matchable):
         allow_gaps: bool = True,
         optional: bool = False,
         ephemeral_name: Optional[str] = None,
+        terminators: Sequence[Union[MatchableType, str]] = (),
+        reset_terminators: bool = False,
     ) -> None:
         """Deal with kwargs common to all grammars.
 
@@ -178,6 +180,18 @@ class BaseGrammar(Matchable):
                 for it. If used widely this is an excellent way of breaking
                 up the parse process and also signposting the name of a given
                 chunk of code that might be parsed separately.
+            terminators (Sequence of :obj:`str` or Matchable): Matchable objects
+                which can terminate the grammar early. These are also used in some
+                parse modes to dictate how many segments to claim when handling
+                unparsable sections. Items passed as :obj:`str` are assumed to
+                refer to keywords and so will be passed to `Ref.keyword()` to
+                be resolved. Terminators are also added to the parse context
+                during deeper matching of child elements.
+            reset_terminators (:obj:`bool`, default `False`): Controls whether
+                any inherited terminators from outer grammars should be cleared
+                before matching child elements. Situations where this might be
+                appropriate are within bracketed expressions, where outer
+                terminators should be temporarily ignored.
         """
         # We provide a common interface for any grammar that allows positional elements.
         # If *any* for the elements are a string and not a grammar, then this is a
@@ -187,6 +201,15 @@ class BaseGrammar(Matchable):
         # Now we deal with the standard kwargs
         self.allow_gaps = allow_gaps
         self.optional: bool = optional
+
+        # The intent here is that if we match something, and then the _next_
+        # item is one of these, we can safely conclude it's a "total" match.
+        # In those cases, we return early without considering more options.
+        self.terminators: Sequence[MatchableType] = [
+            self._resolve_ref(t) for t in terminators
+        ]
+        self.reset_terminators = reset_terminators
+
         # ephemeral_name is a flag to indicate whether we need to make an
         # EphemeralSegment class. This is effectively syntactic sugar
         # to allow us to avoid specifying a EphemeralSegment directly in a dialect.
@@ -876,6 +899,8 @@ class BaseGrammar(Matchable):
         at: Optional[int] = None,
         before: Optional[Any] = None,
         remove: Optional[List[MatchableType]] = None,
+        terminators: List[Union[str, MatchableType]] = [],
+        add_terminators: List[Union[str, MatchableType]] = [],
         # NOTE: Optionally allow other kwargs to be provided to this
         # method for type compatibility. Any provided won't be used.
         **kwargs: Any,
@@ -902,7 +927,16 @@ class BaseGrammar(Matchable):
                 elements to remove from a grammar. Removal is done
                 *after* insertion so that order is preserved.
                 Elements are searched for individually.
-
+            terminators (:obj:`list` of :obj:`str` or Matchable): Override
+                existing terminators with a new list of terminators.
+                :obj:`str` objects will be interpreted as keywords and
+                passed to `Ref.keyword()`. NOTE: Cannot be used together
+                with `add_terminators`.
+            add_terminators (:obj:`list` of :obj:`str` or Matchable): Add
+                new terminators to the existing set.
+                :obj:`str` objects will be interpreted as keywords and
+                passed to `Ref.keyword()`. NOTE: Cannot be used together
+                with `terminators`.
         """
         assert not kwargs, f"Unexpected kwargs to .copy(): {kwargs}"
         # Copy only the *grammar* elements. The rest comes through
@@ -941,9 +975,23 @@ class BaseGrammar(Matchable):
                             elem, self
                         )
                     )
-        new_seg = copy.copy(self)
-        new_seg._elements = new_elems
-        return new_seg
+        new_grammar = copy.copy(self)
+        new_grammar._elements = new_elems
+
+        assert not (
+            terminators and add_terminators
+        ), "Cannot set `terminators` AND `add_terminators`."
+        # Override (NOTE: Not currently used).
+        if terminators:  # pragma: no cover
+            new_grammar.terminators = [self._resolve_ref(t) for t in terminators]
+        # Append
+        elif add_terminators:
+            new_grammar.terminators = [
+                *new_grammar.terminators,
+                *(self._resolve_ref(t) for t in add_terminators),
+            ]
+
+        return new_grammar
 
 
 class Ref(BaseGrammar):
@@ -955,7 +1003,7 @@ class Ref(BaseGrammar):
         self,
         *args: str,
         exclude: Optional[MatchableType] = None,
-        terminators: Optional[Sequence[MatchableType]] = None,
+        terminators: Sequence[Union[MatchableType, str]] = (),
         reset_terminators: bool = False,
         allow_gaps: bool = True,
         optional: bool = False,
@@ -970,17 +1018,16 @@ class Ref(BaseGrammar):
         self._ref = args[0]
         # Any patterns to _prevent_ a match.
         self.exclude = exclude
-        # The intent here is that if we match something, and then the _next_
-        # item is one of these, we can safely conclude it's a "total" match.
-        # In those cases, we return early without considering more options.
-        # Terminators don't take effect directly within this grammar, but
-        # the Ref grammar is an effective place to manage the terminators
-        # inherited via the context.
-        self.terminators = terminators
-        self.reset_terminators = reset_terminators
-        # NOTE: Don't pass on any args (we've already handled it with self._ref)
         super().__init__(
-            allow_gaps=allow_gaps, optional=optional, ephemeral_name=ephemeral_name
+            # NOTE: Don't pass on any args (we've already handled it with self._ref)
+            allow_gaps=allow_gaps,
+            optional=optional,
+            ephemeral_name=ephemeral_name,
+            # Terminators don't take effect directly within this grammar, but
+            # the Ref grammar is an effective place to manage the terminators
+            # inherited via the context.
+            terminators=terminators,
+            reset_terminators=reset_terminators,
         )
 
     @cached_method_for_parse_context

--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -38,7 +38,7 @@ class Delimited(OneOf):
         *args: Union[MatchableType, str],
         delimiter: Union[MatchableType, str] = Ref("CommaSegment"),
         allow_trailing: bool = False,
-        terminators: Optional[Sequence[Union[MatchableType, str]]] = None,
+        terminators: Sequence[Union[MatchableType, str]] = (),
         reset_terminators: bool = False,
         min_delimiters: Optional[int] = None,
         bracket_pairs_set: str = "bracket_pairs",

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -925,11 +925,11 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
     """Enhance unordered SELECT statement to include CLUSTER, DISTRIBUTE, SORT BY."""
 
     match_grammar = ansi.UnorderedSelectStatementSegment.match_grammar.copy(
-        add_terminators=[
+        terminators=[
             Ref("ClusterByClauseSegment"),
             Ref("DistributeByClauseSegment"),
             Ref("SortByClauseSegment"),
-        ]
+        ],
     )
 
     parse_grammar = ansi.UnorderedSelectStatementSegment.parse_grammar.copy()
@@ -953,11 +953,11 @@ class SelectClauseSegment(ansi.SelectClauseSegment):
     """Overriding SelectClauseSegment to allow for additional segment parsing."""
 
     match_grammar = ansi.SelectClauseSegment.match_grammar.copy(
-        add_terminators=[
+        terminators=[
             Sequence("CLUSTER", "BY"),
             Sequence("DISTRIBUTE", "BY"),
             Sequence("SORT", "BY"),
-        ]
+        ],
     )
     parse_grammar = ansi.SelectClauseSegment.parse_grammar.copy()
 

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -1645,13 +1645,13 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
 
     type = "select_statement"
     match_grammar = ansi.UnorderedSelectStatementSegment.match_grammar.copy(
-        add_terminators=[
+        terminators=[
             Ref("IntoClauseSegment"),
             Ref("ForClauseSegment"),
             Ref("IndexHintClauseSegment"),
             Ref("SelectPartitionClauseSegment"),
             Ref("UpsertClauseListSegment"),
-        ]
+        ],
     )
 
     parse_grammar = (
@@ -1681,7 +1681,7 @@ class SelectClauseSegment(ansi.SelectClauseSegment):
     """A group of elements in a select target statement."""
 
     match_grammar = ansi.SelectClauseSegment.match_grammar.copy(
-        add_terminators=[Ref("IntoKeywordSegment")]
+        terminators=[Ref("IntoKeywordSegment")],
     )
     parse_grammar = ansi.SelectClauseSegment.parse_grammar
 
@@ -1693,10 +1693,10 @@ class SelectStatementSegment(ansi.SelectStatementSegment):
     """
 
     match_grammar = ansi.SelectStatementSegment.match_grammar.copy(
-        add_terminators=[
+        terminators=[
             Ref("UpsertClauseListSegment"),
             Ref("WithCheckOptionSegment"),
-        ]
+        ],
     )
 
     # Inherit most of the parse grammar from the original.

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -697,7 +697,7 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
     """
 
     match_grammar = ansi.UnorderedSelectStatementSegment.match_grammar.copy(
-        add_terminators=[Ref("HierarchicalQueryClauseSegment")]
+        terminators=[Ref("HierarchicalQueryClauseSegment")],
     )
     parse_grammar: Matchable = ansi.UnorderedSelectStatementSegment.parse_grammar.copy(
         insert=[Ref("HierarchicalQueryClauseSegment", optional=True)],

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1389,12 +1389,12 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
     """Overrides ANSI Statement, to allow for SELECT INTO statements."""
 
     match_grammar = ansi.UnorderedSelectStatementSegment.match_grammar.copy(
-        add_terminators=[
+        terminators=[
             Sequence("WITH", Ref.keyword("NO", optional=True), "DATA"),
             Sequence("ON", "CONFLICT"),
             Ref.keyword("RETURNING"),
             Ref("WithCheckOptionSegment"),
-        ]
+        ],
     )
 
     parse_grammar = ansi.UnorderedSelectStatementSegment.parse_grammar.copy(
@@ -1409,12 +1409,12 @@ class SelectStatementSegment(ansi.SelectStatementSegment):
     """Overrides ANSI as the parse grammar copy needs to be reapplied."""
 
     match_grammar = ansi.SelectStatementSegment.match_grammar.copy(
-        add_terminators=[
+        terminators=[
             Sequence("WITH", Ref.keyword("NO", optional=True), "DATA"),
             Sequence("ON", "CONFLICT"),
             Ref.keyword("RETURNING"),
             Ref("WithCheckOptionSegment"),
-        ]
+        ],
     )
 
     parse_grammar = UnorderedSelectStatementSegment.parse_grammar.copy(

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -6331,7 +6331,7 @@ class SelectClauseSegment(ansi.SelectClauseSegment):
     """A group of elements in a select target statement."""
 
     match_grammar = ansi.SelectClauseSegment.match_grammar.copy(
-        add_terminators=[Ref.keyword("FETCH"), Ref.keyword("OFFSET")]
+        terminators=[Ref.keyword("FETCH"), Ref.keyword("OFFSET")],
     )
     parse_grammar = ansi.SelectClauseSegment.parse_grammar.copy()
 


### PR DESCRIPTION
This resolves some currently duplicated code in a few places across the grammars. With this PR, all grammars delegate terminator management to the base grammar. This reduces duplication and redundancy across the grammars.