### PR TITLE
Databricks: fix `EXCEPT` with qualified column reference

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -3295,7 +3295,7 @@ class ExceptClauseSegment(BaseSegment):
     type = "select_except_clause"
     match_grammar = Sequence(
         "EXCEPT",
-        Bracketed(Delimited(Ref("SingleIdentifierGrammar"))),
+        Bracketed(Delimited(Ref("ColumnReferenceSegment"))),
     )
 
 

--- a/test/fixtures/dialects/sparksql/select_star_except.sql
+++ b/test/fixtures/dialects/sparksql/select_star_except.sql
@@ -5,3 +5,5 @@ except (col)
 from table_name where row_no = 1;
 
 select * except (col1, col2, col3, col4, col5) from table_name where row_no = 1;
+
+select a.* except (a.b) from a;

--- a/test/fixtures/dialects/sparksql/select_star_except.yml
+++ b/test/fixtures/dialects/sparksql/select_star_except.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cf951c121772e7daad8ad73fa0d9ad5377c234e3d698b732a743316409429048
+_hash: be4429aa76f902654b502847e39a9679f51e7a8dd4a0e622d75ab8486962b5c6
 file:
 - statement:
     select_statement:
@@ -17,7 +17,8 @@ file:
               keyword: except
               bracketed:
                 start_bracket: (
-                naked_identifier: col
+                column_reference:
+                  naked_identifier: col
                 end_bracket: )
       from_clause:
         keyword: from
@@ -47,7 +48,8 @@ file:
               keyword: except
               bracketed:
                 start_bracket: (
-                naked_identifier: col
+                column_reference:
+                  naked_identifier: col
                 end_bracket: )
       from_clause:
         keyword: from
@@ -77,15 +79,20 @@ file:
               keyword: except
               bracketed:
               - start_bracket: (
-              - naked_identifier: col1
+              - column_reference:
+                  naked_identifier: col1
               - comma: ','
-              - naked_identifier: col2
+              - column_reference:
+                  naked_identifier: col2
               - comma: ','
-              - naked_identifier: col3
+              - column_reference:
+                  naked_identifier: col3
               - comma: ','
-              - naked_identifier: col4
+              - column_reference:
+                  naked_identifier: col4
               - comma: ','
-              - naked_identifier: col5
+              - column_reference:
+                  naked_identifier: col5
               - end_bracket: )
       from_clause:
         keyword: from
@@ -102,4 +109,31 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              naked_identifier: a
+              dot: .
+              star: '*'
+            select_except_clause:
+              keyword: except
+              bracketed:
+                start_bracket: (
+                column_reference:
+                - naked_identifier: a
+                - dot: .
+                - naked_identifier: b
+                end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: a
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #5223 
- Fixes `EXCEPT` clause for Databricks with a qualified column reference

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
