### PR TITLE
Change RawSegment `type` to `instance_types`

### DIFF
--- a/src/sqlfluff/core/parser/lexer.py
+++ b/src/sqlfluff/core/parser/lexer.py
@@ -292,8 +292,16 @@ class StringLexer:
         # NOTE: Using a private attribute here feels a bit wrong.
         _segment_class_types = self.segment_class._class_types
         _kwargs = self.segment_kwargs
-        if "type" not in _kwargs and self.name not in _segment_class_types:
-            _kwargs["type"] = self.name
+        assert not (
+            "type" in _kwargs and "instance_types" in _kwargs
+        ), f"Cannot set both `type` and `instance_types` in segment kwargs: {_kwargs}"
+        if "type" in _kwargs:
+            # TODO: At some point we should probably deprecate this API and only
+            # allow setting `instance_types`.
+            assert _kwargs["type"]
+            _kwargs["instance_types"] = (_kwargs.pop("type"),)
+        elif "instance_types" not in _kwargs and self.name not in _segment_class_types:
+            _kwargs["instance_types"] = (self.name,)
         return self.segment_class(raw=raw, pos_marker=pos_marker, **_kwargs)
 
 

--- a/src/sqlfluff/core/parser/parsers.py
+++ b/src/sqlfluff/core/parser/parsers.py
@@ -36,7 +36,7 @@ class BaseParser(Matchable):
         # Store instance_types rather than just type to allow
         # for multiple possible types to be supported in derivative
         # classes.
-        self._instance_types = (type or raw_class.type,)
+        self._instance_types: Tuple[str, ...] = (type or raw_class.type,)
         self.optional = optional
         self._trim_chars = trim_chars
         # Generate a cache key

--- a/src/sqlfluff/core/parser/parsers.py
+++ b/src/sqlfluff/core/parser/parsers.py
@@ -130,8 +130,11 @@ class TypedParser(BaseParser):
         self._target_types = frozenset(_target_types)
         super().__init__(
             raw_class=raw_class,
-            # If no type specified we default to the template
-            type=type or template,
+            # NOTE: We pass the type as a tuple. After matching it is important
+            # that the original type is still preserved as one of the new types.
+            # The new `type` becomes the "main" type, but the template will still
+            # be part of the resulting `class_types`.
+            type=tuple(_target_types),
             optional=optional,
             trim_chars=trim_chars,
         )

--- a/src/sqlfluff/core/parser/parsers.py
+++ b/src/sqlfluff/core/parser/parsers.py
@@ -138,12 +138,13 @@ class TypedParser(BaseParser):
             trim_chars=trim_chars,
         )
         # NOTE: We override the instance types after initialising the base
-        # class. After matching it is important that the original type is
-        # still preserved as one of the new types.
-        # The new `type` becomes the "main" type, but the template will still
+        # class. We want to ensure that re-matching is possible by ensuring that
+        # the `type` pre-matching is still present post-match even if it's not
+        # part of the natural type hierarchy for the new `raw_class`.
+        # The new `type` becomes the "primary" type, but the template will still
         # be part of the resulting `class_types`.
-        # We do this here rather than in the base class to keep the dialect
-        # facing API the same.
+        # We do this here rather than in the base class to keep the dialect-facing
+        # API the same.
         self._instance_types: Tuple[str, ...] = ()
         # Primary type if set.
         if type is not None:

--- a/src/sqlfluff/core/parser/parsers.py
+++ b/src/sqlfluff/core/parser/parsers.py
@@ -124,9 +124,11 @@ class TypedParser(BaseParser):
         # The type kwarg is the eventual type.
         self.template = template
         # Pre-calculate the appropriate frozenset for matching later.
-        _target_types: List[str] = [template]
+        _target_types: Tuple[str, ...] = (template,)
         if type is not None and type != template:
