### PR TITLE
Allow use of STREAM in snowflake CHANGES clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1523,14 +1523,16 @@ class ChangesClauseSegment(BaseSegment):
             "INFORMATION",
             Ref("ParameterAssignerSegment"),
             OneOf("DEFAULT", "APPEND_ONLY"),
+            parse_mode=ParseMode.GREEDY,
         ),
         OneOf(
             Sequence(
                 "AT",
                 Bracketed(
-                    OneOf("TIMESTAMP", "OFFSET", "STATEMENT"),
+                    OneOf("TIMESTAMP", "OFFSET", "STATEMENT", "STREAM"),
                     Ref("ParameterAssignerSegment"),
                     Ref("ExpressionSegment"),
+                    parse_mode=ParseMode.GREEDY,
                 ),
             ),
             Sequence(
@@ -1539,6 +1541,7 @@ class ChangesClauseSegment(BaseSegment):
                     "STATEMENT",
                     Ref("ParameterAssignerSegment"),
                     Ref("ExpressionSegment"),
+                    parse_mode=ParseMode.GREEDY,
                 ),
             ),
         ),
@@ -1548,6 +1551,7 @@ class ChangesClauseSegment(BaseSegment):
                 OneOf("TIMESTAMP", "OFFSET", "STATEMENT"),
                 Ref("ParameterAssignerSegment"),
                 Ref("ExpressionSegment"),
+                parse_mode=ParseMode.GREEDY,
             ),
             optional=True,
         ),

--- a/test/fixtures/dialects/snowflake/changes_clause.sql
+++ b/test/fixtures/dialects/snowflake/changes_clause.sql
@@ -18,3 +18,8 @@ select *
 from t1
   changes(information => default)
   before(statement => '8e5d0ca9-005e-44e6-b858-a8f5b37c5726');
+
+select *
+from st.test
+  changes (information => append_only)
+  at (stream => 'ppr.str_test');

--- a/test/fixtures/dialects/snowflake/changes_clause.yml
+++ b/test/fixtures/dialects/snowflake/changes_clause.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 71297b1cb80e4085221b6c2dba0cd9142e4a1eaa595ecd7645fa6fb1497b717a
+_hash: 18db925256de17a42d506048e40eb2ccde74ec1d0f8e209b46061019025f0a51
 file:
 - statement:
     select_statement:
@@ -154,5 +154,39 @@ file:
               parameter_assigner: =>
               expression:
                 quoted_literal: "'8e5d0ca9-005e-44e6-b858-a8f5b37c5726'"
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: st
+              - dot: .
+              - naked_identifier: test
+          changes_clause:
+          - keyword: changes
+          - bracketed:
+            - start_bracket: (
+            - keyword: information
+            - parameter_assigner: =>
+            - keyword: append_only
+            - end_bracket: )
+          - keyword: at
+          - bracketed:
+              start_bracket: (
+              keyword: stream
+              parameter_assigner: =>
+              expression:
+                quoted_literal: "'ppr.str_test'"
               end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
Does what it says on the tin. Looks like we missed one keyword during the initial implementation https://github.com/sqlfluff/sqlfluff/pull/2764.

This resolves an issue raised on slack.