### PR TITLE
Fix GRANT ALL PRIVILEGES statement in MySQL

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1551,10 +1551,16 @@ class WildcardIdentifierSegment(ObjectReferenceSegment):
     match_grammar: Matchable = Sequence(
         # *, blah.*, blah.blah.*, etc.
         AnyNumberOf(
-            Sequence(
-                Ref("SingleIdentifierGrammar"),
-                Ref("ObjectReferenceDelimiterGrammar"),
-                allow_gaps=True,
+            OneOf(
+                Sequence(
+                    Ref("SingleIdentifierGrammar"),
+                    Ref("ObjectReferenceDelimiterGrammar"),
+                    allow_gaps=True,
+                ),
+                Sequence(
+                    Ref("StarSegment"),
+                    Ref("DotSegment"),
+                ),
             )
         ),
         Ref("StarSegment"),
@@ -3405,6 +3411,7 @@ class AccessStatementSegment(BaseSegment):
                     Ref("FunctionNameSegment"),
                     Ref("FunctionParameterListGrammar", optional=True),
                 ),
+                Ref("WildcardIdentifierSegment"),
                 terminators=["TO", "FROM"],
             ),
         ),

--- a/test/fixtures/dialects/mysql/grant.sql
+++ b/test/fixtures/dialects/mysql/grant.sql
@@ -6,3 +6,6 @@ GRANT INSERT, UPDATE, DELETE, SELECT, REFERENCES ON prj_table TO 'prj_svc'@'%';
 GRANT INSERT, UPDATE, DELETE, SELECT, REFERENCES ON prj_table TO "prj_svc"@"%";
 GRANT INSERT, UPDATE, DELETE, SELECT, REFERENCES ON prj_table TO `prj_svc`@`%`;
 GRANT INSERT, UPDATE, DELETE, SELECT, REFERENCES ON prj_table TO `prj_svc` @`%`;
+GRANT ALL ON db1.* TO 'prj_svc'@'%';
+GRANT ALL PRIVILEGES ON db1.* TO 'prj_svc'@'localhost';
+GRANT ALL PRIVILEGES ON *.* TO 'prj_svc'@'%';

--- a/test/fixtures/dialects/mysql/grant.yml
+++ b/test/fixtures/dialects/mysql/grant.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fd535f609b65d22497d484902183cbfed83028e566ddc56502d9f7cf064c78aa
+_hash: 3247b862cfe5d401832e0b10a68f5acb9adf258b44f136aa9aa669e32f5f5026
 file:
 - statement:
     access_statement:
@@ -164,4 +164,51 @@ file:
       - quoted_identifier: '`prj_svc`'
       - at_sign_literal: '@'
       - quoted_identifier: '`%`'
+- statement_terminator: ;
+- statement:
+    access_statement:
+    - keyword: GRANT
+    - keyword: ALL
+    - keyword: 'ON'
+    - wildcard_identifier:
+        naked_identifier: db1
+        dot: .
+        star: '*'
+    - keyword: TO
+    - role_reference:
+      - quoted_identifier: "'prj_svc'"
+      - at_sign_literal: '@'
+      - quoted_identifier: "'%'"
+- statement_terminator: ;
+- statement:
+    access_statement:
+    - keyword: GRANT
+    - keyword: ALL
+    - keyword: PRIVILEGES
+    - keyword: 'ON'
+    - wildcard_identifier:
+        naked_identifier: db1
+        dot: .
+        star: '*'
+    - keyword: TO
+    - role_reference:
+      - quoted_identifier: "'prj_svc'"
+      - at_sign_literal: '@'
+      - quoted_identifier: "'localhost'"
+- statement_terminator: ;
+- statement:
+    access_statement:
+    - keyword: GRANT
+    - keyword: ALL
+    - keyword: PRIVILEGES
+    - keyword: 'ON'
+    - wildcard_identifier:
+      - star: '*'
+      - dot: .
+      - star: '*'
+    - keyword: TO
+    - role_reference:
+      - quoted_identifier: "'prj_svc'"
+      - at_sign_literal: '@'
+      - quoted_identifier: "'%'"
 - statement_terminator: ;


### PR DESCRIPTION
Fix #5261 and add support for `*.*` grant statament like this: `GRANT ALL PRIVILEGES ON *.* TO ...`

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
