### PR TITLE
[Spark/Databricks] Fix: make COLUMNS in APPLY CHANGES INTO optional

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -3176,7 +3176,7 @@ class ApplyChangesIntoStatementSegment(BaseSegment):
                     Ref("BracketedColumnReferenceListGrammar"),
                 ),
             ),
-            optional=True
+            optional=True,
         ),
         Sequence(
             "STORED",

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -3176,6 +3176,7 @@ class ApplyChangesIntoStatementSegment(BaseSegment):
                     Ref("BracketedColumnReferenceListGrammar"),
                 ),
             ),
+            optional=True
         ),
         Sequence(
             "STORED",

--- a/test/fixtures/dialects/sparksql/databricks_dlt_apply_changes_into.sql
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_apply_changes_into.sql
@@ -43,3 +43,12 @@ APPLY AS TRUNCATE WHEN operation = "TRUNCATE"
 SEQUENCE BY sequence_num
 COLUMNS * EXCEPT (operation, sequence_num)
 STORED AS SCD TYPE 1;
+
+-- Create and populate the target table.
+-- "APPLY CHANGES INTO" without a "COLUMNS" clause
+CREATE OR REFRESH STREAMING LIVE TABLE target;
+
+APPLY CHANGES INTO live.target
+FROM STREAM(cdc_data.users)
+KEYS (user_id)
+SEQUENCE BY sequence_num;

--- a/test/fixtures/dialects/sparksql/databricks_dlt_apply_changes_into.yml
+++ b/test/fixtures/dialects/sparksql/databricks_dlt_apply_changes_into.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5e45c610ddacccbffcbf4ed49cd0db81a4283d99450908feee8fd16b86c4f242
+_hash: bcd83f9b2bb00b52c40cc2140d7dce1c396c9ac0ee2d4290dbd3d99b10c7f42f
 file:
 - statement:
     create_table_statement:
@@ -311,4 +311,52 @@ file:
     - keyword: SCD
     - keyword: TYPE
     - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REFRESH
+    - keyword: STREAMING
+    - keyword: LIVE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: target
+- statement_terminator: ;
+- statement:
+    apply_changes_into_statement:
+    - keyword: APPLY
+    - keyword: CHANGES
+    - keyword: INTO
+    - table_expression:
+        table_reference:
+        - naked_identifier: live
+        - dot: .
+        - naked_identifier: target
+    - from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: STREAM
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                    - naked_identifier: cdc_data
+                    - dot: .
+                    - naked_identifier: users
+                  end_bracket: )
+    - keyword: KEYS
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: user_id
+        end_bracket: )
+    - keyword: SEQUENCE
+    - keyword: BY
+    - column_reference:
+        naked_identifier: sequence_num
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

For Spark / Databricks SQL, according to [the offical SQL language reference](https://docs.databricks.com/en/delta-live-tables/sql-ref.html#change-data-capture-with-sql-in-delta-live-tables), the `COLUMNS` clause in a `AAPLY CHANGES INTO` statement is optional. This is not the case in the sqlfluff parser of `sparksql` at the moment. This PR fixes this by marking `COLUMNS` as optional in the parser code.

> ### [Change data capture with SQL in Delta Live Tables ](https://docs.databricks.com/en/delta-live-tables/sql-ref.html#change-data-capture-with-sql-in-delta-live-tables)
>
> Use the APPLY CHANGES INTO statement to use Delta Live Tables CDC functionality, as described in the following:
>
> ```sql
> CREATE OR REFRESH STREAMING TABLE table_name;
> 
> APPLY CHANGES INTO LIVE.table_name
> FROM source
> KEYS (keys)
> [IGNORE NULL UPDATES]
> [APPLY AS DELETE WHEN condition]
> [APPLY AS TRUNCATE WHEN condition]
> SEQUENCE BY orderByColumn
> [COLUMNS {columnList | * EXCEPT (exceptColumnList)}] -- <-- Note `COLUMNS` is optional here.
> [STORED AS {SCD TYPE 1 | SCD TYPE 2}]
> [TRACK HISTORY ON {columnList | * EXCEPT (exceptColumnList)}]
> ```


### Are there any other side effects of this change that we should be aware of?

No. This PR only affects the parsing of Delta LIve Table statements in the Spark / Databricks SQL dialect.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
