### PR TITLE
Clickhouse: add parsing for select except clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -277,6 +277,32 @@ class AliasExpressionSegment(ansi.AliasExpressionSegment):
     )
 
 
+class WildcardExpressionSegment(ansi.WildcardExpressionSegment):
+    """An extension of the star expression for Clickhouse."""
+
+    match_grammar = ansi.WildcardExpressionSegment.match_grammar.copy(
+        insert=[
+            Ref("ExceptClauseSegment", optional=True),
+        ]
+    )
+
+
+class ExceptClauseSegment(BaseSegment):
+    """A Clickhouse SELECT EXCEPT clause.
+
+    https://clickhouse.com/docs/en/sql-reference/statements/select#except
+    """
+
+    type = "select_except_clause"
+    match_grammar = Sequence(
+        "EXCEPT",
+        OneOf(
+            Bracketed(Delimited(Ref("SingleIdentifierGrammar"))),
+            Ref("SingleIdentifierGrammar"),
+        ),
+    )
+
+
 class SelectClauseModifierSegment(ansi.SelectClauseModifierSegment):
     """Things that come after SELECT but before the columns.
 

--- a/src/sqlfluff/dialects/dialect_clickhouse_keywords.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse_keywords.py
@@ -58,6 +58,7 @@ UNRESERVED_KEYWORDS = [
     "ENGINE",
     "EPHEMERAL",
     "EVENTS",
+    "EXCEPT",
     "EXISTS",
     "EXPLAIN",
     "EXPRESSION",

--- a/test/fixtures/dialects/clickhouse/select_except.sql
+++ b/test/fixtures/dialects/clickhouse/select_except.sql
@@ -1,0 +1,2 @@
+SELECT * EXCEPT (c1) from t1;
+SELECT * EXCEPT (c1, c2) from t1;

--- a/test/fixtures/dialects/clickhouse/select_except.yml
+++ b/test/fixtures/dialects/clickhouse/select_except.yml
@@ -1,0 +1,53 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: ac4e56119ee233d9046cfd776655e3f259a469303a6d656776f6c3c03b47bb84
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_except_clause:
+              keyword: EXCEPT
+              bracketed:
+                start_bracket: (
+                naked_identifier: c1
+                end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_except_clause:
+              keyword: EXCEPT
+              bracketed:
+              - start_bracket: (
+              - naked_identifier: c1
+              - comma: ','
+              - naked_identifier: c2
+              - end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t1
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Adds support for `SELECT * EXCEPT (column_1, column_2)` syntax in Clickhouse. [Reference here](https://clickhouse.com/docs/en/sql-reference/statements/select#except). Similar syntax and segments exist for BigQuery and Snowflake. 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
