### PR TITLE
Memory overhead optimisations during linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dependencies = [
     "toml; python_version < '3.11'",
     # For handling progress bars
     "tqdm",
-    # better type hints for older python versions
+    # Literals and TypedDicts
     "typing_extensions",
 ]
 

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -637,6 +637,9 @@ def lint(
                 ignore_non_existent_files=False,
                 ignore_files=not disregard_sqlfluffignores,
                 processes=processes,
+                # If we're just linting in the CLI, we don't need to retain the
+                # raw file content. This allows us to reduce memory overhead.
+                retain_files=False,
             )
 
     # Output the final stats

--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -164,14 +164,11 @@ class LintedDir:
     @property
     def tree(self) -> Optional[BaseSegment]:
         """A convenience method for when there is only one file and we want the tree."""
-        if not self.retain_files:
-            raise ValueError(".tree() cannot be called if `retain_files` is False.")
-        elif len(self.files) > 1:  # pragma: no cover
-            raise ValueError(
-                ".tree() cannot be called when a LintedDir contains more than one file."
-            )
-        elif not self.files:  # pragma: no cover
-            raise ValueError(
-                "LintedDir has no parsed files. There is probably a parsing error."
-            )
+        assert self.retain_files, ".tree() cannot be called if `retain_files` is False."
+        assert (
+            len(self.files) == 1
+        ), ".tree() cannot be called when a LintedDir contains more than one file."
+        assert (
+            self.files
+        ), "LintedDir has no parsed files. There is probably a parsing error."
         return self.files[0].tree

--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -74,9 +74,10 @@ class LintedDir:
             self._num_unclean += 1
         self._num_violations = file.num_violations()
 
-        # Append timings
-        self.step_timings.append(file.timings.step_timings)
-        self.rule_timings.extend(file.timings.rule_timings)
+        # Append timings if present
+        if file.timings:
+            self.step_timings.append(file.timings.step_timings)
+            self.rule_timings.extend(file.timings.rule_timings)
 
         # Finally, if set to persist files, do that.
         if self.retain_files:

--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -4,7 +4,7 @@ This stores the idea of a collection of linted files at a single start path
 
 """
 
-from typing import Any, Dict, List, Optional, Union, overload
+from typing import Any, Dict, List, Optional, Tuple, Union, overload
 
 from typing_extensions import Literal, TypedDict
 
@@ -38,6 +38,9 @@ class LintedDir:
         self._num_clean: int = 0
         self._num_unclean: int = 0
         self._num_violations: int = 0
+        # Timing
+        self.step_timings: List[Dict[str, float]] = []
+        self.rule_timings: List[Tuple[str, str, float]] = []
 
     def add(self, file: LintedFile) -> None:
         """Add a file to this path.
@@ -70,6 +73,10 @@ class LintedDir:
         else:
             self._num_unclean += 1
         self._num_violations = file.num_violations()
+
+        # Append timings
+        self.step_timings.append(file.timings.step_timings)
+        self.rule_timings.extend(file.timings.rule_timings)
 
         # Finally, if set to persist files, do that.
         if self.retain_files:

--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -106,6 +106,30 @@ class LintedDir:
         """Return a dict of violations by file path."""
         return {file.path: file.get_violations(**kwargs) for file in self.files}
 
