### PR TITLE
DuckDB: Add CREATE OR REPLACE TABLE syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -118,33 +118,31 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
             # Columns and comment syntax:
             Bracketed(
                 Delimited(
-                    OneOf(
-                        Sequence(
-                            Ref("ColumnReferenceSegment"),
-                            OneOf(
-                                Sequence(
-                                    Ref("DatatypeSegment"),
-                                    AnyNumberOf(
-                                        OneOf(
-                                            Ref("ColumnConstraintSegment"),
-                                        ),
+                    Sequence(
+                        Ref("ColumnReferenceSegment"),
+                        OneOf(
+                            Sequence(
+                                Ref("DatatypeSegment"),
+                                AnyNumberOf(
+                                    OneOf(
+                                        Ref("ColumnConstraintSegment"),
                                     ),
-                                ),
-                                Sequence(
-                                    Ref(
-                                        "DatatypeSegment",
-                                        optional=True,
-                                        exclude=Ref.keyword("AS"),
-                                    ),
-                                    Sequence("GENERATED", "ALWAYS", optional=True),
-                                    "AS",
-                                    Bracketed(Ref("ExpressionSegment")),
-                                    OneOf("STORED", "VIRTUAL", optional=True),
                                 ),
                             ),
+                            Sequence(
+                                Ref(
+                                    "DatatypeSegment",
+                                    optional=True,
+                                    exclude=Ref.keyword("AS"),
+                                ),
+                                Sequence("GENERATED", "ALWAYS", optional=True),
+                                "AS",
+                                Bracketed(Ref("ExpressionSegment")),
+                                OneOf("STORED", "VIRTUAL", optional=True),
+                            ),
                         ),
-                        Ref("TableConstraintSegment"),
                     ),
+                    Ref("TableConstraintSegment"),
                 )
             ),
         ),

--- a/test/fixtures/dialects/duckdb/create_table.sql
+++ b/test/fixtures/dialects/duckdb/create_table.sql
@@ -1,0 +1,86 @@
+/* Examples from https://duckdb.org/docs/sql/statements/create_table */
+
+-- create a table with two integer columns (i and j)
+CREATE TABLE t1 (i INTEGER, j INTEGER);
+
+-- create a table with a primary key
+CREATE TABLE t1 (id INTEGER PRIMARY KEY, j VARCHAR);
+
+-- create a table with a composite primary key
+CREATE TABLE t1 (id INTEGER, j VARCHAR, PRIMARY KEY (id, j));
+
+-- create a table with various different types and constraints
+CREATE TABLE t1 (
+    i INTEGER NOT NULL,
+    decimalnr DOUBLE CHECK (decimalnr < 10),
+    date DATE UNIQUE,
+    time TIMESTAMP
+);
+
+-- create a table from the result of a query
+CREATE TABLE t1 AS SELECT
+    42 AS i,
+    84 AS j;
+
+-- create a table from a CSV file using AUTO-DETECT (i.e., automatically detecting column names and types)
+CREATE TABLE t1 AS SELECT * FROM read_csv_auto('path/file.csv');
+
+-- we can use the FROM-first syntax to omit 'SELECT *'
+CREATE TABLE t1 AS FROM read_csv_auto('path/file.csv');
+
+-- create a temporary table from a CSV file (automatically detecting column names and types)
+CREATE TEMP TABLE t1 AS SELECT * FROM read_csv('path/file.csv');
+
+-- create a table with two integer columns (i and j) even if t1 already exists
+CREATE OR REPLACE TABLE t1 (i INTEGER, j INTEGER);
+
+-- create a table with two integer columns (i and j) only if t1 does not exist yet.
+CREATE TABLE IF NOT EXISTS t1 (i INTEGER, j INTEGER);
+
+CREATE TABLE t1 (
+    id INTEGER PRIMARY KEY,
+    percentage INTEGER CHECK (0 <= percentage AND percentage <= 100)
+);
+
+CREATE TABLE t2 (id INTEGER PRIMARY KEY, x INTEGER, y INTEGER CHECK (x < y));
+
+CREATE TABLE t3 (
+    id INTEGER PRIMARY KEY,
+    x INTEGER,
+    y INTEGER,
+    CONSTRAINT x_smaller_than_y CHECK (x < y)
+);
+
+CREATE TABLE t1 (id INTEGER PRIMARY KEY, j VARCHAR);
+CREATE TABLE t2 (
+    id INTEGER PRIMARY KEY,
+    t1_id INTEGER,
+    FOREIGN KEY (t1_id) REFERENCES t1 (id)
+);
+
+CREATE TABLE t3 (id INTEGER, j VARCHAR, PRIMARY KEY (id, j));
+CREATE TABLE t4 (
+    id INTEGER PRIMARY KEY, t3_id INTEGER, t3_j VARCHAR,
+    FOREIGN KEY (t3_id, t3_j) REFERENCES t3 (id, j)
+);
+
+CREATE TABLE t5 (id INTEGER UNIQUE, j VARCHAR);
+CREATE TABLE t6 (
+    id INTEGER PRIMARY KEY,
+    t5_id INTEGER,
+    FOREIGN KEY (t5_id) REFERENCES t5(id)
+);
+
+-- The simplest syntax for a generated column.
+-- The type is derived from the expression, and the variant defaults to VIRTUAL
+CREATE TABLE t1 (x FLOAT, two_x AS (2 * x));
+
+-- Fully specifying the same generated column for completeness
+CREATE TABLE t1 (x FLOAT, two_x FLOAT GENERATED ALWAYS AS (2 * x) VIRTUAL);
+
+
+CREATE TABLE t_values AS VALUES (1);
+
+CREATE TABLE t_dflt_int (id INTEGER DEFAULT 0);
+
+CREATE OR REPLACE TABLE t_dflt_dt (dt DATE DEFAULT CURRENT_DATE);

--- a/test/fixtures/dialects/duckdb/create_table.yml
+++ b/test/fixtures/dialects/duckdb/create_table.yml
@@ -1,0 +1,705 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 55603d359772051b394b4c74721ac95533d5b977f9bd9ee4c35ff272f8f6b67f
+file:
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: i
+      - data_type:
+          keyword: INTEGER
+      - comma: ','
+      - column_reference:
+          naked_identifier: j
+      - data_type:
+          keyword: INTEGER
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: id
+      - data_type:
+          keyword: INTEGER
+      - column_constraint_segment:
+        - keyword: PRIMARY
+        - keyword: KEY
+      - comma: ','
+      - column_reference:
+          naked_identifier: j
+      - data_type:
+          keyword: VARCHAR
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: id
+      - data_type:
+          keyword: INTEGER
+      - comma: ','
+      - column_reference:
+          naked_identifier: j
+      - data_type:
+          keyword: VARCHAR
+      - comma: ','
+      - table_constraint:
+        - keyword: PRIMARY
+        - keyword: KEY
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: id
+          - comma: ','
+          - column_reference:
+              naked_identifier: j
+          - end_bracket: )
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: i
+      - data_type:
+          keyword: INTEGER
+      - column_constraint_segment:
+        - keyword: NOT
+        - keyword: 'NULL'
+      - comma: ','
+      - column_reference:
+          naked_identifier: decimalnr
+      - data_type:
+          data_type_identifier: DOUBLE
+      - column_constraint_segment:
+          keyword: CHECK
+          bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: decimalnr
+              comparison_operator:
+                raw_comparison_operator: <
+              numeric_literal: '10'
+            end_bracket: )
+      - comma: ','
+      - column_reference:
+          naked_identifier: date
+      - data_type:
+          datetime_type_identifier:
+            keyword: DATE
+      - column_constraint_segment:
+          keyword: UNIQUE
+      - comma: ','
+      - column_reference:
+          naked_identifier: time
+      - data_type:
+          datetime_type_identifier:
+            keyword: TIMESTAMP
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            numeric_literal: '42'
+            alias_expression:
+              keyword: AS
+              naked_identifier: i
+        - comma: ','
+        - select_clause_element:
+            numeric_literal: '84'
+            alias_expression:
+              keyword: AS
+              naked_identifier: j
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                function:
+                  function_name:
+                    function_name_identifier: read_csv_auto
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'path/file.csv'"
+                    end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - keyword: AS
+    - select_statement:
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                function:
+                  function_name:
+                    function_name_identifier: read_csv_auto
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'path/file.csv'"
+                    end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TEMP
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                function:
+                  function_name:
+                    function_name_identifier: read_csv
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'path/file.csv'"
+                    end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: i
+      - data_type:
+          keyword: INTEGER
+      - comma: ','
+      - column_reference:
+          naked_identifier: j
+      - data_type:
+          keyword: INTEGER
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: i
+      - data_type:
+          keyword: INTEGER
+      - comma: ','
+      - column_reference:
+          naked_identifier: j
+      - data_type:
+          keyword: INTEGER
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: id
+      - data_type:
+          keyword: INTEGER
+      - column_constraint_segment:
+        - keyword: PRIMARY
+        - keyword: KEY
+      - comma: ','
+      - column_reference:
+          naked_identifier: percentage
+      - data_type:
+          keyword: INTEGER
+      - column_constraint_segment:
+          keyword: CHECK
+          bracketed:
+            start_bracket: (
+            expression:
+            - numeric_literal: '0'
+            - comparison_operator:
+              - raw_comparison_operator: <
+              - raw_comparison_operator: '='
+            - column_reference:
+                naked_identifier: percentage
+            - binary_operator: AND
+            - column_reference:
+                naked_identifier: percentage
+            - comparison_operator:
+              - raw_comparison_operator: <
+              - raw_comparison_operator: '='
+            - numeric_literal: '100'
+            end_bracket: )
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t2
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: id
+      - data_type:
+          keyword: INTEGER
+      - column_constraint_segment:
+        - keyword: PRIMARY
+        - keyword: KEY
+      - comma: ','
+      - column_reference:
+          naked_identifier: x
+      - data_type:
+          keyword: INTEGER
+      - comma: ','
+      - column_reference:
+          naked_identifier: y
+      - data_type:
+          keyword: INTEGER
+      - column_constraint_segment:
+          keyword: CHECK
+          bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: x
+            - comparison_operator:
+                raw_comparison_operator: <
+            - column_reference:
+                naked_identifier: y
+            end_bracket: )
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t3
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: id
+      - data_type:
+          keyword: INTEGER
+      - column_constraint_segment:
+        - keyword: PRIMARY
+        - keyword: KEY
+      - comma: ','
+      - column_reference:
+          naked_identifier: x
+      - data_type:
+          keyword: INTEGER
+      - comma: ','
+      - column_reference:
+          naked_identifier: y
+      - data_type:
+          keyword: INTEGER
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: x_smaller_than_y
+        - keyword: CHECK
+        - bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: x
+            - comparison_operator:
+                raw_comparison_operator: <
+            - column_reference:
+                naked_identifier: y
+            end_bracket: )
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: id
+      - data_type:
+          keyword: INTEGER
+      - column_constraint_segment:
+        - keyword: PRIMARY
+        - keyword: KEY
+      - comma: ','
+      - column_reference:
+          naked_identifier: j
+      - data_type:
+          keyword: VARCHAR
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t2
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: id
+      - data_type:
+          keyword: INTEGER
+      - column_constraint_segment:
+        - keyword: PRIMARY
+        - keyword: KEY
+      - comma: ','
+      - column_reference:
+          naked_identifier: t1_id
+      - data_type:
+          keyword: INTEGER
+      - comma: ','
+      - table_constraint:
+        - keyword: FOREIGN
+        - keyword: KEY
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: t1_id
+            end_bracket: )
+        - keyword: REFERENCES
+        - table_reference:
+            naked_identifier: t1
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: id
+            end_bracket: )
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t3
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: id
+      - data_type:
+          keyword: INTEGER
+      - comma: ','
+      - column_reference:
+          naked_identifier: j
+      - data_type:
+          keyword: VARCHAR
+      - comma: ','
+      - table_constraint:
+        - keyword: PRIMARY
+        - keyword: KEY
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: id
+          - comma: ','
+          - column_reference:
+              naked_identifier: j
+          - end_bracket: )
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t4
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: id
+      - data_type:
+          keyword: INTEGER
+      - column_constraint_segment:
+        - keyword: PRIMARY
+        - keyword: KEY
+      - comma: ','
+      - column_reference:
+          naked_identifier: t3_id
+      - data_type:
+          keyword: INTEGER
+      - comma: ','
+      - column_reference:
+          naked_identifier: t3_j
+      - data_type:
+          keyword: VARCHAR
+      - comma: ','
+      - table_constraint:
+        - keyword: FOREIGN
+        - keyword: KEY
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: t3_id
+          - comma: ','
+          - column_reference:
+              naked_identifier: t3_j
+          - end_bracket: )
+        - keyword: REFERENCES
+        - table_reference:
+            naked_identifier: t3
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: id
+          - comma: ','
+          - column_reference:
+              naked_identifier: j
+          - end_bracket: )
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t5
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: id
+      - data_type:
+          keyword: INTEGER
+      - column_constraint_segment:
+          keyword: UNIQUE
+      - comma: ','
+      - column_reference:
+          naked_identifier: j
+      - data_type:
+          keyword: VARCHAR
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t6
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: id
+      - data_type:
+          keyword: INTEGER
+      - column_constraint_segment:
+        - keyword: PRIMARY
+        - keyword: KEY
+      - comma: ','
+      - column_reference:
+          naked_identifier: t5_id
+      - data_type:
+          keyword: INTEGER
+      - comma: ','
+      - table_constraint:
+        - keyword: FOREIGN
+        - keyword: KEY
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: t5_id
+            end_bracket: )
+        - keyword: REFERENCES
+        - table_reference:
+            naked_identifier: t5
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: id
+            end_bracket: )
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: x
+      - data_type:
+          keyword: FLOAT
+      - comma: ','
+      - column_reference:
+          naked_identifier: two_x
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          expression:
+            numeric_literal: '2'
+            binary_operator: '*'
+            column_reference:
+              naked_identifier: x
+          end_bracket: )
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: x
+      - data_type:
+          keyword: FLOAT
+      - comma: ','
+      - column_reference:
+          naked_identifier: two_x
+      - data_type:
+          keyword: FLOAT
+      - keyword: GENERATED
+      - keyword: ALWAYS
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          expression:
+            numeric_literal: '2'
+            binary_operator: '*'
+            column_reference:
+              naked_identifier: x
+          end_bracket: )
+      - keyword: VIRTUAL
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t_values
+    - keyword: AS
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+          start_bracket: (
+          expression:
+            numeric_literal: '1'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t_dflt_int
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: id
+        data_type:
+          keyword: INTEGER
+        column_constraint_segment:
+          keyword: DEFAULT
+          numeric_literal: '0'
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t_dflt_dt
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: dt
+        data_type:
+          datetime_type_identifier:
+            keyword: DATE
+        column_constraint_segment:
+          keyword: DEFAULT
+          expression:
+            bare_function: CURRENT_DATE
+        end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #5510
- Adds `OR REPLACE` syntax to `CREATE TABLE`


### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
