### PR TITLE
Postgres: AL05, ignore aliases in values clause

### DIFF
--- a/src/sqlfluff/rules/aliasing/AL05.py
+++ b/src/sqlfluff/rules/aliasing/AL05.py
@@ -64,6 +64,7 @@ class Rule_AL05(BaseRule):
     _dialects_requiring_alias_for_values_clause = [
         "snowflake",
         "tsql",
+        "postgres",
     ]
     is_fix_compatible = True
 

--- a/test/fixtures/rules/std_rule_cases/AL05.yml
+++ b/test/fixtures/rules/std_rule_cases/AL05.yml
@@ -350,3 +350,15 @@ test_pass_redshift_semi_structured_op:
   configs:
     core:
       dialect: redshift
+
+test_pass_postgres_values_clause:
+  pass_str: |
+    SELECT *
+    FROM (
+        VALUES
+        (1, 2),
+        (3, 4)
+    ) AS t (x, y)
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Prevent removing aliases in postgres values clause as they are required.
fixes #5600

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
