### PR TITLE
Postgres: Support pgvector vector type

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -867,6 +867,11 @@ class DatatypeSegment(ansi.DatatypeSegment):
                     "DATERANGE",
                     # pg_lsn type
                     "PG_LSN",
+                    # pgvector types
+                    Sequence(
+                        "VECTOR",
+                        Ref("BracketedArguments", optional=True),
+                    ),
                 ),
             ),
             # user defined data types

--- a/src/sqlfluff/dialects/dialect_postgres_keywords.py
+++ b/src/sqlfluff/dialects/dialect_postgres_keywords.py
@@ -1028,9 +1028,14 @@ postgres_postgis_other_keywords = [
     ("EMPTY", "non-reserved"),
 ]
 
+postgres_pgvector_keywords = [
+    ("VECTOR", "non-reserved"),
+]
+
 postgres_keywords = priority_keyword_merge(
     postgres_docs_keywords,
     postgres_nondocs_keywords,
     postgres_postgis_datatype_keywords,
     postgres_postgis_other_keywords,
+    postgres_pgvector_keywords,
 )

--- a/test/fixtures/dialects/postgres/pgvector.sql
+++ b/test/fixtures/dialects/postgres/pgvector.sql
@@ -1,0 +1,3 @@
+CREATE TABLE search (
+    embedding VECTOR(1536)
+);

--- a/test/fixtures/dialects/postgres/pgvector.yml
+++ b/test/fixtures/dialects/postgres/pgvector.yml
@@ -1,0 +1,26 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 1bdf39db0361b096fda47dee34fa19fb470230e4f6ce2ca34c5328df47d9405f
+file:
+  statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: search
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: embedding
+        data_type:
+          keyword: VECTOR
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '1536'
+              end_bracket: )
+        end_bracket: )
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #5700

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
