### PR TITLE
Update publish github action to use kebab case

### DIFF
--- a/.github/workflows/publish-dbt-templater-release-to-pypi.yaml
+++ b/.github/workflows/publish-dbt-templater-release-to-pypi.yaml
@@ -32,4 +32,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_DBT_TEMPLATER_TOKEN }}
-          skip_existing: true
+          skip-existing: true

--- a/.github/workflows/publish-sqlfluff-release-to-pypi.yaml
+++ b/.github/workflows/publish-sqlfluff-release-to-pypi.yaml
@@ -27,4 +27,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
-          skip_existing: true
+          skip-existing: true


### PR DESCRIPTION
This is a tiny PR to resolve some deprecation warnings in the publish action. `skip_existing` is deprecated - we should use `skip-existing` instead.