### PR TITLE
Consistency check in root parse

### DIFF
--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -376,6 +376,8 @@ class Sequence(BaseGrammar):
 
         # If we're in a test environment, we do a sense check to make sure we
         # haven't dropped anything. (Because it's happened before!).
+        # NOTE: This adds an overhead to do on _every_ sequence match so we
+        # only do it here within the test environment.
         if self.test_env:
             check_still_complete(
                 segments,

--- a/src/sqlfluff/core/parser/parser.py
+++ b/src/sqlfluff/core/parser/parser.py
@@ -45,7 +45,7 @@ class Parser:
         parsed = root_segment.parse(parse_context=ctx)
 
         # Basic Validation, that we haven't dropped anything.
-        check_still_complete(segments, parsed, ())
+        check_still_complete(tuple(segments), parsed, ())
 
         if parse_statistics:  # pragma: no cover
             # NOTE: We use ctx.logger.warning here to output the statistics.

--- a/src/sqlfluff/core/parser/parser.py
+++ b/src/sqlfluff/core/parser/parser.py
@@ -45,7 +45,7 @@ class Parser:
         parsed = root_segment.parse(parse_context=ctx)
 
         # Basic Validation, that we haven't dropped anything.
-        check_still_complete(segments, (root,), ())
+        check_still_complete(segments, parsed, ())
 
         if parse_statistics:  # pragma: no cover
             # NOTE: We use ctx.logger.warning here to output the statistics.

--- a/src/sqlfluff/core/parser/parser.py
+++ b/src/sqlfluff/core/parser/parser.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional, Sequence, Type
 
 from sqlfluff.core.config import FluffConfig
 from sqlfluff.core.parser.context import ParseContext
+from sqlfluff.core.parser.helpers import check_still_complete
 
 if TYPE_CHECKING:  # pragma: no cover
     from sqlfluff.core.parser.segments import BaseFileSegment, BaseSegment
@@ -42,6 +43,9 @@ class Parser:
         # instantiation.
         ctx = ParseContext.from_config(config=self.config)
         parsed = root_segment.parse(parse_context=ctx)
+
+        # Basic Validation, that we haven't dropped anything.
+        check_still_complete(segments, (root,), ())
 
         if parse_statistics:  # pragma: no cover
             # NOTE: We use ctx.logger.warning here to output the statistics.

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -40,7 +40,7 @@ from tqdm import tqdm
 from sqlfluff.core.cached_property import cached_property
 from sqlfluff.core.config import progress_bar_configuration
 from sqlfluff.core.parser.context import ParseContext
-from sqlfluff.core.parser.helpers import check_still_complete, trim_non_code_segments
+from sqlfluff.core.parser.helpers import trim_non_code_segments
 from sqlfluff.core.parser.markers import PositionMarker
 from sqlfluff.core.parser.match_logging import parse_match_logging
 from sqlfluff.core.parser.match_result import MatchResult
@@ -470,8 +470,6 @@ class BaseSegment(metaclass=SegmentMetaclass):
             parse_context.logger.info(frame_msg(parse_depth_msg))
             expanded_segments += stmt.parse(parse_context=parse_context)
 
-        # Basic Validation
-        check_still_complete(segments, expanded_segments, ())
         return expanded_segments
 
     @classmethod
@@ -1262,9 +1260,6 @@ class BaseSegment(metaclass=SegmentMetaclass):
             # NOTE: No match_depth kwarg, because this is the start of the matching.
             with parse_context.deeper_match(name=self.__class__.__name__) as ctx:
                 m = parse_grammar.match(segments=segments, parse_context=ctx)
-
-            # Basic Validation, that we haven't dropped anything.
-            check_still_complete(segments, m.matched_segments, m.unmatched_segments)
 
             if m.has_match():
                 if m.is_complete():


### PR DESCRIPTION
Some of our internal consistency checks only work if there's a `parse_grammar`. This obviously presents some issues because these won't _fail_ anymore, but that means they also don't actually work.

This is the first of a few of these changes (all relating to #5124). Starting with an easy one to make sure we haven't dropped anything when we get to the _end_ of the parsing process. This replaces a check that otherwise happened deeper in the parsing process.