### PR TITLE
Validate fix parsing based on match_grammar

### DIFF
--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -110,7 +110,7 @@ class LintedDir:
             raise ValueError(
                 ".tree() cannot be called when a LintedDir contains more than one file."
             )
-        elif not self.files:
+        elif not self.files:  # pragma: no cover
             raise ValueError(
                 "LintedDir has no parsed files. There is probably a parsing error."
             )

--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -110,4 +110,8 @@ class LintedDir:
             raise ValueError(
                 ".tree() cannot be called when a LintedDir contains more than one file."
             )
+        elif not self.files:
+            raise ValueError(
+                "LintedDir has no parsed files. There is probably a parsing error."
+            )
         return self.files[0].tree

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -493,9 +493,10 @@ class Linter:
                             new_tree, _, _, _valid = tree.apply_fixes(
                                 config.get("dialect_obj"), crawler.code, anchor_info
                             )
-                            assert (
-                                _valid
-                            ), "Fix application resulted re-parse check fail."
+                            assert _valid, (
+                                f"Fix application of {crawler.code} resulted re-parse "
+                                f"check fail. Attempted to apply fixes: {fixes}"
+                            )
                             # Check for infinite loops. We use a combination of the
                             # fixed templated file and the list of source fixes to
                             # apply.

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -495,7 +495,8 @@ class Linter:
                             )
                             assert _valid, (
                                 f"Fix application of {crawler.code} resulted re-parse "
-                                f"check fail. Attempted to apply fixes: {fixes}"
+                                f"check fail. Attempted to apply fixes: {fixes}\n"
+                                f"{new_tree.raw!r}"
                             )
                             # Check for infinite loops. We use a combination of the
                             # fixed templated file and the list of source fixes to

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -490,9 +490,12 @@ class Linter:
                             # This is the happy path. We have fixes, now we want to
                             # apply them.
                             last_fixes = fixes
