### PR TITLE
Resolve #5225: Snowflake unparsable select replace

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1456,6 +1456,7 @@ class WildcardExpressionSegment(ansi.WildcardExpressionSegment):
         insert=[
             # Optional Exclude or Rename clause
             Ref("ExcludeClauseSegment", optional=True),
+            Ref("ReplaceClauseSegment", optional=True),
             Ref("RenameClauseSegment", optional=True),
         ]
     )
@@ -1501,6 +1502,27 @@ class RenameClauseSegment(BaseSegment):
                     )
                 )
             ),
+        ),
+    )
+
+
+class ReplaceClauseSegment(BaseSegment):
+    """A snowflake SELECT REPLACE clause.
+
+    https://docs.snowflake.com/en/sql-reference/sql/select.html
+    """
+
+    type = "select_replace_clause"
+    match_grammar = Sequence(
+        "REPLACE",
+        Bracketed(
+            Delimited(
+                Sequence(
+                    Ref("ExpressionSegment"),
+                    "AS",
+                    Ref("SingleIdentifierGrammar"),
+                )
+            )
         ),
     )
 

--- a/test/fixtures/dialects/snowflake/select_replace.sql
+++ b/test/fixtures/dialects/snowflake/select_replace.sql
@@ -1,0 +1,3 @@
+select * replace ('DEPT-' || department_id as department_id) from table1;
+
+select * replace ('prefix1' || col1 as alias1, 'prefix2' || col2 as alias2) from table1;

--- a/test/fixtures/dialects/snowflake/select_replace.yml
+++ b/test/fixtures/dialects/snowflake/select_replace.yml
@@ -1,0 +1,77 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 986831b7a097a626e6a78ed075c5f1be3f4e76518894334a47a2b1bbaeda9a22
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_replace_clause:
+              keyword: replace
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'DEPT-'"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                    naked_identifier: department_id
+                keyword: as
+                naked_identifier: department_id
+                end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_replace_clause:
+              keyword: replace
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'prefix1'"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                    naked_identifier: col1
+              - keyword: as
+              - naked_identifier: alias1
+              - comma: ','
+              - expression:
+                  quoted_literal: "'prefix2'"
+                  binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                  column_reference:
+                    naked_identifier: col2
+              - keyword: as
+              - naked_identifier: alias2
+              - end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Resolves #5225. 

Previously, `SELECT * REPLACE (...)` resulted in an unparsable error. Also added corresponding test cases.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
