### PR TITLE
TSQL: support computed columns

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3282,6 +3282,7 @@ class AlterTableStatementSegment(BaseSegment):
                 Sequence(
                     "ADD",
                     Delimited(
+                        Ref("ComputedColumnDefinitionSegment"),
                         Ref("ColumnDefinitionSegment"),
                     ),
                 ),
@@ -6142,8 +6143,17 @@ class ComputedColumnDefinitionSegment(BaseSegment):
                 Ref("ExpressionSegment"),
             ),
         ),
-        OptionallyBracketed("PERSISTED", optional=True),  # For types like VARCHAR(100)
-        Ref.keyword("PERSISTED", optional=True),
+        #OneOf(
+        #    Sequence("PERSISTED", "NOT", "NULL"),
+        #    Sequence("PERSISTED"),
+        #    optional=True,
+        #),
+        Sequence(
+            "PERSISTED",
+            Sequence( "NOT", "NULL", optional=True),
+            optional=True,
+        ),
+        # Sequence(Ref.keyword("PERSISTED", optional=True), "NOT", "NULL", optional=True),
         AnyNumberOf(
             Ref("ColumnConstraintSegment", optional=True),
         ),

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -6143,19 +6143,12 @@ class ComputedColumnDefinitionSegment(BaseSegment):
                 Ref("ExpressionSegment"),
             ),
         ),
-        #OneOf(
-        #    Sequence("PERSISTED", "NOT", "NULL"),
-        #    Sequence("PERSISTED"),
-        #    optional=True,
-        #),
         Sequence(
             "PERSISTED",
-            Sequence( "NOT", "NULL", optional=True),
+            Sequence("NOT", "NULL", optional=True),
             optional=True,
         ),
-        # Sequence(Ref.keyword("PERSISTED", optional=True), "NOT", "NULL", optional=True),
         AnyNumberOf(
             Ref("ColumnConstraintSegment", optional=True),
         ),
     )
-

--- a/test/fixtures/dialects/tsql/alter_table.sql
+++ b/test/fixtures/dialects/tsql/alter_table.sql
@@ -104,3 +104,9 @@ ALTER TABLE TestTable SET (DATA_DELETION = OFF(FILTER_COLUMN = ColumnName, RETEN
 ALTER TABLE TestTable SET (DATA_DELETION = OFF(FILTER_COLUMN = ColumnName, RETENTION_PERIOD = INFINITE)); GO
 ALTER TABLE TestTable SET (DATA_DELETION = OFF(FILTER_COLUMN = ColumnName, RETENTION_PERIOD = 7 YEARS)); GO
 ALTER TABLE TestTable SET (DATA_DELETION = OFF(FILTER_COLUMN = ColumnName, RETENTION_PERIOD = 7 DAYS)); GO
+
+-- computed columm
+-- https://learn.microsoft.com/en-us/sql/relational-databases/tables/specify-computed-columns-in-a-table?view=sql-server-ver16
+ALTER TABLE dbo.Products ADD RetailValue AS [QtyAvailable] * UnitPrice * 1.5 PERSISTED; GO
+ALTER TABLE dbo.Products ADD RetailValue AS (QtyAvailable * [UnitPrice] * 1.5) PERSISTED NOT NULL; GO
+ALTER TABLE dbo.Products ADD InventoyDate AS CAST([InventoryTs] AS date); GO

--- a/test/fixtures/dialects/tsql/alter_table.yml
+++ b/test/fixtures/dialects/tsql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bc7ad7040e8454374ad40070f2b85fdb9ddb06ffcabe49cd8111153db4f39862
+_hash: 08e12e9160d43c99db40005772eb315a945b74782b70b08564e2a9c837ce4b7b
 file:
 - batch:
     statement:
@@ -815,6 +815,89 @@ file:
           - date_part: DAYS
           - end_bracket: )
         - end_bracket: )
