### PR TITLE
add listagg extras support in trino dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -115,9 +115,7 @@ trino_dialect.replace(
         Ref("TildeSegment"),
         Ref("NotOperatorGrammar"),
     ),
-    PostFunctionGrammar=ansi_dialect.get_grammar(
-        "PostFunctionGrammar"
-    ).copy(
+    PostFunctionGrammar=ansi_dialect.get_grammar("PostFunctionGrammar").copy(
         insert=[
             Ref("WithinGroupClauseSegment"),
         ],

--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -334,3 +334,36 @@ class AnalyzeStatementSegment(BaseSegment):
             optional=True,
         ),
     )
+
+class WithinGroupClauseSegment(BaseSegment):
+    """An WITHIN GROUP clause for window functions.
+    
+    https://trino.io/docs/current/functions/aggregate.html#array_agg
+    """
+
+    type = "withingroup_clause"
+    match_grammar = Sequence(
+        "WITHIN",
+        "GROUP",
+        Bracketed(Ref("OrderByClauseSegment", optional=False)),
+    )
+
+class ListaggOverflowClauseSegment(BaseSegment):
+    """ON OVERFLOW clause of listagg function.
+    
+    https://trino.io/docs/current/functions/aggregate.html#array_agg
+    """
+    type = "listagg_overflow_clause"
+    match_grammar = Sequence(
+        "ON",
+        "OVERFLOW",
+        OneOf(
+            "ERROR",
+            Sequence(
+                "TRUNCATE",
+                Ref("SingleQuotedIdentifierSegment", optional=True),
+                OneOf("WITH", "WITHOUT", optional=True),
+                Ref.keyword("COUNT", optional=True),
+            ),
+        ),
+    )

--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -115,6 +115,9 @@ trino_dialect.replace(
         Ref("TildeSegment"),
         Ref("NotOperatorGrammar"),
     ),
+    PostFunctionGrammar=AnyNumberOf(
+        Ref("WithinGroupClauseSegment"),
+    ),
     FunctionContentsGrammar=AnyNumberOf(
         Ref("ExpressionSegment"),
         # A Cast-like function
@@ -163,6 +166,7 @@ trino_dialect.replace(
         Ref("IgnoreRespectNullsGrammar"),
         Ref("IndexColumnDefinitionSegment"),
         Ref("EmptyStructLiteralSegment"),
+        Ref("ListaggOverflowClauseSegment"),
     ),
 )
 
@@ -335,9 +339,10 @@ class AnalyzeStatementSegment(BaseSegment):
         ),
     )
 
+
 class WithinGroupClauseSegment(BaseSegment):
     """An WITHIN GROUP clause for window functions.
-    
+
     https://trino.io/docs/current/functions/aggregate.html#array_agg
     """
 
@@ -348,11 +353,13 @@ class WithinGroupClauseSegment(BaseSegment):
         Bracketed(Ref("OrderByClauseSegment", optional=False)),
     )
 
+
 class ListaggOverflowClauseSegment(BaseSegment):
     """ON OVERFLOW clause of listagg function.
-    
+
     https://trino.io/docs/current/functions/aggregate.html#array_agg
     """
