### PR TITLE
Sparksql: Fix `LATERAL VIEW` following `JOIN`; `CLUSTER|SORT|DISTRIBUTE BY` or `QUALIFY` without `FROM`

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -269,6 +269,7 @@ sparksql_dialect.replace(
         OneOf(
             Ref("PivotClauseSegment"),
             Ref("UnpivotClauseSegment"),
+            Ref("LateralViewClauseSegment"),
         ),
         Ref("AliasExpressionSegment", optional=True),
     ),
@@ -2893,7 +2894,6 @@ class FromExpressionElementSegment(ansi.FromExpressionElementSegment):
         # NB: `LateralViewClauseSegment`, `NamedWindowSegment`,
         # and `PivotClauseSegment should come after Alias/Sampling
         # expressions so those are matched before
-        AnyNumberOf(Ref("LateralViewClauseSegment")),
         Ref("NamedWindowSegment", optional=True),
         Ref("PostTableExpressionGrammar", optional=True),
     )
@@ -3332,6 +3332,9 @@ class SelectClauseSegment(BaseSegment):
             Sequence("ORDER", "BY"),
             "LIMIT",
             "OVERLAPS",
+            Sequence("CLUSTER", "BY"),
+            Sequence("DISTRIBUTE", "BY"),
+            Sequence("SORT", "BY"),
         ],
         parse_mode=ParseMode.GREEDY_ONCE_STARTED,
     )

--- a/test/fixtures/dialects/sparksql/select_cluster_by.sql
+++ b/test/fixtures/dialects/sparksql/select_cluster_by.sql
@@ -63,3 +63,6 @@ SELECT
     name
 FROM person_cold
 CLUSTER BY age;
+
+SELECT CURRENT_DATE() AS p_data_date
+CLUSTER BY p_data_date;

--- a/test/fixtures/dialects/sparksql/select_cluster_by.yml
+++ b/test/fixtures/dialects/sparksql/select_cluster_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a030205bf2c161478bcf6abd2b798e6e80f83d20844ae0e5221093dbe089b533
+_hash: 1820d460166c454dfaa35c54326a3907bf7eb658f34c59c32ab72f70d158ccfc
 file:
 - statement:
     select_statement:
@@ -279,4 +279,24 @@ file:
         - keyword: BY
         - column_reference:
             naked_identifier: age
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CURRENT_DATE
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: p_data_date
+      cluster_by_clause:
+      - keyword: CLUSTER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: p_data_date
 - statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/select_distribute_by.sql
+++ b/test/fixtures/dialects/sparksql/select_distribute_by.sql
@@ -71,3 +71,6 @@ SELECT
 FROM person_cold
 DISTRIBUTE BY age
 SORT BY age;
+
+SELECT CURRENT_DATE() AS p_data_date
+DISTRIBUTE BY p_data_date;

--- a/test/fixtures/dialects/sparksql/select_distribute_by.yml
+++ b/test/fixtures/dialects/sparksql/select_distribute_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9e06dff72c34220df50e3d92c3498b51f62d8bc752083d27f84d47d6439d3e5a
+_hash: b342901b95972d70ee9d482c16b8de504f9e22d9c71e926ab47740b37d61f6cb
 file:
 - statement:
     select_statement:
@@ -333,4 +333,24 @@ file:
         - keyword: BY
         - column_reference:
             naked_identifier: age
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CURRENT_DATE
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: p_data_date
+      distribute_by_clause:
+      - keyword: DISTRIBUTE
+      - keyword: BY
+      - column_reference:
+          naked_identifier: p_data_date
 - statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/select_from_lateral_view.sql
+++ b/test/fixtures/dialects/sparksql/select_from_lateral_view.sql
@@ -101,3 +101,14 @@ SELECT
     exploded_people.state
 FROM person AS p
     LATERAL VIEW INLINE(array_of_structs) AS name, age, state;
+
+SELECT
+    t1.column1,
+    CAST(GET_JSON_OBJECT(things, '$.percentage') AS DECIMAL(16, 8)
+    ) AS ptc
+FROM table1 AS t1
+LEFT JOIN table2 AS t2
+    ON
+        c.column1 = p.column1
+        AND t2.type = 'SOMETHING'
+    LATERAL VIEW OUTER EXPLODE(t2.column2) AS things;

