### PR TITLE
Add support & test for postgres alter policy with multiple clauses

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -2720,22 +2720,26 @@ class AlterPolicyStatementSegment(BaseSegment):
         Ref("TableReferenceSegment"),
         OneOf(
             Sequence("RENAME", "TO", Ref("ObjectReferenceSegment")),
-            Sequence(
-                "TO",
-                Delimited(
-                    OneOf(
-                        Ref("RoleReferenceSegment"),
-                        "PUBLIC",
-                        "CURRENT_ROLE",
-                        "CURRENT_USER",
-                        "SESSION_USER",
-                    )
+            AnySetOf(
+                Sequence(
+                    "TO",
+                    Delimited(
+                        OneOf(
+                            Ref("RoleReferenceSegment"),
+                            "PUBLIC",
+                            "CURRENT_ROLE",
+                            "CURRENT_USER",
+                            "SESSION_USER",
+                        )
+                    ),
                 ),
-                optional=True,
-            ),
-            Sequence("USING", Bracketed(Ref("ExpressionSegment")), optional=True),
-            Sequence(
-                "WITH", "CHECK", Bracketed(Ref("ExpressionSegment")), optional=True
+                Sequence("USING", Bracketed(Ref("ExpressionSegment"))),
+                Sequence(
+                    "WITH",
+                    "CHECK",
+                    Bracketed(Ref("ExpressionSegment")),
+                ),
+                min_times=1,
             ),
         ),
     )

--- a/test/fixtures/dialects/postgres/alter_policy.sql
+++ b/test/fixtures/dialects/postgres/alter_policy.sql
@@ -24,3 +24,8 @@ ALTER POLICY sales_rep_is_self ON invoices
   WITH CHECK (sales_rep = CURRENT_USER AND CURRENT_USER IN (
     SELECT user_id FROM allowed_users
   ));
+
+ALTER POLICY test_policy ON test_table
+  TO public, session_user
+  USING (username = current_user)
+  WITH CHECK (col > 10);

--- a/test/fixtures/dialects/postgres/alter_policy.yml
+++ b/test/fixtures/dialects/postgres/alter_policy.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5eb64c5153c70b70c75901212bc899bdad414ad3709e4f45899a842bd5d96c39
+_hash: d0fded440272f9f4790a7c6d60e57cbca61dfbc5cc023d473d853f331e932521
 file:
 - statement:
     alter_policy_statement:
@@ -155,5 +155,42 @@ file:
                       table_reference:
                         naked_identifier: allowed_users
             end_bracket: )
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_policy_statement:
+    - keyword: ALTER
+    - keyword: POLICY
+    - object_reference:
+        naked_identifier: test_policy
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: test_table
+    - keyword: TO
+    - role_reference:
+        naked_identifier: public
+    - comma: ','
+    - keyword: session_user
+    - keyword: USING
+    - bracketed:
+        start_bracket: (
+        expression:
+        - column_reference:
+            naked_identifier: username
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+            naked_identifier: current_user
+        end_bracket: )
+    - keyword: WITH
+    - keyword: CHECK
+    - bracketed:
+        start_bracket: (
+        expression:
+          column_reference:
+            naked_identifier: col
+          comparison_operator:
+            raw_comparison_operator: '>'
+          numeric_literal: '10'
         end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
Fixes #5576


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Allows postgres `alter policy` statements with multiple clauses, as described in the postgres docs.


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
