### PR TITLE
[CI] Add a few more mypy ckecks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
             types-colorama,
             types-pyyaml,
             types-regex,
+            types-tqdm,
           ]
         files: ^src/sqlfluff/.*
   - repo: https://github.com/pycqa/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,10 +29,9 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.8.0
     hooks:
       - id: mypy
-        args: [--ignore-missing-imports]
         additional_dependencies:
           [
             types-toml,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,7 @@ ignore_imports = [
 
 [tool.mypy]
 warn_unused_configs = true
+warn_redundant_casts = true
 warn_unused_ignores = true
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,9 +204,6 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 strict_equality = true
 extra_checks = true
-
-[[tool.mypy.overrides]]
-module = "sqlfluff.*"
 implicit_reexport = true
 
 # skip type checking for 3rd party packages for which stubs are not available

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,10 +212,6 @@ module = "diff_cover.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = "tqdm.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
 module = "tblib.*"
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,7 @@ warn_unused_configs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 strict_equality = true
+extra_checks = true
 
 [[tool.mypy.overrides]]
 module = "sqlfluff.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,7 @@ ignore_imports = [
 warn_unused_configs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
+strict_equality = true
 
 [[tool.mypy.overrides]]
 module = "sqlfluff.*"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -26,6 +26,7 @@ types-colorama
 types-pyyaml
 types-Jinja2
 types-regex
+types-tqdm
 # Requests is required for the util script
 requests
 ghapi

--- a/src/sqlfluff/core/dialects/__init__.py
+++ b/src/sqlfluff/core/dialects/__init__.py
@@ -95,3 +95,13 @@ def dialect_selector(s: str) -> Dialect:
     # Expand any callable references at this point.
     # NOTE: The result of .expand() is a new class.
     return dialect.expand()
+
+
+__all__ = [
+    "Dialect",
+    "DialectTuple",
+    "SQLFluffUserError",
+    "load_raw_dialect",
+    "dialect_readout",
+    "dialect_selector",
+]

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -182,10 +182,7 @@ class Linter:
         templating_blocks_indent = bool(templating_blocks_indent)
         # If we're forcing it through we don't check.
         if templating_blocks_indent and not force_block_indent:
-            indent_balance = sum(
-                getattr(elem, "indent_val", 0)
-                for elem in cast(Tuple[BaseSegment, ...], tokens)
-            )
+            indent_balance = sum(getattr(elem, "indent_val", 0) for elem in tokens)
             if indent_balance != 0:  # pragma: no cover
                 linter_logger.debug(
                     "Indent balance test failed for %r. Template indents will not be "
@@ -198,7 +195,7 @@ class Linter:
         # The file will have been lexed without config, so check all indents
         # are enabled.
         new_tokens = []
-        for token in cast(Tuple[BaseSegment, ...], tokens):
+        for token in tokens:
             if token.is_meta:
                 token = cast("MetaSegment", token)
                 if token.indent_val != 0:

--- a/src/sqlfluff/core/parser/context.py
+++ b/src/sqlfluff/core/parser/context.py
@@ -12,7 +12,17 @@ import logging
 import uuid
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Sequence, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterator,
+    List,
+    NoReturn,
+    Optional,
+    Sequence,
+    Tuple,
+)
 
 from tqdm import tqdm
 
@@ -97,7 +107,7 @@ class ParseContext:
         # NOTE: Includes inherited parent terminators.
         self.terminators: Tuple["Matchable", ...] = ()
         # Value for holding a reference to the progress bar.
-        self._tqdm: Optional[tqdm] = None
+        self._tqdm: Optional[tqdm[NoReturn]] = None
         # Variable to store whether we're tracking progress. When looking
         # ahead to terminators or suchlike, we set this to False so as not
         # to confuse the progress bar.

--- a/src/sqlfluff/core/parser/segments/raw.py
+++ b/src/sqlfluff/core/parser/segments/raw.py
@@ -225,3 +225,10 @@ class RawSegment(BaseSegment):
             trim_chars=self.trim_chars,
             source_fixes=source_fixes or self.source_fixes,
         )
+
+
+__all__ = [
+    "PositionMarker",
+    "RawSegment",
+    "SourceFix",
+]

--- a/src/sqlfluff/core/rules/noqa.py
+++ b/src/sqlfluff/core/rules/noqa.py
@@ -283,8 +283,7 @@ class IgnoreMask:
                 (
                     ignore
                     for ignore in ignore_mask
-                    if not ignore.rules
-                    or (v.rule_code() in cast(Tuple[str, ...], ignore.rules))
+                    if not ignore.rules or (v.rule_code() in ignore.rules)
                 ),
                 key=lambda ignore: ignore.line_no,
             )

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -724,6 +724,7 @@ class JinjaTemplater(PythonTemplater):
                         tracer_probe.raw_sliced[branch]
                     ].alternate_code = f"{{% {tag} {new_value} %}}"
                     override_raw_slices.append(branch)
