### PR TITLE
MySQL: fix FIRST keyword in ALTER ADD/MODIFY

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -1258,9 +1258,8 @@ class AlterTableStatementSegment(BaseSegment):
                     Ref("IfNotExistsGrammar", optional=True),
                     Ref("ColumnDefinitionSegment"),
                     OneOf(
-                        Sequence(
-                            OneOf("FIRST", "AFTER"), Ref("ColumnReferenceSegment")
-                        ),
+                        "FIRST",
+                        Sequence("AFTER", Ref("ColumnReferenceSegment")),
                         # Bracketed Version of the same
                         Ref("BracketedColumnReferenceListGrammar"),
                         optional=True,
@@ -1271,9 +1270,8 @@ class AlterTableStatementSegment(BaseSegment):
                     Ref.keyword("COLUMN", optional=True),
                     Ref("ColumnDefinitionSegment"),
                     OneOf(
-                        Sequence(
-                            OneOf("FIRST", "AFTER"), Ref("ColumnReferenceSegment")
-                        ),
+                        "FIRST",
+                        Sequence("AFTER", Ref("ColumnReferenceSegment")),
                         # Bracketed Version of the same
                         Ref("BracketedColumnReferenceListGrammar"),
                         optional=True,

--- a/test/fixtures/dialects/mysql/alter_table.sql
+++ b/test/fixtures/dialects/mysql/alter_table.sql
@@ -3,6 +3,8 @@ ALTER TABLE `users`
     `name` varchar(255) NOT NULL,
     COMMENT "name of user";
 
+ALTER TABLE `users` MODIFY `name` varchar(255) NOT NULL FIRST;
+
 ALTER TABLE `users` RENAME TO `user`;
 
 ALTER TABLE `user` RENAME AS `users`;
@@ -61,3 +63,5 @@ ALTER TABLE `users`
 
 ALTER TABLE `users`
     ADD COLUMN IF NOT EXISTS `active` tinyint(1) DEFAULT '0';
+
+ALTER TABLE `foo` ADD `bar` INT FIRST;

--- a/test/fixtures/dialects/mysql/alter_table.yml
+++ b/test/fixtures/dialects/mysql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7d0df57b5c85a69c3d6155fc53a5d0294c392601ad748cdcf5e78191a73ef7d9
+_hash: 357b65a7038a22a79cdbc89b8225044db33349526560d3f78adc8f0454d8be07
 file:
 - statement:
     alter_table_statement:
@@ -28,6 +28,27 @@ file:
     - comma: ','
     - parameter: COMMENT
     - quoted_literal: '"name of user"'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`users`'
+    - keyword: MODIFY
+    - column_definition:
+        quoted_identifier: '`name`'
+        data_type:
+          data_type_identifier: varchar
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '255'
+              end_bracket: )
+        column_constraint_segment:
+        - keyword: NOT
+        - keyword: 'NULL'
+    - keyword: FIRST
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -510,4 +531,17 @@ file:
         column_constraint_segment:
           keyword: DEFAULT
           quoted_literal: "'0'"
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`foo`'
+    - keyword: ADD
+    - column_definition:
+        quoted_identifier: '`bar`'
+        data_type:
+          data_type_identifier: INT
+    - keyword: FIRST
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixed parsing error in ALTER COLUMN ADD/MODIFY when using FIRST keyword.

### Are there any other side effects of this change that we should be aware of?
I don't think so


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
