### PR TITLE
Improve light colour highlight

### DIFF
--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -516,9 +516,7 @@ class OutputStreamFormatter:
             val = "" if v is None else str(v)
             text_buffer.write(
                 ("    " * i)
-                + self.colorize(
-                    pad_line(str(k) + ":", 20, "left"), color=Color.light
-                )
+                + self.colorize(pad_line(str(k) + ":", 20, "left"), color=Color.light)
                 + pad_line(val, 20, "left")
                 + "\n"
             )

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -155,7 +155,7 @@ class OutputStreamFormatter:
 
     def _format_path(self, path: str) -> str:
         """Format paths."""
-        return f"=== [ path: {self.colorize(path, Color.lightgrey)} ] ===\n"
+        return f"=== [ path: {self.colorize(path, Color.light)} ] ===\n"
 
     def dispatch_path(self, path: str) -> None:
         """Dispatch paths for display."""
@@ -197,14 +197,14 @@ class OutputStreamFormatter:
     def dispatch_compilation_header(self, templater: str, message: str) -> None:
         """Dispatch the header displayed before linting."""
         self._dispatch(
-            f"=== [{self.colorize(templater, Color.lightgrey)}] {message}"
+            f"=== [{self.colorize(templater, Color.light)}] {message}"
         )  # pragma: no cover
 
     def dispatch_processing_header(self, processes: int) -> None:
         """Dispatch the header displayed before linting."""
         if self.verbosity > 0:
             self._dispatch(  # pragma: no cover
-                f"{self.colorize('effective configured processes: ', Color.lightgrey)} "
+                f"{self.colorize('effective configured processes: ', Color.light)} "
                 f"{processes}"
             )
 
@@ -290,7 +290,7 @@ class OutputStreamFormatter:
         max_label_width=10,
         sep_char=": ",
         divider_char=" ",
-        label_color=Color.lightgrey,
+        label_color=Color.light,
         val_align="right",
     ) -> str:
         """Make a row of a CLI table, using wrapped values."""
@@ -350,7 +350,7 @@ class OutputStreamFormatter:
         cols=2,
         divider_char=" ",
         sep_char=": ",
-        label_color=Color.lightgrey,
+        label_color=Color.light,
         float_format="{0:.2f}",
         max_label_width=10,
         val_align="right",
@@ -407,7 +407,7 @@ class OutputStreamFormatter:
         elif status_string in ("FAIL", "ERROR"):
             status_string = self.colorize(status_string, Color.red)
 
-        return f"== [{self.colorize(filename, Color.lightgrey)}] {status_string}"
+        return f"== [{self.colorize(filename, Color.light)}] {status_string}"
 
     def format_violation(
         self,
@@ -441,7 +441,7 @@ class OutputStreamFormatter:
 
         # If the rule has a name, add that the description.
         if name:
-            desc += f" [{self.colorize(name, Color.lightgrey)}]"
+            desc += f" [{self.colorize(name, Color.light)}]"
 
         split_desc = split_string_on_spaces(desc, line_length=max_line_length - 25)
 
@@ -449,7 +449,7 @@ class OutputStreamFormatter:
         # Grey out the violation if we're ignoring or warning it.
         section_color: Color
         if warning:
-            section_color = Color.lightgrey
+            section_color = Color.light
         else:
             section_color = Color.blue
 
@@ -517,7 +517,7 @@ class OutputStreamFormatter:
             text_buffer.write(
                 ("    " * i)
                 + self.colorize(
-                    pad_line(str(k) + ":", 20, "left"), color=Color.lightgrey
+                    pad_line(str(k) + ":", 20, "left"), color=Color.light
                 )
                 + pad_line(val, 20, "left")
                 + "\n"
@@ -536,10 +536,10 @@ class OutputStreamFormatter:
             description = rule.description
 
         if rule.groups:
-            groups = self.colorize(", ".join(rule.groups), Color.lightgrey)
+            groups = self.colorize(", ".join(rule.groups), Color.light)
             description += f"\ngroups: {groups}"
         if rule.aliases:
-            aliases = self.colorize(", ".join(rule.aliases), Color.lightgrey)
+            aliases = self.colorize(", ".join(rule.aliases), Color.light)
             description += f" aliases: {aliases}"
         return description
 
@@ -593,7 +593,7 @@ class OutputStreamFormatter:
                 "WARNING: Parsing errors found and dialect is set to "
                 f"'{dialect}'. Have you configured your dialect correctly?"
             ),
-            Color.lightgrey,
+            Color.light,
         )
 
     def print_out_residual_error_counts(

--- a/src/sqlfluff/core/enums.py
+++ b/src/sqlfluff/core/enums.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 
-from colorama import Back, Fore, Style
+from colorama import Fore
 
 
 class FormatType(Enum):
@@ -22,4 +22,4 @@ class Color(Enum):
     red = Fore.RED
     green = Fore.GREEN
     blue = Fore.BLUE
-    lightgrey = Fore.BLACK + Back.WHITE + Style.BRIGHT
+    light = Fore.YELLOW


### PR DESCRIPTION
Ok, so this might be a little controversial.

I understand why #5458 was merged - the previous situation didn't work well with dark mode terminals (see #1659 and #1170). _However_ I'm finding that the solution of changing the background is _also_ quite hard to read on some other themes (in particular on powershell), so I've played with a few options, and I think this might be an improvement on both.

This changes the `lightgrey` colour to just `light` and maps it to the ANSI _yellow_ code. It does change the overall feel quite a bit, but I think it's a good compromise. Here's some shots of what it looks like on a few different colour schemes:

Ubuntu
![image](https://github.com/sqlfluff/sqlfluff/assets/4670904/a43945e7-4deb-4c26-b6d1-babf4caa02fa)

Monokai
![image](https://github.com/sqlfluff/sqlfluff/assets/4670904/9581ca20-9abd-4ee8-8f4e-c7f8a37076da)

Solarized
![image](https://github.com/sqlfluff/sqlfluff/assets/4670904/8fea0a12-9caf-47f6-aecc-6e83cea19427)

Unfortunately I don't have a mac and so can't confirm exactly what it looks like on MacOS dark solarized as per the original request.

@ryaminal , @louis-vines,  @puetsch - as the original posters of the linked issues, are you able to try this variant and confirm whether it's readable on MacOS dark mode? @WittierDinosaur if you're on a Mac, you might also be able to confirm?

