### PR TITLE
Allow Snowflake pipe integration to be a quoted or unquoted

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -3669,7 +3669,10 @@ class CreateStatementSegment(BaseSegment):
             Sequence(
                 "INTEGRATION",
                 Ref("EqualsSegment"),
-                Ref("QuotedLiteralSegment"),
+                OneOf(
+                    Ref("QuotedLiteralSegment"),
+                    Ref("ObjectReferenceSegment"),
+                ),
                 optional=True,
             ),
             optional=True,

--- a/test/fixtures/dialects/snowflake/create_pipe.sql
+++ b/test/fixtures/dialects/snowflake/create_pipe.sql
@@ -6,3 +6,29 @@ create or replace pipe mypipe_s3
   copy into snowpipe_db.public.mytable
   from @snowpipe_db.public.mystage
   file_format = (type = 'JSON');
+
+create or replace pipe test_pipe
+  auto_ingest = true
+  integration = notification_integration
+  as
+  copy into table_name (
+    column1,
+    column2
+  )
+  from (select
+    $1,
+    current_timestamp() as column2
+  from @stage_name/folder);
+
+create or replace pipe test_pipe
+  auto_ingest = true
+  integration = 'notification_integration'
+  as
+  copy into table_name (
+    column1,
+    column2
+  )
+  from (select
+    $1,
+    current_timestamp() as column2
+  from @stage_name/folder);

--- a/test/fixtures/dialects/snowflake/create_pipe.yml
+++ b/test/fixtures/dialects/snowflake/create_pipe.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3ad1767ff0d5edc1534ef228aded4ff09917d0b84e146917a194a5e6628523c1
+_hash: c27bfb97b5ff0780411b77d50a4966bfcf7e0385ce5639ad4c0ae2c496b10f27
 file:
-  statement:
+- statement:
     create_statement:
     - keyword: create
     - keyword: or
@@ -51,4 +51,123 @@ file:
                 raw_comparison_operator: '='
               file_type: "'JSON'"
             end_bracket: )
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    create_statement:
+    - keyword: create
+    - keyword: or
+    - keyword: replace
+    - keyword: pipe
+    - object_reference:
+        naked_identifier: test_pipe
+    - keyword: auto_ingest
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'true'
+    - keyword: integration
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: notification_integration
+    - keyword: as
+    - copy_into_table_statement:
+      - keyword: copy
+      - keyword: into
+      - table_reference:
+          naked_identifier: table_name
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: column1
+        - comma: ','
+        - column_reference:
+            naked_identifier: column2
+        - end_bracket: )
+      - keyword: from
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: select
+            - select_clause_element:
+                column_reference:
+                  column_index_identifier_segment: $1
+            - comma: ','
+            - select_clause_element:
+                function:
+                  function_name:
+                    function_name_identifier: current_timestamp
+                  bracketed:
+                    start_bracket: (
+                    end_bracket: )
+                alias_expression:
+                  keyword: as
+                  naked_identifier: column2
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      stage_path: '@stage_name/folder'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_statement:
+    - keyword: create
+    - keyword: or
+    - keyword: replace
+    - keyword: pipe
+    - object_reference:
+        naked_identifier: test_pipe
+    - keyword: auto_ingest
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - boolean_literal: 'true'
+    - keyword: integration
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'notification_integration'"
+    - keyword: as
+    - copy_into_table_statement:
+      - keyword: copy
+      - keyword: into
+      - table_reference:
+          naked_identifier: table_name
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: column1
+        - comma: ','
+        - column_reference:
+            naked_identifier: column2
+        - end_bracket: )
+      - keyword: from
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: select
+            - select_clause_element:
+                column_reference:
+                  column_index_identifier_segment: $1
+            - comma: ','
+            - select_clause_element:
+                function:
+                  function_name:
+                    function_name_identifier: current_timestamp
+                  bracketed:
+                    start_bracket: (
+                    end_bracket: )
+                alias_expression:
+                  keyword: as
+                  naked_identifier: column2
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      stage_path: '@stage_name/folder'
+          end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

Fix for issue: #5240 

### Brief summary of the change made
- Even though Snowflake's documentation shows notification integration as a quoted string, Snowflake accepts this value as unquoted. https://docs.snowflake.com/en/sql-reference/sql/create-pipe
- Updating the integration value to be either one of a quoted literal or an object reference segment.
- Adding two tests. Both to test integration being quote vs unquoted, and also to test a slightly more complex pipe statement with the '$' notation.

### Are there any other side effects of this change that we should be aware of?
- Should be no impact anywhere else

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
