### PR TITLE
Stricter recommended config for not_equals convention

### DIFF
--- a/docs/source/partials/starter_config.cfg
+++ b/docs/source/partials/starter_config.cfg
@@ -66,3 +66,11 @@ extended_capitalisation_policy = lower
 capitalisation_policy = lower
 [sqlfluff:rules:capitalisation.types]
 extended_capitalisation_policy = lower
+
+# The default configuration for the not equal convention rule is "consistent"
+# which will auto-detect the setting from the rest of the file. This
+# is less desirable in a new project and you may find this (slightly
+# more strict) setting more useful.
+[sqlfluff:rules:convention.not_equal]
+# Default to preferring the "c_style" (i.e. `!=`)
+preferred_not_equal_style = c_style


### PR DESCRIPTION
Following on from #5539 (which relaxes the default configuration), this updates the _recommended_ starter config to reflect the previous default behaviour.