### PR TITLE
Permit .* after each tbl_name in multi-table delete syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -625,6 +625,19 @@ class InsertStatementSegment(BaseSegment):
     )
 
 
+class DeleteTargetTableSegment(BaseSegment):
+    """A target table used in `DELETE` statement.
+
+    https://dev.mysql.com/doc/refman/8.0/en/delete.html
+    """
+
+    type = "delete_target_table"
+    match_grammar = Sequence(
+        Ref("TableReferenceSegment"),
+        Sequence(Ref("DotSegment"), Ref("StarSegment"), optional=True),
+    )
+
+
 class DeleteUsingClauseSegment(BaseSegment):
     """A `USING` clause froma `DELETE` Statement`."""
 
@@ -653,10 +666,7 @@ class DeleteStatementSegment(BaseSegment):
             Sequence(
                 "FROM",
                 Delimited(
-                    Sequence(
-                        Ref("TableReferenceSegment"),
-                        Sequence(Ref("DotSegment"), Ref("StarSegment"), optional=True),
-                    ),
+                    Ref("DeleteTargetTableSegment"),
                     terminators=["USING"],
                 ),
                 Ref("DeleteUsingClauseSegment"),
@@ -664,10 +674,7 @@ class DeleteStatementSegment(BaseSegment):
             ),
             Sequence(
                 Delimited(
-                    Sequence(
-                        Ref("TableReferenceSegment"),
-                        Sequence(Ref("DotSegment"), Ref("StarSegment"), optional=True),
-                    ),
+                    Ref("DeleteTargetTableSegment"),
                     terminators=["FROM"],
                 ),
                 Ref("FromClauseSegment"),

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -652,12 +652,24 @@ class DeleteStatementSegment(BaseSegment):
         OneOf(
             Sequence(
                 "FROM",
-                Delimited(Ref("TableReferenceSegment"), terminators=["USING"]),
+                Delimited(
+                    Sequence(
+                        Ref("TableReferenceSegment"),
+                        Sequence(Ref("DotSegment"), Ref("StarSegment"), optional=True),
+                    ),
+                    terminators=["USING"],
+                ),
                 Ref("DeleteUsingClauseSegment"),
                 Ref("WhereClauseSegment", optional=True),
             ),
             Sequence(
-                Delimited(Ref("TableReferenceSegment"), terminators=["FROM"]),
+                Delimited(
+                    Sequence(
+                        Ref("TableReferenceSegment"),
+                        Sequence(Ref("DotSegment"), Ref("StarSegment"), optional=True),
+                    ),
+                    terminators=["FROM"],
+                ),
                 Ref("FromClauseSegment"),
                 Ref("WhereClauseSegment", optional=True),
             ),

--- a/test/fixtures/dialects/mysql/delete_multitable.sql
+++ b/test/fixtures/dialects/mysql/delete_multitable.sql
@@ -24,3 +24,9 @@ WHERE t1.id=t2.id AND t2.id=t3.id;
 DELETE a1, a2 FROM t1 AS a1 INNER JOIN t2 AS a2
 WHERE a1.id=a2.id;
 
+-- .* after table name
+DELETE t1.*, t2.* FROM t1 INNER JOIN t2 INNER JOIN t3
+WHERE t1.id=t2.id AND t2.id=t3.id;
+
+DELETE FROM t1.*, t2.* USING t1 INNER JOIN t2 INNER JOIN t3
+WHERE t1.id=t2.id AND t2.id=t3.id;

--- a/test/fixtures/dialects/mysql/delete_multitable.yml
+++ b/test/fixtures/dialects/mysql/delete_multitable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8891f999d204f5ecaae8e896c7a6e185578e86c73f67978e1c5881a8b231eda1
+_hash: ffe881c9638bc869342dbb6864ec931f36196264c3c50e76348d097eecb6d446
 file:
 - statement:
     delete_statement:
@@ -394,6 +394,123 @@ file:
             raw_comparison_operator: '='
         - column_reference:
           - naked_identifier: a2
+          - dot: .
+          - naked_identifier: id
+- statement_terminator: ;
+- statement:
+    delete_statement:
+    - keyword: DELETE
+    - table_reference:
+        naked_identifier: t1
+    - dot: .
+    - star: '*'
+    - comma: ','
+    - table_reference:
+        naked_identifier: t2
+    - dot: .
+    - star: '*'
+    - from_clause:
+        keyword: FROM
+        from_expression:
+        - from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t1
+        - join_clause:
+          - keyword: INNER
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t2
+        - join_clause:
+          - keyword: INNER
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t3
+    - where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: t1
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: t2
+          - dot: .
+          - naked_identifier: id
+        - binary_operator: AND
+        - column_reference:
+          - naked_identifier: t2
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: t3
+          - dot: .
+          - naked_identifier: id
+- statement_terminator: ;
+- statement:
+    delete_statement:
+    - keyword: DELETE
+    - keyword: FROM
+    - table_reference:
+        naked_identifier: t1
+    - dot: .
+    - star: '*'
+    - comma: ','
+    - table_reference:
+        naked_identifier: t2
+    - dot: .
+    - star: '*'
+    - using_clause:
+        keyword: USING
+        from_expression:
+        - from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t1
+        - join_clause:
+          - keyword: INNER
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t2
+        - join_clause:
+          - keyword: INNER
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t3
+    - where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: t1
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: t2
+          - dot: .
+          - naked_identifier: id
+        - binary_operator: AND
+        - column_reference:
+          - naked_identifier: t2
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: t3
           - dot: .
           - naked_identifier: id
 - statement_terminator: ;

--- a/test/fixtures/dialects/mysql/delete_multitable.yml
+++ b/test/fixtures/dialects/mysql/delete_multitable.yml
@@ -3,13 +3,14 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ffe881c9638bc869342dbb6864ec931f36196264c3c50e76348d097eecb6d446
+_hash: ac590f281d42bf98748a58c0d64c99b5fcc8b92bb8a2765fed198bb767c55f12
 file:
 - statement:
     delete_statement:
       keyword: DELETE
-      table_reference:
-        naked_identifier: a
+      delete_target_table:
+        table_reference:
+          naked_identifier: a
       from_clause:
         keyword: FROM
         from_expression:
@@ -72,8 +73,9 @@ file:
     - keyword: LOW_PRIORITY
     - keyword: QUICK
     - keyword: IGNORE
-    - table_reference:
-        naked_identifier: a
+    - delete_target_table:
+        table_reference:
+          naked_identifier: a
     - from_clause:
         keyword: FROM
         from_expression:
@@ -134,11 +136,13 @@ file:
 - statement:
     delete_statement:
     - keyword: DELETE
-    - table_reference:
-        naked_identifier: t1
+    - delete_target_table:
+        table_reference:
+          naked_identifier: t1
     - comma: ','
-    - table_reference:
-        naked_identifier: t2
+    - delete_target_table:
+        table_reference:
+          naked_identifier: t2
     - from_clause:
         keyword: FROM
         from_expression:
@@ -191,11 +195,13 @@ file:
     - keyword: LOW_PRIORITY
     - keyword: QUICK
     - keyword: IGNORE
-    - table_reference:
-        naked_identifier: t1
+    - delete_target_table:
+        table_reference:
+          naked_identifier: t1
     - comma: ','
-    - table_reference:
-        naked_identifier: t2
+    - delete_target_table:
+        table_reference:
+          naked_identifier: t2
     - from_clause:
         keyword: FROM
         from_expression:
@@ -246,11 +252,13 @@ file:
     delete_statement:
     - keyword: DELETE
     - keyword: FROM
-    - table_reference:
-        naked_identifier: t1
+    - delete_target_table:
+        table_reference:
+          naked_identifier: t1
     - comma: ','
-    - table_reference:
-        naked_identifier: t2
+    - delete_target_table:
+        table_reference:
+          naked_identifier: t2
     - using_clause:
         keyword: USING
         from_expression:
@@ -304,11 +312,13 @@ file:
     - keyword: QUICK
     - keyword: IGNORE
     - keyword: FROM
-    - table_reference:
-        naked_identifier: t1
+    - delete_target_table:
+        table_reference:
+          naked_identifier: t1
     - comma: ','
-    - table_reference:
-        naked_identifier: t2
+    - delete_target_table:
+        table_reference:
+          naked_identifier: t2
     - using_clause:
         keyword: USING
         from_expression:
@@ -358,11 +368,13 @@ file:
 - statement:
     delete_statement:
     - keyword: DELETE
-    - table_reference:
-        naked_identifier: a1
+    - delete_target_table:
+        table_reference:
+          naked_identifier: a1
     - comma: ','
-    - table_reference:
-        naked_identifier: a2
+    - delete_target_table:
+        table_reference:
+          naked_identifier: a2
     - from_clause:
         keyword: FROM
         from_expression:
@@ -400,15 +412,17 @@ file:
 - statement:
     delete_statement:
     - keyword: DELETE
-    - table_reference:
-        naked_identifier: t1
-    - dot: .
-    - star: '*'
+    - delete_target_table:
+        table_reference:
+          naked_identifier: t1
+        dot: .
+        star: '*'
     - comma: ','
-    - table_reference:
-        naked_identifier: t2
-    - dot: .
-    - star: '*'
+    - delete_target_table:
+        table_reference:
+          naked_identifier: t2
+        dot: .
+        star: '*'
     - from_clause:
         keyword: FROM
         from_expression:
@@ -459,15 +473,17 @@ file:
     delete_statement:
     - keyword: DELETE
     - keyword: FROM
-    - table_reference:
-        naked_identifier: t1
-    - dot: .
-    - star: '*'
+    - delete_target_table:
+        table_reference:
+          naked_identifier: t1
+        dot: .
+        star: '*'
     - comma: ','
-    - table_reference:
-        naked_identifier: t2
-    - dot: .
-    - star: '*'
+    - delete_target_table:
+        table_reference:
+          naked_identifier: t2
+        dot: .
+        star: '*'
     - using_clause:
         keyword: USING
         from_expression:


### PR DESCRIPTION
https://dev.mysql.com/doc/refman/8.0/en/delete.html


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #5347 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
