### PR TITLE
Cache python dependencies in GHA

### DIFF
--- a/.github/workflows/ci-test-dbt.yml
+++ b/.github/workflows/ci-test-dbt.yml
@@ -58,6 +58,11 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
+        cache: 'pip'
+        cache-dependency-path: |
+          setup.cfg
+          requirements.txt
+          requirements_dev.txt
 
     - name: Install dependencies
       run: pip install tox

--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -40,6 +40,11 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
+        cache: 'pip'
+        cache-dependency-path: |
+          setup.cfg
+          requirements.txt
+          requirements_dev.txt
 
     - name: Install dependencies
       run: pip install tox


### PR DESCRIPTION
Does what it says on the tin. Hopefully should improve CI runtimes somewhat.