### PR TITLE
[CI]: Update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.5.0
     hooks:
       # If adding any exceptions here, make sure to add them to .editorconfig as well
       - id: end-of-file-fixer
@@ -25,11 +25,11 @@ repos:
             test/fixtures/linter/sqlfluffignore/
           )$
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.2.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: mypy
         additional_dependencies:
@@ -45,23 +45,23 @@ repos:
           ]
         files: ^src/sqlfluff/.*
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 7.0.0
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-black>=0.2.4, flake8-docstrings]
+        additional_dependencies: [flake8-black>=0.3.6]
   - repo: https://github.com/pycqa/doc8
-    rev: 0.10.1
+    rev: v1.1.1
     hooks:
       - id: doc8
         args: [--file-encoding, utf8]
         files: docs/source/.*\.rst$
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.26.3
+    rev: v1.35.1
     hooks:
       - id: yamllint
         args: [-c=.yamllint]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.0.243"
+    rev: "v0.3.2"
     hooks:
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,7 +217,7 @@ module = "tblib.*"
 ignore_missing_imports = true
 
 
-[tool.ruff]
+[tool.ruff.lint]
 extend-select = ["I", "D"]
 
 # D105: Missing docstring in magic method
@@ -225,7 +225,7 @@ extend-select = ["I", "D"]
 # D418: Function/ Method decorated with @overload shouldn’t contain a docstring
 ignore = ["D107", "D105", "D418"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 # Mark sqlfluff, test and it's plugins as known first party
 known-first-party = [
     "sqlfluff",
@@ -234,7 +234,7 @@ known-first-party = [
     "test",
 ]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This brings the pre-commit hooks versions up to date to align with the versions used by GitHub Actions linting steps.

### Are there any other side effects of this change that we should be aware of?
There should be no side effects with this change however I'll note the following:

This removes the eventually-to-be-deprecated `flake8-docstrings` (with `pydocstyle` being deprecated and `ruff` being the replacement) from the pre-commit. The updated version of `ruff` now correctly catches the docstrings style with the current configuration. `flake8-docstrings` and `pydocstyle` should probably eventually be removed from the `requirements_dev.txt`

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
