### PR TITLE
Spark Accessor Grammars

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2219,10 +2219,10 @@ ansi_dialect.add(
             Ref("LocalAliasSegment"),
             terminators=[Ref("CommaSegment")],
         ),
-        Ref("Accessor_Grammar", optional=True),
+        Ref("AccessorGrammar", optional=True),
         allow_gaps=True,
     ),
-    Accessor_Grammar=AnyNumberOf(Ref("ArrayAccessorSegment")),
+    AccessorGrammar=AnyNumberOf(Ref("ArrayAccessorSegment")),
 )
 
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2776,6 +2776,7 @@ class WithCompoundStatementSegment(BaseSegment):
         Delimited(
             Ref("CTEDefinitionSegment"),
             terminators=["SELECT"],
+            allow_trailing=True,
         ),
         Conditional(Dedent, indented_ctes=True),
         OneOf(

--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -202,7 +202,7 @@ athena_dialect.replace(
             Ref("ParameterSegment"),
         ]
     ),
-    Accessor_Grammar=Sequence(
+    AccessorGrammar=Sequence(
         AnyNumberOf(
             Ref("ArrayAccessorSegment"),
             optional=True,

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -235,7 +235,7 @@ bigquery_dialect.replace(
     ),
     NaturalJoinKeywordsGrammar=Nothing(),
     MergeIntoLiteralGrammar=Sequence("MERGE", Ref.keyword("INTO", optional=True)),
-    Accessor_Grammar=AnyNumberOf(
+    AccessorGrammar=AnyNumberOf(
         Ref("ArrayAccessorSegment"),
         # Add in semi structured expressions
         Ref("SemiStructuredAccessorSegment"),

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -514,7 +514,7 @@ postgres_dialect.replace(
         Sequence("WITH", "DATA"),
         Ref("ForClauseSegment"),
     ),
-    Accessor_Grammar=AnyNumberOf(
+    AccessorGrammar=AnyNumberOf(
         Ref("ArrayAccessorSegment"),
         # Add in semi structured expressions
         Ref("SemiStructuredAccessorSegment"),

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -491,7 +491,7 @@ snowflake_dialect.replace(
             Ref("ReferencedVariableNameSegment"),
         ]
     ),
-    Accessor_Grammar=AnyNumberOf(
+    AccessorGrammar=AnyNumberOf(
         Ref("ArrayAccessorSegment"),
         # Add in semi structured expressions
         Ref("SemiStructuredAccessorSegment"),

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -543,7 +543,7 @@ tsql_dialect.replace(
             Ref("TypedArrayLiteralSegment"),
             Ref("ArrayLiteralSegment"),
         ),
-        Ref("Accessor_Grammar", optional=True),
+        Ref("AccessorGrammar", optional=True),
         allow_gaps=True,
     ),
     MergeIntoLiteralGrammar=Sequence(

--- a/test/fixtures/dialects/sparksql/databricks_operator_colon_sign.yml
+++ b/test/fixtures/dialects/sparksql/databricks_operator_colon_sign.yml
@@ -3,17 +3,19 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 677133458db91d62118a67dbd7c1bcf81c3606396175e5e7de01565c67b601ed
+_hash: a42f528b0577d8142a3e493762f623fdf3f3f3c76108910e3bd7446fac280748
 file:
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-          - naked_identifier: c1
-          - colon: ':'
-          - naked_identifier: price
+          expression:
+            column_reference:
+              naked_identifier: c1
+            semi_structured_expression:
+              colon: ':'
+              semi_structured_element: price
       from_clause:
         keyword: FROM
         from_expression:
@@ -44,11 +46,10 @@ file:
             cast_expression:
               column_reference:
                 naked_identifier: c1
+              semi_structured_expression:
                 colon: ':'
-              array_accessor:
                 start_square_bracket: '['
-                expression:
-                  quoted_literal: "'price'"
+                semi_structured_element: "'price'"
                 end_square_bracket: ']'
               casting_operator: '::'
               data_type:

--- a/test/generate_parse_fixture_yml.py
+++ b/test/generate_parse_fixture_yml.py
@@ -98,7 +98,7 @@ def generate_one_parse_fixture(
 
     try:
         tree = parse_example_file(dialect, sqlfile)
-    except SQLParseError as err:
+    except Exception as err:
         # Catch parsing errors, and wrap the file path only it.
         return example, SQLParseError(f"Fatal parsing error: {sql_path}: {err}")
 


### PR DESCRIPTION
This came up while working on the next phase of #5124.

The way that JSON accessing is done in the SparkSQL dialect was very fragile. I've instead copied some of the same methodology from the Snowflake dialect which I think is more robust and ported it across to SparkSQL.

In the process, the `Accessor_Grammar` was (I think) the only grammar with an underscore, so I've also renamed it in all dialects to `AccessorGrammar` in line with the convention.