### PR TITLE
Tech Debt: Replace some sequences with their Ref equivalents

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1634,10 +1634,10 @@ class CreateExternalTableStatementSegment(BaseSegment):
 
     match_grammar = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         "EXTERNAL",
         "TABLE",
-        Sequence("IF", "NOT", "EXISTS", optional=True),
+        Ref("IfNotExistsGrammar", optional=True),
         Ref("TableReferenceSegment"),
         Bracketed(
             Delimited(

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -928,7 +928,7 @@ class DropCastStatementSegment(ansi.DropCastStatementSegment):
     match_grammar: Matchable = Sequence(
         "DROP",
         "CAST",
-        Sequence("IF", "EXISTS", optional=True),
+        Ref("IfExistsGrammar", optional=True),
         Bracketed(
             Ref("DatatypeSegment"),
             "AS",
@@ -948,7 +948,7 @@ class DropAggregateStatementSegment(BaseSegment):
     match_grammar: Matchable = Sequence(
         "DROP",
         "AGGREGATE",
-        Sequence("IF", "EXISTS", optional=True),
+        Ref("IfExistsGrammar", optional=True),
         Delimited(
             Sequence(
                 Ref("ObjectReferenceSegment"),
@@ -973,7 +973,7 @@ class CreateAggregateStatementSegment(BaseSegment):
     type = "create_aggregate_statement"
     match_grammar: Matchable = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         "AGGREGATE",
         Ref("ObjectReferenceSegment"),
         Bracketed(
@@ -1034,7 +1034,7 @@ class CreateFunctionStatementSegment(ansi.CreateFunctionStatementSegment):
 
     match_grammar = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         Ref("TemporaryGrammar", optional=True),
         "FUNCTION",
         Ref("IfNotExistsGrammar", optional=True),
@@ -1288,7 +1288,7 @@ class CreateProcedureStatementSegment(BaseSegment):
 
     match_grammar = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         "PROCEDURE",
         Ref("FunctionNameSegment"),
         Ref("FunctionParameterListGrammar"),
@@ -4247,7 +4247,7 @@ class CreateTriggerStatementSegment(ansi.CreateTriggerStatementSegment):
 
     match_grammar = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         Ref.keyword("CONSTRAINT", optional=True),
         "TRIGGER",
         Ref("TriggerReferenceSegment"),

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -2024,7 +2024,7 @@ class AlterWarehouseStatementSegment(BaseSegment):
     match_grammar = Sequence(
         "ALTER",
         "WAREHOUSE",
-        Sequence("IF", "EXISTS", optional=True),
+        Ref("IfExistsGrammar", optional=True),
         OneOf(
             Sequence(
                 Ref("ObjectReferenceSegment", optional=True),
@@ -2086,7 +2086,7 @@ class AlterShareStatementSegment(BaseSegment):
     match_grammar = Sequence(
         "ALTER",
         "SHARE",
-        Sequence("IF", "EXISTS", optional=True),
+        Ref("IfExistsGrammar", optional=True),
         Ref("NakedIdentifierSegment"),
         OneOf(
             Sequence(
@@ -2604,7 +2604,7 @@ class CreateCloneStatementSegment(BaseSegment):
     type = "create_clone_statement"
     match_grammar = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         OneOf(
             "DATABASE",
             "SCHEMA",
@@ -2615,7 +2615,7 @@ class CreateCloneStatementSegment(BaseSegment):
             "STREAM",
             "TASK",
         ),
-        Sequence("IF", "NOT", "EXISTS", optional=True),
+        Ref("IfNotExistsGrammar", optional=True),
         Ref("ObjectReferenceSegment"),
         "CLONE",
         Ref("ObjectReferenceSegment"),
@@ -2652,7 +2652,7 @@ class CreateProcedureStatementSegment(BaseSegment):
     type = "create_procedure_statement"
     match_grammar = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         Sequence("SECURE", optional=True),
         "PROCEDURE",
         Ref("FunctionNameSegment"),
@@ -2933,7 +2933,7 @@ class CreateFunctionStatementSegment(BaseSegment):
     type = "create_function_statement"
     match_grammar = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         Sequence("SECURE", optional=True),
         "FUNCTION",
         Ref("IfNotExistsGrammar", optional=True),
@@ -3020,7 +3020,7 @@ class AlterFunctionStatementSegment(BaseSegment):
     match_grammar = Sequence(
         "ALTER",
         "FUNCTION",
-        Sequence("IF", "EXISTS", optional=True),
+        Ref("IfExistsGrammar", optional=True),
         Ref("FunctionNameSegment"),
         Ref("FunctionParameterListGrammar"),
         OneOf(
@@ -3105,7 +3105,7 @@ class CreateExternalFunctionStatementSegment(BaseSegment):
     type = "create_external_function_statement"
     match_grammar = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         Sequence("SECURE", optional=True),
         "EXTERNAL",
         "FUNCTION",
@@ -3493,7 +3493,7 @@ class CreateSequenceStatementSegment(BaseSegment):
     type = "create_sequence_statement"
     match_grammar = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         "SEQUENCE",
         Ref("IfNotExistsGrammar", optional=True),
         Ref("SequenceReferenceSegment"),
@@ -3560,7 +3560,7 @@ class AlterSchemaStatementSegment(BaseSegment):
     match_grammar = Sequence(
         "ALTER",
         "SCHEMA",
-        Sequence("IF", "EXISTS", optional=True),
+        Ref("IfExistsGrammar", optional=True),
         Ref("SchemaReferenceSegment"),
         OneOf(
             Sequence(
@@ -3756,9 +3756,9 @@ class CreateTaskSegment(BaseSegment):
 
     match_grammar = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         "TASK",
-        Sequence("IF", "NOT", "EXISTS", optional=True),
+        Ref("IfNotExistsGrammar", optional=True),
         Ref("ObjectReferenceSegment"),
         Indent,
         AnyNumberOf(
@@ -4117,9 +4117,9 @@ class CreateUserSegment(BaseSegment):
 
     match_grammar = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         "USER",
-        Sequence("IF", "NOT", "EXISTS", optional=True),
+        Ref("IfNotExistsGrammar", optional=True),
         Ref("ObjectReferenceSegment"),
         Indent,
         AnyNumberOf(
@@ -5013,10 +5013,10 @@ class CreateExternalTableSegment(BaseSegment):
 
     match_grammar = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         "EXTERNAL",
         "TABLE",
-        Sequence("IF", "NOT", "EXISTS", optional=True),
+        Ref("IfNotExistsGrammar", optional=True),
         Ref("TableReferenceSegment"),
         # Columns:
         Bracketed(
@@ -5481,10 +5481,10 @@ class CreateStageSegment(BaseSegment):
 
     match_grammar = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         Ref.keyword("TEMPORARY", optional=True),
         "STAGE",
-        Sequence("IF", "NOT", "EXISTS", optional=True),
+        Ref("IfNotExistsGrammar", optional=True),
         Ref("ObjectReferenceSegment"),
         Indent,
         OneOf(
@@ -5625,7 +5625,7 @@ class AlterStageSegment(BaseSegment):
     match_grammar = Sequence(
         "ALTER",
         "STAGE",
-        Sequence("IF", "EXISTS", optional=True),
+        Ref("IfExistsGrammar", optional=True),
         Ref("ObjectReferenceSegment"),
         OneOf(
             Sequence("RENAME", "TO", Ref("ObjectReferenceSegment")),
@@ -5994,7 +5994,7 @@ class AlterUserStatementSegment(BaseSegment):
     match_grammar = Sequence(
         "ALTER",
         "USER",
-        Sequence("IF", "EXISTS", optional=True),
+        Ref("IfExistsGrammar", optional=True),
         Ref("RoleReferenceSegment"),
         OneOf(
             Sequence("RENAME", "TO", Ref("ObjectReferenceSegment")),
@@ -6053,18 +6053,9 @@ class CreateRoleStatementSegment(ansi.CreateRoleStatementSegment):
 
     match_grammar = Sequence(
         "CREATE",
-        Sequence(
-            "OR",
-            "REPLACE",
-            optional=True,
-        ),
+        Ref("OrReplaceGrammar", optional=True),
         "ROLE",
-        Sequence(
-            "IF",
-            "NOT",
-            "EXISTS",
-            optional=True,
-        ),
+        Ref("IfNotExistsGrammar", optional=True),
         Ref("RoleReferenceSegment"),
         Sequence(
             "COMMENT",
@@ -6308,7 +6299,7 @@ class AlterTaskStatementSegment(BaseSegment):
     match_grammar = Sequence(
         "ALTER",
         "TASK",
-        Sequence("IF", "EXISTS", optional=True),
+        Ref("IfExistsGrammar", optional=True),
         Ref("ObjectReferenceSegment"),
         OneOf(
             "RESUME",
@@ -6740,7 +6731,7 @@ class TruncateStatementSegment(ansi.TruncateStatementSegment):
     match_grammar = Sequence(
         "TRUNCATE",
         Ref.keyword("TABLE", optional=True),
-        Sequence("IF", "EXISTS", optional=True),
+        Ref("IfExistsGrammar", optional=True),
         Ref("TableReferenceSegment"),
     )
 
@@ -6806,11 +6797,7 @@ class CommentStatementSegment(BaseSegment):
     type = "comment_statement"
     match_grammar = Sequence(
         "COMMENT",
-        Sequence(
-            "IF",
-            "EXISTS",
-            optional=True,
-        ),
+        Ref("IfExistsGrammar", optional=True),
         "ON",
         OneOf(
             "COLUMN",

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -1304,7 +1304,7 @@ class CreateFunctionStatementSegment(ansi.CreateFunctionStatementSegment):
 
     match_grammar = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         Ref("TemporaryGrammar", optional=True),
         "FUNCTION",
         Ref("IfNotExistsGrammar", optional=True),

--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -633,12 +633,12 @@ class CreateTableStatementSegment(BaseSegment):
     type = "create_table_statement"
     match_grammar = Sequence(
         "CREATE",
-        Sequence("OR", "REPLACE", optional=True),
+        Ref("OrReplaceGrammar", optional=True),
         # Adding Teradata specific [MULTISET| SET]
         OneOf("SET", "MULTISET", optional=True),
         OneOf(Sequence("GLOBAL", "TEMPORARY"), "VOLATILE", optional=True),
         "TABLE",
-        Sequence("IF", "NOT", "EXISTS", optional=True),
+        Ref("IfNotExistsGrammar", optional=True),
         Ref("TableReferenceSegment"),
         # , NO FALLBACK, NO BEFORE JOURNAL, NO AFTER JOURNAL
         Ref("TdCreateTableOptions", optional=True),


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Replace the Sequence version of IfExists, IfNotExists, and OrReplace, with their simpler Refs
Fixes #5476 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
