### PR TITLE
postgres: add support for bodies of "language sql" functions

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1310,12 +1310,27 @@ class FunctionDefinitionGrammar(ansi.FunctionDefinitionGrammar):
                 ),
             ),
             Sequence(
+                "RETURN",
+                Ref("ExpressionSegment"),
+            ),
+            Sequence(
                 "BEGIN",
                 "ATOMIC",
-                Ref("SelectStatementSegment"),
-                Ref("SemicolonSegment"),
+                AnyNumberOf(
+                    Sequence(
+                        Ref("InsertStatementSegment"),
+                        Ref("SemicolonSegment"),
+                    ),
+                    Sequence(
+                        Ref("UpdateStatementSegment"),
+                        Ref("SemicolonSegment"),
+                    ),
+                    Sequence(
+                        Ref("SelectStatementSegment"),
+                        Ref("SemicolonSegment"),
+                    ),
+                ),
                 "END",
-                Ref("SemicolonSegment"),
             ),
         ),
         Sequence(

--- a/src/sqlfluff/dialects/dialect_postgres_keywords.py
+++ b/src/sqlfluff/dialects/dialect_postgres_keywords.py
@@ -663,7 +663,7 @@ postgres_docs_keywords = [
     ("RESTRICT", "non-reserved"),
     ("RESTRICTIVE", "non-reserved"),
     ("RESULT", "not-keyword"),
-    ("RETURN", "not-keyword"),
+    ("RETURN", "non-reserved"),
     ("RETURNED_CARDINALITY", "not-keyword"),
     ("RETURNED_LENGTH", "not-keyword"),
     ("RETURNED_OCTET_LENGTH", "not-keyword"),

--- a/test/fixtures/dialects/postgres/create_function.yml
+++ b/test/fixtures/dialects/postgres/create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5e159dd09576772d0f482616449f7291ae6875bd834947338133532762478aec
+_hash: e8085ca8c143b2a4f92c5c649fa42732ec82fcabe04ecdea94558c31676e63d6
 file:
 - statement:
     create_function_statement:
@@ -788,4 +788,210 @@ file:
                     naked_identifier: data
       - statement_terminator: ;
       - keyword: END
+- statement_terminator: ;
+- statement:
+    create_function_statement:
+    - keyword: create
+    - keyword: or
+    - keyword: replace
+    - keyword: function
+    - function_name:
+        function_name_identifier: tz_date
+    - function_parameter_list:
+        bracketed:
+        - start_bracket: (
+        - data_type:
+            datetime_type_identifier:
+            - keyword: timestamp
+            - keyword: with
+            - keyword: time
+            - keyword: zone
+        - comma: ','
+        - data_type:
+            keyword: text
+        - end_bracket: )
+    - keyword: returns
+    - data_type:
+        datetime_type_identifier:
+          keyword: date
+    - function_definition:
+      - language_clause:
+          keyword: language
+          naked_identifier: sql
+      - keyword: immutable
+      - keyword: strict
+      - keyword: return
+      - expression:
+          cast_expression:
+            bracketed:
+              start_bracket: (
+              expression:
+                dollar_numeric_literal: $1
+                time_zone_grammar:
+                - keyword: at
+                - keyword: time
+                - keyword: zone
+                - expression:
+                    dollar_numeric_literal: $2
+              end_bracket: )
+            casting_operator: '::'
+            data_type:
+              datetime_type_identifier:
+                keyword: date
+- statement_terminator: ;
+- statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: FUNCTION
+    - function_name:
+        naked_identifier: storage
+        dot: .
+        function_name_identifier: insert_dimension
+    - function_parameter_list:
+        bracketed:
+        - start_bracket: (
+        - parameter: in_ordinality
+        - data_type:
+            keyword: int
+        - comma: ','
+        - parameter: in_fieldname
+        - data_type:
+            keyword: varchar
+        - comma: ','
+        - parameter: in_default_val
+        - data_type:
+            keyword: varchar
+        - comma: ','
+        - parameter: in_valid_from
+        - data_type:
+            datetime_type_identifier:
+              keyword: timestamp
+        - comma: ','
+        - parameter: in_valid_until
+        - data_type:
+            datetime_type_identifier:
+              keyword: timestamp
+        - end_bracket: )
+    - keyword: returns
+    - data_type:
+        naked_identifier: storage
+        dot: .
+        data_type_identifier: dimensions
+    - function_definition:
+      - language_clause:
+          keyword: language
+          naked_identifier: sql
+      - keyword: BEGIN
+      - keyword: ATOMIC
+      - update_statement:
+          keyword: UPDATE
+          table_reference:
+          - naked_identifier: storage
+          - dot: .
+          - naked_identifier: dimensions
+          set_clause_list:
+            keyword: SET
+            set_clause:
+              column_reference:
+                naked_identifier: ordinality
+              comparison_operator:
+                raw_comparison_operator: '='
+              expression:
+                column_reference:
+                  naked_identifier: ordinality
+                binary_operator: +
+                numeric_literal: '1'
+          where_clause:
+            keyword: WHERE
+            expression:
+            - column_reference:
+                naked_identifier: ordinality
+            - comparison_operator:
+              - raw_comparison_operator: '>'
+              - raw_comparison_operator: '='
+            - column_reference:
+                naked_identifier: in_ordinality
       - statement_terminator: ;
+      - insert_statement:
+        - keyword: INSERT
+        - keyword: INTO
+        - table_reference:
+          - naked_identifier: storage
+          - dot: .
+          - naked_identifier: dimensions
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: ordinality
+          - comma: ','
+          - column_reference:
+              naked_identifier: fieldname
+          - comma: ','
+          - column_reference:
+              naked_identifier: default_val
+          - comma: ','
+          - column_reference:
+              naked_identifier: valid_from
+          - comma: ','
+          - column_reference:
+              naked_identifier: valid_until
+          - end_bracket: )
+        - values_clause:
+            keyword: VALUES
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  naked_identifier: in_ordinality
+            - comma: ','
+            - expression:
+                column_reference:
+                  naked_identifier: in_fieldname
+            - comma: ','
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: coalesce
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        naked_identifier: in_default_val
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'notexist'"
+                  - end_bracket: )
+            - comma: ','
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: coalesce
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        naked_identifier: in_valid_from
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'-infinity'"
+                  - end_bracket: )
+            - comma: ','
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: coalesce
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        naked_identifier: in_valid_until
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'infinity'"
+                  - end_bracket: )
+            - end_bracket: )
+        - keyword: RETURNING
+        - star: '*'
+      - statement_terminator: ;
+      - keyword: END
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Postgres's `create function` grammar doesn't only allow to define functions as a string literal, but also as a plain body of SQL, should the function be `language sql`: https://www.postgresql.org/docs/current/sql-createfunction.html

Limited support for this was introduced in: https://github.com/sqlfluff/sqlfluff/issues/5310
#5310 does have some rather serious issues though:
 - Matching a semicolon after `END`  [here](https://github.com/sqlfluff/sqlfluff/pull/5316/files#diff-84df248c7619e658dbf10bea3cad532f9c0d17e06230f791f4cdd419721d2573R1318) means that the lexer doesn't close the function, as it's looking for a semicolon that has already been matched. The generated YAML testcase actually showcases this issue and only accidentally works because the added statement also happens to be the last statement in the file.
   I have fixed this issue.
 - BEGIN ATOMIC {body} END can actually have multiple statements, provided that they all can be executed in an atomic fashion.
 - Technically, these are not `CREATE FUNCTION [...] AS` statements, but their own category. SQLFluff will happily accept functions of `language plpgsql` type with a body of `language sql`. I have not addressed this issue.

Furthermore, I implemented the `CREATE FUNCTION [...] LANGUAGE SQL RETURN expression;` syntax. This has implications discussed below.

### Are there any other side effects of this change that we should be aware of?
Unfortunately, the single statement `RETURN expression` syntax turns `RETURN` into a keyword (because now it is an actual keyword in this context). This may have repercussions I have not considered, but I see little choice in the matter.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).