### PR TITLE
PR Comment action

### DIFF
--- a/.github/workflows/ci-pr-comments.yml
+++ b/.github/workflows/ci-pr-comments.yml
@@ -16,11 +16,9 @@ on:
 jobs:
   upload:
     runs-on: ubuntu-latest
-    #if: >
-    #  github.event.workflow_run.event == 'pull_request'
+    if: >
+      github.event.workflow_run.event == 'pull_request'
     steps:
-      - run: echo "foo  ${{github.event.workflow_run.event}}"
-
       - name: 'Download txt artifact'
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/ci-pr-comments.yml
+++ b/.github/workflows/ci-pr-comments.yml
@@ -1,0 +1,111 @@
+# This Workflow runs in a more secure context and comments
+# on pull requests.
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+name: Comment on the pull request
+
+# Run on completion of the CI job.
+# This workflow has access to write comments on PRs event when
+# that PR is triggered by a forked repo.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: 'Download txt artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "txt-report"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/cov-report.txt', Buffer.from(download.data));
+      
+      # MAYBE NEED TO UNZIP?
+      
+      - name: Update PR comment with coverage report.
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // First list the existing comments
+            const trigger_str = 'Coverage Results';
+            console.log("Getting existing comments...");
+
+            const issue_number = context.issue.number;
+            console.log("Issue number: " + issue_number);
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: 'sqlfluff',
+                repo: 'sqlfluff',
+                issue_number: issue_number
+              }
+            );
+
+            let comment_id = null;
+            console.log("Got %d comments", comments.length);
+
+            comments.forEach(comment => {
+              if (comment.body.indexOf(trigger_str) >= 0) {
+                console.log("Found target comment ID: %d", comment.id);
+                comment_id = comment.id;
+              } else {
+                console.log("Comment ID %d not valid with body:\n%s.", comment.id, comment.body);
+              }
+            });
+
+            const previous_outcome = "${{ steps.report_coverage.outcome }}";
+            console.log("Previous coverage step outcome: %s", previous_outcome);
+            if (previous_outcome == "success") {
+              status_emoji = "✅";
+            } else {
+              status_emoji = "⚠️";
+            }
+
+            const { promises: fs } = require('fs');
+            const content = await fs.readFile('cov-report.txt', 'utf8');
+            body = "# " + trigger_str + " " + status_emoji + "\n```\n" + content + "\n```\n";
+
+            try {
+              if (comment_id > 0) {
+                console.log("Updating comment id: %d", comment_id);
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: comment_id,
+                  body: body
+                });
+              } else {
+                console.log("No existing comment matched, creating a new one...");
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: body
+                });
+              }
+            } catch(err) {
+              // NOTE: This shouldn't happen, but has in the past.
+              console.log("Failed to create/update comment. Skipping...", err);
+            }
+

--- a/.github/workflows/ci-pr-comments.yml
+++ b/.github/workflows/ci-pr-comments.yml
@@ -16,10 +16,10 @@ on:
 jobs:
   upload:
     runs-on: ubuntu-latest
-    if: >
-      github.event.workflow_run.event == 'pull_request'
+    #if: >
+    #  github.event.workflow_run.event == 'pull_request'
     steps:
-      - run: echo "foo"
+      - run: echo "foo  ${{github.event.workflow_run.event}}"
 
       - name: 'Download txt artifact'
         uses: actions/github-script@v6

--- a/.github/workflows/ci-pr-comments.yml
+++ b/.github/workflows/ci-pr-comments.yml
@@ -40,9 +40,10 @@ jobs:
                archive_format: 'zip',
             });
             var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/cov-report.txt', Buffer.from(download.data));
+            fs.writeFileSync('${{github.workspace}}/cov-report.zip', Buffer.from(download.data));
 
-      # MAYBE NEED TO UNZIP?
+      - name: Unzip Downloaded Artifact
+        run: unzip cov-report.zip
 
       - name: Update PR comment with coverage report.
         uses: actions/github-script@v6

--- a/.github/workflows/ci-pr-comments.yml
+++ b/.github/workflows/ci-pr-comments.yml
@@ -8,7 +8,8 @@ name: Comment on the pull request
 # that PR is triggered by a forked repo.
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows:
+      - CI
     types:
       - completed
 
@@ -18,6 +19,8 @@ jobs:
     if: >
       github.event.workflow_run.event == 'pull_request'
     steps:
+      - run: echo "foo"
+
       - name: 'Download txt artifact'
         uses: actions/github-script@v6
         with:
@@ -38,9 +41,9 @@ jobs:
             });
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/cov-report.txt', Buffer.from(download.data));
-      
+
       # MAYBE NEED TO UNZIP?
