### PR TITLE
Upgrades to release actions.

### DIFF
--- a/.github/workflows/add-to-release-notes.yml
+++ b/.github/workflows/add-to-release-notes.yml
@@ -7,11 +7,16 @@ on:
     branches:
       - main
 jobs:
-  release-notes:
+  draft-release:
     runs-on: ubuntu-20.04
     if: github.repository == 'sqlfluff/sqlfluff'
     steps:
     - name: Update release notes
       uses: release-drafter/release-drafter@v5
+      # If it's a release PR, then we should also update
+      # the header and title here too.
+      # with:
+      #   name: ${{    }}
+      #   header: ${{    }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release-pull-request.yaml
+++ b/.github/workflows/create-release-pull-request.yaml
@@ -45,6 +45,9 @@ jobs:
           branch: prep-${{ github.event.inputs.newVersionNumber }}
           commit-message: "Bump to version ${{ github.event.inputs.newVersionNumber }}"
           title: Prep version ${{ github.event.inputs.newVersionNumber }}
+          labels: |
+            release
+            skip-changelog
           body: |
             Prepare version ${{ github.event.inputs.newVersionNumber }}
 
@@ -56,3 +59,14 @@ jobs:
             [1]: https://github.com/sqlfluff/sqlfluff/releases
             [2]: https://github.com/peter-evans/create-pull-request
           labels: release
+
+    - name: Update release title and tag
+      uses: release-drafter/release-drafter@v5
+      with:
+        # NOTE: We should eventually actually populate the date here, but that
+        # will most likely change before the new pull request actually gets
+        # merged, so we just add "YYYY-MM-DD" for now as a placeholder.
+        name: "[${{ github.event.inputs.newVersionNumber }}] - YYYY-MM-DD"
+        tag: ${{ github.event.inputs.newVersionNumber }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release-pull-request.yaml
+++ b/.github/workflows/create-release-pull-request.yaml
@@ -45,9 +45,6 @@ jobs:
           branch: prep-${{ github.event.inputs.newVersionNumber }}
           commit-message: "Bump to version ${{ github.event.inputs.newVersionNumber }}"
           title: Prep version ${{ github.event.inputs.newVersionNumber }}
-          labels: |
-            release
-            skip-changelog
           body: |
             Prepare version ${{ github.event.inputs.newVersionNumber }}
 
@@ -58,15 +55,17 @@ jobs:
 
             [1]: https://github.com/sqlfluff/sqlfluff/releases
             [2]: https://github.com/peter-evans/create-pull-request
-          labels: release
+          labels: |
+            release
+            skip-changelog
 
-    - name: Update release title and tag
-      uses: release-drafter/release-drafter@v5
-      with:
-        # NOTE: We should eventually actually populate the date here, but that
-        # will most likely change before the new pull request actually gets
-        # merged, so we just add "YYYY-MM-DD" for now as a placeholder.
-        name: "[${{ github.event.inputs.newVersionNumber }}] - YYYY-MM-DD"
-        tag: ${{ github.event.inputs.newVersionNumber }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update release title and tag
+        uses: release-drafter/release-drafter@v5
+        with:
+          # NOTE: We should eventually actually populate the date here, but that
+          # will most likely change before the new pull request actually gets
+          # merged, so we just add "YYYY-MM-DD" for now as a placeholder.
+          name: "[${{ github.event.inputs.newVersionNumber }}] - YYYY-MM-DD"
+          tag: ${{ github.event.inputs.newVersionNumber }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is a pretty small PR, with some incremental changes to the release PR action. It should now _tag_ the GitHub release on creating the release PR, add a placeholder title and leaves a note for when the title should get updated.

I'll come back and add more stuff later, but wanted to get this bit merged and tested before _creating_ the next release PR so I can test the update stuff later.