### PR TITLE
Fix implementation for view_column_name_list in BigQuery's CREATE VIEW

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1525,6 +1525,15 @@ class ColumnDefinitionSegment(ansi.ColumnDefinitionSegment):
     )
 
 
+class ViewColumnDefinitionSegment(ansi.ColumnDefinitionSegment):
+    """A column definition, for view_column_name_list of CREATE VIEW statement."""
+
+    match_grammar: Matchable = Sequence(
+        Ref("SingleIdentifierGrammar"),  # Column name
+        Ref("OptionsSegment", optional=True),
+    )
+
+
 class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
     """`CREATE TABLE` statement.
 
@@ -1711,7 +1720,12 @@ class CreateViewStatementSegment(ansi.CreateViewStatementSegment):
         Ref("IfNotExistsGrammar", optional=True),
         Ref("TableReferenceSegment"),
         # Optional list of column names
-        Ref("BracketedColumnReferenceListGrammar", optional=True),
+        Bracketed(
+            Delimited(
+                Ref("ViewColumnDefinitionSegment"),
+            ),
+            optional=True,
+        ),
         Ref("OptionsSegment", optional=True),
         "AS",
         OptionallyBracketed(Ref("SelectableGrammar")),

--- a/test/fixtures/dialects/bigquery/create_view_options_as.sql
+++ b/test/fixtures/dialects/bigquery/create_view_options_as.sql
@@ -8,3 +8,11 @@ AS (SELECT * from bar);
 CREATE OR REPLACE VIEW IF NOT EXISTS foo
 OPTIONS (description = 'copy of bar')
 AS (SELECT * from bar);
+
+CREATE OR REPLACE VIEW foo
+(
+  x OPTIONS (description = 'x'),
+  y OPTIONS (description = 'y')
+)
+OPTIONS (description = 'view_column_name_list')
+AS (SELECT x, y from bar);

--- a/test/fixtures/dialects/bigquery/create_view_options_as.yml
+++ b/test/fixtures/dialects/bigquery/create_view_options_as.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5866457289782a3325bf4d8bcd5ca7d6159222350cb8339923133c5ca619730c
+_hash: d3a855aae54d0929279b15283759ecd93120ab909cafbf7ce1080fe9fbfd3a0d
 file:
 - statement:
     create_view_statement:
@@ -98,6 +98,71 @@ file:
               wildcard_expression:
                 wildcard_identifier:
                   star: '*'
+          from_clause:
+            keyword: from
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: bar
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: foo
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: x
+          options_segment:
+            keyword: OPTIONS
+            bracketed:
+              start_bracket: (
+              parameter: description
+              comparison_operator:
+                raw_comparison_operator: '='
+              quoted_literal: "'x'"
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          naked_identifier: y
+          options_segment:
+            keyword: OPTIONS
+            bracketed:
+              start_bracket: (
+              parameter: description
+              comparison_operator:
+                raw_comparison_operator: '='
+              quoted_literal: "'y'"
+              end_bracket: )
+      - end_bracket: )
+    - options_segment:
+        keyword: OPTIONS
+        bracketed:
+          start_bracket: (
+          parameter: description
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'view_column_name_list'"
+          end_bracket: )
+    - keyword: AS
+    - bracketed:
+        start_bracket: (
+        select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                naked_identifier: x
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: y
           from_clause:
             keyword: from
             from_expression:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

fixes: https://github.com/sqlfluff/sqlfluff/issues/5737

The current BigQuery dialect does not correctly consider CREATE VIEW statements containing `view_column_name_list` so we will attempt to fix this.

### Are there any other side effects of this change that we should be aware of?

As far as I know, there should be no impact beyond being able to parse SQL that cannot currently be parsed.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
