### PR TITLE
Allow ignoring of comments from indentation entirely #3311

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -75,6 +75,8 @@ skip_indentation_in = script_content
 # that a comment precedes the line it describes. However if you prefer
 # comments moved _after_, this configuration setting can be set to "after".
 trailing_comments = before
+# To exclude comment lines from indentation entirely set this to "True".
+ignore_comment_lines = False
 
 # Layout configuration
 # See https://docs.sqlfluff.com/en/stable/layout.html#configuring-layout-and-spacing

--- a/src/sqlfluff/utils/reflow/config.py
+++ b/src/sqlfluff/utils/reflow/config.py
@@ -67,6 +67,7 @@ class ReflowConfig:
     skip_indentation_in: FrozenSet[str] = frozenset()
     allow_implicit_indents: bool = False
     trailing_comments: str = "before"
+    ignore_comment_lines: bool = False
 
     @classmethod
     def from_dict(cls, config_dict: ConfigDictType, **kwargs):
@@ -102,6 +103,7 @@ class ReflowConfig:
                 "allow_implicit_indents", ["indentation"]
             ),
             trailing_comments=config.get("trailing_comments", ["indentation"]),
+            ignore_comment_lines=config.get("ignore_comment_lines", ["indentation"]),
         )
 
     def get_block_config(

--- a/src/sqlfluff/utils/reflow/sequence.py
+++ b/src/sqlfluff/utils/reflow/sequence.py
@@ -580,6 +580,7 @@ class ReflowSequence:
             single_indent=single_indent,
             skip_indentation_in=self.reflow_config.skip_indentation_in,
             allow_implicit_indents=self.reflow_config.allow_implicit_indents,
+            ignore_comment_lines=self.reflow_config.ignore_comment_lines,
         )
 
         return ReflowSequence(

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -346,6 +346,19 @@ test_pass_indented_from_with_comment:
     -- Comment
     JOIN t2 USING (user_id)
 
+test_pass_ignored_comment:
+  # Test ignoring comments entirely.
+  # https://github.com/sqlfluff/sqlfluff/issues/3311
+  pass_str: |
+    SELECT *
+    FROM
+        t1
+                             -- Comment
+    JOIN t2 USING (user_id)
+  configs:
+    indentation:
+      ignore_comment_lines: true
+
 test_fail_indented_from_with_comment_alternate:
   # This shows the alternative position of comments being allowed.
   pass_str: |


### PR DESCRIPTION
This resolves #3311 (and oldie).

I've kept the same config variable name as used before and used in the long line rule config, but this time in the `indentation` config. If set, any comment-only lines will be totally ignored from reindentation.