--- a/test/fixtures/dialects/sparksql/select_from_lateral_view.yml
+++ b/test/fixtures/dialects/sparksql/select_from_lateral_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d2478eb1ff7c9737cdf83e4a4ea9f34b9b5d72181fde839634c86d58a0a54f8e
+_hash: 62f728d2e7b9feae5d39ea4eb9193c0273524076257725e16f12d45d39ce8185
 file:
 - statement:
     select_statement:
@@ -39,57 +39,57 @@ file:
       from_clause:
         keyword: FROM
         from_expression:
-          from_expression_element:
-          - table_expression:
+        - from_expression_element:
+            table_expression:
               table_reference:
                 naked_identifier: person
-          - lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: EXPLODE
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: ARRAY
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          numeric_literal: '30'
-                      - comma: ','
-                      - expression:
-                          numeric_literal: '60'
-                      - end_bracket: )
-                  end_bracket: )
-            - naked_identifier: tbl_name
-            - keyword: AS
-            - naked_identifier: c_age
-          - lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: EXPLODE
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: ARRAY
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          numeric_literal: '40'
-                      - comma: ','
-                      - expression:
-                          numeric_literal: '80'
-                      - end_bracket: )
-                  end_bracket: )
-            - keyword: AS
-            - naked_identifier: d_age
+        - lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        numeric_literal: '30'
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '60'
+                    - end_bracket: )
+                end_bracket: )
+          - naked_identifier: tbl_name
+          - keyword: AS
+          - naked_identifier: c_age
+        - lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        numeric_literal: '40'
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '80'
+                    - end_bracket: )
+                end_bracket: )
+          - keyword: AS
+          - naked_identifier: d_age
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -113,56 +113,56 @@ file:
       from_clause:
         keyword: FROM
         from_expression:
-          from_expression_element:
-          - table_expression:
+        - from_expression_element:
+            table_expression:
               table_reference:
                 naked_identifier: person
-          - lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: EXPLODE
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: ARRAY
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          numeric_literal: '30'
-                      - comma: ','
-                      - expression:
-                          numeric_literal: '60'
-                      - end_bracket: )
-                  end_bracket: )
-            - keyword: AS
-            - naked_identifier: c_age
-          - lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: EXPLODE
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: ARRAY
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          numeric_literal: '40'
-                      - comma: ','
-                      - expression:
-                          numeric_literal: '80'
-                      - end_bracket: )
-                  end_bracket: )
-            - keyword: AS
-            - naked_identifier: d_age
+        - lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        numeric_literal: '30'
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '60'
+                    - end_bracket: )
+                end_bracket: )
+          - keyword: AS
+          - naked_identifier: c_age
+        - lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        numeric_literal: '40'
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '80'
+                    - end_bracket: )
+                end_bracket: )
+          - keyword: AS
+          - naked_identifier: d_age
       groupby_clause:
       - keyword: GROUP
       - keyword: BY
