### PR TITLE
Update rule docs with correct config

### DIFF
--- a/src/sqlfluff/rules/layout/LT03.py
+++ b/src/sqlfluff/rules/layout/LT03.py
@@ -11,9 +11,20 @@ from sqlfluff.utils.reflow import ReflowSequence
 class Rule_LT03(BaseRule):
     """Operators should follow a standard for being before/after newlines.
 
+    The configuration for whether operators should be ``trailing`` or
+    ``leading`` is part of :ref:`layoutconfig`. The default configuration is:
+
+    .. code-block:: cfg
+
+        [sqlfluff:layout:type:binary_operator]
+        line_position = leading
+
+        [sqlfluff:layout:type:comparison_operator]
+        line_position = leading
+
     **Anti-pattern**
 
-    In this example, if ``operator_new_lines = after`` (or unspecified, as is the
+    In this example, if ``line_position = leading`` (or unspecified, as is the
     default), then the operator ``+`` should not be at the end of the second line.
 
     .. code-block:: sql
@@ -26,7 +37,7 @@ class Rule_LT03(BaseRule):
 
     **Best practice**
 
-    If ``operator_new_lines = after`` (or unspecified, as this is the default),
+    If ``line_position = leading`` (or unspecified, as this is the default),
     place the operator after the newline.
 
     .. code-block:: sql
@@ -36,7 +47,7 @@ class Rule_LT03(BaseRule):
             + b
         FROM foo
 
-    If ``operator_new_lines = before``, place the operator before the newline.
+    If ``line_position = trailing``, place the operator before the newline.
 
     .. code-block:: sql
 

--- a/src/sqlfluff/rules/layout/LT04.py
+++ b/src/sqlfluff/rules/layout/LT04.py
@@ -11,6 +11,14 @@ from sqlfluff.utils.reflow import ReflowSequence
 class Rule_LT04(Rule_LT03):
     """Leading/Trailing comma enforcement.
 
+    The configuration for whether operators should be ``trailing`` or
+    ``leading`` is part of :ref:`layoutconfig`. The default configuration is:
+
+    .. code-block:: cfg
+
+        [sqlfluff:layout:type:comma]
+        line_position = trailing
+
     **Anti-pattern**
 
     There is a mixture of leading and trailing commas.


### PR DESCRIPTION
This resolves #5257 . For some reason, these docs didn't get updated when we did the layout rules changes around `2.0.0`.