### PR TITLE
Resolve #5327 (logging to stdout)

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -754,7 +754,9 @@ def _stdin_fix(linter: Linter, formatter, fix_even_unparsable: bool) -> None:
     templater_error = result.num_violations(types=SQLTemplaterError) > 0
     unfixable_error = result.num_violations(types=SQLLintError, fixable=False) > 0
     if not fix_even_unparsable:
-        exit_code = formatter.handle_files_with_tmp_or_prs_errors(result)
+        exit_code = formatter.handle_files_with_tmp_or_prs_errors(
+            result, force_stderr=True
+        )
 
     if result.num_violations(types=SQLLintError, fixable=True) > 0:
         stdout = result.paths[0].files[0].fix_string()[0]

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -583,7 +583,9 @@ class OutputStreamFormatter:
             Color.lightgrey,
         )
 
-    def handle_files_with_tmp_or_prs_errors(self, lint_result: LintingResult) -> int:
+    def handle_files_with_tmp_or_prs_errors(
+        self, lint_result: LintingResult, force_stderr=False
+    ) -> int:
         """Discard lint fixes for files with templating or parse errors.
 
         Returns 1 if there are any files with templating or parse errors after
@@ -608,7 +610,7 @@ class OutputStreamFormatter:
                         color=color,
                     ),
                     color=not self.plain_output,
-                    err=num_filtered_errors > 0,
+                    err=force_stderr or num_filtered_errors > 0,
                 )
         return EXIT_FAIL if num_filtered_errors else EXIT_SUCCESS
 

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1133,6 +1133,24 @@ def test__cli__command_fix_stdin(stdin, rules, stdout):
             "   select    *    FRoM     t    ",
             "select * from t\n",
         ),
+        (
+            # Check that warnings related to parsing errors on input don't
+            # go to stdout. This query shouldn't change, but stdout should
+            # remain clean.
+            # https://github.com/sqlfluff/sqlfluff/issues/5327
+            "select\n"
+            "    count(*) over (\n"
+            "        order by a desc \n"
+            "        range between b row and '10 seconds' following  -- noqa: PRS\n"
+            "    ) as c\n"
+            "from d\n",
+            "select\n"
+            "    count(*) over (\n"
+            "        order by a desc \n"
+            "        range between b row and '10 seconds' following  -- noqa: PRS\n"
+            "    ) as c\n"
+            "from d\n",
+        ),
     ],
 )
 def test__cli__command_format_stdin(stdin, stdout):
@@ -1143,8 +1161,9 @@ def test__cli__command_format_stdin(stdin, stdout):
             ("-", "--disable-progress-bar", "--dialect=ansi"),
         ],
         cli_input=stdin,
+        mix_stderr=False,
     )
-    assert result.output == stdout
+    assert result.stdout == stdout
 
 
 def test__cli__command_fix_stdin_logging_to_stderr(monkeypatch):


### PR DESCRIPTION
There was one of the `echo()` calls in the `stdin` fix codepath which would occasionally log to `stdout` rather than `stderr`. This adds a test case and forces it to always go to `stdout` when fixing directly from the command line.

This resolves #5327 .