### PR TITLE
Set type automatically within the lexer.

### DIFF
--- a/src/sqlfluff/core/parser/lexer.py
+++ b/src/sqlfluff/core/parser/lexer.py
@@ -283,8 +283,18 @@ class StringLexer:
             return LexMatch(forward_string, [])
 
     def construct_segment(self, raw: str, pos_marker: PositionMarker) -> RawSegment:
-        """Construct a segment using the given class a properties."""
-        return self.segment_class(raw=raw, pos_marker=pos_marker, **self.segment_kwargs)
+        """Construct a segment using the given class a properties.
+
+        Unless an override `type` is provided in the `segment_kwargs`,
+        it is assumed that the `name` of the lexer is designated as the
+        intended `type` of the segment.
+        """
+        # NOTE: Using a private attribute here feels a bit wrong.
+        _segment_class_types = self.segment_class._class_types
+        _kwargs = self.segment_kwargs
+        if "type" not in _kwargs and self.name not in _segment_class_types:
+            _kwargs["type"] = self.name
+        return self.segment_class(raw=raw, pos_marker=pos_marker, **_kwargs)
 
 
 class RegexLexer(StringLexer):

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -132,7 +132,7 @@ ansi_dialect.set_lexer_matchers(
             "inline_comment",
             r"(--|#)[^\n]*",
             CommentSegment,
-            segment_kwargs={"trim_start": ("--", "#"), "type": "inline_comment"},
+            segment_kwargs={"trim_start": ("--", "#")},
         ),
         RegexLexer(
             "block_comment",
@@ -148,30 +148,12 @@ ansi_dialect.set_lexer_matchers(
                 r"[^\S\r\n]+",
                 WhitespaceSegment,
             ),
-            segment_kwargs={"type": "block_comment"},
         ),
-        RegexLexer(
-            "single_quote",
-            r"'([^'\\]|\\.|'')*'",
-            CodeSegment,
-            segment_kwargs={"type": "single_quote"},
-        ),
-        RegexLexer(
-            "double_quote",
-            r'"([^"\\]|\\.)*"',
-            CodeSegment,
-            segment_kwargs={"type": "double_quote"},
-        ),
-        RegexLexer(
-            "back_quote", r"`[^`]*`", CodeSegment, segment_kwargs={"type": "back_quote"}
-        ),
+        RegexLexer("single_quote",r"'([^'\\]|\\.|'')*'",CodeSegment),
+        RegexLexer("double_quote",r'"([^"\\]|\\.)*"',CodeSegment),
+        RegexLexer("back_quote", r"`[^`]*`", CodeSegment),
         # See https://www.geeksforgeeks.org/postgresql-dollar-quoted-string-constants/
-        RegexLexer(
-            "dollar_quote",
-            r"\$(\w*)\$[^\1]*?\$\1\$",
-            CodeSegment,
-            segment_kwargs={"type": "dollar_quote"},
-        ),
+        RegexLexer("dollar_quote", r"\$(\w*)\$[^\1]*?\$\1\$",CodeSegment),
         # Numeric literal matches integers, decimals, and exponential formats,
         # Pattern breakdown:
         # (?>                      Atomic grouping
@@ -196,14 +178,8 @@ ansi_dialect.set_lexer_matchers(
             "numeric_literal",
             r"(?>\d+\.\d+|\d+\.(?![\.\w])|\.\d+|\d+)(\.?[eE][+-]?\d+)?((?<=\.)|(?=\b))",
             LiteralSegment,
-            segment_kwargs={"type": "numeric_literal"},
         ),
-        RegexLexer(
-            "like_operator",
-            r"!?~~?\*?",
-            ComparisonOperatorSegment,
-            segment_kwargs={"type": "like_operator"},
-        ),
+        RegexLexer("like_operator",r"!?~~?\*?",ComparisonOperatorSegment),
         RegexLexer("newline", r"\r\n|\n", NewlineSegment),
         StringLexer("casting_operator", "::", CodeSegment),
         StringLexer("equals", "=", CodeSegment),
