### PR TITLE
Revise MatchableType -> Matchable

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -9,7 +9,7 @@ from sqlfluff.core.parser import (
     SegmentGenerator,
     StringParser,
 )
-from sqlfluff.core.parser.grammar.base import BaseGrammar
+from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
@@ -192,7 +192,13 @@ class Dialect:
             # public methods and/or fields as it.
             # NOTE: Other replacements aren't validated.
             subclass = False
-            if isinstance(self._library[n], type):
+            if isinstance(self._library[n], type) and not isinstance(
+                # NOTE: The exception here is we _are_ allowed to replace a
+                # segment with a `Nothing()` grammar, which shows that a segment
+                # has been disabled.
+                replacement,
+                Nothing,
+            ):
                 assert isinstance(
                     replacement, type
                 ), f"Cannot replace {n!r} with {replacement}"

--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -12,11 +12,7 @@ from sqlfluff.core.parser import (
 from sqlfluff.core.parser.grammar.base import BaseGrammar
 from sqlfluff.core.parser.lexer import LexerType
 from sqlfluff.core.parser.matchable import Matchable
-from sqlfluff.core.parser.types import (
-    BracketPairTuple,
-    DialectElementType,
-    MatchableType,
-)
+from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
 
 
 class Dialect:
@@ -180,12 +176,13 @@ class Dialect:
         for n in kwargs:
             if n not in self._library:  # pragma: no cover
                 raise ValueError(f"{n!r} is not already registered in {self!r}")
-            cls = kwargs[n]
-            if self._library[n] is cls:
+            replacement = kwargs[n]
+            # If trying to replace with same, just skip.
+            if self._library[n] is replacement:
                 continue
-            elif self._library[n] == cls:
-                # Check for replacement with a new but identical class.
-                # This would be a sign of redundant definitions in the dialect.
+            # Check for replacement with a new but identical class.
+            # This would be a sign of redundant definitions in the dialect.
+            elif self._library[n] == replacement:
                 raise ValueError(
                     f"Attempted unnecessary identical redefinition of {n!r} in {self!r}"
                 )  # pragma: no cover
@@ -193,21 +190,25 @@ class Dialect:
             # To replace a segment, the replacement must either be a
             # subclass of the original, *or* it must have the same
             # public methods and/or fields as it.
-            base_dir = set(dir(self._library[n]))
+            # NOTE: Other replacements aren't validated.
             subclass = False
-            if isinstance(self._library[n], type) and isinstance(cls, type):
-                seg = cast(Type["BaseSegment"], self._library[n])
-                assert issubclass(seg, BaseSegment)
-                assert issubclass(cls, BaseSegment)
-                subclass = issubclass(cls, seg)
+            if isinstance(self._library[n], type):
+                assert isinstance(
+                    replacement, type
+                ), f"Cannot replace {n!r} with {replacement}"
+                old_seg = cast(Type["BaseSegment"], self._library[n])
+                new_seg = cast(Type["BaseSegment"], replacement)
+                assert issubclass(old_seg, BaseSegment)
+                assert issubclass(new_seg, BaseSegment)
+                subclass = issubclass(new_seg, old_seg)
                 if not subclass:
-                    if seg.type != cls.type:
+                    if old_seg.type != new_seg.type:
                         raise ValueError(  # pragma: no cover
                             f"Cannot replace {n!r} because 'type' property does not "
-                            f"match: {cls.type} != {seg.type}"
+                            f"match: {new_seg.type} != {old_seg.type}"
                         )
-
-                    cls_dir = set(dir(cls))
+                    base_dir = set(dir(self._library[n]))
+                    cls_dir = set(dir(new_seg))
                     missing = set(
                         n for n in base_dir.difference(cls_dir) if not n.startswith("_")
                     )
@@ -217,7 +218,7 @@ class Dialect:
                             f"is missing these from base: {', '.join(missing)}"
                         )
 
-            self._library[n] = cls
+            self._library[n] = replacement
 
     def add_update_segments(self, module_dct: Dict[str, Any]) -> None:
         """Scans module dictionary, adding or replacing segment definitions."""
@@ -262,7 +263,7 @@ class Dialect:
                 f"with get_segment - type{type(segment)}"
             )
 
