### PR TITLE
Resolves #5174: Snowflake alter table constraint

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1873,21 +1873,40 @@ class AlterTableConstraintActionSegment(BaseSegment):
         # Add Column
         Sequence(
             "ADD",
-            Sequence("CONSTRAINT", Ref("NakedIdentifierSegment"), optional=True),
+            Sequence(
+                "CONSTRAINT",
+                OneOf(
+                    Ref("NakedIdentifierSegment"),
+                    Ref("QuotedIdentifierSegment"),
+                ),
+                optional=True,
+            ),
             OneOf(
                 Sequence(
                     Ref("PrimaryKeyGrammar"),
-                    Bracketed(Ref("ColumnReferenceSegment"), optional=True),
+                    Bracketed(
+                        Delimited(
+                            Ref("ColumnReferenceSegment"),
+                        ),
+                    ),
                 ),
                 Sequence(
                     Sequence(
                         Ref("ForeignKeyGrammar"),
-                        Bracketed(Ref("ColumnReferenceSegment"), optional=True),
-                        optional=True,
+                        Bracketed(
+                            Delimited(
+                                Ref("ColumnReferenceSegment"),
+                            )
+                        ),
                     ),
                     "REFERENCES",
                     Ref("TableReferenceSegment"),
-                    Bracketed(Ref("ColumnReferenceSegment")),
+                    Bracketed(
+                        Delimited(
+                            Ref("ColumnReferenceSegment"),
+                        ),
+                        optional=True,
+                    ),
                 ),
                 Sequence(
                     "UNIQUE", Bracketed(Ref("ColumnReferenceSegment"), optional=True)

--- a/test/fixtures/dialects/snowflake/alter_table.sql
+++ b/test/fixtures/dialects/snowflake/alter_table.sql
@@ -14,8 +14,20 @@ ALTER TABLE my_table SET COMMENT = 'my table comment';
 
 ALTER TABLE table1 ADD CONSTRAINT constraint1 PRIMARY KEY ( col1 );
 
+ALTER TABLE table1 ADD CONSTRAINT "constraint1" PRIMARY KEY ( col1 );
+
+ALTER TABLE table1 ADD CONSTRAINT "constraint1" PRIMARY KEY ( col1, col2 );
+
 ALTER TABLE table1 ADD CONSTRAINT constraint1 FOREIGN KEY ( col1 ) REFERENCES table2 ( col2 );
+
+ALTER TABLE table1 ADD CONSTRAINT "constraint1" FOREIGN KEY ( col1 ) REFERENCES table2 ( col2 );
+
+ALTER TABLE table1 ADD CONSTRAINT "constraint1" FOREIGN KEY ( col1 ) REFERENCES "schema1"."table1" ("col2");
+
+ALTER TABLE table1 ADD CONSTRAINT "constraint1" FOREIGN KEY ( col1 ) REFERENCES "schema1"."table1" ( col1, col2 );
 
 ALTER TABLE table1 DROP CONSTRAINT constraint1 UNIQUE pk_col, pk_col2;
 
 ALTER TABLE table1 RENAME CONSTRAINT constraint1 TO constraint2;
+
+ALTER TABLE "ADW_TEMP"."FRUIT_PRICE_SAT" ADD CONSTRAINT "FK_2" FOREIGN KEY ("SPECIAL_OFFER_ID") REFERENCES "ADW_TEMP"."OFFER_SAT" ("SPECIAL_OFFER_ID");

--- a/test/fixtures/dialects/snowflake/alter_table.yml
+++ b/test/fixtures/dialects/snowflake/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 96c77f38cd4ce5188fec6b5388e8ca16e107b239cbe11961100b236111046cdd
+_hash: a1f163734c1f7921014ea72eb0a17ffb2920056606e41b6337e1bae29722ab8e
 file:
 - statement:
     alter_table_statement:
@@ -110,6 +110,45 @@ file:
     - alter_table_constraint_action:
       - keyword: ADD
       - keyword: CONSTRAINT
+      - quoted_identifier: '"constraint1"'
+      - keyword: PRIMARY
+      - keyword: KEY
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            naked_identifier: col1
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table1
+    - alter_table_constraint_action:
+      - keyword: ADD
+      - keyword: CONSTRAINT
+      - quoted_identifier: '"constraint1"'
+      - keyword: PRIMARY
+      - keyword: KEY
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: col1
+        - comma: ','
+        - column_reference:
+            naked_identifier: col2
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table1
+    - alter_table_constraint_action:
+      - keyword: ADD
+      - keyword: CONSTRAINT
       - naked_identifier: constraint1
       - keyword: FOREIGN
       - keyword: KEY
@@ -126,6 +165,91 @@ file:
           column_reference:
             naked_identifier: col2
           end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table1
+    - alter_table_constraint_action:
+      - keyword: ADD
+      - keyword: CONSTRAINT
+      - quoted_identifier: '"constraint1"'
+      - keyword: FOREIGN
+      - keyword: KEY
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            naked_identifier: col1
+          end_bracket: )
+      - keyword: REFERENCES
+      - table_reference:
+          naked_identifier: table2
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            naked_identifier: col2
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table1
+    - alter_table_constraint_action:
+      - keyword: ADD
+      - keyword: CONSTRAINT
+      - quoted_identifier: '"constraint1"'
+      - keyword: FOREIGN
+      - keyword: KEY
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            naked_identifier: col1
+          end_bracket: )
+      - keyword: REFERENCES
+      - table_reference:
+        - quoted_identifier: '"schema1"'
+        - dot: .
+        - quoted_identifier: '"table1"'
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            quoted_identifier: '"col2"'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table1
+    - alter_table_constraint_action:
+      - keyword: ADD
+      - keyword: CONSTRAINT
+      - quoted_identifier: '"constraint1"'
+      - keyword: FOREIGN
+      - keyword: KEY
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            naked_identifier: col1
+          end_bracket: )
+      - keyword: REFERENCES
+      - table_reference:
+        - quoted_identifier: '"schema1"'
+        - dot: .
+        - quoted_identifier: '"table1"'
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: col1
+        - comma: ','
+        - column_reference:
+            naked_identifier: col2
+        - end_bracket: )
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -156,4 +280,34 @@ file:
       - naked_identifier: constraint1
       - keyword: TO
       - naked_identifier: constraint2
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - quoted_identifier: '"ADW_TEMP"'
+      - dot: .
+      - quoted_identifier: '"FRUIT_PRICE_SAT"'
+    - alter_table_constraint_action:
+      - keyword: ADD
+      - keyword: CONSTRAINT
+      - quoted_identifier: '"FK_2"'
+      - keyword: FOREIGN
+      - keyword: KEY
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            quoted_identifier: '"SPECIAL_OFFER_ID"'
+          end_bracket: )
+      - keyword: REFERENCES
+      - table_reference:
+        - quoted_identifier: '"ADW_TEMP"'
+        - dot: .
+        - quoted_identifier: '"OFFER_SAT"'
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            quoted_identifier: '"SPECIAL_OFFER_ID"'
+          end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Resolves #5174. Previously, quoted constraint names were unparsable. Also changed primary key and foreign key references to allow for composite keys (i.e. multiple columns). 

Added corresponding tests.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
