### PR TITLE
ST04: Retain comments when flattening `CASE`

### DIFF
--- a/src/sqlfluff/rules/structure/ST04.py
+++ b/src/sqlfluff/rules/structure/ST04.py
@@ -1,5 +1,7 @@
 """Implementation of Rule ST04."""
 
+from typing import List
+
 from sqlfluff.core.parser import BaseSegment, Indent, NewlineSegment, WhitespaceSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
@@ -164,7 +166,7 @@ class Rule_ST04(BaseRule):
         segment: BaseSegment,
         tab_space_size: int,
         indent_unit: str,
-    ):
+    ) -> str:
         """Calculate the indentation level for rebuilding nested struct.
 
         This is only a best attempt as the input may not be equally indented. The layout
@@ -198,7 +200,7 @@ class Rule_ST04(BaseRule):
         case1_children: Segments,
         case1_else_clause_seg: BaseSegment,
         end_indent_str: str,
-    ):
+    ) -> List[LintFix]:
         """Prepend newline spacing to comments on the final nested `END` line."""
         trailing_end = case1_children.select(
             start_seg=case1_else_clause_seg,
@@ -213,7 +215,9 @@ class Rule_ST04(BaseRule):
             fixes.append(LintFix.create_before(first_comment, segments, segments))
         return fixes
 
-    def _rebuild_spacing(self, indent_str: str, nested_clauses: Segments):
+    def _rebuild_spacing(
+        self, indent_str: str, nested_clauses: Segments
+    ) -> List[BaseSegment]:
         buff = []
         # If the first segment is a comment, add a newline
         prior_newline = nested_clauses.first(sp.not_(sp.is_whitespace())).any(

--- a/src/sqlfluff/rules/structure/ST04.py
+++ b/src/sqlfluff/rules/structure/ST04.py
@@ -1,9 +1,9 @@
 """Implementation of Rule ST04."""
 
-from sqlfluff.core.parser import NewlineSegment, WhitespaceSegment
+from sqlfluff.core.parser import BaseSegment, Indent, NewlineSegment, WhitespaceSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
-from sqlfluff.utils.functional import FunctionalContext, sp
+from sqlfluff.utils.functional import FunctionalContext, Segments, sp
 from sqlfluff.utils.reflow.reindent import construct_single_indent
 
 
@@ -53,6 +53,7 @@ class Rule_ST04(BaseRule):
         assert segment.select(sp.is_type("case_expression"))
         case1_children = segment.children()
         case1_first_case = case1_children.first(sp.is_keyword("CASE")).get()
+        assert case1_first_case
         case1_first_when = case1_children.first(
             sp.is_type("when_clause", "else_clause")
         ).get()
@@ -104,9 +105,20 @@ class Rule_ST04(BaseRule):
         case1_to_delete = case1_children.select(
             start_seg=case1_last_when, stop_seg=case1_else_clause_seg
         )
+        # Restore any comments that were deleted
+        after_last_comment_index = (
+            case1_to_delete.find(case1_to_delete.last(sp.is_comment()).get()) + 1
+        )
+        case1_comments_to_restore = case1_to_delete.select(
+            stop_seg=case1_to_delete.get(after_last_comment_index)
+        )
+        after_else_comment = case1_else_clause.children().select(
+            select_if=sp.is_type("newline", "comment", "whitespace"),
+            stop_seg=case1_else_expressions.get(),
+        )
 
         # Delete the nested "CASE" expression.
-        fixes = case1_to_delete.apply(lambda seg: LintFix.delete(seg))
+        fixes = case1_to_delete.apply(LintFix.delete)
 
         tab_space_size: int = context.config.get("tab_space_size", ["indentation"])
         indent_unit: str = context.config.get("indent_unit", ["indentation"])
@@ -114,26 +126,115 @@ class Rule_ST04(BaseRule):
         # Determine the indentation to use when we move the nested "WHEN"
         # and "ELSE" clauses, based on the indentation of case1_last_when.
         # If no whitespace segments found, use default indent.
-        indent = (
-            case1_children.select(stop_seg=case1_last_when)
-            .reversed()
-            .first(sp.is_type("whitespace"))
+        when_indent_str = self._get_indentation(
+            case1_children, case1_last_when, tab_space_size, indent_unit
         )
-        indent_str = (
-            "".join(seg.raw for seg in indent)
-            if indent
-            else construct_single_indent(indent_unit, tab_space_size)
+        # Again determine indentation, but matching the "CASE"/"END" level.
+        end_indent_str = self._get_indentation(
+            case1_children, case1_first_case, tab_space_size, indent_unit
         )
 
         # Move the nested "when" and "else" clauses after the last outer
         # "when".
-        nested_clauses = case2.children(sp.is_type("when_clause", "else_clause"))
-        create_after_last_when = nested_clauses.apply(
-            lambda seg: [NewlineSegment(), WhitespaceSegment(indent_str), seg]
+        nested_clauses = case2.children(
+            sp.is_type("when_clause", "else_clause", "newline", "comment", "whitespace")
         )
-        segments = [item for sublist in create_after_last_when for item in sublist]
+
+        # Rebuild the nested case statement.
+        # Any comments after the last outer "WHEN" that were deleted
+        segments = list(case1_comments_to_restore)
+        # Any comments between the "ELSE" and nested "CASE"
+        segments += self._rebuild_spacing(when_indent_str, after_else_comment)
+        # The nested "WHEN", "ELSE" or "comments", with logical spacing
+        segments += self._rebuild_spacing(when_indent_str, nested_clauses)
         fixes.append(LintFix.create_after(case1_last_when, segments, source=segments))
 
         # Delete the outer "else" clause.
         fixes.append(LintFix.delete(case1_else_clause_seg))
+        # Add spacing for any comments that may exist after the nested `END`
+        # but only on that same line.
+        fixes += self._nested_end_trailing_comment(
+            case1_children, case1_else_clause_seg, end_indent_str
+        )
         return LintResult(case2[0], fixes=fixes)
+
+    def _get_indentation(
+        self,
+        parent_segments: Segments,
+        segment: BaseSegment,
+        tab_space_size: int,
+        indent_unit: str,
+    ):
+        """Calculate the indentation level for rebuilding nested struct.
+
+        This is only a best attempt as the input may not be equally indented. The layout
+        rules, if run, would resolve this.
+        """
+        leading_whitespace = (
+            parent_segments.select(stop_seg=segment)
+            .reversed()
+            .first(sp.is_type("whitespace"))
+        )
+        seg_indent = parent_segments.select(stop_seg=segment).last(sp.is_type("indent"))
+        indent_level = 1
+        if (
+            seg_indent
+            and (segment_indent := seg_indent.get())
+            and isinstance(segment_indent, Indent)
+        ):
+            indent_level = segment_indent.indent_val + 1
+        indent_str = (
+            "".join(seg.raw for seg in leading_whitespace)
+            if leading_whitespace
+            and (whitespace_seg := leading_whitespace.get())
+            and len(whitespace_seg.raw) > 1
+            else construct_single_indent(indent_unit, tab_space_size) * indent_level
+        )
+
+        return indent_str
+
+    def _nested_end_trailing_comment(
+        self,
+        case1_children: Segments,
+        case1_else_clause_seg: BaseSegment,
+        end_indent_str: str,
+    ):
+        """Prepend newline spacing to comments on the final nested `END` line."""
+        trailing_end = case1_children.select(
+            start_seg=case1_else_clause_seg,
+            loop_while=sp.not_(sp.is_type("newline")),
+        )
+        fixes = trailing_end.select(
+            sp.is_whitespace(), loop_while=sp.not_(sp.is_comment())
+        ).apply(LintFix.delete)
+        first_comment = trailing_end.first(sp.is_comment()).get()
+        if first_comment:
+            segments = [NewlineSegment(), WhitespaceSegment(end_indent_str)]
+            fixes.append(LintFix.create_before(first_comment, segments, segments))
+        return fixes
+
+    def _rebuild_spacing(self, indent_str: str, nested_clauses: Segments):
+        buff = []
+        # If the first segment is a comment, add a newline
+        prior_newline = nested_clauses.first(sp.not_(sp.is_whitespace())).any(
+            sp.is_comment()
+        )
+        prior_whitespace = ""
+        for seg in nested_clauses:
+            if seg.is_type("when_clause", "else_clause") or (
+                prior_newline and seg.is_comment
+            ):
+                buff += [NewlineSegment(), WhitespaceSegment(indent_str), seg]
+                prior_newline = False
+                prior_whitespace = ""
+            elif seg.is_type("newline"):
+                prior_newline = True
+                prior_whitespace = ""
+            elif not prior_newline and seg.is_comment:
+                buff += [WhitespaceSegment(prior_whitespace), seg]
+                prior_newline = False
+                prior_whitespace = ""
+            elif seg.is_whitespace:
+                # Don't reset newline
+                prior_whitespace = seg.raw
+        return buff

--- a/test/fixtures/rules/std_rule_cases/ST04.yml
+++ b/test/fixtures/rules/std_rule_cases/ST04.yml
@@ -284,3 +284,87 @@ test_fail_nested_same_case:
             ELSE 'other'
         END
     FROM tab_a;
+
+test_fail_retain_comments:
+  fail_str: |
+    SELECT
+      CASE
+          WHEN FALSE
+            THEN "value1"  -- a comment
+          ELSE
+            CASE
+                -- another comment
+              WHEN TRUE   -- and here
+                THEN "value2" -- but also here
+            END
+        END
+    FROM table;
+  fix_str: |
+    SELECT
+      CASE
+          WHEN FALSE
+            THEN "value1"  -- a comment
+          -- another comment
+          WHEN TRUE   -- and here
+                THEN "value2" -- but also here
+        END
+    FROM table;
+
+test_fail_retain_comments_after_end:
+  fail_str: |
+    SELECT
+    CASE -- no spaces here
+        WHEN FALSE
+          THEN "value1"  -- a comment
+        ELSE
+          CASE -- after case
+              -- another comment
+        /* before the when */   WHEN TRUE   -- and here
+              THEN "value2" -- but also here
+        END /* after the end */    /* but wait there's more! */
+       -- but here too
+      END
+    FROM table;
+  fix_str: |
+    SELECT
+    CASE -- no spaces here
+        WHEN FALSE
+          THEN "value1"  -- a comment
+        -- after case
+        -- another comment
+        /* before the when */
+        WHEN TRUE   -- and here
+              THEN "value2" -- but also here
+        /* after the end */    /* but wait there's more! */
+       -- but here too
+      END
+    FROM table;
+
+test_fail_retain_comments_after_else:
+  fail_str: |
+    SELECT
+      CASE
+          WHEN FALSE
+            THEN "value1"  -- a comment
+          /* before else*/ ELSE --after else
+            /*before case*/ CASE -- else case
+                -- another comment
+              WHEN TRUE   -- and here
+                THEN "value2" -- but also here
+            END
+        END
+    FROM table;
+  fix_str: |
+    SELECT
+      CASE
+          WHEN FALSE
+            THEN "value1"  -- a comment
+          /* before else*/
+          --after else
+          /*before case*/
+          -- else case
+          -- another comment
+          WHEN TRUE   -- and here
+                THEN "value2" -- but also here
+        END
+    FROM table;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fix to retain comments when flattening nested case statements.
- fixes #4848 
- fixes #4966 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