-                            new_tree, _, _ = tree.apply_fixes(
+                            new_tree, _, _, _valid = tree.apply_fixes(
                                 config.get("dialect_obj"), crawler.code, anchor_info
                             )
+                            assert (
+                                _valid
+                            ), "Fix application resulted re-parse check fail."
                             # Check for infinite loops. We use a combination of the
                             # fixed templated file and the list of source fixes to
                             # apply.

--- a/src/sqlfluff/core/parser/parsers.py
+++ b/src/sqlfluff/core/parser/parsers.py
@@ -4,7 +4,7 @@ Matchable objects which return individual segments.
 """
 
 from abc import abstractmethod
-from typing import Collection, Optional, Tuple, Type, Union
+from typing import Collection, List, Optional, Tuple, Type, Union
 from uuid import uuid4
 
 import regex
@@ -123,6 +123,11 @@ class TypedParser(BaseParser):
         # NB: the template in this case is the _target_ type.
         # The type kwarg is the eventual type.
         self.template = template
+        # Pre-calculate the appropriate frozenset for matching later.
+        _target_types: List[str] = [template]
+        if type is not None and type != template:
+            _target_types.append(type)
+        self._target_types = frozenset(_target_types)
         super().__init__(
             raw_class=raw_class,
             # If no type specified we default to the template
@@ -135,18 +140,20 @@ class TypedParser(BaseParser):
         return f"<TypedParser: {self.template!r}>"
 
     def simple(
-        cls, parse_context: ParseContext, crumbs: Optional[Tuple[str, ...]] = None
+        self, parse_context: ParseContext, crumbs: Optional[Tuple[str, ...]] = None
     ) -> SimpleHintType:
         """Does this matcher support a uppercase hash matching route?
 
         TypedParser segment doesn't support matching against raw strings,
-        but it does support it against types.
+        but it does support it against types. We'll match against the
+        both the template _and_ the resulting type too, so that we
+        also support re-matching.
         """
-        return frozenset(), frozenset((cls.template,))
+        return frozenset(), self._target_types
 
     def _is_first_match(self, segment: BaseSegment) -> bool:
         """Return true if the type matches the target type."""
-        return segment.is_type(self.template)
+        return segment.is_type(*self._target_types)
 
 
 class StringParser(BaseParser):

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1546,7 +1546,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
         if not rematch.is_complete():
             return False
         opening_unparsables = set(segment.recursive_crawl("unparsable"))
-        closing_unparsables = set()
+        closing_unparsables: Set[BaseSegment] = set()
         for seg in rematch.matched_segments:
             closing_unparsables.update(seg.recursive_crawl("unparsable"))
         # Check we don't introduce any _additional_ unparsables.

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -271,13 +271,13 @@ class BaseSegment(metaclass=SegmentMetaclass):
         Once a segment is *not* expandable, it can never become so, which is
         why the variable is cached.
         """
+        # NOTE: This whole method is soon to be removed so coverage is
+        # starting to get patchy.
         if self._is_expandable is False:
-            return self._is_expandable
+            return self._is_expandable  # pragma: no cover
         elif self.parse_grammar:
             return True
         elif self.segments and any(s.is_expandable for s in self.segments):
-            # NOTE: This whole method is soon to be removed so coverage is
-            # starting to get patchy.
             return True  # pragma: no cover
         else:
             # Cache the variable
@@ -1537,15 +1537,12 @@ class BaseSegment(metaclass=SegmentMetaclass):
         if not trimmed_content and self.can_start_end_non_code:
             # Edge case for empty segments which are allowed to be empty.
             return True
-        try:
-            if segment.parse_grammar:
-                # TODO: We should remove this clause when the file segment
-                # is migrated.
-                rematch = segment.parse_grammar.match(trimmed_content, ctx)
-            else:
-                rematch = segment.match(trimmed_content, ctx)
-        except ValueError:
-            return False
+        if segment.parse_grammar:
+            # TODO: We should remove this clause when the file segment
+            # is migrated.
+            rematch = segment.parse_grammar.match(trimmed_content, ctx)
+        else:
+            rematch = segment.match(trimmed_content, ctx)
         return rematch.is_complete()
 
     @staticmethod

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1496,9 +1496,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
             # Only validate if there's a match_grammar. Otherwise we may get
             # strange results (for example with the BracketedSegment).
             if requires_validate and hasattr(r.__class__, "match_grammar"):
-                validated = self._validate_segment_after_fixes(
-                    rule_code, dialect, fixes_applied, r
-                )
+                validated = self._validate_segment_after_fixes(dialect, r)
             else:
                 validated = not requires_validate
             # Return the new segment and any non-code that needs to bubble up

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1444,8 +1444,6 @@ class BaseSegment(metaclass=SegmentMetaclass):
 
         # Then recurse (i.e. deal with the children) (Requeueing)
         requires_validate = bool(fixes_applied)
-        if requires_validate:
-            print(f"Self requires validate: {self}")
         seg_queue = seg_buffer
         seg_buffer = []
         for seg in seg_queue:
@@ -1462,7 +1460,6 @@ class BaseSegment(metaclass=SegmentMetaclass):
             # segment.
             if not validated:
                 requires_validate = True
-                print("Requiring validate because child.")
 
         # After fixing we should be able to rely on whitespace being
         # inserted in appropriate places. That logic now lives in

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1518,7 +1518,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
         fixes_applied: List[LintFix],
         segment: BaseSegment,
     ) -> None:
-        """Checks correctness of new segment against match or parse grammar."""
+        """Checks correctness of new segment by re-parsing it."""
         ctx = ParseContext(dialect=dialect)
         # We're going to check the rematch without any metas because the
         # matching routines will assume they haven't already been added.

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1543,7 +1543,12 @@ class BaseSegment(metaclass=SegmentMetaclass):
             rematch = segment.parse_grammar.match(trimmed_content, ctx)
         else:
             rematch = segment.match(trimmed_content, ctx)