+
     type = "listagg_overflow_clause"
     match_grammar = Sequence(
         "ON",

--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -115,8 +115,12 @@ trino_dialect.replace(
         Ref("TildeSegment"),
         Ref("NotOperatorGrammar"),
     ),
-    PostFunctionGrammar=AnyNumberOf(
-        Ref("WithinGroupClauseSegment"),
+    PostFunctionGrammar=ansi_dialect.get_grammar(
+        "PostFunctionGrammar"
+    ).copy(
+        insert=[
+            Ref("WithinGroupClauseSegment"),
+        ],
     ),
     FunctionContentsGrammar=AnyNumberOf(
         Ref("ExpressionSegment"),

--- a/test/fixtures/dialects/trino/within_group.sql
+++ b/test/fixtures/dialects/trino/within_group.sql
@@ -1,0 +1,19 @@
+--https://trino.io/docs/current/functions/aggregate.html#array_agg
+
+SELECT listagg(value, ',') WITHIN GROUP (ORDER BY value) csv_value
+FROM (VALUES 'a', 'c', 'b') t(value);
+
+SELECT listagg(value, ',' ON OVERFLOW ERROR) WITHIN GROUP (ORDER BY value) csv_value
+FROM (VALUES 'a', 'b', 'c') t(value);
+
+SELECT LISTAGG(value, ',' ON OVERFLOW TRUNCATE '.....' WITH COUNT) WITHIN GROUP (ORDER BY value)
+FROM (VALUES 'a', 'b', 'c') t(value);
+
+SELECT id, LISTAGG(value, ',') WITHIN GROUP (ORDER BY o) csv_value
+FROM (VALUES
+    (100, 1, 'a'),
+    (200, 3, 'c'),
+    (200, 2, 'b')
+) t(id, o, value)
+GROUP BY id
+ORDER BY id;

--- a/test/fixtures/dialects/trino/within_group.yml
+++ b/test/fixtures/dialects/trino/within_group.yml
@@ -1,0 +1,279 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: cd402a357356eace79b2dc1ae0f7d1915e1b42f0bb860dd9c483b51ea4ba5822
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: listagg
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  naked_identifier: value
+            - comma: ','
+            - expression:
+                quoted_literal: "','"
+            - end_bracket: )
+            withingroup_clause:
+            - keyword: WITHIN
+            - keyword: GROUP
+            - bracketed:
+                start_bracket: (
+                orderby_clause:
+                - keyword: ORDER
+                - keyword: BY
+                - column_reference:
+                    naked_identifier: value
+                end_bracket: )
+          alias_expression:
+            naked_identifier: csv_value
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - expression:
+                    quoted_literal: "'a'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'c'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'b'"
+              end_bracket: )
+            alias_expression:
+              naked_identifier: t
+              bracketed:
+                start_bracket: (
+                identifier_list:
+                  naked_identifier: value
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: listagg
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  naked_identifier: value
+            - comma: ','
+            - expression:
+                quoted_literal: "','"
+            - listagg_overflow_clause:
+              - keyword: 'ON'
+              - keyword: OVERFLOW
+              - keyword: ERROR
+            - end_bracket: )
+            withingroup_clause:
+            - keyword: WITHIN
+            - keyword: GROUP
+            - bracketed:
+                start_bracket: (
+                orderby_clause:
+                - keyword: ORDER
+                - keyword: BY
+                - column_reference:
+                    naked_identifier: value
+                end_bracket: )
+          alias_expression:
+            naked_identifier: csv_value
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - expression:
+                    quoted_literal: "'a'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'b'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'c'"
+              end_bracket: )
+            alias_expression:
+              naked_identifier: t
+              bracketed:
+                start_bracket: (
+                identifier_list:
+                  naked_identifier: value
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LISTAGG
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  naked_identifier: value
+            - comma: ','
+            - expression:
+                quoted_literal: "','"
+            - listagg_overflow_clause:
+              - keyword: 'ON'
+              - keyword: OVERFLOW
+              - keyword: TRUNCATE
+              - quoted_identifier: "'.....'"
+              - keyword: WITH
+              - keyword: COUNT
+            - end_bracket: )
+            withingroup_clause:
+            - keyword: WITHIN
+            - keyword: GROUP
+            - bracketed:
+                start_bracket: (
+                orderby_clause:
+                - keyword: ORDER
+                - keyword: BY
+                - column_reference:
+                    naked_identifier: value
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - expression:
+                    quoted_literal: "'a'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'b'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'c'"
+              end_bracket: )
+            alias_expression:
+              naked_identifier: t
+              bracketed:
+                start_bracket: (
+                identifier_list:
+                  naked_identifier: value
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LISTAGG
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  naked_identifier: value
+            - comma: ','
+            - expression:
+                quoted_literal: "','"
+            - end_bracket: )
+            withingroup_clause:
+            - keyword: WITHIN
+            - keyword: GROUP
+            - bracketed:
+                start_bracket: (
+                orderby_clause:
+                - keyword: ORDER
+                - keyword: BY
+                - column_reference:
+                    naked_identifier: o
+                end_bracket: )
+          alias_expression:
+            naked_identifier: csv_value
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - expression:
+                    bracketed:
+                    - start_bracket: (
+                    - numeric_literal: '100'
+                    - comma: ','
+                    - numeric_literal: '1'
+                    - comma: ','
+                    - quoted_literal: "'a'"
+                    - end_bracket: )
+                - comma: ','
+                - expression:
+                    bracketed:
+                    - start_bracket: (
+                    - numeric_literal: '200'
+                    - comma: ','
+                    - numeric_literal: '3'
+                    - comma: ','
+                    - quoted_literal: "'c'"
+                    - end_bracket: )
+                - comma: ','
+                - expression:
+                    bracketed:
+                    - start_bracket: (
+                    - numeric_literal: '200'
+                    - comma: ','
+                    - numeric_literal: '2'
+                    - comma: ','
+                    - quoted_literal: "'b'"
+                    - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              naked_identifier: t
+              bracketed:
+                start_bracket: (
+                identifier_list:
+                - naked_identifier: id
+                - comma: ','
+                - naked_identifier: o
+                - comma: ','
+                - naked_identifier: value
+                end_bracket: )
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: id
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: id
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
adds support for the options to the listagg function.
https://trino.io/docs/current/functions/aggregate.html#array_agg
fixes #5367 

### Are there any other side effects of this change that we should be aware of?
no

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in 
- Added appropriate documentation for the change.
