### PR TITLE
Trino: 'TIMESTAMP(p)' no longer triggers LT01

### DIFF
--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -232,7 +232,7 @@ class DatatypeSegment(BaseSegment):
         "DATE",
         Sequence(
             OneOf("TIME", "TIMESTAMP"),
-            Bracketed(Ref("NumericLiteralSegment"), optional=True),
+            Ref("BracketedArguments", optional=True),
             Sequence(OneOf("WITH", "WITHOUT"), "TIME", "ZONE", optional=True),
         ),
         # Structural

--- a/test/fixtures/dialects/trino/timestamp_resolutions.sql
+++ b/test/fixtures/dialects/trino/timestamp_resolutions.sql
@@ -1,0 +1,43 @@
+-- Trino supports timestamp datatypes at various levels of
+-- precision from TIMESTAMP(0) to TIMESTAMP(12). These
+-- correspond to precision from seconds to picoseconds.
+-- Bare TIMESTAMP is an alias for TIMESTAMP(3).
+-- https://trino.io/docs/current/language/types.html#timestamp
+-- https://trino.io/docs/current/language/types.html#timestamp-p
+
+-- Basic Timestamp
+SELECT CAST((TIMESTAMP '2012-10-31 01:00 UTC') AS TIMESTAMP);
+
+-- Timestamp with minimum precision (seconds)
+SELECT CAST((TIMESTAMP '2012-10-31 01:00 UTC') AS TIMESTAMP(0));
+
+-- Timestamp with maximum precision (picoseconds)
+SELECT CAST((TIMESTAMP '2012-10-31 01:00 UTC') AS TIMESTAMP(12));
+
+-- Timestamp with time zone
+SELECT
+    CAST(
+        (TIMESTAMP '2001-08-22 03:04:05.321 America/Chicago')
+        AS TIMESTAMP WITH TIME ZONE
+    );
+
+-- Timestamp without time zone
+SELECT
+    CAST(
+        (TIMESTAMP '2001-08-22 03:04:05.321 America/Chicago')
+        AS TIMESTAMP WITHOUT TIME ZONE
+    );
+
+-- Timestamp with precision and time zone
+SELECT
+    CAST(
+        (TIMESTAMP '2001-08-22 03:04:05.321 America/Chicago')
+        AS TIMESTAMP(6) WITH TIME ZONE
+    );
+
+-- Timestamp with precision and without time zone
+SELECT
+    CAST(
+        (TIMESTAMP '2001-08-22 03:04:05.321 America/Chicago')
+        AS TIMESTAMP(6) WITHOUT TIME ZONE
+    );

--- a/test/fixtures/dialects/trino/timestamp_resolutions.yml
+++ b/test/fixtures/dialects/trino/timestamp_resolutions.yml
@@ -1,0 +1,193 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e63f762fc6a72b5126a23f61b047941ffac8001a60ec62c8cec4cacea21c6941
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            bracketed:
+              start_bracket: (
+              expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    keyword: TIMESTAMP
+                    date_constructor_literal: "'2012-10-31 01:00 UTC'"
+                  end_bracket: )
+              keyword: AS
+              data_type:
+                keyword: TIMESTAMP
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            bracketed:
+              start_bracket: (
+              expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    keyword: TIMESTAMP
+                    date_constructor_literal: "'2012-10-31 01:00 UTC'"
+                  end_bracket: )
+              keyword: AS
+              data_type:
+                keyword: TIMESTAMP
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '0'
+                    end_bracket: )
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            bracketed:
+              start_bracket: (
+              expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    keyword: TIMESTAMP
+                    date_constructor_literal: "'2012-10-31 01:00 UTC'"
+                  end_bracket: )
+              keyword: AS
+              data_type:
+                keyword: TIMESTAMP
+                bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '12'
+                    end_bracket: )
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            bracketed:
+              start_bracket: (
+              expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    keyword: TIMESTAMP
+                    date_constructor_literal: "'2001-08-22 03:04:05.321 America/Chicago'"
+                  end_bracket: )
+              keyword: AS
+              data_type:
+              - keyword: TIMESTAMP
+              - keyword: WITH
+              - keyword: TIME
+              - keyword: ZONE
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            bracketed:
+              start_bracket: (
+              expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    keyword: TIMESTAMP
+                    date_constructor_literal: "'2001-08-22 03:04:05.321 America/Chicago'"
+                  end_bracket: )
+              keyword: AS
+              data_type:
+              - keyword: TIMESTAMP
+              - keyword: WITHOUT
+              - keyword: TIME
+              - keyword: ZONE
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            bracketed:
+              start_bracket: (
+              expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    keyword: TIMESTAMP
+                    date_constructor_literal: "'2001-08-22 03:04:05.321 America/Chicago'"
+                  end_bracket: )
+              keyword: AS
+              data_type:
+              - keyword: TIMESTAMP
+              - bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '6'
+                    end_bracket: )
+              - keyword: WITH
+              - keyword: TIME
+              - keyword: ZONE
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            bracketed:
+              start_bracket: (
+              expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    keyword: TIMESTAMP
+                    date_constructor_literal: "'2001-08-22 03:04:05.321 America/Chicago'"
+                  end_bracket: )
+              keyword: AS
+              data_type:
+              - keyword: TIMESTAMP
+              - bracketed_arguments:
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '6'
+                    end_bracket: )
+              - keyword: WITHOUT
+              - keyword: TIME
+              - keyword: ZONE
+              end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

This PR aims to address a Trino datatype precision syntax that involves
setting a timestamp with a particular level of numerical precision, such 
as TIMESTAMP(6).

```sql
SELECT CAST(DATE '2024-01-30' AS TIMESTAMP(6))
```

SQLFluff flags that with LT01 and reformats it to 

```sql
SELECT CAST(DATE '2024-01-30' AS TIMESTAMP (6))
```

Note the extra space character between `TIMESTAMP` and `(6)`. That's valid SQL
but looks unusual to practitioners. The type and its resolution usually do not have
whitespace between them. Notably, the Trino SQLFluff dialect does not exhibit this
behavior for `VARCHAR(p)` or `DECIMAL(p)`, just `TIMESTAMP(p)`.

I looked at the datatype specification for `TIMESTAMP(p)` and discovered that 
it looked different than `VARCHAR(p)` and `DECIMAL(p)`, so I made it look the same.
Voila! No more LT01 on `TIMESTAMP(p)`

Old way that raises LT01:

```python
Bracketed(Ref("NumericLiteralSegment"), optional=True),
```

New way that doesn't (and matches VARCHAR/DECIMAL):

```python
Ref("BracketedArguments", optional=True),
```

Fixes #5589 

### Are there any other side effects of this change that we should be aware of?

It's clear that whoever wrote the spec for `TIMESTAMP(p)` in the Trino dialect
had something in mind for that type. It looked reasonable and parsed 
successfully, it just raised LT01 where I don't think it should have. If there's a better
way to do this, I welcome feedback and would be happy to submit another PR
that came at a solution for this with a different strategy.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
