### PR TITLE
ANSI/MYSQL: Support Create Role If Not Exists

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -3870,7 +3870,7 @@ class CreateRoleStatementSegment(BaseSegment):
     match_grammar: Matchable = Sequence(
         "CREATE",
         "ROLE",
-        Ref("IfNotExistsGrammar"),
+        Ref("IfNotExistsGrammar", optional=True),
         Ref("RoleReferenceSegment"),
     )
 

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -3870,6 +3870,7 @@ class CreateRoleStatementSegment(BaseSegment):
     match_grammar: Matchable = Sequence(
         "CREATE",
         "ROLE",
+        Ref("IfNotExistsGrammar"),
         Ref("RoleReferenceSegment"),
     )
 

--- a/test/fixtures/dialects/mysql/create_role.sql
+++ b/test/fixtures/dialects/mysql/create_role.sql
@@ -1,0 +1,1 @@
+CREATE ROLE IF NOT EXISTS 'example-role';

--- a/test/fixtures/dialects/mysql/create_role.yml
+++ b/test/fixtures/dialects/mysql/create_role.yml
@@ -1,0 +1,17 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 75d4b556372a3f4d7c751f5e188b5ff359945dfa35b5a3692c7e1105b9911a5e
+file:
+  statement:
+    create_role_statement:
+    - keyword: CREATE
+    - keyword: ROLE
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - role_reference:
+        quoted_identifier: "'example-role'"
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Makes progress on #5388
The feature was requested for MySQL, so the test has been added there. But I see no harm in adding this to ANSI.

### Are there any other side effects of this change that we should be aware of?
Added to ANSI, though it can't be a destructive change

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
