### PR TITLE
Build: linting black 24.1.0 rules update

### DIFF
--- a/plugins/sqlfluff-plugin-example/setup.py
+++ b/plugins/sqlfluff-plugin-example/setup.py
@@ -1,4 +1,5 @@
 """Setup file for an example rules plugin."""
+
 from setuptools import find_packages, setup
 
 # Change these names in your plugin, e.g. company name or plugin purpose.

--- a/plugins/sqlfluff-plugin-example/test/rules/rule_test_cases_test.py
+++ b/plugins/sqlfluff-plugin-example/test/rules/rule_test_cases_test.py
@@ -1,4 +1,5 @@
 """Runs the rule test cases."""
+
 import os
 
 import pytest

--- a/plugins/sqlfluff-templater-dbt/setup.py
+++ b/plugins/sqlfluff-templater-dbt/setup.py
@@ -1,4 +1,5 @@
 """Setup file for example plugin."""
+
 from setuptools import setup
 
 setup()

--- a/plugins/sqlfluff-templater-dbt/test/conftest.py
+++ b/plugins/sqlfluff-templater-dbt/test/conftest.py
@@ -1,4 +1,5 @@
 """pytest fixtures."""
+
 import os
 
 import pytest

--- a/plugins/sqlfluff-templater-dbt/test/rules_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/rules_test.py
@@ -1,4 +1,5 @@
 """Tests for the standard set of rules."""
+
 import os
 import os.path
 from pathlib import Path

--- a/src/sqlfluff/__init__.py
+++ b/src/sqlfluff/__init__.py
@@ -1,4 +1,5 @@
 """Sqlfluff is a SQL linter for humans."""
+
 import sys
 from importlib import metadata
 

--- a/src/sqlfluff/__main__.py
+++ b/src/sqlfluff/__main__.py
@@ -1,4 +1,5 @@
 """Export cli to __main__ for use like python -m sqlfluff."""
+
 from sqlfluff.cli.commands import cli
 
 if __name__ == "__main__":

--- a/src/sqlfluff/cli/__init__.py
+++ b/src/sqlfluff/cli/__init__.py
@@ -1,6 +1,5 @@
 """init py for cli."""
 
-
 EXIT_SUCCESS = 0
 EXIT_FAIL = 1
 EXIT_ERROR = 2

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -682,9 +682,9 @@ def lint(
                         # to warnings using the `warnings` config value. Any which have
                         # been set to warn rather than fail will always be given the
                         # `notice` annotation level in the serialised result.
-                        "annotation_level": annotation_level
-                        if not violation["warning"]
-                        else "notice",
+                        "annotation_level": (
+                            annotation_level if not violation["warning"] else "notice"
+                        ),
                     }
                 )
         file_output = json.dumps(github_result)
@@ -1300,11 +1300,13 @@ def parse(
         parsed_strings_dict = [
             dict(
                 filepath=linted_result.fname,
-                segments=linted_result.tree.as_record(
-                    code_only=code_only, show_raw=True, include_meta=include_meta
-                )
-                if linted_result.tree
-                else None,
+                segments=(
+                    linted_result.tree.as_record(
+                        code_only=code_only, show_raw=True, include_meta=include_meta
+                    )
+                    if linted_result.tree
+                    else None
+                ),
             )
             for linted_result in parsed_strings
         ]

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -1,4 +1,5 @@
 """Defines the formatters for the CLI."""
+
 import sys
 from io import StringIO
 from typing import List, Optional, Tuple, Union
@@ -486,9 +487,11 @@ class OutputStreamFormatter:
         summary_content = [
             (
                 key,
-                special_formats[key].format(all_stats[key])
-                if key in special_formats
-                else all_stats[key],
+                (
+                    special_formats[key].format(all_stats[key])
+                    if key in special_formats
+                    else all_stats[key]
+                ),
             )
             for key in output_fields
         ]

--- a/src/sqlfluff/cli/outputstream.py
+++ b/src/sqlfluff/cli/outputstream.py
@@ -1,4 +1,5 @@
 """Classes for managing linter output, used with OutputStreamFormatter."""
+
 import abc
 import os
 from typing import Any, Optional

--- a/src/sqlfluff/core/enums.py
+++ b/src/sqlfluff/core/enums.py
@@ -1,4 +1,5 @@
 """Enums used by sqlfluff."""
+
 from enum import Enum
 
 from colorama import Back, Fore, Style

--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -10,6 +10,7 @@ tracking.
 
 https://stackoverflow.com/questions/49715881/how-to-pickle-inherited-exceptions
 """
+
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union, cast
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -247,9 +247,11 @@ class Linter:
                     "Line {0[0]}, Position {0[1]}: Found unparsable section: "
                     "{1!r}".format(
                         unparsable.pos_marker.working_loc,
-                        unparsable.raw
-                        if len(unparsable.raw) < 40
-                        else unparsable.raw[:40] + "...",
+                        (
+                            unparsable.raw
+                            if len(unparsable.raw) < 40
+                            else unparsable.raw[:40] + "..."
+                        ),
                     ),
                     segment=unparsable,
                 )

--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -6,6 +6,7 @@ Implements various runner types for SQLFluff:
   - Multiprocess
   - Multithread (used only by automated tests)
 """
+
 import bdb
 import functools
 import logging

--- a/src/sqlfluff/core/parser/grammar/delimited.py
+++ b/src/sqlfluff/core/parser/grammar/delimited.py
@@ -144,9 +144,9 @@ class Delimited(OneOf):
             ) as ctx:
                 match, _ = longest_match(
                     segments=segments,
-                    matchers=delimiter_matchers
-                    if seeking_delimiter
-                    else self._elements,
+                    matchers=(
+                        delimiter_matchers if seeking_delimiter else self._elements
+                    ),
                     idx=working_idx,
                     parse_context=ctx,
                 )

