### PR TITLE
Unnest fixing and re-address validation triggers

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1302,8 +1302,8 @@ class BaseSegment(metaclass=SegmentMetaclass):
                     # segment on the end
                     seg_buffer.append(seg)
 
-            # Invalidate any caches
-            self.invalidate_caches()
+        # Invalidate any caches
+        self.invalidate_caches()
 
         # If any fixes applied, do an intermediate reposition. When applying
         # fixes to children and then trying to reposition them, that recursion

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1219,79 +1219,90 @@ class BaseSegment(metaclass=SegmentMetaclass):
         after = []
         fixes_applied: List[LintFix] = []
         todo_buffer = list(self.segments)
-        while True:
-            if len(todo_buffer) == 0:
-                break
-            else:
-                seg = todo_buffer.pop(0)
+        requires_validate = False
 
-                # Look for uuid match.
-                # This handles potential positioning ambiguity.
-                anchor_info: Optional[AnchorEditInfo] = fixes.pop(seg.uuid, None)
-                if anchor_info is not None:
-                    seg_fixes = anchor_info.fixes
+        while todo_buffer:
+            seg = todo_buffer.pop(0)
+
+            # Look for uuid match.
+            # This handles potential positioning ambiguity.
+            anchor_info: Optional[AnchorEditInfo] = fixes.pop(seg.uuid, None)
+
+            if anchor_info is None:
+                # No fix matches here, just add the segment and move on.
+                seg_buffer.append(seg)
+                continue
+
+            # Otherwise there is a fix match.
+            seg_fixes = anchor_info.fixes
+            if (
+                len(seg_fixes) == 2 and seg_fixes[0].edit_type == "create_after"
+            ):  # pragma: no cover
+                # Must be create_before & create_after. Swap so the
+                # "before" comes first.
+                seg_fixes.reverse()
+
+            for f in anchor_info.fixes:
+                assert f.anchor.uuid == seg.uuid
+                fixes_applied.append(f)
+                linter_logger.debug(
+                    "Matched fix for %s against segment: %s -> %s",
+                    rule_code,
+                    f,
+                    seg,
+                )
+
+                # Deletes are easy.
+                if f.edit_type == "delete":
+                    # We're just getting rid of this segment.
+                    requires_validate = True
+                    # NOTE: We don't add the segment in this case.
+                    continue
+
+                # Otherwise it must be a replace or a create.
+                assert f.edit_type in (
+                    "replace",
+                    "create_before",
+                    "create_after",
+                ), f"Unexpected edit_type: {f.edit_type!r} in {f!r}"
+
+                if f.edit_type == "create_after" and len(anchor_info.fixes) == 1:
+                    # in the case of a creation after that is not part
+                    # of a create_before/create_after pair, also add
+                    # this segment before the edit.
+                    seg_buffer.append(seg)
+
+                # We're doing a replacement (it could be a single
+                # segment or an iterable)
+                assert f.edit, f"Edit {f.edit_type!r} requires `edit`."
+                consumed_pos = False
+                for s in f.edit:
+                    seg_buffer.append(s)
+                    # If one of them has the same raw representation
+                    # then the first that matches gets to take the
+                    # original position marker.
                     if (
-                        len(seg_fixes) == 2 and seg_fixes[0].edit_type == "create_after"
-                    ):  # pragma: no cover
-                        # Must be create_before & create_after. Swap so the
-                        # "before" comes first.
-                        seg_fixes.reverse()
+                        f.edit_type == "replace"
+                        and s.raw == seg.raw
+                        and not consumed_pos
+                    ):
+                        seg_buffer[-1].pos_marker = seg.pos_marker
+                        consumed_pos = True
 
