### PR TITLE
Add a public API for nesting config strings.

### DIFF
--- a/examples/05_simple_api_config.py
+++ b/examples/05_simple_api_config.py
@@ -19,9 +19,17 @@ sqlfluff.fix("SELECT  1", config_path="test/fixtures/.sqlfluff")
 config = FluffConfig(configs={"core": {"dialect": "bigquery"}})
 # 3b. FluffConfig objects can be created from a config file in a string.
 config = FluffConfig.from_string("[sqlfluff]\ndialect=bigquery\n")
-# 3c. FluffConfig objects can be created from a path containing a config file.
+# 3c. FluffConfig objects can be created from a config file in multiple strings
+#     to simulate the effect of multiple nested config strings.
+config = FluffConfig.from_strings(
+    # NOTE: Given these two strings, the resulting dialect would be "mysql"
+    # as the later files take precedence.
+    "[sqlfluff]\ndialect=bigquery\n",
+    "[sqlfluff]\ndialect=mysql\n",
+)
+# 3d. FluffConfig objects can be created from a path containing a config file.
 config = FluffConfig.from_path("test/fixtures/")
-# 3c. FluffConfig objects can be from keyword arguments
+# 3e. FluffConfig objects can be from keyword arguments
 config = FluffConfig.from_kwargs(dialect="bigquery", rules=["LT01"])
 
 # The FluffConfig is then provided via a config argument.

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -1074,7 +1074,7 @@ class FluffConfig:
         will take precedence over any earlier values.
         """
         loader = ConfigLoader.get_global()
-        config_state = {}
+        config_state: Dict[str, Any] = {}
         for config_string in config_strings:
             config_state = loader.load_config_string(
                 config_string, configs=config_state

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -1076,7 +1076,9 @@ class FluffConfig:
         loader = ConfigLoader.get_global()
         config_state = {}
         for config_string in config_strings:
-            config_state = loader.load_config_string(config_string, configs=config_state)
+            config_state = loader.load_config_string(
+                config_string, configs=config_state
+            )
         return cls(
             configs=config_state,
             extra_config_path=extra_config_path,

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -1047,11 +1047,38 @@ class FluffConfig:
         overrides: Optional[Dict[str, Any]] = None,
         plugin_manager: Optional[pluggy.PluginManager] = None,
     ) -> "FluffConfig":
-        """Loads a config object given a particular path."""
+        """Loads a config object from a single config string."""
         loader = ConfigLoader.get_global()
         c = loader.load_config_string(config_string)
         return cls(
             configs=c,
+            extra_config_path=extra_config_path,
+            ignore_local_config=ignore_local_config,
+            overrides=overrides,
+            plugin_manager=plugin_manager,
+        )
+
+    @classmethod
+    def from_strings(
+        cls,
+        *config_strings: str,
+        extra_config_path: Optional[str] = None,
+        ignore_local_config: bool = False,
+        overrides: Optional[Dict[str, Any]] = None,
+        plugin_manager: Optional[pluggy.PluginManager] = None,
+    ) -> "FluffConfig":
+        """Loads a config object given a series of nested config strings.
+
+        Config strings are incorporated from first to last, treating the
+        first element as the "root" config, and then later config strings
+        will take precedence over any earlier values.
+        """
+        loader = ConfigLoader.get_global()
+        config_state = {}
+        for config_string in config_strings:
+            config_state = loader.load_config_string(config_string, configs=config_state)
+        return cls(
+            configs=config_state,
             extra_config_path=extra_config_path,
             ignore_local_config=ignore_local_config,
             overrides=overrides,

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -1,5 +1,7 @@
 """Module for loading config."""
 
+from __future__ import annotations
+
 try:
     from importlib.resources import files
 except ImportError:  # pragma: no cover
@@ -359,7 +361,7 @@ class ConfigLoader:
         self._config_cache: Dict[str, Dict[str, Any]] = {}
 
     @classmethod
-    def get_global(cls) -> "ConfigLoader":
+    def get_global(cls) -> ConfigLoader:
         """Get the singleton loader."""
         global global_loader
         if not global_loader:
@@ -1022,7 +1024,7 @@ class FluffConfig:
         ignore_local_config: bool = False,
         overrides: Optional[Dict[str, Any]] = None,
         **kw: Any,
-    ) -> "FluffConfig":
+    ) -> FluffConfig:
         """Loads a config object just based on the root directory."""
         loader = ConfigLoader.get_global()
         c = loader.load_config_up_to_path(
@@ -1046,7 +1048,7 @@ class FluffConfig:
         ignore_local_config: bool = False,
         overrides: Optional[Dict[str, Any]] = None,
         plugin_manager: Optional[pluggy.PluginManager] = None,
-    ) -> "FluffConfig":
+    ) -> FluffConfig:
         """Loads a config object from a single config string."""
         loader = ConfigLoader.get_global()
         c = loader.load_config_string(config_string)
@@ -1066,7 +1068,7 @@ class FluffConfig:
         ignore_local_config: bool = False,
         overrides: Optional[Dict[str, Any]] = None,
         plugin_manager: Optional[pluggy.PluginManager] = None,
-    ) -> "FluffConfig":
+    ) -> FluffConfig:
         """Loads a config object given a series of nested config strings.
 
         Config strings are incorporated from first to last, treating the
