### PR TITLE
DuckDB: Add ANTI, SEMI, ASOF, and POSITIONAL joins

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -535,9 +535,12 @@ ansi_dialect.add(
             Ref.keyword("OUTER", optional=True),
         ),
     ),
+    # Extensible in individual dialects
+    NonStandardJoinTypeKeywordsGrammar=Nothing(),
     ConditionalJoinKeywordsGrammar=OneOf(
         Ref("JoinTypeKeywordsGrammar"),
         Ref("ConditionalCrossJoinKeywordsGrammar"),
+        Ref("NonStandardJoinTypeKeywordsGrammar"),
     ),
     # It's as a sequence to allow to parametrize that in Postgres dialect with LATERAL
     JoinKeywordsGrammar=Sequence("JOIN"),
@@ -548,9 +551,13 @@ ansi_dialect.add(
         Ref("JoinTypeKeywordsGrammar", optional=True),
     ),
     UnconditionalCrossJoinKeywordsGrammar=Nothing(),
+    # Some dialects such as DuckDB and Clickhouse support a row by row
+    # join between two tables (e.g. POSITIONAL and PASTE)
+    HorizontalJoinKeywordsGrammar=Nothing(),
     UnconditionalJoinKeywordsGrammar=OneOf(
         Ref("NaturalJoinKeywordsGrammar"),
         Ref("UnconditionalCrossJoinKeywordsGrammar"),
+        Ref("HorizontalJoinKeywordsGrammar"),
     ),
     # This can be overwritten by dialects
     ExtendedNaturalJoinKeywordsGrammar=Nothing(),

--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -40,6 +40,10 @@ duckdb_dialect.sets("reserved_keywords").update(
 
 duckdb_dialect.sets("unreserved_keywords").update(
     [
+        "ANTI",
+        "ASOF",
+        "POSITIONAL",
+        "SEMI",
         "VIRTUAL",
     ]
 )
@@ -75,6 +79,26 @@ duckdb_dialect.replace(
             Ref("SimplifiedPivotExpressionSegment"),
             Ref("SimplifiedUnpivotExpressionSegment"),
         ],
+    ),
+    JoinTypeKeywordsGrammar=postgres_dialect.get_grammar(
+        "JoinTypeKeywordsGrammar"
+    ).copy(
+        insert=[
+            Ref.keyword("ANTI"),
+            Ref.keyword("SEMI"),
+        ],
+    ),
+    ConditionalJoinKeywordsGrammar=postgres_dialect.get_grammar(
+        "ConditionalJoinKeywordsGrammar"
+    ).copy(
+        insert=[
+            Sequence("ASOF", Ref("JoinTypeKeywordsGrammar", optional=True)),
+        ],
+    ),
+    UnconditionalJoinKeywordsGrammar=postgres_dialect.get_grammar(
+        "UnconditionalJoinKeywordsGrammar"
+    ).copy(
+        insert=[Ref.keyword("POSITIONAL")],
     ),
 )
 

--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -80,26 +80,20 @@ duckdb_dialect.replace(
             Ref("SimplifiedUnpivotExpressionSegment"),
         ],
     ),
