### PR TITLE
BigQuery: Support FOR SYSTEM_TIME AS OF in CREATE TABLE CLONE statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1639,6 +1639,7 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
         Sequence(
             OneOf("COPY", "LIKE", "CLONE"),
             Ref("TableReferenceSegment"),
+            Ref("ForSystemTimeAsOfSegment", optional=True),
             optional=True,
         ),
         # Column list

--- a/test/fixtures/dialects/bigquery/create_table_like_copy_clone.sql
+++ b/test/fixtures/dialects/bigquery/create_table_like_copy_clone.sql
@@ -14,3 +14,8 @@ COPY mydataset.sourcetable
 CREATE TABLE mydataset.newtable_clone
 CLONE mydataset.sourcetable
 ;
+
+CREATE TABLE IF NOT EXISTS mydataset.newtable_clone
+CLONE mydataset.sourcetable FOR SYSTEM_TIME AS OF CURRENT_TIMESTAMP()
+OPTIONS(description="example")
+;

--- a/test/fixtures/dialects/bigquery/create_table_like_copy_clone.yml
+++ b/test/fixtures/dialects/bigquery/create_table_like_copy_clone.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1d796951320912d1de1fb4f375e9c181b868fd162508bc7e60e82f88f0097b04
+_hash: 53452e24fda4345fb426d5c1d1df4c0eeeb71f3b343821d0e1629f6f82a3dd88
 file:
 - statement:
     create_table_statement:
@@ -77,4 +77,42 @@ file:
       - naked_identifier: mydataset
       - dot: .
       - naked_identifier: sourcetable
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: mydataset
+      - dot: .
+      - naked_identifier: newtable_clone
+    - keyword: CLONE
+    - table_reference:
+      - naked_identifier: mydataset
+      - dot: .
+      - naked_identifier: sourcetable
+    - for_system_time_as_of_segment:
+      - keyword: FOR
+      - keyword: SYSTEM_TIME
+      - keyword: AS
+      - keyword: OF
+      - expression:
+          function:
+            function_name:
+              function_name_identifier: CURRENT_TIMESTAMP
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+    - options_segment:
+        keyword: OPTIONS
+        bracketed:
+          start_bracket: (
+          parameter: description
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: '"example"'
+          end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

related: #5789

The current BigQuery dialect does not correctly parse CREATE TABLE CLONE statements containing `FOR SYSTEM_TIME AS OF` so we will attempt to fix this.

https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_table_clone_statement

### Are there any other side effects of this change that we should be aware of?

As far as I know, nothing.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