@@ -211,7 +187,7 @@ ansi_dialect.set_lexer_matchers(
         StringLexer("less_than", "<", CodeSegment),
         StringLexer("not", "!", CodeSegment),
         StringLexer("dot", ".", CodeSegment),
-        StringLexer("comma", ",", CodeSegment, segment_kwargs={"type": "comma"}),
+        StringLexer("comma", ",", CodeSegment),
         StringLexer("plus", "+", CodeSegment),
         StringLexer("minus", "-", CodeSegment),
         StringLexer("divide", "/", CodeSegment),
@@ -221,41 +197,22 @@ ansi_dialect.set_lexer_matchers(
         StringLexer("vertical_bar", "|", CodeSegment),
         StringLexer("caret", "^", CodeSegment),
         StringLexer("star", "*", CodeSegment),
-        StringLexer(
-            "start_bracket", "(", CodeSegment, segment_kwargs={"type": "start_bracket"}
-        ),
-        StringLexer(
-            "end_bracket", ")", CodeSegment, segment_kwargs={"type": "end_bracket"}
-        ),
-        StringLexer(
-            "start_square_bracket",
-            "[",
-            CodeSegment,
-            segment_kwargs={"type": "start_square_bracket"},
-        ),
-        StringLexer(
-            "end_square_bracket",
-            "]",
-            CodeSegment,
-            segment_kwargs={"type": "end_square_bracket"},
-        ),
-        StringLexer(
-            "start_curly_bracket",
-            "{",
-            CodeSegment,
-            segment_kwargs={"type": "start_curly_bracket"},
-        ),
-        StringLexer(
-            "end_curly_bracket",
-            "}",
-            CodeSegment,
-            segment_kwargs={"type": "end_curly_bracket"},
-        ),
+        StringLexer("start_bracket", "(", CodeSegment),
+        StringLexer("end_bracket", ")", CodeSegment),
+        StringLexer("start_square_bracket","[",CodeSegment),
+        StringLexer("end_square_bracket","]",CodeSegment),
+        StringLexer("start_curly_bracket","{",CodeSegment),
+        StringLexer("end_curly_bracket","}",CodeSegment),
         StringLexer("colon", ":", CodeSegment),
         StringLexer("semicolon", ";", CodeSegment),
         # This is the "fallback" lexer for anything else which looks like SQL.
         RegexLexer(
-            "code", r"[0-9a-zA-Z_]+", CodeSegment, segment_kwargs={"type": "code"}
+            # NOTE: CodeSegment doesn't automatically add the `type` "code".
+            # This will be resolved soon, but until then we need to specify it here.
+            "code",
+            r"[0-9a-zA-Z_]+",
+            CodeSegment,
+            segment_kwargs={"type": "code"},
         ),
     ]
 )

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -52,7 +52,7 @@ bigquery_dialect.insert_lexer_matchers(
             "at_sign_literal",
             r"@[a-zA-Z_][\w]*",
             ansi.LiteralSegment,
-            segment_kwargs={"type": "at_sign_literal", "trim_chars": ("@",)},
+            segment_kwargs={"trim_chars": ("@",)},
         ),
     ],
     before="equals",