-    def ref(self, name: str) -> MatchableType:
+    def ref(self, name: str) -> Matchable:
         """Return an object which acts as a late binding reference to the element named.
 
         NB: This requires the dialect to be expanded, and only returns Matchables

--- a/src/sqlfluff/core/parser/context.py
+++ b/src/sqlfluff/core/parser/context.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from sqlfluff.core.config import FluffConfig
     from sqlfluff.core.dialects.base import Dialect
     from sqlfluff.core.parser.match_result import MatchResult
+    from sqlfluff.core.parser.matchable import Matchable
     from sqlfluff.core.parser.segments import BaseSegment
-    from sqlfluff.core.parser.types import MatchableType
 
 # Get the parser logger
 parser_logger = logging.getLogger("sqlfluff.parser")
@@ -88,7 +88,7 @@ class ParseContext:
         # a little more overhead than a list, but we manage this by only
         # copying it when necessary.
         # NOTE: Includes inherited parent terminators.
-        self.terminators: Tuple["MatchableType", ...] = ()
+        self.terminators: Tuple["Matchable", ...] = ()
         # Value for holding a reference to the progress bar.
         self._tqdm: Optional[tqdm] = None
         # Variable to store whether we're tracking progress. When looking
@@ -117,8 +117,8 @@ class ParseContext:
     def _set_terminators(
         self,
         clear_terminators: bool = False,
-        push_terminators: Optional[Sequence["MatchableType"]] = None,
-    ) -> Tuple[int, Tuple["MatchableType", ...]]:
+        push_terminators: Optional[Sequence["Matchable"]] = None,
+    ) -> Tuple[int, Tuple["Matchable", ...]]:
         _appended = 0
         # Retain a reference to the original terminators.
         _terminators = self.terminators
@@ -140,7 +140,7 @@ class ParseContext:
     def _reset_terminators(
         self,
         appended: int,
-        terminators: Tuple["MatchableType", ...],
+        terminators: Tuple["Matchable", ...],
         clear_terminators: bool = False,
     ) -> None:
         # If we totally reset them, just reinstate the old object.
@@ -159,7 +159,7 @@ class ParseContext:
         self,
         name: str,
         clear_terminators: bool = False,
-        push_terminators: Optional[Sequence["MatchableType"]] = None,
+        push_terminators: Optional[Sequence["Matchable"]] = None,
         track_progress: Optional[bool] = None,
     ) -> Iterator["ParseContext"]:
         """Increment match depth.

--- a/src/sqlfluff/core/parser/grammar/anyof.py
+++ b/src/sqlfluff/core/parser/grammar/anyof.py
@@ -14,8 +14,9 @@ from sqlfluff.core.parser.helpers import trim_non_code_segments
 from sqlfluff.core.parser.match_algorithms import greedy_match
 from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.match_wrapper import match_wrapper