--- a/src/sqlfluff/core/parser/lexer.py
+++ b/src/sqlfluff/core/parser/lexer.py
@@ -812,9 +812,11 @@ class Lexer:
         # Add an end of file marker
         segment_buffer.append(
             EndOfFile(
-                pos_marker=segment_buffer[-1].pos_marker.end_point_marker()
-                if segment_buffer
-                else PositionMarker.from_point(0, 0, templated_file)
+                pos_marker=(
+                    segment_buffer[-1].pos_marker.end_point_marker()
+                    if segment_buffer
+                    else PositionMarker.from_point(0, 0, templated_file)
+                )
             )
         )
         # Convert to tuple before return

--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -7,6 +7,7 @@ Here we define:
   function failed on this block of segments and to prevent further
   analysis.
 """
+
 # Import annotations for py 3.7 to allow `weakref.ReferenceType["BaseSegment"]`
 from __future__ import annotations
 

--- a/src/sqlfluff/core/parser/types.py
+++ b/src/sqlfluff/core/parser/types.py
@@ -1,4 +1,5 @@
 """Complex Type helpers."""
+
 from enum import Enum
 from typing import TYPE_CHECKING, FrozenSet, Optional, Tuple, Union
 

--- a/src/sqlfluff/core/plugin/__init__.py
+++ b/src/sqlfluff/core/plugin/__init__.py
@@ -1,4 +1,5 @@
 """Marker to be imported and used in plugins (and for own implementations)."""
+
 from typing import Any, Callable, TypeVar, cast
 
 import pluggy

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -512,9 +512,12 @@ class BaseRule(metaclass=RuleMetaclass):
             except Exception as e:
                 # If a filename is present, include it in the critical exception.
                 self.logger.critical(
-                    f"Applying rule {self.code} to {fname!r} threw an Exception: {e}"
-                    if fname
-                    else f"Applying rule {self.code} threw an Exception: {e}",
+                    (
+                        f"Applying rule {self.code} to {fname!r} "
+                        f"threw an Exception: {e}"
+                        if fname
+                        else f"Applying rule {self.code} threw an Exception: {e}"
+                    ),
                     exc_info=True,
                 )
                 assert context.segment.pos_marker
@@ -743,9 +746,11 @@ class BaseRule(metaclass=RuleMetaclass):
             if fix.anchor:
                 fix.anchor = cls._choose_anchor_segment(
                     # If no parent stack, that means the segment itself is the root
-                    context.parent_stack[0]
-                    if context.parent_stack
-                    else context.segment,
+                    (
+                        context.parent_stack[0]
+                        if context.parent_stack
+                        else context.segment
+                    ),
                     fix.edit_type,
                     fix.anchor,
                 )

--- a/src/sqlfluff/core/rules/context.py
+++ b/src/sqlfluff/core/rules/context.py
@@ -1,6 +1,5 @@
 """Define RuleContext class."""
 
-
 import pathlib
 from dataclasses import dataclass, field
 from typing import Any, Optional, Tuple

--- a/src/sqlfluff/core/rules/doc_decorators.py
+++ b/src/sqlfluff/core/rules/doc_decorators.py
@@ -5,6 +5,7 @@ NOTE: All of these decorators are deprecated from SQLFluff 2.0.0 onwards.
 They are still included to allow a transition period, but the functionality
 is now packaged in the BaseRule class via the RuleMetaclass.
 """
+
 from typing import TYPE_CHECKING, Any, Type
 
 from sqlfluff.core.rules.base import rules_logger  # noqa

--- a/src/sqlfluff/core/rules/reference.py
+++ b/src/sqlfluff/core/rules/reference.py
@@ -1,4 +1,5 @@
 """Components for working with object and table references."""
+
 from typing import Sequence, Tuple
 
 

--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -1,4 +1,5 @@
 """Defines the templaters."""
+
 import copy
 import importlib
 import logging
