### PR TITLE
Refactor LT09

### DIFF
--- a/src/sqlfluff/rules/layout/LT09.py
+++ b/src/sqlfluff/rules/layout/LT09.py
@@ -381,25 +381,6 @@ class Rule_LT09(BaseRule):
                             select_children=select_children,
                             delete_segments=to_delete,
                         )
-                elif select_stmt.segments[after_select_clause_idx].is_type(
-                    "whitespace"
-                ):
-                    # The select_clause has stuff after (most likely a comment)
-                    # Delete the whitespace immediately after the select clause
-                    # so the other stuff aligns nicely based on where the select
-                    # clause started.
-                    fixes += [
-                        LintFix.delete(
-                            select_stmt.segments[after_select_clause_idx],
-                        ),
-                    ]
-                    add_fixes_for_move_after_select_clause(
-                        fixes,
-                        start_seg,
-                        target_seg,
-                        select_clause=select_clause,
-                        select_children=select_children,
-                    )
                 elif select_stmt.segments[after_select_clause_idx].is_type("dedent"):
                     # Again let's strip back the whitespace, but simpler
                     # as don't need to worry about new line so just break
@@ -422,6 +403,18 @@ class Rule_LT09(BaseRule):
                             ),
                         )
                 else:
+                    if select_stmt.segments[after_select_clause_idx].is_type(
+                        "whitespace"
+                    ):
+                        # The select_clause has stuff after (most likely a comment)
+                        # Delete the whitespace immediately after the select clause
+                        # so the other stuff aligns nicely based on where the select
+                        # clause started.
+                        fixes += [
+                            LintFix.delete(
+                                select_stmt.segments[after_select_clause_idx],
+                            ),
+                        ]
                     add_fixes_for_move_after_select_clause(
                         fixes,
                         start_seg,

--- a/src/sqlfluff/rules/layout/LT09.py
+++ b/src/sqlfluff/rules/layout/LT09.py
@@ -354,6 +354,9 @@ class Rule_LT09(BaseRule):
             after_select_clause_idx = select_clause_idx + 1
 
             if len(select_stmt.segments) > after_select_clause_idx:
+                add_newline = True
+                to_delete = [target_seg]
+
                 if select_stmt.segments[after_select_clause_idx].is_type("newline"):
                     # Since we're deleting the newline, we should also delete all
                     # whitespace before it or it will add random whitespace to
@@ -381,14 +384,6 @@ class Rule_LT09(BaseRule):
                                 )
                             )
 
-                        add_fixes_for_move_after_select_clause(
-                            fixes,
-                            start_seg,
-                            to_delete[-1],
-                            select_clause=select_clause,
-                            select_children=select_children,
-                            delete_segments=to_delete,
-                        )
                 elif select_stmt.segments[after_select_clause_idx].is_type("dedent"):
                     # Again let's strip back the whitespace, but simpler
                     # as don't need to worry about new line so just break
@@ -398,37 +393,33 @@ class Rule_LT09(BaseRule):
                         start_seg=select_children[select_clause_idx - 1],
                     )
                     if to_delete:
