### PR TITLE
[snowflake dialect] support ALTER TABLE ... ADD COLUMN IF NOT EXISTS

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1721,7 +1721,7 @@ class AlterTableTableColumnActionSegment(BaseSegment):
         Sequence(
             "ADD",
             Ref.keyword("COLUMN", optional=True),
-            # @TODO: Cannot specify IF NOT EXISTS if also specifying 
+            # @TODO: Cannot specify IF NOT EXISTS if also specifying
             # DEFAULT, AUTOINCREMENT, IDENTITY UNIQUE, PRIMARY KEY, FOREIGN KEY
             Ref("IfNotExistsGrammar", optional=True),
             # Handle Multiple Columns

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1721,6 +1721,9 @@ class AlterTableTableColumnActionSegment(BaseSegment):
         Sequence(
             "ADD",
             Ref.keyword("COLUMN", optional=True),
+            # @TODO: Cannot specify IF NOT EXISTS if also specifying 
+            # DEFAULT, AUTOINCREMENT, IDENTITY UNIQUE, PRIMARY KEY, FOREIGN KEY
+            Ref("IfNotExistsGrammar", optional=True),
             # Handle Multiple Columns
             Delimited(
                 Sequence(

--- a/test/fixtures/dialects/snowflake/alter_table_column.sql
+++ b/test/fixtures/dialects/snowflake/alter_table_column.sql
@@ -2,6 +2,7 @@
 ---- Base cases
 ALTER TABLE my_table ADD COLUMN my_column INTEGER;
 ALTER TABLE my_table ADD COLUMN my_column VARCHAR(5000) NOT NULL;
+ALTER TABLE my_table ADD COLUMN IF NOT EXISTS my_column INTEGER;
 
 ------ Multiple columns
 ALTER TABLE my_table ADD COLUMN column_1 varchar, column_2 integer;

--- a/test/fixtures/dialects/snowflake/alter_table_column.yml
+++ b/test/fixtures/dialects/snowflake/alter_table_column.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a661d921f72d807ed26fa97225e83c40b6e705e975a7fe0622e259a0999323e8
+_hash: 5d13fc0e5461c17cc822abce14e000655fc3eb1b319d5dfcf4d669eb375b2e62
 file:
 - statement:
     alter_table_statement:
@@ -40,6 +40,23 @@ file:
           column_constraint_segment:
           - keyword: NOT
           - keyword: 'NULL'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: my_table
+    - alter_table_table_column_action:
+      - keyword: ADD
+      - keyword: COLUMN
+      - keyword: IF
+      - keyword: NOT
+      - keyword: EXISTS
+      - column_reference:
+          naked_identifier: my_column
+      - data_type:
+          data_type_identifier: INTEGER
 - statement_terminator: ;
 - statement:
     alter_table_statement:


### PR DESCRIPTION

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Previously this resulted in an unparseable section.


snowflake documentation that shows this is valid: https://docs.snowflake.com/en/sql-reference/sql/alter-table#table-column-actions-tablecolumnaction


### Are there any other side effects of this change that we should be aware of?
Added a TODO, technically using IF NOT EXISTS with DEFAULT, AUTOINCREMENT, IDENTITY, UNIQUE, PRIMARY KEY, FOREIGN KEY is not valid. However this still closes the gap with what is parseable by the dialect.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