@@ -71,7 +71,6 @@ bigquery_dialect.patch_lexer_matchers(
             r"([rR]?[bB]?|[bB]?[rR]?)?('''((?<!\\)(\\{2})*\\'|'{,2}(?!')|[^'])"
             r"*(?<!\\)(\\{2})*'''|'((?<!\\)(\\{2})*\\'|[^'])*(?<!\\)(\\{2})*')",
             CodeSegment,
-            segment_kwargs={"type": "single_quote"},
         ),
         RegexLexer(
             "double_quote",
@@ -79,7 +78,6 @@ bigquery_dialect.patch_lexer_matchers(
             r'|[^\"])*(?<!\\)(\\{2})*\"\"\"|"((?<!\\)(\\{2})*\\"|[^"])*(?<!\\)'
             r'(\\{2})*")',
             CodeSegment,
-            segment_kwargs={"type": "double_quote"},
         ),
     ]
 )

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -51,7 +51,7 @@ clickhouse_dialect.replace(
 
 clickhouse_dialect.insert_lexer_matchers(
     # https://clickhouse.com/docs/en/sql-reference/functions#higher-order-functions---operator-and-lambdaparams-expr-function
-    [StringLexer("lambda", r"->", SymbolSegment, segment_kwargs={"type": "lambda"})],
+    [StringLexer("lambda", r"->", SymbolSegment)],
     before="newline",
 )
 

--- a/src/sqlfluff/dialects/dialect_db2.py
+++ b/src/sqlfluff/dialects/dialect_db2.py
@@ -63,21 +63,19 @@ db2_dialect.patch_lexer_matchers(
             "inline_comment",
             r"(--)[^\n]*",
             CommentSegment,
-            segment_kwargs={"trim_start": ("--"), "type": "inline_comment"},
+            segment_kwargs={"trim_start": ("--")},
         ),
         # In Db2, the only escape character is ' for single quote strings
         RegexLexer(
             "single_quote",
             r"(?s)('')+?(?!')|('.*?(?<!')(?:'')*'(?!'))",
             CodeSegment,
-            segment_kwargs={"type": "single_quote"},
         ),
         # In Db2, there is no escape character for double quote strings
         RegexLexer(
             "double_quote",
             r'(?s)".+?"',
             CodeSegment,
-            segment_kwargs={"type": "double_quote"},
         ),
         # In Db2, a field could have a # pound/hash sign
         RegexLexer(

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -79,19 +79,16 @@ exasol_dialect.insert_lexer_matchers(
             "escaped_identifier",
             r"\[\w+\]",
             CodeSegment,
-            segment_kwargs={"type": "escaped_identifier"},
         ),
         RegexLexer(
             "udf_param_dot_syntax",
             r"\.{3}",
             CodeSegment,
-            segment_kwargs={"type": "udf_param_dot_syntax"},
         ),
         RegexLexer(
             "range_operator",
             r"\.{2}",
             SymbolSegment,
-            segment_kwargs={"type": "range_operator"},
         ),
         StringLexer("hash", "#", CodeSegment),
         StringLexer("walrus_operator", ":=", CodeSegment),
@@ -99,7 +96,6 @@ exasol_dialect.insert_lexer_matchers(
             "function_script_terminator",
             r"\n/\n|\n/$",
             SymbolSegment,
-            segment_kwargs={"type": "function_script_terminator"},
             subdivider=RegexLexer(
                 "newline",
                 r"(\n|\r\n)+",
@@ -123,19 +119,17 @@ exasol_dialect.patch_lexer_matchers(
             "single_quote",
             r"'([^']|'')*'",
             CodeSegment,
-            segment_kwargs={"type": "single_quote"},
         ),
         RegexLexer(
             "double_quote",
             r'"([^"]|"")*"',
             CodeSegment,
-            segment_kwargs={"type": "double_quote"},
         ),
         RegexLexer(
             "inline_comment",
             r"--[^\n]*",
             CommentSegment,
-            segment_kwargs={"trim_start": ("--"), "type": "inline_comment"},
+            segment_kwargs={"trim_start": ("--")},
         ),
     ]
 )

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -45,7 +45,7 @@ mysql_dialect.patch_lexer_matchers(
             "inline_comment",
             r"(-- |#)[^\n]*",
             CommentSegment,
-            segment_kwargs={"trim_start": ("-- ", "#"), "type": "inline_comment"},
+            segment_kwargs={"trim_start": ("-- ", "#")},
         ),
         # Pattern breakdown:
         # (?s)                     DOTALL (dot matches newline)
@@ -64,13 +64,11 @@ mysql_dialect.patch_lexer_matchers(
             "single_quote",
             r"(?s)('(?:\\'|''|\\\\|[^'])*'(?!'))",
             CodeSegment,
-            segment_kwargs={"type": "single_quote"},
         ),
         RegexLexer(
             "double_quote",
             r'(?s)("(?:\\"|""|\\\\|[^"])*"(?!"))',
             CodeSegment,
-            segment_kwargs={"type": "double_quote"},
         ),
     ]
 )

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -77,7 +77,6 @@ postgres_dialect.insert_lexer_matchers(
             r"(?s)U&(('')+?(?!')|('.*?(?<!')(?:'')*'(?!')))(\s*UESCAPE\s*'"
             r"[^0-9A-Fa-f'+\-\s)]')?",
             CodeSegment,
-            segment_kwargs={"type": "unicode_single_quote"},
         ),
         # This is similar to the Unicode regex, the key differences being:
         # - E - must start with E