+    def as_records(self) -> List[dict]:
+        """Return the result as a list of dictionaries.
+
+        Each record contains a key specifying the filepath, and a list of violations.
+        This method is useful for serialization as all objects will be builtin python
+        types (ints, strs).
+        """
+        return [
+            {
+                "filepath": path,
+                "violations": sorted(
+                    # Sort violations by line and then position
+                    (v.to_dict() for v in violations),
+                    # The tuple allows sorting by line number, then position, then code
+                    key=lambda v: (v["start_line_no"], v["start_line_pos"], v["code"]),
+                ),
+            }
+            for path, violations in self.violation_dict(
+                # Keep the warnings
+                filter_warning=False
+            ).items()
+            if violations
+        ]
+
     def stats(self) -> Dict[str, int]:
         """Return a dict containing linting stats about this path."""
         return {

--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -127,7 +127,7 @@ class LintedDir:
         """Return a dict of violations by file path."""
         return {file.path: file.get_violations(**kwargs) for file in self.files}
 
-    def as_records(self) -> List[dict]:
+    def as_records(self) -> List[LintingRecord]:
         """Return the result as a list of dictionaries.
 
         Each record contains a key specifying the filepath, and a list of violations.

--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -27,10 +27,10 @@ class LintedDir:
     and save memory overhead if not required.
     """
 
-    def __init__(self, path: str, persist_files: bool = True) -> None:
+    def __init__(self, path: str, retain_files: bool = True) -> None:
         self.files: List[LintedFile] = []
         self.path: str = path
-        self.persist_files: bool = persist_files
+        self.retain_files: bool = retain_files
         # Records
         self._records: List[LintingRecord] = []
         # Stats
@@ -44,7 +44,7 @@ class LintedDir:
 
         This function _always_ updates the metadata tracking, but may
         or may not persist the `file` object itself depending on the
-        `persist_files` argument given on instantiation.
+        `retain_files` argument given on instantiation.
         """
         # Generate serialised violations.
         violation_records = sorted(
@@ -72,7 +72,7 @@ class LintedDir:
         self._num_violations = file.num_violations()
 
         # Finally, if set to persist files, do that.
-        if self.persist_files:
+        if self.retain_files:
             self.files.append(file)
 
     @overload
@@ -96,7 +96,7 @@ class LintedDir:
         file the violations are from. Good for testing though.
         For more control set the `by_path` argument to true.
         """
-        assert self.persist_files, "cannot `check_tuples()` without `persist_files`"
+        assert self.retain_files, "cannot `check_tuples()` without `retain_files`"
         if by_path:
             return {
                 file.path: file.check_tuples(
@@ -152,7 +152,7 @@ class LintedDir:
 
         This also logs the output as we go using the formatter if present.
         """
-        assert self.persist_files, "cannot `persist_changes()` without `persist_files`"
+        assert self.retain_files, "cannot `persist_changes()` without `retain_files`"
         # Run all the fixes for all the files and return a dict
         buffer: Dict[str, Union[bool, str]] = {}
         for file in self.files:
@@ -164,8 +164,8 @@ class LintedDir:
     @property
     def tree(self) -> Optional[BaseSegment]:
         """A convenience method for when there is only one file and we want the tree."""
-        if not self.persist_files:
-            raise ValueError(".tree() cannot be called if `persist_files` is False.")
+        if not self.retain_files:
+            raise ValueError(".tree() cannot be called if `retain_files` is False.")
         elif len(self.files) > 1:  # pragma: no cover
             raise ValueError(
                 ".tree() cannot be called when a LintedDir contains more than one file."

--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -31,7 +31,6 @@ class LintedDir:
         self.files: List[LintedFile] = []
         self.path: str = path
         self.persist_files: bool = persist_files
-        # self._check_tupes: Dict[str, List[CheckTuple]] = {}
         # Records
         self._records: List[LintingRecord] = []
         # Stats
@@ -97,6 +96,7 @@ class LintedDir:
         file the violations are from. Good for testing though.
         For more control set the `by_path` argument to true.
         """
+        assert self.persist_files, "cannot `check_tuples()` without `persist_files`"
         if by_path:
             return {
                 file.path: file.check_tuples(

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -1029,6 +1029,7 @@ class Linter:
         apply_fixes: bool = False,
         fixed_file_suffix: str = "",
         fix_even_unparsable: bool = False,
+        retain_files: bool = True,
     ) -> LintingResult:
         """Lint an iterable of paths."""
         # If no paths specified - assume local
@@ -1040,7 +1041,7 @@ class Linter:
         expanded_paths: List[str] = []
         expanded_path_to_linted_dir = {}
         for path in paths:
-            linted_dir = LintedDir(path)
+            linted_dir = LintedDir(path, retain_files=retain_files)
             result.add(linted_dir)
             for fname in self.paths_from_path(
                 path,

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -126,10 +126,11 @@ class LintingResult:
         timing = TimingSummary()
         rules_timing = RuleTimingSummary()
         for dir in self.paths:
-            for file in dir.files:
-                if file.timings:
-                    timing.add(file.timings.step_timings)
-                    rules_timing.add(file.timings.rule_timings)
+            # Add timings from cached values.
+            # NOTE: This is so we don't rely on having the raw file objects any more.
+            for t in dir.step_timings:
+                timing.add(t)
+            rules_timing.add(dir.rule_timings)
         return {**timing.summary(), **rules_timing.summary()}
 
     def persist_timing_records(self, filename: str) -> None:

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union, 
 from typing_extensions import Literal
 
 from sqlfluff.core.errors import CheckTuple
-from sqlfluff.core.linter.linted_dir import LintedDir
+from sqlfluff.core.linter.linted_dir import LintedDir, LintingRecord
 from sqlfluff.core.linter.linted_file import TMP_PRS_ERROR_TYPES
 from sqlfluff.core.timing import RuleTimingSummary, TimingSummary
 
@@ -193,7 +193,7 @@ class LintingResult:
                         }
                     )
 
-    def as_records(self) -> List[dict]:
+    def as_records(self) -> List[LintingRecord]:
         """Return the result as a list of dictionaries.
 
         Each record contains a key specifying the filepath, and a list of violations.

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -201,21 +201,7 @@ class LintingResult:
         types (ints, strs).
         """
         return [
-            {
-                "filepath": path,
-                "violations": sorted(
-                    # Sort violations by line and then position
-                    (v.to_dict() for v in violations),
-                    # The tuple allows sorting by line number, then position, then code
-                    key=lambda v: (v["start_line_no"], v["start_line_pos"], v["code"]),
-                ),
-            }
-            for LintedDir in self.paths
-            for path, violations in LintedDir.violation_dict(
-                # Keep the warnings
-                filter_warning=False
-            ).items()
-            if violations
+            record for linted_dir in self.paths for record in linted_dir.as_records()
         ]
 
     def persist_changes(self, formatter, fixed_file_suffix: str = "") -> dict:

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -357,27 +357,9 @@ def test__cli__command_render_stdin():
         # Check parsing with no output (used mostly for testing)
         (parse, ["-n", "test/fixtures/cli/passing_b.sql", "--format", "none"]),
         # Check the benching commands
-        (parse, ["-n", "test/fixtures/cli/passing_b.sql", "--bench"]),
-        (
-            lint,
-            [
-                "-n",
-                "test/fixtures/cli/passing_b.sql",
-                "--bench",
-                "--exclude-rules",
-                "AM05",
-            ],
-        ),
-        (
-            fix,
-            [
-                "-n",
-                "test/fixtures/cli/passing_b.sql",
-                "--bench",
-                "--exclude-rules",
-                "AM05",
-            ],
-        ),
+        (parse, ["-n", "test/fixtures/cli/passing_timing.sql", "--bench"]),
+        (lint, ["-n", "test/fixtures/cli/passing_timing.sql", "--bench"]),
+        (fix, ["-n", "test/fixtures/cli/passing_timing.sql", "--bench"]),
         # Check linting works in specifying rules
         (
             lint,

--- a/test/fixtures/cli/passing_timing.sql
+++ b/test/fixtures/cli/passing_timing.sql
@@ -1,0 +1,18 @@
+-- NOTE: This query is duplicated many times so the test
+-- takes longer and can effectively measure timing routines.
+
+{% for i in range(10) %}
+    SELECT
+        tbl.name,
+        b.value,
+        /*
+        This is a block comment
+        */
+        d.something,    -- Which a comment after it
+        tbl.foo,
+        d.val + b.val / -2 AS a_calculation
+    FROM tbl
+    INNER JOIN b ON (tbl.common_id = b.common_id)
+    LEFT JOIN d ON (tbl.id = d.other_id)
+    ORDER BY tbl.name ASC;
+{% endfor %}


### PR DESCRIPTION
Resolves #5566 .

It adds a setting which doesn't keep the full parsed and linted file during linting operations. Only the metadata would then be kept - in theory lowering the memory overhead during long linting operations.

@noel - this is the feature I was talking about. UPDATE: Tested by noel on their big project and seems to reduce OOM killing events.
