### PR TITLE
TSQL: allow 'OR ALTER' on 'CREATE TRIGGER'

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -5039,6 +5039,7 @@ class CreateTriggerStatementSegment(BaseSegment):
 
     match_grammar: Matchable = Sequence(
         "CREATE",
+        Sequence("OR", "ALTER", optional=True),
         "TRIGGER",
         Ref("TriggerReferenceSegment"),
         "ON",

--- a/test/fixtures/dialects/tsql/triggers.sql
+++ b/test/fixtures/dialects/tsql/triggers.sql
@@ -121,3 +121,9 @@ GO
 
 DISABLE TRIGGER safety ON DATABASE;
 GO
+
+CREATE OR ALTER TRIGGER reminder1
+ON Sales.Customer
+AFTER INSERT, UPDATE
+AS RAISERROR ('Notify Customer Relations', 16, 10);
+GO

--- a/test/fixtures/dialects/tsql/triggers.yml
+++ b/test/fixtures/dialects/tsql/triggers.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cd35978be7ba6609d00c6c3fab646c1ad57806dfc4fbeb7fc4d04ef40784acba
+_hash: 876d3e99f9a162ad647cc28a39d0eaa9c9e5e52570c8248c9e4ae9eb87ce2c90
 file:
 - batch:
     statement:
@@ -629,5 +629,38 @@ file:
       - keyword: 'ON'
       - keyword: DATABASE
     statement_terminator: ;
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      create_trigger:
+      - keyword: CREATE
+      - keyword: OR
+      - keyword: ALTER
+      - keyword: TRIGGER
+      - trigger_reference:
+          naked_identifier: reminder1
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: Sales
+        - dot: .
+        - naked_identifier: Customer
+      - keyword: AFTER
+      - keyword: INSERT
+      - comma: ','
+      - keyword: UPDATE
+      - keyword: AS
+      - statement:
+          raiserror_statement:
+            keyword: RAISERROR
+            bracketed:
+            - start_bracket: (
+            - quoted_literal: "'Notify Customer Relations'"
+            - comma: ','
+            - numeric_literal: '16'
+            - comma: ','
+            - numeric_literal: '10'
+            - end_bracket: )
+      - statement_terminator: ;
 - go_statement:
     keyword: GO


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Allow the optional `OR ALTER` on `CREATE TRIGGER` statements in T-SQL dialect.  This is already possible on `VIEW`, `FUNCTION` and `PROCEDURE`.

### Are there any other side effects of this change that we should be aware of?
Not as far as I know.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