@@ -207,25 +207,25 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: person
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: EXPLODE
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: ARRAY
-                      bracketed:
-                        start_bracket: (
-                        end_bracket: )
-                  end_bracket: )
-            - naked_identifier: tbl_name
-            - keyword: AS
-            - naked_identifier: c_age
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                      start_bracket: (
+                      end_bracket: )
+                end_bracket: )
+          - naked_identifier: tbl_name
+          - keyword: AS
+          - naked_identifier: c_age
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -265,26 +265,26 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: person
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - keyword: OUTER
-            - function:
-                function_name:
-                  function_name_identifier: EXPLODE
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: ARRAY
-                      bracketed:
-                        start_bracket: (
-                        end_bracket: )
-                  end_bracket: )
-            - naked_identifier: tbl_name
-            - keyword: AS
-            - naked_identifier: c_age
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - keyword: OUTER
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                      start_bracket: (
+                      end_bracket: )
+                end_bracket: )
+          - naked_identifier: tbl_name
+          - keyword: AS
+          - naked_identifier: c_age
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -324,25 +324,25 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: person
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - keyword: OUTER
-            - function:
-                function_name:
-                  function_name_identifier: EXPLODE
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: ARRAY
-                      bracketed:
-                        start_bracket: (
-                        end_bracket: )
-                  end_bracket: )
-            - naked_identifier: tbl_name
-            - naked_identifier: c_age
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - keyword: OUTER
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                      start_bracket: (
+                      end_bracket: )
+                end_bracket: )
+          - naked_identifier: tbl_name
+          - naked_identifier: c_age
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -382,24 +382,24 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: person
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - keyword: OUTER
-            - function:
-                function_name:
-                  function_name_identifier: EXPLODE
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: ARRAY
-                      bracketed:
-                        start_bracket: (
-                        end_bracket: )
-                  end_bracket: )
-            - naked_identifier: c_age
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - keyword: OUTER
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                      start_bracket: (
+                      end_bracket: )
+                end_bracket: )
+          - naked_identifier: c_age
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -435,25 +435,25 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: person
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: INLINE
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    column_reference:
-                      naked_identifier: array_of_structs
-                  end_bracket: )
-            - naked_identifier: exploded_people
-            - keyword: AS
-            - naked_identifier: name
-            - comma: ','
-            - naked_identifier: age
-            - comma: ','
-            - naked_identifier: state
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: INLINE
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: array_of_structs
+                end_bracket: )
+          - naked_identifier: exploded_people
+          - keyword: AS
+          - naked_identifier: name
+          - comma: ','
+          - naked_identifier: age
+          - comma: ','
+          - naked_identifier: state
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -492,25 +492,25 @@ file:
             alias_expression:
               keyword: AS
               naked_identifier: p
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: INLINE
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    column_reference:
-                      naked_identifier: array_of_structs
-                  end_bracket: )
-            - naked_identifier: exploded_people
-            - keyword: AS
-            - naked_identifier: name
-            - comma: ','
-            - naked_identifier: age
-            - comma: ','
-            - naked_identifier: state
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: INLINE
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: array_of_structs
+                end_bracket: )
+          - naked_identifier: exploded_people
+          - keyword: AS
+          - naked_identifier: name
+          - comma: ','
+          - naked_identifier: age
+          - comma: ','
+          - naked_identifier: state
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -549,19 +549,19 @@ file:
             alias_expression:
               keyword: AS
               naked_identifier: p
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: INLINE
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    column_reference:
-                      naked_identifier: array_of_structs
-                  end_bracket: )
-            - naked_identifier: exploded_people
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: INLINE
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: array_of_structs
+                end_bracket: )
+          - naked_identifier: exploded_people
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -600,24 +600,24 @@ file:
             alias_expression:
               keyword: AS
               naked_identifier: p
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: INLINE
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    column_reference:
-                      naked_identifier: array_of_structs
-                  end_bracket: )
-            - naked_identifier: exploded_people
-            - naked_identifier: name
-            - comma: ','
-            - naked_identifier: age
-            - comma: ','
-            - naked_identifier: state
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: INLINE
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: array_of_structs
+                end_bracket: )
+          - naked_identifier: exploded_people
+          - naked_identifier: name
+          - comma: ','
+          - naked_identifier: age
+          - comma: ','
+          - naked_identifier: state
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -656,22 +656,125 @@ file:
             alias_expression:
               keyword: AS
               naked_identifier: p
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: INLINE
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    column_reference:
-                      naked_identifier: array_of_structs
-                  end_bracket: )
-            - keyword: AS
-            - naked_identifier: name
-            - comma: ','
-            - naked_identifier: age
-            - comma: ','
-            - naked_identifier: state
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: INLINE
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: array_of_structs
+                end_bracket: )
+          - keyword: AS
+          - naked_identifier: name
+          - comma: ','
+          - naked_identifier: age
+          - comma: ','
+          - naked_identifier: state
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: t1
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            bracketed:
+              start_bracket: (
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: GET_JSON_OBJECT
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        naked_identifier: things
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'$.percentage'"
+                  - end_bracket: )
+              keyword: AS
+              data_type:
+                primitive_type:
+                  keyword: DECIMAL
+                  bracketed_arguments:
+                    bracketed:
+                    - start_bracket: (
+                    - numeric_literal: '16'
+                    - comma: ','
+                    - numeric_literal: '8'
+                    - end_bracket: )
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: ptc
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+            alias_expression:
+              keyword: AS
+              naked_identifier: t1
+          join_clause:
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table2
+              alias_expression:
+                keyword: AS
+                naked_identifier: t2
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - naked_identifier: c
+                - dot: .
+                - naked_identifier: column1
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: column1
+              - binary_operator: AND
+              - column_reference:
+                - naked_identifier: t2
+                - dot: .
+                - naked_identifier: type
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - quoted_literal: "'SOMETHING'"
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - keyword: OUTER
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                  - naked_identifier: t2
+                  - dot: .
+                  - naked_identifier: column2
+                end_bracket: )
+          - keyword: AS
+          - naked_identifier: things
 - statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/select_lateral_view_supported_tvf.yml
