### PR TITLE
Disable JJ01 unless jinja active

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -921,8 +921,9 @@ it may be useful to other people and simplify your configuration.
 Python templater
 ^^^^^^^^^^^^^^^^
 
-Uses native Python f-strings. As described in :ref:`generic_variable_templating`,
-an example usage would look be configured as follows:
+Uses native Python f-strings. As described in
+:ref:`generic_variable_templating`, an example usage would look be
+configured as follows:
 
 If passed the following *.sql* file:
 
@@ -936,7 +937,7 @@ If passed the following *.sql* file:
 
     [sqlfluff]
     templater = python
-    
+
     [sqlfluff:templater:python:context]
     tbl_name = my_table
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -408,6 +408,8 @@ Also, SQLFluff has an integration to use :code:`dbt` as a templater.
 
     This is functionality we hope to support in future.
 
+.. _generic_variable_templating:
+
 Generic Variable Templating
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -415,10 +417,10 @@ Variables are available in all the templaters.
 By default the templating engine will expect variables for templating to be
 available in the config, and the templater will be look in the section
 corresponding to the context for that templater. By convention, the config for
-the *jinja* templater is found in the *sqlfluff:templater:jinja:context
-section, the config for the *python* templater is found in the
-*sqlfluff:templater:python:context* section, the one for the *placeholder*
-templater is found in the *sqlfluff:templater:placeholder:context* section
+the ``jinja`` templater is found in the ``sqlfluff:templater:jinja:context``
+section, the config for the ``python`` templater is found in the
+``sqlfluff:templater:python:context`` section, the one for the ``placeholder``
+templater is found in the ``sqlfluff:templater:placeholder:context`` section.
 
 For example, if passed the following *.sql* file:
 
@@ -919,7 +921,31 @@ it may be useful to other people and simplify your configuration.
 Python templater
 ^^^^^^^^^^^^^^^^
 
-Uses native Python f-strings.
+Uses native Python f-strings. As described in :ref:`generic_variable_templating`,
+an example usage would look be configured as follows:
+
+If passed the following *.sql* file:
+
+.. code-block::
+
+    SELECT * FROM {tbl_name}
+
+...and the following configuration in *.sqlfluff* in the same directory:
+
+.. code-block:: cfg
+
+    [sqlfluff]
+    templater = python
+    
+    [sqlfluff:templater:python:context]
+    tbl_name = my_table
+
+...then before parsing, the sql will be transformed to:
+
+.. code-block:: sql
+
+    SELECT * FROM my_table
+
 
 :code:`dbt` templater
 ^^^^^^^^^^^^^^^^^^^^^

--- a/src/sqlfluff/rules/jinja/JJ01.py
+++ b/src/sqlfluff/rules/jinja/JJ01.py
@@ -4,10 +4,14 @@ from typing import List, Tuple
 from sqlfluff.core.parser.segments import BaseSegment, SourceFix
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import RootOnlyCrawler
+from sqlfluff.core.templaters import JinjaTemplater
 
 
 class Rule_JJ01(BaseRule):
     """Jinja tags should have a single whitespace on either side.
+
+    This rule is only active if the ``jinja`` templater (or one of it's
+    subclasses, like the ``dbt`` templater) are used for the current file.
 
     **Anti-pattern**
 
@@ -118,6 +122,13 @@ class Rule_JJ01(BaseRule):
         # We'll need the templated file. If for whatever reason it's
         # not present, abort.
         if not context.templated_file:  # pragma: no cover
+            return []
+
+        # We also only work with setups which use the jinja templater
+        # or a derivative of that. Otherwise return empty.
+        _templater = context.config.get("templater_obj")
+        if not isinstance(_templater, JinjaTemplater):
+            self.logger.debug(f"Detected non-jinja templater: {_templater}")
             return []
 
         results = []

--- a/test/fixtures/rules/std_rule_cases/JJ01.yml
+++ b/test/fixtures/rules/std_rule_cases/JJ01.yml
@@ -58,3 +58,13 @@ test_fail_jinja_tags_no_space_no_content:
 test_fail_jinja_tags_across_segment_boundaries:
   fail_str: SELECT a{{-"1 + b"}}2
   fix_str: SELECT a{{- "1 + b" }}2
+
+test_pass_python_templater:
+  pass_str: SELECT * FROM hello.{my_table};
+  configs:
+    core:
+      templater: python
+    templater:
+      python:
+        context:
+          my_table: foo


### PR DESCRIPTION
This resolves #5219 by disabling `JJ01` unless the templater is a subclass of `JinjaTemplater` (which would also include the `dbt` templater too). I've also updated a couple of the relevant docs at the same time.