### PR TITLE
T-SQL Fix relative sql filepath lexer

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -180,7 +180,7 @@ tsql_dialect.insert_lexer_matchers(
         RegexLexer(
             "unquoted_relative_sql_file_path",
             # currently there is no way to pass `regex.IGNORECASE` flag to `RegexLexer`
-            r"[.\w\\/#-]+\.[sS][qQ][lL]",
+            r"[.\w\\/#-]+\.[sS][qQ][lL]\b",
             CodeSegment,
         ),
     ],

--- a/test/fixtures/dialects/tsql/select.sql
+++ b/test/fixtures/dialects/tsql/select.sql
@@ -112,3 +112,8 @@ SELECT
 FROM dbo . all_pop;
 
 SELECT DISTINCT TOP 5 some_value FROM some_table;
+
+select
+    'Tabellen' as Objekt,
+    Count(*) as Anzahl
+from dbo.sql_modules;

--- a/test/fixtures/dialects/tsql/select.yml
+++ b/test/fixtures/dialects/tsql/select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1d69fef2bd5e7ce6121b0b367ea7517bfc62c4baac0e8db01a13f77b2b16e360
+_hash: 59a35b46fcaf8ea8fc2fb65f68781819778331f671e63b3a8e12bb24096596dd
 file:
   batch:
   - statement:
@@ -897,4 +897,35 @@ file:
               table_expression:
                 table_reference:
                   naked_identifier: some_table
+          statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            quoted_literal: "'Tabellen'"
+            alias_expression:
+              keyword: as
+              naked_identifier: Objekt
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: Count
+              bracketed:
+                start_bracket: (
+                star: '*'
+                end_bracket: )
+            alias_expression:
+              keyword: as
+              naked_identifier: Anzahl
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: dbo
+                - dot: .
+                - naked_identifier: sql_modules
           statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
This adds a word terminator to unquoted_relative_sql_file_path, allowing `sql` to be the start of a longer string.
Fixes #5481 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
