### PR TITLE
Update publish actions and Dockerfile.

### DIFF
--- a/.github/workflows/publish-dbt-templater-release-to-pypi.yaml
+++ b/.github/workflows/publish-dbt-templater-release-to-pypi.yaml
@@ -28,7 +28,7 @@ jobs:
         run: cp -r plugins/sqlfluff-templater-dbt/dist/. dist/
 
       - name: Publish Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_DBT_TEMPLATER_TOKEN }}

--- a/.github/workflows/publish-sqlfluff-docker-image-to-dockerhub.yaml
+++ b/.github/workflows/publish-sqlfluff-docker-image-to-dockerhub.yaml
@@ -25,15 +25,15 @@ jobs:
       # Setup QEMU and Buildx to allow for multi-platform builds.
       - name: Set up QEMU
         id: docker_qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         id: docker_buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       # Authenticate with DockerHub.
       - name: Login to DockerHub
         id: docker_login
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
       # Build amd64 image to use in the integration test.
       - name: Build and export to Docker
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           load: true
           tags: ${{ env.TEST_TAG }}
@@ -59,7 +59,7 @@ jobs:
       # N.B. We tag this image as both latest and with its version number.
       - name: Build and push
         id: docker_build_push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-sqlfluff-release-to-pypi.yaml
+++ b/.github/workflows/publish-sqlfluff-release-to-pypi.yaml
@@ -23,7 +23,7 @@ jobs:
         run: tox -e build-dist
 
       - name: Publish Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,23 +103,6 @@ Changes = "https://github.com/sqlfluff/sqlfluff/blob/main/CHANGELOG.md"
 Twitter = "https://twitter.com/SQLFluff"
 Chat = "https://github.com/sqlfluff/sqlfluff#sqlfluff-on-slack"
 
-
-[tool.sqlfluff_docs]
-# NOTE: Stable version is used by docs/conf.py
-stable_version = "2.3.5"
-
-
-[tool.setuptools]
-package-dir = {"" = "src"}
-
-[tool.setuptools.packages.find]
-where = ["src"]
-namespaces = false
-
-[tool.setuptools.package-data]
-sqlfluff = ["config.ini", "core/default_config.cfg", "py.typed"]
-
-
 [project.scripts]
 sqlfluff = "sqlfluff.cli.commands:cli"
 
@@ -141,6 +124,15 @@ sqlfluff_rules_structure = "sqlfluff.rules.structure"
 sqlfluff_rules_convention = "sqlfluff.rules.convention"
 sqlfluff_rules_jinja = "sqlfluff.rules.jinja"
 sqlfluff_rules_tsql = "sqlfluff.rules.tsql"
+
+
+[tool.sqlfluff_docs]
+# NOTE: Stable version is used by docs/conf.py
+stable_version = "2.3.5"
+
+
+[tool.setuptools.package-data]
+sqlfluff = ["core/default_config.cfg", "py.typed"]
 
 
 [tool.importlinter]


### PR DESCRIPTION
On publishing 3.0.0a1, several of the publish actions complained.

Mostly due to old version numbers (which I've updated here), but also because the update to `pyproject.toml` broke the docker image. This fixes that too.