### PR TITLE
Two depth map performance improvements

### DIFF
--- a/src/sqlfluff/utils/reflow/depthmap.py
+++ b/src/sqlfluff/utils/reflow/depthmap.py
@@ -28,10 +28,12 @@ class StackPosition:
         # If there's only one code element, this must be it.
         elif len(path_step.code_idxs) == 1:
             return "solo"
-        # Check for whether first or last code element
-        elif path_step.idx == min(path_step.code_idxs):
+        # Check for whether first or last code element.
+        # NOTE: code_idxs is always sorted because of how it's constructed.
+        # That means the lowest is always as the start and the highest at the end.
+        elif path_step.idx == path_step.code_idxs[0]:
             return "start"
-        elif path_step.idx == max(path_step.code_idxs):
+        elif path_step.idx == path_step.code_idxs[-1]:
             return "end"
         else:
             return ""  # NOTE: Empty string evaluates as falsy.
@@ -73,7 +75,9 @@ class DepthInfo:
             stack_hash_set=frozenset(stack_hashes),
             stack_class_types=tuple(frozenset(ps.segment.class_types) for ps in stack),
             stack_positions={
-                hash(ps.segment): StackPosition.from_path_step(ps) for ps in stack
+                # Reuse the hash first calculated above.
+                stack_hashes[idx]: StackPosition.from_path_step(ps)
+                for idx, ps in enumerate(stack)
             },
         )
 


### PR DESCRIPTION
Two very small performance improvements in `DepthMap`:
1. Rather than using `min()` and `max()` on the `code_idxs` we can rely on the tuple always being sorted so just taking the first and last values instead.
2. We're calculating the `hash()` of a segment twice in this code - let's just calculate it once and then reuse it.