### PR TITLE
Resolve broken loop limit test

### DIFF
--- a/test/core/rules/rules_test.py
+++ b/test/core/rules/rules_test.py
@@ -229,10 +229,26 @@ def test__rules__result_unparsable():
     assert res.tree.raw == raw_sql
 
 
-def test__rules__runaway_fail_catch():
+@pytest.mark.parametrize(
+    "sql_query, check_tuples",
+    [
+        (
+            "SELECT * FROM foo",
+            # Even though there's a runaway fix, we should still
+            # find each issue once and not duplicates of them.
+            [
+                ("T001", 1, 7),
+                ("T001", 1, 9),
+                ("T001", 1, 14),
+            ],
+        ),
+        # If the errors are disabled, they shouldn't come through.
+        ("-- noqa: disable=all\nSELECT * FROM foo", []),
+    ],
+)
+def test__rules__runaway_fail_catch(sql_query, check_tuples):
     """Test that we catch runaway rules."""
     runaway_limit = 5
-    my_query = "SELECT * FROM foo"
     # Set up the config to only use the rule we are testing.
     cfg = FluffConfig(
         overrides={"rules": "T001", "runaway_limit": runaway_limit, "dialect": "ansi"}
@@ -241,9 +257,11 @@ def test__rules__runaway_fail_catch():
     linter = Linter(config=cfg, user_rules=[Rule_T001])
     # In theory this step should result in an infinite
     # loop, but the loop limit should catch it.
-    linted = linter.lint_string(my_query, fix=True)
+    result = linter.lint_string(sql_query, fix=True)
     # When the linter hits the runaway limit, it returns the original SQL tree.
-    assert linted.tree.raw == my_query
+    assert result.tree.raw == sql_query
+    # Check the issues found.
+    assert result.check_tuples() == check_tuples
 
 
 def test_rules_cannot_be_instantiated_without_declared_configs():


### PR DESCRIPTION
I think I found an issue.

We have a test case `test__cli__fix_loop_limit_behavior` which designed to check error behaviour around the loop limit on fixes. We have one test case designed to see what happens when the limit is reached - and look for an exit code of 1 if it does.

What is _actually_ happening here however is that we're getting an exception because `BaseRule._eval()` raises a `NotImplementedError` when run rather than actually because we're hitting the loop limit. That means this test case is misleading.

If I resolve that first issue - the test case then doesn't work anymore because the error code is different. @barrywhart - you're the last person in that chunk of code, what's your view on what we do here?