### PR TITLE
Simplify Snowflake regexes

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -336,20 +336,19 @@ snowflake_dialect.add(
     ),
     S3Path=RegexParser(
         # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-        r"'s3://[a-zA-Z0-9_][a-zA-Z0-9_\.]{0,255}[a-zA-Z0-9_](?:/.*)?'",
+        r"'s3://.*'",
         CodeSegment,
         type="bucket_path",
     ),
     GCSPath=RegexParser(
         # https://cloud.google.com/storage/docs/naming-buckets
-        r"'gcs://[a-z0-9][\w\.-]{1,61}[a-z0-9](?:/.+)?'",
+        r"'gcs://.*",
         CodeSegment,
         type="bucket_path",
     ),
     AzureBlobStoragePath=RegexParser(
         # https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage
-        r"'azure://[a-z0-9][a-z0-9-]{1,61}[a-z0-9]\.blob\.core\.windows\.net/[a-z0-9]"
-        r"[a-z0-9\.-]{1,61}[a-z0-9](?:/.+)?'",
+        r"'azure://.*",
         CodeSegment,
         type="bucket_path",
     ),
@@ -5467,97 +5466,97 @@ class CreateStageSegment(BaseSegment):
                     optional=True,
                 ),
             ),
-            # External S3 stage
             Sequence(
                 "URL",
                 Ref("EqualsSegment"),
-                Ref("S3Path"),
-                Ref("S3ExternalStageParameters", optional=True),
-                Sequence(
-                    "DIRECTORY",
-                    Ref("EqualsSegment"),
-                    Bracketed(
+                OneOf(
+                    # External S3 stage
+                    Sequence(
+                        Ref("S3Path"),
+                        Ref("S3ExternalStageParameters", optional=True),
                         Sequence(
-                            "ENABLE",
+                            "DIRECTORY",
                             Ref("EqualsSegment"),
-                            Ref("BooleanLiteralGrammar"),
-                        ),
-                        Sequence(
-                            "AUTO_REFRESH",
-                            Ref("EqualsSegment"),
-                            Ref("BooleanLiteralGrammar"),
-                            optional=True,
-                        ),
-                    ),
-                    optional=True,
-                ),
-            ),
-            # External GCS stage
-            Sequence(
-                "URL",
-                Ref("EqualsSegment"),
-                Ref("GCSPath"),
-                Ref("GCSExternalStageParameters", optional=True),
-                Sequence(
-                    "DIRECTORY",
-                    Ref("EqualsSegment"),
-                    Bracketed(
-                        Sequence(
-                            "ENABLE",
-                            Ref("EqualsSegment"),
-                            Ref("BooleanLiteralGrammar"),
-                        ),
-                        Sequence(
-                            "AUTO_REFRESH",
-                            Ref("EqualsSegment"),
-                            Ref("BooleanLiteralGrammar"),
-                            optional=True,
-                        ),
-                        Sequence(
-                            "NOTIFICATION_INTEGRATION",
-                            Ref("EqualsSegment"),
-                            OneOf(
-                                Ref("NakedIdentifierSegment"),
-                                Ref("QuotedLiteralSegment"),
+                            Bracketed(
+                                Sequence(
+                                    "ENABLE",
+                                    Ref("EqualsSegment"),
+                                    Ref("BooleanLiteralGrammar"),
+                                ),
+                                Sequence(
+                                    "AUTO_REFRESH",
+                                    Ref("EqualsSegment"),
+                                    Ref("BooleanLiteralGrammar"),
+                                    optional=True,
+                                ),
                             ),
                             optional=True,
                         ),
                     ),
-                    optional=True,
-                ),
-            ),
-            # External Azure Blob Storage stage
-            Sequence(
-                "URL",
-                Ref("EqualsSegment"),
-                Ref("AzureBlobStoragePath"),
-                Ref("AzureBlobStorageExternalStageParameters", optional=True),
-                Sequence(
-                    "DIRECTORY",
-                    Ref("EqualsSegment"),
-                    Bracketed(
+                    # External GCS stage
+                    Sequence(
+                        Ref("GCSPath"),
+                        Ref("GCSExternalStageParameters", optional=True),
                         Sequence(
-                            "ENABLE",
+                            "DIRECTORY",
                             Ref("EqualsSegment"),
-                            Ref("BooleanLiteralGrammar"),
-                        ),
-                        Sequence(
-                            "AUTO_REFRESH",
-                            Ref("EqualsSegment"),
-                            Ref("BooleanLiteralGrammar"),
-                            optional=True,
-                        ),
-                        Sequence(
-                            "NOTIFICATION_INTEGRATION",
-                            Ref("EqualsSegment"),
-                            OneOf(
-                                Ref("NakedIdentifierSegment"),
-                                Ref("QuotedLiteralSegment"),
+                            Bracketed(
+                                Sequence(
+                                    "ENABLE",
+                                    Ref("EqualsSegment"),
+                                    Ref("BooleanLiteralGrammar"),
+                                ),
+                                Sequence(
+                                    "AUTO_REFRESH",
+                                    Ref("EqualsSegment"),
+                                    Ref("BooleanLiteralGrammar"),
+                                    optional=True,
+                                ),
+                                Sequence(
+                                    "NOTIFICATION_INTEGRATION",
+                                    Ref("EqualsSegment"),
+                                    OneOf(
+                                        Ref("NakedIdentifierSegment"),
+                                        Ref("QuotedLiteralSegment"),
+                                    ),
+                                    optional=True,
+                                ),
                             ),
                             optional=True,
                         ),
                     ),
-                    optional=True,
+                    # External Azure Blob Storage stage
+                    Sequence(
+                        Ref("AzureBlobStoragePath"),
+                        Ref("AzureBlobStorageExternalStageParameters", optional=True),
+                        Sequence(
+                            "DIRECTORY",
+                            Ref("EqualsSegment"),
+                            Bracketed(
+                                Sequence(
+                                    "ENABLE",
+                                    Ref("EqualsSegment"),
+                                    Ref("BooleanLiteralGrammar"),
+                                ),
+                                Sequence(
+                                    "AUTO_REFRESH",
+                                    Ref("EqualsSegment"),
+                                    Ref("BooleanLiteralGrammar"),
+                                    optional=True,
+                                ),
+                                Sequence(
+                                    "NOTIFICATION_INTEGRATION",
+                                    Ref("EqualsSegment"),
+                                    OneOf(
+                                        Ref("NakedIdentifierSegment"),
+                                        Ref("QuotedLiteralSegment"),
+                                    ),
+                                    optional=True,
+                                ),
+                            ),
+                            optional=True,
+                        ),
+                    ),
                 ),
             ),
             optional=True,

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -336,7 +336,7 @@ snowflake_dialect.add(
     ),
     S3Path=RegexParser(
         # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-        r"'s3://[a-z0-9][a-z0-9\.-]{1,61}[a-z0-9](?:/.*)?'",
+        r"'s3://[a-zA-Z0-9_][a-zA-Z0-9_\.]{0,255}[a-zA-Z0-9_](?:/.*)?'",
         CodeSegment,
         type="bucket_path",
     ),

--- a/test/fixtures/dialects/snowflake/create_stage.sql
+++ b/test/fixtures/dialects/snowflake/create_stage.sql
@@ -83,3 +83,6 @@ CREATE OR REPLACE STAGE foo.bar
 
 CREATE OR REPLACE STAGE your_stage_name
   URL = 's3://your_s3_bucket/your_path_in_s3';
+
+CREATE OR REPLACE STAGE your_stage_name
+  URL = 's3://your-s3-bucket/your-path-in-s3';

--- a/test/fixtures/dialects/snowflake/create_stage.sql
+++ b/test/fixtures/dialects/snowflake/create_stage.sql
@@ -80,3 +80,6 @@ CREATE OR REPLACE STAGE foo.bar
   STORAGE_INTEGRATION = foo
   FILE_FORMAT = (FORMAT_NAME = foo.bar.baz)
 ;
+
+CREATE OR REPLACE STAGE your_stage_name
+  URL = 's3://your_s3_bucket/your_path_in_s3';

--- a/test/fixtures/dialects/snowflake/create_stage.yml
+++ b/test/fixtures/dialects/snowflake/create_stage.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 624645bd6d3167a1ded47fab25130bf61c3bc682b56a9cd7651a92836f2802a0
+_hash: 7c376dd08ae00442a51f158580babbfee5c272e15c4a833d79812d143b7e939c
 file:
 - statement:
     create_stage_statement:
@@ -547,4 +547,17 @@ file:
           - dot: .
           - naked_identifier: baz
           end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_stage_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: STAGE
+    - object_reference:
+        naked_identifier: your_stage_name
+    - keyword: URL
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bucket_path: "'s3://your_s3_bucket/your_path_in_s3'"
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/create_stage.yml
+++ b/test/fixtures/dialects/snowflake/create_stage.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7c376dd08ae00442a51f158580babbfee5c272e15c4a833d79812d143b7e939c
+_hash: e74ae003f42dd1f8b6c8bcc13b4fb44aa4fa94610156d9e8737ae3ef3e728369
 file:
 - statement:
     create_stage_statement:
@@ -560,4 +560,17 @@ file:
     - comparison_operator:
         raw_comparison_operator: '='
     - bucket_path: "'s3://your_s3_bucket/your_path_in_s3'"
+- statement_terminator: ;
+- statement:
+    create_stage_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: STAGE
+    - object_reference:
+        naked_identifier: your_stage_name
+    - keyword: URL
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bucket_path: "'s3://your-s3-bucket/your-path-in-s3'"
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Closes https://github.com/sqlfluff/sqlfluff/issues/5418

### Are there any other side effects of this change that we should be aware of?
The [link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) in the comment above the regex says:

```
Note
Before March 1, 2018, buckets created in the US East (N. Virginia) Region could have names that were up to 255 characters long and included uppercase letters and underscores. Beginning March 1, 2018, new buckets in US East (N. Virginia) must conform to the same rules applied in all other Regions.
```

But like, why bother maintaining these regexes? We just need to find that they start with the right thing to know which one it is.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
