### PR TITLE
MySql: create table: allow null/not null in any position

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -354,7 +354,6 @@ class ColumnDefinitionSegment(BaseSegment):
                         ),
                         optional=True,
                     ),
-                    min_times=1,
                     optional=True,
                 ),
             ),

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -322,40 +322,39 @@ class ColumnDefinitionSegment(BaseSegment):
             ),
             Sequence(
                 OneOf("DATETIME", "TIMESTAMP"),
-                Sequence(
-                    Bracketed(Ref("NumericLiteralSegment"), optional=True),
-                    optional=True,
-                ),
-                Sequence(Sequence("NOT", optional=True), "NULL", optional=True),
-                Sequence(
-                    "DEFAULT",
-                    OneOf(
-                        Sequence(
-                            OneOf("CURRENT_TIMESTAMP", "NOW"),
+                Bracketed(Ref("NumericLiteralSegment"), optional=True),  # Precision
+                AnyNumberOf(
+                    # Allow NULL/NOT NULL, DEFAULT, and ON UPDATE in any order
+                    Sequence(Sequence("NOT", optional=True), "NULL", optional=True),
+                    Sequence(
+                        "DEFAULT",
+                        OneOf(
+                            Sequence(
+                                OneOf("CURRENT_TIMESTAMP", "NOW"),
+                                Bracketed(
+                                    Ref("NumericLiteralSegment", optional=True),
+                                    optional=True,
+                                ),
+                            ),
+                            Ref("NumericLiteralSegment"),
+                            Ref("QuotedLiteralSegment"),
+                        ),
+                        optional=True,
+                    ),
+                    Sequence(
+                        "ON",
+                        "UPDATE",
+                        OneOf(
+                            "CURRENT_TIMESTAMP",
+                            "NOW",
                             Bracketed(
                                 Ref("NumericLiteralSegment", optional=True),
                                 optional=True,
                             ),
                         ),
-                        Ref("NumericLiteralSegment"),
-                        Ref("QuotedLiteralSegment"),
                         optional=True,
                     ),
-                    optional=True,
-                ),
-                Sequence(
-                    Sequence("ON", "UPDATE", optional=True),
-                    Sequence(
-                        OneOf("CURRENT_TIMESTAMP", "NOW"),
-                        Bracketed(
-                            Ref("NumericLiteralSegment", optional=True),
-                            optional=True,
-                        ),
-                    ),
-                    Sequence(
-                        Bracketed(Ref("NumericLiteralSegment")),
-                        optional=True,
-                    ),
+                    min_times=1,
                     optional=True,
                 ),
             ),

--- a/test/fixtures/dialects/mysql/create_table_datetime.yml
+++ b/test/fixtures/dialects/mysql/create_table_datetime.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 37b2a74b15a9dd3b024b90fe985bd48e80b07477eacd4e2b224f992196ac4ac5
+_hash: e9c33e67e5d27f30efd11d52a52f8df18d2b949a6a4585b07a9053b6d4e5f1a8
 file:
   statement:
     create_table_statement:
@@ -18,9 +18,8 @@ file:
         - keyword: DATETIME
         - keyword: DEFAULT
         - keyword: CURRENT_TIMESTAMP
-        - column_constraint_segment:
-          - keyword: NOT
-          - keyword: 'NULL'
+        - keyword: NOT
+        - keyword: 'NULL'
       - comma: ','
       - column_definition:
         - naked_identifier: ts1
@@ -138,9 +137,9 @@ file:
         - naked_identifier: ts8
         - keyword: TIMESTAMP
         - keyword: 'NULL'
-        - keyword: DEFAULT
         - column_constraint_segment:
-            keyword: 'NULL'
+            keyword: DEFAULT
+            null_literal: 'NULL'
       - comma: ','
       - column_definition:
         - naked_identifier: ts9

--- a/test/fixtures/dialects/mysql/create_table_null_position.sql
+++ b/test/fixtures/dialects/mysql/create_table_null_position.sql
@@ -2,5 +2,6 @@ CREATE TABLE IF NOT EXISTS db_name.table_name
 (
     updated_at1   timestamp default CURRENT_TIMESTAMP not null on update CURRENT_TIMESTAMP,
     updated_at2   timestamp not null default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP,
-    updated_at3   timestamp default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP not null
+    updated_at3   timestamp default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP not null,
+    updated_at4   timestamp
 );

--- a/test/fixtures/dialects/mysql/create_table_null_position.sql
+++ b/test/fixtures/dialects/mysql/create_table_null_position.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS db_name.table_name
+(
+    updated_at1   timestamp default CURRENT_TIMESTAMP not null on update CURRENT_TIMESTAMP,
+    updated_at2   timestamp not null default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP,
+    updated_at3   timestamp default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP not null
+);

--- a/test/fixtures/dialects/mysql/create_table_null_position.yml
+++ b/test/fixtures/dialects/mysql/create_table_null_position.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b74bc0769b390bda56924ae50f7352afbf7f253dcba4cbd3ef16064aede7716f
+_hash: 15f782abb1331d16b725b8b668192875e574c8c085ef79377398499dd95efbf1
 file:
   statement:
     create_table_statement:
@@ -50,5 +50,9 @@ file:
         - keyword: CURRENT_TIMESTAMP
         - keyword: not
         - keyword: 'null'
+      - comma: ','
+      - column_definition:
+          naked_identifier: updated_at4
+          keyword: timestamp
       - end_bracket: )
   statement_terminator: ;

--- a/test/fixtures/dialects/mysql/create_table_null_position.yml
+++ b/test/fixtures/dialects/mysql/create_table_null_position.yml
@@ -1,0 +1,54 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: b74bc0769b390bda56924ae50f7352afbf7f253dcba4cbd3ef16064aede7716f
+file:
+  statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+        - naked_identifier: updated_at1
+        - keyword: timestamp
+        - keyword: default
+        - keyword: CURRENT_TIMESTAMP
+        - keyword: not
+        - keyword: 'null'
+        - keyword: 'on'
+        - keyword: update
+        - keyword: CURRENT_TIMESTAMP
+      - comma: ','
+      - column_definition:
+        - naked_identifier: updated_at2
+        - keyword: timestamp
+        - keyword: not
+        - keyword: 'null'
+        - keyword: default
+        - keyword: CURRENT_TIMESTAMP
+        - keyword: 'on'
+        - keyword: update
+        - keyword: CURRENT_TIMESTAMP
+      - comma: ','
+      - column_definition:
+        - naked_identifier: updated_at3
+        - keyword: timestamp
+        - keyword: default
+        - keyword: CURRENT_TIMESTAMP
+        - keyword: 'on'
+        - keyword: update
+        - keyword: CURRENT_TIMESTAMP
+        - keyword: not
+        - keyword: 'null'
+      - end_bracket: )
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #5443
Prior to this change `null/not null` statements in between `default` and `on update` caused `Found unparsable section` error even though mysql executes such statements without errors.


### Are there any other side effects of this change that we should be aware of?
I hope not

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
