### PR TITLE
Resolve SparkSQL re-parsing issue + test validation in test suite.

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1407,6 +1407,8 @@ class BaseSegment(metaclass=SegmentMetaclass):
             f"Validation Check Fail for {segment}.\nFound additional Unparsables: "
             f"{closing_unparsables - opening_unparsables}"
         )
+        for unparsable in closing_unparsables - opening_unparsables:
+            linter_logger.debug(f"Unparsable:\n{unparsable.stringify()}\n")
         return False
 
     @staticmethod

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -516,8 +516,8 @@ sparksql_dialect.add(
     ),
     # Adding Hint related segments so they are not treated as generic comments
     # https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-hints.html
-    StartHintSegment=StringParser("/*+", KeywordSegment, type="start_hint"),
-    EndHintSegment=StringParser("*/", KeywordSegment, type="end_hint"),
+    StartHintSegment=StringParser("/*+", SymbolSegment, type="start_hint"),
+    EndHintSegment=StringParser("*/", SymbolSegment, type="end_hint"),
     PartitionSpecGrammar=Sequence(
         OneOf(
             "PARTITION",
@@ -743,14 +743,14 @@ sparksql_dialect.add(
 # https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-hints.html
 sparksql_dialect.insert_lexer_matchers(
     [
-        RegexLexer("start_hint", r"\/\*\+", CodeSegment),
+        StringLexer("start_hint", "/*+", CodeSegment),
     ],
     before="block_comment",
 )
 
 sparksql_dialect.insert_lexer_matchers(
     [
-        RegexLexer("end_hint", r"\*\/", CodeSegment),
+        StringLexer("end_hint", "*/", CodeSegment),
     ],
     before="single_quote",
 )

--- a/test/dialects/dialects_test.py
+++ b/test/dialects/dialects_test.py
@@ -73,6 +73,12 @@ def test__dialect__base_file_parse(dialect, file):
     # Check that there's nothing unparsable
     typs = parsed.tree.type_set()
     assert "unparsable" not in typs
+    # When testing the validity of fixes we re-parse sections of the file.
+    # To ensure this is safe - here we re-parse the unfixed file to ensure
+    # it's still valid.
+    assert parsed.tree._validate_segment_after_fixes(
+        parsed.config.get("dialect_obj"), parsed.tree
+    )
 
 
 @pytest.mark.integration

--- a/test/dialects/dialects_test.py
+++ b/test/dialects/dialects_test.py
@@ -75,7 +75,7 @@ def test__dialect__base_file_parse(dialect, file):
     assert "unparsable" not in typs
     # When testing the validity of fixes we re-parse sections of the file.
     # To ensure this is safe - here we re-parse the unfixed file to ensure
-    # it's still valid.
+    # it's still valid even in the case that no fixes have been applied.
     assert parsed.tree._validate_segment_after_fixes(
         parsed.config.get("dialect_obj"), parsed.tree
     )


### PR DESCRIPTION
This resolves part of #5325. There are two queries in that post, this resolves the issue with the latter one. The first one I couldn't recreate the issue.

In short - reparsing for sparksql was failing because a `KeywordSegment` rather than `SymbolSegment` was being used.

To try and catch situations like this I've added a validation check to the parse suite so that we know that any un-edited files automatically pass the "re-parse" check in advance.