-            _target_types.append(type)
+            # Make sure to _prepend_ because the first item in the list
+            # takes precedence.
+            _target_types = (type,) + _target_types
         self._target_types = frozenset(_target_types)
         super().__init__(
             raw_class=raw_class,
@@ -134,7 +136,7 @@ class TypedParser(BaseParser):
             # that the original type is still preserved as one of the new types.
             # The new `type` becomes the "main" type, but the template will still
             # be part of the resulting `class_types`.
-            type=tuple(_target_types),
+            type=_target_types,
             optional=optional,
             trim_chars=trim_chars,
         )

--- a/src/sqlfluff/core/parser/parsers.py
+++ b/src/sqlfluff/core/parser/parsers.py
@@ -33,7 +33,10 @@ class BaseParser(Matchable):
         trim_chars: Optional[Tuple[str, ...]] = None,
     ) -> None:
         self.raw_class = raw_class
-        self.type: str = type or raw_class.type
+        # Store instance_types rather than just type to allow
+        # for multiple possible types to be supported in derivative
+        # classes.
+        self._instance_types = (type or raw_class.type,)
         self.optional = optional
         self._trim_chars = trim_chars
         # Generate a cache key
@@ -62,7 +65,7 @@ class BaseParser(Matchable):
         return self.raw_class(
             raw=segment.raw,
             pos_marker=segment.pos_marker,
-            type=self.type,
+            instance_types=self._instance_types,
             trim_chars=self._trim_chars,
         )
 
@@ -81,7 +84,7 @@ class BaseParser(Matchable):
             return None
         # If it does, we might have already matched it. Is it the right type
         # already? If so, just return it unchanged.
-        if isinstance(segment, self.raw_class) and segment.type == self.type:
+        if isinstance(segment, self.raw_class) and segment.type in self._instance_types:
             return segment
         # Otherwise create a new match segment
         return self._make_match_from_segment(segment)
@@ -132,14 +135,17 @@ class TypedParser(BaseParser):
         self._target_types = frozenset(_target_types)
         super().__init__(
             raw_class=raw_class,
-            # NOTE: We pass the type as a tuple. After matching it is important
-            # that the original type is still preserved as one of the new types.
-            # The new `type` becomes the "main" type, but the template will still
-            # be part of the resulting `class_types`.
-            type=_target_types,
             optional=optional,
             trim_chars=trim_chars,
         )
+        # NOTE: We override the instance types after initialising the base
+        # class. After matching it is important that the original type is
+        # still preserved as one of the new types.
+        # The new `type` becomes the "main" type, but the template will still
+        # be part of the resulting `class_types`.
+        # We do this here rather than in the base class to keep the dialect
+        # facing API the same.
+        self._instance_types = _target_types
 
     def __repr__(self) -> str:
         return f"<TypedParser: {self.template!r}>"

--- a/src/sqlfluff/core/parser/segments/keyword.py
+++ b/src/sqlfluff/core/parser/segments/keyword.py
@@ -21,7 +21,7 @@ class KeywordSegment(WordSegment):
         self,
         raw: Optional[str] = None,
         pos_marker: Optional[PositionMarker] = None,
-        type: Optional[str] = None,
+        instance_types: Tuple[str, ...] = (),
         source_fixes: Optional[List[SourceFix]] = None,
         trim_chars: Optional[Tuple[str, ...]] = None,
     ):
@@ -29,7 +29,7 @@ class KeywordSegment(WordSegment):
         super().__init__(
             raw=raw,
             pos_marker=pos_marker,
-            type=type,
+            instance_types=instance_types,
             source_fixes=source_fixes,
         )
 
@@ -49,7 +49,7 @@ class KeywordSegment(WordSegment):
         return self.__class__(
             raw=raw or self.raw,
             pos_marker=self.pos_marker,
-            type=self.instance_types,
+            instance_types=self.instance_types,
             source_fixes=source_fixes or self.source_fixes,
         )
 

--- a/src/sqlfluff/core/parser/segments/keyword.py
+++ b/src/sqlfluff/core/parser/segments/keyword.py
@@ -49,7 +49,7 @@ class KeywordSegment(WordSegment):
         return self.__class__(
             raw=raw or self.raw,
             pos_marker=self.pos_marker,
-            type=self._surrogate_type,
+            type=self.instance_types,
             source_fixes=source_fixes or self.source_fixes,
         )
 

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -27,7 +27,7 @@ class RawSegment(BaseSegment):
         raw: Optional[str] = None,
         pos_marker: Optional[PositionMarker] = None,
         # Optionally, type can also be a tuple of types, where