-                    for f in anchor_info.fixes:
-                        assert f.anchor.uuid == seg.uuid
-                        fixes_applied.append(f)
-                        linter_logger.debug(
-                            "Matched fix for %s against segment: %s -> %s",
-                            rule_code,
-                            f,
-                            seg,
-                        )
-                        if f.edit_type == "delete":
-                            # We're just getting rid of this segment.
-                            pass
-                        elif f.edit_type in (
-                            "replace",
-                            "create_before",
-                            "create_after",
-                        ):
-                            if (
-                                f.edit_type == "create_after"
-                                and len(anchor_info.fixes) == 1
-                            ):
-                                # in the case of a creation after that is not part
-                                # of a create_before/create_after pair, also add
-                                # this segment before the edit.
-                                seg_buffer.append(seg)
+                # If we're just editing a segment AND keeping the type the
+                # same then no need to validate. Otherwise we should
+                # trigger a validation (e.g. for creations or
+                # multi-replace).
+                if not (
+                    f.edit_type == "replace"
+                    and len(f.edit) == 1
+                    and f.edit[0].class_types == seg.class_types
+                ):
+                    requires_validate = True
 
-                            # We're doing a replacement (it could be a single
-                            # segment or an iterable)
-                            assert f.edit, f"Edit {f.edit_type!r} requires `edit`."
-                            consumed_pos = False
-                            for s in f.edit:
-                                seg_buffer.append(s)
-                                # If one of them has the same raw representation
-                                # then the first that matches gets to take the
-                                # original position marker.
-                                if (
-                                    f.edit_type == "replace"
-                                    and s.raw == seg.raw
-                                    and not consumed_pos
-                                ):
-                                    seg_buffer[-1].pos_marker = seg.pos_marker
-                                    consumed_pos = True
-
-                            if f.edit_type == "create_before":
-                                # in the case of a creation before, also add this
-                                # segment on the end
-                                seg_buffer.append(seg)
-
-                        else:  # pragma: no cover
-                            raise ValueError(
-                                "Unexpected edit_type: {!r} in {!r}".format(
-                                    f.edit_type, f
-                                )
-                            )
-                else:
+                if f.edit_type == "create_before":
+                    # in the case of a creation before, also add this
+                    # segment on the end
                     seg_buffer.append(seg)
 
             # Invalidate any caches
@@ -1308,7 +1319,6 @@ class BaseSegment(metaclass=SegmentMetaclass):
             )
 
         # Then recurse (i.e. deal with the children) (Requeueing)
-        requires_validate = bool(fixes_applied)
         seg_queue = seg_buffer
         seg_buffer = []
         for seg in seg_queue:

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1311,8 +1311,6 @@ class BaseSegment(metaclass=SegmentMetaclass):
         # of the fixes applied there first. This ensures those segments have
         # working positions to work with.
         if fixes_applied:
-            # TODO: REMOVE THIS TEMPORARY FLAG
-            requires_validate = True
             seg_buffer = list(
                 self._position_segments(tuple(seg_buffer), parent_pos=self.pos_marker)
             )

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1218,12 +1218,9 @@ class BaseSegment(metaclass=SegmentMetaclass):
         before = []
         after = []
         fixes_applied: List[LintFix] = []
-        todo_buffer = list(self.segments)
         requires_validate = False
 
-        while todo_buffer:
-            seg = todo_buffer.pop(0)
-
+        for seg in self.segments:
             # Look for uuid match.
             # This handles potential positioning ambiguity.
             anchor_info: Optional[AnchorEditInfo] = fixes.pop(seg.uuid, None)
@@ -1314,6 +1311,8 @@ class BaseSegment(metaclass=SegmentMetaclass):
         # of the fixes applied there first. This ensures those segments have
         # working positions to work with.
         if fixes_applied:
+            # TODO: REMOVE THIS TEMPORARY FLAG
+            requires_validate = True
             seg_buffer = list(
                 self._position_segments(tuple(seg_buffer), parent_pos=self.pos_marker)
             )


### PR DESCRIPTION
Found this while working on #5230.

The `.apply_fixes()` method was very deeply nested, in a way that made the code hard to follow. This flips some `if` statments so that we can un-nest that code, make it easier to follow and cleaner.

In the process I've also slightly changed the conditions for validating things. The the segment _type_ is the same and we're just editing the content (e.g. capitalisation changes) then we don't do a full re-parse validation (and we trust that the rule is being sensible). For anything else more significant we do still trigger a validation though.