### PR TITLE
`Set` to `FrozenSet` in segment class_types

### DIFF
--- a/src/sqlfluff/core/parser/match_algorithms.py
+++ b/src/sqlfluff/core/parser/match_algorithms.py
@@ -5,7 +5,7 @@ or BaseGrammar to un-bloat those classes.
 """
 
 from collections import defaultdict
-from typing import DefaultDict, List, Optional, Sequence, Set, Tuple, cast
+from typing import DefaultDict, FrozenSet, List, Optional, Sequence, Tuple, cast
 
 from sqlfluff.core.errors import SQLParseError
 from sqlfluff.core.parser.context import ParseContext
@@ -65,7 +65,7 @@ def first_trimmed_raw(seg: BaseSegment) -> str:
 def first_non_whitespace(
     segments: Sequence[BaseSegment],
     start_idx: int = 0,
-) -> Optional[Tuple[str, Set[str]]]:
+) -> Optional[Tuple[str, FrozenSet[str]]]:
     """Return the upper first non-whitespace segment in the iterable."""
     for i in range(start_idx, len(segments)):
         _segment = segments[i]

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -4,7 +4,7 @@ This is designed to be the root segment, without
 any children, and the output of the lexer.
 """
 
-from typing import Any, List, Optional, Set, Tuple
+from typing import Any, FrozenSet, List, Optional, Tuple
 from uuid import UUID, uuid4
 
 from sqlfluff.core.parser.markers import PositionMarker
@@ -113,12 +113,12 @@ class RawSegment(BaseSegment):
         return [self]
 
     @property
-    def class_types(self) -> Set[str]:
+    def class_types(self) -> FrozenSet[str]:
         """The set of full types for this segment, including inherited.
 
         Add the surrogate type for raw segments.
         """
-        return set(self.instance_types) | super().class_types
+        return frozenset(self.instance_types) | super().class_types
 
     @property
     def source_fixes(self) -> List[SourceFix]:

--- a/src/sqlfluff/utils/reflow/depthmap.py
+++ b/src/sqlfluff/utils/reflow/depthmap.py
@@ -71,7 +71,7 @@ class DepthInfo:
             stack_depth=len(stack),
             stack_hashes=stack_hashes,
             stack_hash_set=frozenset(stack_hashes),
-            stack_class_types=tuple(frozenset(ps.segment.class_types) for ps in stack),
+            stack_class_types=tuple(ps.segment.class_types for ps in stack),
             stack_positions={
                 hash(ps.segment): StackPosition.from_path_step(ps) for ps in stack
             },


### PR DESCRIPTION
This was triggered by the overhead of converting a `set` to `frozenset` in `depthmap.py`, but really the `class_types` attribute of a segment should already be a `frozenset`. The reasons we hadn't done that already were that I couldn't work out an elegant way of doing it. This makes the change so that we're always dealing with `frozenset` objects right from the start. This should have a double whammy performance improvement, first on segment creation, and then later on `DepthMap` construction.