### PR TITLE
Change drop function to allow DropBehaviourGrammar with space after function name

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -956,7 +956,7 @@ class DropFunctionStatementSegment(BaseSegment):
         Ref("IfExistsGrammar", optional=True),
         Delimited(
             Sequence(
-                Ref("FunctionNameSegment"),
+                Ref("ObjectReferenceSegment"),
                 Ref("FunctionParameterListGrammar", optional=True),
             )
         ),

--- a/test/fixtures/dialects/postgres/drop_function.sql
+++ b/test/fixtures/dialects/postgres/drop_function.sql
@@ -1,5 +1,6 @@
-DROP FUNCTION sqrt(integer);
-DROP FUNCTION sqrt(integer), sqrt(bigint);
+DROP FUNCTION sqrt (integer);
+DROP FUNCTION sqrt (integer), sqrt (bigint);
 DROP FUNCTION update_employee_salaries;
-DROP FUNCTION update_employee_salaries();
+DROP FUNCTION update_employee_salaries ();
 DROP FUNCTION IF EXISTS foo (IN my_var integer, VARIADIC my_var_2 text);
+DROP FUNCTION IF EXISTS f_name CASCADE;

--- a/test/fixtures/dialects/postgres/drop_function.yml
+++ b/test/fixtures/dialects/postgres/drop_function.yml
@@ -3,14 +3,14 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: af4657c34d959e21cd5ac7fa31e0be4aed673cb2baf503b2a9b1431c2270f063
+_hash: c558b7e99c57564a274aa6d3dde08cbc81b55855a124d4df7cc3531f991db2ed
 file:
 - statement:
     drop_function_statement:
     - keyword: DROP
     - keyword: FUNCTION
-    - function_name:
-        function_name_identifier: sqrt
+    - object_reference:
+        naked_identifier: sqrt
     - function_parameter_list:
         bracketed:
           start_bracket: (
@@ -22,8 +22,8 @@ file:
     drop_function_statement:
     - keyword: DROP
     - keyword: FUNCTION
-    - function_name:
-        function_name_identifier: sqrt
+    - object_reference:
+        naked_identifier: sqrt
     - function_parameter_list:
         bracketed:
           start_bracket: (
@@ -31,8 +31,8 @@ file:
             keyword: integer
           end_bracket: )
     - comma: ','
-    - function_name:
-        function_name_identifier: sqrt
+    - object_reference:
+        naked_identifier: sqrt
     - function_parameter_list:
         bracketed:
           start_bracket: (
@@ -44,15 +44,15 @@ file:
     drop_function_statement:
     - keyword: DROP
     - keyword: FUNCTION
-    - function_name:
-        function_name_identifier: update_employee_salaries
+    - object_reference:
+        naked_identifier: update_employee_salaries
 - statement_terminator: ;
 - statement:
     drop_function_statement:
     - keyword: DROP
     - keyword: FUNCTION
-    - function_name:
-        function_name_identifier: update_employee_salaries
+    - object_reference:
+        naked_identifier: update_employee_salaries
     - function_parameter_list:
         bracketed:
           start_bracket: (
@@ -64,8 +64,8 @@ file:
     - keyword: FUNCTION
     - keyword: IF
     - keyword: EXISTS
-    - function_name:
-        function_name_identifier: foo
+    - object_reference:
+        naked_identifier: foo
     - function_parameter_list:
         bracketed:
         - start_bracket: (
@@ -79,4 +79,14 @@ file:
         - data_type:
             keyword: text
         - end_bracket: )
+- statement_terminator: ;
+- statement:
+    drop_function_statement:
+    - keyword: DROP
+    - keyword: FUNCTION
+    - keyword: IF
+    - keyword: EXISTS
+    - object_reference:
+        naked_identifier: f_name
+    - keyword: CASCADE
 - statement_terminator: ;


### PR DESCRIPTION
Fix #5211 

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
