### PR TITLE
Hive: allow UDTF to return multiple column aliases in SELECT

### DIFF
--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -429,6 +429,25 @@ class FromExpressionElementSegment(ansi.FromExpressionElementSegment):
     )
 
 
+class AliasExpressionSegment(ansi.AliasExpressionSegment):
+    """Modified to allow UDTF in SELECT clause to return multiple columns aliases.
+
+    Full Apache Hive `Built-in Table-Generating Functions (UDTF)` reference here:
+    https://cwiki.apache.org/confluence/display/hive/languagemanual+udf#LanguageManualUDF-Built-inTable-GeneratingFunctions(UDTF)
+    """
+
+    match_grammar = Sequence(
+        Ref.keyword("AS", optional=True),
+        OneOf(
+            Sequence(
+                Ref("SingleIdentifierGrammar", optional=True),
+                Bracketed(Ref("SingleIdentifierListSegment")),
+            ),
+            Ref("SingleIdentifierGrammar"),
+        ),
+    )
+
+
 class LateralViewClauseSegment(BaseSegment):
     """A `LATERAL VIEW` in a `FROM` clause.
 

--- a/test/fixtures/dialects/hive/select_lateral_view.sql
+++ b/test/fixtures/dialects/hive/select_lateral_view.sql
@@ -17,3 +17,12 @@ LATERAL VIEW explode(col2) myTable2 AS myCol2;
 SELECT * FROM src LATERAL VIEW explode(array()) C AS a limit 10;
 
 SELECT * FROM src LATERAL VIEW OUTER explode(array()) C AS a limit 10;
+
+-- besides as a part of LATERAL VIEW, UDTF can also be used in the SELECT expression
+SELECT explode(map('A', 10, 'B', 20, 'C', 30)) AS (key,value);
+
+SELECT posexplode(array('A', 'B', 'C')) AS (pos,val);
+
+SELECT inline(array(struct('A', 10, DATE '2015-01-01'), struct('B', 20, DATE '2016-02-02'))) AS (col1,col2,col3);
+
+SELECT stack(2, 'A', 10, DATE '2015-01-01', 'B', 20, DATE '2016-01-01') AS (col0,col1,col2);

--- a/test/fixtures/dialects/hive/select_lateral_view.yml
+++ b/test/fixtures/dialects/hive/select_lateral_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 42595fd8445bfd6551382c053b6f52b96f0690bd47979028dff4cfd3d862add3
+_hash: 8b745501faab5270d0a39402a5a7f56217bcd43dcf399c8fea0962c5c51fd5da
 file:
 - statement:
     select_statement:
@@ -255,4 +255,193 @@ file:
       limit_clause:
         keyword: limit
         numeric_literal: '10'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: explode
+            bracketed:
+              start_bracket: (
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: map
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'A'"
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '10'
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'B'"
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '20'
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'C'"
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '30'
+                  - end_bracket: )
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - naked_identifier: key
+              - comma: ','
+              - naked_identifier: value
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: posexplode
+            bracketed:
+              start_bracket: (
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: array
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'A'"
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'B'"
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'C'"
+                  - end_bracket: )
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - naked_identifier: pos
+              - comma: ','
+              - naked_identifier: val
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: inline
+            bracketed:
+              start_bracket: (
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: array
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      function:
+                        function_name:
+                          function_name_identifier: struct
+                        bracketed:
+                        - start_bracket: (
+                        - expression:
+                            quoted_literal: "'A'"
+                        - comma: ','
+                        - expression:
+                            numeric_literal: '10'
+                        - comma: ','
+                        - expression:
+                            keyword: DATE
+                            date_constructor_literal: "'2015-01-01'"
+                        - end_bracket: )
+                  - comma: ','
+                  - expression:
+                      function:
+                        function_name:
+                          function_name_identifier: struct
+                        bracketed:
+                        - start_bracket: (
+                        - expression:
+                            quoted_literal: "'B'"
+                        - comma: ','
+                        - expression:
+                            numeric_literal: '20'
+                        - comma: ','
+                        - expression:
+                            keyword: DATE
+                            date_constructor_literal: "'2016-02-02'"
+                        - end_bracket: )
+                  - end_bracket: )
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - naked_identifier: col1
+              - comma: ','
+              - naked_identifier: col2
+              - comma: ','
+              - naked_identifier: col3
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: stack
+            bracketed:
+            - start_bracket: (
+            - expression:
+                numeric_literal: '2'
+            - comma: ','
+            - expression:
+                quoted_literal: "'A'"
+            - comma: ','
+            - expression:
+                numeric_literal: '10'
+            - comma: ','
+            - expression:
+                keyword: DATE
+                date_constructor_literal: "'2015-01-01'"
+            - comma: ','
+            - expression:
+                quoted_literal: "'B'"
+            - comma: ','
+            - expression:
+                numeric_literal: '20'
+            - comma: ','
+            - expression:
+                keyword: DATE
+                date_constructor_literal: "'2016-01-01'"
+            - end_bracket: )
+          alias_expression:
+            keyword: AS
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - naked_identifier: col0
+              - comma: ','
+              - naked_identifier: col1
+              - comma: ','
+              - naked_identifier: col2
+              end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #3160 , where UDTF returning multiple column aliases used in SELECT cause is unparsable, even though Hive supports this feature. See https://cwiki.apache.org/confluence/display/hive/languagemanual+udf#LanguageManualUDF-Built-inTable-GeneratingFunctions(UDTF)


### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
