### PR TITLE
Parse modes for `AnyNumberOf`

### DIFF
--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -11,14 +11,53 @@ from sqlfluff.core.parser.grammar.base import (
 )
 from sqlfluff.core.parser.grammar.sequence import Bracketed, Sequence
 from sqlfluff.core.parser.helpers import trim_non_code_segments
+from sqlfluff.core.parser.match_algorithms import greedy_match
 from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.match_wrapper import match_wrapper
-from sqlfluff.core.parser.segments import BaseSegment
-from sqlfluff.core.parser.types import MatchableType, SimpleHintType
+from sqlfluff.core.parser.segments import BaseSegment, UnparsableSegment
+from sqlfluff.core.parser.types import MatchableType, ParseMode, SimpleHintType
+
+
+def _parse_mode_match_result(
+    matched_segments,
+    unmatched_segments,
+    tail,
+    parse_mode,
+) -> MatchResult:
+    # If we're being strict, just return.
+    if parse_mode == ParseMode.STRICT:
+        return MatchResult(matched_segments, unmatched_segments + tail)
+
+    # Nothing in unmatched anyway?
+    if not unmatched_segments or all(not s.is_code for s in unmatched_segments):
+        return MatchResult(matched_segments, unmatched_segments + tail)
+
+    _trim_idx = 0
+    for _trim_idx in range(len(unmatched_segments)):
+        if unmatched_segments[_trim_idx].is_code:
+            break
+
+    # Create an unmatched segment
+    _expected = "Nothing else"
+    if tail:
+        _expected += f" before {tail[0].raw!r}"
+
+    unmatched_seg = UnparsableSegment(
+        unmatched_segments[_trim_idx:], expected=_expected
+    )
+    return MatchResult(
+        matched_segments + unmatched_segments[:_trim_idx] + (unmatched_seg,),
+        tail,
+    )
 
 
 class AnyNumberOf(BaseGrammar):
     """A more configurable version of OneOf."""
+
+    supported_parse_modes = {
+        ParseMode.STRICT,
+        ParseMode.GREEDY,
+    }
 
     def __init__(
         self,
@@ -31,6 +70,7 @@ class AnyNumberOf(BaseGrammar):
         reset_terminators: bool = False,
         allow_gaps: bool = True,
         optional: bool = False,
+        parse_mode: ParseMode = ParseMode.STRICT,
     ) -> None:
         self.max_times = max_times
         self.min_times = min_times
@@ -43,6 +83,7 @@ class AnyNumberOf(BaseGrammar):
             optional=optional,
             terminators=terminators,
             reset_terminators=reset_terminators,
+            parse_mode=parse_mode,
         )
 
     @cached_method_for_parse_context
@@ -117,31 +158,51 @@ class AnyNumberOf(BaseGrammar):
                 if self.exclude.match(segments, ctx):
                     return MatchResult.from_unmatched(segments)
 
-        # Match on each of the options
         matched_segments: MatchResult = MatchResult.from_empty()
         unmatched_segments: Tuple[BaseSegment, ...] = segments
-        n_matches = 0
+        tail: Tuple[BaseSegment, ...] = ()
+
+        # Secondly, if we're in a greedy mode, handle that first.
+        if self.parse_mode == ParseMode.GREEDY:
+            _terminators = [*self.terminators, *parse_context.terminators]
+            _term_match = greedy_match(
+                segments,
+                parse_context,
+                matchers=_terminators,
+            )
+            if _term_match:
+                # If we found a terminator, trim off the tail of the available
+                # segments to match on.
+                unmatched_segments = _term_match.matched_segments
+                tail = _term_match.unmatched_segments
 
         # Keep track of the number of times each option has been matched.
+        n_matches = 0
         option_counter = {elem.cache_key(): 0 for elem in self._elements}
 
         while True:
             if self.max_times and n_matches >= self.max_times:
                 # We've matched as many times as we can
