### PR TITLE
BigQuery: Support DEFAULT COLLATE segment

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1525,6 +1525,20 @@ class ClusterBySegment(BaseSegment):
     )
 
 
+class DefaultCollateSegment(BaseSegment):
+    """DEFAULT COLLATE clause for a table or a dataset.
+
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/collation-concepts#default_collation
+    """
+
+    type = "default_collate"
+    match_grammar: Matchable = Sequence(
+        "DEFAULT",
+        "COLLATE",
+        Ref("LiteralGrammar"),
+    )
+
+
 class OptionsSegment(BaseSegment):
     """OPTIONS clause for a table."""
 
@@ -1593,6 +1607,22 @@ class ViewColumnDefinitionSegment(ansi.ColumnDefinitionSegment):
     )
 
 
+class CreateSchemaStatementSegment(ansi.CreateSchemaStatementSegment):
+    """A `CREATE SCHEMA` statement.
+
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_schema_statement
+    """
+
+    match_grammar: Matchable = Sequence(
+        "CREATE",
+        "SCHEMA",
+        Ref("IfNotExistsGrammar", optional=True),
+        Ref("TableReferenceSegment"),
+        Ref("DefaultCollateSegment", optional=True),
+        Ref("OptionsSegment", optional=True),
+    )
+
+
 class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
     """`CREATE TABLE` statement.
 
@@ -1624,6 +1654,7 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
             ),
             optional=True,
         ),
+        Ref("DefaultCollateSegment", optional=True),
         Ref("PartitionBySegment", optional=True),
         Ref("ClusterBySegment", optional=True),
         Ref("OptionsSegment", optional=True),

--- a/test/fixtures/dialects/bigquery/create_schema.sql
+++ b/test/fixtures/dialects/bigquery/create_schema.sql
@@ -1,0 +1,5 @@
+CREATE SCHEMA dataset_name;
+
+CREATE SCHEMA IF NOT EXISTS project_name.dataset_name
+DEFAULT COLLATE 'und:ci'
+OPTIONS(description="example");

--- a/test/fixtures/dialects/bigquery/create_schema.yml
+++ b/test/fixtures/dialects/bigquery/create_schema.yml
@@ -1,0 +1,39 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 63923201aae2f869be7942426ee156f17ae35bac4164277a1e3c0e9e79d336c1
+file:
+- statement:
+    create_schema_statement:
+    - keyword: CREATE
+    - keyword: SCHEMA
+    - table_reference:
+        naked_identifier: dataset_name
+- statement_terminator: ;
+- statement:
+    create_schema_statement:
+    - keyword: CREATE
+    - keyword: SCHEMA
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: project_name
+      - dot: .
+      - naked_identifier: dataset_name
+    - default_collate:
+      - keyword: DEFAULT
+      - keyword: COLLATE
+      - quoted_literal: "'und:ci'"
+    - options_segment:
+        keyword: OPTIONS
+        bracketed:
+          start_bracket: (
+          parameter: description
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: '"example"'
+          end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/create_table_default_collate.sql
+++ b/test/fixtures/dialects/bigquery/create_table_default_collate.sql
@@ -1,0 +1,13 @@
+CREATE TABLE example_dataset.example_table
+(x INT64)
+DEFAULT COLLATE 'und:ci';
+
+CREATE OR REPLACE TABLE
+example-project.example_dataset.example_table
+(
+  x INT64 OPTIONS(description="example"),
+  y INT64 OPTIONS(description="example")
+)
+DEFAULT COLLATE 'und:ci'
+CLUSTER BY x, y
+OPTIONS(description="example");

--- a/test/fixtures/dialects/bigquery/create_table_default_collate.yml
+++ b/test/fixtures/dialects/bigquery/create_table_default_collate.yml
@@ -1,0 +1,95 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 0b31a7338881cd7e1b6d1af9f5c39ccbcda641535a866adb24b23c0cc376cb2d
+file:
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_table
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          naked_identifier: x
+          data_type:
+            data_type_identifier: INT64
+        end_bracket: )
+    - default_collate:
+      - keyword: DEFAULT
+      - keyword: COLLATE
+      - quoted_literal: "'und:ci'"
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: example
+      - dash: '-'
+      - naked_identifier: project
+      - dot: .
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_table
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: x
+          data_type:
+            data_type_identifier: INT64
+          options_segment:
+            keyword: OPTIONS
+            bracketed:
+              start_bracket: (
+              parameter: description
+              comparison_operator:
+                raw_comparison_operator: '='
+              quoted_literal: '"example"'
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          naked_identifier: y
+          data_type:
+            data_type_identifier: INT64
+          options_segment:
+            keyword: OPTIONS
+            bracketed:
+              start_bracket: (
+              parameter: description
+              comparison_operator:
+                raw_comparison_operator: '='
+              quoted_literal: '"example"'
+              end_bracket: )
+      - end_bracket: )
+    - default_collate:
+      - keyword: DEFAULT
+      - keyword: COLLATE
+      - quoted_literal: "'und:ci'"
+    - cluster_by_segment:
+      - keyword: CLUSTER
+      - keyword: BY
+      - expression:
+          column_reference:
+            naked_identifier: x
+      - comma: ','
+      - expression:
+          column_reference:
+            naked_identifier: y
+    - options_segment:
+        keyword: OPTIONS
+        bracketed:
+          start_bracket: (
+          parameter: description
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: '"example"'
+          end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

related: #5789

The current BigQuery dialect does not correctly parse CREATE SCHEMA / CREATE TABLE statements containing `DEFAULT COLLATE` so we will attempt to fix this.

### Are there any other side effects of this change that we should be aware of?

As far as I know, nothing.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
