### PR TITLE
Oracle: parse length qualifier in types

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -708,7 +708,18 @@ class ColumnDefinitionSegment(BaseSegment):
             ),
             Sequence(
                 Ref("DatatypeSegment"),  # Column type
-                Bracketed(Anything(), optional=True),  # For types like VARCHAR(100)
+                # For types like VARCHAR(100), VARCHAR(100 BYTE), VARCHAR (100 CHAR)
+                Bracketed(
+                    Sequence(
+                        Anything(),
+                        OneOf(
+                            "BYTE",
+                            "CHAR",
+                            optional=True,
+                        ),
+                    ),
+                    optional=True,
+                ),
                 AnyNumberOf(
                     Ref("ColumnConstraintSegment", optional=True),
                 ),

--- a/test/fixtures/dialects/oracle/temporary_table.sql
+++ b/test/fixtures/dialects/oracle/temporary_table.sql
@@ -18,13 +18,13 @@ ON COMMIT PRESERVE ROWS;
 
 CREATE PRIVATE TEMPORARY TABLE ora$ptt_my_temp_table (
   id           NUMBER,
-  description  VARCHAR2(20)
+  description  VARCHAR2(20 BYTE)
 )
 ON COMMIT DROP DEFINITION;
 
 CREATE PRIVATE TEMPORARY TABLE ora$ptt_my_temp_table (
   id           NUMBER,
-  description  VARCHAR2(20)
+  description  VARCHAR2(20 CHAR)
 )
 ON COMMIT PRESERVE DEFINITION;
 

--- a/test/fixtures/dialects/oracle/temporary_table.yml
+++ b/test/fixtures/dialects/oracle/temporary_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8cbfbb0ebb67e9974ae411e9fcace308dfa8cb3db044bcba8e0a3c684853699e
+_hash: ca868384d802f535ba528cb300ea943a1e0e47a38c09240a0fda06b65c8123e1
 file:
 - statement:
     create_table_statement:
@@ -145,11 +145,11 @@ file:
           naked_identifier: description
           data_type:
             data_type_identifier: VARCHAR2
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '20'
-                end_bracket: )
+          bracketed:
+            start_bracket: (
+            numeric_literal: '20'
+            word: BYTE
+            end_bracket: )
       - end_bracket: )
     - keyword: 'ON'
     - keyword: COMMIT
@@ -175,11 +175,11 @@ file:
           naked_identifier: description
           data_type:
             data_type_identifier: VARCHAR2
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '20'
-                end_bracket: )
+          bracketed:
+            start_bracket: (
+            numeric_literal: '20'
+            word: CHAR
+            end_bracket: )
       - end_bracket: )
     - keyword: 'ON'
     - keyword: COMMIT


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


Oracle allows length specifiers for types `CHAR` and `VARCHAR2`

- https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/Data-Types.html

Allow parsing of `VARCHAR2(100 BYTE)`, `VARCHAR2(100 CHAR)`, etc.

Fix Oracle dialect to support parsing this, e.g. in create table statement.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
