### PR TITLE
Add Postgres CREATE FOREIGN TABLE statement

### DIFF
--- a/test/fixtures/dialects/postgres/create_foreign_table.sql
+++ b/test/fixtures/dialects/postgres/create_foreign_table.sql
@@ -1,0 +1,14 @@
+CREATE FOREIGN TABLE films (
+    code        char(5) NOT NULL,
+    title       varchar(40) NOT NULL,
+    did         integer NOT NULL,
+    date_prod   date,
+    kind        varchar(10),
+    -- len         interval hour to minute
+    len         interval
+)
+SERVER film_server;
+
+CREATE FOREIGN TABLE measurement_y2016m07
+    PARTITION OF measurement FOR VALUES FROM ('2016-07-01') TO ('2016-08-01')
+    SERVER server_07;

--- a/test/fixtures/dialects/postgres/create_foreign_table.yml
+++ b/test/fixtures/dialects/postgres/create_foreign_table.yml
@@ -1,0 +1,106 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: ac839af9d970e1525f098e77f7b59e6c039edd63489f3ca9715fff5c63fb4c35
+file:
+- statement:
+    create_foreign_table_statement:
+    - keyword: CREATE
+    - keyword: FOREIGN
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: films
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: code
+      - data_type:
+          keyword: char
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '5'
+              end_bracket: )
+      - column_constraint_segment:
+        - keyword: NOT
+        - keyword: 'NULL'
+      - comma: ','
+      - column_reference:
+          naked_identifier: title
+      - data_type:
+          keyword: varchar
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '40'
+              end_bracket: )
+      - column_constraint_segment:
+        - keyword: NOT
+        - keyword: 'NULL'
+      - comma: ','
+      - column_reference:
+          naked_identifier: did
+      - data_type:
+          keyword: integer
+      - column_constraint_segment:
+        - keyword: NOT
+        - keyword: 'NULL'
+      - comma: ','
+      - column_reference:
+          naked_identifier: date_prod
+      - data_type:
+          datetime_type_identifier:
+            keyword: date
+      - comma: ','
+      - column_reference:
+          naked_identifier: kind
+      - data_type:
+          keyword: varchar
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '10'
+              end_bracket: )
+      - comma: ','
+      - column_reference:
+          naked_identifier: len
+      - data_type:
+          datetime_type_identifier:
+            keyword: interval
+      - end_bracket: )
+    - keyword: SERVER
+    - server_reference:
+        naked_identifier: film_server
+- statement_terminator: ;
+- statement:
+    create_foreign_table_statement:
+    - keyword: CREATE
+    - keyword: FOREIGN
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: measurement_y2016m07
+    - keyword: PARTITION
+    - keyword: OF
+    - table_reference:
+        naked_identifier: measurement
+    - keyword: FOR
+    - keyword: VALUES
+    - partition_bound_spec:
+      - keyword: FROM
+      - bracketed:
+          start_bracket: (
+          expression:
+            quoted_literal: "'2016-07-01'"
+          end_bracket: )
+      - keyword: TO
+      - bracketed:
+          start_bracket: (
+          expression:
+            quoted_literal: "'2016-08-01'"
+          end_bracket: )
+    - keyword: SERVER
+    - server_reference:
+        naked_identifier: server_07
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

I was unable to parse a SQL file which included a `CREATE FOREIGN TABLE` statement

```sh
(venv) ed@laptop:~/repos/project$ sqlfluff lint scripts/sql/
== [scripts/sql/create_foreign_data_wrapper_in_buildtracker_prod.sql] FAIL                                                                                                             
L:  23 | P:   1 |  PRS | Line 23, Position 1: Found unparsable section: 'CREATE                                                                                                        
                       | FOREIGN TABLE salesforce.servicea...'
WARNING: Parsing errors found and dialect is set to 'postgres'. Have you configured your dialect correctly?                                                                            
All Finished 📜 🎉!    
```

So I've added it.

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
