### PR TITLE
Add array type support to Trino dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -401,3 +401,13 @@ class ListaggOverflowClauseSegment(BaseSegment):
             ),
         ),
     )
+
+
+class ArrayTypeSegment(ansi.ArrayTypeSegment):
+    """Prefix for array literals.
+
+    Trino supports "ARRAY"
+    """
+
+    type = "array_type"
+    match_grammar = Ref.keyword("ARRAY")

--- a/test/fixtures/dialects/trino/array.sql
+++ b/test/fixtures/dialects/trino/array.sql
@@ -1,0 +1,11 @@
+SELECT ARRAY[1,2] || ARRAY[3,4];
+
+SELECT ARRAY[ARRAY['meeting', 'lunch'], ARRAY['training', 'presentation']];
+
+SELECT column FROM UNNEST(ARRAY[1, 2]);
+
+SELECT FILTER(ARRAY[5, -6, NULL, 7], x -> x > 0);
+
+SELECT ANY_MATCH(ARRAY[5, -6, NULL, 7], x -> x > 0);
+
+SELECT ELEMENT_AT(ARRAY['apple', 'banana', 'orange'], 2);

--- a/test/fixtures/dialects/trino/array.yml
+++ b/test/fixtures/dialects/trino/array.yml
@@ -1,0 +1,198 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: dcc622c0648aef07203d023a12caf0dbdba82f5165d5908f2a116b6ac662d3dd
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - typed_array_literal:
+              array_type:
+                keyword: ARRAY
+              array_literal:
+              - start_square_bracket: '['
+              - numeric_literal: '1'
+              - comma: ','
+              - numeric_literal: '2'
+              - end_square_bracket: ']'
+          - binary_operator:
+            - pipe: '|'
+            - pipe: '|'
+          - typed_array_literal:
+              array_type:
+                keyword: ARRAY
+              array_literal:
+              - start_square_bracket: '['
+              - numeric_literal: '3'
+              - comma: ','
+              - numeric_literal: '4'
+              - end_square_bracket: ']'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          typed_array_literal:
+            array_type:
+              keyword: ARRAY
+            array_literal:
+            - start_square_bracket: '['
+            - typed_array_literal:
+                array_type:
+                  keyword: ARRAY
+                array_literal:
+                - start_square_bracket: '['
+                - quoted_literal: "'meeting'"
+                - comma: ','
+                - quoted_literal: "'lunch'"
+                - end_square_bracket: ']'
+            - comma: ','
+            - typed_array_literal:
+                array_type:
+                  keyword: ARRAY
+                array_literal:
+                - start_square_bracket: '['
+                - quoted_literal: "'training'"
+                - comma: ','
+                - quoted_literal: "'presentation'"
+                - end_square_bracket: ']'
+            - end_square_bracket: ']'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: column
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: UNNEST
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    typed_array_literal:
+                      array_type:
+                        keyword: ARRAY
+                      array_literal:
+                      - start_square_bracket: '['
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - numeric_literal: '2'
+                      - end_square_bracket: ']'
+                  end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: FILTER
+            bracketed:
+            - start_bracket: (
+            - expression:
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '5'
+                  - comma: ','
+                  - numeric_literal:
+                      sign_indicator: '-'
+                      numeric_literal: '6'
+                  - comma: ','
+                  - null_literal: 'NULL'
+                  - comma: ','
+                  - numeric_literal: '7'
+                  - end_square_bracket: ']'
+            - comma: ','
+            - expression:
+              - column_reference:
+                  naked_identifier: x
+              - binary_operator: ->
+              - column_reference:
+                  naked_identifier: x
+              - comparison_operator:
+                  raw_comparison_operator: '>'
+              - numeric_literal: '0'
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: ANY_MATCH
+            bracketed:
+            - start_bracket: (
+            - expression:
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '5'
+                  - comma: ','
+                  - numeric_literal:
+                      sign_indicator: '-'
+                      numeric_literal: '6'
+                  - comma: ','
+                  - null_literal: 'NULL'
+                  - comma: ','
+                  - numeric_literal: '7'
+                  - end_square_bracket: ']'
+            - comma: ','
+            - expression:
+              - column_reference:
+                  naked_identifier: x
+              - binary_operator: ->
+              - column_reference:
+                  naked_identifier: x
+              - comparison_operator:
+                  raw_comparison_operator: '>'
+              - numeric_literal: '0'
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: ELEMENT_AT
+            bracketed:
+            - start_bracket: (
+            - expression:
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - quoted_literal: "'apple'"
+                  - comma: ','
+                  - quoted_literal: "'banana'"
+                  - comma: ','
+                  - quoted_literal: "'orange'"
+                  - end_square_bracket: ']'
+            - comma: ','
+            - expression:
+                numeric_literal: '2'
+            - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Adds an `ArrayTypeSegment` to match on `ARRAY` so array tokens are parsed as a `typed_array_literal` instead of being naked.

Before this, `ARRAY` was not getting parsed as an `array_type` causing an 'array' of issues with linting and parsing. Most notably:

```sql
SELECT ARRAY[ARRAY[1,2], ARRAY[3,4]];
```

would return unparsable errors when this in fact valid sql for trino.

Fixes #5721
Makes progress on #5705
Fixes #5617


### Are there any other side effects of this change that we should be aware of?
Not that I'm aware of.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