+++ b/test/fixtures/dialects/sparksql/select_lateral_view_supported_tvf.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 178acfd014cf9b8b0815c26e4b85e0121265e0f2aa05a2f1146a3c8f60f91449
+_hash: 6dffb30e69d9125d6bb7e0c1ecc5558f6160c97d39b71865759e72451e504f4f
 file:
 - statement:
     select_statement:
@@ -75,29 +75,29 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: test
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: explode
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: array
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          numeric_literal: '3'
-                      - comma: ','
-                      - expression:
-                          numeric_literal: '4'
-                      - end_bracket: )
-                  end_bracket: )
-            - keyword: AS
-            - naked_identifier: c2
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: explode
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: array
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        numeric_literal: '3'
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '4'
+                    - end_bracket: )
+                end_bracket: )
+          - keyword: AS
+          - naked_identifier: c2
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -121,29 +121,29 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: test
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: explode_outer
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: array
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          numeric_literal: '3'
-                      - comma: ','
-                      - expression:
-                          numeric_literal: '4'
-                      - end_bracket: )
-                  end_bracket: )
-            - keyword: AS
-            - naked_identifier: c2
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: explode_outer
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: array
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        numeric_literal: '3'
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '4'
+                    - end_bracket: )
+                end_bracket: )
+          - keyword: AS
+          - naked_identifier: c2
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -255,51 +255,51 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: test
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: inline
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: array
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          function:
-                            function_name:
-                              function_name_identifier: struct
-                            bracketed:
-                            - start_bracket: (
-                            - expression:
-                                numeric_literal: '1'
-                            - comma: ','
-                            - expression:
-                                quoted_literal: "'a'"
-                            - end_bracket: )
-                      - comma: ','
-                      - expression:
-                          function:
-                            function_name:
-                              function_name_identifier: struct
-                            bracketed:
-                            - start_bracket: (
-                            - expression:
-                                numeric_literal: '2'
-                            - comma: ','
-                            - expression:
-                                quoted_literal: "'b'"
-                            - end_bracket: )
-                      - end_bracket: )
-                  end_bracket: )
-            - keyword: AS
-            - naked_identifier: c1
-            - comma: ','
-            - naked_identifier: c2
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: inline
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: array
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        function:
+                          function_name:
+                            function_name_identifier: struct
+                          bracketed:
+                          - start_bracket: (
+                          - expression:
+                              numeric_literal: '1'
+                          - comma: ','
+                          - expression:
+                              quoted_literal: "'a'"
+                          - end_bracket: )
+                    - comma: ','
+                    - expression:
+                        function:
+                          function_name:
+                            function_name_identifier: struct
+                          bracketed:
+                          - start_bracket: (
+                          - expression:
+                              numeric_literal: '2'
+                          - comma: ','
+                          - expression:
+                              quoted_literal: "'b'"
+                          - end_bracket: )
+                    - end_bracket: )
+                end_bracket: )
+          - keyword: AS
+          - naked_identifier: c1
+          - comma: ','
+          - naked_identifier: c2
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -323,51 +323,51 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: test
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: inline_outer
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: array
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          function:
-                            function_name:
-                              function_name_identifier: struct
-                            bracketed:
-                            - start_bracket: (
-                            - expression:
-                                numeric_literal: '1'
-                            - comma: ','
-                            - expression:
-                                quoted_literal: "'a'"
-                            - end_bracket: )
-                      - comma: ','
-                      - expression:
-                          function:
-                            function_name:
-                              function_name_identifier: struct
-                            bracketed:
-                            - start_bracket: (
-                            - expression:
-                                numeric_literal: '2'
-                            - comma: ','
-                            - expression:
-                                quoted_literal: "'b'"
-                            - end_bracket: )
-                      - end_bracket: )
-                  end_bracket: )
-            - keyword: AS
-            - naked_identifier: c1
-            - comma: ','
-            - naked_identifier: c2
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: inline_outer
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: array
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        function:
+                          function_name:
+                            function_name_identifier: struct
+                          bracketed:
+                          - start_bracket: (
+                          - expression:
+                              numeric_literal: '1'
+                          - comma: ','
+                          - expression:
+                              quoted_literal: "'a'"
+                          - end_bracket: )
+                    - comma: ','
+                    - expression:
+                        function:
+                          function_name:
+                            function_name_identifier: struct
+                          bracketed:
+                          - start_bracket: (
+                          - expression:
+                              numeric_literal: '2'
+                          - comma: ','
+                          - expression:
+                              quoted_literal: "'b'"
+                          - end_bracket: )
+                    - end_bracket: )
+                end_bracket: )
+          - keyword: AS
+          - naked_identifier: c1
+          - comma: ','
+          - naked_identifier: c2
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -439,29 +439,29 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: test
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: posexplode
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: array
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          numeric_literal: '10'
-                      - comma: ','
-                      - expression:
-                          numeric_literal: '20'
-                      - end_bracket: )
-                  end_bracket: )
-            - keyword: AS
-            - naked_identifier: c1
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: posexplode
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: array
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        numeric_literal: '10'
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '20'
+                    - end_bracket: )
+                end_bracket: )
+          - keyword: AS
+          - naked_identifier: c1
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -485,29 +485,29 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: test
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: posexplode_outer
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    function:
-                      function_name:
-                        function_name_identifier: array
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          numeric_literal: '10'
-                      - comma: ','
-                      - expression:
-                          numeric_literal: '20'
-                      - end_bracket: )
-                  end_bracket: )
-            - keyword: AS
-            - naked_identifier: c1
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: posexplode_outer
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: array
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        numeric_literal: '10'
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '20'
+                    - end_bracket: )
+                end_bracket: )
+          - keyword: AS
+          - naked_identifier: c1
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -554,30 +554,30 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: test
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: stack
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    numeric_literal: '2'
-                - comma: ','
-                - expression:
-                    numeric_literal: '1'
-                - comma: ','
-                - expression:
-                    numeric_literal: '2'
-                - comma: ','
-                - expression:
-                    numeric_literal: '3'
-                - end_bracket: )
-            - keyword: AS
-            - naked_identifier: c1
-            - comma: ','
-            - naked_identifier: c2
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: stack
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  numeric_literal: '2'
+              - comma: ','
+              - expression:
+                  numeric_literal: '1'
+              - comma: ','
+              - expression:
+                  numeric_literal: '2'
+              - comma: ','
+              - expression:
+                  numeric_literal: '3'
+              - end_bracket: )
+          - keyword: AS
+          - naked_identifier: c1
+          - comma: ','
+          - naked_identifier: c2
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -621,27 +621,27 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: test
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: json_tuple
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    quoted_literal: "'{\"a\":1, \"b\":2}'"
-                - comma: ','
-                - expression:
-                    quoted_literal: "'a'"
-                - comma: ','
-                - expression:
-                    quoted_literal: "'b'"
-                - end_bracket: )
-            - keyword: AS
-            - naked_identifier: c1
-            - comma: ','
-            - naked_identifier: c2
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: json_tuple
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'{\"a\":1, \"b\":2}'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'a'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'b'"
+              - end_bracket: )
+          - keyword: AS
+          - naked_identifier: c1
+          - comma: ','
+          - naked_identifier: c2
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -682,20 +682,20 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: test
-            lateral_view_clause:
-            - keyword: LATERAL
-            - keyword: VIEW
-            - function:
-                function_name:
-                  function_name_identifier: parse_url
-                bracketed:
-                - start_bracket: (
-                - expression:
-                    quoted_literal: "'http://spark.apache.org/path?query=1'"
-                - comma: ','
-                - expression:
-                    quoted_literal: "'HOST'"
-                - end_bracket: )
-            - keyword: AS
-            - naked_identifier: c1
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: parse_url
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'http://spark.apache.org/path?query=1'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'HOST'"
+              - end_bracket: )
+          - keyword: AS
+          - naked_identifier: c1
 - statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/select_qualify.sql