@@ -93,20 +92,17 @@ postgres_dialect.insert_lexer_matchers(
             r"(?s)E(('')+?(?!')|'.*?((?<!\\)(?:\\\\)*(?<!')(?:'')*|(?<!\\)(?:\\\\)*\\"
             r"(?<!')(?:'')*')'(?!'))",
             CodeSegment,
-            segment_kwargs={"type": "escaped_single_quote"},
         ),
         # Double quote Unicode string cannot be empty, and have no single quote escapes
         RegexLexer(
             "unicode_double_quote",
             r'(?s)U&".+?"(\s*UESCAPE\s*\'[^0-9A-Fa-f\'+\-\s)]\')?',
             CodeSegment,
-            segment_kwargs={"type": "unicode_double_quote"},
         ),
         RegexLexer(
             "json_operator",
             r"->>|#>>|->|#>|@>|<@|\?\||\?|\?&|#-",
             SymbolSegment,
-            segment_kwargs={"type": "json_operator"},
         ),
         StringLexer("at", "@", CodeSegment),
         # https://www.postgresql.org/docs/current/sql-syntax-lexical.html
@@ -115,7 +111,6 @@ postgres_dialect.insert_lexer_matchers(
             # binary (e.g. b'1001') or hex (e.g. X'1FF')
             r"[bBxX]'[0-9a-fA-F]*'",
             CodeSegment,
-            segment_kwargs={"type": "bit_string_literal"},
         ),
     ],
     before="like_operator",
@@ -154,7 +149,6 @@ postgres_dialect.insert_lexer_matchers(
             "dollar_numeric_literal",
             r"\$\d+",
             ansi.LiteralSegment,
-            segment_kwargs={"type": "dollar_numeric_literal"},
         ),
     ],
     before="code",  # Final thing to search for - as psql specific
@@ -167,21 +161,19 @@ postgres_dialect.patch_lexer_matchers(
             "inline_comment",
             r"(--)[^\n]*",
             CommentSegment,
-            segment_kwargs={"trim_start": ("--"), "type": "inline_comment"},
+            segment_kwargs={"trim_start": ("--")},
         ),
         # In Postgres, the only escape character is ' for single quote strings
         RegexLexer(
             "single_quote",
             r"(?s)('')+?(?!')|('.*?(?<!')(?:'')*'(?!'))",
             CodeSegment,
-            segment_kwargs={"type": "single_quote"},
         ),
         # In Postgres, there is no escape character for double quote strings
         RegexLexer(
             "double_quote",
             r'(?s)".+?"',
             CodeSegment,
-            segment_kwargs={"type": "double_quote"},
         ),
         RegexLexer(
             "code",

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -50,13 +50,12 @@ snowflake_dialect.patch_lexer_matchers(
             "single_quote",
             r"'([^'\\]|\\.|'')*'",
             CodeSegment,
-            segment_kwargs={"type": "single_quote"},
         ),
         RegexLexer(
             "inline_comment",
             r"(--|#|//)[^\n]*",
             CommentSegment,
-            segment_kwargs={"trim_start": ("--", "#", "//"), "type": "inline_comment"},
+            segment_kwargs={"trim_start": ("--", "#", "//")},
         ),
     ]
 )
