### PR TITLE
Capitalise boolean values in example configs, for consistency

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -167,7 +167,7 @@ A few common examples are shown below:
 .. code-block:: sql
 
     -- Set Indented Joins
-    -- sqlfluff:indentation:indented_joins:true
+    -- sqlfluff:indentation:indented_joins:True
 
     -- Set a smaller indent for this file
     -- sqlfluff:indentation:tab_space_size:2

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -42,15 +42,15 @@ supported cfg file types):
     sql_file_exts = .sql,.sql.j2,.dml,.ddl
 
     [sqlfluff:indentation]
-    indented_joins = false
-    indented_using_on = true
-    template_blocks_indent = false
+    indented_joins = False
+    indented_using_on = True
+    template_blocks_indent = False
 
     [sqlfluff:templater]
-    unwrap_wrapped_queries = true
+    unwrap_wrapped_queries = True
 
     [sqlfluff:templater:jinja]
-    apply_dbt_builtins = true
+    apply_dbt_builtins = True
 
 For the `pyproject.toml file`_, all valid sections start with
 :code:`tool.sqlfluff` and subsections are delimited by a dot. For example the
@@ -66,15 +66,15 @@ For example, a snippet from a :code:`pyproject.toml` file:
     sql_file_exts = ".sql,.sql.j2,.dml,.ddl"
 
     [tool.sqlfluff.indentation]
-    indented_joins = false
-    indented_using_on = true
-    template_blocks_indent = false
+    indented_joins = False
+    indented_using_on = True
+    template_blocks_indent = False
 
     [tool.sqlfluff.templater]
-    unwrap_wrapped_queries = true
+    unwrap_wrapped_queries = True
 
     [tool.sqlfluff.templater.jinja]
-    apply_dbt_builtins = true
+    apply_dbt_builtins = True
 
     # For rule specific configuration, use dots between the names exactly
     # as you would in .sqlfluff. In the background, SQLFluff will unpack the
@@ -493,7 +493,7 @@ options:
     templater = jinja
 
     [sqlfluff:templater:jinja]
-    apply_dbt_builtins = true
+    apply_dbt_builtins = True
     load_macros_from_path = my_macros
     library_path = sqlfluff_libs
 

--- a/docs/source/partials/starter_config.cfg
+++ b/docs/source/partials/starter_config.cfg
@@ -34,7 +34,7 @@ project_dir = ./
 [sqlfluff:indentation]
 # While implicit indents are not enabled by default. Many of the
 # SQLFluff maintainers do use them in their projects.
-allow_implicit_indents = true
+allow_implicit_indents = True
 
 # The default configuration for aliasing rules is "consistent"
 # which will auto-detect the setting from the rest of the file. This


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

**Following up on this [Slack thread](https://sqlfluff.slack.com/archives/C01GX4L213J/p1694012643958789), here is a consistency fix for documentation, i.e. keeping boolean values capitalised.**

### Are there any other side effects of this change that we should be aware of?

**None.**

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below. (**N/A**)

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
