### PR TITLE
Support parsing CONSTRAINT definitions when creating Delta Live Tables in SparkSQL/Databricks

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -700,6 +700,7 @@ sparksql_dialect.add(
                         ),
                         Ref("CommentGrammar", optional=True),
                     ),
+                    Ref("ConstraintStatementSegment", optional=True),
                 ),
             ),
             # Like Syntax
@@ -1319,6 +1320,7 @@ class CreateViewStatementSegment(ansi.CreateViewStatementSegment):
                         Ref("ColumnReferenceSegment"),
                         Ref("CommentGrammar", optional=True),
                     ),
+                    Ref("ConstraintStatementSegment", optional=True),
                 ),
             ),
             optional=True,

--- a/test/fixtures/dialects/sparksql/databricks_dlt_create_table.sql
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_create_table.sql
@@ -33,3 +33,14 @@ AS SELECT
     a,
     b
 FROM STREAM(live.customers_bronze);
+
+CREATE OR REFRESH LIVE TABLE taxi_raw(
+    a STRING COMMENT 'a',
+    b INT COMMENT 'b',
+    CONSTRAINT valid_a EXPECT (a IS NOT NULL),
+    CONSTRAINT valid_b EXPECT (b > 0)
+)
+AS SELECT
+    a,
+    b
+FROM JSON.`/databricks-datasets/nyctaxi/sample/json/`;

--- a/test/fixtures/dialects/sparksql/databricks_dlt_create_table.yml
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9750d4c4207e59c2192fde953b250ed0456fd3ab755f5e21b24309d66f934273
+_hash: 6865f6ecd86e015884d5f86a75b0ece68cce4b15f099a618ac80145d688274ef
 file:
 - statement:
     create_table_statement:
@@ -210,4 +210,86 @@ file:
                       - dot: .
                       - naked_identifier: customers_bronze
                     end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REFRESH
+    - keyword: LIVE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: taxi_raw
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: a
+          data_type:
+            primitive_type:
+              keyword: STRING
+          column_constraint_segment:
+            comment_clause:
+              keyword: COMMENT
+              quoted_literal: "'a'"
+      - comma: ','
+      - column_definition:
+          naked_identifier: b
+          data_type:
+            primitive_type:
+              keyword: INT
+          column_constraint_segment:
+            comment_clause:
+              keyword: COMMENT
+              quoted_literal: "'b'"
+      - comma: ','
+      - constraint_statement:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: valid_a
+        - keyword: EXPECT
+        - bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: a
+            - keyword: IS
+            - keyword: NOT
+            - null_literal: 'NULL'
+            end_bracket: )
+      - comma: ','
+      - constraint_statement:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: valid_b
+        - keyword: EXPECT
+        - bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: b
+              comparison_operator:
+                raw_comparison_operator: '>'
+              numeric_literal: '0'
+            end_bracket: )
+      - end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                file_reference:
+                  keyword: JSON
+                  dot: .
+                  quoted_identifier: '`/databricks-datasets/nyctaxi/sample/json/`'
 - statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/databricks_dlt_create_view.sql
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_create_view.sql
@@ -11,3 +11,14 @@ AS SELECT
     a,
     b
 FROM stream(live.customers_bronze);
+
+CREATE TEMPORARY LIVE VIEW filtered_data(
+    a COMMENT 'a',
+    b COMMENT 'b',
+    CONSTRAINT valid_a EXPECT (a IS NOT NULL),
+    CONSTRAINT valid_b EXPECT (b > 0)
+)
+AS SELECT
+    a,
+    b
+FROM live.taxi_raw;

--- a/test/fixtures/dialects/sparksql/databricks_dlt_create_view.yml
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_create_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 408ecb04633aa2ae4271bb41dd60e415eb94b20cde131120e50c133b6f3d536e
+_hash: edf92b2b8ae3b3d8197468edb50ab31c5835247527474925fef3e1b213bd5fc6
 file:
 - statement:
     create_view_statement:
@@ -70,4 +70,75 @@ file:
                       - dot: .
                       - naked_identifier: customers_bronze
                     end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: TEMPORARY
+    - keyword: LIVE
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: filtered_data
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: a
+      - keyword: COMMENT
+      - quoted_literal: "'a'"
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - keyword: COMMENT
+      - quoted_literal: "'b'"
+      - comma: ','
+      - constraint_statement:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: valid_a
+        - keyword: EXPECT
+        - bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: a
+            - keyword: IS
+            - keyword: NOT
+            - null_literal: 'NULL'
+            end_bracket: )
+      - comma: ','
+      - constraint_statement:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: valid_b
+        - keyword: EXPECT
+        - bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: b
+              comparison_operator:
+                raw_comparison_operator: '>'
+              numeric_literal: '0'
+            end_bracket: )
+      - end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: a
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: b
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: live
+                - dot: .
+                - naked_identifier: taxi_raw
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

[The Delta Live Table in Databricks](https://docs.databricks.com/en/delta-live-tables/sql-ref.html) allows one to add constrains on columns while creating a table or view. This syntax is not supportted by sqlfluff at the moment (yielding parsing errors), even though a `ConstraintStatementSegment` already exists for the sparksql and databricks dialects.

This PR uses the existing `ConstraintStatementSegment` in `CreateViewStatementSegment` and `TableDefinitionSegment` so the syntax is supported.

Examples:

```sql
CREATE OR REFRESH LIVE TABLE taxi_raw(
    a STRING COMMENT 'a',
    b INT COMMENT 'b',
    CONSTRAINT valid_a EXPECT (a IS NOT NULL),  <-- This is supported now by this PR
    CONSTRAINT valid_b EXPECT (b > 0)  <-- This is supported now by this PR
)
AS SELECT
    a,
    b
FROM JSON.`/databricks-datasets/nyctaxi/sample/json/`;
```

```sql
CREATE TEMPORARY LIVE VIEW filtered_data(
    a COMMENT 'a',
    b COMMENT 'b',
    CONSTRAINT valid_a EXPECT (a IS NOT NULL),  <-- This is supported now by this PR
    CONSTRAINT valid_b EXPECT (b > 0)  <-- This is supported now by this PR
)
AS SELECT
    a,
    b
FROM live.taxi_raw;
```

I hope this fix would not only go to the future `3.0` release but also the next `2.x` minor/patch release.

### Are there any other side effects of this change that we should be aware of?

No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