-                        add_fixes_for_move_after_select_clause(
-                            fixes,
-                            start_seg,
-                            to_delete[-1],
-                            select_clause=select_clause,
-                            select_children=select_children,
-                            delete_segments=to_delete,
-                            # If we deleted a newline, create a newline.
-                            add_newline=any(
-                                seg for seg in to_delete if seg.is_type("newline")
-                            ),
+                        # If we deleted a newline, create a newline.
+                        add_newline = any(
+                            seg for seg in to_delete if seg.is_type("newline")
                         )
-                else:
-                    if select_stmt.segments[after_select_clause_idx].is_type(
-                        "whitespace"
-                    ):
-                        # The select_clause has stuff after (most likely a comment)
-                        # Delete the whitespace immediately after the select clause
-                        # so the other stuff aligns nicely based on where the select
-                        # clause started.
-                        fixes += [
-                            LintFix.delete(
-                                select_stmt.segments[after_select_clause_idx],
-                            ),
-                        ]
+
+                elif select_stmt.segments[after_select_clause_idx].is_type(
+                    "whitespace"
+                ):
+                    # The select_clause has stuff after (most likely a comment)
+                    # Delete the whitespace immediately after the select clause
+                    # so the other stuff aligns nicely based on where the select
+                    # clause started.
+                    fixes += [
+                        LintFix.delete(
+                            select_stmt.segments[after_select_clause_idx],
+                        ),
+                    ]
+
+                if to_delete:
                     add_fixes_for_move_after_select_clause(
                         fixes,
                         start_seg,
-                        target_seg,
+                        to_delete[-1],
                         select_clause=select_clause,
                         select_children=select_children,
+                        delete_segments=to_delete,
+                        add_newline=add_newline,
                     )
 
         fixes += [

--- a/src/sqlfluff/rules/layout/LT09.py
+++ b/src/sqlfluff/rules/layout/LT09.py
@@ -21,6 +21,48 @@ class SelectTargetsInfo(NamedTuple):
     pre_from_whitespace: List[BaseSegment]
 
 
+def add_fixes_for_move_after_select_clause(
+    existing_fixes: List[LintFix],
+    start_seg: BaseSegment,
+    stop_seg: BaseSegment,
+    select_clause,
+    select_children,
+    delete_segments: Sequence[BaseSegment] = (),
+    add_newline: bool = True,
+) -> None:
+    """Cleans up by moving leftover select_clause segments.
+
+    Context: Some of the other fixes we make in
+    _eval_single_select_target_element() leave leftover
+    child segments that need to be moved to become
+    *siblings* of the select_clause.
+
+    NOTE: This method mutates `existing_fixes`. This is so
+    that we can check for duplicate fixes.
+    """
+    move_after_select_clause = select_children.select(
+        start_seg=start_seg,
+        stop_seg=stop_seg,
+    )
+    # :TRICKY: Below, we have a couple places where we
+    # filter to guard against deleting the same segment
+    # multiple times -- this is illegal.
+    all_deletes = set(fix.anchor for fix in existing_fixes if fix.edit_type == "delete")
+    for seg in (*delete_segments, *move_after_select_clause):
+        if seg not in all_deletes:
+            existing_fixes.append(LintFix.delete(seg))
+            all_deletes.add(seg)
+
+    if move_after_select_clause or add_newline:
+        existing_fixes.append(
+            LintFix.create_after(
+                select_clause[0],
+                ([NewlineSegment()] if add_newline else [])
+                + list(move_after_select_clause),
+            )
+        )
+
+
 class Rule_LT09(BaseRule):
     """Select targets should be on a new line unless there is only one select target.
 
@@ -217,45 +259,44 @@ class Rule_LT09(BaseRule):
     ):
         select_clause = FunctionalContext(context).segment
         parent_stack = context.parent_stack
+        target_idx = select_targets_info.first_select_target_idx
+        select_children = select_clause.children()
+        target_seg = select_children[target_idx]
 
         # If it's all on one line, then there's no issue.
         if not (
             select_targets_info.select_idx
             < select_targets_info.first_new_line_idx
-            < select_targets_info.first_select_target_idx
+            < target_idx
         ):
             self.logger.info(
                 "Target at index %s is already on a single line.",
-                select_targets_info.first_select_target_idx,
+                target_idx,
             )
             return None
-
-        # Do we have a modifier?
-        select_children = select_clause.children()
-        modifier: Optional[Segments]
-        modifier = select_children.first(sp.is_type("select_clause_modifier"))
 
         # Does the target contain a newline?
         # i.e. even if it's a single element, does it already span more than
         # one line?
-        if (
-            "newline"
-            in select_children[
-                select_targets_info.first_select_target_idx
-            ].descendant_type_set
-        ):
+        if "newline" in target_seg.descendant_type_set:
             self.logger.info(
                 "Target at index %s spans multiple lines so ignoring.",
-                select_targets_info.first_select_target_idx,
+                target_idx,
             )
             return None
 
         # Prepare the select clause which will be inserted
-        insert_buff = [
-            WhitespaceSegment(),
-            select_children[select_targets_info.first_select_target_idx],
+        insert_buff = [WhitespaceSegment(), target_seg]
+        fixes = [
+            # Delete the first select target from its original location.
+            # We'll add it to the right section at the end, once we know
+            # what to add.
+            LintFix.delete(target_seg),
         ]
 
+        # Do we have a modifier?
+        modifier: Optional[Segments]
+        modifier = select_children.first(sp.is_type("select_clause_modifier"))
         # Check if the modifier is one we care about
         if modifier:
             # If it's already on the first line, ignore it.
@@ -264,18 +305,10 @@ class Rule_LT09(BaseRule):
                 < select_targets_info.first_new_line_idx
             ):
                 modifier = None
-        fixes = [
-            # Delete the first select target from its original location.
-            # We'll add it to the right section at the end, once we know
-            # what to add.
-            LintFix.delete(
-                select_children[select_targets_info.first_select_target_idx],
-            ),
-        ]
 
         # If we have a modifier to move:
         if modifier:
-            # Add it to the insert
+            # Prepend it to the insert buffer
             insert_buff = [WhitespaceSegment(), modifier[0]] + insert_buff
 
             modifier_idx = select_children.index(modifier.get())
@@ -300,64 +333,19 @@ class Rule_LT09(BaseRule):
             # Set the position marker for removing the preceding
             # whitespace and newline, which we'll use below.
             start_idx = modifier_idx
+            start_seg = modifier[0]
         else:
             # Set the position marker for removing the preceding
             # whitespace and newline, which we'll use below.
-            start_idx = select_targets_info.first_select_target_idx
+            start_idx = target_idx
+            start_seg = select_children[select_targets_info.first_new_line_idx]
 
         if parent_stack and parent_stack[-1].is_type("select_statement"):
             select_stmt = parent_stack[-1]
             select_clause_idx = select_stmt.segments.index(select_clause.get())
             after_select_clause_idx = select_clause_idx + 1
+
             if len(select_stmt.segments) > after_select_clause_idx:
-
-                def _fixes_for_move_after_select_clause(
-                    stop_seg: BaseSegment,
-                    delete_segments: Optional[Segments] = None,
-                    add_newline: bool = True,
-                ) -> List[LintFix]:
-                    """Cleans up by moving leftover select_clause segments.
-
-                    Context: Some of the other fixes we make in
-                    _eval_single_select_target_element() leave leftover
-                    child segments that need to be moved to become
-                    *siblings* of the select_clause.
-                    """
-                    start_seg = (
-                        modifier[0]
-                        if modifier
-                        else select_children[select_targets_info.first_new_line_idx]
-                    )
-                    move_after_select_clause = select_children.select(
-                        start_seg=start_seg,
-                        stop_seg=stop_seg,
-                    )
-                    # :TRICKY: Below, we have a couple places where we
-                    # filter to guard against deleting the same segment
-                    # multiple times -- this is illegal.
-                    all_deletes = set(
-                        fix.anchor for fix in fixes if fix.edit_type == "delete"
-                    )
-                    fixes_ = []
-                    for seg in delete_segments or []:
-                        if seg not in all_deletes:
-                            fixes.append(LintFix.delete(seg))
-                            all_deletes.add(seg)
-                    fixes_ += [
-                        LintFix.delete(seg)
-                        for seg in move_after_select_clause
-                        if seg not in all_deletes
-                    ]
-                    if move_after_select_clause or add_newline:
-                        fixes_.append(
-                            LintFix.create_after(
-                                select_clause[0],
-                                ([NewlineSegment()] if add_newline else [])
-                                + list(move_after_select_clause),
-                            )
-                        )
-                    return fixes_
-
                 if select_stmt.segments[after_select_clause_idx].is_type("newline"):
                     # Since we're deleting the newline, we should also delete all
                     # whitespace before it or it will add random whitespace to
@@ -385,8 +373,13 @@ class Rule_LT09(BaseRule):
                                 )
                             )
 
-                        fixes += _fixes_for_move_after_select_clause(
-                            to_delete[-1], to_delete
+                        add_fixes_for_move_after_select_clause(
+                            fixes,
+                            start_seg,
+                            to_delete[-1],
+                            select_clause=select_clause,
+                            select_children=select_children,
+                            delete_segments=to_delete,
                         )
                 elif select_stmt.segments[after_select_clause_idx].is_type(
                     "whitespace"
@@ -400,8 +393,12 @@ class Rule_LT09(BaseRule):
                             select_stmt.segments[after_select_clause_idx],
                         ),
                     ]
-                    fixes += _fixes_for_move_after_select_clause(
-                        select_children[select_targets_info.first_select_target_idx],
+                    add_fixes_for_move_after_select_clause(
+                        fixes,
+                        start_seg,
+                        target_seg,
+                        select_clause=select_clause,
+                        select_children=select_children,
                     )
                 elif select_stmt.segments[after_select_clause_idx].is_type("dedent"):
                     # Again let's strip back the whitespace, but simpler
@@ -412,15 +409,25 @@ class Rule_LT09(BaseRule):
                         start_seg=select_children[select_clause_idx - 1],
                     )
                     if to_delete:
-                        fixes += _fixes_for_move_after_select_clause(
+                        add_fixes_for_move_after_select_clause(
+                            fixes,
+                            start_seg,
                             to_delete[-1],
-                            to_delete,
+                            select_clause=select_clause,
+                            select_children=select_children,
+                            delete_segments=to_delete,
                             # If we deleted a newline, create a newline.
-                            any(seg for seg in to_delete if seg.is_type("newline")),
+                            add_newline=any(
+                                seg for seg in to_delete if seg.is_type("newline")
+                            ),
                         )
                 else:
-                    fixes += _fixes_for_move_after_select_clause(
-                        select_children[select_targets_info.first_select_target_idx],
+                    add_fixes_for_move_after_select_clause(
+                        fixes,
+                        start_seg,
+                        target_seg,
+                        select_clause=select_clause,
+                        select_children=select_children,
                     )
 
         if select_targets_info.comment_after_select_idx == -1:


### PR DESCRIPTION
This is part of #5294, but without the logic changes. Fixing that issue required delving into LT09 which has needed some attention for a while. In particular it defined a nested function with slightly confusing scope. This extracts out that method, reduces duplication and overall reduces the lines of code in this rule.

Overall function is unchanged - this is pure refactoring.