### PR TITLE
SQLite: Add `GLOB`, `MATCH`. Improved `REGEXP`

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -414,6 +414,7 @@ ansi_dialect.add(
     IfExistsGrammar=Sequence("IF", "EXISTS"),
     IfNotExistsGrammar=Sequence("IF", "NOT", "EXISTS"),
     LikeGrammar=OneOf("LIKE", "RLIKE", "ILIKE"),
+    PatternMatchingGrammar=Nothing(),
     UnionGrammar=Sequence("UNION", OneOf("DISTINCT", "ALL", optional=True)),
     IsClauseGrammar=OneOf(
         Ref("NullLiteralSegment"),
@@ -2087,6 +2088,10 @@ ansi_dialect.add(
                     Ref("Expression_B_Grammar"),
                     "AND",
                     Ref("Tail_Recurse_Expression_A_Grammar"),
+                ),
+                Sequence(
+                    Ref("PatternMatchingGrammar"),
+                    Ref("Expression_A_Grammar"),
                 ),
             )
         ),

--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -61,9 +61,6 @@ sqlite_dialect.patch_lexer_matchers(
 )
 
 sqlite_dialect.replace(
-    BooleanBinaryOperatorGrammar=OneOf(
-        Ref("AndOperatorGrammar"), Ref("OrOperatorGrammar"), "REGEXP"
-    ),
     PrimaryKeyGrammar=Sequence(
         "PRIMARY", "KEY", Sequence("AUTOINCREMENT", optional=True)
     ),
@@ -194,6 +191,10 @@ sqlite_dialect.replace(
         Sequence("DISTINCT", "FROM", optional=True),
     ),
     NanLiteralSegment=Nothing(),
+    PatternMatchingGrammar=Sequence(
+        Ref.keyword("NOT", optional=True),
+        OneOf("GLOB", "REGEXP", "MATCH"),
+    ),
 )
 
 

--- a/test/fixtures/dialects/sqlite/pattern_matching.sql
+++ b/test/fixtures/dialects/sqlite/pattern_matching.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS task (
+    id TEXT PRIMARY KEY CHECK (length(id) = 15),
+    priority TEXT CHECK (priority GLOB '[A-Z]'),
+    regex_col TEXT CHECK (priority REGEXP '[A-Z]'),
+    match_col TEXT CHECK (priority MATCH 'tacos'),
+    title TEXT NOT NULL,
+    note TEXT,
+    created_at DATETIME NOT NULL DEFAULT current_timestamp,
+    updated_at DATETIME NOT NULL DEFAULT current_timestamp
+);
+
+SELECT col1
+FROM tab_a
+WHERE this_col MATCH 'that';
+
+SELECT col1
+FROM tab_a
+WHERE this_col REGEXP '(that|other)';
+
+SELECT col1
+FROM tab_a
+WHERE this_col GLOB 'one*two';
+
+SELECT col1
+FROM tab_a
+WHERE this_col NOT MATCH 'that';
+
+SELECT col1
+FROM tab_a
+WHERE this_col NOT REGEXP '(that|other)';
+
+SELECT col1
+FROM tab_a
+WHERE this_col NOT GLOB 'one*two';
+
+SELECT col1
+FROM tab_a
+WHERE NOT this_col MATCH 'that';
+
+SELECT col1
+FROM tab_a
+WHERE NOT this_col REGEXP '(that|other)';
+
+SELECT col1
+FROM tab_a
+WHERE NOT this_col GLOB 'one*two';

--- a/test/fixtures/dialects/sqlite/pattern_matching.yml
+++ b/test/fixtures/dialects/sqlite/pattern_matching.yml
@@ -1,0 +1,329 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: b2979003cd812334d237b951b99ba18e2b10ec548714540c5343078c87ff3cdb
+file:
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: task
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+        - naked_identifier: id
+        - data_type:
+            data_type_identifier: TEXT
+        - column_constraint_segment:
+          - keyword: PRIMARY
+          - keyword: KEY
+        - column_constraint_segment:
+            keyword: CHECK
+            bracketed:
+              start_bracket: (
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: length
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: id
+                    end_bracket: )
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '15'
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          naked_identifier: priority
+          data_type:
+            data_type_identifier: TEXT
+          column_constraint_segment:
+            keyword: CHECK
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: priority
+                keyword: GLOB
+                quoted_literal: "'[A-Z]'"
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          naked_identifier: regex_col
+          data_type:
+            data_type_identifier: TEXT
+          column_constraint_segment:
+            keyword: CHECK
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: priority
+                keyword: REGEXP
+                quoted_literal: "'[A-Z]'"
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          naked_identifier: match_col
+          data_type:
+            data_type_identifier: TEXT
+          column_constraint_segment:
+            keyword: CHECK
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: priority
+                keyword: MATCH
+                quoted_literal: "'tacos'"
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          naked_identifier: title
+          data_type:
+            data_type_identifier: TEXT
+          column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+      - comma: ','
+      - column_definition:
+          naked_identifier: note
+          data_type:
+            data_type_identifier: TEXT
+      - comma: ','
+      - column_definition:
+        - naked_identifier: created_at
+        - data_type:
+            data_type_identifier: DATETIME
+        - column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+        - column_constraint_segment:
+            keyword: DEFAULT
+            bare_function: current_timestamp
+      - comma: ','
+      - column_definition:
+        - naked_identifier: updated_at
+        - data_type:
+            data_type_identifier: DATETIME
+        - column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+        - column_constraint_segment:
+            keyword: DEFAULT
+            bare_function: current_timestamp
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tab_a
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: this_col
+          keyword: MATCH
+          quoted_literal: "'that'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tab_a
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: this_col
+          keyword: REGEXP
+          quoted_literal: "'(that|other)'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tab_a
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: this_col
+          keyword: GLOB
+          quoted_literal: "'one*two'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tab_a
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: this_col
+        - keyword: NOT
+        - keyword: MATCH
+        - quoted_literal: "'that'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tab_a
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: this_col
+        - keyword: NOT
+        - keyword: REGEXP
+        - quoted_literal: "'(that|other)'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tab_a
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: this_col
+        - keyword: NOT
+        - keyword: GLOB
+        - quoted_literal: "'one*two'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tab_a
+      where_clause:
+        keyword: WHERE
+        expression:
+        - keyword: NOT
+        - column_reference:
+            naked_identifier: this_col
+        - keyword: MATCH
+        - quoted_literal: "'that'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tab_a
+      where_clause:
+        keyword: WHERE
+        expression:
+        - keyword: NOT
+        - column_reference:
+            naked_identifier: this_col
+        - keyword: REGEXP
+        - quoted_literal: "'(that|other)'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tab_a
+      where_clause:
+        keyword: WHERE
+        expression:
+        - keyword: NOT
+        - column_reference:
+            naked_identifier: this_col
+        - keyword: GLOB
+        - quoted_literal: "'one*two'"
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds `GLOB`, `MATCH`, and improves `REGEXP` in SQLite.
- Fixed handling of `NOT REGEXP`
- Added `PatternMatchingGrammar` in ANSI for future support in other dialects such as DuckDB.

fixes #5717 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
