### PR TITLE
SQLite: Make `DISTINCT FROM` optional; SQLite/TSQL/Exasol: Nothing'd `NanLiteralSegment`

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -353,6 +353,9 @@ ansi_dialect.add(
     BooleanBinaryOperatorGrammar=OneOf(
         Ref("AndOperatorGrammar"), Ref("OrOperatorGrammar")
     ),
+    IsDistinctFromGrammar=Sequence(
+        "IS", Ref.keyword("NOT", optional=True), "DISTINCT", "FROM"
+    ),
     ComparisonOperatorGrammar=OneOf(
         Ref("EqualsSegment"),
         Ref("GreaterThanSegment"),
@@ -361,8 +364,7 @@ ansi_dialect.add(
         Ref("LessThanOrEqualToSegment"),
         Ref("NotEqualToSegment"),
         Ref("LikeOperatorSegment"),
-        Sequence("IS", "DISTINCT", "FROM"),
-        Sequence("IS", "NOT", "DISTINCT", "FROM"),
+        Ref("IsDistinctFromGrammar"),
     ),
     # hookpoint for other dialects
     # e.g. EXASOL str to date cast with DATE '2021-01-01'

--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -225,10 +225,7 @@ exasol_dialect.replace(
         type="parameter",
     ),
     LikeGrammar=Ref.keyword("LIKE"),
-    IsClauseGrammar=OneOf(
-        "NULL",
-        Ref("BooleanLiteralGrammar"),
-    ),
+    NanLiteralSegment=Nothing(),
     SelectClauseTerminatorGrammar=OneOf(
         "FROM",
         "WHERE",

--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -188,10 +188,12 @@ sqlite_dialect.replace(
         Ref("TildeSegment"),
         Ref("NotOperatorGrammar"),
     ),
-    IsClauseGrammar=OneOf(
-        "NULL",
-        Ref("BooleanLiteralGrammar"),
+    IsDistinctFromGrammar=Sequence(
+        "IS",
+        Ref.keyword("NOT", optional=True),
+        Sequence("DISTINCT", "FROM", optional=True),
     ),
+    NanLiteralSegment=Nothing(),
 )
 
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -434,11 +434,7 @@ tsql_dialect.replace(
             + r")$",
         )
     ),
-    # Override ANSI IsClauseGrammar to remove TSQL non-keyword NAN
-    IsClauseGrammar=OneOf(
-        "NULL",
-        Ref("BooleanLiteralGrammar"),
-    ),
+    NanLiteralSegment=Nothing(),
     DatatypeIdentifierSegment=SegmentGenerator(
         # Generate the anti template reserved keywords
         lambda dialect: OneOf(

--- a/test/fixtures/dialects/exasol/create_function_statement.yml
+++ b/test/fixtures/dialects/exasol/create_function_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f33f127aa0ec656ffa63587a2620ba4bdcbca0870d610d867b8b656a567b6784
+_hash: f4b86a7638518705da9729065b94d36abfa0744a661096299f037753b0d767d3
 file:
 - statement:
     create_function_statement:
@@ -538,13 +538,13 @@ file:
               naked_identifier: p1
           - keyword: IS
           - keyword: NOT
-          - keyword: 'NULL'
+          - null_literal: 'NULL'
           - binary_operator: AND
           - column_reference:
               naked_identifier: p2
           - keyword: IS
           - keyword: NOT
-          - keyword: 'NULL'
+          - null_literal: 'NULL'
         - keyword: THEN
         - function_body:
             function_if_branch:

--- a/test/fixtures/dialects/sqlite/create_index.yml
+++ b/test/fixtures/dialects/sqlite/create_index.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 42ff8ffbd151fb9e46fbdc962aa6479bceaf758ac2bdb4827d6f88e167e0ae88
+_hash: 60a5ec841e31d0c343ef489afa1a956dbf7f7a7ed7888fd12bcd01ebb55fcfcb
 file:
 - statement:
     create_index_statement:
@@ -153,7 +153,7 @@ file:
             naked_identifier: parent_po
         - keyword: IS
         - keyword: NOT
-        - keyword: 'NULL'
+        - null_literal: 'NULL'
 - statement_terminator: ;
 - statement:
     create_index_statement:
@@ -179,5 +179,5 @@ file:
             naked_identifier: c
         - keyword: IS
         - keyword: NOT
-        - keyword: 'NULL'
+        - null_literal: 'NULL'
 - statement_terminator: ;

--- a/test/fixtures/dialects/sqlite/is_clause.sql
+++ b/test/fixtures/dialects/sqlite/is_clause.sql
@@ -1,0 +1,19 @@
+CREATE TABLE Repro (
+    col TEXT NOT NULL CHECK (col IS DATE(col))
+);
+
+CREATE TABLE Repro (
+    col TEXT NOT NULL CHECK (col IS NOT DATE(col))
+);
+
+SELECT *
+FROM Tab
+WHERE col1 IS NOT DATE(col2);
+
+SELECT *
+FROM Tab
+WHERE col1 IS col2;
+
+SELECT *
+FROM Tab
+WHERE col1 IS NOT col2;

--- a/test/fixtures/dialects/sqlite/is_clause.yml
+++ b/test/fixtures/dialects/sqlite/is_clause.yml
@@ -1,0 +1,159 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 2dbd2c9931c3eac15da53a94cf26cc4a69da3720e2211cd2481a8d79102e2596
+file:
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: Repro
+    - bracketed:
+        start_bracket: (
+        column_definition:
+        - naked_identifier: col
+        - data_type:
+            data_type_identifier: TEXT
+        - column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+        - column_constraint_segment:
+            keyword: CHECK
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: col
+                keyword: IS
+                function:
+                  function_name:
+                    function_name_identifier: DATE
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: col
+                    end_bracket: )
+              end_bracket: )
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: Repro
+    - bracketed:
+        start_bracket: (
+        column_definition:
+        - naked_identifier: col
+        - data_type:
+            data_type_identifier: TEXT
+        - column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+        - column_constraint_segment:
+            keyword: CHECK
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: col
+              - keyword: IS
+              - keyword: NOT
+              - function:
+                  function_name:
+                    function_name_identifier: DATE
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: col
+                    end_bracket: )
+              end_bracket: )
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: Tab
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: col1
+        - keyword: IS
+        - keyword: NOT
+        - function:
+            function_name:
+              function_name_identifier: DATE
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: col2
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: Tab
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: col1
+        - keyword: IS
+        - column_reference:
+            naked_identifier: col2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: Tab
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: col1
+        - keyword: IS
+        - keyword: NOT
+        - column_reference:
+            naked_identifier: col2
+- statement_terminator: ;

--- a/test/fixtures/dialects/tsql/add_index.yml
+++ b/test/fixtures/dialects/tsql/add_index.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 32467a3df7496155a7a70394a04634d094a226fc21bbbc56ee5756e664acf72b
+_hash: 5e079e1d5e1fe2df880e0e1f65031734037df6e5cf77126d2e9319bfac4cbbe2
 file:
 - batch:
     statement:
@@ -203,10 +203,10 @@ file:
           bracketed:
             start_bracket: (
             expression:
-            - column_reference:
+              column_reference:
                 quoted_identifier: '[column3]'
-            - keyword: IS
-            - keyword: 'NULL'
+              keyword: IS
+              null_literal: 'NULL'
             end_bracket: )
       - statement_terminator: ;
 - go_statement:

--- a/test/fixtures/dialects/tsql/create_procedure.yml
+++ b/test/fixtures/dialects/tsql/create_procedure.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 675c65a45426a06227ba37b639eb5625154210effad6819e2e9071d5b61f066a
+_hash: ce323929c8e0bfe1e786a4a5d107c5fba6b29a442f63d335ff3946cb38b97417
 file:
 - batch:
     create_procedure_statement:
@@ -257,9 +257,9 @@ file:
                 if_clause:
                   keyword: IF
                   expression:
-                  - parameter: '@id'
-                  - keyword: IS
-                  - keyword: 'NULL'
+                    parameter: '@id'
+                    keyword: IS
+                    null_literal: 'NULL'
                 statement:
                   begin_end_block:
                   - keyword: BEGIN

--- a/test/fixtures/dialects/tsql/create_view_with_cte.yml
+++ b/test/fixtures/dialects/tsql/create_view_with_cte.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 951d51cf8b09c685fcd1dd86f94137588be1f2bda875d0bee4c132f58f7035a6
+_hash: fec8581096c183915cc746afd0dc8c2cd00475a945089037d762df9344ae3b6c
 file:
   batch:
     statement:
@@ -61,7 +61,7 @@ file:
                         naked_identifier: ManagerID
                     - keyword: IS
                     - keyword: NOT
-                    - keyword: 'NULL'
+                    - null_literal: 'NULL'
               - set_operator:
                 - keyword: UNION
                 - keyword: ALL

--- a/test/fixtures/dialects/tsql/create_view_with_set_statements.yml
+++ b/test/fixtures/dialects/tsql/create_view_with_set_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3c4376ca88135168a4d7c082dc67d118bb7bf79ea8f244951072a2c4c99409e7
+_hash: 36403e664435e85a58a2f9863ed08a411bcedd0b733c7ca365176dd01d45eb4e
 file:
 - batch:
     statement:
@@ -132,10 +132,10 @@ file:
                 - when_clause:
                   - keyword: WHEN
                   - expression:
-                    - column_reference:
+                      column_reference:
                         naked_identifier: OLD_VALUE
-                    - keyword: IS
-                    - keyword: 'NULL'
+                      keyword: IS
+                      null_literal: 'NULL'
                   - keyword: THEN
                   - expression:
                       numeric_literal: '0'
@@ -156,10 +156,10 @@ file:
                 - when_clause:
                   - keyword: WHEN
                   - expression:
-                    - column_reference:
+                      column_reference:
                         quoted_identifier: '[DIFFERENCE]'
-                    - keyword: IS
-                    - keyword: 'NULL'
+                      keyword: IS
+                      null_literal: 'NULL'
                   - keyword: THEN
                   - expression:
                       numeric_literal: '0'

--- a/test/fixtures/dialects/tsql/cte_s.yml
+++ b/test/fixtures/dialects/tsql/cte_s.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 00cee9d2c0d7a5946f8c3b726fc6c88810c061a192cdcd90fa1c23f3f64a5f28
+_hash: 784faa8eecac7eea5c5d415755498d13b962cf2ad57deaaaf51a2613ac99b3b7
 file:
   batch:
     statement:
@@ -53,7 +53,7 @@ file:
                     naked_identifier: SalesPersonID
                 - keyword: IS
                 - keyword: NOT
-                - keyword: 'NULL'
+                - null_literal: 'NULL'
               groupby_clause:
               - keyword: GROUP
               - keyword: BY

--- a/test/fixtures/dialects/tsql/cursor.yml
+++ b/test/fixtures/dialects/tsql/cursor.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9575b8d9a12401ef837abd4a8a7621be306d389f2908bf191fc06a6646ecc962
+_hash: fa41197cd43f3e5dafdf93790658245f09fe3af641711997f525e23cf60b8b00
 file:
   batch:
   - statement:
@@ -39,7 +39,7 @@ file:
                 naked_identifier: column_a
             - keyword: IS
             - keyword: NOT
-            - keyword: 'NULL'
+            - null_literal: 'NULL'
           orderby_clause:
           - keyword: ORDER
           - keyword: BY

--- a/test/fixtures/dialects/tsql/declare_with_following_statements.yml
+++ b/test/fixtures/dialects/tsql/declare_with_following_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 965bf0479aba3f070f232c24f5cd5972ded3a634a9f5752eead4702eb1548291
+_hash: 782ad823185da6f2f21d8d74297b732c9867f0158d1fe204ae9c0433c682ad3b
 file:
   batch:
     create_procedure_statement:
@@ -146,7 +146,7 @@ file:
                         end_bracket: )
                   - keyword: IS
                   - keyword: NOT
-                  - keyword: 'NULL'
+                  - null_literal: 'NULL'
                 statement:
                   drop_table_statement:
                   - keyword: DROP

--- a/test/fixtures/dialects/tsql/delete.yml
+++ b/test/fixtures/dialects/tsql/delete.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 499e9012f5cb95c4d85b318e244cf97db07a0782422e2f77aa327eb635e1e8a9
+_hash: f279ff3e7dd7a2c8b514304c240ff92d27cc76364368f94f00f9c753244c7165
 file:
 - batch:
     statement:
@@ -58,7 +58,7 @@ file:
           - column_reference:
               naked_identifier: EndDate
           - keyword: IS
-          - keyword: 'NULL'
+          - null_literal: 'NULL'
         statement_terminator: ;
   - statement:
       print_statement:

--- a/test/fixtures/dialects/tsql/function_no_return.yml
+++ b/test/fixtures/dialects/tsql/function_no_return.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d1b3caca4f104b93e196ae36b12749b06d10cc6e41868e5c89903c3c5273bc51
+_hash: fab5713014db6548904ddfa6adbd64a6af716c545137767bf833386f55b6edd1
 file:
   batch:
     create_procedure_statement:
@@ -26,9 +26,9 @@ file:
           - if_clause:
               keyword: IF
               expression:
-              - parameter: '@nm'
-              - keyword: IS
-              - keyword: 'NULL'
+                parameter: '@nm'
+                keyword: IS
+                null_literal: 'NULL'
           - statement:
               begin_end_block:
               - keyword: BEGIN

--- a/test/fixtures/dialects/tsql/functions_a.yml
+++ b/test/fixtures/dialects/tsql/functions_a.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 35529ba8804ad93991b801f34ea63c8abc1f6ece22ba11cd1d91ce801ef6f64a
+_hash: f60e9801e15851a78f11aac0d0e84972dcbc06d48aed8a6436f24dae8ec810c9
 file:
 - batch:
     statement:
@@ -261,12 +261,12 @@ file:
         where_clause:
           keyword: WHERE
           expression:
-          - column_reference:
+            column_reference:
             - naked_identifier: b
             - dot: .
             - naked_identifier: FIN
-          - keyword: IS
-          - keyword: 'NULL'
+            keyword: IS
+            null_literal: 'NULL'
         statement_terminator: ;
 - go_statement:
     keyword: GO

--- a/test/fixtures/dialects/tsql/hints.yml
+++ b/test/fixtures/dialects/tsql/hints.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6fe6077b68d1043a06174c757f1566f29133888aab96b254faa753d3b667b133
+_hash: 327eef4aeb76cfc878ab63160eaa830b5deef4bd512edd796e6a9a3b81c2e3a5
 file:
 - batch:
     statement:
@@ -202,7 +202,7 @@ file:
                       naked_identifier: PersonID
                   - keyword: IS
                   - keyword: NOT
-                  - keyword: 'NULL'
+                  - null_literal: 'NULL'
             - set_operator:
               - keyword: UNION
               - keyword: ALL

--- a/test/fixtures/dialects/tsql/merge.yml
+++ b/test/fixtures/dialects/tsql/merge.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: eeed743b0f3ee6e127b892a23031b17bc824eeb3d889397a2755b167a44cea34
+_hash: ddabe931655863f15126960566dd5c63b797b355e7e59f802c02d2a0c1d9989c
 file:
 - batch:
     statement:
@@ -38,7 +38,7 @@ file:
             - dot: .
             - naked_identifier: e_date_to
           - keyword: is
-          - keyword: 'null'
+          - null_literal: 'null'
           - binary_operator: and
           - column_reference:
             - naked_identifier: dst
@@ -126,7 +126,7 @@ file:
                 - column_reference:
                     naked_identifier: e_date_to
                 - keyword: is
-                - keyword: 'null'
+                - null_literal: 'null'
                 - binary_operator: and
                 - column_reference:
                     naked_identifier: l_id
@@ -348,7 +348,7 @@ file:
               - naked_identifier: c_id
             - keyword: is
             - keyword: not
-            - keyword: 'null'
+            - null_literal: 'null'
           - keyword: then
           - merge_insert_clause:
             - keyword: insert


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #5619 
- Makes the `DISTINCT FROM` optional in SQLite
- Defaulted `IsClauseGrammar` in all dialects and set `NanLiteralSegment` to `Nothing` for current dialects removing it

### Are there any other side effects of this change that we should be aware of?
This could impact SQLite, TSQL, or Exasol rules where CP01 and CP04 are set different for `IS [NOT] NULL`. This is the default behavior for all other dialects as noted in #5099.

Input:
```sql
SELECT true from tab where col is not null;
```

Fixed:
```sql
SELECT true FROM tab WHERE col IS NOT null; 
```

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
