### PR TITLE
dbt templater: Raise UserError when using stdin

### DIFF
--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -453,7 +453,7 @@ class DbtTemplater(JinjaTemplater):
         self.sqlfluff_config = config
         self.project_dir = self._get_project_dir()
         self.profiles_dir = self._get_profiles_dir()
-        fname_absolute_path = os.path.abspath(fname)
+        fname_absolute_path = os.path.abspath(fname) if fname != "stdin" else fname
 
         try:
             # These are the names in dbt-core 1.4.1+
@@ -516,7 +516,7 @@ class DbtTemplater(JinjaTemplater):
                 "For the dbt templater, the `process()` method requires a file name"
             )
         elif fname == "stdin":  # pragma: no cover
-            raise ValueError(
+            raise SQLFluffUserError(
                 "The dbt templater does not support stdin input, provide a path instead"
             )
         selected = self.dbt_selector_method.search(

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -13,7 +13,7 @@ import pytest
 
 from sqlfluff.cli.commands import lint
 from sqlfluff.core import FluffConfig, Lexer, Linter
-from sqlfluff.core.errors import SQLFluffSkipFile
+from sqlfluff.core.errors import SQLFluffSkipFile, SQLFluffUserError
 from sqlfluff.utils.testing.cli import invoke_assert_code
 from sqlfluff.utils.testing.logging import fluff_log_catcher
 from sqlfluff_templater_dbt.templater import DbtTemplater
@@ -298,6 +298,16 @@ def test__templater_dbt_skips_file(
         dbt_templater.process(
             in_str="",
             fname=os.path.join(project_dir, path),
+            config=FluffConfig(configs=DBT_FLUFF_CONFIG),
+        )
+
+
+def test_dbt_fails_stdin(dbt_templater):  # noqa: F811
+    """Reading from stdin is not supported with dbt templater."""
+    with pytest.raises(SQLFluffUserError):
+        dbt_templater.process(
+            in_str="",
+            fname="stdin",
             config=FluffConfig(configs=DBT_FLUFF_CONFIG),
         )
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixed raising an error when using the dbt templater with stdin.
- A SQLFluffUserError is used to pretty print the error

fixes #5750 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