@@ -727,10 +728,12 @@ class JinjaTemplater(PythonTemplater):
 
             # Render and analyze the template with the overrides.
             variant_key = tuple(
-                cast(str, tracer_trace.raw_slice_info[rs].alternate_code)
-                if idx in override_raw_slices
-                and tracer_trace.raw_slice_info[rs].alternate_code is not None
-                else rs.raw
+                (
+                    cast(str, tracer_trace.raw_slice_info[rs].alternate_code)
+                    if idx in override_raw_slices
+                    and tracer_trace.raw_slice_info[rs].alternate_code is not None
+                    else rs.raw
+                )
                 for idx, rs in enumerate(tracer_trace.raw_sliced)
             )
             # In some cases (especially with nested if statements), we may

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -2,6 +2,7 @@
 
 This is a newer slicing algorithm that handles cases heuristic.py does not.
 """
+
 # Import annotations for py 3.7 to allow `regex.Match[str]`
 from __future__ import annotations
 
@@ -68,9 +69,11 @@ class JinjaTracer:
     ) -> JinjaTrace:
         """Executes raw_str. Returns template output and trace."""
         trace_template_str = "".join(
-            cast(str, self.raw_slice_info[rs].alternate_code)
-            if self.raw_slice_info[rs].alternate_code is not None
-            else rs.raw
+            (
+                cast(str, self.raw_slice_info[rs].alternate_code)
+                if self.raw_slice_info[rs].alternate_code is not None
+                else rs.raw
+            )
             for rs in self.raw_sliced
         )
         trace_template_output = self.render_func(trace_template_str)
@@ -218,9 +221,11 @@ class JinjaTracer:
                 slice_type,
                 slice(
                     self.raw_sliced[slice_idx].source_idx,
-                    self.raw_sliced[slice_idx + 1].source_idx
-                    if slice_idx + 1 < len(self.raw_sliced)
-                    else len(self.raw_str),
+                    (
+                        self.raw_sliced[slice_idx + 1].source_idx
+                        if slice_idx + 1 < len(self.raw_sliced)
+                        else len(self.raw_str)
+                    ),
                 ),
                 slice(self.source_idx, self.source_idx + target_slice_length),
             )
@@ -474,9 +479,9 @@ class JinjaAnalyzer:
                             block_idx,
                         )
                     )
-                    self.raw_slice_info[
-                        self.raw_sliced[-1]
-                    ] = self.slice_info_for_literal(0)
+                    self.raw_slice_info[self.raw_sliced[-1]] = (
+                        self.slice_info_for_literal(0)
+                    )
                     self.idx_raw += trailing_chars
                 else:
                     self.raw_sliced.append(

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -2,6 +2,7 @@
 
 https://clickhouse.com/
 """
+
 from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
     AnyNumberOf,

--- a/src/sqlfluff/dialects/dialect_materialize.py
+++ b/src/sqlfluff/dialects/dialect_materialize.py
@@ -3,6 +3,7 @@
 This is based on postgres dialect, since it was initially based off of Postgres.
 We should monitor in future and see if it should be rebased off of ANSI
 """
+
 from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
     Anything,

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -2,6 +2,7 @@
 
 This inherits from the ansi dialect.
 """
+
 from typing import cast
 
 from sqlfluff.core.dialects import load_raw_dialect
@@ -380,7 +381,7 @@ class AlterTableColumnClausesSegment(BaseSegment):
             Ref("ColumnReferenceSegment"),
             "TO",
             Ref("ColumnReferenceSegment"),
-        )
+        ),
         # @TODO: modify_collection_retrieval
         # @TODO: modify_LOB_storage_clause
         # @TODO: alter_varray_col_properties

--- a/src/sqlfluff/dialects/dialect_postgres_keywords.py
+++ b/src/sqlfluff/dialects/dialect_postgres_keywords.py
@@ -8,6 +8,7 @@ default keyword definition, these keywords are, or have been, an ANSI keyword.
 There are also some keywords that are(n't) supported as types and function, but there
 isn't support for that distinction at present.
 """
+
 from typing import List, Tuple
 
 

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -3,6 +3,7 @@
 This is based on postgres dialect, since it was initially based off of Postgres 8.
 We should monitor in future and see if it should be rebased off of ANSI
 """
+
 from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
     AnyNumberOf,

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2361,7 +2361,7 @@ class ColumnConstraintSegment(BaseSegment):
             ),
             # computed_column_definition
             Sequence("AS", Ref("ExpressionSegment")),
-            Sequence("PERSISTED", Sequence("NOT", "NULL", optional=True))
+            Sequence("PERSISTED", Sequence("NOT", "NULL", optional=True)),
             # other optional blocks (RelationalIndexOptionsSegment,
             # OnIndexOptionSegment, ReferencesConstraintGrammar, CheckConstraintGrammar)
             # are mentioned above

--- a/src/sqlfluff/diff_quality_plugin.py
+++ b/src/sqlfluff/diff_quality_plugin.py
@@ -1,4 +1,5 @@
 """This module integrates SQLFluff with diff_cover's "diff-quality" tool."""
+
 import copy
 import json
 import logging
@@ -101,9 +102,11 @@ class SQLFluffViolationReporter(QualityReporter):
                 # Run SQLFluff.
                 printable_command = " ".join(
                     [
-                        c.decode(sys.getfilesystemencoding())
-                        if isinstance(c, bytes)
-                        else c
+                        (
+                            c.decode(sys.getfilesystemencoding())
+                            if isinstance(c, bytes)
+                            else c
+                        )
                         for c in command
                     ]
                 )

--- a/src/sqlfluff/rules/aliasing/AL01.py
+++ b/src/sqlfluff/rules/aliasing/AL01.py
@@ -1,4 +1,5 @@
 """Implementation of Rule AL01."""
