### PR TITLE
Fix `sqlite` dialect implementation breaking original `ansi` rules

### DIFF
--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -36,7 +36,7 @@ sqlite_dialect = ansi_dialect.copy_as("sqlite")
 
 sqlite_dialect.sets("reserved_keywords").clear()
 sqlite_dialect.sets("reserved_keywords").update(RESERVED_KEYWORDS)
-sqlite_dialect.sets("unreserved_keywords").clear()
+# sqlite_dialect.sets("unreserved_keywords").clear()
 sqlite_dialect.sets("unreserved_keywords").update(UNRESERVED_KEYWORDS)
 
 sqlite_dialect.patch_lexer_matchers(

--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -36,7 +36,6 @@ sqlite_dialect = ansi_dialect.copy_as("sqlite")
 
 sqlite_dialect.sets("reserved_keywords").clear()
 sqlite_dialect.sets("reserved_keywords").update(RESERVED_KEYWORDS)
-# sqlite_dialect.sets("unreserved_keywords").clear()
 sqlite_dialect.sets("unreserved_keywords").update(UNRESERVED_KEYWORDS)
 
 sqlite_dialect.patch_lexer_matchers(

--- a/test/fixtures/dialects/sqlite/alter_table.sql
+++ b/test/fixtures/dialects/sqlite/alter_table.sql
@@ -1,0 +1,3 @@
+ALTER TABLE message RENAME TO nachrichten;
+ALTER TABLE distributors ADD COLUMN address varchar(30);
+ALTER TABLE old_table_name RENAME TO new_table_name;

--- a/test/fixtures/dialects/sqlite/alter_table.yml
+++ b/test/fixtures/dialects/sqlite/alter_table.yml
@@ -1,0 +1,57 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: eeaf81f5a4ed4bb708106107f7b77941a4caa0b454c94de2deacb9eea19c6f4e
+file:
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: something
+    - keyword: RENAME
+    - keyword: TO
+    - table_reference:
+        naked_identifier: nachrichten
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: something
+    - keyword: RENAME
+    - table_reference:
+        naked_identifier: nachrichten
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: distributors
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        naked_identifier: address
+        data_type:
+          data_type_identifier: varchar
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '30'
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: old_table_name
+    - keyword: RENAME
+    - keyword: TO
+    - table_reference:
+        naked_identifier: new_table_name
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Responding to https://github.com/sqlfluff/sqlfluff/issues/5732, I figured that `sqlite` dialect implementation somehow breaks the original `ansi` rules for `ALTER` statements. Trial and error showed that keeping the original unreserved keywords rectifies it.

### Are there any other side effects of this change that we should be aware of?

My fix is fairly rough, that is why I would want to request a second opinion from the sqlruff maintainers with deeper knowledge of the code. Could you share your thoughts?

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
