### PR TITLE
Output coverage report direct to PR

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -383,8 +383,8 @@ jobs:
           script: |
             // First list the existing comments
 
-            const trigger_str = 'Coverage Results'
-            console.log("Getting existing comments...")
+            const trigger_str = 'Coverage Results';
+            console.log("Getting existing comments...");
 
             const comments = await github.paginate(
               github.rest.issues.listComments,
@@ -393,46 +393,46 @@ jobs:
                 repo: 'sqlfluff',
                 issue_number: context.issue.number
               }
-            )
+            );
 
-            comment_id = null
-            console.log("Got %d comments", comments.length)
+            let comment_id = null;
+            console.log("Got %d comments", comments.length);
 
             for (const comment of comments) {
               if (comment.body.indexOf(trigger_str) >= 0) {
-                console.log("Found target comment ID: %d", comment.id)
-                comment_id = comment.id
+                console.log("Found target comment ID: %d", comment.id);
+                comment_id = comment.id;
               } else {
-                console.log("Comment ID %d not valid with body:\n%s.", comment.id, comment.body)
+                console.log("Comment ID %d not valid with body:\n%s.", comment.id, comment.body);
               }
             }
 
-            previous_outcome = "${{ steps.report_coverage.outcome }}"
-            console.log("Previous coverage step outcome: %s", previous_outcome)
+            const previous_outcome = "${{ steps.report_coverage.outcome }}";
+            console.log("Previous coverage step outcome: %s", previous_outcome);
             if (previous_outcome == "success") {
-              status_emoji = "✅"
+              status_emoji = "✅";
             } else {
-              status_emoji = "⚠️"
+              status_emoji = "⚠️";
             }
 
-            const { promises: fs } = require('fs')
-            let content = await fs.readFile('coverage-report.txt', 'utf8')
-            body = "# " + trigger_str + " " + status_emoji + "\n```\n" + content + "\n```\n"
+            const { promises: fs } = require('fs');
+            const content = await fs.readFile('coverage-report.txt', 'utf8');
+            body = "# " + trigger_str + " " + status_emoji + "\n```\n" + content + "\n```\n";
 
             if (comment_id > 0) {
-              console.log("Updating comment id: %d", comment_id)
+              console.log("Updating comment id: %d", comment_id);
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: comment_id,
                 body: body
-              })
+              });
             } else {
-              console.log("No existing comment matched, creating a new one...")
+              console.log("No existing comment matched, creating a new one...");
               await github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body: body
-              })
+              });
             }

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -378,7 +378,7 @@ jobs:
       - name: Update PR Comment.
         uses: actions/github-script@v6
         # Run even if the coverage step failed.
-        if: always()
+        if: github.event_name == 'pull_request'
         with:
           script: |
             // First list the existing comments

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -398,14 +398,14 @@ jobs:
             let comment_id = null;
             console.log("Got %d comments", comments.length);
 
-            for (const comment of comments) {
+            comments.forEach(comment => {
               if (comment.body.indexOf(trigger_str) >= 0) {
                 console.log("Found target comment ID: %d", comment.id);
                 comment_id = comment.id;
               } else {
                 console.log("Comment ID %d not valid with body:\n%s.", comment.id, comment.body);
               }
-            }
+            });
 
             const previous_outcome = "${{ steps.report_coverage.outcome }}";
             console.log("Previous coverage step outcome: %s", previous_outcome);

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -358,10 +358,15 @@ jobs:
           name: coverage-data
 
       - name: Combine coverage & fail if it's <100%.
+        id: report_coverage
+        # NOTE: Setting the pipefail option here means that even when
+        # piping the output to `tee`, we still get the exit code of the
+        # `coverage report` command.
         run: |
+          set -o pipefail
           python -m coverage combine
           python -m coverage html --skip-covered --skip-empty
-          python -m coverage report --fail-under=100
+          python -m coverage report --fail-under=100 --skip-covered --skip-empty -m | tee coverage-report.txt
 
       - name: Upload HTML report if check failed.
         uses: actions/upload-artifact@v3
@@ -369,3 +374,65 @@ jobs:
           name: html-report
           path: htmlcov
         if: ${{ failure() }}
+
+      - name: Update PR Comment.
+        uses: actions/github-script@v6
+        # Run even if the coverage step failed.
+        if: always()
+        with:
+          script: |
+            // First list the existing comments
+
+            const trigger_str = 'Coverage Results'
+            console.log("Getting existing comments...")
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: 'sqlfluff',
+                repo: 'sqlfluff',
+                issue_number: context.issue.number
+              }
+            )
+
+            comment_id = null
+            console.log("Got %d comments", comments.length)
+
+            for (const comment of comments) {
+              if (comment.body.indexOf(trigger_str) >= 0) {
+                console.log("Found target comment ID: %d", comment.id)
+                comment_id = comment.id
+              } else {
+                console.log("Comment ID %d not valid with body:\n%s.", comment.id, comment.body)
+              }
+            }
+
+            previous_outcome = "${{ steps.report_coverage.outcome }}"
+            console.log("Previous coverage step outcome: %s", previous_outcome)
+            if (previous_outcome == "success") {
+              status_emoji = "✅"
+            } else {
+              status_emoji = "⚠️"
+            }
+
+            const { promises: fs } = require('fs')
+            let content = await fs.readFile('coverage-report.txt', 'utf8')
+            body = "# " + trigger_str + " " + status_emoji + "\n```\n" + content + "\n```\n"
+
+            if (comment_id > 0) {
+              console.log("Updating comment id: %d", comment_id)
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: comment_id,
+                body: body
+              })
+            } else {
+              console.log("No existing comment matched, creating a new one...")
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              })
+            }

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -386,12 +386,15 @@ jobs:
             const trigger_str = 'Coverage Results';
             console.log("Getting existing comments...");
 
+            const issue_number = context.issue.number;
+            console.log("Issue number: " + issue_number);
+
             const comments = await github.paginate(
               github.rest.issues.listComments,
               {
                 owner: 'sqlfluff',
                 repo: 'sqlfluff',
-                issue_number: context.issue.number
+                issue_number: issue_number
               }
             );
 


### PR DESCRIPTION
Coveralls is being buggy again.

This posts the coverage report from out internal coverage report directly onto the PR using a comment. Tested on #5177.