@@ -74,7 +73,6 @@ snowflake_dialect.insert_lexer_matchers(
             "dollar_quote",
             r"\$\$.*\$\$",
             CodeSegment,
-            segment_kwargs={"type": "dollar_quote"},
         ),
         RegexLexer(
             "dollar_literal",
@@ -93,7 +91,6 @@ snowflake_dialect.insert_lexer_matchers(
             "unquoted_file_path",
             r"file://(?:[a-zA-Z]+:|/)+(?:[0-9a-zA-Z\\/_*?-]+)(?:\.[0-9a-zA-Z]+)?",
             CodeSegment,
-            segment_kwargs={"type": "unquoted_file_path"},
         ),
         StringLexer("question_mark", "?", CodeSegment),
         StringLexer("exclude_bracket_open", "{-", CodeSegment),

--- a/src/sqlfluff/dialects/dialect_soql.py
+++ b/src/sqlfluff/dialects/dialect_soql.py
@@ -27,13 +27,11 @@ soql_dialect.insert_lexer_matchers(
             "datetime_literal",
             r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|(\+|\-)[0-9]{2}:[0-9]{2})",  # noqa E501
             CodeSegment,
-            segment_kwargs={"type": "datetime_literal"},
         ),
         RegexLexer(
             "date_literal",
             r"[0-9]{4}-[0-9]{2}-[0-9]{2}",
             CodeSegment,
-            segment_kwargs={"type": "date_literal"},
         ),
     ],
     before="numeric_literal",

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -58,7 +58,7 @@ sparksql_dialect.patch_lexer_matchers(
             "inline_comment",
             r"(--)[^\n]*",
             CommentSegment,
-            segment_kwargs={"trim_start": "--", "type": "inline_comment"},
+            segment_kwargs={"trim_start": "--"},
         ),
         # == and <=> are valid equal operations
         # <=> is a non-null equals in Spark SQL
@@ -73,7 +73,6 @@ sparksql_dialect.patch_lexer_matchers(
             "back_quote",
             r"`([^`]|``)*`",
             CodeSegment,
-            segment_kwargs={"type": "back_quote"},
         ),
         # Numeric literal matches integers, decimals, and exponential formats.
         # https://spark.apache.org/docs/latest/sql-ref-literals.html#numeric-literal
@@ -118,7 +117,6 @@ sparksql_dialect.patch_lexer_matchers(
                 r"((?<=\.)|(?=\b))"
             ),
             CodeSegment,
-            segment_kwargs={"type": "numeric_literal"},
         ),
     ]
 )
@@ -129,13 +127,11 @@ sparksql_dialect.insert_lexer_matchers(
             "bytes_single_quote",
             r"X'([^'\\]|\\.)*'",
             CodeSegment,
-            segment_kwargs={"type": "bytes_single_quote"},
         ),
         RegexLexer(
             "bytes_double_quote",
             r'X"([^"\\]|\\.)*"',
             CodeSegment,
-            segment_kwargs={"type": "bytes_double_quote"},
         ),
     ],
     before="single_quote",
@@ -147,7 +143,6 @@ sparksql_dialect.insert_lexer_matchers(
             "at_sign_literal",
             r"@\w*",
             CodeSegment,
-            segment_kwargs={"type": "at_sign_literal"},
         ),
     ],
     before="code",
@@ -162,7 +157,6 @@ sparksql_dialect.insert_lexer_matchers(
                 r"|([a-zA-Z0-9\-_\.]*\.[a-z]+))"
             ),
             CodeSegment,