-        return rematch.is_complete()
+        if not rematch.is_complete():
+            return False
+        # Check we don't contain any unparsables.
+        return not any(
+            "unparsable" in seg.descendant_type_set for seg in rematch.matched_segments
+        )
 
     @staticmethod
     def _log_apply_fixes_check_issue(

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1544,10 +1544,9 @@ class BaseSegment(metaclass=SegmentMetaclass):
                 rematch = segment.parse_grammar.match(trimmed_content, ctx)
             else:
                 rematch = segment.match(trimmed_content, ctx)
-            assert rematch.is_complete()
-        except (ValueError, AssertionError):
+        except ValueError:
             return False
-        return True
+        return rematch.is_complete()
 
     @staticmethod
     def _log_apply_fixes_check_issue(

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1545,10 +1545,10 @@ class BaseSegment(metaclass=SegmentMetaclass):
             rematch = segment.match(trimmed_content, ctx)
         if not rematch.is_complete():
             return False
-        assert len(rematch.matched_segments) == 1
-        new_segment = rematch.matched_segments[0]
         opening_unparsables = set(segment.recursive_crawl("unparsable"))
-        closing_unparsables = set(new_segment.recursive_crawl("unparsable"))
+        closing_unparsables = set()
+        for seg in rematch.matched_segments:
+            closing_unparsables.update(seg.recursive_crawl("unparsable"))
         # Check we don't introduce any _additional_ unparsables.
         # Pre-existing unparsables are ok, and for some rules that's as
         # designed. The idea is that we shouldn't make the situation _worse_.

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1345,170 +1345,172 @@ class BaseSegment(metaclass=SegmentMetaclass):
         of raw segments, they will be replaced or removed by their parent and
         so this function should just return self.
         """
-        if fixes and not self.is_raw():
-            # Get a reference to self to start with, but this will rapidly
-            # become a working copy.
-            r = self
-
-            # Make a working copy
-            seg_buffer = []
-            fixes_applied: List[LintFix] = []
-            todo_buffer = list(self.segments)
-            while True:
-                if len(todo_buffer) == 0:
-                    break
-                else:
-                    seg = todo_buffer.pop(0)
-
-                    # Look for uuid match.
-                    # This handles potential positioning ambiguity.
-                    anchor_info: Optional[AnchorEditInfo] = fixes.pop(seg.uuid, None)
-                    if anchor_info is not None:
-                        seg_fixes = anchor_info.fixes
-                        if (
-                            len(seg_fixes) == 2
-                            and seg_fixes[0].edit_type == "create_after"
-                        ):  # pragma: no cover
-                            # Must be create_before & create_after. Swap so the
-                            # "before" comes first.
-                            seg_fixes.reverse()
-
-                        for f in anchor_info.fixes:
-                            assert f.anchor.uuid == seg.uuid
-                            fixes_applied.append(f)
-                            linter_logger.debug(
-                                "Matched fix for %s against segment: %s -> %s",
-                                rule_code,
-                                f,
-                                seg,
-                            )
-                            if f.edit_type == "delete":
-                                # We're just getting rid of this segment.
-                                pass
-                            elif f.edit_type in (
-                                "replace",
-                                "create_before",
-                                "create_after",
-                            ):
-                                if (
-                                    f.edit_type == "create_after"
-                                    and len(anchor_info.fixes) == 1
-                                ):
-                                    # in the case of a creation after that is not part
-                                    # of a create_before/create_after pair, also add
-                                    # this segment before the edit.
-                                    seg_buffer.append(seg)
-                                    seg.set_parent(self)
-
-                                # We're doing a replacement (it could be a single
-                                # segment or an iterable)
-                                assert f.edit, f"Edit {f.edit_type!r} requires `edit`."
-                                consumed_pos = False
-                                for s in f.edit:
-                                    seg_buffer.append(s)
-                                    s.set_parent(self)
-                                    # If one of them has the same raw representation
-                                    # then the first that matches gets to take the
-                                    # original position marker.
-                                    if (
-                                        f.edit_type == "replace"
-                                        and s.raw == seg.raw
-                                        and not consumed_pos
-                                    ):
-                                        seg_buffer[-1].pos_marker = seg.pos_marker
-                                        consumed_pos = True
-
-                                if f.edit_type == "create_before":
-                                    # in the case of a creation before, also add this
-                                    # segment on the end
-                                    seg_buffer.append(seg)
-                                    seg.set_parent(self)
-
-                            else:  # pragma: no cover
-                                raise ValueError(
-                                    "Unexpected edit_type: {!r} in {!r}".format(
-                                        f.edit_type, f
-                                    )
-                                )
-                    else:
-                        seg_buffer.append(seg)
-                        seg.set_parent(self)
-                # Invalidate any caches
-                self.invalidate_caches()
-
-            # If any fixes applied, do an intermediate reposition. When applying
-            # fixes to children and then trying to reposition them, that recursion
-            # may rely on the parent having already populated positions for any
-            # of the fixes applied there first. This ensures those segments have
-            # working positions to work with.
-            if fixes_applied:
-                seg_buffer = list(
-                    self._position_segments(tuple(seg_buffer), parent_pos=r.pos_marker)
-                )
-
-            # Then recurse (i.e. deal with the children) (Requeueing)
-            requires_validate = fixes_applied
-            seg_queue = seg_buffer
-            seg_buffer = []
-            for seg in seg_queue:
-                s, before, after, validated = seg.apply_fixes(dialect, rule_code, fixes)
-                # 'before' and 'after' will usually be empty. Only used when
-                # lower-level fixes left 'seg' with non-code (usually
-                # whitespace) segments as the first or last children. This is
-                # generally not allowed (see the can_start_end_non_code field),
-                # and these segments need to be "bubbled up" the tree.
-                seg_buffer.extend(before)
-                seg_buffer.append(s)
-                seg_buffer.extend(after)
-                # If we fail to validate a child segment, make sure to validate this
-                # segment.
-                if not validated:
-                    requires_validate = True
-
-            # After fixing we should be able to rely on whitespace being
-            # inserted in appropriate places. That logic now lives in
-            # `BaseRule._choose_anchor_segment()`, rather than here.
-
-            # Rather than fix that here, we simply assert that it has been
-            # done. This will raise issues in testing, but shouldn't in use.
-            if (
-                # TODO: Rethink this assertion once parse_grammar is gone.
-                r.parse_grammar
-                and not r.can_start_end_non_code
-                and seg_buffer
-            ):  # pragma: no cover
-                assert not self._find_start_or_end_non_code(seg_buffer), (
-                    "Found inappropriate fix application: inappropriate "
-                    "whitespace positioning. Post `_choose_anchor_segment`. "
-                    "Please report this issue on GitHub with your SQL query. "
-                )
-
-            # Reform into a new segment
-            r = r.__class__(
-                # Realign the segments within
-                segments=self._position_segments(
-                    tuple(seg_buffer), parent_pos=r.pos_marker
-                ),
-                pos_marker=r.pos_marker,
-                # Pass through any additional kwargs
-                **{k: getattr(self, k) for k in self.additional_kwargs},
-            )
-            # Only validate if there's a match_grammar. Otherwise we may get
-            # strange results (for example with the BracketedSegment).
-            if requires_validate and hasattr(r.__class__, "match_grammar"):
-                validated = self._validate_segment_after_fixes(dialect, r)
-            else:
-                validated = not requires_validate
-            # Return the new segment and any non-code that needs to bubble up
-            # the tree.
-            # NOTE: We pass on whether this segment has been validated. It's
-            # very possible that our parsing here may fail depending on the
-            # type of segment that has been replaced, but if not we rely on
-            # a parent segment still being valid. If we get all the way up
-            # to the root and it's still not valid - that's a problem.
-            return r, before, after, validated
-        else:
+        if not fixes or self.is_raw():
             return self, [], [], True
+
+        seg_buffer = []
+        fixes_applied: List[LintFix] = []
+        todo_buffer = list(self.segments)
+        while True:
+            if len(todo_buffer) == 0:
+                break
+            else:
+                seg = todo_buffer.pop(0)
+
+                # Look for uuid match.
+                # This handles potential positioning ambiguity.
+                anchor_info: Optional[AnchorEditInfo] = fixes.pop(seg.uuid, None)
+                if anchor_info is not None:
+                    seg_fixes = anchor_info.fixes
+                    if (
+                        len(seg_fixes) == 2 and seg_fixes[0].edit_type == "create_after"
+                    ):  # pragma: no cover
+                        # Must be create_before & create_after. Swap so the
+                        # "before" comes first.
+                        seg_fixes.reverse()
+
+                    for f in anchor_info.fixes:
+                        assert f.anchor.uuid == seg.uuid
+                        fixes_applied.append(f)
+                        linter_logger.debug(
+                            "Matched fix for %s against segment: %s -> %s",
+                            rule_code,
+                            f,
+                            seg,
+                        )
+                        if f.edit_type == "delete":
+                            # We're just getting rid of this segment.
+                            pass
+                        elif f.edit_type in (
+                            "replace",
+                            "create_before",
+                            "create_after",
+                        ):
+                            if (
+                                f.edit_type == "create_after"
+                                and len(anchor_info.fixes) == 1
+                            ):
+                                # in the case of a creation after that is not part
+                                # of a create_before/create_after pair, also add
+                                # this segment before the edit.
+                                seg_buffer.append(seg)
+                                seg.set_parent(self)
+
+                            # We're doing a replacement (it could be a single
+                            # segment or an iterable)
+                            assert f.edit, f"Edit {f.edit_type!r} requires `edit`."
+                            consumed_pos = False
+                            for s in f.edit:
+                                seg_buffer.append(s)
+                                s.set_parent(self)
+                                # If one of them has the same raw representation
+                                # then the first that matches gets to take the
+                                # original position marker.
+                                if (
+                                    f.edit_type == "replace"
+                                    and s.raw == seg.raw
+                                    and not consumed_pos
+                                ):
+                                    seg_buffer[-1].pos_marker = seg.pos_marker
+                                    consumed_pos = True
+
+                            if f.edit_type == "create_before":
+                                # in the case of a creation before, also add this
+                                # segment on the end
+                                seg_buffer.append(seg)
+                                seg.set_parent(self)
+
+                        else:  # pragma: no cover
+                            raise ValueError(
+                                "Unexpected edit_type: {!r} in {!r}".format(
+                                    f.edit_type, f
+                                )
+                            )
+                else:
+                    seg_buffer.append(seg)
+                    seg.set_parent(self)
+            # Invalidate any caches
+            self.invalidate_caches()
+
+        # If any fixes applied, do an intermediate reposition. When applying
+        # fixes to children and then trying to reposition them, that recursion
+        # may rely on the parent having already populated positions for any
+        # of the fixes applied there first. This ensures those segments have
+        # working positions to work with.
+        if fixes_applied:
+            seg_buffer = list(
+                self._position_segments(tuple(seg_buffer), parent_pos=self.pos_marker)
+            )
+
+        # Then recurse (i.e. deal with the children) (Requeueing)
+        requires_validate = bool(fixes_applied)
+        if requires_validate:
+            print(f"Self requires validate: {self}")
+        seg_queue = seg_buffer
+        seg_buffer = []
+        for seg in seg_queue:
+            s, before, after, validated = seg.apply_fixes(dialect, rule_code, fixes)
+            # 'before' and 'after' will usually be empty. Only used when
+            # lower-level fixes left 'seg' with non-code (usually
+            # whitespace) segments as the first or last children. This is
+            # generally not allowed (see the can_start_end_non_code field),
+            # and these segments need to be "bubbled up" the tree.
+            seg_buffer.extend(before)
+            seg_buffer.append(s)
+            seg_buffer.extend(after)
+            # If we fail to validate a child segment, make sure to validate this
+            # segment.
+            if not validated:
+                requires_validate = True
+                print("Requiring validate because child.")
+
+        # After fixing we should be able to rely on whitespace being
+        # inserted in appropriate places. That logic now lives in
+        # `BaseRule._choose_anchor_segment()`, rather than here.
+
+        # Rather than fix that here, we simply assert that it has been
+        # done. This will raise issues in testing, but shouldn't in use.
+        if (
+            # TODO: Rethink this assertion once parse_grammar is gone.
+            self.parse_grammar
+            and not self.can_start_end_non_code
+            and seg_buffer
+        ):  # pragma: no cover
+            assert not self._find_start_or_end_non_code(seg_buffer), (
+                "Found inappropriate fix application: inappropriate "
+                "whitespace positioning. Post `_choose_anchor_segment`. "
+                "Please report this issue on GitHub with your SQL query. "
+            )
+
+        # Reform into a new segment
+        new_seg = self.__class__(
+            # Realign the segments within
+            segments=self._position_segments(
+                tuple(seg_buffer), parent_pos=self.pos_marker
+            ),
+            pos_marker=self.pos_marker,
+            # Pass through any additional kwargs
+            **{k: getattr(self, k) for k in self.additional_kwargs},
+        )
+        # Only validate if there's a match_grammar. Otherwise we may get
+        # strange results (for example with the BracketedSegment).
+        if requires_validate and (
+            hasattr(new_seg, "match_grammar")
+            # TODO: We temporarily allow parse_grammar here until the file segment
+            # has been migrated. Then we should remove this.
+            or new_seg.parse_grammar
+        ):
+            validated = self._validate_segment_after_fixes(dialect, new_seg)
+        else:
+            validated = not requires_validate
+        # Return the new segment and any non-code that needs to bubble up
+        # the tree.
+        # NOTE: We pass on whether this segment has been validated. It's
+        # very possible that our parsing here may fail depending on the
+        # type of segment that has been replaced, but if not we rely on
+        # a parent segment still being valid. If we get all the way up
+        # to the root and it's still not valid - that's a problem.
+        return new_seg, before, after, validated
 
     @classmethod
     def compute_anchor_edit_info(
@@ -1536,7 +1538,12 @@ class BaseSegment(metaclass=SegmentMetaclass):
         raw_content = tuple(s for s in segment.raw_segments if not s.is_meta)
         _, trimmed_content, _ = trim_non_code_segments(raw_content)
         try:
-            rematch = segment.match(trimmed_content, ctx)
+            if segment.parse_grammar:
+                # TODO: We should remove this clause when the file segment
+                # is migrated.
+                rematch = segment.parse_grammar.match(trimmed_content, ctx)
+            else:
+                rematch = segment.match(trimmed_content, ctx)
             assert rematch.is_complete()
         except (ValueError, AssertionError):
             return False

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1545,10 +1545,14 @@ class BaseSegment(metaclass=SegmentMetaclass):
             rematch = segment.match(trimmed_content, ctx)
         if not rematch.is_complete():
             return False
-        # Check we don't contain any unparsables.
-        return not any(
-            "unparsable" in seg.descendant_type_set for seg in rematch.matched_segments
-        )
+        assert len(rematch.matched_segments) == 1
+        new_segment = rematch.matched_segments[0]
+        opening_unparsables = set(segment.recursive_crawl("unparsable"))
+        closing_unparsables = set(new_segment.recursive_crawl("unparsable"))
+        # Check we don't introduce any _additional_ unparsables.
+        # Pre-existing unparsables are ok, and for some rules that's as
+        # designed. The idea is that we shouldn't make the situation _worse_.
+        return opening_unparsables == closing_unparsables
 
     @staticmethod
     def _log_apply_fixes_check_issue(

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1534,6 +1534,9 @@ class BaseSegment(metaclass=SegmentMetaclass):
         # We also strip any non-code from the ends which might have moved.
         raw_content = tuple(s for s in segment.raw_segments if not s.is_meta)
         _, trimmed_content, _ = trim_non_code_segments(raw_content)
+        if not trimmed_content and self.can_start_end_non_code:
+            # Edge case for empty segments which are allowed to be empty.
+            return True
         try:
             if segment.parse_grammar:
                 # TODO: We should remove this clause when the file segment

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1527,9 +1527,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
 
     def _validate_segment_after_fixes(
         self,
-        rule_code: str,
         dialect: "Dialect",
-        fixes_applied: List[LintFix],
         segment: BaseSegment,
     ) -> bool:
         """Checks correctness of new segment by re-parsing it."""
@@ -1542,16 +1540,8 @@ class BaseSegment(metaclass=SegmentMetaclass):
         try:
             rematch = segment.match(trimmed_content, ctx)
             assert rematch.is_complete()
-        except (ValueError, AssertionError):  # pragma: no cover
+        except (ValueError, AssertionError):
             return False
-            self._log_apply_fixes_check_issue(
-                "After %s fixes were applied, segment %r failed the "
-                "rematch check. Fixes: %r. New raw: %r",
-                rule_code,
-                segment,
-                fixes_applied,
-                segment.raw,
-            )
         return True
 
     @staticmethod

--- a/src/sqlfluff/rules/convention/CV11.py
+++ b/src/sqlfluff/rules/convention/CV11.py
@@ -1,17 +1,17 @@
 """Implementation of Rule CV11."""
 
-from typing import Optional, List, Iterable
-
-from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.utils.functional import sp, FunctionalContext, Segments
+from typing import Iterable, List, Optional
 
 from sqlfluff.core.parser import (
-    WhitespaceSegment,
-    SymbolSegment,
-    KeywordSegment,
     BaseSegment,
+    CodeSegment,
+    KeywordSegment,
+    SymbolSegment,
+    WhitespaceSegment,
 )
+from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+from sqlfluff.utils.functional import FunctionalContext, Segments, sp
 
 
 class Rule_CV11(BaseRule):
@@ -89,7 +89,7 @@ class Rule_CV11(BaseRule):
         # Add cast and opening parenthesis.
         edits = (
             [
-                KeywordSegment("cast"),
+                CodeSegment("cast", type="function_name_identifier"),
                 SymbolSegment("(", type="start_bracket"),
             ]
             + list(cast_arg_1)
@@ -104,7 +104,7 @@ class Rule_CV11(BaseRule):
 
         if later_types:
             pre_edits: List[BaseSegment] = [
-                KeywordSegment("cast"),
+                CodeSegment("cast", type="function_name_identifier"),
                 SymbolSegment("(", type="start_bracket"),
             ]
             in_edits: List[BaseSegment] = [
@@ -136,7 +136,7 @@ class Rule_CV11(BaseRule):
         """Generate list of fixes to convert CAST and ShorthandCast to CONVERT."""
         # Add convert and opening parenthesis.
         edits = [
-            KeywordSegment("convert"),
+            CodeSegment("convert", type="function_name_identifier"),
             SymbolSegment("(", type="start_bracket"),
             convert_arg_1,
             SymbolSegment(",", type="comma"),
@@ -147,7 +147,7 @@ class Rule_CV11(BaseRule):
 
         if later_types:
             pre_edits: List[BaseSegment] = [
-                KeywordSegment("convert"),
+                CodeSegment("convert", type="function_name_identifier"),
                 SymbolSegment("(", type="start_bracket"),
             ]
             in_edits: List[BaseSegment] = [

--- a/src/sqlfluff/rules/structure/ST02.py
+++ b/src/sqlfluff/rules/structure/ST02.py
@@ -2,15 +2,15 @@
 from typing import List, Optional, Tuple
 
 from sqlfluff.core.parser import (
-    WhitespaceSegment,
-    SymbolSegment,
+    CodeSegment,
     KeywordSegment,
+    SymbolSegment,
+    WhitespaceSegment,
 )
 from sqlfluff.core.parser.segments.base import BaseSegment
-
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.utils.functional import Segments, sp, FunctionalContext
+from sqlfluff.utils.functional import FunctionalContext, Segments, sp
 
 
 class Rule_ST02(BaseRule):
@@ -91,7 +91,7 @@ class Rule_ST02(BaseRule):
         """Generate list of fixes to convert CASE statement to COALESCE function."""
         # Add coalesce and opening parenthesis.
         edits = [
-            KeywordSegment("coalesce"),
+            CodeSegment("coalesce", type="function_name_identifier"),
             SymbolSegment("(", type="start_bracket"),
             coalesce_arg_1,
             SymbolSegment(",", type="comma"),

--- a/test/dialects/dialects_test.py
+++ b/test/dialects/dialects_test.py
@@ -3,21 +3,21 @@
 Any files in the test/fixtures/dialects/ directory will be picked up
 and automatically tested against the appropriate dialect.
 """
-import logging
 from typing import Any, Dict, Optional
+
 import pytest
 
-from sqlfluff.core.templaters import TemplatedFile
-from sqlfluff.core.linter import RenderedFile, ParsedString
 from sqlfluff.core import FluffConfig, Linter
+from sqlfluff.core.linter import ParsedString, RenderedFile
 from sqlfluff.core.parser.segments.base import BaseSegment
+from sqlfluff.core.templaters import TemplatedFile
 
 from ..conftest import (
     compute_parse_tree_hash,
+    get_parse_fixtures,
     load_file,
     make_dialect_path,
     parse_example_file,
-    get_parse_fixtures,
 )
 
 parse_success_examples, parse_structure_examples = get_parse_fixtures(
@@ -92,6 +92,9 @@ def test__dialect__base_broad_fix(
     a wide range of test sql examples, and the full range of rules
     to find any potential critical errors raised by any interactions
     between different dialects and rules.
+
+    We also do not use DEBUG logging here because it gets _very_
+    noisy.
     """
     raw = load_file(dialect, file)
     config_overrides = dict(dialect=dialect)
@@ -107,12 +110,11 @@ def test__dialect__base_broad_fix(
     rule_pack = linter.get_rulepack()
     # Due to "raise_critical_errors_after_fix" fixture "fix",
     # will now throw.
-    with caplog.at_level(logging.DEBUG, logger="sqlfluff.rules"):
-        linter.lint_parsed(
-            parsed,
-            rule_pack,
-            fix=True,
-        )
+    linter.lint_parsed(
+        parsed,
+        rule_pack,
+        fix=True,
+    )
 
 
 @pytest.mark.integration

--- a/test/utils/reflow/reindent_test.py
+++ b/test/utils/reflow/reindent_test.py
@@ -643,7 +643,7 @@ def test_reflow__lint_indent_points(raw_sql_in, raw_sql_out, default_config, cap
     fixed_tree, _, _, valid = root.apply_fixes(
         default_config.get("dialect_obj"), "TEST", anchor_info
     )
-    assert valid, "Reparse check failed."
+    assert valid, f"Reparse check failed: {fixed_tree.raw!r}"
     assert fixed_tree.raw == raw_sql_out, "Element check passed - but fix check failed!"
 
 

--- a/test/utils/reflow/reindent_test.py
+++ b/test/utils/reflow/reindent_test.py
@@ -7,20 +7,19 @@ Specifically:
 """
 
 import logging
+
 import pytest
 
 from sqlfluff.core import Linter
 from sqlfluff.core.parser.segments.base import BaseSegment
-
-from sqlfluff.utils.reflow.helpers import fixes_from_results
-from sqlfluff.utils.reflow.sequence import ReflowSequence
-from sqlfluff.utils.reflow.helpers import deduce_line_indent
+from sqlfluff.utils.reflow.helpers import deduce_line_indent, fixes_from_results
 from sqlfluff.utils.reflow.reindent import (
-    lint_indent_points,
     _crawl_indent_points,
-    _IndentPoint,
     _IndentLine,
+    _IndentPoint,
+    lint_indent_points,
 )
+from sqlfluff.utils.reflow.sequence import ReflowSequence
 
 
 def parse_ansi_string(sql, config):
@@ -641,9 +640,10 @@ def test_reflow__lint_indent_points(raw_sql_in, raw_sql_out, default_config, cap
     # the same place.
     print("Results:", results)
     anchor_info = BaseSegment.compute_anchor_edit_info(fixes_from_results(results))
-    fixed_tree, _, _ = root.apply_fixes(
+    fixed_tree, _, _, valid = root.apply_fixes(
         default_config.get("dialect_obj"), "TEST", anchor_info
     )
+    assert valid, "Reparse check failed."
     assert fixed_tree.raw == raw_sql_out, "Element check passed - but fix check failed!"
 
 


### PR DESCRIPTION
This is the third of a few of these changes (all relating to #5124). This updates the parsing checks after fixes to use `.match()` instead of `.parse()`.

Some of our internal consistency checks only work if there's a parse_grammar. This obviously presents some issues because these won't fail anymore, but that means they also don't actually work.

The effect of this PR is that we're much more extensively and effectively testing the impact on fixes to make sure we don't break parsing of the file in question (or at least don't make it worse).

This is going to look like a strange combination of things. Here's why:
1. The core of this PR is the changes to `linter.py` and `segments/base.py`. It takes the `_validate_segment_after_fixes` and uses `.match()` rather than `.parse()`. This is a **great thing**, because it means we can much more accurately identify segments that do and don't parse.
2. There are a chunk of dialect changes which I found in this process where exactly that was happening - fixes were being applied that were breaking SQL and we hadn't noticed 🤯. Particularly in the layout config which you'll see I've edited a few times. I've resolved _most_ of this in #5205.
3. One of the big places that it was happening is when an inner segment becomes unparsable, but the outer one is fine, just because of exactly how fixes were being applied. In those cases, the "unparsable" warning just _bubbles up_ and we re-test the outer segment until we get something that works _OR_ we get to the root segment. If we get to the root, rather than raising an exception, we skip the rule, so that the process can continue.

**For Reviewers**: Makes sure you've got the "show whitespace" review option _off_ otherwise this will be really hard to read.