### PR TITLE
Postgres ALTER EXTENSION support: dialect & tests

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -2239,6 +2239,138 @@ class DropExtensionStatementSegment(BaseSegment):
     )
 
 
+class AlterExtensionStatementSegment(BaseSegment):
+    """An `ALTER EXTENSION` statement.
+
+    https://www.postgresql.org/docs/16/sql-alterextension.html
+    """
+
+    type = "alter_extension_statement"
+    match_grammar: Matchable = Sequence(
+        "ALTER",
+        "EXTENSION",
+        Ref("ExtensionReferenceSegment"),
+        OneOf(
+            Sequence(
+                "UPDATE",
+                Sequence(
+                    "TO",
+                    Ref("LiteralGrammar"),
+                    optional=True,
+                ),
+            ),
+            Sequence(
+                "SET",
+                "SCHEMA",
+                OneOf(Ref("SchemaReferenceSegment"), "CURRENT_SCHEMA"),
+            ),
+            Sequence(
+                OneOf(
+                    "ADD",
+                    "DROP",
+                ),
+                OneOf(
+                    Sequence(
+                        OneOf(
+                            Sequence("ACCESS", "METHOD"),
+                            "COLLATION",
+                            "CONVERSION",
+                            "DOMAIN",
+                            Sequence("EVENT", "TRIGGER"),
+                            Sequence("FOREIGN", "DATA", "WRAPPER"),
+                            Sequence("FOREIGN", "TABLE"),
+                            Sequence(
+                                Ref.keyword("PROCEDURAL", optional=True),
+                                "LANGUAGE",
+                            ),
+                            "SCHEMA",
+                            "SEQUENCE",
+                            "SERVER",
+                            Sequence(
+                                "TEXT",
+                                "SEARCH",
+                                OneOf(
+                                    "CONFIGURATION",
+                                    "DICTIONARY",
+                                    "PARSER",
+                                    "TEMPLATE",
+                                ),
+                            ),
+                            "TYPE",
+                        ),
+                        Ref("ObjectReferenceSegment"),
+                    ),
+                    Sequence(
+                        OneOf(
+                            Sequence("MATERIALIZED", "VIEW"),
+                            "TABLE",
+                            "VIEW",
+                        ),
+                        Ref("TableReferenceSegment"),
+                    ),
+                    Sequence(
+                        "AGGREGATE",
+                        Ref("ObjectReferenceSegment"),
+                        Bracketed(
+                            Sequence(
+                                # TODO: Is this too permissive?
+                                Anything(),
+                                optional=True,
+                            ),
+                            optional=True,
+                        ),
+                    ),
+                    Sequence(
+                        "CAST",
+                        Bracketed(
+                            Sequence(
+                                Ref("ObjectReferenceSegment"),
+                                "AS",
+                                Ref("ObjectReferenceSegment"),
+                            ),
+                        ),
+                    ),
+                    Sequence(
+                        OneOf(
+                            "FUNCTION",
+                            "PROCEDURE",
+                            "ROUTINE",
+                        ),
+                        Delimited(
+                            Sequence(
+                                Ref("FunctionNameSegment"),
+                                Ref("FunctionParameterListGrammar", optional=True),
+                            ),
+                        ),
+                    ),
+                    Sequence(
+                        "OPERATOR",
+                        OneOf(
+                            Sequence(
+                                Ref("ObjectReferenceSegment"),
+                                Bracketed(
+                                    Delimited(
+                                        Ref("DatatypeSegment"),
+                                        Ref("CommaSegment"),
+                                        Ref("DatatypeSegment"),
+                                    ),
+                                ),
+                            ),
+                            Sequence(
+                                OneOf("CLASS", "FAMILY"),
+                                Ref("ObjectReferenceSegment"),
+                                "USING",
+                                Ref("IndexAccessMethodSegment"),
+                            ),
+                        ),
+                    ),
+                    Sequence("TRANSFORM", "FOR", "TYPE", Ref("ParameterNameSegment")),
+                ),
+            ),
+        ),
+    )
+
+
 class PublicationReferenceSegment(ansi.ObjectReferenceSegment):
     """A reference to a publication."""
 
@@ -3955,6 +4087,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("AlterRoleStatementSegment"),
             Ref("CreateExtensionStatementSegment"),
             Ref("DropExtensionStatementSegment"),
+            Ref("AlterExtensionStatementSegment"),
             Ref("CreatePublicationStatementSegment"),
             Ref("AlterPublicationStatementSegment"),
             Ref("DropPublicationStatementSegment"),

--- a/test/fixtures/dialects/postgres/alter_extension.sql
+++ b/test/fixtures/dialects/postgres/alter_extension.sql
@@ -1,0 +1,5 @@
+ALTER EXTENSION hstore SET SCHEMA utils;
+ALTER EXTENSION hstore ADD FUNCTION populate_record(anyelement, hstore);
+ALTER EXTENSION "hstore" DROP TABLE public.ref_table;
+ALTER EXTENSION hstore UPDATE TO '2.0';
+ALTER EXTENSION repmgr UPDATE;

--- a/test/fixtures/dialects/postgres/alter_extension.yml
+++ b/test/fixtures/dialects/postgres/alter_extension.yml
@@ -1,0 +1,69 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 4ef89f401daaafa6f0ca8f43d53a3ae10e351d4f387256c0649d29dbe8b8603b
+file:
+- statement:
+    alter_extension_statement:
+    - keyword: ALTER
+    - keyword: EXTENSION
+    - extension_reference:
+        naked_identifier: hstore
+    - keyword: SET
+    - keyword: SCHEMA
+    - schema_reference:
+        naked_identifier: utils
+- statement_terminator: ;
+- statement:
+    alter_extension_statement:
+    - keyword: ALTER
+    - keyword: EXTENSION
+    - extension_reference:
+        naked_identifier: hstore
+    - keyword: ADD
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: populate_record
+    - function_parameter_list:
+        bracketed:
+        - start_bracket: (
+        - data_type:
+            data_type_identifier: anyelement
+        - comma: ','
+        - data_type:
+            data_type_identifier: hstore
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_extension_statement:
+    - keyword: ALTER
+    - keyword: EXTENSION
+    - extension_reference:
+        quoted_identifier: '"hstore"'
+    - keyword: DROP
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: public
+      - dot: .
+      - naked_identifier: ref_table
+- statement_terminator: ;
+- statement:
+    alter_extension_statement:
+    - keyword: ALTER
+    - keyword: EXTENSION
+    - extension_reference:
+        naked_identifier: hstore
+    - keyword: UPDATE
+    - keyword: TO
+    - quoted_literal: "'2.0'"
+- statement_terminator: ;
+- statement:
+    alter_extension_statement:
+    - keyword: ALTER
+    - keyword: EXTENSION
+    - extension_reference:
+        naked_identifier: repmgr
+    - keyword: UPDATE
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #5526 


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
