### PR TITLE
Change Color.lightgrey to have a white background - dark theme friendly

### DIFF
--- a/src/sqlfluff/core/enums.py
+++ b/src/sqlfluff/core/enums.py
@@ -1,7 +1,7 @@
 """Enums used by sqlfluff."""
 from enum import Enum
 
-from colorama import Fore, Style
+from colorama import Back, Fore, Style
 
 
 class FormatType(Enum):
@@ -21,4 +21,4 @@ class Color(Enum):
     red = Fore.RED
     green = Fore.GREEN
     blue = Fore.BLUE
-    lightgrey = Fore.BLACK + Style.BRIGHT
+    lightgrey = Fore.BLACK + Back.WHITE + Style.BRIGHT


### PR DESCRIPTION
### Brief summary of the change made
To allow a better experience for dark-background users, adding a background of WHITE seems to be a good experience.

Tested on about 10 themes in MacOS' Terminal.app and alacritty for both dark and light backgrounds.

Related to #1170 

Explored replacing the output formatter with `rich`, but that seems like too much work when I think this simple fix will do.
### Are there any other side effects of this change that we should be aware of?
No known side effects

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
