### PR TITLE
Remove exceptions for typing stubs that now exist.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,19 +216,7 @@ implicit_reexport = true
 
 # skip type checking for 3rd party packages for which stubs are not available
 [[tool.mypy.overrides]]
-module = "pathspec.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
 module = "diff_cover.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "dbt.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "pluggy.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
This is a follow on from #5373. Our mypy config includes exceptions for `pathspec`, `dbt` and `pluggy` because in the past they didn't have type stubs. I believe they now do and so we can remove those exceptions.