### PR TITLE
Unify lexer names and types for brackets

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -221,12 +221,36 @@ ansi_dialect.set_lexer_matchers(
         StringLexer("vertical_bar", "|", CodeSegment),
         StringLexer("caret", "^", CodeSegment),
         StringLexer("star", "*", CodeSegment),
-        StringLexer("bracket_open", "(", CodeSegment),
-        StringLexer("bracket_close", ")", CodeSegment),
-        StringLexer("sq_bracket_open", "[", CodeSegment),
-        StringLexer("sq_bracket_close", "]", CodeSegment),
-        StringLexer("crly_bracket_open", "{", CodeSegment),
-        StringLexer("crly_bracket_close", "}", CodeSegment),
+        StringLexer(
+            "start_bracket", "(", CodeSegment, segment_kwargs={"type": "start_bracket"}
+        ),
+        StringLexer(
+            "end_bracket", ")", CodeSegment, segment_kwargs={"type": "end_bracket"}
+        ),
+        StringLexer(
+            "start_square_bracket",
+            "[",
+            CodeSegment,
+            segment_kwargs={"type": "start_square_bracket"},
+        ),
+        StringLexer(
+            "end_square_bracket",
+            "]",
+            CodeSegment,
+            segment_kwargs={"type": "end_square_bracket"},
+        ),
+        StringLexer(
+            "start_curly_bracket",
+            "{",
+            CodeSegment,
+            segment_kwargs={"type": "start_curly_bracket"},
+        ),
+        StringLexer(
+            "end_curly_bracket",
+            "}",
+            CodeSegment,
+            segment_kwargs={"type": "end_curly_bracket"},
+        ),
         StringLexer("colon", ":", CodeSegment),
         StringLexer("semicolon", ";", CodeSegment),
         # This is the "fallback" lexer for anything else which looks like SQL.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -203,10 +203,10 @@ def generate_test_segments():
                 SegClass = NewlineSegment
             elif elem == "(":
                 SegClass = SymbolSegment
-                seg_kwargs = {"type": "bracket_open"}
+                seg_kwargs = {"type": "start_bracket"}
             elif elem == ")":
                 SegClass = SymbolSegment
-                seg_kwargs = {"type": "bracket_close"}
+                seg_kwargs = {"type": "end_bracket"}
             elif elem.startswith("--"):
                 SegClass = CommentSegment
                 seg_kwargs = {"type": "inline_comment"}


### PR DESCRIPTION
For reasons lost to the mists of time, the lexers and parsers for brackets have different labels. We also don't _type_ the bracket segments on parsing. This PR resolves that, and is also helpful for the future parsing of brackets.