+    statement_terminator: ;
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: Products
+      - keyword: ADD
+      - computed_column_definition:
+        - naked_identifier: RetailValue
+        - keyword: AS
+        - expression:
+          - column_reference:
+              quoted_identifier: '[QtyAvailable]'
+          - binary_operator: '*'
+          - column_reference:
+              naked_identifier: UnitPrice
+          - binary_operator: '*'
+          - numeric_literal: '1.5'
+        - keyword: PERSISTED
+    statement_terminator: ;
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: Products
+      - keyword: ADD
+      - computed_column_definition:
+        - naked_identifier: RetailValue
+        - keyword: AS
+        - bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: QtyAvailable
+            - binary_operator: '*'
+            - column_reference:
+                quoted_identifier: '[UnitPrice]'
+            - binary_operator: '*'
+            - numeric_literal: '1.5'
+            end_bracket: )
+        - keyword: PERSISTED
+        - keyword: NOT
+        - keyword: 'NULL'
+    statement_terminator: ;
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: Products
+      - keyword: ADD
+      - computed_column_definition:
+          naked_identifier: InventoyDate
+          keyword: AS
+          function:
+            function_name:
+              keyword: CAST
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  quoted_identifier: '[InventoryTs]'
+              keyword: AS
+              data_type:
+                data_type_identifier: date
+              end_bracket: )
     statement_terminator: ;
 - go_statement:
     keyword: GO

--- a/test/fixtures/dialects/tsql/create_table.sql
+++ b/test/fixtures/dialects/tsql/create_table.sql
@@ -23,7 +23,10 @@ CREATE TABLE dbo.Products (
     , QtyAvailable smallint
     , QtySold smallint
     , UnitPrice money
-    , InventoryValue AS QtyAvailable * UnitPrice
-    , [SoldValue] AS (QtySold * [UnitPrice])
+    , InventoryValue1 AS QtyAvailable * UnitPrice PERSISTED
+    , InventoryValue2 AS QtyAvailable * UnitPrice PERSISTED NOT NULL
+    , InventoryValue3 AS QtyAvailable * UnitPrice 
+    , InventoryValue4 AS QtyAvailable * UnitPrice PRIMARY KEY
+    , [SoldValue] AS (QtySold * UnitPrice)
     , InventoyDate AS CAST(InventoryTs AS date)
 );

--- a/test/fixtures/dialects/tsql/create_table.sql
+++ b/test/fixtures/dialects/tsql/create_table.sql
@@ -25,7 +25,7 @@ CREATE TABLE dbo.Products (
     , UnitPrice money
     , InventoryValue1 AS QtyAvailable * UnitPrice PERSISTED
     , InventoryValue2 AS QtyAvailable * UnitPrice PERSISTED NOT NULL
-    , InventoryValue3 AS QtyAvailable * UnitPrice 
+    , InventoryValue3 AS QtyAvailable * UnitPrice
     , InventoryValue4 AS QtyAvailable * UnitPrice PRIMARY KEY
     , [SoldValue] AS (QtySold * UnitPrice)
     , InventoyDate AS CAST(InventoryTs AS date)

--- a/test/fixtures/dialects/tsql/create_table.sql
+++ b/test/fixtures/dialects/tsql/create_table.sql
@@ -13,3 +13,17 @@ CREATE TABLE foo (
     more_quoted "my schema"."custom udt",
     quoted_udt sch.[custom udt]
 );
+
+-- computed column
+-- https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql?view=sql-server-ver16#column_name-as-computed_column_expression
+-- https://learn.microsoft.com/en-us/sql/relational-databases/tables/specify-computed-columns-in-a-table?view=sql-server-ver16
+CREATE TABLE dbo.Products (
+    ProductID int IDENTITY (1,1) NOT NULL
+    , InventoryTs datetime2(0)
+    , QtyAvailable smallint
+    , QtySold smallint
+    , UnitPrice money
+    , InventoryValue AS QtyAvailable * UnitPrice
+    , [SoldValue] AS (QtySold * [UnitPrice])
+    , InventoyDate AS CAST(InventoryTs AS date)
+);

--- a/test/fixtures/dialects/tsql/create_table.yml
+++ b/test/fixtures/dialects/tsql/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cfcae343a1e7dffe16887fb99acfec87e64823d1dbbe32c94bd4a971757073cb
+_hash: 65d54fa08f6406ab6dc5bdd1e55b8210e10ed76df6170ddce299d7e27a8267e8
 file:
   batch:
   - statement:
@@ -100,5 +100,98 @@ file:
               naked_identifier: sch
               dot: .
               quoted_identifier: '[custom udt]'
+        - end_bracket: )
+      - statement_terminator: ;
+  - statement:
+      create_table_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: Products
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+          - naked_identifier: ProductID
+          - data_type:
+              data_type_identifier: int
+          - column_constraint_segment:
+              identity_grammar:
+                keyword: IDENTITY
+                bracketed:
+                - start_bracket: (
+                - numeric_literal: '1'
+                - comma: ','
+                - numeric_literal: '1'
+                - end_bracket: )
+          - column_constraint_segment:
+            - keyword: NOT
+            - keyword: 'NULL'
+        - comma: ','
+        - column_definition:
+            naked_identifier: InventoryTs
+            data_type:
+              data_type_identifier: datetime2
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '0'
+                  end_bracket: )
+        - comma: ','
+        - column_definition:
+            naked_identifier: QtyAvailable
+            data_type:
+              data_type_identifier: smallint
+        - comma: ','
+        - column_definition:
+            naked_identifier: QtySold
+            data_type:
+              data_type_identifier: smallint
+        - comma: ','
+        - column_definition:
+            naked_identifier: UnitPrice
+            data_type:
+              data_type_identifier: money
+        - comma: ','
+        - computed_column_definition:
+            naked_identifier: InventoryValue
+            keyword: AS
+            expression:
+            - column_reference:
+                naked_identifier: QtyAvailable
+            - binary_operator: '*'
+            - column_reference:
+                naked_identifier: UnitPrice
+        - comma: ','
+        - computed_column_definition:
+            quoted_identifier: '[SoldValue]'
+            keyword: AS
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: QtySold
+              - binary_operator: '*'
+              - column_reference:
+                  quoted_identifier: '[UnitPrice]'
+              end_bracket: )
+        - comma: ','
+        - computed_column_definition:
+            naked_identifier: InventoyDate
+            keyword: AS
+            function:
+              function_name:
+                keyword: CAST
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: InventoryTs
+                keyword: AS
+                data_type:
+                  data_type_identifier: date
+                end_bracket: )
         - end_bracket: )
       - statement_terminator: ;