-                return MatchResult(
-                    matched_segments.matched_segments, unmatched_segments
+                return _parse_mode_match_result(
+                    matched_segments.matched_segments,
+                    unmatched_segments,
+                    tail,
+                    self.parse_mode,
                 )
 
             # Is there anything left to match?
             if len(unmatched_segments) == 0:
                 # No...
                 if n_matches >= self.min_times:
-                    return MatchResult(
-                        matched_segments.matched_segments, unmatched_segments
+                    return _parse_mode_match_result(
+                        matched_segments.matched_segments,
+                        unmatched_segments,
+                        tail,
+                        self.parse_mode,
                     )
                 else:  # pragma: no cover TODO?
                     # We didn't meet the hurdle
-                    return MatchResult.from_unmatched(unmatched_segments)
+                    return MatchResult.from_unmatched(segments)
 
             # If we've already matched once...
             if n_matches > 0 and self.allow_gaps:
@@ -165,8 +226,11 @@ class AnyNumberOf(BaseGrammar):
                         self.max_times_per_element
                         and option_counter[matched_key] > self.max_times_per_element
                     ):
-                        return MatchResult(
-                            matched_segments.matched_segments, unmatched_segments
+                        return _parse_mode_match_result(
+                            matched_segments.matched_segments,
+                            pre_seg + unmatched_segments,
+                            tail,
+                            self.parse_mode,
                         )
 
             if match:
@@ -178,12 +242,22 @@ class AnyNumberOf(BaseGrammar):
                 # unmatched segments are meaningful, i.e. they're not what we're
                 # looking for.
                 if n_matches >= self.min_times:
-                    return MatchResult(
-                        matched_segments.matched_segments, pre_seg + unmatched_segments
+                    return _parse_mode_match_result(
+                        matched_segments.matched_segments,
+                        pre_seg + unmatched_segments,
+                        tail,
+                        self.parse_mode,
                     )
                 else:
                     # We didn't meet the hurdle
-                    return MatchResult.from_unmatched(unmatched_segments)
+                    return _parse_mode_match_result(
+                        (),
+                        matched_segments.matched_segments
+                        + pre_seg
+                        + unmatched_segments,
+                        tail,
+                        self.parse_mode,
+                    )
 
 
 class OneOf(AnyNumberOf):
@@ -201,6 +275,7 @@ class OneOf(AnyNumberOf):
         reset_terminators: bool = False,
         allow_gaps: bool = True,
         optional: bool = False,
+        parse_mode: ParseMode = ParseMode.STRICT,
     ) -> None:
         super().__init__(
             *args,
@@ -211,6 +286,7 @@ class OneOf(AnyNumberOf):
             reset_terminators=reset_terminators,
             allow_gaps=allow_gaps,
             optional=optional,
+            parse_mode=parse_mode,
         )
 
 
@@ -228,6 +304,7 @@ class OptionallyBracketed(OneOf):
         terminators: SequenceType[Union[MatchableType, str]] = (),
         reset_terminators: bool = False,
         optional: bool = False,
+        parse_mode: ParseMode = ParseMode.STRICT,
     ) -> None:
         super().__init__(
             Bracketed(*args),
@@ -237,6 +314,7 @@ class OptionallyBracketed(OneOf):
             terminators=terminators,
             reset_terminators=reset_terminators,
             optional=optional,
+            parse_mode=parse_mode,
         )
 
 
@@ -253,6 +331,7 @@ class AnySetOf(AnyNumberOf):
         reset_terminators: bool = False,
         allow_gaps: bool = True,
         optional: bool = False,
+        parse_mode: ParseMode = ParseMode.STRICT,
     ) -> None:
         super().__init__(
             *args,
@@ -264,4 +343,5 @@ class AnySetOf(AnyNumberOf):
             reset_terminators=reset_terminators,
             allow_gaps=allow_gaps,
             optional=optional,
+            parse_mode=parse_mode,
         )

--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -19,11 +19,16 @@ from sqlfluff.core.parser.types import MatchableType, ParseMode, SimpleHintType
 
 
 def _parse_mode_match_result(
-    matched_segments,
-    unmatched_segments,
-    tail,
-    parse_mode,
+    matched_segments: Tuple[BaseSegment, ...],
+    unmatched_segments: Tuple[BaseSegment, ...],
+    tail: Tuple[BaseSegment, ...],
+    parse_mode: ParseMode,
 ) -> MatchResult:
+    """A helper function for the return values of AnyNumberOf.
+
+    This method creates UnparsableSegments as appropriate
+    depending on the parse mode and return values.
+    """
     # If we're being strict, just return.
     if parse_mode == ParseMode.STRICT:
         return MatchResult(matched_segments, unmatched_segments + tail)