+
 from typing import Optional, Tuple, cast
 
 from sqlfluff.core.parser import (

--- a/src/sqlfluff/rules/aliasing/AL02.py
+++ b/src/sqlfluff/rules/aliasing/AL02.py
@@ -1,4 +1,5 @@
 """Implementation of Rule AL02."""
+
 from typing import Optional
 
 from sqlfluff.core.rules import LintResult, RuleContext

--- a/src/sqlfluff/rules/aliasing/AL03.py
+++ b/src/sqlfluff/rules/aliasing/AL03.py
@@ -1,4 +1,5 @@
 """Implementation of Rule AL03."""
+
 from typing import Optional
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext

--- a/src/sqlfluff/rules/ambiguous/AM01.py
+++ b/src/sqlfluff/rules/ambiguous/AM01.py
@@ -1,4 +1,5 @@
 """Implementation of Rule AM01."""
+
 from typing import Optional, Tuple
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext

--- a/src/sqlfluff/rules/ambiguous/AM02.py
+++ b/src/sqlfluff/rules/ambiguous/AM02.py
@@ -1,4 +1,5 @@
 """Implementation of Rule AM02."""
+
 from typing import Tuple
 
 from sqlfluff.core.parser import (

--- a/src/sqlfluff/rules/ambiguous/AM04.py
+++ b/src/sqlfluff/rules/ambiguous/AM04.py
@@ -1,4 +1,5 @@
 """Implementation of Rule AM04."""
+
 from typing import Optional, Tuple
 
 from sqlfluff.core.parser import BaseSegment

--- a/src/sqlfluff/rules/ambiguous/AM05.py
+++ b/src/sqlfluff/rules/ambiguous/AM05.py
@@ -1,4 +1,5 @@
 """Implementation of Rule AM05."""
+
 from typing import Optional, Tuple
 
 from sqlfluff.core.parser import KeywordSegment, WhitespaceSegment

--- a/src/sqlfluff/rules/ambiguous/AM06.py
+++ b/src/sqlfluff/rules/ambiguous/AM06.py
@@ -1,4 +1,5 @@
 """Implementation of Rule AM06."""
+
 from typing import List, Optional, Tuple
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
@@ -155,9 +156,9 @@ class Rule_AM06(BaseRule):
                         memory=context.memory,
                     )
 
-                context.memory[
-                    "prior_group_by_order_by_convention"
-                ] = current_group_by_order_by_convention
+                context.memory["prior_group_by_order_by_convention"] = (
+                    current_group_by_order_by_convention
+                )
         else:
             # If explicit or implicit naming then raise lint error
             # if the opposite reference type is detected.

--- a/src/sqlfluff/rules/ambiguous/AM07.py
+++ b/src/sqlfluff/rules/ambiguous/AM07.py
@@ -1,4 +1,5 @@
 """Implementation of Rule AM07."""
+
 from typing import Optional, Set, Tuple
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext

--- a/src/sqlfluff/rules/convention/CV03.py
+++ b/src/sqlfluff/rules/convention/CV03.py
@@ -1,4 +1,5 @@
 """Implementation of Rule CV03."""
+
 from typing import Optional
 
 from sqlfluff.core.parser import BaseSegment, SymbolSegment

--- a/src/sqlfluff/rules/convention/CV04.py
+++ b/src/sqlfluff/rules/convention/CV04.py
@@ -1,4 +1,5 @@
 """Implementation of Rule CV04."""
+
 from typing import Optional
 
 from sqlfluff.core.parser import RawSegment, SymbolSegment

--- a/src/sqlfluff/rules/convention/CV05.py
+++ b/src/sqlfluff/rules/convention/CV05.py
@@ -1,4 +1,5 @@
 """Implementation of Rule CV05."""
+
 from typing import List, Optional, Union
 
 from sqlfluff.core.parser import KeywordSegment, WhitespaceSegment

--- a/src/sqlfluff/rules/convention/CV06.py
+++ b/src/sqlfluff/rules/convention/CV06.py
@@ -1,4 +1,5 @@
 """Implementation of Rule CV06."""
+
 from typing import List, NamedTuple, Optional, Sequence, cast
 
 from sqlfluff.core.parser import BaseSegment, NewlineSegment, RawSegment, SymbolSegment
@@ -222,10 +223,7 @@ class Rule_CV06(BaseRule):
         # Adjust before_segment and anchor_segment for preceding inline
         # comments. Inline comments can contain noqa logic so we need to add the
         # newline after the inline comment.
-        (
-            before_segment,
-            anchor_segment,
-        ) = self._handle_preceding_inline_comments(
+        (before_segment, anchor_segment) = self._handle_preceding_inline_comments(
             info.before_segment, info.anchor_segment
         )
 

--- a/src/sqlfluff/rules/convention/CV07.py
+++ b/src/sqlfluff/rules/convention/CV07.py
@@ -1,4 +1,5 @@
 """Implementation of Rule CV07."""
+
 from typing import List
 
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext

--- a/src/sqlfluff/rules/convention/CV08.py
+++ b/src/sqlfluff/rules/convention/CV08.py
@@ -1,4 +1,5 @@
 """Implementation of Rule CV08."""
+
 from typing import Optional
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext

--- a/src/sqlfluff/rules/convention/CV10.py
+++ b/src/sqlfluff/rules/convention/CV10.py
@@ -145,9 +145,9 @@ class Rule_CV10(BaseRule):
                     if context.segment.raw[-1] == '"'
                     else "single_quotes"
                 )
-                memory[
-                    "preferred_quoted_literal_style"
-                ] = preferred_quoted_literal_style
+                memory["preferred_quoted_literal_style"] = (
+                    preferred_quoted_literal_style
+                )
                 self.logger.debug(
                     "Preferred string quotes is set to `consistent`. Derived quoting "
                     "style %s from first quoted literal.",

--- a/src/sqlfluff/rules/jinja/JJ01.py
+++ b/src/sqlfluff/rules/jinja/JJ01.py
@@ -1,4 +1,5 @@
 """Implementation of Rule JJ01."""
+
 from typing import List, Tuple
 
 from sqlfluff.core.parser.segments import BaseSegment, SourceFix

--- a/src/sqlfluff/rules/layout/LT01.py
+++ b/src/sqlfluff/rules/layout/LT01.py
@@ -1,4 +1,5 @@
 """Implementation of Rule LT01."""
+
 from typing import List, Optional
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext

--- a/src/sqlfluff/rules/layout/LT02.py
+++ b/src/sqlfluff/rules/layout/LT02.py
@@ -1,4 +1,5 @@
 """Implementation of Rule LT02."""
+
 from typing import List
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext

--- a/src/sqlfluff/rules/layout/LT09.py
+++ b/src/sqlfluff/rules/layout/LT09.py
@@ -202,9 +202,11 @@ class Rule_LT09(BaseRule):
                     start_seg = segment.segments.index(modifier)
 
                 ws_to_delete = segment.select_children(
-                    start_seg=segment.segments[start_seg]
-                    if not i
-                    else select_targets_info.select_targets[i - 1],
+                    start_seg=(
+                        segment.segments[start_seg]
+                        if not i
+                        else select_targets_info.select_targets[i - 1]
+                    ),
                     select_if=lambda s: s.is_type("whitespace"),
                     loop_while=lambda s: s.is_type("whitespace", "comma") or s.is_meta,
                 )

--- a/src/sqlfluff/rules/layout/LT10.py
+++ b/src/sqlfluff/rules/layout/LT10.py
@@ -1,4 +1,5 @@
 """Implementation of Rule LT10."""
+
 from typing import Optional
 
 from sqlfluff.core.parser import NewlineSegment, WhitespaceSegment

--- a/src/sqlfluff/rules/layout/LT11.py
+++ b/src/sqlfluff/rules/layout/LT11.py
@@ -1,4 +1,5 @@
 """Implementation of Rule LT11."""
+
 from typing import List
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext

--- a/src/sqlfluff/rules/layout/LT12.py
+++ b/src/sqlfluff/rules/layout/LT12.py
@@ -1,4 +1,5 @@
 """Implementation of Rule LT12."""
+
 from typing import List, Optional, Tuple
 
 from sqlfluff.core.parser import BaseSegment, NewlineSegment

--- a/src/sqlfluff/rules/layout/LT13.py
+++ b/src/sqlfluff/rules/layout/LT13.py
@@ -1,4 +1,5 @@
 """Implementation of Rule LT13."""
+
 from typing import Optional
 
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext

--- a/src/sqlfluff/rules/references/RF01.py
+++ b/src/sqlfluff/rules/references/RF01.py
@@ -1,4 +1,5 @@
 """Implementation of Rule RF01."""
+
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple, cast
 

--- a/src/sqlfluff/rules/references/RF02.py
+++ b/src/sqlfluff/rules/references/RF02.py
@@ -1,4 +1,5 @@
 """Implementation of Rule RF02."""
+
 from typing import List, Optional
 
 import regex

--- a/src/sqlfluff/rules/references/RF04.py
+++ b/src/sqlfluff/rules/references/RF04.py
@@ -1,4 +1,5 @@
 """Implementation of Rule RF04."""
+
 from typing import List, Optional
 
 import regex

--- a/src/sqlfluff/rules/references/RF05.py
+++ b/src/sqlfluff/rules/references/RF05.py
@@ -1,4 +1,5 @@
 """Implementation of Rule RF05."""
+
 from typing import List, Optional, Set
 
 import regex

--- a/src/sqlfluff/rules/structure/ST01.py
+++ b/src/sqlfluff/rules/structure/ST01.py
@@ -1,4 +1,5 @@
 """Implementation of Rule ST01."""
+
 from typing import Optional, Tuple
 
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext

--- a/src/sqlfluff/rules/structure/ST02.py
+++ b/src/sqlfluff/rules/structure/ST02.py
@@ -1,4 +1,5 @@
 """Implementation of Rule ST02."""
+
 from typing import List, Optional, Tuple
 
 from sqlfluff.core.parser import (

--- a/src/sqlfluff/rules/structure/ST03.py
+++ b/src/sqlfluff/rules/structure/ST03.py
@@ -1,4 +1,5 @@
 """Implementation of Rule ST03."""
+
 from sqlfluff.core.rules import BaseRule, EvalResultType, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.utils.analysis.query import Query

--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -1,4 +1,5 @@
 """Implementation of Rule ST05."""
+
 from functools import partial
 from typing import Iterator, List, NamedTuple, Optional, Set, Tuple, Type, TypeVar, cast
 

--- a/src/sqlfluff/rules/structure/ST06.py
+++ b/src/sqlfluff/rules/structure/ST06.py
@@ -1,4 +1,5 @@
 """Implementation of Rule ST06."""
+
 from typing import Iterator, List, Optional, Tuple, Union
 
 from sqlfluff.core.parser import BaseSegment

--- a/src/sqlfluff/rules/structure/ST07.py
+++ b/src/sqlfluff/rules/structure/ST07.py
@@ -1,4 +1,5 @@
 """Implementation of Rule ST07."""
+
 from typing import List, Optional, Tuple
 
 from sqlfluff.core.parser import (

--- a/src/sqlfluff/rules/structure/ST08.py
+++ b/src/sqlfluff/rules/structure/ST08.py
@@ -1,4 +1,5 @@
 """Implementation of Rule ST08."""
+
 from typing import Optional, Tuple
 
 from sqlfluff.core.parser import BaseSegment, KeywordSegment, WhitespaceSegment

--- a/src/sqlfluff/rules/structure/ST09.py
+++ b/src/sqlfluff/rules/structure/ST09.py
@@ -1,4 +1,5 @@
 """Implementation of Rule ST09."""
+
 from typing import List, Optional, Tuple, cast
 
 from sqlfluff.core.parser import BaseSegment, SymbolSegment

--- a/src/sqlfluff/rules/tsql/TQ01.py
+++ b/src/sqlfluff/rules/tsql/TQ01.py
@@ -1,4 +1,5 @@
 """Implementation of Rule TQ01."""
+
 from typing import Optional
 
 from sqlfluff.core.rules import BaseRule, LintResult, RuleContext

--- a/src/sqlfluff/utils/analysis/query.py
+++ b/src/sqlfluff/utils/analysis/query.py
@@ -1,4 +1,5 @@
 """Tools for more complex analysis of SELECT statements."""
+
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
@@ -139,9 +140,11 @@ class Selectable:
                         WildcardInfo(
                             seg,
                             [
-                                alias_info.ref_str
-                                if alias_info.aliased
-                                else alias_info.from_expression_element.raw
+                                (
+                                    alias_info.ref_str
+                                    if alias_info.aliased
+                                    else alias_info.from_expression_element.raw
+                                )
                                 for alias_info in self.select_info.table_aliases
                                 if alias_info.ref_str
                             ],

--- a/src/sqlfluff/utils/analysis/select.py
+++ b/src/sqlfluff/utils/analysis/select.py
@@ -1,4 +1,5 @@
 """Basic code analysis tools for SELECT statements."""
+
 from typing import List, NamedTuple, Optional, cast
 
 from sqlfluff.core.dialects.base import Dialect

--- a/src/sqlfluff/utils/functional/raw_file_slice_predicates.py
+++ b/src/sqlfluff/utils/functional/raw_file_slice_predicates.py
@@ -8,6 +8,7 @@ This is not necessarily a complete set of predicates covering all possible
 requirements. Rule authors can define their own predicates as needed, either
 as regular functions, `lambda`, etc.
 """
+
 from typing import Callable
 
 from sqlfluff.core.templaters.base import RawFileSlice

--- a/src/sqlfluff/utils/functional/raw_file_slices.py
+++ b/src/sqlfluff/utils/functional/raw_file_slices.py
@@ -1,4 +1,5 @@
 """Surrogate class for working with RawFileSlice collections."""
+
 from typing import Callable, Optional
 
 from sqlfluff.core.templaters.base import RawFileSlice, TemplatedFile

--- a/src/sqlfluff/utils/functional/segment_predicates.py
+++ b/src/sqlfluff/utils/functional/segment_predicates.py
@@ -8,6 +8,7 @@ This is not necessarily a complete set of predicates covering all possible
 requirements. Rule authors can define their own predicates as needed, either
 as regular functions, `lambda`, etc.
 """
+
 from typing import Callable, Optional
 
 from sqlfluff.core.parser import BaseSegment

--- a/src/sqlfluff/utils/functional/segments.py
+++ b/src/sqlfluff/utils/functional/segments.py
@@ -1,4 +1,5 @@
 """Surrogate class for working with Segment collections."""
+
 from typing import (
     Any,
     Callable,

--- a/src/sqlfluff/utils/functional/templated_file_slice_predicates.py
+++ b/src/sqlfluff/utils/functional/templated_file_slice_predicates.py
@@ -8,6 +8,7 @@ This is not necessarily a complete set of predicates covering all possible
 requirements. Rule authors can define their own predicates as needed, either
 as regular functions, `lambda`, etc.
 """
+
 from typing import Callable
 
 from sqlfluff.core.templaters.base import TemplatedFileSlice

--- a/src/sqlfluff/utils/functional/templated_file_slices.py
+++ b/src/sqlfluff/utils/functional/templated_file_slices.py
@@ -1,4 +1,5 @@
 """Surrogate class for working with TemplatedFileSlice collections."""
+
 from typing import Callable, Optional
 
 from sqlfluff.core.templaters.base import TemplatedFile, TemplatedFileSlice

--- a/src/sqlfluff/utils/reflow/config.py
+++ b/src/sqlfluff/utils/reflow/config.py
@@ -1,6 +1,5 @@
 """Methods to set up appropriate reflow config from file."""
 
-
 # Until we have a proper structure this will work.
 # TODO: Migrate this to the config file.
 from dataclasses import dataclass

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -594,9 +594,9 @@ def _revise_comment_lines(
                     "  Comment Only Line: %s. Anchoring to %s", comment_line_idx, idx
                 )
                 # Mutate reference lines to match this one.
-                lines[
-                    comment_line_idx
-                ].initial_indent_balance = line.initial_indent_balance
+                lines[comment_line_idx].initial_indent_balance = (
+                    line.initial_indent_balance
+                )
             # Reset the buffer
             comment_line_buffer = []
 

--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -1,6 +1,5 @@
 """Static methods to support ReflowPoint.respace_point()."""
 
-
 import logging
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, cast
 

--- a/src/sqlfluff/utils/testing/cli.py
+++ b/src/sqlfluff/utils/testing/cli.py
@@ -1,4 +1,5 @@
 """Testing utils for working with the CLIs."""
+
 from typing import Any, Dict, List, Optional
 
 from click.testing import CliRunner, Result

--- a/src/sqlfluff/utils/testing/rules.py
+++ b/src/sqlfluff/utils/testing/rules.py
@@ -1,4 +1,5 @@
 """Testing utils for rule plugins."""
+
 from glob import glob
 from typing import List, NamedTuple, Optional, Set, Tuple
 

--- a/test/cli/autocomplete_test.py
+++ b/test/cli/autocomplete_test.py
@@ -1,4 +1,5 @@
 """Test autocomplete commands."""
+
 import pytest
 
 from sqlfluff.cli.autocomplete import dialect_shell_complete

--- a/test/cli/click_deprecated_option_test.py
+++ b/test/cli/click_deprecated_option_test.py
@@ -1,4 +1,5 @@
 """The Test suite for `DeprecatedOption` - extension for click options."""
+
 from typing import List
 
 import click

--- a/test/cli/formatters_test.py
+++ b/test/cli/formatters_test.py
@@ -1,4 +1,5 @@
 """The Test file for CLI Formatters."""
+
 import pathlib
 import re
 import textwrap

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 """Common Test Fixtures."""
+
 import hashlib
 import io
 import os

--- a/test/core/linter/fix_test.py
+++ b/test/core/linter/fix_test.py
@@ -1,4 +1,5 @@
 """Test routines for fixing errors."""
+
 import logging
 
 import pytest

--- a/test/core/parser/match_algorithms_test.py
+++ b/test/core/parser/match_algorithms_test.py
@@ -57,9 +57,11 @@ def make_result_tuple(result_slice, matcher_keywords, test_segments):
         return ()
 
     return tuple(
-        KeywordSegment(elem.raw, pos_marker=elem.pos_marker)
-        if elem.raw in matcher_keywords
-        else elem
+        (
+            KeywordSegment(elem.raw, pos_marker=elem.pos_marker)
+            if elem.raw in matcher_keywords
+            else elem
+        )
         for elem in test_segments[result_slice]
     )
 

--- a/test/core/plugin_test.py
+++ b/test/core/plugin_test.py
@@ -1,4 +1,5 @@
 """Plugin related tests."""
+
 import logging
 import sys
 

--- a/test/core/rules/docstring_test.py
+++ b/test/core/rules/docstring_test.py
@@ -1,4 +1,5 @@
 """Test rules docstring."""
+
 import re
 
 import pytest

--- a/test/core/rules/functional/raw_file_slices_test.py
+++ b/test/core/rules/functional/raw_file_slices_test.py
@@ -1,4 +1,5 @@
 """Tests for the raw_file_slices module."""
+
 import pytest
 
 from sqlfluff.core.templaters.base import RawFileSlice

--- a/test/core/rules/functional/segments_test.py
+++ b/test/core/rules/functional/segments_test.py
@@ -1,4 +1,5 @@
 """Tests for the segments module."""
+
 import pytest
 
 import sqlfluff.utils.functional.segment_predicates as sp

--- a/test/core/rules/reference_test.py
+++ b/test/core/rules/reference_test.py
@@ -1,4 +1,5 @@
 """Test components for working with object and table references."""
+
 import pytest
 
 from sqlfluff.core.rules import reference

--- a/test/core/rules/rules_test.py
+++ b/test/core/rules/rules_test.py
@@ -1,4 +1,5 @@
 """Tests for the standard set of rules."""
+
 import logging
 
 import pytest

--- a/test/core/templaters/placeholder_test.py
+++ b/test/core/templaters/placeholder_test.py
@@ -1,4 +1,5 @@
 """Tests for templaters."""
+
 import pytest
 
 from sqlfluff.core import FluffConfig

--- a/test/dialects/conftest.py
+++ b/test/dialects/conftest.py
@@ -1,4 +1,5 @@
 """Sharing fixtures to test the dialects."""
+
 import logging
 
 import pytest

--- a/test/dialects/dialects_test.py
+++ b/test/dialects/dialects_test.py
@@ -3,6 +3,7 @@
 Any files in the test/fixtures/dialects/ directory will be picked up
 and automatically tested against the appropriate dialect.
 """
+
 from typing import Any, Dict, Optional
 
 import pytest

--- a/test/dialects/exasol_test.py
+++ b/test/dialects/exasol_test.py
@@ -1,4 +1,5 @@
 """Tests specific to the exasol dialect."""
+
 import pytest
 
 TEST_DIALECT = "exasol"

--- a/test/dialects/postgres_test.py
+++ b/test/dialects/postgres_test.py
@@ -1,4 +1,5 @@
 """Tests specific to the postgres dialect."""
+
 from typing import Callable
 
 import pytest

--- a/test/dialects/soql_test.py
+++ b/test/dialects/soql_test.py
@@ -1,4 +1,5 @@
 """Tests specific to the soql dialect."""
+
 import pytest
 
 from sqlfluff.core import FluffConfig, Linter

--- a/test/diff_quality_plugin_test.py
+++ b/test/diff_quality_plugin_test.py
@@ -1,4 +1,5 @@
 """Tests for the SQLFluff integration with the "diff-quality" tool."""
+
 import sys
 from pathlib import Path
 

--- a/test/fixtures/templater/jinja_j_libraries/libs/foo.py
+++ b/test/fixtures/templater/jinja_j_libraries/libs/foo.py
@@ -1,4 +1,5 @@
 """Module used to test foo within the jinja template."""
+
 schema = "sch1"
 
 

--- a/test/fixtures/templater/jinja_m_libraries_module/libs/foo/__init__.py
+++ b/test/fixtures/templater/jinja_m_libraries_module/libs/foo/__init__.py
@@ -1,4 +1,5 @@
 """Module used to test foo within the jinja template."""
+
 schema = "sch1"
 
 

--- a/test/fixtures/templater/jinja_r_library_in_macro/libs/foo.py
+++ b/test/fixtures/templater/jinja_r_library_in_macro/libs/foo.py
@@ -1,4 +1,5 @@
 """Module used to test foo within the jinja template."""
+
 schema = "sch1"
 
 

--- a/test/fixtures/templater/jinja_s_filters_in_library/libs/__init__.py
+++ b/test/fixtures/templater/jinja_s_filters_in_library/libs/__init__.py
@@ -1,4 +1,5 @@
 """Module used to test filters within the jinja template."""
+
 from __future__ import annotations
 
 import datetime

--- a/test/generate_parse_fixture_yml.py
+++ b/test/generate_parse_fixture_yml.py
@@ -1,4 +1,5 @@
 """Utility to generate yml files for all the parsing examples."""
+
 import fnmatch
 import multiprocessing
 import os

--- a/test/patch_lcov.py
+++ b/test/patch_lcov.py
@@ -13,6 +13,7 @@ SF:.tox/py/lib/python3.10/site-packages/sqlfluff/__init__.py
 to this:
 SF:src/sqlfluff/__init__.py
 """
+
 import re
 from pathlib import Path
 

--- a/test/rules/std_AM06_test.py
+++ b/test/rules/std_AM06_test.py
@@ -1,4 +1,5 @@
 """Tests the python routines within AM06."""
+
 import sqlfluff
 
 

--- a/test/rules/std_CV02_test.py
+++ b/test/rules/std_CV02_test.py
@@ -1,4 +1,5 @@
 """Tests the python routines within CV02."""
+
 import sqlfluff
 
 

--- a/test/rules/std_CV09_test.py
+++ b/test/rules/std_CV09_test.py
@@ -1,4 +1,5 @@
 """Tests the python routines within CV09."""
+
 from sqlfluff.core import FluffConfig, Linter
 
 

--- a/test/rules/std_LT01_LT04_test.py
+++ b/test/rules/std_LT01_LT04_test.py
@@ -1,4 +1,5 @@
 """Tests the python routines within LT01."""
+
 import sqlfluff
 
 

--- a/test/rules/std_LT12_CV06_test.py
+++ b/test/rules/std_LT12_CV06_test.py
@@ -1,4 +1,5 @@
 """Tests the python routines within LT12 and CV06."""
+
 from sqlfluff.core import FluffConfig, Linter
 
 

--- a/test/rules/std_RF01_LT09_test.py
+++ b/test/rules/std_RF01_LT09_test.py
@@ -2,6 +2,7 @@
 
 Root cause was BaseSegment.copy().
 """
+
 from sqlfluff.core import FluffConfig, Linter
 
 

--- a/test/rules/std_test.py
+++ b/test/rules/std_test.py
@@ -1,4 +1,5 @@
 """Tests for the standard set of rules."""
+
 import pytest
 
 from sqlfluff.core.config import FluffConfig

--- a/test/rules/yaml_test_cases_test.py
+++ b/test/rules/yaml_test_cases_test.py
@@ -1,4 +1,5 @@
 """Runs the rule test cases."""
+
 import logging
 import os
 

--- a/test/utils/analysis/query_test.py
+++ b/test/utils/analysis/query_test.py
@@ -1,4 +1,5 @@
 """Test the select_crawler module."""
+
 import pytest
 
 from sqlfluff.core.linter.linter import Linter

--- a/util.py
+++ b/util.py
@@ -117,9 +117,9 @@ def release(new_version_num):
             # If the release is already in the changelog, update it
             if f"## [{new_version_num}]" in input_changelog[existing_entry_start]:
                 click.echo(f"...found existing entry for {new_version_num}")
-                input_changelog[
-                    existing_entry_start
-                ] = f"## [{new_version_num}] - {time.strftime('%Y-%m-%d')}\n"
+                input_changelog[existing_entry_start] = (
+                    f"## [{new_version_num}] - {time.strftime('%Y-%m-%d')}\n"
+                )
 
                 # Delete the existing What’s Changed and New Contributors sections
                 remaining_changelog = input_changelog[existing_entry_start:]


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #5572 
Apply fixes for new rule from black's 24.1.0 update:
- Add parentheses around if-else expressions
- If an assignment statement is too long, we now prefer splitting on the right-hand side
- Enforce newline after module docstrings
- Add trailing commas to collection literals even if there's a comment after the last entry

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
