### PR TITLE
Databricks: Fix Aliases for Join-like objects

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -281,7 +281,14 @@ sparksql_dialect.replace(
             Ref("UnpivotClauseSegment"),
             Ref("LateralViewClauseSegment"),
         ),
-        Ref("AliasExpressionSegment", optional=True),
+        Ref(
+            "AliasExpressionSegment",
+            exclude=OneOf(
+                Ref("FromClauseTerminatorGrammar"),
+                Ref("JoinLikeClauseGrammar"),
+            ),
+            optional=True,
+        ),
     ),
     LikeGrammar=OneOf(
         # https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-like.html

--- a/test/fixtures/dialects/databricks/select_from_lateral_view.sql
+++ b/test/fixtures/dialects/databricks/select_from_lateral_view.sql
@@ -1,0 +1,114 @@
+SELECT
+    id,
+    name,
+    age,
+    class,
+    address,
+    c_age,
+    d_age
+FROM person
+    LATERAL VIEW EXPLODE(ARRAY(30, 60)) tbl_name AS c_age
+    LATERAL VIEW EXPLODE(ARRAY(40, 80)) AS d_age;
+
+SELECT
+    c_age,
+    COUNT(*) AS record_count
+FROM person
+    LATERAL VIEW EXPLODE(ARRAY(30, 60)) AS c_age
+    LATERAL VIEW EXPLODE(ARRAY(40, 80)) AS d_age
+GROUP BY c_age;
+
+SELECT
+    id,
+    name,
+    age,
+    class,
+    address,
+    c_age,
+    d_age
+FROM person
+    LATERAL VIEW EXPLODE(ARRAY()) tbl_name AS c_age;
+
+SELECT
+    id,
+    name,
+    age,
+    class,
+    address,
+    time,
+    c_age
+FROM person
+    LATERAL VIEW OUTER EXPLODE(ARRAY()) tbl_name AS c_age;
+
+SELECT
+    id,
+    name,
+    age,
+    class,
+    address,
+    time,
+    c_age
+FROM person
+    LATERAL VIEW OUTER EXPLODE(ARRAY()) tbl_name c_age;
+
+SELECT
+    id,
+    name,
+    age,
+    class,
+    address,
+    time,
+    c_age
+FROM person
+    LATERAL VIEW OUTER EXPLODE(ARRAY()) c_age;
+
+SELECT
+    person.id,
+    exploded_people.name,
+    exploded_people.age,
+    exploded_people.state
+FROM person
+    LATERAL VIEW INLINE(array_of_structs) exploded_people AS name, age, state;
+
+SELECT
+    p.id,
+    exploded_people.name,
+    exploded_people.age,
+    exploded_people.state
+FROM person AS p
+    LATERAL VIEW INLINE(array_of_structs) exploded_people AS name, age, state;
+
+SELECT
+    p.id,
+    exploded_people.name,
+    exploded_people.age,
+    exploded_people.state
+FROM person AS p
+    LATERAL VIEW INLINE(array_of_structs) exploded_people;
+
+SELECT
+    p.id,
+    exploded_people.name,
+    exploded_people.age,
+    exploded_people.state
+FROM person AS p
+    LATERAL VIEW INLINE(array_of_structs) exploded_people name, age, state;
+
+SELECT
+    p.id,
+    exploded_people.name,
+    exploded_people.age,
+    exploded_people.state
+FROM person AS p
+    LATERAL VIEW INLINE(array_of_structs) AS name, age, state;
+
+SELECT
+    t1.column1,
+    CAST(GET_JSON_OBJECT(things, '$.percentage') AS DECIMAL(16, 8)
+    ) AS ptc
+FROM table1 AS t1
+LEFT JOIN table2 AS t2
+    ON
+        c.column1 = p.column1
+        AND t2.type = 'SOMETHING'
+    LATERAL VIEW OUTER EXPLODE(t2.column2) AS things;

--- a/test/fixtures/dialects/databricks/select_from_lateral_view.yml
+++ b/test/fixtures/dialects/databricks/select_from_lateral_view.yml
@@ -1,0 +1,780 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: d9094b5883b9701ffcf0943176b342b57020bc6aa8b63ad964bb38b393ac46b5
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: class
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: address
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: c_age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: d_age
+      from_clause:
+        keyword: FROM
+        from_expression:
+        - from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+        - lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        numeric_literal: '30'
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '60'
+                    - end_bracket: )
+                end_bracket: )
+          - naked_identifier: tbl_name
+          - keyword: AS
+          - naked_identifier: c_age
+        - lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        numeric_literal: '40'
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '80'
+                    - end_bracket: )
+                end_bracket: )
+          - naked_identifier: AS
+          - naked_identifier: d_age
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: c_age
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: COUNT
+            bracketed:
+              start_bracket: (
+              star: '*'
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: record_count
+      from_clause:
+        keyword: FROM
+        from_expression:
+        - from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+        - lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        numeric_literal: '30'
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '60'
+                    - end_bracket: )
+                end_bracket: )
+          - naked_identifier: AS
+          - naked_identifier: c_age
+        - lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        numeric_literal: '40'
+                    - comma: ','
+                    - expression:
+                        numeric_literal: '80'
+                    - end_bracket: )
+                end_bracket: )
+          - naked_identifier: AS
+          - naked_identifier: d_age
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: c_age
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: class
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: address
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: c_age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: d_age
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                      start_bracket: (
+                      end_bracket: )
+                end_bracket: )
+          - naked_identifier: tbl_name
+          - keyword: AS
+          - naked_identifier: c_age
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: class
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: address
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: time
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: c_age
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - keyword: OUTER
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                      start_bracket: (
+                      end_bracket: )
+                end_bracket: )
+          - naked_identifier: tbl_name
+          - keyword: AS
+          - naked_identifier: c_age
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: class
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: address
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: time
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: c_age
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - keyword: OUTER
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                      start_bracket: (
+                      end_bracket: )
+                end_bracket: )
+          - naked_identifier: tbl_name
+          - naked_identifier: c_age
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: class
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: address
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: time
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: c_age
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - keyword: OUTER
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: ARRAY
+                    bracketed:
+                      start_bracket: (
+                      end_bracket: )
+                end_bracket: )
+          - naked_identifier: c_age
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: person
+          - dot: .
+          - naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: state
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: INLINE
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: array_of_structs
+                end_bracket: )
+          - naked_identifier: exploded_people
+          - keyword: AS
+          - naked_identifier: name
+          - comma: ','
+          - naked_identifier: age
+          - comma: ','
+          - naked_identifier: state
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: p
+          - dot: .
+          - naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: state
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+            alias_expression:
+              keyword: AS
+              naked_identifier: p
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: INLINE
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: array_of_structs
+                end_bracket: )
+          - naked_identifier: exploded_people
+          - keyword: AS
+          - naked_identifier: name
+          - comma: ','
+          - naked_identifier: age
+          - comma: ','
+          - naked_identifier: state
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: p
+          - dot: .
+          - naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: state
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+            alias_expression:
+              keyword: AS
+              naked_identifier: p
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: INLINE
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: array_of_structs
+                end_bracket: )
+          - naked_identifier: exploded_people
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: p
+          - dot: .
+          - naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: state
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+            alias_expression:
+              keyword: AS
+              naked_identifier: p
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: INLINE
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: array_of_structs
+                end_bracket: )
+          - naked_identifier: exploded_people
+          - naked_identifier: name
+          - comma: ','
+          - naked_identifier: age
+          - comma: ','
+          - naked_identifier: state
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: p
+          - dot: .
+          - naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: exploded_people
+          - dot: .
+          - naked_identifier: state
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+            alias_expression:
+              keyword: AS
+              naked_identifier: p
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - function:
+              function_name:
+                function_name_identifier: INLINE
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: array_of_structs
+                end_bracket: )
+          - naked_identifier: AS
+          - naked_identifier: name
+          - comma: ','
+          - naked_identifier: age
+          - comma: ','
+          - naked_identifier: state
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: t1
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            bracketed:
+              start_bracket: (
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: GET_JSON_OBJECT
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        naked_identifier: things
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'$.percentage'"
+                  - end_bracket: )
+              keyword: AS
+              data_type:
+                primitive_type:
+                  keyword: DECIMAL
+                  bracketed_arguments:
+                    bracketed:
+                    - start_bracket: (
+                    - numeric_literal: '16'
+                    - comma: ','
+                    - numeric_literal: '8'
+                    - end_bracket: )
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: ptc
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+            alias_expression:
+              keyword: AS
+              naked_identifier: t1
+          join_clause:
+          - keyword: LEFT
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table2
+              alias_expression:
+                keyword: AS
+                naked_identifier: t2
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - naked_identifier: c
+                - dot: .
+                - naked_identifier: column1
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: p
+                - dot: .
+                - naked_identifier: column1
+              - binary_operator: AND
+              - column_reference:
+                - naked_identifier: t2
+                - dot: .
+                - naked_identifier: type
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - quoted_literal: "'SOMETHING'"
+          lateral_view_clause:
+          - keyword: LATERAL
+          - keyword: VIEW
+          - keyword: OUTER
+          - function:
+              function_name:
+                function_name_identifier: EXPLODE
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                  - naked_identifier: t2
+                  - dot: .
+                  - naked_identifier: column2
+                end_bracket: )
+          - naked_identifier: AS
+          - naked_identifier: things
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes alias exclusions that may follow a join-like object in Databricks.
fixes #5746 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
