### PR TITLE
Move doc8 over to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,3 +269,8 @@ markers = [
     "fix_suite: Marks the suite of fixing tests across a range of dialects (part of integration).",
     "rules_suite: Marks the suite of rules tests. Also known as the yaml tests (part of integration).",
 ]
+
+
+[tool.doc8]
+# Ignore auto-generated docs
+ignore-path = "docs/source/partials/"

--- a/tox.ini
+++ b/tox.ini
@@ -195,7 +195,3 @@ source =
     D:\a\sqlfluff\sqlfluff\.tox\winpy\Lib\site-packages\
     /home/runner/work/sqlfluff/sqlfluff/src/
     /home/runner/work/sqlfluff/sqlfluff/.tox/*/lib/*/site-packages/
-
-[doc8]
-# Ignore auto-generated docs
-ignore-path=docs/source/partials/


### PR DESCRIPTION
This is half of #5383 , for reasons I don't understand yet, I think moving the `pytest` config breaks test coverage. This takes the `doc8` config out of that PR so I can debug what's going on.