### PR TITLE
Fix parsing error when using quoted slash in Oracle

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -81,6 +81,11 @@ oracle_dialect.sets("bare_functions").update(
 oracle_dialect.patch_lexer_matchers(
     [
         RegexLexer("word", r"[a-zA-Z][0-9a-zA-Z_$#]*", WordSegment),
+        RegexLexer(
+            "single_quote",
+            r"'([^'\\]|\\|\\.|'')*'",
+            CodeSegment,
+        ),
     ]
 )
 

--- a/test/fixtures/dialects/oracle/quoted_slash.sql
+++ b/test/fixtures/dialects/oracle/quoted_slash.sql
@@ -1,0 +1,12 @@
+select a.column_a || '\' || a.column_b test
+from   test_table a;
+
+select *
+from   test_table a
+where  a.column_a || '\' || a.column_b = '10\10';
+
+select 'Test\ '
+from   dual;
+
+select '\Test\'
+from   dual;

--- a/test/fixtures/dialects/oracle/quoted_slash.yml
+++ b/test/fixtures/dialects/oracle/quoted_slash.yml
@@ -1,0 +1,107 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 830296ff81b1d612284c9e9c29eaaa29c5af1c83047c5bd133de3a5f6b4798bc
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: a
+            - dot: .
+            - naked_identifier: column_a
+          - binary_operator:
+            - pipe: '|'
+            - pipe: '|'
+          - quoted_literal: "'\\'"
+          - binary_operator:
+            - pipe: '|'
+            - pipe: '|'
+          - column_reference:
+            - naked_identifier: a
+            - dot: .
+            - naked_identifier: column_b
+          alias_expression:
+            naked_identifier: test
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+            alias_expression:
+              naked_identifier: a
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+            alias_expression:
+              naked_identifier: a
+      where_clause:
+        keyword: where
+        expression:
+        - column_reference:
+          - naked_identifier: a
+          - dot: .
+          - naked_identifier: column_a
+        - binary_operator:
+          - pipe: '|'
+          - pipe: '|'
+        - quoted_literal: "'\\'"
+        - binary_operator:
+          - pipe: '|'
+          - pipe: '|'
+        - column_reference:
+          - naked_identifier: a
+          - dot: .
+          - naked_identifier: column_b
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - quoted_literal: "'10\\10'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          quoted_literal: "'Test\\ '"
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dual
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          quoted_literal: "'\\Test\\'"
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dual
+- statement_terminator: ;


### PR DESCRIPTION
Closes #5297 

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