+
             # Render and analyze the template with the overrides.
             variant_key = tuple(
                 cast(str, tracer_trace.raw_slice_info[rs].alternate_code)
@@ -735,8 +736,8 @@ class JinjaTemplater(PythonTemplater):
             # In some cases (especially with nested if statements), we may
             # generate a variant that duplicates an existing variant. Skip
             # those.
-            if variant_key not in variants:
-                variant_raw_str = "".join(variant_key)
+            variant_raw_str = "".join(variant_key)
+            if variant_raw_str not in variants:
                 analyzer = JinjaAnalyzer(variant_raw_str, self._get_jinja_env())
                 tracer_trace = analyzer.analyze(render_func)
                 try:

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -744,7 +744,7 @@ class JinjaTemplater(PythonTemplater):
                     trace = tracer_trace.trace(
                         append_to_templated=append_to_templated,
                     )
-                except:  # noqa: E722
+                except Exception:
                     # If we get an error tracing the variant, skip it. This may
                     # happen for a variety of reasons. Basically there's no
                     # guarantee that the variant will be valid Jinja.

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -2051,7 +2051,7 @@ def lint_line_length(
             # we know there's always a trailing block.
             "end_of_file" in elem_buffer[i + 1].class_types
             # Or is there a newline?
-            or has_untemplated_newline(cast(ReflowPoint, elem))
+            or has_untemplated_newline(elem)
         ):
             # In either case we want to process this, so carry on.
             pass

--- a/test/core/linter/linted_file_test.py
+++ b/test/core/linter/linted_file_test.py
@@ -257,7 +257,7 @@ def test_safe_create_replace_file(case, tmp_path):
         LintedFile._safe_create_replace_file(
             str(p), str(p), case["update"], case["encoding"]
         )
-    except:  # noqa: E722
+    except Exception:
         pass
     actual = p.read_text(encoding=case["encoding"])
     assert case["expected"] == actual


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

This is my first contribution here. I hope to contribute to adding more features in the future. For now I'm reading the contributing guide and looking at the code structure and the linting/test stages. Which leads to this small MR.  
Antoine

### Brief summary of the change made

This MR proposes to add theses `mypy` checks:
 - [`warn_redundant_casts`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-warn_redundant_casts)
 - [`strict_equality`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-strict_equality)
 - [`extra_checks`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-strict_concatenate) (previously named `strict_concatenate`)
 - [`no_implicit_reexport`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-implicit_reexport)

I chose theses checks by taking the first ones on this [list](https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options) in the `mypy` doc.

`warn_redundant_casts` is similar to `warn_unused_ignores` by alerting on `mypy` elements that can be removed.

`no_implicit_reexport` and `extra_checks` are already ok on the whole repository, so by adding them, it will remain ok. 

By activating `strict_equality`, an "always true" condition has been revealed. I try to fix it with my comprehension of the code.
In the future, with `strict_equality`, this type of issue could be detected before merging.

This MR also updates the `mypy` version used for `pre-commit` and changes the `pre-commit` `mypy` config to match with the `tox` one.

Since the typing stubs for `tqdm` exist, this MR adds this package to enable typing with `tqdm`.

And finally, I transform `except:  # noqa: E722` to `except Exception: ` to avoid catching `SystemExit` and `KeyboardInterrupt` exceptions.

Related to #378

### Are there any other side effects of this change that we should be aware of?
Imho, no, except maybe, the ones I made in `src/sqlfluff/core/templaters/jinja.py` file.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
