### PR TITLE
Better error reporting for invalid macros

### DIFF
--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -559,7 +559,7 @@ def test__cli__command_lint_parse(command):
                 lint,
                 ["test/fixtures/cli/unknown_jinja_tag/test.sql"],
             ),
-            2,
+            1,
         ),
         # Test overriding library path when it doesn't cause an issue
         (

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -559,7 +559,7 @@ def test__cli__command_lint_parse(command):
                 lint,
                 ["test/fixtures/cli/unknown_jinja_tag/test.sql"],
             ),
-            1,
+            2,
         ),
         # Test overriding library path when it doesn't cause an issue
         (


### PR DESCRIPTION
This resolves #5276 .

It doesn't raise the original posted issue as a templating error, because it's not a templating error on a file - it's a configuration issue, but this PR wraps it in a better output and makes it clearer what the error was to help users resolve it themselves.