-            segment_kwargs={"type": "file_literal"},
         ),
     ],
     before="newline",

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -38,7 +38,6 @@ teradata_dialect.patch_lexer_matchers(
             "numeric_literal",
             r"([0-9]+(\.[0-9]*)?)",
             CodeSegment,
-            segment_kwargs={"type": "numeric_literal"},
         ),
     ]
 )

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -135,39 +135,33 @@ tsql_dialect.insert_lexer_matchers(
             "atsign",
             r"[@][a-zA-Z0-9_]+",
             CodeSegment,
-            segment_kwargs={"type": "atsign"},
         ),
         RegexLexer(
             "var_prefix",
             r"[$][a-zA-Z0-9_]+",
             CodeSegment,
-            segment_kwargs={"type": "var_prefix"},
         ),
         RegexLexer(
             "square_quote",
             r"\[([^\[\]]*)*\]",
             CodeSegment,
-            segment_kwargs={"type": "square_quote"},
         ),
         # T-SQL unicode strings
         RegexLexer(
             "single_quote_with_n",
             r"N'([^']|'')*'",
             CodeSegment,
-            segment_kwargs={"type": "single_quote_with_n"},
         ),
         RegexLexer(
             "hash_prefix",
             r"[#][#]?[a-zA-Z0-9_]+",
             CodeSegment,
-            segment_kwargs={"type": "hash_prefix"},
         ),
         RegexLexer(
             "unquoted_relative_sql_file_path",
             # currently there is no way to pass `regex.IGNORECASE` flag to `RegexLexer`
             r"[.\w\\/#-]+\.[sS][qQ][lL]",
             CodeSegment,
-            segment_kwargs={"type": "unquoted_relative_sql_file_path"},
         ),
     ],
     before="back_quote",
@@ -180,14 +174,13 @@ tsql_dialect.patch_lexer_matchers(
             "single_quote",
             r"'([^']|'')*'",
             CodeSegment,
-            segment_kwargs={"type": "single_quote"},
         ),
         # Patching comments to remove hash comments
         RegexLexer(
             "inline_comment",
             r"(--)[^\n]*",
             CommentSegment,
-            segment_kwargs={"trim_start": ("--"), "type": "inline_comment"},
+            segment_kwargs={"trim_start": ("--")},
         ),
         # Patching block comments to account for nested blocks.
         # N.B. this syntax is only possible via the non-standard-library
@@ -226,7 +219,6 @@ tsql_dialect.patch_lexer_matchers(
                 r"[^\S\r\n]+",
                 WhitespaceSegment,
             ),
-            segment_kwargs={"type": "block_comment"},
         ),
         RegexLexer(
             "code", r"[0-9a-zA-Z_#@]+", CodeSegment

--- a/test/core/parser/lexer_test.py
+++ b/test/core/parser/lexer_test.py
@@ -1,19 +1,16 @@
 """The Test file for The New Parser (Lexing steps)."""
 
-import pytest
 import logging
-from typing import Any, Dict, Tuple, NamedTuple, List, Union
+from typing import Any, Dict, List, NamedTuple, Tuple, Union
 
-from sqlfluff.core.parser import Lexer, CodeSegment, NewlineSegment
+import pytest
+
+from sqlfluff.core import FluffConfig, SQLLexError
+from sqlfluff.core.parser import CodeSegment, Lexer, NewlineSegment
+from sqlfluff.core.parser.lexer import LexMatch, RegexLexer, StringLexer
 from sqlfluff.core.parser.segments.meta import TemplateSegment
-from sqlfluff.core.templaters import JinjaTemplater, TemplatedFile, RawFileSlice
+from sqlfluff.core.templaters import JinjaTemplater, RawFileSlice, TemplatedFile
 from sqlfluff.core.templaters.base import TemplatedFileSlice
-from sqlfluff.core.parser.lexer import (
-    StringLexer,
-    LexMatch,
-    RegexLexer,
-)
-from sqlfluff.core import SQLLexError, FluffConfig
 
 
 def assert_matches(instring, matcher, matchstring):


### PR DESCRIPTION
@pwildenhain brought up a good question here: https://github.com/sqlfluff/sqlfluff/pull/5229#pullrequestreview-1639883063

> For all of these, the "type" key in the kwargs dictionary is just the name of the segment. Is there a reason we need to double document this for each of these segments?

That _was_ necessary but I think it's easily resolvable. This PR does that.