-        # the first is the "main" type.
+        # the first is the "primary" type.
         instance_types: Tuple[str, ...] = (),
         trim_start: Optional[Tuple[str, ...]] = None,
         trim_chars: Optional[Tuple[str, ...]] = None,
@@ -51,7 +51,6 @@ class RawSegment(BaseSegment):
         self.pos_marker: PositionMarker = pos_marker  # type: ignore
         # Set the segments attribute to be an empty tuple.
         self.segments = ()
-        # if instance types are provided, store it for later.
         self.instance_types = instance_types
         # What should we trim off the ends to get to content
         self.trim_start = trim_start

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -4,7 +4,7 @@ This is designed to be the root segment, without
 any children, and the output of the lexer.
 """
 
-from typing import Any, List, Optional, Set, Tuple
+from typing import Any, List, Optional, Set, Tuple, Union
 from uuid import UUID, uuid4
 
 from sqlfluff.core.parser.markers import PositionMarker
@@ -26,7 +26,9 @@ class RawSegment(BaseSegment):
         self,
         raw: Optional[str] = None,
         pos_marker: Optional[PositionMarker] = None,
-        type: Optional[str] = None,
+        # Optionally, type can also be a tuple of types, where
+        # the first is the "main" type.
+        type: Optional[Union[str, Tuple[str, ...]]] = None,
         trim_start: Optional[Tuple[str, ...]] = None,
         trim_chars: Optional[Tuple[str, ...]] = None,
         source_fixes: Optional[List[SourceFix]] = None,
@@ -49,8 +51,15 @@ class RawSegment(BaseSegment):
         self.pos_marker: PositionMarker = pos_marker  # type: ignore
         # Set the segments attribute to be an empty tuple.
         self.segments = ()
-        # if a surrogate type is provided, store it for later.
-        self._surrogate_type = type
+        # if instance types are provided, store it for later.
+        self.instance_types: Tuple[str, ...]
+        if type is None:
+            self.instance_types = ()
+        elif isinstance(type, str):
+            self.instance_types = (type,)
+        else:
+            assert isinstance(type, tuple)
+            self.instance_types = type
         # What should we trim off the ends to get to content
         self.trim_start = trim_start
         self.trim_chars = trim_chars
@@ -115,9 +124,7 @@ class RawSegment(BaseSegment):
 
         Add the surrogate type for raw segments.
         """
-        return (
-            {self._surrogate_type} if self._surrogate_type else set()
-        ) | super().class_types
+        return set(self.instance_types) | super().class_types
 
     @property
     def source_fixes(self) -> List[SourceFix]:
@@ -132,11 +139,13 @@ class RawSegment(BaseSegment):
 
     def get_type(self) -> str:
         """Returns the type of this segment as a string."""
-        return self._surrogate_type or self.type
+        if self.instance_types:
+            return self.instance_types[0]
+        return self.type
 
     def is_type(self, *seg_type: str) -> bool:
         """Extend the parent class method with the surrogate types."""
-        if self._surrogate_type and self._surrogate_type in seg_type:
+        if set(self.instance_types).intersection(seg_type):
             return True
         return self.class_is_type(*seg_type)
 
