### PR TITLE
Fix ScalingPolicy and WarehouseType Refs in WarehouseObjectProperties

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -152,6 +152,14 @@ snowflake_dialect.sets("files_types").update(
     ["CSV", "JSON", "AVRO", "ORC" "PARQUET", "XML"],
 )
 
+snowflake_dialect.sets("warehouse_types").clear()
+snowflake_dialect.sets("warehouse_types").update(
+    [
+        "STANDARD",
+        "SNOWPARK-OPTIMIZED",
+    ],
+)
+
 snowflake_dialect.sets("warehouse_sizes").clear()
 snowflake_dialect.sets("warehouse_sizes").update(
     [
@@ -176,6 +184,15 @@ snowflake_dialect.sets("warehouse_sizes").update(
         "6X-LARGE",
     ],
 )
+
+snowflake_dialect.sets("warehouse_scaling_policies").clear()
+snowflake_dialect.sets("warehouse_scaling_policies").update(
+    [
+        "STANDARD",
+        "ECONOMY",
+    ],
+)
+
 
 snowflake_dialect.add(
     # In snowflake, these are case sensitive even though they're not quoted
@@ -221,6 +238,22 @@ snowflake_dialect.add(
     ),
     # We use a RegexParser instead of keywords as some (those with dashes) require
     # quotes:
+    WarehouseType=OneOf(
+        MultiStringParser(
+            [
+                type
+                for type in snowflake_dialect.sets("warehouse_types")
+                if "-" not in type
+            ],
+            CodeSegment,
+            type="warehouse_size",
+        ),
+        MultiStringParser(
+            [f"'{type}'" for type in snowflake_dialect.sets("warehouse_types")],
+            CodeSegment,
+            type="warehouse_size",
+        ),
+    ),
     WarehouseSize=OneOf(
         MultiStringParser(
             [
@@ -250,6 +283,23 @@ snowflake_dialect.add(
             ],
             KeywordSegment,
             type="compression_type",
+        ),
+    ),
+    ScalingPolicy=OneOf(
+        MultiStringParser(
+            snowflake_dialect.sets("warehouse_scaling_policies"),
+            KeywordSegment,
+            type="scaling_policy",
+        ),
+        MultiStringParser(
+            [
+                f"'{scaling_policy}'"
+                for scaling_policy in snowflake_dialect.sets(
+                    "warehouse_scaling_policies"
+                )
+            ],
+            KeywordSegment,
+            type="scaling_policy",
         ),
     ),
     ValidationModeOptionSegment=RegexParser(
@@ -2995,7 +3045,7 @@ class WarehouseObjectPropertiesSegment(BaseSegment):
         Sequence(
             "WAREHOUSE_TYPE",
             Ref("EqualsSegment"),
-            "STANDARD",
+            Ref("WarehouseType"),
         ),
         Sequence(
             "WAREHOUSE_SIZE",
@@ -3020,10 +3070,7 @@ class WarehouseObjectPropertiesSegment(BaseSegment):
         Sequence(
             "SCALING_POLICY",
             Ref("EqualsSegment"),
-            OneOf(
-                "STANDARD",
-                "ECONOMY",
-            ),
+            Ref("ScalingPolicy"),
         ),
         Sequence(
             "AUTO_SUSPEND",

--- a/test/fixtures/dialects/snowflake/alter_warehouse.sql
+++ b/test/fixtures/dialects/snowflake/alter_warehouse.sql
@@ -4,7 +4,13 @@ alter warehouse LOAD_WH set warehouse_size = XXLARGE;
 alter warehouse LOAD_WH set WAIT_FOR_COMPLETION = TRUE;
 alter warehouse LOAD_WH set MAX_CLUSTER_COUNT = 5;
 alter warehouse LOAD_WH set MIN_CLUSTER_COUNT = 1;
+
 alter warehouse LOAD_WH set SCALING_POLICY = STANDARD;
+alter warehouse LOAD_WH set SCALING_POLICY = 'STANDARD';
+alter warehouse LOAD_WH set SCALING_POLICY = ECONOMY;
+alter warehouse LOAD_WH set SCALING_POLICY = 'ECONOMY';
+
+
 alter warehouse LOAD_WH set AUTO_SUSPEND = 1;
 alter warehouse LOAD_WH set AUTO_RESUME = FALSE;
 alter warehouse LOAD_WH set RESOURCE_MONITOR = monitor_name;
@@ -23,4 +29,7 @@ alter warehouse LOAD_WH UNSET WAREHOUSE_SIZE;
 alter warehouse LOAD_WH UNSET WAREHOUSE_SIZE, WAIT_FOR_COMPLETION;
 
 ALTER WAREHOUSE SET WAREHOUSE_SIZE='X-LARGE';
-alter warehouse set warehouse_size=medium
+alter warehouse set warehouse_size=medium;
+
+alter warehouse LOAD_WH set WAREHOUSE_TYPE = STANDARD;
+alter warehouse LOAD_WH set WAREHOUSE_TYPE = 'SNOWPARK-OPTIMIZED';

--- a/test/fixtures/dialects/snowflake/alter_warehouse.yml
+++ b/test/fixtures/dialects/snowflake/alter_warehouse.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6aef694b439b392aca42cbf1d8e3d55dd6b90b9c6489ff07af83528e281a1fdc
+_hash: f1bb6965c9638608e557a761468b94b91b4b2f20232b19ead91ba62de9e7e614
 file:
 - statement:
     alter_warehouse_statement:
@@ -83,10 +83,46 @@ file:
     - naked_identifier: LOAD_WH
     - keyword: set
     - warehouse_object_properties:
-      - keyword: SCALING_POLICY
-      - comparison_operator:
+        keyword: SCALING_POLICY
+        comparison_operator:
           raw_comparison_operator: '='
-      - keyword: STANDARD
+        scaling_policy: STANDARD
+- statement_terminator: ;
+- statement:
+    alter_warehouse_statement:
+    - keyword: alter
+    - keyword: warehouse
+    - naked_identifier: LOAD_WH
+    - keyword: set
+    - warehouse_object_properties:
+        keyword: SCALING_POLICY
+        comparison_operator:
+          raw_comparison_operator: '='
+        scaling_policy: "'STANDARD'"
+- statement_terminator: ;
+- statement:
+    alter_warehouse_statement:
+    - keyword: alter
+    - keyword: warehouse
+    - naked_identifier: LOAD_WH
+    - keyword: set
+    - warehouse_object_properties:
+        keyword: SCALING_POLICY
+        comparison_operator:
+          raw_comparison_operator: '='
+        scaling_policy: ECONOMY
+- statement_terminator: ;
+- statement:
+    alter_warehouse_statement:
+    - keyword: alter
+    - keyword: warehouse
+    - naked_identifier: LOAD_WH
+    - keyword: set
+    - warehouse_object_properties:
+        keyword: SCALING_POLICY
+        comparison_operator:
+          raw_comparison_operator: '='
+        scaling_policy: "'ECONOMY'"
 - statement_terminator: ;
 - statement:
     alter_warehouse_statement:
@@ -292,3 +328,28 @@ file:
         comparison_operator:
           raw_comparison_operator: '='
         warehouse_size: medium
+- statement_terminator: ;
+- statement:
+    alter_warehouse_statement:
+    - keyword: alter
+    - keyword: warehouse
+    - naked_identifier: LOAD_WH
+    - keyword: set
+    - warehouse_object_properties:
+        keyword: WAREHOUSE_TYPE
+        comparison_operator:
+          raw_comparison_operator: '='
+        warehouse_size: STANDARD
+- statement_terminator: ;
+- statement:
+    alter_warehouse_statement:
+    - keyword: alter
+    - keyword: warehouse
+    - naked_identifier: LOAD_WH
+    - keyword: set
+    - warehouse_object_properties:
+        keyword: WAREHOUSE_TYPE
+        comparison_operator:
+          raw_comparison_operator: '='
+        warehouse_size: "'SNOWPARK-OPTIMIZED'"
+- statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/create_warehouse.sql
+++ b/test/fixtures/dialects/snowflake/create_warehouse.sql
@@ -2,4 +2,11 @@ create or replace warehouse my_wh with warehouse_size='X-LARGE';
 create or replace warehouse my_wh warehouse_size=large initially_suspended=true;
 create warehouse if not exists LOAD_WH warehouse_size='medium';
 create warehouse if not exists LOAD_WH warehouse_size='medium' warehouse_type = standard;
-create warehouse my_wh warehouse_size = 'medium' comment = 'comment' auto_suspend = 60;
+
+create warehouse my_wh
+    WAREHOUSE_TYPE = 'SNOWPARK-OPTIMIZED'
+    warehouse_size = 'medium'
+    SCALING_POLICY = ECONOMY
+    comment = 'comment'
+    auto_suspend = 60
+;

--- a/test/fixtures/dialects/snowflake/create_warehouse.yml
+++ b/test/fixtures/dialects/snowflake/create_warehouse.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: dd89532d265e4eb040d5a3d7556e1b6a400f53621522df236934489c30dd6db2
+_hash: 3194a56a124b29b4e8ccc62a397597b01bbcb39dd0523445316a2e3a89f7a4b8
 file:
 - statement:
     create_statement:
@@ -70,7 +70,7 @@ file:
       - keyword: warehouse_type
       - comparison_operator:
           raw_comparison_operator: '='
-      - keyword: standard
+      - warehouse_size: standard
 - statement_terminator: ;
 - statement:
     create_statement:
@@ -79,10 +79,18 @@ file:
     - object_reference:
         naked_identifier: my_wh
     - warehouse_object_properties:
-        keyword: warehouse_size
-        comparison_operator:
+      - keyword: WAREHOUSE_TYPE
+      - comparison_operator:
           raw_comparison_operator: '='
-        warehouse_size: "'medium'"
+      - warehouse_size: "'SNOWPARK-OPTIMIZED'"
+      - keyword: warehouse_size
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - warehouse_size: "'medium'"
+      - keyword: SCALING_POLICY
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - scaling_policy: ECONOMY
     - comment_equals_clause:
         keyword: comment
         comparison_operator:


### PR DESCRIPTION


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

The main issue was that SCALING_POLICY can be quoted (cf #4937) and that was not dealt with. 
I changed the way SCALING_POLICY works in `WarehouseObjectPropertiesSegment` to mimic how `WarehouseSize` is working. 
Doing that I saw that there is a new WAREHOUSE_TYPE in the [snowflake docs (SNOWPARK-OPTIMIZED) so I did the same work for WarehouseType.
](https://docs.snowflake.com/en/sql-reference/sql/alter-warehouse)![Capture d’écran 2023-10-02 à 17 11 27](https://github.com/sqlfluff/sqlfluff/assets/50910271/3bc30872-0e8b-431f-ae15-e2d91d87b02e)

Then I udpated the tests accordingly.

makes progress on #4937

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
