### PR TITLE
Remove `--force` flag from pre-commit hook definition

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -11,11 +11,10 @@
 - id: sqlfluff-fix
   name: sqlfluff-fix
   # Set a couple of default flags:
-  #  - `--force` to disable confirmation
   #  - `--show-lint-violations` shows issues to not require running `sqlfluff lint`
   #  - `--processes 0` to use maximum parallelism
   # By default, this hook applies all rules.
-  entry: sqlfluff fix --force --show-lint-violations --processes 0
+  entry: sqlfluff fix --show-lint-violations --processes 0
   language: python
   description: "Fixes sql lint errors with `SQLFluff`"
   types: [sql]


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

In v3, SQLFluff does not require the `--force` flag for `sqlfluff fix` anymore and emits a warning.

### Are there any other side effects of this change that we should be aware of?

n/a

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
