### PR TITLE
Resolve click import options on autocomplete

### DIFF
--- a/src/sqlfluff/cli/autocomplete.py
+++ b/src/sqlfluff/cli/autocomplete.py
@@ -1,19 +1,26 @@
 """autocompletion commands."""
 
-from sqlfluff import list_dialects
 from typing import List
+
+from sqlfluff import list_dialects
 
 # Older versions of click don't have shell completion
 # so handle for now, as version 8 still fairly recent
 # See: https://github.com/sqlfluff/sqlfluff/issues/2543
 shell_completion_enabled = True
 try:
-    from click import shell_completion as completion
+    from click.shell_completion import CompletionItem
 except ImportError:  # pragma: no cover
+    # In older versions don't enable completion.
+    # We don't force newer versions of click however.
+    # See: https://github.com/sqlfluff/sqlfluff/issues/2543
     shell_completion_enabled = False
 
 
-def dialect_shell_complete(ctx, param, incomplete) -> List[completion.CompletionItem]:
+# NOTE: Important that we refer to the "CompletionItem" type
+# as a string rather than a direct reference so that we don't
+# get import errors when running with older versions of click.
+def dialect_shell_complete(ctx, param, incomplete) -> List["CompletionItem"]:
     """Shell completion for possible dialect names.
 
     We use this over click.Choice as we want to internally
@@ -21,7 +28,5 @@ def dialect_shell_complete(ctx, param, incomplete) -> List[completion.Completion
     """
     dialect_names = [e.label for e in list_dialects()]
     return [
-        completion.CompletionItem(name)
-        for name in dialect_names
-        if name.startswith(incomplete)
+        CompletionItem(name) for name in dialect_names if name.startswith(incomplete)
     ]


### PR DESCRIPTION
I think this is an alternative solution to #5195 (rather than #5197). We've previously tried not to force CLI related libraries on users who don't need them. See #2543.

This ensures older `click` versions don't error with an import error due to the type checking.

Resolves #5195 .

@jdahlbom - could you check whether this also solves the problem you highlighted in your PR?