@@ -1095,7 +1097,7 @@ class FluffConfig:
         ignore_local_config: bool = False,
         overrides: Optional[Dict[str, Any]] = None,
         plugin_manager: Optional[pluggy.PluginManager] = None,
-    ) -> "FluffConfig":
+    ) -> FluffConfig:
         """Loads a config object given a particular path."""
         loader = ConfigLoader.get_global()
         c = loader.load_config_up_to_path(
@@ -1114,12 +1116,12 @@ class FluffConfig:
     @classmethod
     def from_kwargs(
         cls,
-        config: Optional["FluffConfig"] = None,
+        config: Optional[FluffConfig] = None,
         dialect: Optional[str] = None,
         rules: Optional[List[str]] = None,
         exclude_rules: Optional[List[str]] = None,
         require_dialect: bool = True,
-    ) -> "FluffConfig":
+    ) -> FluffConfig:
         """Instantiate a config from either an existing config or kwargs.
 
         This is a convenience method for the ways that the public classes
@@ -1172,7 +1174,7 @@ class FluffConfig:
                 "{}".format(templater_name, ", ".join(templater_lookup.keys()))
             )
 
-    def make_child_from_path(self, path: str) -> "FluffConfig":
+    def make_child_from_path(self, path: str) -> FluffConfig:
         """Make a child config at a path but pass on overrides and extra_config_path."""
         return self.from_path(
             path,
@@ -1182,7 +1184,7 @@ class FluffConfig:
             plugin_manager=self._plugin_manager,
         )
 
-    def diff_to(self, other: "FluffConfig") -> Dict[str, Any]:
+    def diff_to(self, other: FluffConfig) -> Dict[str, Any]:
         """Compare this config to another.
 
         Args:

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -100,6 +100,19 @@ def test__config__load_from_string():
     assert cfg == config_a
 
 
+def test__config__from_strings():
+    """Test loading config from multiple strings."""
+    strings = [
+        "[sqlfluff]\ndialect=mysql\ntesting_val=foobar",
+        "[sqlfluff]\ndialect=postgres\ntesting_val2=bar",
+        "[sqlfluff]\ndialect=mysql\ntesting_val=foo",
+    ]
+    cfg = FluffConfig.from_strings(*strings)
+    assert cfg.get("dialect") == "mysql"
+    assert cfg.get("testing_val2") == "bar"
+    assert cfg.get("testing_val") == "foo"
+
+
 def test__config__load_file_f():
     """Test loading config from a file path."""
     c = ConfigLoader()


### PR DESCRIPTION
This PR resolves #5207. This mostly uses existing machinery to create nested configs, but exposes it in an easier way and includes an example in the API examples folder. Eventually we might want to deprecate `from_string` and only allow `from_strings`, but that turns this into a more breaking release than it needs to be.