### PR TITLE
Revise segment whitespace validation

### DIFF
--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -169,8 +169,9 @@ class Delimited(OneOf):
                 )
 
             if not match:
-                matched_segments += pre_non_code
-                unmatched_segments = match.unmatched_segments + post_non_code
+                unmatched_segments = (
+                    pre_non_code + match.unmatched_segments + post_non_code
+                )
                 break
 
             if seeking_delimiter:

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1499,7 +1499,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
 
         # Rather than fix that here, we simply assert that it has been
         # done. This will raise issues in testing, but shouldn't in use.
-        if not r.can_start_end_non_code and seg_buffer:
+        if not self.can_start_end_non_code and seg_buffer:
             assert self._find_start_or_end_non_code(seg_buffer) is None, (
                 "Found inappropriate fix application: inappropriate "
                 "whitespace positioning. Post `_choose_anchor_segment`. \n\n"

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1500,7 +1500,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
         # Rather than fix that here, we simply assert that it has been
         # done. This will raise issues in testing, but shouldn't in use.
         if not r.can_start_end_non_code and seg_buffer:
-            assert not self._find_start_or_end_non_code(seg_buffer), (
+            assert self._find_start_or_end_non_code(seg_buffer) is None, (
                 "Found inappropriate fix application: inappropriate "
                 "whitespace positioning. Post `_choose_anchor_segment`. "
                 "Please report this issue on GitHub with your SQL query. "

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -185,6 +185,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
         # Tracker for matching when things start moving.
         self.uuid = uuid or uuid4()
 
+        self.set_as_parent(recurse=False)
         self.validate_non_code_ends()
         self._recalculate_caches()
 
@@ -1508,9 +1509,6 @@ class BaseSegment(metaclass=SegmentMetaclass):
             seg_buffer.extend(pre)
             seg_buffer.append(s)
             seg_buffer.extend(post)
-            # Set parents of any ejected segments:
-            for s in (*pre, *post):
-                s.set_parent(self)
             # If we fail to validate a child segment, make sure to validate this
             # segment.
             if not validated:
@@ -1558,7 +1556,6 @@ class BaseSegment(metaclass=SegmentMetaclass):
             if hasattr(err, "add_note"):
                 err.add_note(f" After applying fixes: {fixes_applied}.")
             raise err
-        new_seg.set_as_parent(recurse=False)
 
         # Only validate if there's a match_grammar. Otherwise we may get
         # strange results (for example with the BracketedSegment).

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1548,7 +1548,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
                 # Pass through any additional kwargs
                 **{k: getattr(self, k) for k in self.additional_kwargs},
             )
-        except AssertionError as err:
+        except AssertionError as err:  # pragma: no cover
             # An AssertionError on creating a new segment is likely a whitespace
             # check fail. If possible add information about the fixes we tried to
             # apply, before re-raising.

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1375,7 +1375,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
         """
         if self.can_start_end_non_code:
             return None
-        if not self.segments:
+        if not self.segments:  # pragma: no cover
             return None
         assert self._is_code_or_meta(self.segments[0]), (
             f"Segment {self} starts with whitespace segment: "

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1502,7 +1502,9 @@ class BaseSegment(metaclass=SegmentMetaclass):
         if not r.can_start_end_non_code and seg_buffer:
             assert self._find_start_or_end_non_code(seg_buffer) is None, (
                 "Found inappropriate fix application: inappropriate "
-                "whitespace positioning. Post `_choose_anchor_segment`. "
+                "whitespace positioning. Post `_choose_anchor_segment`. \n\n"
+                f"{self}\n{fixes_applied}\n\n"
+                f"{[(s.type, s.raw) for s in seg_buffer]}\n\n"
                 "Please report this issue on GitHub with your SQL query. "
             )
 

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1299,14 +1299,19 @@ class BaseSegment(metaclass=SegmentMetaclass):
                     # Incomplete match.
                     # For now this means the parsing has failed. Lets add the unmatched
                     # bit at the end as something unparsable.
-                    # TODO: Do something more intelligent here.
+                    # NOTE: Don't claim any additional whitespace in the failed match.
+                    _idx = 0
+                    for _idx in range(len(m.unmatched_segments)):
+                        if m.unmatched_segments[_idx].is_code:
+                            break
                     self.segments = (
                         pre_nc
                         + m.matched_segments
+                        + m.unmatched_segments[:_idx]
                         + (
                             UnparsableSegment(
-                                segments=m.unmatched_segments + post_nc,
-                                expected="Nothing...",
+                                segments=m.unmatched_segments[_idx:] + post_nc,
+                                expected=f"Nothing else within {self.__class__.__name__}",
                             ),
                         )
                     )
@@ -1797,6 +1802,8 @@ class UnparsableSegment(BaseSegment):
     type = "unparsable"
     # From here down, comments are printed separately.
     comment_separate = True
+    # Unparsable segments could contain anything.
+    can_start_end_non_code = True
     _expected = ""
 
     def __init__(

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1499,12 +1499,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
 
         # Rather than fix that here, we simply assert that it has been
         # done. This will raise issues in testing, but shouldn't in use.
-        if (
-            # TODO: Rethink this assertion once parse_grammar is gone.
-            self.parse_grammar
-            and not self.can_start_end_non_code
-            and seg_buffer
-        ):  # pragma: no cover
+        if not r.can_start_end_non_code and seg_buffer:
             assert not self._find_start_or_end_non_code(seg_buffer), (
                 "Found inappropriate fix application: inappropriate "
                 "whitespace positioning. Post `_choose_anchor_segment`. "

--- a/test/core/parser/segments/segments_base_test.py
+++ b/test/core/parser/segments/segments_base_test.py
@@ -152,7 +152,6 @@ def test__parser_base_segments_validate_non_code_ends(
     generate_test_segments, DummySegment, list_in, result
 ):
     """Test BaseSegment.validate_non_code_ends()."""
-
     if result:
         # Assert that it _does_ raise an exception.
         with pytest.raises(AssertionError):

--- a/test/core/parser/segments/segments_base_test.py
+++ b/test/core/parser/segments/segments_base_test.py
@@ -140,22 +140,26 @@ def test__parser__base_segments_count_segments(
 @pytest.mark.parametrize(
     "list_in, result",
     [
-        (["foo"], None),
-        (["foo", " "], -1),
-        ([" ", "foo", " "], 0),
-        ([" ", "foo"], 0),
-        ([" "], 0),
-        ([], None),
+        (["foo"], False),
+        (["foo", " "], True),
+        ([" ", "foo", " "], True),
+        ([" ", "foo"], True),
+        ([" "], True),
+        (["foo", " ", "foo"], False),
     ],
 )
-def test__parser_base_segments_find_start_or_end_non_code(
-    generate_test_segments, list_in, result
+def test__parser_base_segments_validate_non_code_ends(
+    generate_test_segments, DummySegment, list_in, result
 ):
-    """Test BaseSegment._find_start_or_end_non_code()."""
-    assert (
-        BaseSegment._find_start_or_end_non_code(generate_test_segments(list_in))
-        == result
-    )
+    """Test BaseSegment.validate_non_code_ends()."""
+    seg = DummySegment(segments=generate_test_segments(list_in))
+    if result:
+        # Assert that it _does_ raise an exception.
+        with pytest.raises(AssertionError):
+            seg.validate_non_code_ends()
+    else:
+        # Check that it _doesn't_ raise an exception.
+        seg.validate_non_code_ends()
 
 
 def test__parser_base_segments_compute_anchor_edit_info(raw_seg_list):

--- a/test/core/parser/segments/segments_base_test.py
+++ b/test/core/parser/segments/segments_base_test.py
@@ -152,13 +152,16 @@ def test__parser_base_segments_validate_non_code_ends(
     generate_test_segments, DummySegment, list_in, result
 ):
     """Test BaseSegment.validate_non_code_ends()."""
-    seg = DummySegment(segments=generate_test_segments(list_in))
+
     if result:
         # Assert that it _does_ raise an exception.
         with pytest.raises(AssertionError):
-            seg.validate_non_code_ends()
+            # Validation happens on instantiation.
+            seg = DummySegment(segments=generate_test_segments(list_in))
     else:
-        # Check that it _doesn't_ raise an exception.
+        # Check that it _doesn't_ raise an exception...
+        seg = DummySegment(segments=generate_test_segments(list_in))
+        # ...even when explicitly validating.
         seg.validate_non_code_ends()
 
 

--- a/test/core/parser/segments/segments_base_test.py
+++ b/test/core/parser/segments/segments_base_test.py
@@ -346,15 +346,8 @@ def test__parser__base_segments_parent_ref(DummySegment, raw_seg_list):
     """Test getting and setting parents on BaseSegment."""
     # Check initially no parent (because not set)
     assert not raw_seg_list[0].get_parent()
-    # Add it to a segment (still not set)
+    # Add it to a segment (which also sets the parent value)
     seg = DummySegment(segments=raw_seg_list)
-    assert not seg.segments[0].get_parent()
-    # Set one parent on one of them (but not another)
-    seg.segments[0].set_parent(seg)
-    assert seg.segments[0].get_parent() is seg
-    assert not seg.segments[1].get_parent()
-    # Set parent on all of them
-    seg.set_as_parent()
     assert seg.segments[0].get_parent() is seg
     assert seg.segments[1].get_parent() is seg
     # Remove segment from parent, but don't unset.
@@ -363,3 +356,5 @@ def test__parser__base_segments_parent_ref(DummySegment, raw_seg_list):
     seg.segments = seg.segments[1:]
     assert seg_0 not in seg.segments
     assert not seg_0.get_parent()
+    # Check the other still works.
+    assert seg.segments[0].get_parent()

--- a/test/fixtures/templater/jinja_l_metas/001.yml
+++ b/test/fixtures/templater/jinja_l_metas/001.yml
@@ -42,8 +42,8 @@ file:
                       - dot: .
                       - naked_identifier: SNAPSHOT_DAILY
                   dedent: ''
-              - newline: "\n"
-              - whitespace: '    '
+            - newline: "\n"
+            - whitespace: '    '
             - where_clause:
                 keyword: WHERE
                 indent: ''

--- a/test/fixtures/templater/jinja_l_metas/009.yml
+++ b/test/fixtures/templater/jinja_l_metas/009.yml
@@ -28,10 +28,10 @@ file:
               table_reference:
                 naked_identifier: a
           dedent: ""
-      - newline: "\n"
-      - dedent: ""
-      - placeholder: '{% endif %}'
-      - newline: "\n"
+    - newline: "\n"
+    - dedent: ""
+    - placeholder: '{% endif %}'
+    - newline: "\n"
     - limit_clause:
         keyword: LIMIT
         indent: ""

--- a/test/rules/std_fix_auto_test.py
+++ b/test/rules/std_fix_auto_test.py
@@ -4,17 +4,17 @@ Any files in the test/fixtures/linter/autofix directory will be picked up
 and automatically tested against the appropriate dialect.
 """
 
-from typing import Optional
-import pytest
-import os
-import tempfile
-import shutil
 import json
 import logging
+import os
+import shutil
+import tempfile
+from typing import Optional
+
+import pytest
 import yaml
 
 from sqlfluff.core import FluffConfig, Linter
-
 
 # Construct the tests from the filepath
 test_cases = []
@@ -118,6 +118,8 @@ def auto_fix_test(dialect, folder, caplog):
     lnt = Linter(config=cfg)
     res = lnt.lint_path(filepath, fix=True)
 
+    if not res.files:
+        raise ValueError("LintedDir empty: Parsing likely failed.")
     print(f"## Templated file:\n{res.tree.raw}")
 
     # We call the check_tuples here, even to makes sure any non-linting

--- a/test/utils/analysis/test_query.py
+++ b/test/utils/analysis/test_query.py
@@ -13,6 +13,8 @@ def _parse_and_crawl_outer(sql):
     """
     linter = Linter(dialect="ansi")
     parsed = linter.parse_string(sql)
+    # Make sure it's fully parsable.
+    assert not "unparsable" in parsed.tree.descendant_type_set
     # Create a crawler from the root segment.
     query = Query.from_root(parsed.tree, linter.dialect)
     # Analyse the segment.

--- a/test/utils/analysis/test_query.py
+++ b/test/utils/analysis/test_query.py
@@ -181,10 +181,10 @@ join prep_1 using (x)
         ),
         # Test with a VALUES clause in a WITH
         (
-            "WITH txt AS ( VALUES (1, 'foo') AS t (id, name) ) SELECT * FROM txt\n",
+            "WITH txt AS ( VALUES (1, 'foo') ) SELECT * FROM txt\n",
             {
                 "ctes": {
-                    "TXT": {"selectables": ["VALUES (1, 'foo') "]},
+                    "TXT": {"selectables": ["VALUES (1, 'foo')"]},
                 },
                 "query_type": "WithCompound",
                 "selectables": [

--- a/test/utils/analysis/test_query.py
+++ b/test/utils/analysis/test_query.py
@@ -14,7 +14,7 @@ def _parse_and_crawl_outer(sql):
     linter = Linter(dialect="ansi")
     parsed = linter.parse_string(sql)
     # Make sure it's fully parsable.
-    assert not "unparsable" in parsed.tree.descendant_type_set
+    assert "unparsable" not in parsed.tree.descendant_type_set
     # Create a crawler from the root segment.
     query = Query.from_root(parsed.tree, linter.dialect)
     # Analyse the segment.


### PR DESCRIPTION
Within segments, there is a convention that they do not start or end with whitespace. If that was going to occur, the same whitespace segments should be delegated up to a parent segment such that they aren't at the ends (except for the outer `FileSegment`, or more specifically, any segment which sets `can_start_end_non_code`).

There was a consistency check whenever fixes were applied which made sure that was the case. _However_ it was only applied if there was a `parse_grammar`. This is bad a) because nothing has a parse grammar anymore and b) because it was mostly not applied anyway c) because it _also_ wasn't being applied on new segments.

This PR resolves that by making the test not dependent on `parse_grammar`, and also applying it more liberally. It's not got a lot of computational overhead so, not a big deal to apply in more places. There's a new method for it (`validate_non_code_ends()`), and it's applied both on `BaseSegment` instantiation and on `apply_fixes()`.

Working through the implications of _better validation_ meant I found several bugs an inconsistencies which needed to be resolved:
- `Delimited` was consuming extra whitespace.
- `LintFix` objects of type `replace` weren't appropriately passing whitespace segments up to parent segments.
- `UnparsableSegments` were consuming too much whitespace

On a somewhat unrelated note it also highlighted a test case for the ansi dialect which doesn't parse in the ANSI dialect. That's also now resolved.