### PR TITLE
Parser test nits

### DIFF
--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -230,7 +230,7 @@ class BaseGrammar(Matchable):
         using the `parse_stats` object on the context.
 
         The things which determine the performance of this method are:
-        1. Pruning. This method uses `_prune_options()` to filter down which matchable
+        1. Pruning. This method uses `prune_options()` to filter down which matchable
            options proceed to the full matching step. Ideally only very few do and this
            can handle the majority of the filtering.
         2. Caching. This method uses the parse cache (`check_parse_cache` and

--- a/test/core/parser/conftest.py
+++ b/test/core/parser/conftest.py
@@ -13,7 +13,7 @@ def fresh_ansi_dialect():
 
 
 @pytest.fixture(scope="function")
-def seg_list(generate_test_segments):
+def test_segments(generate_test_segments):
     """A preset list of segments for testing.
 
     Includes a templated segment for completeness.
@@ -28,7 +28,7 @@ def seg_list(generate_test_segments):
 
 
 @pytest.fixture(scope="function")
-def bracket_seg_list(generate_test_segments):
+def bracket_segments(generate_test_segments):
     """Another preset list of segments for testing."""
     return generate_test_segments(
         ["bar", " \t ", "(", "foo", "    ", ")", "baar", " \t ", "foo"]

--- a/test/core/parser/grammar/grammar_anyof_test.py
+++ b/test/core/parser/grammar/grammar_anyof_test.py
@@ -38,25 +38,24 @@ def test__parser__grammar__oneof__copy():
 
 
 @pytest.mark.parametrize("allow_gaps", [True, False])
-def test__parser__grammar_oneof(seg_list, allow_gaps):
+def test__parser__grammar_oneof(test_segments, allow_gaps):
     """Test the OneOf grammar.
 
-    NB: Should behave the same regardless of code_only.
-
+    NOTE: Should behave the same regardless of allow_gaps.
     """
     bs = StringParser("bar", KeywordSegment)
     fs = StringParser("foo", KeywordSegment)
     g = OneOf(fs, bs, allow_gaps=allow_gaps)
     ctx = ParseContext(dialect=None)
     # Check directly
-    assert g.match(seg_list, parse_context=ctx).matched_segments == (
-        KeywordSegment("bar", seg_list[0].pos_marker),
+    assert g.match(test_segments, parse_context=ctx).matched_segments == (
+        KeywordSegment("bar", test_segments[0].pos_marker),
     )
     # Check with a bit of whitespace
-    assert not g.match(seg_list[1:], parse_context=ctx)
+    assert not g.match(test_segments[1:], parse_context=ctx)
 
 
-def test__parser__grammar_oneof_templated(seg_list):
+def test__parser__grammar_oneof_templated(test_segments):
     """Test the OneOf grammar.
 
     NB: Should behave the same regardless of code_only.
@@ -68,22 +67,22 @@ def test__parser__grammar_oneof_templated(seg_list):
     ctx = ParseContext(dialect=None)
     # This shouldn't match, but it *ALSO* shouldn't raise an exception.
     # https://github.com/sqlfluff/sqlfluff/issues/780
-    assert not g.match(seg_list[5:], parse_context=ctx)
+    assert not g.match(test_segments[5:], parse_context=ctx)
 
 
-def test__parser__grammar_oneof_exclude(seg_list):
+def test__parser__grammar_oneof_exclude(test_segments):
     """Test the OneOf grammar exclude option."""
     bs = StringParser("bar", KeywordSegment)
     fs = StringParser("foo", KeywordSegment)
     g = OneOf(bs, exclude=Sequence(bs, fs))
     ctx = ParseContext(dialect=None)
     # Just against the first alone
-    assert g.match(seg_list[:1], parse_context=ctx)
+    assert g.match(test_segments[:1], parse_context=ctx)
     # Now with the bit to exclude included
-    assert not g.match(seg_list, parse_context=ctx)
+    assert not g.match(test_segments, parse_context=ctx)
 
 
-def test__parser__grammar_oneof_take_longest_match(seg_list):
+def test__parser__grammar_oneof_take_longest_match(test_segments):
     """Test that the OneOf grammar takes the longest match."""
     fooRegex = RegexParser(r"fo{2}", KeywordSegment)
     baar = StringParser("baar", KeywordSegment)
@@ -97,16 +96,16 @@ def test__parser__grammar_oneof_take_longest_match(seg_list):
     # is a longer match and should be taken
     g = OneOf(fooRegex, fooBaar)
     ctx = ParseContext(dialect=None)
-    assert fooRegex.match(seg_list[2:], parse_context=ctx).matched_segments == (
-        KeywordSegment("foo", seg_list[2].pos_marker),
+    assert fooRegex.match(test_segments[2:], parse_context=ctx).matched_segments == (
+        KeywordSegment("foo", test_segments[2].pos_marker),
     )
-    assert g.match(seg_list[2:], parse_context=ctx).matched_segments == (
-        KeywordSegment("foo", seg_list[2].pos_marker),
-        KeywordSegment("baar", seg_list[3].pos_marker),
+    assert g.match(test_segments[2:], parse_context=ctx).matched_segments == (
+        KeywordSegment("foo", test_segments[2].pos_marker),
+        KeywordSegment("baar", test_segments[3].pos_marker),
     )
 
 
-def test__parser__grammar_oneof_take_first(seg_list):
+def test__parser__grammar_oneof_take_first(test_segments):
     """Test that the OneOf grammar takes first match in case they are of same length."""
     fooRegex = RegexParser(r"fo{2}", KeywordSegment)
     foo = StringParser("foo", KeywordSegment)
@@ -116,31 +115,31 @@ def test__parser__grammar_oneof_take_first(seg_list):
     g1 = OneOf(fooRegex, foo)
     g2 = OneOf(foo, fooRegex)
     ctx = ParseContext(dialect=None)
-    assert g1.match(seg_list[2:], parse_context=ctx).matched_segments == (
-        KeywordSegment("foo", seg_list[2].pos_marker),
+    assert g1.match(test_segments[2:], parse_context=ctx).matched_segments == (
+        KeywordSegment("foo", test_segments[2].pos_marker),
     )
-    assert g2.match(seg_list[2:], parse_context=ctx).matched_segments == (
-        KeywordSegment("foo", seg_list[2].pos_marker),
+    assert g2.match(test_segments[2:], parse_context=ctx).matched_segments == (
+        KeywordSegment("foo", test_segments[2].pos_marker),
     )
 
 
 def test__parser__grammar_anysetof(generate_test_segments):
     """Test the AnySetOf grammar."""
     token_list = ["bar", "  \t ", "foo", "  \t ", "bar"]
-    seg_list = generate_test_segments(token_list)
+    segments = generate_test_segments(token_list)
 
-    bs = StringParser("bar", KeywordSegment)
-    fs = StringParser("foo", KeywordSegment)
-    g = AnySetOf(fs, bs)
+    bar = StringParser("bar", KeywordSegment)
+    foo = StringParser("foo", KeywordSegment)
+    g = AnySetOf(foo, bar)
     ctx = ParseContext(dialect=None)
     # Check directly
-    assert g.match(seg_list, parse_context=ctx).matched_segments == (
-        KeywordSegment("bar", seg_list[0].pos_marker),
-        WhitespaceSegment("  \t ", seg_list[1].pos_marker),
-        KeywordSegment("foo", seg_list[2].pos_marker),
+    assert g.match(segments, parse_context=ctx).matched_segments == (
+        KeywordSegment("bar", segments[0].pos_marker),
+        WhitespaceSegment("  \t ", segments[1].pos_marker),
+        KeywordSegment("foo", segments[2].pos_marker),
     )
     # Check with a bit of whitespace
-    assert not g.match(seg_list[1:], parse_context=ctx)
+    assert not g.match(segments[1:], parse_context=ctx)
 
 
 @pytest.mark.parametrize(

--- a/test/core/parser/grammar/grammar_base_test.py
+++ b/test/core/parser/grammar/grammar_base_test.py
@@ -15,7 +15,7 @@ from sqlfluff.core.parser.grammar.base import BaseGrammar
 # NB: All of these tests depend somewhat on the KeywordSegment working as planned
 
 
-def make_result_tuple(result_slice, matcher_keywords, seg_list):
+def make_result_tuple(result_slice, matcher_keywords, test_segments):
     """Make a comparison tuple for test matching."""
     # No result slice means no match.
     if not result_slice:
@@ -25,7 +25,7 @@ def make_result_tuple(result_slice, matcher_keywords, seg_list):
         KeywordSegment(elem.raw, pos_marker=elem.pos_marker)
         if elem.raw in matcher_keywords
         else elem
-        for elem in seg_list[result_slice]
+        for elem in test_segments[result_slice]
     )
 
 
@@ -43,7 +43,7 @@ def make_result_tuple(result_slice, matcher_keywords, seg_list):
     ],
 )
 def test__parser__grammar__base__longest_trimmed_match__basic(
-    seg_list, seg_list_slice, matcher_keywords, trim_noncode, result_slice
+    test_segments, seg_list_slice, matcher_keywords, trim_noncode, result_slice
 ):
     """Test the _longest_trimmed_match method of the BaseGrammar."""
     # Make the matcher keywords
@@ -51,20 +51,20 @@ def test__parser__grammar__base__longest_trimmed_match__basic(
 
     ctx = ParseContext(dialect=None)
     m, _ = BaseGrammar._longest_trimmed_match(
-        seg_list[seg_list_slice], matchers, ctx, trim_noncode=trim_noncode
+        test_segments[seg_list_slice], matchers, ctx, trim_noncode=trim_noncode
     )
 
     # Make the check tuple
     expected_result = make_result_tuple(
         result_slice=result_slice,
         matcher_keywords=matcher_keywords,
-        seg_list=seg_list,
+        test_segments=test_segments,
     )
 
     assert m.matched_segments == expected_result
 
 
-def test__parser__grammar__base__longest_trimmed_match__adv(seg_list, caplog):
+def test__parser__grammar__base__longest_trimmed_match__adv(test_segments, caplog):
     """Test the _longest_trimmed_match method of the BaseGrammar."""
     bs = StringParser("bar", KeywordSegment)
     fs = StringParser("foo", KeywordSegment)
@@ -78,7 +78,9 @@ def test__parser__grammar__base__longest_trimmed_match__adv(seg_list, caplog):
     ctx = ParseContext(dialect=None)
     # Matching the first element of the list
     with caplog.at_level(logging.DEBUG, logger="sqluff.parser"):
-        match, matcher = BaseGrammar._longest_trimmed_match(seg_list, matchers, ctx)
+        match, matcher = BaseGrammar._longest_trimmed_match(
+            test_segments, matchers, ctx
+        )
     # Check we got a match
     assert match
     # Check we got the right one.

--- a/test/core/parser/grammar/grammar_base_test.py
+++ b/test/core/parser/grammar/grammar_base_test.py
@@ -30,7 +30,7 @@ def make_result_tuple(result_slice, matcher_keywords, test_segments):
 
 
 @pytest.mark.parametrize(
-    "seg_list_slice,matcher_keywords,trim_noncode,result_slice",
+    "segments_slice,matcher_keywords,trim_noncode,result_slice",
     [
         # Matching the first element of the list
         (slice(None, None), ["bar"], False, slice(None, 1)),
@@ -43,7 +43,7 @@ def make_result_tuple(result_slice, matcher_keywords, test_segments):
     ],
 )
 def test__parser__grammar__base__longest_trimmed_match__basic(
-    test_segments, seg_list_slice, matcher_keywords, trim_noncode, result_slice
+    test_segments, segments_slice, matcher_keywords, trim_noncode, result_slice
 ):
     """Test the _longest_trimmed_match method of the BaseGrammar."""
     # Make the matcher keywords
@@ -51,7 +51,7 @@ def test__parser__grammar__base__longest_trimmed_match__basic(
 
     ctx = ParseContext(dialect=None)
     m, _ = BaseGrammar._longest_trimmed_match(
-        test_segments[seg_list_slice], matchers, ctx, trim_noncode=trim_noncode
+        test_segments[segments_slice], matchers, ctx, trim_noncode=trim_noncode
     )
 
     # Make the check tuple

--- a/test/core/parser/grammar/grammar_other_test.py
+++ b/test/core/parser/grammar/grammar_other_test.py
@@ -9,7 +9,7 @@ import pytest
 
 from sqlfluff.core.parser import KeywordSegment, StringParser, SymbolSegment
 from sqlfluff.core.parser.context import ParseContext
-from sqlfluff.core.parser.grammar import Anything, Delimited, GreedyUntil
+from sqlfluff.core.parser.grammar import Anything, Delimited, GreedyUntil, Nothing
 from sqlfluff.core.parser.grammar.noncode import NonCodeMatcher
 
 
@@ -123,6 +123,12 @@ def test__parser__grammar_anything(
     terms = [StringParser(kw, KeywordSegment) for kw in terminators]
     result = Anything(terminators=terms).match(test_segments, parse_context=ctx)
     assert len(result) == match_length
+
+
+def test__parser__grammar_nothing(test_segments, fresh_ansi_dialect):
+    """Test the Nothing grammar."""
+    ctx = ParseContext(dialect=fresh_ansi_dialect)
+    assert not Nothing().match(test_segments, parse_context=ctx)
 
 
 def test__parser__grammar_noncode(test_segments, fresh_ansi_dialect):

--- a/test/core/parser/grammar/grammar_other_test.py
+++ b/test/core/parser/grammar/grammar_other_test.py
@@ -48,7 +48,7 @@ def test__parser__grammar_delimited(
     fresh_ansi_dialect,
 ):
     """Test the Delimited grammar when not code_only."""
-    seg_list = generate_test_segments(token_list)
+    test_segments = generate_test_segments(token_list)
     g = Delimited(
         StringParser("bar", KeywordSegment),
         delimiter=StringParser(".", SymbolSegment),
@@ -59,7 +59,7 @@ def test__parser__grammar_delimited(
     ctx = ParseContext(dialect=fresh_ansi_dialect)
     with caplog.at_level(logging.DEBUG, logger="sqlfluff.parser"):
         # Matching with whitespace shouldn't match if we need at least one delimiter
-        m = g.match(seg_list, parse_context=ctx)
+        m = g.match(test_segments, parse_context=ctx)
         assert len(m) == match_len
 
 
@@ -77,23 +77,25 @@ def test__parser__grammar_delimited(
         ("baar", 6),
     ],
 )
-def test__parser__grammar_greedyuntil(keyword, seg_list, slice_len, fresh_ansi_dialect):
+def test__parser__grammar_greedyuntil(
+    keyword, test_segments, slice_len, fresh_ansi_dialect
+):
     """Test the GreedyUntil grammar."""
     grammar = GreedyUntil(StringParser(keyword, KeywordSegment))
     ctx = ParseContext(dialect=fresh_ansi_dialect)
     assert (
-        grammar.match(seg_list, parse_context=ctx).matched_segments
-        == seg_list[:slice_len]
+        grammar.match(test_segments, parse_context=ctx).matched_segments
+        == test_segments[:slice_len]
     )
 
 
-def test__parser__grammar_greedyuntil_bracketed(bracket_seg_list, fresh_ansi_dialect):
+def test__parser__grammar_greedyuntil_bracketed(bracket_segments, fresh_ansi_dialect):
     """Test the GreedyUntil grammar with brackets."""
     fs = StringParser("foo", KeywordSegment)
     g = GreedyUntil(fs)
     ctx = ParseContext(dialect=fresh_ansi_dialect)
     # Check that we can make it past the brackets
-    match = g.match(bracket_seg_list, parse_context=ctx)
+    match = g.match(bracket_segments, parse_context=ctx)
     assert len(match) == 4
     # Check we successfully constructed a bracketed segment
     assert match.matched_segments[2].is_type("bracketed")
@@ -114,25 +116,25 @@ def test__parser__grammar_greedyuntil_bracketed(bracket_seg_list, fresh_ansi_dia
     ],
 )
 def test__parser__grammar_anything(
-    terminators, match_length, seg_list, fresh_ansi_dialect
+    terminators, match_length, test_segments, fresh_ansi_dialect
 ):
     """Test the Anything grammar."""
     ctx = ParseContext(dialect=fresh_ansi_dialect)
     terms = [StringParser(kw, KeywordSegment) for kw in terminators]
-    result = Anything(terminators=terms).match(seg_list, parse_context=ctx)
+    result = Anything(terminators=terms).match(test_segments, parse_context=ctx)
     assert len(result) == match_length
 
 
-def test__parser__grammar_nothing(seg_list, fresh_ansi_dialect):
+def test__parser__grammar_nothing_match2(test_segments, fresh_ansi_dialect):
     """Test the Nothing grammar."""
     ctx = ParseContext(dialect=fresh_ansi_dialect)
-    assert not Nothing().match(seg_list, parse_context=ctx)
+    assert not Nothing().match2(test_segments, 0, ctx)
 
 
-def test__parser__grammar_noncode(seg_list, fresh_ansi_dialect):
+def test__parser__grammar_noncode(test_segments, fresh_ansi_dialect):
     """Test the NonCodeMatcher."""
     ctx = ParseContext(dialect=fresh_ansi_dialect)
-    m = NonCodeMatcher().match(seg_list[1:], parse_context=ctx)
+    m = NonCodeMatcher().match(test_segments[1:], parse_context=ctx)
     # NonCode Matcher doesn't work with simple
     assert NonCodeMatcher().simple(ctx) is None
     # We should match one and only one segment

--- a/test/core/parser/grammar/grammar_other_test.py
+++ b/test/core/parser/grammar/grammar_other_test.py
@@ -125,12 +125,6 @@ def test__parser__grammar_anything(
     assert len(result) == match_length
 
 
-def test__parser__grammar_nothing_match2(test_segments, fresh_ansi_dialect):
-    """Test the Nothing grammar."""
-    ctx = ParseContext(dialect=fresh_ansi_dialect)
-    assert not Nothing().match2(test_segments, 0, ctx)
-
-
 def test__parser__grammar_noncode(test_segments, fresh_ansi_dialect):
     """Test the NonCodeMatcher."""
     ctx = ParseContext(dialect=fresh_ansi_dialect)

--- a/test/core/parser/grammar/grammar_other_test.py
+++ b/test/core/parser/grammar/grammar_other_test.py
@@ -9,7 +9,7 @@ import pytest
 
 from sqlfluff.core.parser import KeywordSegment, StringParser, SymbolSegment
 from sqlfluff.core.parser.context import ParseContext
-from sqlfluff.core.parser.grammar import Anything, Delimited, GreedyUntil, Nothing
+from sqlfluff.core.parser.grammar import Anything, Delimited, GreedyUntil
 from sqlfluff.core.parser.grammar.noncode import NonCodeMatcher
 
 

--- a/test/core/parser/grammar/grammar_ref_test.py
+++ b/test/core/parser/grammar/grammar_ref_test.py
@@ -34,7 +34,7 @@ def test__parser__grammar_ref_exclude(generate_test_segments, fresh_ansi_dialect
     ni = Ref("NakedIdentifierSegment", exclude=Ref.keyword("ABS"))
     ts = generate_test_segments(["ABS", "ABSOLUTE"])
     ctx = ParseContext(dialect=fresh_ansi_dialect)
-    # Asset ABS does not match, due to the exclude
+    # Assert ABS does not match, due to the exclude
     assert not ni.match([ts[0]], parse_context=ctx)
-    # Asset ABSOLUTE does match
+    # Assert ABSOLUTE does match
     assert ni.match([ts[1]], parse_context=ctx)

--- a/test/core/parser/grammar/grammar_sequence_test.py
+++ b/test/core/parser/grammar/grammar_sequence_test.py
@@ -14,7 +14,7 @@ from sqlfluff.core.parser.grammar import Conditional, Sequence
 from sqlfluff.core.parser.types import ParseMode
 
 
-def test__parser__grammar_sequence(seg_list, caplog):
+def test__parser__grammar_sequence(test_segments, caplog):
     """Test the Sequence grammar."""
     bs = StringParser("bar", KeywordSegment)
     fs = StringParser("foo", KeywordSegment)
@@ -27,20 +27,20 @@ def test__parser__grammar_sequence(seg_list, caplog):
     with caplog.at_level(logging.DEBUG, logger="sqlfluff.parser"):
         # Should be able to match the list using the normal matcher
         logging.info("#### TEST 1")
-        m = g.match(seg_list, parse_context=ctx)
+        m = g.match(test_segments, parse_context=ctx)
         assert m
         assert len(m) == 3
         assert m.matched_segments == (
-            KeywordSegment("bar", seg_list[0].pos_marker),
-            seg_list[1],  # This will be the whitespace segment
-            KeywordSegment("foo", seg_list[2].pos_marker),
+            KeywordSegment("bar", test_segments[0].pos_marker),
+            test_segments[1],  # This will be the whitespace segment
+            KeywordSegment("foo", test_segments[2].pos_marker),
         )
         # Shouldn't with the allow_gaps matcher
         logging.info("#### TEST 2")
-        assert not gc.match(seg_list, parse_context=ctx)
+        assert not gc.match(test_segments, parse_context=ctx)
         # Shouldn't match even on the normal one if we don't start at the beginning
         logging.info("#### TEST 2")
-        assert not g.match(seg_list[1:], parse_context=ctx)
+        assert not g.match(test_segments[1:], parse_context=ctx)
 
 
 def test__parser__grammar_sequence_repr():
@@ -54,7 +54,7 @@ def test__parser__grammar_sequence_repr():
     )
 
 
-def test__parser__grammar_sequence_nested(seg_list, caplog):
+def test__parser__grammar_sequence_nested(test_segments, caplog):
     """Test the Sequence grammar when nested."""
     bs = StringParser("bar", KeywordSegment)
     fs = StringParser("foo", KeywordSegment)
@@ -64,33 +64,33 @@ def test__parser__grammar_sequence_nested(seg_list, caplog):
     with caplog.at_level(logging.DEBUG, logger="sqlfluff.parser"):
         # Matching the start of the list shouldn't work
         logging.info("#### TEST 1")
-        assert not g.match(seg_list[:2], parse_context=ctx)
+        assert not g.match(test_segments[:2], parse_context=ctx)
         # Matching the whole list should, and the result should be flat
         logging.info("#### TEST 2")
-        assert g.match(seg_list, parse_context=ctx).matched_segments == (
-            KeywordSegment("bar", seg_list[0].pos_marker),
-            seg_list[1],  # This will be the whitespace segment
-            KeywordSegment("foo", seg_list[2].pos_marker),
-            KeywordSegment("baar", seg_list[3].pos_marker)
+        assert g.match(test_segments, parse_context=ctx).matched_segments == (
+            KeywordSegment("bar", test_segments[0].pos_marker),
+            test_segments[1],  # This will be the whitespace segment
+            KeywordSegment("foo", test_segments[2].pos_marker),
+            KeywordSegment("baar", test_segments[3].pos_marker)
             # NB: No whitespace at the end, this shouldn't be consumed.
         )
 
 
-def test__parser__grammar_sequence_indent(seg_list, caplog):
+def test__parser__grammar_sequence_indent(test_segments, caplog):
     """Test the Sequence grammar with indents."""
     bs = StringParser("bar", KeywordSegment)
     fs = StringParser("foo", KeywordSegment)
     g = Sequence(Indent, bs, fs)
     ctx = ParseContext(dialect=None)
     with caplog.at_level(logging.DEBUG, logger="sqlfluff.parser"):
-        m = g.match(seg_list, parse_context=ctx)
+        m = g.match(test_segments, parse_context=ctx)
         assert m
         # check we get an indent.
         assert isinstance(m.matched_segments[0], Indent)
         assert isinstance(m.matched_segments[1], KeywordSegment)
 
 
-def test__parser__grammar_sequence_indent_conditional(seg_list, caplog):
+def test__parser__grammar_sequence_indent_conditional(test_segments, caplog):
     """Test the Sequence grammar with indents."""
     bs = StringParser("bar", KeywordSegment)
     fs = StringParser("foo", KeywordSegment)
@@ -105,7 +105,7 @@ def test__parser__grammar_sequence_indent_conditional(seg_list, caplog):
     )
     ctx = ParseContext(dialect=None)
     with caplog.at_level(logging.DEBUG, logger="sqlfluff.parser"):
-        m = g.match(seg_list, parse_context=ctx)
+        m = g.match(test_segments, parse_context=ctx)
         assert m
         # Check we get an Indent.
         assert isinstance(m.matched_segments[0], Indent)

--- a/test/core/parser/helpers_test.py
+++ b/test/core/parser/helpers_test.py
@@ -22,11 +22,11 @@ def test__parser__helper_trim_non_code_segments(
     generate_test_segments,
 ):
     """Test trim_non_code_segments."""
-    seg_list = generate_test_segments(token_list)
-    pre, mid, post = trim_non_code_segments(seg_list)
+    segments = generate_test_segments(token_list)
+    pre, mid, post = trim_non_code_segments(segments)
     # Assert lengths
     assert (len(pre), len(mid), len(post)) == (pre_len, mid_len, post_len)
     # Assert content
     assert [elem.raw for elem in pre] == list(token_list[:pre_len])
     assert [elem.raw for elem in mid] == list(token_list[pre_len : pre_len + mid_len])
-    assert [elem.raw for elem in post] == list(token_list[len(seg_list) - post_len :])
+    assert [elem.raw for elem in post] == list(token_list[len(segments) - post_len :])

--- a/test/core/parser/parse_test.py
+++ b/test/core/parser/parse_test.py
@@ -15,12 +15,12 @@ class BasicSegment(BaseSegment):
     match_grammar = Anything()
 
 
-def test__parser__parse_match(seg_list):
+def test__parser__parse_match(test_segments):
     """Test match method on a real segment."""
     ctx = ParseContext(dialect=None)
     # This should match and have consumed everything, which should
     # now be part of a BasicSegment.
-    m = BasicSegment.match(seg_list[:1], parse_context=ctx)
+    m = BasicSegment.match(test_segments[:1], parse_context=ctx)
     assert m
     assert len(m.matched_segments) == 1
     assert isinstance(m.matched_segments[0], BasicSegment)

--- a/test/core/parser/parser_test.py
+++ b/test/core/parser/parser_test.py
@@ -3,6 +3,7 @@
 from sqlfluff.core.parser import (
     KeywordSegment,
     MultiStringParser,
+    RawSegment,
     RegexParser,
     StringParser,
     TypedParser,
@@ -25,22 +26,49 @@ def test__parser__repr():
     assert repr(RegexParser(r"fo|o", KeywordSegment)) == "<RegexParser: 'fo|o'>"
 
 
+class ExampleSegment(RawSegment):
+    """A minimal example segment for testing."""
+
+    type = "example"
+
+
+def test__parser__typedparser__simple():
+    """Test the simple method of TypedParser."""
+    parser = TypedParser("single_quote", ExampleSegment)
+    ctx = ParseContext(dialect=None)
+    assert parser.simple(ctx) == (frozenset(), frozenset(["single_quote"]))
+
+
+def test__parser__stringparser__simple():
+    """Test the simple method of StringParser."""
+    parser = StringParser("foo", ExampleSegment)
+    ctx = ParseContext(dialect=None)
+    assert parser.simple(ctx) == (frozenset(["FOO"]), frozenset())
+
+
+def test__parser__regexparser__simple():
+    """Test the simple method of RegexParser."""
+    parser = RegexParser(r"b.r", ExampleSegment)
+    ctx = ParseContext(dialect=None)
+    assert parser.simple(ctx) is None
+
+
 def test__parser__multistringparser__match(generate_test_segments):
     """Test the MultiStringParser matchable."""
     parser = MultiStringParser(["foo", "bar"], KeywordSegment)
     ctx = ParseContext(dialect=None)
     # Check directly
-    seg_list = generate_test_segments(["foo", "fo"])
+    segments = generate_test_segments(["foo", "fo"])
     # Matches when it should
-    assert parser.match(seg_list[:1], parse_context=ctx).matched_segments == (
-        KeywordSegment("foo", seg_list[0].pos_marker),
+    assert parser.match(segments[:1], parse_context=ctx).matched_segments == (
+        KeywordSegment("foo", segments[0].pos_marker),
     )
     # Doesn't match when it shouldn't
-    assert parser.match(seg_list[1:], parse_context=ctx).matched_segments == tuple()
+    assert parser.match(segments[1:], parse_context=ctx).matched_segments == tuple()
 
 
 def test__parser__multistringparser__simple():
     """Test the MultiStringParser matchable."""
     parser = MultiStringParser(["foo", "bar"], KeywordSegment)
     ctx = ParseContext(dialect=None)
-    assert parser.simple(ctx)
+    assert parser.simple(ctx) == (frozenset(["FOO", "BAR"]), frozenset())

--- a/test/core/parser/segments/conftest.py
+++ b/test/core/parser/segments/conftest.py
@@ -6,15 +6,15 @@ from sqlfluff.core.parser import BaseSegment
 
 
 @pytest.fixture(scope="module")
-def raw_seg_list(generate_test_segments):
+def raw_segments(generate_test_segments):
     """Construct a list of raw segments as a fixture."""
     return generate_test_segments(["foobar", ".barfoo"])
 
 
 @pytest.fixture(scope="module")
-def raw_seg(raw_seg_list):
+def raw_seg(raw_segments):
     """Construct a raw segment as a fixture."""
-    return raw_seg_list[0]
+    return raw_segments[0]
 
 
 @pytest.fixture(scope="session")

--- a/test/core/parser/segments/segments_base_test.py
+++ b/test/core/parser/segments/segments_base_test.py
@@ -26,34 +26,34 @@ def test__parser__base_segments_class_types(DummySegment):
 
 
 def test__parser__base_segments_descendant_type_set(
-    raw_seg_list, DummySegment, DummyAuxSegment
+    raw_segments, DummySegment, DummyAuxSegment
 ):
     """Test the .descendant_type_set() method."""
-    test_seg = DummySegment([DummyAuxSegment(raw_seg_list)])
+    test_seg = DummySegment([DummyAuxSegment(raw_segments)])
     assert test_seg.descendant_type_set == {"raw", "base", "dummy_aux"}
 
 
 def test__parser__base_segments_direct_descendant_type_set(
-    raw_seg_list, DummySegment, DummyAuxSegment
+    raw_segments, DummySegment, DummyAuxSegment
 ):
     """Test the .direct_descendant_type_set() method."""
-    test_seg = DummySegment([DummyAuxSegment(raw_seg_list)])
+    test_seg = DummySegment([DummyAuxSegment(raw_segments)])
     assert test_seg.direct_descendant_type_set == {"base", "dummy_aux"}
 
 
-def test__parser__base_segments_to_tuple_a(raw_seg_list, DummySegment, DummyAuxSegment):
+def test__parser__base_segments_to_tuple_a(raw_segments, DummySegment, DummyAuxSegment):
     """Test the .to_tuple() method."""
-    test_seg = DummySegment([DummyAuxSegment(raw_seg_list)])
+    test_seg = DummySegment([DummyAuxSegment(raw_segments)])
     assert test_seg.to_tuple() == (
         "dummy",
         (("dummy_aux", (("raw", ()), ("raw", ()))),),
     )
 
 
-def test__parser__base_segments_to_tuple_b(raw_seg_list, DummySegment, DummyAuxSegment):
+def test__parser__base_segments_to_tuple_b(raw_segments, DummySegment, DummyAuxSegment):
     """Test the .to_tuple() method."""
     test_seg = DummySegment(
-        [DummyAuxSegment(raw_seg_list + (DummyAuxSegment(raw_seg_list[:1]),))]
+        [DummyAuxSegment(raw_segments + (DummyAuxSegment(raw_segments[:1]),))]
     )
     assert test_seg.to_tuple() == (
         "dummy",
@@ -61,10 +61,10 @@ def test__parser__base_segments_to_tuple_b(raw_seg_list, DummySegment, DummyAuxS
     )
 
 
-def test__parser__base_segments_to_tuple_c(raw_seg_list, DummySegment, DummyAuxSegment):
+def test__parser__base_segments_to_tuple_c(raw_segments, DummySegment, DummyAuxSegment):
     """Test the .to_tuple() method with show_raw=True."""
     test_seg = DummySegment(
-        [DummyAuxSegment(raw_seg_list + (DummyAuxSegment(raw_seg_list[:1]),))]
+        [DummyAuxSegment(raw_segments + (DummyAuxSegment(raw_segments[:1]),))]
     )
     assert test_seg.to_tuple(show_raw=True) == (
         "dummy",
@@ -82,21 +82,21 @@ def test__parser__base_segments_to_tuple_c(raw_seg_list, DummySegment, DummyAuxS
 
 
 def test__parser__base_segments_as_record_a(
-    raw_seg_list, DummySegment, DummyAuxSegment
+    raw_segments, DummySegment, DummyAuxSegment
 ):
     """Test the .as_record() method.
 
     NOTE: In this test, note that there are lists, as some segment types
     are duplicated within their parent segment.
     """
-    test_seg = DummySegment([DummyAuxSegment(raw_seg_list)])
+    test_seg = DummySegment([DummyAuxSegment(raw_segments)])
     assert test_seg.as_record() == {
         "dummy": {"dummy_aux": [{"raw": None}, {"raw": None}]}
     }
 
 
 def test__parser__base_segments_as_record_b(
-    raw_seg_list, DummySegment, DummyAuxSegment
+    raw_segments, DummySegment, DummyAuxSegment
 ):
     """Test the .as_record() method.
 
@@ -104,7 +104,7 @@ def test__parser__base_segments_as_record_b(
     is unique within it's parent segment, and so there is no need.
     """
     test_seg = DummySegment(
-        [DummyAuxSegment(raw_seg_list[:1] + (DummyAuxSegment(raw_seg_list[:1]),))]
+        [DummyAuxSegment(raw_segments[:1] + (DummyAuxSegment(raw_segments[:1]),))]
     )
     assert test_seg.as_record() == {
         "dummy": {"dummy_aux": {"raw": None, "dummy_aux": {"raw": None}}}
@@ -112,7 +112,7 @@ def test__parser__base_segments_as_record_b(
 
 
 def test__parser__base_segments_as_record_c(
-    raw_seg_list, DummySegment, DummyAuxSegment
+    raw_segments, DummySegment, DummyAuxSegment
 ):
     """Test the .as_record() method with show_raw=True.
 
@@ -120,7 +120,7 @@ def test__parser__base_segments_as_record_c(
     is unique within it's parent segment, and so there is no need.
     """
     test_seg = DummySegment(
-        [DummyAuxSegment(raw_seg_list[:1] + (DummyAuxSegment(raw_seg_list[:1]),))]
+        [DummyAuxSegment(raw_segments[:1] + (DummyAuxSegment(raw_segments[:1]),))]
     )
     assert test_seg.as_record(show_raw=True) == {
         "dummy": {"dummy_aux": {"raw": "foobar", "dummy_aux": {"raw": "foobar"}}}
@@ -128,10 +128,10 @@ def test__parser__base_segments_as_record_c(
 
 
 def test__parser__base_segments_count_segments(
-    raw_seg_list, DummySegment, DummyAuxSegment
+    raw_segments, DummySegment, DummyAuxSegment
 ):
     """Test the .count_segments() method."""
-    test_seg = DummySegment([DummyAuxSegment(raw_seg_list)])
+    test_seg = DummySegment([DummyAuxSegment(raw_segments)])
     assert test_seg.count_segments() == 4
     assert test_seg.count_segments(raw_only=True) == 2
 
@@ -163,38 +163,38 @@ def test__parser_base_segments_validate_non_code_ends(
         seg.validate_non_code_ends()
 
 
-def test__parser_base_segments_compute_anchor_edit_info(raw_seg_list):
+def test__parser_base_segments_compute_anchor_edit_info(raw_segments):
     """Test BaseSegment.compute_anchor_edit_info()."""
     # Construct a fix buffer, intentionally with:
     # - one duplicate.
     # - two different incompatible fixes on the same segment.
     fixes = [
-        LintFix.replace(raw_seg_list[0], [raw_seg_list[0].edit(raw="a")]),
-        LintFix.replace(raw_seg_list[0], [raw_seg_list[0].edit(raw="a")]),
-        LintFix.replace(raw_seg_list[0], [raw_seg_list[0].edit(raw="b")]),
+        LintFix.replace(raw_segments[0], [raw_segments[0].edit(raw="a")]),
+        LintFix.replace(raw_segments[0], [raw_segments[0].edit(raw="a")]),
+        LintFix.replace(raw_segments[0], [raw_segments[0].edit(raw="b")]),
     ]
     anchor_info_dict = BaseSegment.compute_anchor_edit_info(fixes)
     # Check the target segment is the only key we have.
-    assert list(anchor_info_dict.keys()) == [raw_seg_list[0].uuid]
-    anchor_info = anchor_info_dict[raw_seg_list[0].uuid]
+    assert list(anchor_info_dict.keys()) == [raw_segments[0].uuid]
+    anchor_info = anchor_info_dict[raw_segments[0].uuid]
     # Check that the duplicate as been deduplicated.
     # i.e. this isn't 3.
     assert anchor_info.replace == 2
     # Check the fixes themselves.
     # NOTE: There's no duplicated first fix.
     assert anchor_info.fixes == [
-        LintFix.replace(raw_seg_list[0], [raw_seg_list[0].edit(raw="a")]),
-        LintFix.replace(raw_seg_list[0], [raw_seg_list[0].edit(raw="b")]),
+        LintFix.replace(raw_segments[0], [raw_segments[0].edit(raw="a")]),
+        LintFix.replace(raw_segments[0], [raw_segments[0].edit(raw="b")]),
     ]
     # Check the first replace
     assert anchor_info._first_replace == LintFix.replace(
-        raw_seg_list[0], [raw_seg_list[0].edit(raw="a")]
+        raw_segments[0], [raw_segments[0].edit(raw="a")]
     )
 
 
-def test__parser__base_segments_path_to(raw_seg_list, DummySegment, DummyAuxSegment):
+def test__parser__base_segments_path_to(raw_segments, DummySegment, DummyAuxSegment):
     """Test the .path_to() method."""
-    test_seg_a = DummyAuxSegment(raw_seg_list)
+    test_seg_a = DummyAuxSegment(raw_segments)
     test_seg_b = DummySegment([test_seg_a])
     # With a direct parent/child relationship we only get
     # one element of path.
@@ -202,11 +202,11 @@ def test__parser__base_segments_path_to(raw_seg_list, DummySegment, DummyAuxSegm
     # so that means the do appear in code_idxs.
     assert test_seg_b.path_to(test_seg_a) == [PathStep(test_seg_b, 0, 1, (0,))]
     # With a three segment chain - we get two path elements.
-    assert test_seg_b.path_to(raw_seg_list[0]) == [
+    assert test_seg_b.path_to(raw_segments[0]) == [
         PathStep(test_seg_b, 0, 1, (0,)),
         PathStep(test_seg_a, 0, 2, (0, 1)),
     ]
-    assert test_seg_b.path_to(raw_seg_list[1]) == [
+    assert test_seg_b.path_to(raw_segments[1]) == [
         PathStep(test_seg_b, 0, 1, (0,)),
         PathStep(test_seg_a, 1, 2, (0, 1)),
     ]
@@ -240,17 +240,17 @@ def test__parser__base_segments_raw(raw_seg):
     assert raw_seg.to_tuple(show_raw=True) == ("raw", "foobar")
 
 
-def test__parser__base_segments_base(raw_seg_list, fresh_ansi_dialect, DummySegment):
+def test__parser__base_segments_base(raw_segments, fresh_ansi_dialect, DummySegment):
     """Test base segments behave as expected."""
-    base_seg = DummySegment(raw_seg_list)
+    base_seg = DummySegment(raw_segments)
     # Check we assume the position correctly
     assert (
         base_seg.pos_marker.start_point_marker()
-        == raw_seg_list[0].pos_marker.start_point_marker()
+        == raw_segments[0].pos_marker.start_point_marker()
     )
     assert (
         base_seg.pos_marker.end_point_marker()
-        == raw_seg_list[-1].pos_marker.end_point_marker()
+        == raw_segments[-1].pos_marker.end_point_marker()
     )
 
     # Check that we correctly reconstruct the raw
@@ -258,7 +258,7 @@ def test__parser__base_segments_base(raw_seg_list, fresh_ansi_dialect, DummySegm
     # Check tuple
     assert base_seg.to_tuple() == (
         "dummy",
-        (raw_seg_list[0].to_tuple(), raw_seg_list[1].to_tuple()),
+        (raw_segments[0].to_tuple(), raw_segments[1].to_tuple()),
     )
     # Check Formatting and Stringification
     assert str(base_seg) == repr(base_seg) == "<DummySegment: ([L:  1, P:  1])>"
@@ -295,9 +295,9 @@ def test__parser__base_segments_base_compare(DummySegment, DummyAuxSegment):
     assert ds1 != dsa2
 
 
-def test__parser__base_segments_pickle_safe(raw_seg_list):
+def test__parser__base_segments_pickle_safe(raw_segments):
     """Test pickling and unpickling of BaseSegment."""
-    test_seg = BaseSegment([BaseSegment(raw_seg_list)])
+    test_seg = BaseSegment([BaseSegment(raw_segments)])
     test_seg.set_as_parent()
     pickled = pickle.dumps(test_seg)
     result_seg = pickle.loads(pickled)
@@ -306,13 +306,13 @@ def test__parser__base_segments_pickle_safe(raw_seg_list):
     assert result_seg.segments[0].get_parent() is result_seg
 
 
-def test__parser__base_segments_copy_isolation(DummySegment, raw_seg_list):
+def test__parser__base_segments_copy_isolation(DummySegment, raw_segments):
     """Test copy isolation in BaseSegment.
 
     First on one of the raws and then on the dummy segment.
     """
     # On a raw
-    a_seg = raw_seg_list[0]
+    a_seg = raw_segments[0]
     a_copy = a_seg.copy()
     assert a_seg is not a_copy
     assert a_seg == a_copy
@@ -322,7 +322,7 @@ def test__parser__base_segments_copy_isolation(DummySegment, raw_seg_list):
     assert a_seg.pos_marker is not None
 
     # On a base
-    b_seg = DummySegment(segments=raw_seg_list)
+    b_seg = DummySegment(segments=raw_segments)
     b_copy = b_seg.copy()
     assert b_seg is not b_copy
     assert b_seg == b_copy
@@ -338,12 +338,12 @@ def test__parser__base_segments_copy_isolation(DummySegment, raw_seg_list):
     assert b_seg.pos_marker
 
 
-def test__parser__base_segments_parent_ref(DummySegment, raw_seg_list):
+def test__parser__base_segments_parent_ref(DummySegment, raw_segments):
     """Test getting and setting parents on BaseSegment."""
     # Check initially no parent (because not set)
-    assert not raw_seg_list[0].get_parent()
+    assert not raw_segments[0].get_parent()
     # Add it to a segment (which also sets the parent value)
-    seg = DummySegment(segments=raw_seg_list)
+    seg = DummySegment(segments=raw_segments)
     assert seg.segments[0].get_parent() is seg
     assert seg.segments[1].get_parent() is seg
     # Remove segment from parent, but don't unset.

--- a/test/core/parser/segments/segments_common_test.py
+++ b/test/core/parser/segments/segments_common_test.py
@@ -8,12 +8,12 @@ from sqlfluff.core.parser.context import ParseContext
 
 # NOTE: For legacy reasons we override this fixture for this module
 @pytest.fixture(scope="module")
-def raw_seg_list(generate_test_segments):
+def raw_segments(generate_test_segments):
     """A generic list of raw segments to test against."""
     return generate_test_segments(["bar", "foo", "bar"])
 
 
-def test__parser__core_keyword(raw_seg_list):
+def test__parser__core_keyword(raw_segments):
     """Test the Mystical KeywordSegment."""
     # First make a keyword
     FooKeyword = StringParser("foo", KeywordSegment, type="bar")
@@ -21,20 +21,20 @@ def test__parser__core_keyword(raw_seg_list):
     assert FooKeyword.template.upper() == "FOO"
     ctx = ParseContext(dialect=None)
     # Match it against a list and check it doesn't match
-    assert not FooKeyword.match(raw_seg_list, parse_context=ctx)
+    assert not FooKeyword.match(raw_segments, parse_context=ctx)
     # Match it against a the first element and check it doesn't match
-    assert not FooKeyword.match(raw_seg_list[0], parse_context=ctx)
+    assert not FooKeyword.match(raw_segments[0], parse_context=ctx)
     # Match it against a the first element as a list and check it doesn't match
-    assert not FooKeyword.match([raw_seg_list[0]], parse_context=ctx)
+    assert not FooKeyword.match([raw_segments[0]], parse_context=ctx)
     # Match it against the final element (returns tuple)
-    m = FooKeyword.match(raw_seg_list[1], parse_context=ctx)
+    m = FooKeyword.match(raw_segments[1], parse_context=ctx)
     assert m
     assert m.matched_segments[0].raw == "foo"
     assert isinstance(m.matched_segments[0], KeywordSegment)
     # Match it against the final element as a list
-    assert FooKeyword.match([raw_seg_list[1]], parse_context=ctx)
+    assert FooKeyword.match([raw_segments[1]], parse_context=ctx)
     # Match it against a list slice and check it still works
-    assert FooKeyword.match(raw_seg_list[1:], parse_context=ctx)
+    assert FooKeyword.match(raw_segments[1:], parse_context=ctx)
     # Check that the types work right. Importantly that the "bar"
     # type makes it in.
     assert m.matched_segments[0].class_types == {"base", "keyword", "raw", "bar"}

--- a/test/core/parser/segments/segments_file_test.py
+++ b/test/core/parser/segments/segments_file_test.py
@@ -1,14 +1,6 @@
 """Test the BaseFileSegment class."""
 
-import pytest
-
 from sqlfluff.core.parser import BaseFileSegment
-
-
-@pytest.fixture(scope="module")
-def raw_segments(generate_test_segments):
-    """Construct a list of raw segments as a fixture."""
-    return generate_test_segments(["foobar", ".barfoo"])
 
 
 def test__parser__base_segments_file(raw_segments):

--- a/test/core/parser/segments/segments_file_test.py
+++ b/test/core/parser/segments/segments_file_test.py
@@ -6,14 +6,14 @@ from sqlfluff.core.parser import BaseFileSegment
 
 
 @pytest.fixture(scope="module")
-def raw_seg_list(generate_test_segments):
+def raw_segments(generate_test_segments):
     """Construct a list of raw segments as a fixture."""
     return generate_test_segments(["foobar", ".barfoo"])
 
 
-def test__parser__base_segments_file(raw_seg_list):
+def test__parser__base_segments_file(raw_segments):
     """Test BaseFileSegment to behave as expected."""
-    base_seg = BaseFileSegment(raw_seg_list, fname="/some/dir/file.sql")
+    base_seg = BaseFileSegment(raw_segments, fname="/some/dir/file.sql")
     assert base_seg.type == "file"
     assert base_seg.file_path == "/some/dir/file.sql"
     assert base_seg.can_start_end_non_code

--- a/test/core/parser/segments/segments_raw_test.py
+++ b/test/core/parser/segments/segments_raw_test.py
@@ -3,28 +3,28 @@
 from sqlfluff.core.parser.segments.base import PathStep
 
 
-def test__parser__raw_get_raw_segments(raw_seg_list):
+def test__parser__raw_get_raw_segments(raw_segments):
     """Test niche case of calling get_raw_segments on a raw segment."""
-    for s in raw_seg_list:
+    for s in raw_segments:
         assert s.get_raw_segments() == [s]
 
 
 def test__parser__raw_segments_with_ancestors(
-    raw_seg_list, DummySegment, DummyAuxSegment
+    raw_segments, DummySegment, DummyAuxSegment
 ):
     """Test raw_segments_with_ancestors.
 
     This is used in the reflow module to assess parse depth.
     """
-    test_seg = DummySegment([DummyAuxSegment(raw_seg_list[:1]), raw_seg_list[1]])
+    test_seg = DummySegment([DummyAuxSegment(raw_segments[:1]), raw_segments[1]])
     # Result should be the same raw segment, but with appropriate parents
     assert test_seg.raw_segments_with_ancestors == [
         (
-            raw_seg_list[0],
+            raw_segments[0],
             [
                 PathStep(test_seg, 0, 2, (0, 1)),
                 PathStep(test_seg.segments[0], 0, 1, (0,)),
             ],
         ),
-        (raw_seg_list[1], [PathStep(test_seg, 1, 2, (0, 1))]),
+        (raw_segments[1], [PathStep(test_seg, 1, 2, (0, 1))]),
     ]

--- a/test/dialects/conftest.py
+++ b/test/dialects/conftest.py
@@ -17,10 +17,10 @@ def lex(raw, config):
     # Lex the string for matching. For a good test, this would
     # arguably happen as a fixture, but it's easier to pass strings
     # as parameters than pre-lexed segment strings.
-    seg_list, vs = lex.lex(raw)
+    segments, vs = lex.lex(raw)
     assert not vs
-    print(seg_list)
-    return seg_list
+    print(segments)
+    return segments
 
 
 def validate_segment(segmentref, config):
@@ -47,16 +47,16 @@ def _dialect_specific_segment_parses(dialect, segmentref, raw, caplog):
     function of the parent will not be tested.
     """
     config = FluffConfig(overrides=dict(dialect=dialect))
-    seg_list = lex(raw, config=config)
+    segments = lex(raw, config=config)
     Seg = validate_segment(segmentref, config=config)
 
     # Most segments won't handle the end of file marker. We should strip it.
-    if seg_list[-1].is_type("end_of_file"):
-        seg_list = seg_list[:-1]
+    if segments[-1].is_type("end_of_file"):
+        segments = segments[:-1]
 
     ctx = ParseContext.from_config(config)
     with caplog.at_level(logging.DEBUG):
-        parsed = Seg.match(segments=seg_list, parse_context=ctx)
+        parsed = Seg.match(segments=segments, parse_context=ctx)
     assert isinstance(parsed, MatchResult)
     assert len(parsed.matched_segments) == 1
     print(parsed)
@@ -80,12 +80,12 @@ def _dialect_specific_segment_not_match(dialect, segmentref, raw, caplog):
     This is the opposite to the above.
     """
     config = FluffConfig(overrides=dict(dialect=dialect))
-    seg_list = lex(raw, config=config)
+    segments = lex(raw, config=config)
     Seg = validate_segment(segmentref, config=config)
 
     ctx = ParseContext.from_config(config)
     with caplog.at_level(logging.DEBUG):
-        match = Seg.match(segments=seg_list, parse_context=ctx)
+        match = Seg.match(segments=segments, parse_context=ctx)
 
     assert not match
 


### PR DESCRIPTION
This is almost entirely a _find-and-replace_ job (with a couple of other nits).

In particular, lots of tests refer to `seg_list` or `raw_seg_list`, and both are **always tuples**. This renames them so they're not labelled as lists.

Other than that, this fixes some typos, adds a few more test cases to `.simple()`. Hopefully non-controversial, and would otherwise complicate a separate PR.