### PR TITLE
Snowflake: Parse EXECUTE IMMEDIATE clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1061,6 +1061,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("CreateDatabaseFromShareStatementSegment"),
             Ref("AlterRoleStatementSegment"),
             Ref("AlterStorageIntegrationSegment"),
+            Ref("ExecuteImmediateClauseSegment"),
             Ref("ExecuteTaskClauseSegment"),
         ],
         remove=[
@@ -5998,6 +5999,44 @@ class AlterTaskUnsetClauseSegment(BaseSegment):
     match_grammar = Sequence(
         "UNSET",
         Delimited(Ref("ParameterNameSegment")),
+    )
+
+
+class ExecuteImmediateClauseSegment(BaseSegment):
+    """Snowflake's EXECUTE IMMEDIATE clause.
+
+    ```
+    EXECUTE IMMEDIATE '<string_literal>'
+        [ USING ( <bind_variable> [ , <bind_variable> ... ] ) ]
+
+    EXECUTE IMMEDIATE <variable>
+        [ USING ( <bind_variable> [ , <bind_variable> ... ] ) ]
+
+    EXECUTE IMMEDIATE $<session_variable>
+        [ USING ( <bind_variable> [ , <bind_variable> ... ] ) ]
+    ```
+
+    https://docs.snowflake.com/en/sql-reference/sql/execute-immediate
+    """
+
+    type = "execute_immediate_clause"
+
+    match_grammar = Sequence(
+        "EXECUTE",
+        "IMMEDIATE",
+        OneOf(
+            Ref("QuotedLiteralSegment"),
+            Ref("ReferencedVariableNameSegment"),
+            Sequence(
+                Ref("ColonSegment"),
+                Ref("LocalVariableNameSegment"),
+            ),
+        ),
+        Sequence(
+            "USING",
+            Bracketed(Delimited(Ref("LocalVariableNameSegment"))),
+            optional=True,
+        ),
     )
 
 

--- a/test/fixtures/dialects/snowflake/execute_immediate.sql
+++ b/test/fixtures/dialects/snowflake/execute_immediate.sql
@@ -1,0 +1,21 @@
+EXECUTE IMMEDIATE 'select 1';
+
+EXECUTE IMMEDIATE $$
+  SELECT PI();
+$$;
+
+SET pie =
+$$
+  SELECT PI();
+$$
+;
+
+SET one = 1;
+SET two = 2;
+
+EXECUTE IMMEDIATE $pie;
+EXECUTE IMMEDIATE $pie USING (one, two);
+
+SET three = 'select ? + ?';
+EXECUTE IMMEDIATE :three;
+EXECUTE IMMEDIATE :three USING (one, two);

--- a/test/fixtures/dialects/snowflake/execute_immediate.yml
+++ b/test/fixtures/dialects/snowflake/execute_immediate.yml
@@ -1,0 +1,95 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 8e04c349292c858194d9339483207da94a5fdf7483fa466ba1eb05a2eae1efb6
+file:
+- statement:
+    execute_immediate_clause:
+    - keyword: EXECUTE
+    - keyword: IMMEDIATE
+    - quoted_literal: "'select 1'"
+- statement_terminator: ;
+- statement:
+    execute_immediate_clause:
+    - keyword: EXECUTE
+    - keyword: IMMEDIATE
+    - quoted_literal: "$$\n  SELECT PI();\n$$"
+- statement_terminator: ;
+- statement:
+    set_statement:
+      keyword: SET
+      variable: pie
+      comparison_operator:
+        raw_comparison_operator: '='
+      expression:
+        quoted_literal: "$$\n  SELECT PI();\n$$"
+- statement_terminator: ;
+- statement:
+    set_statement:
+      keyword: SET
+      variable: one
+      comparison_operator:
+        raw_comparison_operator: '='
+      expression:
+        numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    set_statement:
+      keyword: SET
+      variable: two
+      comparison_operator:
+        raw_comparison_operator: '='
+      expression:
+        numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    execute_immediate_clause:
+    - keyword: EXECUTE
+    - keyword: IMMEDIATE
+    - variable: $pie
+- statement_terminator: ;
+- statement:
+    execute_immediate_clause:
+    - keyword: EXECUTE
+    - keyword: IMMEDIATE
+    - variable: $pie
+    - keyword: USING
+    - bracketed:
+      - start_bracket: (
+      - variable: one
+      - comma: ','
+      - variable: two
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    set_statement:
+      keyword: SET
+      variable: three
+      comparison_operator:
+        raw_comparison_operator: '='
+      expression:
+        quoted_literal: "'select ? + ?'"
+- statement_terminator: ;
+- statement:
+    execute_immediate_clause:
+    - keyword: EXECUTE
+    - keyword: IMMEDIATE
+    - colon: ':'
+    - variable: three
+- statement_terminator: ;
+- statement:
+    execute_immediate_clause:
+    - keyword: EXECUTE
+    - keyword: IMMEDIATE
+    - colon: ':'
+    - variable: three
+    - keyword: USING
+    - bracketed:
+      - start_bracket: (
+      - variable: one
+      - comma: ','
+      - variable: two
+      - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
Fixes #5216
Parses Snowflake's `EXECUTE IMMEDIATE` statement.

Original SQL snippet:

```sql
EXECUTE IMMEDIATE
  $$
  BEGIN
    CALL META.PROCEDURE_DROP
      ('FOO','REFERENCE');
  END;
$$;
```

now successfully parses to:

```yaml
file:
    statement:
        execute_immediate_clause:
            keyword:    'EXECUTE'
            whitespace: ' '
            keyword:    'IMMEDIATE'
            newline:    '\n'
            whitespace: '  '
            quoted_literal: "$$\n  BEGIN\n    CALL META.PROCEDURE_DROP\n      ('FOO','REFERENCE');\n  END;\n$$"
    statement_terminator: ';'
    newline:              '\n'
    [META] end_of_file:
```

### Brief summary of the change made

Followed the examples and added a class `ExecuteImmediateClauseSegment` to parse the statement.

One issue: Snowflake has a variable syntax like `:var` for [binding a variable](https://docs.snowflake.com/en/developer-guide/snowflake-scripting/variables#using-a-variable-in-a-sql-statement-binding). I didn't see that anywhere else and thought it could be reusable. I tried to create a segment like the `ReferencedVariableNameSegment` or `LocalVariableNameSegment`, but could not get that working. I do not recall coming across that syntax elsewhere in Snowflake though.

### Are there any other side effects of this change that we should be aware of?

None that I am aware of.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
