### PR TITLE
CLI: Suppress tracebacks on render/fix/format

### DIFF
--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -124,19 +124,31 @@ def test__cli__command_dialect():
     )
 
 
-def test__cli__command_no_dialect():
+@pytest.mark.parametrize(
+    "command",
+    [
+        render,
+        parse,
+        lint,
+        cli_format,
+        fix,
+    ],
+)
+def test__cli__command_no_dialect(command):
     """Check the script raises the right exception no dialect."""
     # The dialect is unknown should be a non-zero exit code
     result = invoke_assert_code(
         ret_code=2,
         args=[
-            lint,
+            command,
             ["-"],
         ],
         cli_input="SELECT 1",
     )
     assert "User Error" in result.stdout
     assert "No dialect was specified" in result.stdout
+    # No traceback should be in the output
+    assert "Traceback (most recent call last)" not in result.stdout
 
 
 def test__cli__command_parse_error_dialect_explicit_warning():


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This suppresses the traceback output from user errors being printed as output from the CLI.

This fixes the issue in sqlfluff/vscode-sqlfluff#122 where the useful error message is hidden.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
