### PR TITLE
Fix parsing error with table name '_' in MySQL

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -27,6 +27,7 @@ from sqlfluff.core.parser import (
     Ref,
     RegexLexer,
     RegexParser,
+    SegmentGenerator,
     Sequence,
     StringLexer,
     StringParser,
@@ -246,6 +247,14 @@ mysql_dialect.replace(
     ColumnConstraintDefaultGrammar=OneOf(
         Bracketed(ansi_dialect.get_grammar("ColumnConstraintDefaultGrammar")),
         ansi_dialect.get_grammar("ColumnConstraintDefaultGrammar"),
+    ),
+    NakedIdentifierSegment=SegmentGenerator(
+        lambda dialect: RegexParser(
+            r"([A-Z0-9_]*[A-Z][A-Z0-9_]*)|_",
+            IdentifierSegment,
+            type="naked_identifier",
+            anti_template=r"^(" + r"|".join(dialect.sets("reserved_keywords")) + r")$",
+        )
     ),
 )
 

--- a/test/fixtures/dialects/mysql/create_table.sql
+++ b/test/fixtures/dialects/mysql/create_table.sql
@@ -11,3 +11,5 @@ create table `tickets` (
     `date_created` date not null default (current_date),
     `date_closed` date default null
 );
+
+create table _ (a int);

--- a/test/fixtures/dialects/mysql/create_table.yml
+++ b/test/fixtures/dialects/mysql/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8b01380b9e2eb5f2835a3759151adbc2cc39a2effa8df0525b8b074fdcb0013f
+_hash: 6f28a08cecf7c9aa1e1307f542e733f7375214f368705d08276c01e474442702
 file:
 - statement:
     create_table_statement:
@@ -127,4 +127,18 @@ file:
             keyword: default
             null_literal: 'null'
       - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: create
+    - keyword: table
+    - table_reference:
+        naked_identifier: _
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          naked_identifier: a
+          data_type:
+            data_type_identifier: int
+        end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
Fixes #3944 

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
