### PR TITLE
Trino: Parse regexp_replace with lambda func

### DIFF
--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -9,6 +9,7 @@ from sqlfluff.core.parser import (
     Anything,
     BaseSegment,
     Bracketed,
+    CodeSegment,
     Delimited,
     LiteralSegment,
     Matchable,
@@ -16,6 +17,9 @@ from sqlfluff.core.parser import (
     OneOf,
     Ref,
     Sequence,
+    StringLexer,
+    StringParser,
+    SymbolSegment,
     TypedParser,
 )
 from sqlfluff.dialects import dialect_ansi as ansi
@@ -41,6 +45,18 @@ trino_dialect.update_keywords_set_from_multiline_string(
 trino_dialect.sets("reserved_keywords").clear()
 trino_dialect.update_keywords_set_from_multiline_string(
     "reserved_keywords", trino_reserved_keywords
+)
+
+trino_dialect.insert_lexer_matchers(
+    # Regexp Replace w/ Lambda: https://trino.io/docs/422/functions/regexp.html
+    [
+        StringLexer("right_arrow", "->", CodeSegment),
+    ],
+    before="like_operator",
+)
+
+trino_dialect.add(
+    RightArrowOperator=StringParser("->", SymbolSegment, type="binary_operator"),
 )
 
 trino_dialect.replace(
@@ -169,6 +185,14 @@ trino_dialect.replace(
         Ref("IndexColumnDefinitionSegment"),
         Ref("EmptyStructLiteralSegment"),
         Ref("ListaggOverflowClauseSegment"),
+    ),
+    BinaryOperatorGrammar=OneOf(
+        Ref("ArithmeticBinaryOperatorGrammar"),
+        Ref("StringBinaryOperatorGrammar"),
+        Ref("BooleanBinaryOperatorGrammar"),
+        Ref("ComparisonOperatorGrammar"),
+        # Add arrow operators for functions (e.g. regexp_replace)
+        Ref("RightArrowOperator"),
     ),
 )
 

--- a/test/fixtures/dialects/trino/regexp_replace_with_lambda.sql
+++ b/test/fixtures/dialects/trino/regexp_replace_with_lambda.sql
@@ -1,0 +1,8 @@
+-- The variant of REGEXP_REPLACE that accepts a function
+-- lambda expression as an argument can be tricky to parse.
+-- Signature:
+--    regexp_replace(string, pattern, function) → varchar
+-- Reference:
+--     https://trino.io/docs/422/functions/regexp.html
+
+SELECT REGEXP_REPLACE('new york', '(\w)(\w*)', x -> UPPER(x[1]) || LOWER(x[2]));

--- a/test/fixtures/dialects/trino/regexp_replace_with_lambda.yml
+++ b/test/fixtures/dialects/trino/regexp_replace_with_lambda.yml
@@ -1,0 +1,58 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 190e4d9807b6575ec7d095ea537b945ca05dd8756032e18af9fbd795b00dcdaf
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: REGEXP_REPLACE
+            bracketed:
+            - start_bracket: (
+            - expression:
+                quoted_literal: "'new york'"
+            - comma: ','
+            - expression:
+                quoted_literal: "'(\\w)(\\w*)'"
+            - comma: ','
+            - expression:
+              - column_reference:
+                  naked_identifier: x
+              - binary_operator: ->
+              - function:
+                  function_name:
+                    function_name_identifier: UPPER
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: x
+                      array_accessor:
+                        start_square_bracket: '['
+                        numeric_literal: '1'
+                        end_square_bracket: ']'
+                    end_bracket: )
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - function:
+                  function_name:
+                    function_name_identifier: LOWER
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: x
+                      array_accessor:
+                        start_square_bracket: '['
+                        numeric_literal: '2'
+                        end_square_bracket: ']'
+                    end_bracket: )
+            - end_bracket: )
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

This PR aims to address a particular syntax that invloves a lambda expression
inside of the REGEXP_REPLACE function.

```sql
SELECT REGEXP_REPLACE('new york', '(\w)(\w*)', x -> UPPER(x[1]) || LOWER(x[2]))
```

Fixes #5582

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?

I found the changes required for this from the Athena dialect implementation. Athena
and Trino share some code history, and both make use of lambda expressions for array
functions (which is not the target of this PR). I don't believe I've done enough work on
this to enable all the Trino array functions to be parseable in the Trino dialect though. 
Hopefully this is a step towards that support in the future _and_ it parses the
`REGEXP_REPLACE` with lambda parameter syntax as-is.


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