+from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.segments import BaseSegment, UnparsableSegment
-from sqlfluff.core.parser.types import MatchableType, ParseMode, SimpleHintType
+from sqlfluff.core.parser.types import ParseMode, SimpleHintType
 
 
 def _parse_mode_match_result(
@@ -66,12 +67,12 @@ class AnyNumberOf(BaseGrammar):
 
     def __init__(
         self,
-        *args: Union[MatchableType, str],
+        *args: Union[Matchable, str],
         max_times: Optional[int] = None,
         min_times: int = 0,
         max_times_per_element: Optional[int] = None,
-        exclude: Optional[MatchableType] = None,
-        terminators: SequenceType[Union[MatchableType, str]] = (),
+        exclude: Optional[Matchable] = None,
+        terminators: SequenceType[Union[Matchable, str]] = (),
         reset_terminators: bool = False,
         allow_gaps: bool = True,
         optional: bool = False,
@@ -125,7 +126,7 @@ class AnyNumberOf(BaseGrammar):
 
     def _match_once(
         self, segments: Tuple[BaseSegment, ...], parse_context: ParseContext
-    ) -> Tuple[MatchResult, Optional["MatchableType"]]:
+    ) -> Tuple[MatchResult, Optional["Matchable"]]:
         """Match the forward segments against the available elements once.
 
         This serves as the main body of OneOf, but also a building block
@@ -278,9 +279,9 @@ class OneOf(AnyNumberOf):
 
     def __init__(
         self,
-        *args: Union[MatchableType, str],
-        exclude: Optional[MatchableType] = None,
-        terminators: SequenceType[Union[MatchableType, str]] = (),
+        *args: Union[Matchable, str],
+        exclude: Optional[Matchable] = None,
+        terminators: SequenceType[Union[Matchable, str]] = (),
         reset_terminators: bool = False,
         allow_gaps: bool = True,
         optional: bool = False,
@@ -308,9 +309,9 @@ class OptionallyBracketed(OneOf):
 
     def __init__(
         self,
-        *args: Union[MatchableType, str],
-        exclude: Optional[MatchableType] = None,
-        terminators: SequenceType[Union[MatchableType, str]] = (),
+        *args: Union[Matchable, str],
+        exclude: Optional[Matchable] = None,
+        terminators: SequenceType[Union[Matchable, str]] = (),
         reset_terminators: bool = False,
         optional: bool = False,
         parse_mode: ParseMode = ParseMode.STRICT,
@@ -332,11 +333,11 @@ class AnySetOf(AnyNumberOf):
 
     def __init__(
         self,
-        *args: Union[MatchableType, str],
+        *args: Union[Matchable, str],
         max_times: Optional[int] = None,
         min_times: int = 0,
-        exclude: Optional[MatchableType] = None,
-        terminators: SequenceType[Union[MatchableType, str]] = (),
+        exclude: Optional[Matchable] = None,
+        terminators: SequenceType[Union[Matchable, str]] = (),
         reset_terminators: bool = False,
         allow_gaps: bool = True,
         optional: bool = False,

--- a/src/sqlfluff/core/parser/grammar/base.py
+++ b/src/sqlfluff/core/parser/grammar/base.py
@@ -95,8 +95,7 @@ class BaseGrammar(Matchable):
         if isinstance(elem, str):
             return Ref.keyword(elem)
         elif isinstance(elem, Matchable):
-            return elem
-        elif issubclass(elem, BaseSegment):
+            # NOTE: BaseSegment types are an instance of Matchable.
             return elem
 
         raise TypeError(

--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -9,8 +9,8 @@ from sqlfluff.core.parser.grammar.noncode import NonCodeMatcher
 from sqlfluff.core.parser.helpers import trim_non_code_segments
 from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.match_wrapper import match_wrapper
+from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.segments import BaseSegment
-from sqlfluff.core.parser.types import MatchableType
 
 
 class Delimited(OneOf):
@@ -32,10 +32,10 @@ class Delimited(OneOf):
 
     def __init__(
         self,
-        *args: Union[MatchableType, str],
-        delimiter: Union[MatchableType, str] = Ref("CommaSegment"),
+        *args: Union[Matchable, str],
+        delimiter: Union[Matchable, str] = Ref("CommaSegment"),
         allow_trailing: bool = False,
-        terminators: Sequence[Union[MatchableType, str]] = (),
+        terminators: Sequence[Union[Matchable, str]] = (),
         reset_terminators: bool = False,
         min_delimiters: Optional[int] = None,
         bracket_pairs_set: str = "bracket_pairs",

--- a/src/sqlfluff/core/parser/grammar/greedy.py
+++ b/src/sqlfluff/core/parser/grammar/greedy.py
@@ -7,7 +7,7 @@ from sqlfluff.core.parser.grammar.base import BaseGrammar, BaseSegment
 from sqlfluff.core.parser.match_algorithms import greedy_match
 from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.match_wrapper import match_wrapper
-from sqlfluff.core.parser.types import MatchableType
+from sqlfluff.core.parser.matchable import Matchable
 
 
 class GreedyUntil(BaseGrammar):
@@ -15,9 +15,9 @@ class GreedyUntil(BaseGrammar):
 
     def __init__(
         self,
-        *args: Union[MatchableType, str],
+        *args: Union[Matchable, str],
         optional: bool = False,
-        terminators: Sequence[Union[MatchableType, str]] = (),
+        terminators: Sequence[Union[Matchable, str]] = (),
         reset_terminators: bool = False,
     ) -> None:
         # NOTE: This grammar does not support allow_gaps=False,

--- a/src/sqlfluff/core/parser/grammar/sequence.py
+++ b/src/sqlfluff/core/parser/grammar/sequence.py
@@ -22,6 +22,7 @@ from sqlfluff.core.parser.match_algorithms import (
 )
 from sqlfluff.core.parser.match_result import MatchResult
 from sqlfluff.core.parser.match_wrapper import match_wrapper
+from sqlfluff.core.parser.matchable import Matchable
 from sqlfluff.core.parser.segments import (
     BaseSegment,
     BracketedSegment,
@@ -29,13 +30,13 @@ from sqlfluff.core.parser.segments import (
     Indent,
     UnparsableSegment,
 )
-from sqlfluff.core.parser.types import MatchableType, ParseMode, SimpleHintType
+from sqlfluff.core.parser.types import ParseMode, SimpleHintType
 
 
 def _trim_to_terminator(
     segments: Tuple[BaseSegment, ...],
     tail: Tuple[BaseSegment, ...],
-    terminators: SequenceType[MatchableType],
+    terminators: SequenceType[Matchable],
     parse_context: ParseContext,
 ) -> Tuple[Tuple[BaseSegment, ...], Tuple[BaseSegment, ...]]:
     """Trim forward segments based on terminators.
@@ -423,11 +424,11 @@ class Bracketed(Sequence):
 
     def __init__(
         self,
-        *args: Union[MatchableType, str],
+        *args: Union[Matchable, str],
         bracket_type: str = "round",
         bracket_pairs_set: str = "bracket_pairs",
-        start_bracket: Optional[MatchableType] = None,
-        end_bracket: Optional[MatchableType] = None,
+        start_bracket: Optional[Matchable] = None,
+        end_bracket: Optional[Matchable] = None,
         allow_gaps: bool = True,
         optional: bool = False,
         parse_mode: ParseMode = ParseMode.STRICT,
@@ -459,7 +460,7 @@ class Bracketed(Sequence):
 
     def get_bracket_from_dialect(
         self, parse_context: ParseContext
-    ) -> Tuple[MatchableType, MatchableType, bool]:
+    ) -> Tuple[Matchable, Matchable, bool]:
         """Rehydrate the bracket segments in question."""
         bracket_pairs = parse_context.dialect.bracket_sets(self.bracket_pairs_set)
         for bracket_type, start_ref, end_ref, persists in bracket_pairs:

--- a/src/sqlfluff/core/parser/matchable.py
+++ b/src/sqlfluff/core/parser/matchable.py
@@ -16,8 +16,6 @@ T = TypeVar("T", bound="Matchable")
 class Matchable(ABC):
     """A base object defining the matching interface."""
 
-    # Matchables are expected to have a type
-    type: str
     # Matchables are also not meta unless otherwise defined
     is_meta = False
 

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -77,11 +77,16 @@ class PathStep:
     code_idxs: Tuple[int, ...]
 
 
-class SegmentMetaclass(type):
+class SegmentMetaclass(type, Matchable):
     """The metaclass for segments.
 
     This metaclass provides pre-computed class attributes
     based on the defined attributes of specific classes.
+
+    Segments as a *type* should also implement the Matchable
+    interface too. Once instantiated they no longer need to
+    but we should be able to treat the BaseSegment class
+    as a Matchable interface.
     """
 
     def __new__(

--- a/src/sqlfluff/core/parser/types.py
+++ b/src/sqlfluff/core/parser/types.py
@@ -1,18 +1,13 @@
 """Complex Type helpers."""
 from enum import Enum
-from typing import TYPE_CHECKING, FrozenSet, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, FrozenSet, Optional, Tuple, Union
 
 if TYPE_CHECKING:  # pragma: no cover
     from sqlfluff.core.parser.matchable import Matchable
-    from sqlfluff.core.parser.segments.base import BaseSegment
     from sqlfluff.core.parser.segments.generator import SegmentGenerator
 
-# When defining elements of a dialect they can be matchables, segments or generators.
-DialectElementType = Union[Type["BaseSegment"], "Matchable", "SegmentGenerator"]
-
-# Either a Matchable (a grammar or parser) or a Segment CLASS
-# NOTE: Post expansion, no generators remain
-MatchableType = Union["Matchable", Type["BaseSegment"]]
+# When defining elements of a dialect they can be matchables or generators.
+DialectElementType = Union["Matchable", "SegmentGenerator"]
 
 # Simple hints has a set of strings first and a set of types second.
 SimpleHintType = Optional[Tuple[FrozenSet[str], FrozenSet[str]]]


### PR DESCRIPTION
I've wanted to do this for *AAAAAAGES*.

For a long while the dependency path for the common matching interface has been quite complex. We define the interface fairly clearly with `Matchable`, but a similar interface needs to be defined on the _uninstantiated_ `BaseSegment` class.

This led to the slightly strange `MatchableType`, which was `Union[Type[BaseSegment], Matchable]`, but this PR adds `Matchable` to the inherited classes for `SegmentMetaclass`, which means we can get rid of `MatchableType` and use the a _single_ interface definition.

I've also removed `type` as a defined attribute on `Matchable` because it was poorly and inconsistently implemented (grammar classes didn't support it). There were a few places where we were using it, notably in bracket matching and in dialect replacements, but those were fairly easy to resolve.