### PR TITLE
SparkSQL: allow distribute/sort/cluster by at end of set operation

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -1786,7 +1786,12 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
     """
 
     match_grammar = ansi.UnorderedSelectStatementSegment.match_grammar.copy(
-        insert=[Ref("QualifyClauseSegment", optional=True)],
+        insert=[
+            Ref("QualifyClauseSegment", optional=True),
+            Ref("ClusterByClauseSegment", optional=True),
+            Ref("DistributeByClauseSegment", optional=True),
+            Ref("SortByClauseSegment", optional=True),
+        ],
         # Removing non-valid clauses that exist in ANSI dialect
         remove=[Ref("OverlapsClauseSegment", optional=True)],
     )

--- a/test/fixtures/dialects/sparksql/select_cluster_by.sql
+++ b/test/fixtures/dialects/sparksql/select_cluster_by.sql
@@ -52,3 +52,14 @@ FROM person
 GROUP BY age
 HAVING COUNT(age) > 1
 CLUSTER BY age;
+
+SELECT
+    age,
+    name
+FROM person
+UNION ALL
+SELECT
+    age,
+    name
+FROM person_cold
+CLUSTER BY age;

--- a/test/fixtures/dialects/sparksql/select_cluster_by.yml
+++ b/test/fixtures/dialects/sparksql/select_cluster_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0e2f4d9b1508eac0bc91d3eb8ccb54f67814f7f1092115425e5dbaa8f723b8fc
+_hash: a030205bf2c161478bcf6abd2b798e6e80f83d20844ae0e5221093dbe089b533
 file:
 - statement:
     select_statement:
@@ -234,4 +234,49 @@ file:
       - keyword: BY
       - column_reference:
           naked_identifier: age
+- statement_terminator: ;
+- statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: age
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: person
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: age
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: person_cold
+        cluster_by_clause:
+        - keyword: CLUSTER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: age
 - statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/select_distribute_by.sql
+++ b/test/fixtures/dialects/sparksql/select_distribute_by.sql
@@ -59,3 +59,15 @@ GROUP BY age
 HAVING COUNT(age) > 1
 DISTRIBUTE BY age
 SORT BY age;
+
+SELECT
+    age,
+    name
+FROM person
+UNION ALL
+SELECT
+    age,
+    name
+FROM person_cold
+DISTRIBUTE BY age
+SORT BY age;

--- a/test/fixtures/dialects/sparksql/select_distribute_by.yml
+++ b/test/fixtures/dialects/sparksql/select_distribute_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9ce5dad4768aabdc2d0ae563cdd3b7b9db42c3608bc643d818f18cc212079131
+_hash: 9e06dff72c34220df50e3d92c3498b51f62d8bc752083d27f84d47d6439d3e5a
 file:
 - statement:
     select_statement:
@@ -283,4 +283,54 @@ file:
       - keyword: BY
       - column_reference:
           naked_identifier: age
+- statement_terminator: ;
+- statement:
+    set_expression:
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: age
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: person
+    - set_operator:
+      - keyword: UNION
+      - keyword: ALL
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: age
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: person_cold
+        distribute_by_clause:
+        - keyword: DISTRIBUTE
+        - keyword: BY
+        - column_reference:
+            naked_identifier: age
+        sort_by_clause:
+        - keyword: SORT
+        - keyword: BY
+        - column_reference:
+            naked_identifier: age
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #5501 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