--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -257,7 +257,7 @@ class BaseGrammar(Matchable):
         # Prune available options, based on their simple representation for efficiency.
         # NOTE: We're also passing in terminators as options.
         available_options = prune_options(
-            (*matchers, *parse_context.terminators),
+            matchers,
             segments,
             parse_context=parse_context,
         )
@@ -318,11 +318,6 @@ class BaseGrammar(Matchable):
             # No match. Skip this one.
             if not res_match:
                 continue
-
-            # If there's a match but it's a terminator, we're done.
-            if matcher in parse_context.terminators:
-                # We hit a terminator. No match.
-                return MatchResult.from_unmatched(segments), None
 
             if res_match.is_complete():
                 # Just return it! (WITH THE RIGHT OTHER STUFF)

--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -255,8 +255,11 @@ class BaseGrammar(Matchable):
             return MatchResult.from_unmatched(segments), None
 
         # Prune available options, based on their simple representation for efficiency.
+        # NOTE: We're also passing in terminators as options.
         available_options = prune_options(
-            matchers, segments, parse_context=parse_context
+            (*matchers, *parse_context.terminators),
+            segments,
+            parse_context=parse_context,
         )
 
         # If we've pruned all the options, return no match
@@ -271,9 +274,6 @@ class BaseGrammar(Matchable):
         # than only being used in a per-grammar basis.
         if parse_context.terminators:
             parse_context.increment("ltm_calls_w_ctx_terms")
-            terminators = parse_context.terminators
-        else:
-            terminators = ()
 
         # If gaps are allowed, trim the ends.
         if trim_noncode:
@@ -315,6 +315,15 @@ class BaseGrammar(Matchable):
                 # Cache it for later to for performance.
                 parse_context.put_parse_cache(loc_key, matcher_key, res_match)
 
+            # No match. Skip this one.
+            if not res_match:
+                continue
+
+            # If there's a match but it's a terminator, we're done.
+            if matcher in parse_context.terminators:
+                # We hit a terminator. No match.
+                return MatchResult.from_unmatched(segments), None
+
             if res_match.is_complete():
                 # Just return it! (WITH THE RIGHT OTHER STUFF)
                 parse_context.increment("complete_match")
@@ -342,11 +351,11 @@ class BaseGrammar(Matchable):
                         # We're going to end anyway, so we can skip that step.
                         terminated = True
                         break
-                    elif terminators:
+                    elif parse_context.terminators:
                         _, segs, _ = trim_non_code_segments(
                             best_match[0].unmatched_segments
                         )
-                        for terminator in terminators:
+                        for terminator in parse_context.terminators:
                             terminator_match: MatchResult = terminator.match(
                                 segs, parse_context
                             )

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -638,7 +638,7 @@ class LoopStatementsSegment(BaseSegment):
             ),
             Ref("DelimiterGrammar"),
         ),
