### PR TITLE
Add support for bpchar datatype in postgres

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -705,6 +705,7 @@ class DatatypeSegment(ansi.DatatypeSegment):
                     OneOf(
                         Sequence(
                             OneOf(
+                                "BPCHAR",
                                 "CHAR",
                                 # CHAR VARYING is not documented, but it's
                                 # in the real grammar:

--- a/src/sqlfluff/dialects/dialect_postgres_keywords.py
+++ b/src/sqlfluff/dialects/dialect_postgres_keywords.py
@@ -112,6 +112,7 @@ postgres_docs_keywords = [
     ("BOOL", "non-reserved-(cannot-be-function-or-type)"),
     ("BOTH", "reserved"),
     ("BOX", "non-reserved-(cannot-be-function-or-type)"),
+    ("BPCHAR", "non-reserved-(cannot-be-function-or-type)"),
     ("BREADTH", "not-keyword"),
     ("BY", "non-reserved"),
     ("BYTEA", "non-reserved-(cannot-be-function-or-type)"),

--- a/test/fixtures/dialects/postgres/datatypes.sql
+++ b/test/fixtures/dialects/postgres/datatypes.sql
@@ -157,3 +157,7 @@ SELECT
     b,
     c::DATE
 FROM a;
+
+create table test (
+    situation bpchar(1) null default 'A'::bpchar
+);

--- a/test/fixtures/dialects/postgres/datatypes.yml
+++ b/test/fixtures/dialects/postgres/datatypes.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7cf843dbbfd1ddd3907ede58652e56d6e0a9c7446e8b623461a83834f985e330
+_hash: 12b835637c480381b3232c23c43d461412fd2f32613bdc3a16137e43b515c598
 file:
 - statement:
     create_table_statement:
@@ -825,4 +825,32 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: a
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: create
+    - keyword: table
+    - table_reference:
+        naked_identifier: test
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: situation
+      - data_type:
+          keyword: bpchar
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '1'
+              end_bracket: )
+      - column_constraint_segment:
+          keyword: 'null'
+      - column_constraint_segment:
+          keyword: default
+          cast_expression:
+            quoted_literal: "'A'"
+            casting_operator: '::'
+            data_type:
+              keyword: bpchar
+      - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
Closes #5214 

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
