### PR TITLE
TSQL: Fix bare functions in default constraints

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -2435,6 +2435,7 @@ class ColumnConstraintSegment(BaseSegment):
                 OptionallyBracketed(
                     OneOf(
                         OptionallyBracketed(Ref("LiteralGrammar")),  # ((-1))
+                        Ref("BareFunctionSegment"),
                         Ref("FunctionSegment"),
                         Ref("NextValueSequenceSegment"),
                     ),

--- a/test/fixtures/dialects/tsql/create_table_constraints.sql
+++ b/test/fixtures/dialects/tsql/create_table_constraints.sql
@@ -3,6 +3,7 @@ CREATE TABLE [dbo].[example](
     [Column B] [int] IDENTITY(1, 1) NOT NULL,
     [ColumnC] varchar(100) DEFAULT 'mydefault',
     [ColumnDecimal] DATE DEFAULT GETDATE(),
+    [ColumnUser] char(30) DEFAULT CURRENT_USER,
     [col1] int default ((-1)) not null,
     [col1] int default (-1) not null,
     [col1] int default -1 not null,

--- a/test/fixtures/dialects/tsql/create_table_constraints.yml
+++ b/test/fixtures/dialects/tsql/create_table_constraints.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 64ba76dd590a430fec124b6c9c189c2d5c2961c3406a0b510accba6391210307
+_hash: c75e9d7b8dd1b4bafaa40bb49ba25f4732ecef4cc1c4adc176a43dc05b9dabbe
 file:
 - batch:
     statement:
@@ -67,6 +67,20 @@ file:
                 bracketed:
                   start_bracket: (
                   end_bracket: )
+        - comma: ','
+        - column_definition:
+            quoted_identifier: '[ColumnUser]'
+            data_type:
+              data_type_identifier: char
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '30'
+                  end_bracket: )
+            column_constraint_segment:
+              keyword: DEFAULT
+              bare_function: CURRENT_USER
         - comma: ','
         - column_definition:
           - quoted_identifier: '[col1]'


### PR DESCRIPTION
### Brief summary of the change made

Adds support for bare functions in column default constraints for TSQL.
Fixes #4631 


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