+++ b/test/fixtures/dialects/sparksql/select_qualify.sql
@@ -48,10 +48,13 @@ SELECT
   item,
   RANK() OVER (PARTITION BY category ORDER BY purchases DESC) AS rank
 FROM Produce
+WHERE Produce.category = 'vegetable'
 WINDOW item_window AS (
   PARTITION BY category
   ORDER BY purchases
   ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING)
-WHERE Produce.category = 'vegetable'
 QUALIFY rank <= 3
-ORDER BY item
+ORDER BY item;
+
+SELECT CURRENT_DATE() AS p_data_date
+QUALIFY ROW_NUMBER() OVER (ORDER BY p_data_date) = 1;

--- a/test/fixtures/dialects/sparksql/select_qualify.yml
+++ b/test/fixtures/dialects/sparksql/select_qualify.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6be6f8cc477e592f46d4295f5a1f1af51289aec2aac6d4a159d82733da3b4f62
+_hash: 87725f7798fdced1451ee1f98dd29dea5c1c9379084d8acb961bb71885d65b8e
 file:
 - statement:
     select_statement:
@@ -435,34 +435,6 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: Produce
-            named_window:
-              keyword: WINDOW
-              named_window_expression:
-                naked_identifier: item_window
-                keyword: AS
-                bracketed:
-                  start_bracket: (
-                  window_specification:
-                    partitionby_clause:
-                    - keyword: PARTITION
-                    - keyword: BY
-                    - expression:
-                        column_reference:
-                          naked_identifier: category
-                    orderby_clause:
-                    - keyword: ORDER
-                    - keyword: BY
-                    - column_reference:
-                        naked_identifier: purchases
-                    frame_clause:
-                    - keyword: ROWS
-                    - keyword: BETWEEN
-                    - numeric_literal: '2'
-                    - keyword: PRECEDING
-                    - keyword: AND
-                    - numeric_literal: '2'
-                    - keyword: FOLLOWING
-                  end_bracket: )
       where_clause:
         keyword: WHERE
         expression:
@@ -473,6 +445,34 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           quoted_literal: "'vegetable'"
+      named_window:
+        keyword: WINDOW
+        named_window_expression:
+          naked_identifier: item_window
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              partitionby_clause:
+              - keyword: PARTITION
+              - keyword: BY
+              - expression:
+                  column_reference:
+                    naked_identifier: category
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: purchases
+              frame_clause:
+              - keyword: ROWS
+              - keyword: BETWEEN
+              - numeric_literal: '2'
+              - keyword: PRECEDING
+              - keyword: AND
+              - numeric_literal: '2'
+              - keyword: FOLLOWING
+            end_bracket: )
       qualify_clause:
         keyword: QUALIFY
         expression:
@@ -487,3 +487,42 @@ file:
       - keyword: BY
       - column_reference:
           naked_identifier: item
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CURRENT_DATE
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: p_data_date
+      qualify_clause:
+        keyword: QUALIFY
+        expression:
+          function:
+            function_name:
+              function_name_identifier: ROW_NUMBER
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: p_data_date
+                end_bracket: )
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+- statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/select_sort_by.sql
+++ b/test/fixtures/dialects/sparksql/select_sort_by.sql
@@ -132,3 +132,6 @@ FROM person
 GROUP BY age
 HAVING COUNT(age) > 1
 SORT BY age;
+
+SELECT CURRENT_DATE() AS p_data_date
+SORT BY p_data_date;

--- a/test/fixtures/dialects/sparksql/select_sort_by.yml
+++ b/test/fixtures/dialects/sparksql/select_sort_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 165a27d604367bcfd0b6120bd77f56eb432074fd3ca1bed5785f1491971e8cea
+_hash: c1bb719e195a3c42ae6a7d34b6b83a752ddf32241fd5cf88bdc13f97c6d120de
 file:
 - statement:
     select_statement:
@@ -582,4 +582,24 @@ file:
       - keyword: BY
       - column_reference:
           naked_identifier: age
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CURRENT_DATE
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: p_data_date
+      sort_by_clause:
+      - keyword: SORT
+      - keyword: BY
+      - column_reference:
+          naked_identifier: p_data_date
 - statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/window_functions.yml
+++ b/test/fixtures/dialects/sparksql/window_functions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 00bbbff73f8f9a420c42c4cdd5d98e0f36c435b97662e439e295403c96aae249
+_hash: fe52383d09720aa200bc7d56570fb86f312e6f78d1dd1d39748173bc0c46fa68
 file:
 - statement:
     select_statement:
