### PR TITLE
Postgres: Update ReferentialActionGrammar to support sets of columns

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -603,6 +603,19 @@ postgres_dialect.replace(
         ),
     ),
     BracketedSetExpressionGrammar=Bracketed(Ref("SetExpressionSegment")),
+    ReferentialActionGrammar=OneOf(
+        "CASCADE",
+        Sequence(
+            "SET",
+            OneOf("DEFAULT", "NULL"),
+            Bracketed(
+                Delimited(Ref("ColumnReferenceSegment")),
+                optional=True,
+            ),
+        ),
+        "RESTRICT",
+        Sequence("NO", "ACTION"),
+    ),
 )
 
 
@@ -3440,23 +3453,6 @@ class IndexParametersSegment(BaseSegment):
             Ref("TablespaceReferenceSegment"),
             optional=True,
         ),
-    )
-
-
-class ReferentialActionSegment(BaseSegment):
-    """Foreign Key constraints.
-
-    https://www.postgresql.org/docs/13/infoschema-referential-constraints.html
-    """
-
-    type = "referential_action"
-
-    match_grammar = OneOf(
-        "CASCADE",
-        Sequence("SET", "NULL"),
-        Sequence("SET", "DEFAULT"),
-        "RESTRICT",
-        Sequence("NO", "ACTION"),
     )
 
 

--- a/test/fixtures/dialects/postgres/create_table.sql
+++ b/test/fixtures/dialects/postgres/create_table.sql
@@ -341,3 +341,23 @@ CREATE TABLE many_options (
 );
 
 CREATE TABLE example_table () INHERITS (parent_table);
+
+CREATE TABLE IF NOT EXISTS table2(
+  col1 int,
+  col2 int NOT NULL,
+  col3 int,
+
+  FOREIGN KEY (col1, col2)
+  REFERENCES table1 (col1, col2)
+  ON DELETE SET NULL (col1)
+);
+
+CREATE TABLE IF NOT EXISTS table2(
+  col1 int,
+  col2 int NOT NULL,
+  col3 int,
+
+  FOREIGN KEY (col1, col2)
+  REFERENCES table1 (col1, col2)
+  ON DELETE SET DEFAULT (col1)
+);

--- a/test/fixtures/dialects/postgres/create_table.yml
+++ b/test/fixtures/dialects/postgres/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8df5f4f21b70c5cf33fa4443295289fdd156cf3290c0f437389f5906a0e9f983
+_hash: 38fa8e10c52dfc7ad0f16ca0d9ae95f0cd82e34c6fb0bb3e340f5f8baf896eb1
 file:
 - statement:
     create_table_statement:
@@ -2301,4 +2301,128 @@ file:
         table_reference:
           naked_identifier: parent_table
         end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: table2
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: col1
+      - data_type:
+          keyword: int
+      - comma: ','
+      - column_reference:
+          naked_identifier: col2
+      - data_type:
+          keyword: int
+      - column_constraint_segment:
+        - keyword: NOT
+        - keyword: 'NULL'
+      - comma: ','
+      - column_reference:
+          naked_identifier: col3
+      - data_type:
+          keyword: int
+      - comma: ','
+      - table_constraint:
+        - keyword: FOREIGN
+        - keyword: KEY
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: col1
+          - comma: ','
+          - column_reference:
+              naked_identifier: col2
+          - end_bracket: )
+        - keyword: REFERENCES
+        - table_reference:
+            naked_identifier: table1
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: col1
+          - comma: ','
+          - column_reference:
+              naked_identifier: col2
+          - end_bracket: )
+        - keyword: 'ON'
+        - keyword: DELETE
+        - keyword: SET
+        - keyword: 'NULL'
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: col1
+            end_bracket: )
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: table2
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: col1
+      - data_type:
+          keyword: int
+      - comma: ','
+      - column_reference:
+          naked_identifier: col2
+      - data_type:
+          keyword: int
+      - column_constraint_segment:
+        - keyword: NOT
+        - keyword: 'NULL'
+      - comma: ','
+      - column_reference:
+          naked_identifier: col3
+      - data_type:
+          keyword: int
+      - comma: ','
+      - table_constraint:
+        - keyword: FOREIGN
+        - keyword: KEY
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: col1
+          - comma: ','
+          - column_reference:
+              naked_identifier: col2
+          - end_bracket: )
+        - keyword: REFERENCES
+        - table_reference:
+            naked_identifier: table1
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: col1
+          - comma: ','
+          - column_reference:
+              naked_identifier: col2
+          - end_bracket: )
+        - keyword: 'ON'
+        - keyword: DELETE
+        - keyword: SET
+        - keyword: DEFAULT
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: col1
+            end_bracket: )
+      - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #5622 

Also. deletes the redundant and unused ReferentialActionSegment

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