-        terminators=["END", "LOOP"],
+        terminators=[Sequence("END", "LOOP")],
         parse_mode=ParseMode.GREEDY,
     )
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -17,7 +17,6 @@ from sqlfluff.core.parser import (
     CodeSegment,
     Dedent,
     Delimited,
-    GreedyUntil,
     Indent,
     Matchable,
     MultiStringParser,

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -488,8 +488,7 @@ class ForInStatementsSegment(BaseSegment):
     """
 
     type = "for_in_statements"
-    match_grammar = GreedyUntil(Sequence("END", "FOR"))
-    parse_grammar = AnyNumberOf(
+    match_grammar = AnyNumberOf(
         Sequence(
             OneOf(
                 Ref("StatementSegment"),
@@ -497,6 +496,8 @@ class ForInStatementsSegment(BaseSegment):
             ),
             Ref("DelimiterGrammar"),
         ),
+        terminators=[Sequence("END", "FOR")],
+        parse_mode=ParseMode.GREEDY,
     )
 
 
@@ -530,8 +531,7 @@ class RepeatStatementsSegment(BaseSegment):
     """
 
     type = "repeat_statements"
-    match_grammar = GreedyUntil(Ref.keyword("UNTIL"))
-    parse_grammar = AnyNumberOf(
+    match_grammar = AnyNumberOf(
         Sequence(
             OneOf(
                 Ref("StatementSegment"),
@@ -539,6 +539,8 @@ class RepeatStatementsSegment(BaseSegment):
             ),
             Ref("DelimiterGrammar"),
         ),
+        terminators=["UNTIL"],
+        parse_mode=ParseMode.GREEDY,
     )
 
 
@@ -568,8 +570,7 @@ class IfStatementsSegment(BaseSegment):
     """
 
     type = "if_statements"
-    match_grammar = GreedyUntil(OneOf("ELSE", "ELSEIF", Sequence("END", "IF")))
-    parse_grammar = AnyNumberOf(
+    match_grammar = AnyNumberOf(
         Sequence(
             OneOf(
                 Ref("StatementSegment"),
@@ -577,6 +578,12 @@ class IfStatementsSegment(BaseSegment):
             ),
             Ref("DelimiterGrammar"),
         ),
+        terminators=[
+            "ELSE",
+            "ELSEIF",
+            Sequence("END", "IF"),
+        ],
+        parse_mode=ParseMode.GREEDY,
     )
 
 
@@ -623,8 +630,7 @@ class LoopStatementsSegment(BaseSegment):
     """
 
     type = "loop_statements"
-    match_grammar = GreedyUntil(Sequence("END", "LOOP"))
-    parse_grammar = AnyNumberOf(
+    match_grammar = AnyNumberOf(
         Sequence(
             OneOf(
                 Ref("StatementSegment"),
@@ -632,6 +638,8 @@ class LoopStatementsSegment(BaseSegment):
             ),
             Ref("DelimiterGrammar"),
         ),
+        terminators=["END", "LOOP"],
+        parse_mode=ParseMode.GREEDY,
     )
 
 
@@ -659,12 +667,13 @@ class WhileStatementsSegment(BaseSegment):
     """
 
     type = "while_statements"
-    match_grammar = GreedyUntil(Sequence("END", "WHILE"))
-    parse_grammar = AnyNumberOf(
+    match_grammar = AnyNumberOf(
         Sequence(
             Ref("StatementSegment"),
             Ref("DelimiterGrammar"),
         ),
+        terminators=[Sequence("END", "WHILE")],
+        parse_mode=ParseMode.GREEDY,
     )
 
 
@@ -1735,8 +1744,11 @@ class PivotForClauseSegment(BaseSegment):
     """
 
     type = "pivot_for_clause"
-    match_grammar = GreedyUntil("IN")
-    parse_grammar = Ref("BaseExpressionElementGrammar")
+    match_grammar = Sequence(
+        Ref("BaseExpressionElementGrammar"),
+        terminators=["IN"],
+        parse_mode=ParseMode.GREEDY,
+    )
 
 
 class FromPivotExpressionSegment(BaseSegment):
@@ -2084,12 +2096,13 @@ class ProcedureStatements(BaseSegment):
     """
 
     type = "procedure_statements"
-    match_grammar = GreedyUntil("END")
-    parse_grammar = AnyNumberOf(
+    match_grammar = AnyNumberOf(
         Sequence(
             Ref("StatementSegment"),
             Ref("DelimiterGrammar"),
         ),
+        terminators=["END"],
+        parse_mode=ParseMode.GREEDY,
     )
 
 

--- a/test/core/parser/grammar/grammar_anyof_test.py
+++ b/test/core/parser/grammar/grammar_anyof_test.py
@@ -175,15 +175,6 @@ def test__parser__grammar_anysetof(generate_test_segments):
             {"max_times": 1},
             (("keyword", "a"),),
         ),
-        # 5. Terminated match
-        (
-            ParseMode.STRICT,
-            ["b", "a"],
-            ["b"],
-            slice(None, None),
-            {},
-            (("keyword", "a"),),
-        ),
         # #####
         # Greedy matches
         # #####
@@ -205,7 +196,7 @@ def test__parser__grammar_anysetof(generate_test_segments):
             {},
             (("unparsable", (("raw", "a"),)),),
         ),
-        # 2. Terminated, but not matching the first element.
+        # 3. Terminated, but only a partial match.
         (
             ParseMode.GREEDY,
             ["a"],


### PR DESCRIPTION
Another step on #5124 .

Combined with #5186 , this removes the last parts of `parse_grammar` (apart from the `FileSegment` which is the final puzzle piece and will come last). We do this by adding greedy support to `AnyNumberOf` (and therefore to `OneOf` and all the other similar grammars).

Interestingly, most of the effects of this are in the `bigquery` dialect.