### PR TITLE
Add support for date operations with intervals in Oracle

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -16,6 +16,7 @@ from sqlfluff.core.parser import (
     CommentSegment,
     Delimited,
     IdentifierSegment,
+    LiteralSegment,
     Matchable,
     OneOf,
     OptionallyBracketed,
@@ -28,6 +29,7 @@ from sqlfluff.core.parser import (
     StringLexer,
     StringParser,
     SymbolSegment,
+    TypedParser,
     WordSegment,
 )
 from sqlfluff.dialects import dialect_ansi as ansi
@@ -128,6 +130,7 @@ oracle_dialect.add(
             Ref("ColumnReferenceSegment"),
         ),
     ),
+    IntervalUnitsGrammar=OneOf("YEAR", "MONTH", "DAY", "HOUR", "MINUTE", "SECOND"),
 )
 
 oracle_dialect.replace(
@@ -245,6 +248,14 @@ oracle_dialect.replace(
         ),
         Ref("AccessorGrammar", optional=True),
         allow_gaps=True,
+    ),
+    DateTimeLiteralGrammar=Sequence(
+        OneOf("DATE", "TIME", "TIMESTAMP", "INTERVAL"),
+        TypedParser("single_quote", LiteralSegment, type="date_constructor_literal"),
+        Sequence(
+            Ref("IntervalUnitsGrammar"),
+            Sequence("TO", Ref("IntervalUnitsGrammar"), optional=True),
+        ),
     ),
 )
 

--- a/test/fixtures/dialects/oracle/interval_operations.sql
+++ b/test/fixtures/dialects/oracle/interval_operations.sql
@@ -1,0 +1,16 @@
+select 1
+from   dual
+where  sysdate > sysdate - interval '2' hour;
+
+select sysdate - interval '3' year
+from   dual;
+
+select interval '2 3:04:11.333' day to second
+from   dual;
+
+select 1
+from   dual
+where  sysdate > to_date('01/01/1970', 'dd/mm/yyyy') + interval '600' month;
+
+select sysdate + interval '10' minute
+from   dual;

--- a/test/fixtures/dialects/oracle/interval_operations.yml
+++ b/test/fixtures/dialects/oracle/interval_operations.yml
@@ -1,0 +1,123 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 75c92164df465af4705b75019cbed005252cff6f553ba67ca21c682c1568788b
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          numeric_literal: '1'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dual
+      where_clause:
+        keyword: where
+        expression:
+        - bare_function: sysdate
+        - comparison_operator:
+            raw_comparison_operator: '>'
+        - bare_function: sysdate
+        - binary_operator: '-'
+        - keyword: interval
+        - date_constructor_literal: "'2'"
+        - keyword: hour
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          expression:
+          - bare_function: sysdate
+          - binary_operator: '-'
+          - keyword: interval
+          - date_constructor_literal: "'3'"
+          - keyword: year
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dual
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+        - keyword: interval
+        - date_constructor_literal: "'2 3:04:11.333'"
+        - keyword: day
+        - keyword: to
+        - keyword: second
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dual
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          numeric_literal: '1'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dual
+      where_clause:
+        keyword: where
+        expression:
+        - bare_function: sysdate
+        - comparison_operator:
+            raw_comparison_operator: '>'
+        - function:
+            function_name:
+              function_name_identifier: to_date
+            bracketed:
+            - start_bracket: (
+            - expression:
+                quoted_literal: "'01/01/1970'"
+            - comma: ','
+            - expression:
+                quoted_literal: "'dd/mm/yyyy'"
+            - end_bracket: )
+        - binary_operator: +
+        - keyword: interval
+        - date_constructor_literal: "'600'"
+        - keyword: month
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          expression:
+          - bare_function: sysdate
+          - binary_operator: +
+          - keyword: interval
+          - date_constructor_literal: "'10'"
+          - keyword: minute
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dual
+- statement_terminator: ;


### PR DESCRIPTION
Closes #5259 

Oracle interval syntax is `interval '1' hour`, diffrent than other dialects.

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
