### PR TITLE
Allows using dbt cross project ref in jinja templater

### DIFF
--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -253,7 +253,9 @@ class JinjaTemplater(PythonTemplater):
                 return self.name
 
         dbt_builtins = {
-            "ref": lambda model_ref: model_ref,
+            "ref": lambda *args: args[-1],
+            # In case of a cross project ref in dbt, model_ref is the second
+            # argument. Otherwise it is the only argument.
             "source": lambda source_name, table: f"{source_name}_{table}",
             "config": lambda **kwargs: "",
             "var": lambda variable, default="": "item",

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -680,6 +680,7 @@ def assert_structure(yaml_loader, path, code_only=True, include_meta=False):
         # Macros
         ("jinja_b/jinja", False, False),
         # dbt builtins
+        ("jinja_c_dbt/dbt_builtins_cross_ref", True, False),
         ("jinja_c_dbt/dbt_builtins_config", True, False),
         ("jinja_c_dbt/dbt_builtins_is_incremental", True, False),
         ("jinja_c_dbt/dbt_builtins_ref", True, False),

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins_cross_ref.sql
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins_cross_ref.sql
@@ -1,0 +1,2 @@
+SELECT col1
+FROM {{ ref('other_project', 'my_table') }}

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins_cross_ref.yml
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins_cross_ref.yml
@@ -1,0 +1,15 @@
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Dbt introduced the possibilty to reference models from other projects, by using two arguments in the ref() function: https://docs.getdbt.com/docs/collaborate/govern/project-dependencies 
This breaks the current jinja templater as it expects exactly one argument.
This change works also for cross project refs by extracting the model_ref as the last argument in the ref() function.
Fixes #5472

### Are there any other side effects of this change that we should be aware of?

No side effects were observed. The project reference, which is the additional argument in the cross project ref case is not used.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
