### PR TITLE
Upgrades to the parse fixture generation script

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,7 +2,7 @@
 import hashlib
 import io
 import os
-from typing import NamedTuple
+from typing import List, NamedTuple, Tuple
 
 import pytest
 import yaml
@@ -10,17 +10,17 @@ import yaml
 from sqlfluff.cli.commands import quoted_presenter
 from sqlfluff.core import FluffConfig
 from sqlfluff.core.linter import Linter
-from sqlfluff.core.parser import Parser, Lexer
+from sqlfluff.core.parser import Lexer, Parser
 from sqlfluff.core.parser.markers import PositionMarker
 from sqlfluff.core.parser.segments import (
-    Indent,
+    BaseSegment,
+    CodeSegment,
+    CommentSegment,
     Dedent,
-    WhitespaceSegment,
+    Indent,
     NewlineSegment,
     SymbolSegment,
-    CommentSegment,
-    CodeSegment,
-    BaseSegment,
+    WhitespaceSegment,
 )
 from sqlfluff.core.rules import BaseRule
 from sqlfluff.core.templaters import TemplatedFile
@@ -36,7 +36,9 @@ class ParseExample(NamedTuple):
     sqlfile: str
 
 
-def get_parse_fixtures(fail_on_missing_yml=False):
+def get_parse_fixtures(
+    fail_on_missing_yml=False,
+) -> Tuple[List[ParseExample], List[Tuple[str, str, bool, str]]]:
     """Search for all parsing fixtures."""
     parse_success_examples = []
     parse_structure_examples = []

--- a/test/generate_parse_fixture_yml.py
+++ b/test/generate_parse_fixture_yml.py
@@ -107,9 +107,6 @@ def generate_one_parse_fixture(
     if "base" in types:
         return example, SQLParseError(f"Unnamed base section when parsing: {sql_path}")
     if "unparsable" in types:
-        # for unparsable in tree.iter_unparsables():
-        #    print("Found unparsable segment...")
-        #    print(unparsable.stringify())
         return example, SQLParseError(f"Could not parse: {sql_path}")
 
     _hash = compute_parse_tree_hash(tree)


### PR DESCRIPTION
Quality of life improvements to the `generate_parse_fixtures.yml` script. Functionality unchanged, but the user feedback is now much better. In particular, it doesn't just stop on the first file. We now get feedback like this (taken from my testing of the new parse modes - which is a good way to show what's failing and what's not):

```
py .\test\generate_parse_fixture_yml.py
Match Pattern Received:
        filter=* dialect=all new-only=False
Found 1292 file(s) to generate
'ansi' complete.                All Success ✅
'athena' complete.              All Success ✅
'bigquery' complete.            All Success ✅
'databricks' complete.          All Success ✅
'db2' complete.         All Success ✅
'duckdb' complete.              All Success ✅
'clickhouse' complete.          All Success ✅
'greenplum' complete.           All Success ✅
'hive' complete.                All Success ✅
'materialize' complete.         All Success ✅
'exasol' complete.              1 fails. ⚠️
  - 'select_statement.sql'
'mysql' complete.               All Success ✅
'oracle' complete.              2 fails. ⚠️
  - 'within_group.sql'
  - 'hierarchical_queries.sql'
'postgres' complete.            All Success ✅
'redshift' complete.            All Success ✅
'soql' complete.                All Success ✅
'snowflake' complete.           28 fails. ⚠️
  - 'bare_functions.sql'
  - 'col_position.sql'
  - 'connect_by.sql'
  - 'create_view.sql'
  - 'datetime_intervals.sql'
  - 'create_table.sql'
  - 'escape.sql'
  - 'first_value_ignore_nulls.sql'
  - 'frame_clause.sql'
  - 'create_task.sql'
  - 'group_by_all.sql'
  - 'lateral_flatten_after_join.sql'
  - 'insert.sql'
  - 'qualify.sql'
  - 'qualify_union.sql'
  - 'select.sql'
  - 'select_clause_modifiers.sql'
  - 'select_group_by_cube_rollup.sql'
  - 'select_grouping_sets.sql'
  - 'select_stages_files.sql'
  - 'select_where_is_distinct_from.sql'
  - 'semi_structured_2.sql'
  - 'select_like_clause.sql'
  - 'semi_structured.sql'
  - 'semi_structured_3.sql'
  - 'datetime_units.sql'
  - 'within_group.sql'
  - 'match_recognize.sql'
'sqlite' complete.              All Success ✅
'teradata' complete.            All Success ✅
'trino' complete.               All Success ✅
'sparksql' complete.            All Success ✅
'tsql' complete.                9 fails. ⚠️
  - 'begin_end_nested.sql'
  - 'begin_end_no_semicolon.sql'
  - 'begin_end.sql'
  - 'create_function.sql'
  - 'select_into.sql'
  - 'select_for.sql'
  - 'stored_procedured_mixed_statements.sql'
  - 'stored_procedure_begin_end.sql'
  - 'try_catch.sql'
FAILED TO GENERATE ALL CASES
```