@@ -194,7 +203,7 @@ class RawSegment(BaseSegment):
         return self.__class__(
             raw=raw or self.raw,
             pos_marker=self.pos_marker,
-            type=self._surrogate_type,
+            type=self.instance_types,
             trim_start=self.trim_start,
             trim_chars=self.trim_chars,
             source_fixes=source_fixes or self.source_fixes,

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -28,7 +28,7 @@ class RawSegment(BaseSegment):
         pos_marker: Optional[PositionMarker] = None,
         # Optionally, type can also be a tuple of types, where
         # the first is the "main" type.
-        type: Optional[Union[str, Tuple[str, ...]]] = None,
+        instance_types: Tuple[str, ...] = (),
         trim_start: Optional[Tuple[str, ...]] = None,
         trim_chars: Optional[Tuple[str, ...]] = None,
         source_fixes: Optional[List[SourceFix]] = None,
@@ -52,14 +52,7 @@ class RawSegment(BaseSegment):
         # Set the segments attribute to be an empty tuple.
         self.segments = ()
         # if instance types are provided, store it for later.
-        self.instance_types: Tuple[str, ...]
-        if type is None:
-            self.instance_types = ()
-        elif isinstance(type, str):
-            self.instance_types = (type,)
-        else:
-            assert isinstance(type, tuple)
-            self.instance_types = type
+        self.instance_types = instance_types
         # What should we trim off the ends to get to content
         self.trim_start = trim_start
         self.trim_chars = trim_chars
@@ -141,7 +134,7 @@ class RawSegment(BaseSegment):
         """Returns the type of this segment as a string."""
         if self.instance_types:
             return self.instance_types[0]
-        return self.type
+        return super().get_type()
 
     def is_type(self, *seg_type: str) -> bool:
         """Extend the parent class method with the surrogate types."""
@@ -203,7 +196,7 @@ class RawSegment(BaseSegment):
         return self.__class__(
             raw=raw or self.raw,
             pos_marker=self.pos_marker,
-            type=self.instance_types,
+            instance_types=self.instance_types,
             trim_start=self.trim_start,
             trim_chars=self.trim_chars,
             source_fixes=source_fixes or self.source_fixes,

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -26,8 +26,10 @@ class RawSegment(BaseSegment):
         self,
         raw: Optional[str] = None,
         pos_marker: Optional[PositionMarker] = None,
-        # Optionally, type can also be a tuple of types, where
-        # the first is the "primary" type.
+        # For legacy and syntactic sugar we allow the simple
+        # `type` argument here, but for more precise inheritance
+        # we suggest using the `instance_types` option.
+        type: Optional[str] = None,
         instance_types: Tuple[str, ...] = (),
         trim_start: Optional[Tuple[str, ...]] = None,
         trim_chars: Optional[Tuple[str, ...]] = None,
@@ -51,7 +53,11 @@ class RawSegment(BaseSegment):
         self.pos_marker: PositionMarker = pos_marker  # type: ignore
         # Set the segments attribute to be an empty tuple.
         self.segments = ()
-        self.instance_types = instance_types
+        if type:
+            assert not instance_types, "Cannot set `type` and `instance_types`."
+            self.instance_types = (type,)
+        else:
+            self.instance_types = instance_types
         # What should we trim off the ends to get to content
         self.trim_start = trim_start
         self.trim_chars = trim_chars

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -53,6 +53,7 @@ class RawSegment(BaseSegment):
         self.pos_marker: PositionMarker = pos_marker  # type: ignore
         # Set the segments attribute to be an empty tuple.
         self.segments = ()
+        self.instance_types: Tuple[str, ...]
         if type:
             assert not instance_types, "Cannot set `type` and `instance_types`."
             self.instance_types = (type,)

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -4,7 +4,7 @@ This is designed to be the root segment, without
 any children, and the output of the lexer.
 """
 
-from typing import Any, List, Optional, Set, Tuple, Union
+from typing import Any, List, Optional, Set, Tuple
 from uuid import UUID, uuid4
 
 from sqlfluff.core.parser.markers import PositionMarker

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -259,6 +259,7 @@ mysql_dialect.add(
     AtSignLiteralSegment=TypedParser(
         "at_sign_literal",
         LiteralSegment,
+        type="at_sign_literal",
     ),
     SystemVariableSegment=RegexParser(
         r"@@(session|global)\.[A-Za-z0-9_]+",

--- a/src/sqlfluff/rules/convention/CV02.py
+++ b/src/sqlfluff/rules/convention/CV02.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 
-from sqlfluff.core.parser import CodeSegment
+from sqlfluff.core.parser import WordSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 
@@ -58,7 +58,7 @@ class Rule_CV02(BaseRule):
         fix = LintFix.replace(
             context.segment,
             [
-                CodeSegment(
+                WordSegment(
                     raw="COALESCE",
                     type="function_name_identifier",
                 )

--- a/src/sqlfluff/rules/convention/CV10.py
+++ b/src/sqlfluff/rules/convention/CV10.py
@@ -4,11 +4,11 @@ from typing import Optional
 
 import regex
 
-from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
-from sqlfluff.utils.functional import rsp, FunctionalContext
 from sqlfluff.core.parser.markers import PositionMarker
+from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.dialects.dialect_ansi import LiteralSegment
+from sqlfluff.utils.functional import FunctionalContext, rsp
 
 
 class Rule_CV10(BaseRule):
@@ -167,6 +167,12 @@ class Rule_CV10(BaseRule):
         )
 
         if fixed_string != context.segment.raw:
+            # We can't just set the primary type, but we have to ensure that the
+            # subtypes are properly set too so that the re-parse checks pass.
+            if fixed_string[0] == "'":
+                _instance_types = ("quoted_literal", "single_quote")
+            else:
+                _instance_types = ("quoted_literal", "double_quote")
             return LintResult(
                 anchor=context.segment,
                 memory=context.memory,
@@ -176,7 +182,7 @@ class Rule_CV10(BaseRule):
                         [
                             LiteralSegment(
                                 raw=fixed_string,
-                                type="quoted_literal",
+                                instance_types=_instance_types,
                             )
                         ],
                     )

--- a/src/sqlfluff/rules/convention/CV11.py
+++ b/src/sqlfluff/rules/convention/CV11.py
@@ -4,10 +4,10 @@ from typing import Iterable, List, Optional
 
 from sqlfluff.core.parser import (
     BaseSegment,
-    CodeSegment,
     KeywordSegment,
     SymbolSegment,
     WhitespaceSegment,
+    WordSegment,
 )
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
@@ -89,7 +89,7 @@ class Rule_CV11(BaseRule):
         # Add cast and opening parenthesis.
         edits = (
             [
-                CodeSegment("cast", type="function_name_identifier"),
+                WordSegment("cast", type="function_name_identifier"),
                 SymbolSegment("(", type="start_bracket"),
             ]
             + list(cast_arg_1)
@@ -104,7 +104,7 @@ class Rule_CV11(BaseRule):
 
         if later_types:
             pre_edits: List[BaseSegment] = [
-                CodeSegment("cast", type="function_name_identifier"),
+                WordSegment("cast", type="function_name_identifier"),
                 SymbolSegment("(", type="start_bracket"),
             ]
             in_edits: List[BaseSegment] = [
@@ -136,7 +136,7 @@ class Rule_CV11(BaseRule):
         """Generate list of fixes to convert CAST and ShorthandCast to CONVERT."""
         # Add convert and opening parenthesis.
         edits = [
-            CodeSegment("convert", type="function_name_identifier"),
+            WordSegment("convert", type="function_name_identifier"),
             SymbolSegment("(", type="start_bracket"),
             convert_arg_1,
             SymbolSegment(",", type="comma"),
@@ -147,7 +147,7 @@ class Rule_CV11(BaseRule):
 
         if later_types:
             pre_edits: List[BaseSegment] = [
-                CodeSegment("convert", type="function_name_identifier"),
+                WordSegment("convert", type="function_name_identifier"),
                 SymbolSegment("(", type="start_bracket"),
             ]
             in_edits: List[BaseSegment] = [

--- a/src/sqlfluff/rules/structure/ST02.py
+++ b/src/sqlfluff/rules/structure/ST02.py
@@ -2,10 +2,10 @@
 from typing import List, Optional, Tuple
 
 from sqlfluff.core.parser import (
-    CodeSegment,
     KeywordSegment,
     SymbolSegment,
     WhitespaceSegment,
+    WordSegment,
 )
 from sqlfluff.core.parser.segments.base import BaseSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
@@ -91,7 +91,7 @@ class Rule_ST02(BaseRule):
         """Generate list of fixes to convert CASE statement to COALESCE function."""
         # Add coalesce and opening parenthesis.
         edits = [
-            CodeSegment("coalesce", type="function_name_identifier"),
+            WordSegment("coalesce", type="function_name_identifier"),
             SymbolSegment("(", type="start_bracket"),
             coalesce_arg_1,
             SymbolSegment(",", type="comma"),

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -203,19 +203,19 @@ def generate_test_segments():
                 SegClass = NewlineSegment
             elif elem == "(":
                 SegClass = SymbolSegment
-                seg_kwargs = {"type": "start_bracket"}
+                seg_kwargs = {"instance_types": ("start_bracket",)}
             elif elem == ")":
                 SegClass = SymbolSegment
-                seg_kwargs = {"type": "end_bracket"}
+                seg_kwargs = {"instance_types": ("end_bracket",)}
             elif elem.startswith("--"):
                 SegClass = CommentSegment
-                seg_kwargs = {"type": "inline_comment"}
+                seg_kwargs = {"instance_types": ("inline_comment",)}
             elif elem.startswith('"'):
                 SegClass = CodeSegment
-                seg_kwargs = {"type": "double_quote"}
+                seg_kwargs = {"instance_types": ("double_quote",)}
             elif elem.startswith("'"):
                 SegClass = CodeSegment
-                seg_kwargs = {"type": "single_quote"}
+                seg_kwargs = {"instance_types": ("single_quote",)}
             else:
                 SegClass = CodeSegment
 

--- a/test/core/parser/parser_test.py
+++ b/test/core/parser/parser_test.py
@@ -72,3 +72,52 @@ def test__parser__multistringparser__simple():
     parser = MultiStringParser(["foo", "bar"], KeywordSegment)
     ctx = ParseContext(dialect=None)
     assert parser.simple(ctx) == (frozenset(["FOO", "BAR"]), frozenset())
+
+
+def test__parser__typedparser_rematch(generate_test_segments):
+    """Test that TypedParser allows rematching.
+
+    Because the TypedParser looks for types and then changes the
+    type as a result, there is a risk of preventing rematching.
+    This is a problem because we use it when checking that fix edits
+    haven't broken the parse tree.
+
+    In this example the TypedParser is looking for a "single_quote"
+    type segment, but is due to mutate to an Example segment, which
+    inherits directly from `RawSegment`. Unless the TypedParser
+    steps in, this would apparently present a rematching issue.
+    """
+    segments = generate_test_segments(["'foo'"])
+    # Check types pre-match
+    assert segments[0].class_types == {
+        "single_quote",
+        "raw",
+        "base",
+    }
+    parser = TypedParser("single_quote", ExampleSegment)
+    # Just check that our assumptions about inheritance are right.
+    assert not ExampleSegment.class_is_type("single_quote")
+    ctx = ParseContext(dialect=None)
+    match1 = parser.match(segments, ctx)
+    assert match1
+    # Check types post-match 1
+    assert match1.matched_segments[0].class_types == {
+        # Make sure we got the "example" class
+        "example",
+        # But we *also* get the "single_quote" class.
+        "single_quote",
+        "raw",
+        "base",
+    }
+    # Do a rematch to check it works.
+    match2 = parser.match(match1.matched_segments, ctx)
+    assert match2
+    # Check types post-match 2
+    assert match2.matched_segments[0].class_types == {
+        # Make sure we got the same classes on the *rematch*.
+        # This is the main crux of the test.
+        "example",
+        "single_quote",
+        "raw",
+        "base",
+    }


### PR DESCRIPTION
Now that `type` isn't a required attribute of `Matchable` (see #5252), this frees up the ability to adjust the interface on `RawSegment` to be a bit more helpful.

There are two sources of types for a `RawSegment`, those which come from the class (already called `_class_types`), and those linked to the instance ... currently called ... `type` 🤦 . This changes that _singluar_ type argument to a tuple called `instance_types`.

Apart from being more intuitive, it's not obvious _why_ we need to do this change. The reason for that is that it's a dependency of #5230 - especially making sure that the re-parse check can still succeed in that world . (I'm hoping it's also the _last_ required dependency to get that one merged too 🤞 ) 