### PR TITLE
DuckDB: Qualify and From-First

### DIFF
--- a/test/fixtures/dialects/duckdb/extract_temporal.sql
+++ b/test/fixtures/dialects/duckdb/extract_temporal.sql
@@ -1,0 +1,13 @@
+/* Checks for functions that use `FROM` */
+
+SELECT extract('year' FROM DATE '1992-09-20');
+
+SELECT extract('year' FROM '1992-09-20'::DATE);
+
+VALUES (extract('year' FROM DATE '1992-09-20'));
+
+SELECT extract('hour' FROM TIMESTAMP '1992-09-20 20:38:48');
+
+SELECT extract('hour' FROM TIMESTAMPTZ '1992-09-20 20:38:48');
+
+SELECT extract('hour' FROM TIME '14:21:13');

--- a/test/fixtures/dialects/duckdb/extract_temporal.yml
+++ b/test/fixtures/dialects/duckdb/extract_temporal.yml
@@ -1,0 +1,131 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 8d08a9152bcd284c72bb1fe506fdaf3a098b45f64bacddd3ad20a3c7f11adbfb
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: extract
+            bracketed:
+            - start_bracket: (
+            - expression:
+                quoted_literal: "'year'"
+            - keyword: FROM
+            - expression:
+                datetime_literal:
+                  datetime_type_identifier:
+                    keyword: DATE
+                  quoted_literal: "'1992-09-20'"
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: extract
+            bracketed:
+            - start_bracket: (
+            - expression:
+                quoted_literal: "'year'"
+            - keyword: FROM
+            - expression:
+                cast_expression:
+                  quoted_literal: "'1992-09-20'"
+                  casting_operator: '::'
+                  data_type:
+                    datetime_type_identifier:
+                      keyword: DATE
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+    values_clause:
+      keyword: VALUES
+      bracketed:
+        start_bracket: (
+        expression:
+          function:
+            function_name:
+              function_name_identifier: extract
+            bracketed:
+            - start_bracket: (
+            - expression:
+                quoted_literal: "'year'"
+            - keyword: FROM
+            - expression:
+                datetime_literal:
+                  datetime_type_identifier:
+                    keyword: DATE
+                  quoted_literal: "'1992-09-20'"
+            - end_bracket: )
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: extract
+            bracketed:
+            - start_bracket: (
+            - expression:
+                quoted_literal: "'hour'"
+            - keyword: FROM
+            - expression:
+                datetime_literal:
+                  datetime_type_identifier:
+                    keyword: TIMESTAMP
+                  quoted_literal: "'1992-09-20 20:38:48'"
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: extract
+            bracketed:
+            - start_bracket: (
+            - expression:
+                quoted_literal: "'hour'"
+            - keyword: FROM
+            - expression:
+                datetime_literal:
+                  datetime_type_identifier:
+                    keyword: TIMESTAMPTZ
+                  quoted_literal: "'1992-09-20 20:38:48'"
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: extract
+            bracketed:
+            - start_bracket: (
+            - expression:
+                quoted_literal: "'hour'"
+            - keyword: FROM
+            - expression:
+                datetime_literal:
+                  datetime_type_identifier:
+                    keyword: TIME
+                  quoted_literal: "'14:21:13'"
+            - end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/duckdb/from_first.sql
+++ b/test/fixtures/dialects/duckdb/from_first.sql
@@ -1,0 +1,8 @@
+/* Examples from https://duckdb.org/docs/sql/query_syntax/from */
+
+-- select all columns from the table called "table_name" using the FROM-first syntax
+FROM table_name SELECT *;
+-- select all columns using the FROM-first syntax and omitting the SELECT clause
+FROM table_name;
+-- use the FROM-first syntax with WHERE clause and aggregation
+FROM range(100) AS t (i) SELECT sum(t.i) WHERE t.i % 2 = 0;

--- a/test/fixtures/dialects/duckdb/from_first.yml
+++ b/test/fixtures/dialects/duckdb/from_first.yml
@@ -1,0 +1,83 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: b0fe3de7171dde996ba48218d48ce3e5d057d19ff7f8165a1b5790477579b2d9
+file:
+- statement:
+    select_statement:
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table_name
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table_name
+- statement_terminator: ;
+- statement:
+    select_statement:
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: range
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: t
+              bracketed:
+                start_bracket: (
+                identifier_list:
+                  naked_identifier: i
+                end_bracket: )
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: sum
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: i
+              end_bracket: )
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: t
+          - dot: .
+          - naked_identifier: i
+        - binary_operator: '%'
+        - numeric_literal: '2'
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '0'
+- statement_terminator: ;

--- a/test/fixtures/dialects/duckdb/qualify.sql
+++ b/test/fixtures/dialects/duckdb/qualify.sql
@@ -1,0 +1,47 @@
+/* Examples from https://duckdb.org/docs/sql/query_syntax/qualify */
+
+-- Filter based on a WINDOW function defined in the QUALIFY clause
+SELECT
+    schema_name,
+    function_name,
+    -- In this example the function_rank column in the select clause is for reference
+    row_number()
+        OVER (PARTITION BY schema_name ORDER BY function_name)
+    AS function_rank
+FROM duckdb_functions
+QUALIFY
+    row_number() OVER (PARTITION BY schema_name ORDER BY function_name) < 3;
+
+-- Filter based on a WINDOW function defined in the SELECT clause
+SELECT
+    schema_name,
+    function_name,
+    row_number()
+        OVER (PARTITION BY schema_name ORDER BY function_name)
+    AS function_rank
+FROM duckdb_functions()
+QUALIFY
+    function_rank < 3;
+
+-- Filter based on a WINDOW function defined in the QUALIFY clause, but using the WINDOW clause
+SELECT
+    schema_name,
+    function_name,
+    -- In this example the function_rank column in the select clause is for reference
+    row_number() OVER my_window AS function_rank
+FROM duckdb_functions()
+WINDOW
+    my_window AS (PARTITION BY schema_name ORDER BY function_name)
+QUALIFY
+    row_number() OVER my_window < 3;
+
+-- Filter based on a WINDOW function defined in the SELECT clause, but using the WINDOW clause
+SELECT
+    schema_name,
+    function_name,
+    row_number() OVER my_window AS function_rank
+FROM duckdb_functions()
+WINDOW
+    my_window AS (PARTITION BY schema_name ORDER BY function_name)
+QUALIFY
+    function_rank < 3;

--- a/test/fixtures/dialects/duckdb/qualify.yml
+++ b/test/fixtures/dialects/duckdb/qualify.yml
@@ -1,0 +1,279 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: c93ebbe02f1dd96b192f4cf31468234356b7f0702c46e4575b64d24264207c5f
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: schema_name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: function_name
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: row_number
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: schema_name
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: function_name
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: function_rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: duckdb_functions
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          function:
+            function_name:
+              function_name_identifier: row_number
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: schema_name
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: function_name
+                end_bracket: )
+          comparison_operator:
+            raw_comparison_operator: <
+          numeric_literal: '3'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: schema_name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: function_name
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: row_number
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: schema_name
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: function_name
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: function_rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: duckdb_functions
+                bracketed:
+                  start_bracket: (
+                  end_bracket: )
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          column_reference:
+            naked_identifier: function_rank
+          comparison_operator:
+            raw_comparison_operator: <
+          numeric_literal: '3'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: schema_name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: function_name
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: row_number
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              naked_identifier: my_window
+          alias_expression:
+            keyword: AS
+            naked_identifier: function_rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: duckdb_functions
+                bracketed:
+                  start_bracket: (
+                  end_bracket: )
+      named_window:
+        keyword: WINDOW
+        named_window_expression:
+          naked_identifier: my_window
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              partitionby_clause:
+              - keyword: PARTITION
+              - keyword: BY
+              - expression:
+                  column_reference:
+                    naked_identifier: schema_name
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: function_name
+            end_bracket: )
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          function:
+            function_name:
+              function_name_identifier: row_number
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              naked_identifier: my_window
+          comparison_operator:
+            raw_comparison_operator: <
+          numeric_literal: '3'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: schema_name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: function_name
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: row_number
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              naked_identifier: my_window
+          alias_expression:
+            keyword: AS
+            naked_identifier: function_rank
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: duckdb_functions
+                bracketed:
+                  start_bracket: (
+                  end_bracket: )
+      named_window:
+        keyword: WINDOW
+        named_window_expression:
+          naked_identifier: my_window
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              partitionby_clause:
+              - keyword: PARTITION
+              - keyword: BY
+              - expression:
+                  column_reference:
+                    naked_identifier: schema_name
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: function_name
+            end_bracket: )
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          column_reference:
+            naked_identifier: function_rank
+          comparison_operator:
+            raw_comparison_operator: <
+          numeric_literal: '3'
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
makes progress on #5051
Supports the `qualify` statement for DuckDB.
Supports the `from-first` syntax for DuckDB.


### Are there any other side effects of this change that we should be aware of?
The `SelectStatementSegment` now inherits from ansi rather than postgres as the majority of postgres's grammar does not apply to duckdb.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
