### PR TITLE
adds few fixes for databricks/sparksql

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -696,6 +696,7 @@ sparksql_dialect.add(
                         OneOf(
                             Ref("ColumnDefinitionSegment"),
                             Ref("GeneratedColumnDefinitionSegment"),
+                            Ref("TableConstraintSegment", optional=True),
                         ),
                         Ref("CommentGrammar", optional=True),
                     ),
@@ -1055,10 +1056,12 @@ class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
                 OneOf(
                     Sequence(
                         "COLUMN",
+                        Ref("IfExistsGrammar", optional=True),
                         Ref("ColumnReferenceSegment"),
                     ),
                     Sequence(
                         "COLUMNS",
+                        Ref("IfExistsGrammar", optional=True),
                         Bracketed(
                             Delimited(AnyNumberOf(Ref("ColumnReferenceSegment"))),
                         ),
@@ -1291,15 +1294,6 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
     """
 
     match_grammar = Sequence("CREATE", Ref("TableDefinitionSegment"))
-
-
-class CreateHiveFormatTableStatementSegment(hive.CreateTableStatementSegment):
-    """A `CREATE TABLE` statement using Hive format.
-
-    https://spark.apache.org/docs/latest/sql-ref-syntax-ddl-create-table-hiveformat.html
-    """
-
-    pass
 
 
 class CreateViewStatementSegment(ansi.CreateViewStatementSegment):
@@ -2545,7 +2539,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("AlterDatabaseStatementSegment"),
             Ref("AlterTableStatementSegment"),
             Ref("AlterViewStatementSegment"),
-            Ref("CreateHiveFormatTableStatementSegment"),
+            Ref("CreateTableStatementSegment"),
             Ref("MsckRepairTableStatementSegment"),
             Ref("UseDatabaseStatementSegment"),
             # Auxiliary Statements
@@ -2918,7 +2912,7 @@ class UpdateStatementSegment(ansi.UpdateStatementSegment):
             optional=True,
         ),
         Ref("SetClauseListSegment"),
-        Ref("WhereClauseSegment"),
+        Ref("WhereClauseSegment", optional=True),
     )
 
 


### PR DESCRIPTION
Following sql was causing parse errors:

```
CREATE TABLE alembic_version (
    version_num STRING NOT NULL,
    CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
) USING DELTA;
```

This was fixed by setting sparksql to use the unused createtable implementation. There was a slight error there, that I also fixed. Now it works great.

Another parse error was with an update statement without where clause:

```
UPDATE table1
SET col1= 0
```

This was fixed by making the where clause optional.

Let me know what you think of it.