### PR TITLE
fix assertion in `test__api__lint_string_specific_exclude_single`

### DIFF
--- a/test/api/simple_test.py
+++ b/test/api/simple_test.py
@@ -147,7 +147,7 @@ def test__api__lint_string_specific_exclude_single():
     result = sqlfluff.lint(my_bad_query, exclude_rules=exclude_rules)
     # Check only AM04 is found
     assert len(result) == 9
-    set(["LT12", "CP01", "AL03", "CP02", "LT09", "AM04"]) == set(
+    assert set(["LT12", "CP01", "AL03", "CP02", "LT09", "AM04"]) == set(
         [r["code"] for r in result]
     )
 


### PR DESCRIPTION
### Brief summary of the change made

The modification in simple_test.py involves adding an assert statement in the test `test__api__lint_string_specific_exclude_single`. This change ensures that the test accurately checks the specific set of rule codes, particularly confirming the presence of rule `AM04` and others in the result. This adjustment improves the precision of the test in verifying the functionality of rule exclusions.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