-    JoinTypeKeywordsGrammar=postgres_dialect.get_grammar(
-        "JoinTypeKeywordsGrammar"
-    ).copy(
-        insert=[
-            Ref.keyword("ANTI"),
-            Ref.keyword("SEMI"),
-        ],
+    NonStandardJoinTypeKeywordsGrammar=OneOf(
+        "ANTI",
+        "SEMI",
+        Sequence(
+            "ASOF",
+            OneOf(
+                Ref("JoinTypeKeywordsGrammar"),
+                "ANTI",
+                "SEMI",
+                optional=True,
+            ),
+        ),
     ),
-    ConditionalJoinKeywordsGrammar=postgres_dialect.get_grammar(
-        "ConditionalJoinKeywordsGrammar"
-    ).copy(
-        insert=[
-            Sequence("ASOF", Ref("JoinTypeKeywordsGrammar", optional=True)),
-        ],
-    ),
-    UnconditionalJoinKeywordsGrammar=postgres_dialect.get_grammar(
-        "UnconditionalJoinKeywordsGrammar"
-    ).copy(
-        insert=[Ref.keyword("POSITIONAL")],
-    ),
+    HorizontalJoinKeywordsGrammar=Ref.keyword("POSITIONAL"),
 )
 
 duckdb_dialect.insert_lexer_matchers(

--- a/test/fixtures/dialects/duckdb/anti_semi_join.sql
+++ b/test/fixtures/dialects/duckdb/anti_semi_join.sql
@@ -1,0 +1,15 @@
+SELECT cars.name, cars.manufacturer
+FROM cars SEMI JOIN region
+ON cars.region = region.id;
+
+SELECT cars.name, cars.manufacturer
+FROM cars ANTI JOIN safety_data
+ON cars.safety_report_id = safety_data.report_id;
+
+SELECT cars.name, cars.manufacturer
+FROM cars SEMI JOIN region
+USING (region_id);
+
+SELECT cars.name, cars.manufacturer
+FROM cars ANTI JOIN region
+USING (region_id);

--- a/test/fixtures/dialects/duckdb/anti_semi_join.yml
+++ b/test/fixtures/dialects/duckdb/anti_semi_join.yml
@@ -1,0 +1,93 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: baa236dee663f5af04feb422cb15ff1cedea974b235e9895f76f5bb1d3850d16
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: manufacturer
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: cars
+          join_clause:
+          - keyword: SEMI
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: region
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - naked_identifier: cars
+                - dot: .
+                - naked_identifier: region
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: region
+                - dot: .
+                - naked_identifier: id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: manufacturer
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: cars
+          join_clause:
+          - keyword: ANTI
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: safety_data
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - naked_identifier: cars
+                - dot: .
+                - naked_identifier: safety_report_id
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: safety_data
+                - dot: .
+                - naked_identifier: report_id
+- statement_terminator: ;

--- a/test/fixtures/dialects/duckdb/anti_semi_join.yml
+++ b/test/fixtures/dialects/duckdb/anti_semi_join.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: baa236dee663f5af04feb422cb15ff1cedea974b235e9895f76f5bb1d3850d16
+_hash: 1c574210a093244da340d0d2579eb64c78c83f678b1c2e34a9d1bc63889680b6
 file:
 - statement:
     select_statement:
@@ -90,4 +90,74 @@ file:
                 - naked_identifier: safety_data
                 - dot: .
                 - naked_identifier: report_id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: manufacturer
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: cars
+          join_clause:
+          - keyword: SEMI
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: region
+          - keyword: USING
+          - bracketed:
+              start_bracket: (
+              naked_identifier: region_id
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: cars
+          - dot: .
+          - naked_identifier: manufacturer
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: cars
+          join_clause:
+          - keyword: ANTI
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: region
+          - keyword: USING
+          - bracketed:
+              start_bracket: (
+              naked_identifier: region_id
+              end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/duckdb/asof_join.sql
+++ b/test/fixtures/dialects/duckdb/asof_join.sql
@@ -1,0 +1,40 @@
+SELECT
+    t.*,
+    p.price
+FROM trades AS t ASOF JOIN prices AS p
+    ON t.symbol = p.symbol AND t.when >= p.when;
+
+SELECT *
+FROM trades AS t ASOF LEFT JOIN prices AS p
+    ON t.symbol = p.symbol AND t.when >= p.when;
+
+SELECT *
+FROM trades AS t ASOF RIGHT JOIN prices AS p
+    ON t.symbol = p.symbol AND t.when >= p.when;
+
+SELECT *
+FROM trades AS t ASOF FULL OUTER JOIN prices AS p
+    ON t.symbol = p.symbol AND t.when >= p.when;
+
+SELECT *
+FROM trades AS t ASOF ANTI JOIN prices AS p
+    ON t.symbol = p.symbol AND t.when >= p.when;
+
+SELECT *
+FROM trades AS t ASOF SEMI JOIN prices AS p
+    ON t.symbol = p.symbol AND t.when >= p.when;
+
+
+-- ASOF joins can also specify join conditions on matching column names with
+-- the USING syntax, but the last attribute in the list must be the inequality,
+-- which will be greater than or equal to (>=):
+SELECT *
+FROM trades ASOF JOIN prices USING (symbol, "when");
+-- Returns symbol, trades.when, price (but NOT prices.when)
+
+SELECT
+    t.symbol,
+    t.when AS trade_when,
+    p.when AS price_when,
+    price
+FROM trades AS t ASOF LEFT JOIN prices AS p USING (symbol, "when");

--- a/test/fixtures/dialects/duckdb/asof_join.yml
+++ b/test/fixtures/dialects/duckdb/asof_join.yml
@@ -1,0 +1,435 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e822c0f9ea346cb2ecac9dba634ddc798bee26c466402d20c982e94dfbb57078
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              naked_identifier: t
+              dot: .
+              star: '*'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: p
+          - dot: .
+          - naked_identifier: price
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: trades
+            alias_expression:
+              keyword: AS
+              naked_identifier: t
+          join_clause:
+          - keyword: ASOF
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: prices
+              alias_expression:
+                keyword: AS
+                naked_identifier: p
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: symbol
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: symbol
+              - binary_operator: AND
+              - column_reference:
+                  naked_identifier: t
+                  dot: .
+                  naked_identifier_all: when
+              - comparison_operator:
+                - raw_comparison_operator: '>'
+                - raw_comparison_operator: '='
+              - column_reference:
+                  naked_identifier: p
+                  dot: .
+                  naked_identifier_all: when
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: trades
+            alias_expression:
+              keyword: AS
+              naked_identifier: t
+          join_clause:
+          - keyword: ASOF
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: prices
+              alias_expression:
+                keyword: AS
+                naked_identifier: p
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: symbol
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: symbol
+              - binary_operator: AND
+              - column_reference:
+                  naked_identifier: t
+                  dot: .
+                  naked_identifier_all: when
+              - comparison_operator:
+                - raw_comparison_operator: '>'
+                - raw_comparison_operator: '='
+              - column_reference:
+                  naked_identifier: p
+                  dot: .
+                  naked_identifier_all: when
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: trades
+            alias_expression:
+              keyword: AS
+              naked_identifier: t
+          join_clause:
+          - keyword: ASOF
+          - keyword: RIGHT
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: prices
+              alias_expression:
+                keyword: AS
+                naked_identifier: p
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: symbol
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: symbol
+              - binary_operator: AND
+              - column_reference:
+                  naked_identifier: t
+                  dot: .
+                  naked_identifier_all: when
+              - comparison_operator:
+                - raw_comparison_operator: '>'
+                - raw_comparison_operator: '='
+              - column_reference:
+                  naked_identifier: p
+                  dot: .
+                  naked_identifier_all: when
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: trades
+            alias_expression:
+              keyword: AS
+              naked_identifier: t
+          join_clause:
+          - keyword: ASOF
+          - keyword: FULL
+          - keyword: OUTER
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: prices
+              alias_expression:
+                keyword: AS
+                naked_identifier: p
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: symbol
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: symbol
+              - binary_operator: AND
+              - column_reference:
+                  naked_identifier: t
+                  dot: .
+                  naked_identifier_all: when
+              - comparison_operator:
+                - raw_comparison_operator: '>'
+                - raw_comparison_operator: '='
+              - column_reference:
+                  naked_identifier: p
+                  dot: .
+                  naked_identifier_all: when
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: trades
+            alias_expression:
+              keyword: AS
+              naked_identifier: t
+          join_clause:
+          - keyword: ASOF
+          - keyword: ANTI
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: prices
+              alias_expression:
+                keyword: AS
+                naked_identifier: p
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: symbol
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: symbol
+              - binary_operator: AND
+              - column_reference:
+                  naked_identifier: t
+                  dot: .
+                  naked_identifier_all: when
+              - comparison_operator:
+                - raw_comparison_operator: '>'
+                - raw_comparison_operator: '='
+              - column_reference:
+                  naked_identifier: p
+                  dot: .
+                  naked_identifier_all: when
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: trades
+            alias_expression:
+              keyword: AS
+              naked_identifier: t
+          join_clause:
+          - keyword: ASOF
+          - keyword: SEMI
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: prices
+              alias_expression:
+                keyword: AS
+                naked_identifier: p
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: symbol
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: symbol
+              - binary_operator: AND
+              - column_reference:
+                  naked_identifier: t
+                  dot: .
+                  naked_identifier_all: when
+              - comparison_operator:
+                - raw_comparison_operator: '>'
+                - raw_comparison_operator: '='
+              - column_reference:
+                  naked_identifier: p
+                  dot: .
+                  naked_identifier_all: when
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: trades
+          join_clause:
+          - keyword: ASOF
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: prices
+          - keyword: USING
+          - bracketed:
+              start_bracket: (
+              naked_identifier: symbol
+              comma: ','
+              quoted_identifier: '"when"'
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: t
+          - dot: .
+          - naked_identifier: symbol
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: t
+            dot: .
+            naked_identifier_all: when
+          alias_expression:
+            keyword: AS
+            naked_identifier: trade_when
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: p
+            dot: .
+            naked_identifier_all: when
+          alias_expression:
+            keyword: AS
+            naked_identifier: price_when
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: price
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: trades
+            alias_expression:
+              keyword: AS
+              naked_identifier: t
+          join_clause:
+          - keyword: ASOF
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: prices
+              alias_expression:
+                keyword: AS
+                naked_identifier: p
+          - keyword: USING
+          - bracketed:
+              start_bracket: (
+              naked_identifier: symbol
+              comma: ','
+              quoted_identifier: '"when"'
+              end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/duckdb/positional_join.sql
+++ b/test/fixtures/dialects/duckdb/positional_join.sql
@@ -1,0 +1,5 @@
+-- treat two data frames as a single table
+SELECT
+    df1.*,
+    df2.*
+FROM df1 POSITIONAL JOIN df2;

--- a/test/fixtures/dialects/duckdb/positional_join.yml
+++ b/test/fixtures/dialects/duckdb/positional_join.yml
@@ -1,0 +1,39 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 627d2700c6b7ee556b3ea7b2ab29f4634cc939f80fac84e6f45f5239ac117968
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              naked_identifier: df1
+              dot: .
+              star: '*'
+      - comma: ','
+      - select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              naked_identifier: df2
+              dot: .
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: df1
+          join_clause:
+          - keyword: POSITIONAL
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: df2
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #5536 
- Add the conditional joins `ANTI`, `SEMI`, and `ASOF`
- Add the unconditional join `POSITIONAL`

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
