### PR TITLE
Resolve #5647: Snowflake unparsable variant access after cast

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -7325,6 +7325,9 @@ class ShorthandCastSegment(BaseSegment):
                     AnyNumberOf(
                         Ref("ArrayAccessorSegment"),
                     ),
+                    AnyNumberOf(
+                        Ref("SemiStructuredAccessorSegment"),
+                    ),
                     optional=True,
                 ),
             ),

--- a/test/fixtures/dialects/snowflake/cast_datatype_accessor.sql
+++ b/test/fixtures/dialects/snowflake/cast_datatype_accessor.sql
@@ -3,3 +3,15 @@ SELECT bar::array[0] AS channel
     , bar::array[0][1] AS channel3
     , raw:foo::array[0]::string AS channel4
 FROM my_table;
+
+SELECT
+    foo::variant:field::array[0]::string AS name
+FROM my_table;
+
+SELECT DISTINCT
+    payload::variant::object:name::text AS name,
+    payload::variant::object AS details,
+    payload::variant::object:createdAt::timestamp_ntz AS created,
+    payload::variant::object:updatedAt::timestamp_ntz AS updated,
+    payload::variant::object:id::number AS id
+FROM raw_source_table

--- a/test/fixtures/dialects/snowflake/cast_datatype_accessor.yml
+++ b/test/fixtures/dialects/snowflake/cast_datatype_accessor.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b4d0dd3efafa1a377726c160270be1d9204731518fd317a69985974fa30ac1b8
+_hash: 265b7e1c7c92d729cd3d21ef525adfd5980b488d8ecdafa9af0fef2b6d3a9d57
 file:
-  statement:
+- statement:
     select_statement:
       select_clause:
       - keyword: SELECT
@@ -92,4 +92,151 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: my_table
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            cast_expression:
+            - column_reference:
+                naked_identifier: foo
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: variant
+            - semi_structured_expression:
+                colon: ':'
+                semi_structured_element: field
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: array
+            - array_accessor:
+                start_square_bracket: '['
+                numeric_literal: '0'
+                end_square_bracket: ']'
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: string
+          alias_expression:
+            keyword: AS
+            naked_identifier: name
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_modifier:
+          keyword: DISTINCT
+      - select_clause_element:
+          expression:
+            cast_expression:
+            - column_reference:
+                naked_identifier: payload
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: variant
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: object
+            - semi_structured_expression:
+                colon: ':'
+                semi_structured_element: name
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: text
+          alias_expression:
+            keyword: AS
+            naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          expression:
+            cast_expression:
+            - column_reference:
+                naked_identifier: payload
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: variant
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: object
+          alias_expression:
+            keyword: AS
+            naked_identifier: details
+      - comma: ','
+      - select_clause_element:
+          expression:
+            cast_expression:
+            - column_reference:
+                naked_identifier: payload
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: variant
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: object
+            - semi_structured_expression:
+                colon: ':'
+                semi_structured_element: createdAt
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: timestamp_ntz
+          alias_expression:
+            keyword: AS
+            naked_identifier: created
+      - comma: ','
+      - select_clause_element:
+          expression:
+            cast_expression:
+            - column_reference:
+                naked_identifier: payload
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: variant
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: object
+            - semi_structured_expression:
+                colon: ':'
+                semi_structured_element: updatedAt
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: timestamp_ntz
+          alias_expression:
+            keyword: AS
+            naked_identifier: updated
+      - comma: ','
+      - select_clause_element:
+          expression:
+            cast_expression:
+            - column_reference:
+                naked_identifier: payload
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: variant
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: object
+            - semi_structured_expression:
+                colon: ':'
+                semi_structured_element: id
+            - casting_operator: '::'
+            - data_type:
+                data_type_identifier: number
+          alias_expression:
+            keyword: AS
+            naked_identifier: id
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: raw_source_table


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fixes https://github.com/sqlfluff/sqlfluff/issues/5647. Previously, traversing semi-structured data after casting to `variant` was unparsable.

Added corresponding tests.


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