--- a/test/fixtures/dialects/tsql/create_table.yml
+++ b/test/fixtures/dialects/tsql/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 65d54fa08f6406ab6dc5bdd1e55b8210e10ed76df6170ddce299d7e27a8267e8
+_hash: 79da78c613cc371329828508a62c84ef826111bc98cd7e8b884f337a29bc91cc
 file:
   batch:
   - statement:
@@ -156,7 +156,31 @@ file:
               data_type_identifier: money
         - comma: ','
         - computed_column_definition:
-            naked_identifier: InventoryValue
+          - naked_identifier: InventoryValue1
+          - keyword: AS
+          - expression:
+            - column_reference:
+                naked_identifier: QtyAvailable
+            - binary_operator: '*'
+            - column_reference:
+                naked_identifier: UnitPrice
+          - keyword: PERSISTED
+        - comma: ','
+        - computed_column_definition:
+          - naked_identifier: InventoryValue2
+          - keyword: AS
+          - expression:
+            - column_reference:
+                naked_identifier: QtyAvailable
+            - binary_operator: '*'
+            - column_reference:
+                naked_identifier: UnitPrice
+          - keyword: PERSISTED
+          - keyword: NOT
+          - keyword: 'NULL'
+        - comma: ','
+        - computed_column_definition:
+            naked_identifier: InventoryValue3
             keyword: AS
             expression:
             - column_reference:
@@ -164,6 +188,19 @@ file:
             - binary_operator: '*'
             - column_reference:
                 naked_identifier: UnitPrice
+        - comma: ','
+        - computed_column_definition:
+            naked_identifier: InventoryValue4
+            keyword: AS
+            expression:
+            - column_reference:
+                naked_identifier: QtyAvailable
+            - binary_operator: '*'
+            - column_reference:
+                naked_identifier: UnitPrice
+            column_constraint_segment:
+            - keyword: PRIMARY
+            - keyword: KEY
         - comma: ','
         - computed_column_definition:
             quoted_identifier: '[SoldValue]'
@@ -175,7 +212,7 @@ file:
                   naked_identifier: QtySold
               - binary_operator: '*'
               - column_reference:
-                  quoted_identifier: '[UnitPrice]'
+                  naked_identifier: UnitPrice
               end_bracket: )
         - comma: ','
         - computed_column_definition:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
fixes #4971 
Proper support for [TSQL computed columns:](https://learn.microsoft.com/en-us/sql/relational-databases/tables/specify-computed-columns-in-a-table?view=sql-server-ver16)
- `CREATE TABLE`
- `ALTER TABLE`


### Are there any other side effects of this change that we should be aware of?
no

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
