### PR TITLE
Update click dependency to >=8.1.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ appdirs
 backports.cached-property; python_version < '3.8'
 # To get the encoding of files.
 chardet
-click
+click>=8.1.7
 colorama>=0.3
 # Used for diffcover plugin
 diff-cover>=2.5.0


### PR DESCRIPTION
Updates the requirements.txt to specify version `click>=8.1.7`
Makes progress on #5195  (does not fix the broken code logic there, just bypasses the issue for users)
Any future users running `pip3 install sqlfluff` with existing old version of `click` will have required click version autoinstalled.