### PR TITLE
Upgraded dbt-core from 1.0.0 to 1.6.0 because of security

### DIFF
--- a/plugins/sqlfluff-templater-dbt/setup.cfg
+++ b/plugins/sqlfluff-templater-dbt/setup.cfg
@@ -65,7 +65,7 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     sqlfluff==3.0.0a5
-    dbt-core>=1.0.0
+    dbt-core>=1.6.0
     jinja2-simple-tags>=0.3.1
     markupsafe
     pydantic


### PR DESCRIPTION
dbt-core below version 1.6 contains a library called 'werkzeug' which contains a 'high' risk vulnerability mentioned here: https://www.mend.io/vulnerability-database/CVE-2023-46136  In dbt-core 1.6.0 this library was removed, as it was not used anyways, and thereby also removing the security thread.  In big organizations, having these transient vulnerabilities in a repo is cause for for not allowing the use of the packages. Tools like whitesource/mend are often used to scan all repos to find and flag them for threads.

### Brief summary of the change made
Solve security thread caused by implicitly using older werkzeug package


### Are there any other side effects of this change that we should be aware of?
Requires using dbt-core 1.6.0 or higher when using the dbt-templater

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
