### PR TITLE
Terminators on `Anything()` + Strip _most_ of the other `parse_grammar`

### DIFF
--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -650,10 +650,7 @@ class Anything(BaseGrammar):
         if not terminators:
             return MatchResult.from_matched(segments)
 
-        _match = greedy_match(segments, parse_context, terminators)
-        if not _match:
-            return MatchResult.from_matched(segments)
-        return _match
+        return greedy_match(segments, parse_context, terminators)
 
 
 class Nothing(BaseGrammar):

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -596,16 +596,8 @@ class Bracketed(Sequence):
 
         # Reconstruct the bracket segment post match.
         # We need to realign the meta segments so the pos markers are correct.
-        # Have we already got indents?
-        meta_idx = None
-        for idx, _seg in enumerate(bracket_segment.segments):
-            if _seg.is_meta:
-                _meta_seg = cast(MetaSegment, _seg)
-                if _meta_seg.indent_val > 0 and not _meta_seg.is_template:
-                    meta_idx = idx
-                    break
         # If we've already got indents, don't add more.
-        if meta_idx:
+        if any(isinstance(s, Indent) for s in bracket_segment.segments):
             bracket_segment.segments = BaseSegment._position_segments(
                 bracket_segment.start_bracket
                 + pre_segs

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -27,7 +27,6 @@ from sqlfluff.core.parser.segments import (
     BracketedSegment,
     Dedent,
     Indent,
-    MetaSegment,
     UnparsableSegment,
 )
 from sqlfluff.core.parser.types import MatchableType, ParseMode, SimpleHintType
@@ -596,8 +595,9 @@ class Bracketed(Sequence):
 
         # Reconstruct the bracket segment post match.
         # We need to realign the meta segments so the pos markers are correct.
-        # If we've already got indents, don't add more.
-        if any(isinstance(s, Indent) for s in bracket_segment.segments):
+        # If we've already got indents, don't add more (we only need to check
+        # the initial non-code section).
+        if any(isinstance(s, Indent) for s in pre_segs):
             bracket_segment.segments = BaseSegment._position_segments(
                 bracket_segment.start_bracket
                 + pre_segs

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -597,7 +597,11 @@ class Bracketed(Sequence):
         # We need to realign the meta segments so the pos markers are correct.
         # If we've already got indents, don't add more (we only need to check
         # the initial non-code section).
-        if any(isinstance(s, Indent) for s in pre_segs):
+        if any(isinstance(s, Indent) for s in pre_segs):  # pragma: no cover
+            # NOTE: In single pass parsing, this is no longer required.
+            # While it's not covered any longer in tests, it is still
+            # theoretically reachable. I'll remove this once parse_grammar
+            # is fully gone.
             bracket_segment.segments = BaseSegment._position_segments(
                 bracket_segment.start_bracket
                 + pre_segs

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -276,7 +276,9 @@ class BaseSegment(metaclass=SegmentMetaclass):
         elif self.parse_grammar:
             return True
         elif self.segments and any(s.is_expandable for s in self.segments):
-            return True
+            # NOTE: This whole method is soon to be removed so coverage is
+            # starting to get patchy.
+            return True  # pragma: no cover
         else:
             # Cache the variable
             self._is_expandable = False

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1469,7 +1469,12 @@ class BaseSegment(metaclass=SegmentMetaclass):
 
             # Rather than fix that here, we simply assert that it has been
             # done. This will raise issues in testing, but shouldn't in use.
-            if r.parse_grammar and not r.can_start_end_non_code and seg_buffer:
+            if (
+                # TODO: Rethink this assertion once parse_grammar is gone.
+                r.parse_grammar
+                and not r.can_start_end_non_code
+                and seg_buffer
+            ):  # pragma: no cover
                 assert not self._find_start_or_end_non_code(seg_buffer), (
                     "Found inappropriate fix application: inappropriate "
                     "whitespace positioning. Post `_choose_anchor_segment`. "

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -30,7 +30,6 @@ from sqlfluff.core.parser import (
     Conditional,
     Dedent,
     Delimited,
-    GreedyUntil,
     ImplicitIndent,
     Indent,
     KeywordSegment,

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -3901,9 +3901,7 @@ class StatementSegment(BaseSegment):
     """A generic segment, to any of its child subsegments."""
 
     type = "statement"
-    match_grammar: Matchable = GreedyUntil(Ref("DelimiterGrammar"))
-
-    parse_grammar: Matchable = OneOf(
+    match_grammar: Matchable = OneOf(
         Ref("SelectableGrammar"),
         Ref("MergeStatementSegment"),
         Ref("InsertStatementSegment"),
@@ -3943,6 +3941,7 @@ class StatementSegment(BaseSegment):
         Ref("DropSequenceStatementSegment"),
         Ref("CreateTriggerStatementSegment"),
         Ref("DropTriggerStatementSegment"),
+        terminators=[Ref("DelimiterGrammar")],
     )
 
     def get_table_references(self) -> Set[str]:

--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -396,7 +396,7 @@ class DatatypeSegment(BaseSegment):
 class StatementSegment(ansi.StatementSegment):
     """Overriding StatementSegment to allow for additional segment parsing."""
 
-    parse_grammar = ansi.StatementSegment.parse_grammar.copy(
+    match_grammar = ansi.StatementSegment.match_grammar.copy(
         insert=[
             Ref("MsckRepairTableStatementSegment"),
             Ref("UnloadStatementSegment"),
@@ -412,7 +412,6 @@ class StatementSegment(ansi.StatementSegment):
             Ref("DropModelStatementSegment"),
         ],
     )
-    match_grammar = ansi.StatementSegment.match_grammar
 
 
 class CreateTableStatementSegment(BaseSegment):
@@ -484,7 +483,7 @@ class CreateTableStatementSegment(BaseSegment):
                 OptionallyBracketed(
                     Ref("SelectableGrammar"),
                 ),
-                Sequence("WITH NO DATA", optional=True),
+                Sequence("WITH", "NO", "DATA", optional=True),
             ),
         ),
     )

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -441,8 +441,7 @@ class FileSegment(BaseFileSegment):
 class StatementSegment(ansi.StatementSegment):
     """Overriding StatementSegment to allow for additional segment parsing."""
 
-    match_grammar = ansi.StatementSegment.match_grammar
-    parse_grammar = ansi.StatementSegment.parse_grammar.copy(
+    match_grammar = ansi.StatementSegment.match_grammar.copy(
         insert=[
             Ref("DeclareStatementSegment"),
             Ref("SetStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -1227,8 +1227,7 @@ class SystemStatementSegment(BaseSegment):
 class StatementSegment(ansi.StatementSegment):
     """Overriding StatementSegment to allow for additional segment parsing."""
 
-    match_grammar = ansi.StatementSegment.match_grammar
-    parse_grammar = ansi.StatementSegment.parse_grammar.copy(
+    match_grammar = ansi.StatementSegment.match_grammar.copy(
         insert=[
             Ref("CreateMaterializedViewStatementSegment"),
             Ref("DropDictionaryStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -6,19 +6,13 @@ It also has some extensions.
 """
 
 from sqlfluff.core.dialects import load_raw_dialect
-from sqlfluff.core.parser import (
-    BaseSegment,
-    OneOf,
-    Ref,
-    Sequence,
-)
+from sqlfluff.core.parser import BaseSegment, OneOf, Ref, Sequence
+from sqlfluff.dialects import dialect_ansi as ansi
+from sqlfluff.dialects import dialect_sparksql as sparksql
 from sqlfluff.dialects.dialect_databricks_keywords import (
     RESERVED_KEYWORDS,
     UNRESERVED_KEYWORDS,
 )
-
-from sqlfluff.dialects import dialect_ansi as ansi
-from sqlfluff.dialects import dialect_sparksql as sparksql
 
 sparksql_dialect = load_raw_dialect("sparksql")
 databricks_dialect = sparksql_dialect.copy_as("databricks")
@@ -142,8 +136,7 @@ class SetTimeZoneStatementSegment(BaseSegment):
 class StatementSegment(sparksql.StatementSegment):
     """Overriding StatementSegment to allow for additional segment parsing."""
 
-    match_grammar = sparksql.StatementSegment.match_grammar
-    parse_grammar = sparksql.StatementSegment.parse_grammar.copy(
+    match_grammar = sparksql.StatementSegment.match_grammar.copy(
         # Segments defined in Databricks SQL dialect
         insert=[
             # Unity Catalog

--- a/src/sqlfluff/dialects/dialect_db2.py
+++ b/src/sqlfluff/dialects/dialect_db2.py
@@ -7,24 +7,17 @@ from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
     CodeSegment,
     CommentSegment,
+    ParseMode,
     RegexLexer,
     RegexParser,
     SegmentGenerator,
 )
-from sqlfluff.dialects import dialect_ansi as ansi
-
-from sqlfluff.dialects.dialect_db2_keywords import UNRESERVED_KEYWORDS
-
+from sqlfluff.core.parser.grammar.anyof import AnyNumberOf, OneOf
 from sqlfluff.core.parser.grammar.base import Ref
-from sqlfluff.core.parser.grammar.sequence import Sequence
+from sqlfluff.core.parser.grammar.sequence import Bracketed, Sequence
 from sqlfluff.core.parser.segments.base import BaseSegment
-
-from sqlfluff.core.parser.grammar.base import Anything
-from sqlfluff.core.parser.grammar.sequence import Bracketed
-
-from sqlfluff.core.parser.grammar.anyof import OneOf
-
-from sqlfluff.core.parser.grammar.anyof import AnyNumberOf
+from sqlfluff.dialects import dialect_ansi as ansi
+from sqlfluff.dialects.dialect_db2_keywords import UNRESERVED_KEYWORDS
 
 ansi_dialect = load_raw_dialect("ansi")
 
@@ -98,14 +91,11 @@ class WithinGroupClauseSegment(BaseSegment):
     """An WITHIN GROUP clause for window functions."""
 
     type = "withingroup_clause"
+
     match_grammar = Sequence(
         "WITHIN",
         "GROUP",
-        Bracketed(Anything(optional=True)),
-    )
-
-    parse_grammar = Sequence(
-        "WITHIN",
-        "GROUP",
-        Bracketed(Ref("OrderByClauseSegment", optional=True)),
+        Bracketed(
+            Ref("OrderByClauseSegment", optional=True), parse_mode=ParseMode.GREEDY
+        ),
     )

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -3367,9 +3367,7 @@ class StatementSegment(ansi.StatementSegment):
 
     type = "statement"
 
-    match_grammar = GreedyUntil(Ref("DelimiterGrammar"))
-
-    parse_grammar = OneOf(
+    match_grammar = OneOf(
         # Data Query Language (DQL)
         Ref("SelectableGrammar"),
         # Data Modifying Language (DML)
@@ -3424,6 +3422,7 @@ class StatementSegment(ansi.StatementSegment):
         # Others
         Ref("TransactionStatementSegment"),
         Ref("ExecuteScriptSegment"),
+        terminators=[Ref("DelimiterGrammar")],
     )
 
 

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -654,7 +654,7 @@ class SetStatementSegment(BaseSegment):
 class StatementSegment(ansi.StatementSegment):
     """Overriding StatementSegment to allow for additional segment parsing."""
 
-    parse_grammar = ansi.StatementSegment.parse_grammar.copy(
+    match_grammar = ansi.StatementSegment.match_grammar.copy(
         insert=[
             Ref("AlterDatabaseStatementSegment"),
             Ref("MsckRepairTableStatementSegment"),
@@ -669,7 +669,6 @@ class StatementSegment(ansi.StatementSegment):
             Ref("DropModelStatementSegment"),
         ],
     )
-    match_grammar = ansi.StatementSegment.match_grammar
 
 
 class InsertStatementSegment(BaseSegment):

--- a/src/sqlfluff/dialects/dialect_materialize.py
+++ b/src/sqlfluff/dialects/dialect_materialize.py
@@ -9,10 +9,10 @@ from sqlfluff.core.parser import (
     BaseSegment,
     Bracketed,
     Delimited,
+    MultiStringParser,
     OneOf,
     Ref,
     Sequence,
-    MultiStringParser,
 )
 from sqlfluff.core.parser.segments.raw import KeywordSegment
 from sqlfluff.dialects import dialect_ansi as ansi
@@ -37,8 +37,7 @@ materialize_dialect.update_keywords_set_from_multiline_string(
 class StatementSegment(ansi.StatementSegment):
     """A generic segment, to any of its child subsegments."""
 
-    match_grammar = ansi.StatementSegment.match_grammar
-    parse_grammar = ansi.StatementSegment.parse_grammar.copy(
+    match_grammar = ansi.StatementSegment.match_grammar.copy(
         insert=[
             Ref("AlterConnectionRotateKeys"),
             Ref("AlterIndexStatementSegment"),
@@ -336,11 +335,7 @@ class CreateConnectionStatementSegment(BaseSegment):
                 "TUNNEL",
             ),
         ),
-        Bracketed(
-            Delimited(
-                Anything(),
-            )
-        ),
+        Bracketed(Anything()),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -1070,8 +1070,7 @@ class DeclareStatement(BaseSegment):
 class StatementSegment(ansi.StatementSegment):
     """Overriding StatementSegment to allow for additional segment parsing."""
 
-    match_grammar = ansi.StatementSegment.match_grammar
-    parse_grammar = ansi.StatementSegment.parse_grammar.copy(
+    match_grammar = ansi.StatementSegment.match_grammar.copy(
         insert=[
             Ref("DelimiterStatement"),
             Ref("CreateProcedureStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -15,7 +15,6 @@ from sqlfluff.core.parser import (
     CodeSegment,
     CommentSegment,
     Delimited,
-    GreedyUntil,
     Matchable,
     OneOf,
     OptionallyBracketed,

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -54,7 +54,7 @@ oracle_dialect.sets("reserved_keywords").update(
 )
 
 oracle_dialect.sets("unreserved_keywords").update(
-    ["EDITIONABLE", "EDITIONING", "NONEDITIONABLE"]
+    ["EDITIONABLE", "EDITIONING", "NONEDITIONABLE", "KEEP"]
 )
 
 oracle_dialect.sets("bare_functions").clear()
@@ -360,10 +360,7 @@ class StatementSegment(ansi.StatementSegment):
 
     type = "statement"
 
-    match_grammar = OneOf(
-        GreedyUntil(Ref("DelimiterGrammar")), exclude=Ref("ExecuteFileSegment")
-    )
-    parse_grammar = ansi.StatementSegment.parse_grammar.copy(
+    match_grammar = ansi.StatementSegment.match_grammar.copy(
         insert=[
             Ref("CommentStatementSegment"),
         ],

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -3899,8 +3899,7 @@ class AnalyzeStatementSegment(BaseSegment):
 class StatementSegment(ansi.StatementSegment):
     """A generic segment, to any of its child subsegments."""
 
-    match_grammar = ansi.StatementSegment.match_grammar
-    parse_grammar = ansi.StatementSegment.parse_grammar.copy(
+    match_grammar = ansi.StatementSegment.match_grammar.copy(
         insert=[
             Ref("AlterDefaultPrivilegesStatementSegment"),
             Ref("DropOwnedStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2024,8 +2024,7 @@ class StatementSegment(postgres.StatementSegment):
 
     type = "statement"
 
-    match_grammar = postgres.StatementSegment.match_grammar
-    parse_grammar = postgres.StatementSegment.parse_grammar.copy(
+    match_grammar = postgres.StatementSegment.match_grammar.copy(
         insert=[
             Ref("CreateLibraryStatementSegment"),
             Ref("CreateGroupStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1071,16 +1071,11 @@ class WithinGroupClauseSegment(BaseSegment):
     """
 
     type = "withingroup_clause"
+
     match_grammar = Sequence(
         "WITHIN",
         "GROUP",
-        Bracketed(Anything(optional=True)),
-    )
-
-    parse_grammar = Sequence(
-        "WITHIN",
-        "GROUP",
-        Bracketed(Ref("OrderByClauseSegment", optional=True)),
+        Bracketed(Ref("OrderByClauseSegment", optional=True), parse_mode=ParseMode.GREEDY),
     )
 
 
@@ -1273,14 +1268,13 @@ class FromBeforeExpressionSegment(BaseSegment):
     """A BEFORE expression."""
 
     type = "from_before_expression"
-    match_grammar = Sequence("BEFORE", Bracketed(Anything()))
-
-    parse_grammar = Sequence(
+    match_grammar = Sequence(
         "BEFORE",
         Bracketed(
             OneOf("TIMESTAMP", "OFFSET", "STATEMENT"),
             Ref("ParameterAssignerSegment"),
             Ref("ExpressionSegment"),
+            parse_mode=ParseMode.GREEDY,
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -9,7 +9,6 @@ from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
     AnyNumberOf,
     AnySetOf,
-    Anything,
     BaseSegment,
     Bracketed,
     CodeSegment,
@@ -1075,7 +1074,9 @@ class WithinGroupClauseSegment(BaseSegment):
     match_grammar = Sequence(
         "WITHIN",
         "GROUP",
-        Bracketed(Ref("OrderByClauseSegment", optional=True), parse_mode=ParseMode.GREEDY),
+        Bracketed(
+            Ref("OrderByClauseSegment", optional=True), parse_mode=ParseMode.GREEDY
+        ),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -961,8 +961,7 @@ class FunctionDefinitionGrammar(ansi.FunctionDefinitionGrammar):
 class StatementSegment(ansi.StatementSegment):
     """A generic segment, to any of its child subsegments."""
 
-    match_grammar = ansi.StatementSegment.match_grammar
-    parse_grammar = ansi.StatementSegment.parse_grammar.copy(
+    match_grammar = ansi.StatementSegment.match_grammar.copy(
         insert=[
             Ref("AccessStatementSegment"),
             Ref("CreateStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_soql.py
+++ b/src/sqlfluff/dialects/dialect_soql.py
@@ -3,17 +3,17 @@
 https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm
 """
 
-from sqlfluff.dialects import dialect_ansi as ansi
+from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
     BaseSegment,
+    CodeSegment,
     OneOf,
     Ref,
-    Sequence,
     RegexLexer,
-    CodeSegment,
+    Sequence,
     TypedParser,
 )
-from sqlfluff.core.dialects import load_raw_dialect
+from sqlfluff.dialects import dialect_ansi as ansi
 
 ansi_dialect = load_raw_dialect("ansi")
 
@@ -129,4 +129,3 @@ class StatementSegment(ansi.StatementSegment):
     """
 
     match_grammar = Ref("SelectableGrammar")
-    parse_grammar = Ref("SelectableGrammar")

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -2493,8 +2493,7 @@ class UncacheTableSegment(BaseSegment):
 class StatementSegment(ansi.StatementSegment):
     """Overriding StatementSegment to allow for additional segment parsing."""
 
-    match_grammar = ansi.StatementSegment.match_grammar
-    parse_grammar = ansi.StatementSegment.parse_grammar.copy(
+    match_grammar = ansi.StatementSegment.match_grammar.copy(
         # Segments defined in Spark3 dialect
         insert=[
             # Data Definition Statements

--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -553,5 +553,3 @@ class StatementSegment(ansi.StatementSegment):
         Ref("UpdateStatementSegment"),
         Bracketed(Ref("StatementSegment")),
     )
-
-    parse_grammar = match_grammar

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -710,7 +710,7 @@ class StatementSegment(ansi.StatementSegment):
 
     type = "statement"
 
-    parse_grammar = ansi.StatementSegment.parse_grammar.copy(
+    match_grammar = ansi.StatementSegment.match_grammar.copy(
         insert=[
             Ref("TdCollectStatisticsStatementSegment"),
             Ref("BteqStatementSegment"),
@@ -722,8 +722,6 @@ class StatementSegment(ansi.StatementSegment):
             Ref("SetQueryBandStatementSegment"),
         ],
     )
-
-    match_grammar = ansi.StatementSegment.match_grammar.copy()
 
 
 class QualifyClauseSegment(BaseSegment):

--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -305,9 +305,8 @@ class SetOperatorSegment(BaseSegment):
 class StatementSegment(ansi.StatementSegment):
     """Overriding StatementSegment to allow for additional segment parsing."""
 
-    parse_grammar = ansi.StatementSegment.parse_grammar.copy(
+    match_grammar = ansi.StatementSegment.match_grammar.copy(
         remove=[
             Ref("TransactionStatementSegment"),
         ],
     )
-    match_grammar = ansi.StatementSegment.match_grammar

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -691,8 +691,6 @@ class SelectClauseElementSegment(ansi.SelectClauseElementSegment):
         ),
     )
 
-    parse_grammar = None
-
 
 class AltAliasExpressionSegment(BaseSegment):
     """An alternative alias clause as used by tsql using `=`."""
@@ -2752,7 +2750,6 @@ class PartitionClauseSegment(ansi.PartitionClauseSegment):
             )
         ),
     )
-    parse_grammar = None
 
 
 class OnPartitionsSegment(BaseSegment):
@@ -2946,8 +2943,6 @@ class CreateTableStatementSegment(BaseSegment):
         Ref("TableOptionSegment", optional=True),
         Ref("DelimiterGrammar", optional=True),
     )
-
-    parse_grammar = match_grammar
 
 
 class AlterTableStatementSegment(BaseSegment):

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -564,7 +564,7 @@ tsql_dialect.replace(
 class StatementSegment(ansi.StatementSegment):
     """Overriding StatementSegment to allow for additional segment parsing."""
 
-    match_grammar = ansi.StatementSegment.parse_grammar.copy(
+    match_grammar = ansi.StatementSegment.match_grammar.copy(
         insert=[
             Ref("IfExpressionStatement"),
             Ref("DeclareStatementSegment"),
@@ -616,8 +616,6 @@ class StatementSegment(ansi.StatementSegment):
             Ref("DescribeStatementSegment"),
         ],
     )
-
-    parse_grammar = match_grammar
 
 
 class GreaterThanOrEqualToSegment(ansi.CompositeComparisonOperatorSegment):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -118,7 +118,7 @@ def parse_example_file(dialect: str, sqlfile: str):
     raw = load_file(dialect, sqlfile)
     # Lex and parse the file
     tokens, _ = Lexer(config=config).lex(raw)
-    tree = Parser(config=config).parse(tokens)
+    tree = Parser(config=config).parse(tokens, fname=dialect + "/" + sqlfile)
     return tree
 
 

--- a/test/core/parser/grammar/grammar_other_test.py
+++ b/test/core/parser/grammar/grammar_other_test.py
@@ -102,10 +102,25 @@ def test__parser__grammar_greedyuntil_bracketed(bracket_seg_list, fresh_ansi_dia
     assert len(match.unmatched_segments) == 2
 
 
-def test__parser__grammar_anything(seg_list, fresh_ansi_dialect):
+@pytest.mark.parametrize(
+    "terminators,match_length",
+    [
+        # No terminators, full match.
+        ([], 6),
+        # If terminate with foo - match length 1.
+        (["foo"], 1),
+        # If terminate with foof - unterminated. Match everything
+        (["foof"], 6),
+    ],
+)
+def test__parser__grammar_anything(
+    terminators, match_length, seg_list, fresh_ansi_dialect
+):
     """Test the Anything grammar."""
     ctx = ParseContext(dialect=fresh_ansi_dialect)
-    assert Anything().match(seg_list, parse_context=ctx)
+    terms = [StringParser(kw, KeywordSegment) for kw in terminators]
+    result = Anything(terminators=terms).match(seg_list, parse_context=ctx)
+    assert len(result) == match_length
 
 
 def test__parser__grammar_nothing(seg_list, fresh_ansi_dialect):

--- a/test/dialects/ansi_test.py
+++ b/test/dialects/ansi_test.py
@@ -1,7 +1,8 @@
 """Tests specific to the ansi dialect."""
 
-import pytest
 import logging
+
+import pytest
 
 from sqlfluff.core import FluffConfig, Linter
 from sqlfluff.core.parser import Lexer
@@ -163,12 +164,12 @@ def test__dialect__ansi_specific_segment_not_match(
         ("SELECT 1 + (2 ", [(1, 12)]),
         # Set expression with inappropriate ORDER BY or LIMIT. Error
         # raised on the UNION.
-        ("SELECT * FROM a ORDER BY 1 UNION SELECT * FROM b", [(1, 27)]),
-        ("SELECT * FROM a LIMIT 1 UNION SELECT * FROM b", [(1, 24)]),
-        ("SELECT * FROM a ORDER BY 1 LIMIT 1 UNION SELECT * FROM b", [(1, 35)]),
+        ("SELECT * FROM a ORDER BY 1 UNION SELECT * FROM b", [(1, 28)]),
+        ("SELECT * FROM a LIMIT 1 UNION SELECT * FROM b", [(1, 25)]),
+        ("SELECT * FROM a ORDER BY 1 LIMIT 1 UNION SELECT * FROM b", [(1, 36)]),
     ],
 )
-def test__dialect__ansi_specific_segment_not_parse(raw, err_locations, caplog):
+def test__dialect__ansi_specific_segment_not_parse(raw, err_locations):
     """Test queries do not parse, with parsing errors raised properly."""
     lnt = Linter(dialect="ansi")
     parsed = lnt.parse_string(raw)


### PR DESCRIPTION
This is another step on #5124.

It only adds a little more functionality (making the `Anything()` grammar terminator aware), but mostly cleans out a bunch of grammars using `parse_grammar` following #5167.

In particular it removes `parse_grammar` from `StatementSegment` (and all the dialect versions of that). That one didn't need any special features to remove now that we're part way through the work.

After this I believe that the only remaining parse grammars are in the bigquery dialect, which will need a little more work.