### PR TITLE
Test Script Timing

### DIFF
--- a/test/generate_parse_fixture_yml.py
+++ b/test/generate_parse_fixture_yml.py
@@ -4,6 +4,7 @@ import multiprocessing
 import os
 import re
 import sys
+import time
 from collections import defaultdict
 from typing import Callable, Dict, List, Optional, Tuple, TypeVar
 
@@ -193,13 +194,15 @@ def generate_parse_fixtures(
     print(f"\tfilter={filter_str} dialect={dialect_str} new-only={new_only}")
     parse_success_examples = gather_file_list(dialect, filter, new_only)
     print(f"Found {len(parse_success_examples)} file(s) to generate")
+    t0 = time.monotonic()
     try:
         distribute_work(parse_success_examples, generate_one_parse_fixture)
     except SQLParseError as err:
         # If one fails, exit early and cleanly.
         print(f"PARSING FAILED: {err}")
         sys.exit(1)
-    print(f"Fixture built: {len(parse_success_examples)}")
+    dt = time.monotonic() - t0
+    print(f"Fixture built: {len(parse_success_examples)} [in {dt:.2f}s]")
 
 
 def main():

--- a/test/generate_parse_fixture_yml.py
+++ b/test/generate_parse_fixture_yml.py
@@ -202,7 +202,7 @@ def generate_parse_fixtures(
         print(f"PARSING FAILED: {err}")
         sys.exit(1)
     dt = time.monotonic() - t0
-    print(f"Fixture built: {len(parse_success_examples)} [in {dt:.2f}s]")
+    print(f"Built {len(parse_success_examples)} fixtures in {dt:.2f}s.")
 
 
 def main():


### PR DESCRIPTION
This is a tiny change to the yaml generation script which adds a timer. Useful to assess the impact of improvements to the parsing algorithms.