### PR TITLE
Clickhouse Dialect - Support BackQuoted Identifiers

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -32,26 +32,6 @@ ansi_dialect = load_raw_dialect("ansi")
 clickhouse_dialect = ansi_dialect.copy_as("clickhouse")
 clickhouse_dialect.sets("unreserved_keywords").update(UNRESERVED_KEYWORDS)
 
-clickhouse_dialect.replace(
-    SingleIdentifierGrammar=OneOf(
-        Ref("NakedIdentifierSegment"),
-        Ref("QuotedIdentifierSegment"),
-        Ref("SingleQuotedIdentifierSegment"),
-        Ref("BackQuotedIdentifierSegment"),
-    ),
-    QuotedLiteralSegment=OneOf(
-        TypedParser(
-            "single_quote",
-            LiteralSegment,
-            type="quoted_literal",
-        ),
-        TypedParser(
-            "dollar_quote",
-            LiteralSegment,
-            type="quoted_literal",
-        ),
-    ),
-)
 
 clickhouse_dialect.insert_lexer_matchers(
     # https://clickhouse.com/docs/en/sql-reference/functions#higher-order-functions---operator-and-lambdaparams-expr-function
@@ -145,15 +125,30 @@ clickhouse_dialect.replace(
         # Add Lambda Function
         Ref("LambdaFunctionSegment"),
     ),
-)
-
-clickhouse_dialect.replace(
     JoinLikeClauseGrammar=Sequence(
         AnyNumberOf(
             Ref("ArrayJoinClauseSegment"),
             min_times=1,
         ),
         Ref("AliasExpressionSegment", optional=True),
+    ),
+    QuotedLiteralSegment=OneOf(
+        TypedParser(
+            "single_quote",
+            LiteralSegment,
+            type="quoted_literal",
+        ),
+        TypedParser(
+            "dollar_quote",
+            LiteralSegment,
+            type="quoted_literal",
+        ),
+    ),
+    SingleIdentifierGrammar=OneOf(
+        Ref("NakedIdentifierSegment"),
+        Ref("QuotedIdentifierSegment"),
+        Ref("SingleQuotedIdentifierSegment"),
+        Ref("BackQuotedIdentifierSegment"),
     ),
 )
 

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -32,14 +32,6 @@ ansi_dialect = load_raw_dialect("ansi")
 clickhouse_dialect = ansi_dialect.copy_as("clickhouse")
 clickhouse_dialect.sets("unreserved_keywords").update(UNRESERVED_KEYWORDS)
 
-clickhouse_dialect.add(
-    BackQuotedIdentifierSegment=TypedParser(
-        "back_quote",
-        IdentifierSegment,
-        type="quoted_identifier",
-    ),
-)
-
 clickhouse_dialect.replace(
     SingleIdentifierGrammar=OneOf(
         Ref("NakedIdentifierSegment"),
@@ -68,6 +60,11 @@ clickhouse_dialect.insert_lexer_matchers(
 )
 
 clickhouse_dialect.add(
+    BackQuotedIdentifierSegment=TypedParser(
+        "back_quote",
+        IdentifierSegment,
+        type="quoted_identifier",
+    ),
     JoinTypeKeywords=OneOf(
         # This case INNER [ANY,ALL] JOIN
         Sequence("INNER", OneOf("ALL", "ANY", optional=True)),

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -11,6 +11,7 @@ from sqlfluff.core.parser import (
     Conditional,
     Dedent,
     Delimited,
+    IdentifierSegment,
     Indent,
     LiteralSegment,
     Matchable,
@@ -30,11 +31,21 @@ ansi_dialect = load_raw_dialect("ansi")
 
 clickhouse_dialect = ansi_dialect.copy_as("clickhouse")
 clickhouse_dialect.sets("unreserved_keywords").update(UNRESERVED_KEYWORDS)
+
+clickhouse_dialect.add(
+    BackQuotedIdentifierSegment=TypedParser(
+        "back_quote",
+        IdentifierSegment,
+        type="quoted_identifier",
+    ),
+)
+
 clickhouse_dialect.replace(
     SingleIdentifierGrammar=OneOf(
         Ref("NakedIdentifierSegment"),
         Ref("QuotedIdentifierSegment"),
         Ref("SingleQuotedIdentifierSegment"),
+        Ref("BackQuotedIdentifierSegment"),
     ),
     QuotedLiteralSegment=OneOf(
         TypedParser(

--- a/test/fixtures/dialects/clickhouse/back_quoted_identifier.sql
+++ b/test/fixtures/dialects/clickhouse/back_quoted_identifier.sql
@@ -1,0 +1,7 @@
+SELECT * FROM `foo`.`bar`;
+
+SELECT bar AS `baz` FROM foo;
+
+SELECT * FROM foo.bar `baz`;
+
+SELECT * FROM foo.bar AS `baz`;

--- a/test/fixtures/dialects/clickhouse/back_quoted_identifier.yml
+++ b/test/fixtures/dialects/clickhouse/back_quoted_identifier.yml
@@ -1,0 +1,84 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: a4b44d138b63f82c7af85fb1f8a2bcb42a4aa7a2b513e1cff3a78b0ad6f253ff
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - quoted_identifier: '`foo`'
+              - dot: .
+              - quoted_identifier: '`bar`'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: bar
+          alias_expression:
+            keyword: AS
+            quoted_identifier: '`baz`'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foo
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: foo
+              - dot: .
+              - naked_identifier: bar
+            alias_expression:
+              quoted_identifier: '`baz`'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: foo
+              - dot: .
+              - naked_identifier: bar
+            alias_expression:
+              keyword: AS
+              quoted_identifier: '`baz`'
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes https://github.com/sqlfluff/sqlfluff/issues/5356
Fixes https://github.com/sqlfluff/sqlfluff/issues/4637

Prior to this change, backquoted identifiers failed to parse when using the Clickhouse Dialect. 

Examples as identified in tests. 

This became a bigger issue as of the release of [dbt-clickhouse v1.6.1](https://github.com/ClickHouse/dbt-clickhouse/compare/v1.6.0...v1.6.1#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7) yesterday (2023/12/4), which expands dbt references with backticks.


### Are there any other side effects of this change that we should be aware of?
I don't think so

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
