### PR TITLE
minor: update docs with correct link to airflow ds_filter

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -738,7 +738,7 @@ the following to the `__init__.py` of the library:
 
 .. code-block:: python
 
-     # https://github.com/apache/airflow/blob/main/airflow/templates.py#L50
+     # https://github.com/apache/airflow/blob/main/airflow/templates.py#L53
      def ds_filter(value: datetime.date | datetime.time | None) -> str | None:
         """Date filter."""
         if value is None:


### PR DESCRIPTION

### Brief summary of the change made

- In the configuration documentation, the [Library Templating](https://docs.sqlfluff.com/en/2.3.2/configuration.html#library-templating) section contains a sample snippet for adding the Airflow filter `ds` with a comment linking to the  `ds_filter` function at `airflow/template.py#L50`.  
- The previous link is outdated as of  https://github.com/apache/airflow/commit/b82ce61285f3f4f0c7eccb2c3effaef53c9fb84e/airflow/templates.py.

**This change updates the sample snippet to correctly link the `ds_filter` function**

-------

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

> - Included test cases to demonstrate any code changes, which may be one or more of the following:
>   - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
>   - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
>   - Full autofix test cases in `test/fixtures/linter/autofix`.
>   - Other.
> - Added appropriate documentation for the change.
> - Created GitHub issues for any relevant followup/future enhancements if appropriate.
