### PR TITLE
Clickhouse: add parsing for "distinct on" syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -277,6 +277,26 @@ class AliasExpressionSegment(ansi.AliasExpressionSegment):
     )
 
 
+class SelectClauseModifierSegment(ansi.SelectClauseModifierSegment):
+    """Things that come after SELECT but before the columns.
+
+    Overridden from ANSI to allow DISTINCT ON ()
+    https://clickhouse.com/docs/en/sql-reference/statements/select/distinct
+    """
+
+    match_grammar = OneOf(
+        Sequence(
+            "DISTINCT",
+            Sequence(
+                "ON",
+                Bracketed(Delimited(Ref("ExpressionSegment"))),
+                optional=True,
+            ),
+        ),
+        "ALL",
+    )
+
+
 class FromExpressionElementSegment(ansi.FromExpressionElementSegment):
     """A table expression.
 

--- a/test/fixtures/dialects/clickhouse/select_distinct_on.sql
+++ b/test/fixtures/dialects/clickhouse/select_distinct_on.sql
@@ -1,0 +1,5 @@
+SELECT DISTINCT ON (a,b) * FROM t1;
+SELECT DISTINCT ON (a,b) * FROM t1 ORDER BY b ASC;
+
+-- Distinct on clause can contain expressions
+SELECT DISTINCT ON (a = b, c) * FROM t1 ORDER BY b ASC;

--- a/test/fixtures/dialects/clickhouse/select_distinct_on.yml
+++ b/test/fixtures/dialects/clickhouse/select_distinct_on.yml
@@ -1,0 +1,110 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 35ce57bce74263c26149e6c293b62fc8ee6fd6f95eedd5132fd8ce0030f885e1
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_modifier:
+        - keyword: DISTINCT
+        - keyword: 'ON'
+        - bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+                naked_identifier: a
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: b
+          - end_bracket: )
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_modifier:
+        - keyword: DISTINCT
+        - keyword: 'ON'
+        - bracketed:
+          - start_bracket: (
+          - expression:
+              column_reference:
+                naked_identifier: a
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: b
+          - end_bracket: )
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t1
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: b
+      - keyword: ASC
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_modifier:
+        - keyword: DISTINCT
+        - keyword: 'ON'
+        - bracketed:
+          - start_bracket: (
+          - expression:
+            - column_reference:
+                naked_identifier: a
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - column_reference:
+                naked_identifier: b
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: c
+          - end_bracket: )
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t1
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: b
+      - keyword: ASC
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Adds parsing for the "distinct on" syntax [available in Clickhouse](https://clickhouse.com/docs/en/sql-reference/statements/select/distinct). This is similar to Postgres.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.