-      
+
       - name: Update PR comment with coverage report.
         uses: actions/github-script@v6
         with:
@@ -108,4 +111,3 @@ jobs:
               // NOTE: This shouldn't happen, but has in the past.
               console.log("Failed to create/update comment. Skipping...", err);
             }
-

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -8,16 +8,15 @@
 # (images, markdown files, )
 #
 name: CI
+
 on:
   workflow_dispatch:
   schedule:
     # 2am each night
     - cron: '00 2 * * *'
-  # We use pull_request_target rather than pull_request, because the
-  # former runs in the context of the base project (rather than a potentially
-  # forked repo) and has slightly more permissions. That allows us to update
-  # comments on the pull request.
-  pull_request_target:
+  # Don't use pull_request_target here. See:
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request:
   push:
     branches:
       - main
@@ -378,73 +377,13 @@ jobs:
           name: html-report
           path: htmlcov
         if: failure() && github.event_name == 'pull_request'
-
-      - name: Update PR comment with coverage report.
-        uses: actions/github-script@v6
-        # Run even if the coverage step failed.
-        if: always() && github.event_name == 'pull_request'
+      
+      - name: Upload TXT report always (to add as comment to PR).
+        # NOTE: We don't actually comment on the PR from here, we'll do that in
+        # a more secure way by triggering a more secure workflow.
+        # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+        uses: actions/upload-artifact@v2
         with:
-          script: |
-            // First list the existing comments
-            const trigger_str = 'Coverage Results';
-            console.log("Getting existing comments...");
-
-            const issue_number = context.issue.number;
-            console.log("Issue number: " + issue_number);
-
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              {
-                owner: 'sqlfluff',
-                repo: 'sqlfluff',
-                issue_number: issue_number
-              }
-            );
-
-            let comment_id = null;
-            console.log("Got %d comments", comments.length);
-
-            comments.forEach(comment => {
-              if (comment.body.indexOf(trigger_str) >= 0) {
-                console.log("Found target comment ID: %d", comment.id);
-                comment_id = comment.id;
-              } else {
-                console.log("Comment ID %d not valid with body:\n%s.", comment.id, comment.body);
-              }
-            });
-
-            const previous_outcome = "${{ steps.report_coverage.outcome }}";
-            console.log("Previous coverage step outcome: %s", previous_outcome);
-            if (previous_outcome == "success") {
-              status_emoji = "✅";
-            } else {
-              status_emoji = "⚠️";
-            }
-
-            const { promises: fs } = require('fs');
-            const content = await fs.readFile('coverage-report.txt', 'utf8');
-            body = "# " + trigger_str + " " + status_emoji + "\n```\n" + content + "\n```\n";
-
-            try {
-              if (comment_id > 0) {
-                console.log("Updating comment id: %d", comment_id);
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: comment_id,
-                  body: body
-                });
-              } else {
-                console.log("No existing comment matched, creating a new one...");
-                await github.rest.issues.createComment({
-                  issue_number: context.issue.number,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  body: body
-                });
-              }
-            } catch(err) {
-              // NOTE: This is most likely if the PR is opened from a branch
-              // of a forked repo.
-              console.log("Failed to create/update comment. Skipping...");
-            }
+          name: txt-report
+          path: coverage-report.txt
+        if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -377,7 +377,7 @@ jobs:
           name: html-report
           path: htmlcov
         if: failure() && github.event_name == 'pull_request'
-      
+
       - name: Upload TXT report always (to add as comment to PR).
         # NOTE: We don't actually comment on the PR from here, we'll do that in
         # a more secure way by triggering a more secure workflow.

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -382,7 +382,7 @@ jobs:
         # NOTE: We don't actually comment on the PR from here, we'll do that in
         # a more secure way by triggering a more secure workflow.
         # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: txt-report
           path: coverage-report.txt

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -13,7 +13,11 @@ on:
   schedule:
     # 2am each night
     - cron: '00 2 * * *'
-  pull_request:
+  # We use pull_request_target rather than pull_request, because the
+  # former runs in the context of the base project (rather than a potentially
+  # forked repo) and has slightly more permissions. That allows us to update
+  # comments on the pull request.
+  pull_request_target:
   push:
     branches:
       - main


### PR DESCRIPTION
As discussed by myself and @greg-finley - we think this should fix the issue people see when staging external PRs and the new coverage commenter failing.

Relates to #5188 .

This follows advice from https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

Unfortunately (or perhaps fortunately?), I don't think this will trigger until _after_ the PR is merged. So I think we'll have to test in prod 🤷 . I'll keep an eye on it post merge and we can always revisit if it fails at that point.