### PR TITLE
adding snake_case to CP01 extended_capitalisation_policy

### DIFF
--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -60,9 +60,10 @@ STANDARD_CONFIG_INFO_DICT: Dict[str, Dict[str, Any]] = {
         "definition": "The capitalisation policy to enforce.",
     },
     "extended_capitalisation_policy": {
-        "validation": ["consistent", "upper", "lower", "pascal", "capitalise"],
+        "validation": ["consistent", "upper", "lower", "pascal", "capitalise", "snake"],
         "definition": (
-            "The capitalisation policy to enforce, extended with PascalCase. "
+            "The capitalisation policy to enforce, extended with PascalCase "
+            "and snake_case. "
             "This is separate from ``capitalisation_policy`` as it should not be "
             "applied to keywords."
         ),

--- a/src/sqlfluff/rules/capitalisation/CP01.py
+++ b/src/sqlfluff/rules/capitalisation/CP01.py
@@ -145,6 +145,7 @@ class Rule_CP01(BaseRule):
             first_letter_is_lowercase = False
 
         if first_letter_is_lowercase:
+            # snake added here as it cannot be inferred (presents as lower)
             refuted_cases.update(["upper", "capitalise", "pascal", "snake"])
             if segment.raw != segment.raw.lower():
                 refuted_cases.update(["lower"])

--- a/src/sqlfluff/rules/capitalisation/CP01.py
+++ b/src/sqlfluff/rules/capitalisation/CP01.py
@@ -145,7 +145,7 @@ class Rule_CP01(BaseRule):
             first_letter_is_lowercase = False
 
         if first_letter_is_lowercase:
-            refuted_cases.update(["upper", "capitalise", "pascal"])
+            refuted_cases.update(["upper", "capitalise", "pascal", "snake"])
             if segment.raw != segment.raw.lower():
                 refuted_cases.update(["lower"])
         else:
@@ -155,7 +155,7 @@ class Rule_CP01(BaseRule):
             if segment.raw != segment.raw.capitalize():
                 refuted_cases.update(["capitalise"])
             if not segment.raw.isalnum():
-                refuted_cases.update(["pascal"])
+                refuted_cases.update(["pascal", "snake"])
 
         # Update the memory
         memory["refuted_cases"] = refuted_cases
@@ -218,6 +218,15 @@ class Rule_CP01(BaseRule):
                 lambda match: match.group(1) + match.group(2).upper() + match.group(3),
                 segment.raw,
             )
+        elif concrete_policy == "snake":
+            if segment.raw.isupper():
+                fixed_raw = segment.raw.lower()
+            else:
+                fixed_raw = regex.sub(
+                    r"(?<=[a-z0-9])([A-Z])|(?<=[A-Za-z])([0-9])|(?<=[0-9])([A-Za-z])",
+                    lambda match: "_" + match.group(),
+                    segment.raw,
+                ).lower()
 
         if fixed_raw == segment.raw:
             # No need to fix
@@ -236,6 +245,8 @@ class Rule_CP01(BaseRule):
                 policy = "capitalised."
             elif concrete_policy == "pascal":
                 policy = "pascal case."
+            elif concrete_policy == "snake":
+                policy = "snake case."
 
             # Return the fixed segment
             self.logger.debug(

--- a/test/fixtures/rules/std_rule_cases/CP02.yml
+++ b/test/fixtures/rules/std_rule_cases/CP02.yml
@@ -253,3 +253,31 @@ test_pass_databricks_case_sensitive_property:
   configs:
     core:
       dialect: databricks
+
+test_fail_snake_aliases:
+  # Test for issue #5470
+  # similar to PascalCase, case logic defined in CP01, but tested in CP02
+  fail_str: |
+    SELECT
+    test1,
+    test_2,
+    testColumn3,
+    TestColumn4,
+    TESTCOLUMN5,
+    TEST_COLUMN6,
+    test_column_7_
+  fix_str: |
+    SELECT
+    test_1,
+    test_2,
+    test_column_3,
+    test_column_4,
+    testcolumn_5,
+    test_column_6,
+    test_column_7_
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      capitalisation.identifiers:
+        extended_capitalisation_policy: snake

--- a/test/fixtures/rules/std_rule_cases/CP03.yml
+++ b/test/fixtures/rules/std_rule_cases/CP03.yml
@@ -111,3 +111,11 @@ test_pass_ignore_words_regex_bigquery_complex:
     rules:
       capitalisation.functions:
         ignore_words_regex: (^_f_|\._f_)
+
+test_bare_functions_4:
+  fail_str: SELECT Current_Timestamp, Min(a) from table
+  fix_str: SELECT current_timestamp, min(a) from table
+  configs:
+    rules:
+      capitalisation.functions:
+        extended_capitalisation_policy: snake


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #5470

Hi sqlfluff! in this pr, I'm adding desired capitalisation policy of `snake` for snake_case enforcement and correction

### Are there any other side effects of this change that we should be aware of?

None indicated by running tests.
Tested regex on multiple test cases, but would love a second opinion on it (the lookbehinds cause worry, but should be structured to only look 1 character behind)
Note: tests for this change have been added in `CP02.yml` and `CP03.yml` to follow the current pattern of testing `pascal` capitalisation policy


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
