### PR TITLE
Snowflake dialect: Add support for DATABASE ROLE in GRANT/REVOKE

### DIFF
--- a/test/fixtures/dialects/snowflake/create_database_role.yml
+++ b/test/fixtures/dialects/snowflake/create_database_role.yml
@@ -3,14 +3,14 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d06d6d65331fc37545e9d69c7311a2b0babf375128af2b71e3fb99e547f6f071
+_hash: 8a192cf4ddea53c091d92c24c2029bf1f3807a87327ab497edf6edaf66c2416f
 file:
   statement:
     create_database_role_statement:
     - keyword: create
     - keyword: database
     - keyword: role
-    - object_reference:
+    - database_role_reference:
       - naked_identifier: dbname
       - dot: .
       - naked_identifier: rolename

--- a/test/fixtures/dialects/snowflake/grant_revoke.sql
+++ b/test/fixtures/dialects/snowflake/grant_revoke.sql
@@ -101,3 +101,12 @@ GRANT MANAGE ORGANIZATION SUPPORT CASES ON ACCOUNT TO ROLE my_role;
 GRANT MANAGE USER SUPPORT CASES ON ACCOUNT TO ROLE my_role;
 
 GRANT ADD SEARCH OPTIMIZATION ON SCHEMA MY_SCHEMA TO ROLE MY_ROLE;
+
+grant database role dbname.rolename to role public;
+grant database role dbrolename to role public;
+revoke database role dbname.rolename from role public;
+revoke database role dbrolename from role public;
+grant select on table dbname.schemaname.tablename to database role dbname.rolename;
+grant select on table dbname.schemaname.tablename to database role dbrolename;
+revoke select on table dbname.schemaname.tablename from database role dbname.rolename;
+revoke select on table dbname.schemaname.tablename from database role dbrolename;

--- a/test/fixtures/dialects/snowflake/grant_revoke.yml
+++ b/test/fixtures/dialects/snowflake/grant_revoke.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9ff408e7f2a732c6b9cf12615e65df3c543082a559b68f96d3e0c366e7751999
+_hash: 60742b98d9081885cbf3076cd3802c9bac4507c6570fa9d6b285a77debb0e290
 file:
 - statement:
     access_statement:
@@ -1206,4 +1206,132 @@ file:
     - keyword: ROLE
     - role_reference:
         naked_identifier: MY_ROLE
+- statement_terminator: ;
+- statement:
+    access_statement:
+    - keyword: grant
+    - keyword: database
+    - keyword: role
+    - database_role_reference:
+      - naked_identifier: dbname
+      - dot: .
+      - naked_identifier: rolename
+    - keyword: to
+    - keyword: role
+    - role_reference:
+        naked_identifier: public
+- statement_terminator: ;
+- statement:
+    access_statement:
+    - keyword: grant
+    - keyword: database
+    - keyword: role
+    - database_role_reference:
+        naked_identifier: dbrolename
+    - keyword: to
+    - keyword: role
+    - role_reference:
+        naked_identifier: public
+- statement_terminator: ;
+- statement:
+    access_statement:
+    - keyword: revoke
+    - keyword: database
+    - keyword: role
+    - database_role_reference:
+      - naked_identifier: dbname
+      - dot: .
+      - naked_identifier: rolename
+    - keyword: from
+    - keyword: role
+    - object_reference:
+        naked_identifier: public
+- statement_terminator: ;
+- statement:
+    access_statement:
+    - keyword: revoke
+    - keyword: database
+    - keyword: role
+    - database_role_reference:
+        naked_identifier: dbrolename
+    - keyword: from
+    - keyword: role
+    - object_reference:
+        naked_identifier: public
+- statement_terminator: ;
+- statement:
+    access_statement:
+    - keyword: grant
+    - keyword: select
+    - keyword: 'on'
+    - keyword: table
+    - object_reference:
+      - naked_identifier: dbname
+      - dot: .
+      - naked_identifier: schemaname
+      - dot: .
+      - naked_identifier: tablename
+    - keyword: to
+    - keyword: database
+    - keyword: role
+    - database_role_reference:
+      - naked_identifier: dbname
+      - dot: .
+      - naked_identifier: rolename
+- statement_terminator: ;
+- statement:
+    access_statement:
+    - keyword: grant
+    - keyword: select
+    - keyword: 'on'
+    - keyword: table
+    - object_reference:
+      - naked_identifier: dbname
+      - dot: .
+      - naked_identifier: schemaname
+      - dot: .
+      - naked_identifier: tablename
+    - keyword: to
+    - keyword: database
+    - keyword: role
+    - role_reference:
+        naked_identifier: dbrolename
+- statement_terminator: ;
+- statement:
+    access_statement:
+    - keyword: revoke
+    - keyword: select
+    - keyword: 'on'
+    - keyword: table
+    - object_reference:
+      - naked_identifier: dbname
+      - dot: .
+      - naked_identifier: schemaname
+      - dot: .
+      - naked_identifier: tablename
+    - keyword: from
+    - keyword: database
+    - keyword: role
+    - object_reference:
+      - naked_identifier: dbname
+      - dot: .
+      - naked_identifier: rolename
+- statement_terminator: ;
+- statement:
+    access_statement:
+    - keyword: revoke
+    - keyword: select
+    - keyword: 'on'
+    - keyword: table
+    - object_reference:
+      - naked_identifier: dbname
+      - dot: .
+      - naked_identifier: schemaname
+      - dot: .
+      - naked_identifier: tablename
+    - keyword: from
+    - keyword: database
+    - keyword: role
+    - object_reference:
+        naked_identifier: dbrolename
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
fixes #5489, and related issues with REVOKE and GRANT <permission> TO DATABASE ROLE which weren't discovered at the time I reported the issue. 


### Are there any other side effects of this change that we should be aware of?

Modified existing test fixtures for Snowflake (`grant_revoke.sql`, `grant_revoke.yml` and `create_database_role.yml`).

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
