### PR TITLE
[Docs] Use extended policy for identifier capitalisation in starter config

### DIFF
--- a/docs/source/partials/starter_config.cfg
+++ b/docs/source/partials/starter_config.cfg
@@ -59,7 +59,7 @@ min_alias_length = 3
 [sqlfluff:rules:capitalisation.keywords]
 capitalisation_policy = lower
 [sqlfluff:rules:capitalisation.identifiers]
-capitalisation_policy = lower
+extended_capitalisation_policy = lower
 [sqlfluff:rules:capitalisation.functions]
 extended_capitalisation_policy = lower
 [sqlfluff:rules:capitalisation.literals]


### PR DESCRIPTION
Update docs starter config to use `extended_capitalisation_policy` for `capitalisation.identifiers`, since `capitalisation_policy` seems to not work there.

https://docs.sqlfluff.com/en/stable/rules.html#rule-capitalisation.identifiers