@@ -611,20 +611,20 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: test_ignore_null
-            named_window:
-              keyword: WINDOW
-              named_window_expression:
-                naked_identifier: w
-                keyword: AS
-                bracketed:
-                  start_bracket: (
-                  window_specification:
-                    orderby_clause:
-                    - keyword: ORDER
-                    - keyword: BY
-                    - column_reference:
-                        naked_identifier: id
-                  end_bracket: )
+      named_window:
+        keyword: WINDOW
+        named_window_expression:
+          naked_identifier: w
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: id
+            end_bracket: )
       orderby_clause:
       - keyword: ORDER
       - keyword: BY
@@ -753,20 +753,20 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: test_ignore_null
-            named_window:
-              keyword: WINDOW
-              named_window_expression:
-                naked_identifier: w
-                keyword: AS
-                bracketed:
-                  start_bracket: (
-                  window_specification:
-                    orderby_clause:
-                    - keyword: ORDER
-                    - keyword: BY
-                    - column_reference:
-                        naked_identifier: id
-                  end_bracket: )
+      named_window:
+        keyword: WINDOW
+        named_window_expression:
+          naked_identifier: w
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                  naked_identifier: id
+            end_bracket: )
       orderby_clause:
       - keyword: ORDER
       - keyword: BY
@@ -912,22 +912,22 @@ file:
             alias_expression:
               keyword: AS
               naked_identifier: ignore_nulls
-            named_window:
-              keyword: WINDOW
-              named_window_expression:
-                naked_identifier: w
-                keyword: AS
-                bracketed:
-                  start_bracket: (
-                  window_specification:
-                    orderby_clause:
-                    - keyword: ORDER
-                    - keyword: BY
-                    - column_reference:
-                      - naked_identifier: ignore_nulls
-                      - dot: .
-                      - naked_identifier: id
-                  end_bracket: )
+      named_window:
+        keyword: WINDOW
+        named_window_expression:
+          naked_identifier: w
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                - naked_identifier: ignore_nulls
+                - dot: .
+                - naked_identifier: id
+            end_bracket: )
       orderby_clause:
       - keyword: ORDER
       - keyword: BY
@@ -1075,34 +1075,34 @@ file:
             alias_expression:
               keyword: AS
               naked_identifier: ignore_nulls
-            named_window:
-              keyword: WINDOW
-              named_window_expression:
-                naked_identifier: w
-                keyword: AS
-                bracketed:
-                  start_bracket: (
-                  window_specification:
-                    orderby_clause:
-                    - keyword: ORDER
-                    - keyword: BY
-                    - column_reference:
-                      - naked_identifier: ignore_nulls
-                      - dot: .
-                      - naked_identifier: id
-                    frame_clause:
-                    - keyword: range
-                    - keyword: between
-                    - interval_expression:
-                        keyword: interval
-                        interval_literal:
-                          numeric_literal: '6'
-                          date_part: days
-                    - keyword: preceding
-                    - keyword: and
-                    - keyword: current
-                    - keyword: row
-                  end_bracket: )
+      named_window:
+        keyword: WINDOW
+        named_window_expression:
+          naked_identifier: w
+          keyword: AS
+          bracketed:
+            start_bracket: (
+            window_specification:
+              orderby_clause:
+              - keyword: ORDER
+              - keyword: BY
+              - column_reference:
+                - naked_identifier: ignore_nulls
+                - dot: .
+                - naked_identifier: id
+              frame_clause:
+              - keyword: range
+              - keyword: between
+              - interval_expression:
+                  keyword: interval
+                  interval_literal:
+                    numeric_literal: '6'
+                    date_part: days
+              - keyword: preceding
+              - keyword: and
+              - keyword: current
+              - keyword: row
+            end_bracket: )
       orderby_clause:
       - keyword: ORDER
       - keyword: BY


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #5439 
- `LATERAL VIEW` handled as a JOIN-like clause
- Fix `SELECT ... CLUSTER BY` without `FROM`
- Fix `SELECT ... DISTRIBUTE BY` without `FROM`
- Fix `SELECT ... SORT BY` without `FROM`
- Fix `SELECT ... QUALIFY` without `FROM`

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
