### PR TITLE
SQLite: Allow block comments to be terminated by end of input

### DIFF
--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -44,7 +44,7 @@ sqlite_dialect.patch_lexer_matchers(
         # SQLite allows block comments to be terminated by end of input
         RegexLexer(
             "block_comment",
-            r"\/\*([^\*]|\*(?!\/))*(\*\/|\Z)?",
+            r"\/\*([^\*]|\*(?!\/))*(\*\/|\Z)",
             CommentSegment,
             subdivider=RegexLexer(
                 "newline",

--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -508,7 +508,7 @@ def _create_table_ref(table_name: str, dialect: Dialect) -> TableExpressionSegme
     IdentifierSegment = cast(
         Type[CodeSegment], dialect.get_segment("IdentifierSegment")
     )
-    table_seg = TableExpressionSeg(
+    return TableExpressionSeg(
         segments=(
             TableReferenceSeg(
                 segments=(
@@ -520,7 +520,6 @@ def _create_table_ref(table_name: str, dialect: Dialect) -> TableExpressionSegme
             ),
         ),
     )
-    return table_seg  # type: ignore
 
 
 def _get_case_preference(root_select: Segments):

--- a/test/fixtures/dialects/sqlite/block_comment_end_of_input.sql
+++ b/test/fixtures/dialects/sqlite/block_comment_end_of_input.sql
@@ -1,0 +1,4 @@
+/*
+	According to https://www.sqlite.org/lang_comment.html, it is valid for a C-style comment to end
+	at the "end-of-input", without being closed explicitly. This document is a valid SQLite file,
+	but gives a parsing error in SQLFluff.

--- a/test/fixtures/dialects/sqlite/block_comment_end_of_input.yml
+++ b/test/fixtures/dialects/sqlite/block_comment_end_of_input.yml
@@ -1,0 +1,7 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: fdda373cd9cd649f82a9c5cf7ba9e290375c0ceae29477b0bad5a25f24a52ae3
+file: null


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #5394 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
