### PR TITLE
Don't apply LT05 on templated rebreak locations #5096

### DIFF
--- a/src/sqlfluff/utils/reflow/rebreak.py
+++ b/src/sqlfluff/utils/reflow/rebreak.py
@@ -163,6 +163,20 @@ def identify_rebreak_spans(
             continue
         # Does the element itself have config? (The easy case)
         if elem.line_position:
+            # We should check whether this is a valid place to break based
+            # on whether it's in a templated tag. If it's not a literal, then skip
+            # it.
+            # TODO: We probably only care if the side of the element that we would
+            # break at (i.e. the start if it's `leading` or the end if it's
+            # `trailing`), but we'll go with the blunt logic for simplicity first.
+            if not elem.segments[0].pos_marker.is_literal():
+                reflow_logger.debug(
+                    "        ! Skipping rebreak span on %s because "
+                    "non-literal location.",
+                    elem.segments[0],
+                )
+                continue
+
             # Blocks should only have one segment so it's easy to pick it.
             spans.append(
                 _RebreakSpan(

--- a/test/fixtures/rules/std_rule_cases/LT05.yml
+++ b/test/fixtures/rules/std_rule_cases/LT05.yml
@@ -774,3 +774,9 @@ test_pass_window_function:
             order by d desc
         ) as rnk
     from foo
+
+test_fail_no_fix_long_templated:
+  # Test we fail but don't try and fix a long templated line
+  fail_str: |
+    select
+        '{{ "', '".join(["foo", "bar", "whatever", "whatever", "whatever", "whatever"]) }}'


### PR DESCRIPTION
This *should* resolve #5096.

Ignores any potential rebreak locations inside templated tags so that we don't mistakenly try and break on them. There might be other places we need to do this, but I think this solves the immediate one.