### PR TITLE
CV01: Add options for ANSI and consistent style.

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -325,6 +325,10 @@ max_alias_length = None
 # We suggest instead using aliasing.length (AL06) in most cases.
 force_enable = False
 
+[sqlfluff:rules:convention.not_equal]
+# Consistent usage of preferred "not equal to" comparison
+preferred_not_equal_style = consistent
+
 [sqlfluff:rules:convention.select_trailing_comma]
 # Trailing commas
 select_clause_trailing_comma = forbid

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -221,11 +221,17 @@ STANDARD_CONFIG_INFO_DICT: Dict[str, Dict[str, Any]] = {
             "Defaults to ``earlier``."
         ),
     },
+    "preferred_not_equal_style": {
+        "validation": ["consistent", "c_style", "ansi"],
+        "definition": (
+            "The style for using not equal to operator. Defaults to ``consistent``."
+        ),
+    },
 }
 
 
 def get_config_info() -> Dict[str, Any]:
-    """Gets the config from core sqlfluff and sqlfluff plugins and merges them."""
+    """Get the config from core sqlfluff and sqlfluff plugins and merges them."""
     plugin_manager = get_plugin_manager()
     configs_info = plugin_manager.hook.get_configs_info()
     return {

--- a/src/sqlfluff/rules/convention/CV01.py
+++ b/src/sqlfluff/rules/convention/CV01.py
@@ -9,24 +9,21 @@ from sqlfluff.utils.functional import FunctionalContext, sp
 
 
 class Rule_CV01(BaseRule):
-    """Use ``!=`` instead of ``<>`` for "not equal to" comparisons.
+    """Consistent usage of ``!=`` or ``<>`` for "not equal to" operator.
 
     **Anti-pattern**
 
-    ``<>`` means ``not equal`` but doesn't sound like this when we say it out loud.
-
     .. code-block:: sql
 
-        SELECT * FROM X WHERE 1 <> 2;
+        SELECT * FROM X WHERE 1 <> 2 AND 3 != 4;
 
     **Best practice**
 
-    Use ``!=`` instead because its sounds more natural and is more common in other
-    programming languages.
+    Ensure all "not equal to" comparisons are consistent, not mixing ``!=`` and ``<>``.
 
     .. code-block:: sql
 
-        SELECT * FROM X WHERE 1 != 2;
+        SELECT * FROM X WHERE 1 != 2 AND 3 != 4;
 
     """
 
@@ -34,10 +31,13 @@ class Rule_CV01(BaseRule):
     aliases = ("L061",)
     groups = ("all", "convention")
     crawl_behaviour = SegmentSeekerCrawler({"comparison_operator"})
+    config_keywords = ["preferred_not_equal_style"]
     is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[LintResult]:
-        """Use ``!=`` instead of ``<>`` for "not equal to" comparison."""
+        """Enforce consistent "not equal to" style."""
+        self.preferred_not_equal_style: str
+
         # Get the comparison operator children
         raw_comparison_operators = (
             FunctionalContext(context)
@@ -45,23 +45,46 @@ class Rule_CV01(BaseRule):
             .select(select_if=sp.is_type("raw_comparison_operator"))
         )
 
-        # Only care about ``<>``
-        if [r.raw for r in raw_comparison_operators] != ["<", ">"]:
+        # Only check ``<>`` or ``!=`` operators
+        raw_operator_list = [r.raw for r in raw_comparison_operators]
+        if raw_operator_list not in [["<", ">"], ["!", "="]]:
             return None
+
+        memory = context.memory
+        # If style is consistent, add the style of the first occurence to memory
+        if self.preferred_not_equal_style == "consistent":
+            preferred_not_equal_style = context.memory.get("preferred_not_equal_style")
+            if not preferred_not_equal_style:
+                preferred_not_equal_style = (
+                    "ansi" if raw_operator_list == ["<", ">"] else "c_style"
+                )
+                memory["preferred_not_equal_style"] = preferred_not_equal_style
+        else:
+            preferred_not_equal_style = self.preferred_not_equal_style
+
+        if preferred_not_equal_style == "c_style":
+            replacement = ["!", "="]
+        elif preferred_not_equal_style == "ansi":
+            replacement = ["<", ">"]
+
+        # This operator already matches the existing style
+        if raw_operator_list == replacement:
+            return LintResult(memory=memory)
 
         # Provide a fix and replace ``<>`` with ``!=``
         # As each symbol is a separate symbol this is done in two steps:
-        # 1. Replace < with !
-        # 2. Replace > with =
+        # Depending on style type, flip any inconsistent operators
+        # 1. Flip < and !
+        # 2. Flip > and =
         fixes = [
             LintFix.replace(
                 raw_comparison_operators[0],
-                [SymbolSegment(raw="!", type="raw_comparison_operator")],
+                [SymbolSegment(raw=replacement[0], type="raw_comparison_operator")],
             ),
             LintFix.replace(
                 raw_comparison_operators[1],
-                [SymbolSegment(raw="=", type="raw_comparison_operator")],
+                [SymbolSegment(raw=replacement[1], type="raw_comparison_operator")],
             ),
         ]
 
-        return LintResult(context.segment, fixes)
+        return LintResult(anchor=context.segment, fixes=fixes, memory=memory)

--- a/test/fixtures/rules/std_rule_cases/CV01.yml
+++ b/test/fixtures/rules/std_rule_cases/CV01.yml
@@ -1,35 +1,106 @@
 rule: CV01
 
-test_pass_not_equal_to:
+# tests
+test_pass_consistent_c_style_not_equal_to:
   pass_str: |
     SELECT * FROM X WHERE 1 != 2
 
-test_fail_not_equal_to:
-  fail_str: |
+test_fail_consistent_ansi_not_equal_to:
+  pass_str: |
     SELECT * FROM X WHERE 1 <> 2
-  fix_str: |
-    SELECT * FROM X WHERE 1 != 2
-test_less_than_passes:
+
+test_pass_consistent_less_than:
   pass_str: |
     SELECT * FROM X WHERE 1 < 2
-test_non_comparison_passes:
+
+test_pass_consistent_non_comparison:
   pass_str: |
     SELECT col1 AS "alias_<>" FROM X
 
-test_fail_not_equal_to_multi:
+test_fail_consistent_c_style_not_equal_to_multi:
   fail_str: |
-    SELECT * FROM X WHERE 1 <> 2 AND 2 <> 1 AND 3 != 1
+    SELECT * FROM X WHERE 1 != 2 AND 2 <> 1 AND 3 <> 1
   fix_str: |
     SELECT * FROM X WHERE 1 != 2 AND 2 != 1 AND 3 != 1
 
-test_pass_not_equal_to_tsql:
+test_fail_consistent_ansi_not_equal_to_multi:
+  fail_str: |
+    SELECT * FROM X WHERE 1 <> 2 AND 2 != 1 AND 3 != 1
+  fix_str: |
+    SELECT * FROM X WHERE 1 <> 2 AND 2 <> 1 AND 3 <> 1
+
+test_pass_consistent_c_style_not_equal_to_tsql:
   pass_str: |
     SELECT * FROM X WHERE 1 !   = 2
   configs:
     core:
       dialect: tsql
 
-test_fail_not_equal_to_tsql:
+test_pass_consistent_ansi_not_equal_to_tsql:
+  pass_str: |
+    SELECT * FROM X WHERE 1  <
+      -- some comment
+    > 2
+  configs:
+    core:
+      dialect: tsql
+
+# c_style tests
+test_pass_c_style_not_equal_to:
+  pass_str: |
+    SELECT * FROM X WHERE 1 != 2
+  configs:
+    rules:
+      convention.not_equal:
+        preferred_not_equal_style: "c_style"
+
+test_fail_c_style_not_equal_to:
+  fail_str: |
+    SELECT * FROM X WHERE 1 <> 2
+  fix_str: |
+    SELECT * FROM X WHERE 1 != 2
+  configs:
+    rules:
+      convention.not_equal:
+        preferred_not_equal_style: "c_style"
+
+test_pass_c_style_less_than:
+  pass_str: |
+    SELECT * FROM X WHERE 1 < 2
+  configs:
+    rules:
+      convention.not_equal:
+        preferred_not_equal_style: "c_style"
+
+test_pass_c_style_non_comparison:
+  pass_str: |
+    SELECT col1 AS "alias_<>" FROM X
+  configs:
+    rules:
+      convention.not_equal:
+        preferred_not_equal_style: "c_style"
+
+test_fail_c_style_not_equal_to_multi:
+  fail_str: |
+    SELECT * FROM X WHERE 1 <> 2 AND 2 <> 1 AND 3 != 1
+  fix_str: |
+    SELECT * FROM X WHERE 1 != 2 AND 2 != 1 AND 3 != 1
+  configs:
+    rules:
+      convention.not_equal:
+        preferred_not_equal_style: "c_style"
+
+test_pass_c_style_not_equal_to_tsql:
+  pass_str: |
+    SELECT * FROM X WHERE 1 !   = 2
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      convention.not_equal:
+        preferred_not_equal_style: "c_style"
+
+test_fail_c_style_not_equal_to_tsql:
   fail_str: |
     SELECT * FROM X WHERE 1  <
       -- some comment
@@ -41,3 +112,77 @@ test_fail_not_equal_to_tsql:
   configs:
     core:
       dialect: tsql
+    rules:
+      convention.not_equal:
+        preferred_not_equal_style: "c_style"
+
+# ansi tests
+test_pass_ansi_not_equal_to:
+  pass_str: |
+    SELECT * FROM X WHERE 1 <> 2
+  configs:
+    rules:
+      convention.not_equal:
+        preferred_not_equal_style: "ansi"
+
+test_fail_ansi_not_equal_to:
+  fail_str: |
+    SELECT * FROM X WHERE 1 != 2
+  fix_str: |
+    SELECT * FROM X WHERE 1 <> 2
+  configs:
+    rules:
+      convention.not_equal:
+        preferred_not_equal_style: "ansi"
+
+test_pass_ansi_less_than:
+  pass_str: |
+    SELECT * FROM X WHERE 1 < 2
+  configs:
+    rules:
+      convention.not_equal:
+        preferred_not_equal_style: "ansi"
+
+test_pass_ansi_non_comparison:
+  pass_str: |
+    SELECT col1 AS "alias_<>" FROM X
+  configs:
+    rules:
+      convention.not_equal:
+        preferred_not_equal_style: "ansi"
+
+test_fail_ansi_not_equal_to_multi:
+  fail_str: |
+    SELECT * FROM X WHERE 1 <> 2 AND 2 != 1 AND 3 != 1
+  fix_str: |
+    SELECT * FROM X WHERE 1 <> 2 AND 2 <> 1 AND 3 <> 1
+  configs:
+    rules:
+      convention.not_equal:
+        preferred_not_equal_style: "ansi"
+
+test_pass_ansi_not_equal_to_tsql:
+  pass_str: |
+    SELECT * FROM X WHERE 1 <   > 2
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      convention.not_equal:
+        preferred_not_equal_style: "ansi"
+
+test_fail_ansi_not_equal_to_tsql:
+  fail_str: |
+    SELECT * FROM X WHERE 1  !
+      -- some comment
+    = 2
+  fix_str: |
+    SELECT * FROM X WHERE 1  <
+      -- some comment
+    > 2
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      convention.not_equal:
+        preferred_not_equal_style: "ansi"


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #5529 
This adds an ANSI (`<>`) style and consistent configuration option to CV01.

### Are there any other side effects of this change that we should be aware of?
This changes the default setting from the C (`!=`) style to consistent.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
