### PR TITLE
SparkSQL: allow value in set_statement to be Java class name

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -442,7 +442,11 @@ sparksql_dialect.add(
         Ref("EqualsSegment", optional=True),
         OneOf(
             Ref("LiteralGrammar"),
-            Ref("SingleIdentifierGrammar"),
+            # when property value is Java Class Name
+            Delimited(
+                Ref("PropertiesNakedIdentifierSegment"),
+                delimiter=Ref("DotSegment"),
+            ),
         ),
     ),
     PropertyNameListGrammar=Delimited(Ref("PropertyNameSegment")),

--- a/test/fixtures/dialects/sparksql/set.sql
+++ b/test/fixtures/dialects/sparksql/set.sql
@@ -5,3 +5,5 @@ SET -v;
 SET;
 
 SET spark.sql.variable.substitute;
+
+SET spark.sql.cache.serializer=org.apache.spark.sql.execution.columnar.DefaultCachedBatchSerializer;

--- a/test/fixtures/dialects/sparksql/set.yml
+++ b/test/fixtures/dialects/sparksql/set.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 71c5e26841b7b96426ef4127afa93633f3f29bab63d71888bbe5ce951edf4a47
+_hash: 1d054a4501b36dd0006dc6e682760051d612bf5ad29ee4f907259886819b57d5
 file:
 - statement:
     set_statement:
@@ -42,4 +42,31 @@ file:
       - properties_naked_identifier: variable
       - dot: .
       - properties_naked_identifier: substitute
+- statement_terminator: ;
+- statement:
+    set_statement:
+    - keyword: SET
+    - property_name_identifier:
+      - properties_naked_identifier: spark
+      - dot: .
+      - properties_naked_identifier: sql
+      - dot: .
+      - properties_naked_identifier: cache
+      - dot: .
+      - properties_naked_identifier: serializer
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - properties_naked_identifier: org
+    - dot: .
+    - properties_naked_identifier: apache
+    - dot: .
+    - properties_naked_identifier: spark
+    - dot: .
+    - properties_naked_identifier: sql
+    - dot: .
+    - properties_naked_identifier: execution
+    - dot: .
+    - properties_naked_identifier: columnar
+    - dot: .
+    - properties_naked_identifier: DefaultCachedBatchSerializer
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #5503

### Are there any other side effects of this change that we should be aware of?
This is a simple fix to make SQL statement parsable
```sql
SET spark.sql.cache.serializer=org.apache.spark.sql.execution.columnar.DefaultCachedBatchSerializer;
```

Parsed Tree:
```
[L:  1, P:  1]      |file:
[L:  1, P:  1]      |    statement:
[L:  1, P:  1]      |        set_statement:
[L:  1, P:  1]      |            keyword:                                          'SET'
[L:  1, P:  4]      |            whitespace:                                       ' '
[L:  1, P:  5]      |            property_name_identifier:
[L:  1, P:  5]      |                properties_naked_identifier:                  'spark'
[L:  1, P: 10]      |                dot:                                          '.'
[L:  1, P: 11]      |                properties_naked_identifier:                  'sql'
[L:  1, P: 14]      |                dot:                                          '.'
[L:  1, P: 15]      |                properties_naked_identifier:                  'cache'
[L:  1, P: 20]      |                dot:                                          '.'
[L:  1, P: 21]      |                properties_naked_identifier:                  'serializer'
[L:  1, P: 31]      |            comparison_operator:
[L:  1, P: 31]      |                raw_comparison_operator:                      '='
[L:  1, P: 32]      |            properties_naked_identifier:                      'org'
[L:  1, P: 35]      |            dot:                                              '.'
[L:  1, P: 36]      |            properties_naked_identifier:                      'apache'
[L:  1, P: 42]      |            dot:                                              '.'
[L:  1, P: 43]      |            properties_naked_identifier:                      'spark'
[L:  1, P: 48]      |            dot:                                              '.'
[L:  1, P: 49]      |            properties_naked_identifier:                      'sql'
[L:  1, P: 52]      |            dot:                                              '.'
[L:  1, P: 53]      |            properties_naked_identifier:                      'execution'
[L:  1, P: 62]      |            dot:                                              '.'
[L:  1, P: 63]      |            properties_naked_identifier:                      'columnar'
[L:  1, P: 71]      |            dot:                                              '.'
[L:  1, P: 72]      |            properties_naked_identifier:                      'DefaultCachedBatchSerializer'
[L:  1, P:100]      |    statement_terminator:                                     ';'
[L:  1, P:101]      |    newline:                                                  '\n'
[L:  2, P:  1]      |    [META] end_of_file:
```

The property value is flattened, which might not be desirable for high level use case beyond parsing.

I was thinking adding a property_value_identifier, mimicking property_name_identifier and making all properties_naked_identifier as its children. This way the SQL can also be successfully parsed but it turns out to touch a lot of other yml in sparksql dialect. 
```python
class PropertyValueSegment(BaseSegment):
    """A segment for a property value to set."""

    type = "property_value_identifier"

    match_grammar = Sequence(
        OneOf(
            Ref("LiteralGrammar"),
            # when value is Java Class Name
            Delimited(
                Ref("PropertiesNakedIdentifierSegment"),
                delimiter=Ref("DotSegment"),
            ),
        ),
    )
```
Not sure if that's preferable, so in this PR I still go with the simple approach. Let me know your thoughts.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
