### PR TITLE
ST04: Ignore simplifying `CASE`s with different expressions

### DIFF
--- a/test/fixtures/rules/std_rule_cases/ST04.yml
+++ b/test/fixtures/rules/std_rule_cases/ST04.yml
@@ -227,3 +227,60 @@ test_fail_no_copy_code_out_of_template:
       jinja:
         context:
           inner_when: "WHEN species = 'Dog' THEN 'Woof'"
+
+test_pass_different_case_expressions1:
+  pass_str: |
+    SELECT
+        CASE
+            WHEN DayOfMonth IN (11, 12, 13) THEN 'TH'
+            ELSE
+                CASE MOD(DayOfMonth, 10)
+                    WHEN 1 THEN 'ST'
+                    WHEN 2 THEN 'ND'
+                    WHEN 3 THEN 'RD'
+                    ELSE 'TH'
+                END
+        END AS OrdinalSuffix
+    FROM Calendar;
+
+test_pass_different_case_expressions2:
+  pass_str: |
+    SELECT
+        CASE DayOfMonth
+            WHEN 11 THEN 'TH'
+            WHEN 12 THEN 'TH'
+            WHEN 13 THEN 'TH'
+            ELSE
+                CASE MOD(DayOfMonth, 10)
+                    WHEN 1 THEN 'ST'
+                    WHEN 2 THEN 'ND'
+                    WHEN 3 THEN 'RD'
+                    ELSE 'TH'
+                END
+        END AS OrdinalSuffix
+    FROM Calendar;
+
+test_fail_nested_same_case:
+  fail_str: |
+    SELECT
+        CASE x
+            WHEN 0 THEN 'zero'
+            WHEN 5 THEN 'five'
+            ELSE
+                CASE x
+                    WHEN 10 THEN 'ten'
+                    WHEN 20 THEN 'twenty'
+                    ELSE 'other'
+                END
+        END
+    FROM tab_a;
+  fix_str: |
+    SELECT
+        CASE x
+            WHEN 0 THEN 'zero'
+            WHEN 5 THEN 'five'
+            WHEN 10 THEN 'ten'
+            WHEN 20 THEN 'twenty'
+            ELSE 'other'
+        END
+    FROM tab_a;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixed issue with collapsing nested case statements with mismatched case criteria.
fixes #5670

### Are there any other side effects of this change that we should be aware of?
None.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
