### PR TITLE
Fix the snippet from a pyproject.toml in configuration.rst

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -66,15 +66,15 @@ For example, a snippet from a :code:`pyproject.toml` file:
     sql_file_exts = ".sql,.sql.j2,.dml,.ddl"
 
     [tool.sqlfluff.indentation]
-    indented_joins = False
-    indented_using_on = True
-    template_blocks_indent = False
+    indented_joins = false
+    indented_using_on = true
+    template_blocks_indent = false
 
     [tool.sqlfluff.templater]
-    unwrap_wrapped_queries = True
+    unwrap_wrapped_queries = true
 
     [tool.sqlfluff.templater.jinja]
-    apply_dbt_builtins = True
+    apply_dbt_builtins = true
 
     # For rule specific configuration, use dots between the names exactly
     # as you would in .sqlfluff. In the background, SQLFluff will unpack the


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

I got an error when executing `sqlfluff` command using `pyproject.toml` in `docs/source/configuration.rst`.

```
toml.decoder.TomlDecodeError: Only all lowercase booleans allowed (line 26 column 1 char 476)
```

There is invalid syntax in `docs/source/configuration.rst`. I update to use all lowercase booleans in `pyproject.toml`.

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
