### PR TITLE
Documentation update: Remove reference to alias' default config being "consistent"

### DIFF
--- a/docs/source/partials/starter_config.cfg
+++ b/docs/source/partials/starter_config.cfg
@@ -36,14 +36,6 @@ project_dir = ./
 # SQLFluff maintainers do use them in their projects.
 allow_implicit_indents = True
 
-# The default configuration for aliasing rules is "consistent"
-# which will auto-detect the setting from the rest of the file. This
-# is less desirable in a new project and you may find this (slightly
-# more strict) setting more useful.
-[sqlfluff:rules:aliasing.table]
-aliasing = explicit
-[sqlfluff:rules:aliasing.column]
-aliasing = explicit
 [sqlfluff:rules:aliasing.length]
 min_alias_length = 3
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes the starter config to be consistent with the aliasing default of 'explicit' - explicit as the default is mentioned elsewhere in the [docs](https://docs.sqlfluff.com/en/stable/rules.html#aliasing-bundle), and enforced in the [code](https://github.com/sqlfluff/sqlfluff/blob/main/src/sqlfluff/rules/aliasing/AL01.py). "consistent" is not the default.

### Are there any other side effects of this change that we should be aware of?

Just a documentation update so no.


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
