### PR TITLE
TSQL: parse `CREATE/ALTER/DROP MASTER KEY`

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -677,6 +677,9 @@ class StatementSegment(ansi.StatementSegment):
             Ref("AlterPartitionSchemeSegment"),
             Ref("CreatePartitionSchemeSegment"),
             Ref("AlterPartitionFunctionSegment"),
+            Ref("CreateMasterKeySegment"),
+            Ref("AlterMasterKeySegment"),
+            Ref("DropMasterKeySegment"),
         ],
         remove=[
             Ref("CreateModelStatementSegment"),
@@ -6248,4 +6251,85 @@ class AlterPartitionSchemeSegment(BaseSegment):
         "NEXT",
         "USED",
         Ref("ObjectReferenceSegment", optional=True),
+    )
+
+
+class CreateMasterKeySegment(BaseSegment):
+    """A `CREATE MASTER KEY` statement."""
+
+    # https://learn.microsoft.com/en-us/sql/t-sql/statements/create-master-key-transact-sql
+
+    type = "create_master_key_statement"
+
+    match_grammar: Matchable = Sequence(
+        "CREATE",
+        "MASTER",
+        "KEY",
+        Sequence(
+            "ENCRYPTION",
+            "BY",
+            "PASSWORD",
+            Ref("EqualsSegment"),
+            Ref("QuotedLiteralSegment"),
+            optional=True,
+        ),
+    )
+
+
+class MasterKeyEncryptionSegment(BaseSegment):
+    """Master key encryptopn option."""
+
+    type = "master_key_encryption_option"
+
+    match_grammar: Matchable = OneOf(
+        Sequence("SERVICE", "MASTER", "KEY"),
+        Sequence(
+            "PASSWORD",
+            Ref("EqualsSegment"),
+            Ref("QuotedLiteralSegment"),
+        ),
+    )
+
+
+class AlterMasterKeySegment(BaseSegment):
+    """A `ALTER MASTER KEY` statement."""
+
+    # https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-master-key-transact-sql
+
+    type = "alter_master_key_statement"
+
+    match_grammar: Matchable = Sequence(
+        "ALTER",
+        "MASTER",
+        "KEY",
+        OneOf(
+            Sequence(
+                Ref.keyword("FORCE", optional=True),
+                "REGENERATE",
+                "WITH",
+                "ENCRYPTION",
+                "BY",
+                Ref("MasterKeyEncryptionSegment"),
+            ),
+            Sequence(
+                OneOf("ADD", "DROP"),
+                "ENCRYPTION",
+                "BY",
+                Ref("MasterKeyEncryptionSegment"),
+            ),
+        ),
+    )
+
+
+class DropMasterKeySegment(BaseSegment):
+    """A `DROP MASTER KEY` statement."""
+
+    # https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-master-key-transact-sql
+
+    type = "drop_master_key_statement"
+
+    match_grammar: Matchable = Sequence(
+        "DROP",
+        "MASTER",
+        "KEY",
     )

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -46,9 +46,9 @@ RESERVED_KEYWORDS = [
     "BY",
     "CASCADE",
     "CASE",
+    "CHECK_CONSTRAINTS",
     "CHECK",
     "CHECKPOINT",
-    "CHECK_CONSTRAINTS",
     "CLOSE",
     "CLUSTERED",
     "COALESCE",
@@ -63,7 +63,6 @@ RESERVED_KEYWORDS = [
     "CONVERT",
     "CREATE",
     "CROSS",
-    "CURRENT",
     "CURRENT_CATALOG",  # *future*
     "CURRENT_DATE",
     "CURRENT_DEFAULT_TRANSFORM_GROUP",  # *future*
@@ -74,6 +73,7 @@ RESERVED_KEYWORDS = [
     "CURRENT_TIMESTAMP",
     "CURRENT_TRANSFORM_GROUP_FOR_TYPE",  # *future*
     "CURRENT_USER",
+    "CURRENT",
     "CURSOR",
     "DATABASE",
     "DBCC",
@@ -103,8 +103,8 @@ RESERVED_KEYWORDS = [
     "FILE",
     "FILLFACTOR",
     "FOR",
-    "FORWARD_ONLY",
     "FOREIGN",
+    "FORWARD_ONLY",
     "FREETEXT",
     "FREETEXTTABLE",
     "FROM",
@@ -171,8 +171,8 @@ RESERVED_KEYWORDS = [
     "PROCEDURE",
     "PUBLIC",
     "RAISERROR",
-    "READ",
     "READ_ONLY",
+    "READ",
     "READTEXT",
     "RECONFIGURE",
     "REFERENCES",
@@ -190,8 +190,8 @@ RESERVED_KEYWORDS = [
     "RULE",
     "SAVE",
     "SCHEMA",
-    "SCROLL",
     "SCROLL_LOCKS",
+    "SCROLL",
     "SELECT",
     "SEMANTICKEYPHRASETABLE",
     "SEMANTICSIMILARITYDETAILSTABLE",
@@ -211,8 +211,8 @@ RESERVED_KEYWORDS = [
     "TO",
     "TOP",
     "TRAN",
-    "TRANSACTION",
     "TRAN",
+    "TRANSACTION",
     "TRIGGER",
     "TRUNCATE",
     "TRY_CONVERT",
@@ -248,16 +248,15 @@ FUTURE_RESERVED_KEYWORDS = [
 ]
 
 UNRESERVED_KEYWORDS = [
-    "ABORT",
     "ABORT_AFTER_WAIT",
+    "ABORT",
     "ABSENT",
     "ACTION",
-    "ATOMIC",
     "AFTER",
     "ALGORITHM",
-    "ALLOWED",
     "ALLOW_PAGE_LOCKS",
     "ALLOW_ROW_LOCKS",
+    "ALLOWED",
     "ALWAYS",
     "ANSI_DEFAULTS",
     "ANSI_NULL_DFLT_OFF",
@@ -270,6 +269,7 @@ UNRESERVED_KEYWORDS = [
     "ARITHABORT",
     "ARITHIGNORE",
     "AT",
+    "ATOMIC",
     "AUTO_CREATE_TABLE",
     "AUTO",
     "BEFORE",  # *future*
@@ -297,8 +297,8 @@ UNRESERVED_KEYWORDS = [
     "CONTAINED",
     "CONTINUE",
     "CONTROL",
-    "CREDENTIAL",
     "COPY",
+    "CREDENTIAL",
     "CURSOR_CLOSE_ON_COMMIT",
     "CYCLE",
     "DATA_COMPRESSION",
@@ -345,11 +345,11 @@ UNRESERVED_KEYWORDS = [
     "FIELDQUOTE",
     "FIELDTERMINATOR",
     "FILE_FORMAT",
+    "FILE_TYPE",
     "FILEGROUP",
-    "FILESTREAM",
     "FILESTREAM_ON",
     "FILESTREAM",
-    "FILE_TYPE",
+    "FILESTREAM",
     "FILETABLE_COLLATE_FILENAME",
     "FILETABLE_DIRECTORY",
     "FILETABLE_FULLPATH_UNIQUE_CONSTRAINT_NAME",
@@ -411,8 +411,8 @@ UNRESERVED_KEYWORDS = [
     "LANGUAGE",
     "LAST",
     "LASTROW",
-    "LEDGER",
     "LEDGER_VIEW",
+    "LEDGER",
     "LEGACY_CARDINALITY_ESTIMATION",
     "LEVEL",
     "LOAD",  # listed as reserved but functionally unreserved
@@ -423,9 +423,9 @@ UNRESERVED_KEYWORDS = [
     "LOGIN",
     "LOOP",
     "LOW",
-    "MASTER",
     "MANUAL",
     "MASKED",
+    "MASTER",
     "MATCHED",
     "MAX_DURATION",
     "MAX_GRANT_PERCENT",
@@ -472,8 +472,8 @@ UNRESERVED_KEYWORDS = [
     "PAGE",
     "PAGLOCK",
     "PARAMETER",
-    "PARAMETERS",  # *future*
     "PARAMETERIZATION",
+    "PARAMETERS",  # *future*
     "PARQUET",
     "PARSEONLY",
     "PARSER_VERSION",
@@ -524,10 +524,10 @@ UNRESERVED_KEYWORDS = [
     "REGR_SXX",  # *future*
     "REGR_SXY",  # *future*
     "REGR_SYY",  # *future*
-    "REJECTED_ROW_LOCATION",
     "REJECT_SAMPLE_VALUE",
     "REJECT_TYPE",
     "REJECT_VALUE",
+    "REJECTED_ROW_LOCATION",
     "REMOTE_DATA_ARCHIVE",
     "REMOTE_PROC_TRANSACTIONS",
     "RENAME",  # Azure Synapse Analytics specific
@@ -632,6 +632,7 @@ UNRESERVED_KEYWORDS = [
     "WORK",
     "XACT_ABORT",
     "XLOCK",
+    "XML_COMPRESSION",
     "XML",
     "XMLAGG",  # *future*
     "XMLATTRIBUTES",  # *future*
@@ -654,7 +655,6 @@ UNRESERVED_KEYWORDS = [
     "XMLTABLE",  # *future*
     "XMLTEXT",  # *future*
     "XMLVALIDATE",  # *future*
-    "XML_COMPRESSION",
     "XSINIL",
     "YEAR",
     "YEARS",

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -423,6 +423,7 @@ UNRESERVED_KEYWORDS = [
     "LOGIN",
     "LOOP",
     "LOW",
+    "MASTER",
     "MANUAL",
     "MASKED",
     "MATCHED",
@@ -479,6 +480,7 @@ UNRESERVED_KEYWORDS = [
     "PARTIAL",  # *future*
     "PARTITION",
     "PARTITIONS",
+    "PASSWORD",
     "PATH",
     "PAUSE",
     "PAUSED",
@@ -512,6 +514,7 @@ UNRESERVED_KEYWORDS = [
     "RECEIVE",
     "RECOMPILE",
     "RECURSIVE",
+    "REGENERATE",
     "REGR_AVGX",  # *future*
     "REGR_AVGY",  # *future*
     "REGR_COUNT",  # *future*
@@ -567,6 +570,7 @@ UNRESERVED_KEYWORDS = [
     "SERDE_METHOD",
     "SERIALIZABLE",
     "SERVER",
+    "SERVICE",
     "SETERROR",
     "SETVAR",  # sqlcmd command
     "SHOWPLAN_ALL",

--- a/test/fixtures/dialects/tsql/create_master_key.sql
+++ b/test/fixtures/dialects/tsql/create_master_key.sql
@@ -1,0 +1,23 @@
+-- https://learn.microsoft.com/en-us/sql/t-sql/statements/create-master-key-transact-sql
+-- https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-master-key-transact-sql
+-- https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-master-key-transact-sql
+
+--CREATE ROLE testuser AUTHORIZATION dbo;
+
+
+
+CREATE MASTER KEY ENCRYPTION BY PASSWORD = '<strong password>';
+
+CREATE MASTER KEY;
+
+ALTER MASTER KEY REGENERATE WITH ENCRYPTION BY PASSWORD = '<even stronger password>';
+
+ALTER MASTER KEY FORCE REGENERATE WITH ENCRYPTION BY PASSWORD = '<even stronger password>';
+
+ALTER MASTER KEY ADD ENCRYPTION BY PASSWORD = '<even stronger password>';
+
+ALTER MASTER KEY ADD ENCRYPTION BY SERVICE MASTER KEY;
+
+ALTER MASTER KEY DROP ENCRYPTION BY PASSWORD = '<even stronger password>';
+
+DROP MASTER KEY;

--- a/test/fixtures/dialects/tsql/create_master_key.sql
+++ b/test/fixtures/dialects/tsql/create_master_key.sql
@@ -2,10 +2,6 @@
 -- https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-master-key-transact-sql
 -- https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-master-key-transact-sql
 
---CREATE ROLE testuser AUTHORIZATION dbo;
-
-
-
 CREATE MASTER KEY ENCRYPTION BY PASSWORD = '<strong password>';
 
 CREATE MASTER KEY;

--- a/test/fixtures/dialects/tsql/create_master_key.yml
+++ b/test/fixtures/dialects/tsql/create_master_key.yml
@@ -1,0 +1,104 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e0c4f0fa04d09ab59ddd81685b6c1fd2f716bbe299a3add6f9ae79ff486957db
+file:
+  batch:
+  - statement:
+      create_master_key_statement:
+      - keyword: CREATE
+      - keyword: MASTER
+      - keyword: KEY
+      - keyword: ENCRYPTION
+      - keyword: BY
+      - keyword: PASSWORD
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'<strong password>'"
+  - statement_terminator: ;
+  - statement:
+      create_master_key_statement:
+      - keyword: CREATE
+      - keyword: MASTER
+      - keyword: KEY
+  - statement_terminator: ;
+  - statement:
+      alter_master_key_statement:
+      - keyword: ALTER
+      - keyword: MASTER
+      - keyword: KEY
+      - keyword: REGENERATE
+      - keyword: WITH
+      - keyword: ENCRYPTION
+      - keyword: BY
+      - master_key_encryption_option:
+          keyword: PASSWORD
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'<even stronger password>'"
+  - statement_terminator: ;
+  - statement:
+      alter_master_key_statement:
+      - keyword: ALTER
+      - keyword: MASTER
+      - keyword: KEY
+      - keyword: FORCE
+      - keyword: REGENERATE
+      - keyword: WITH
+      - keyword: ENCRYPTION
+      - keyword: BY
+      - master_key_encryption_option:
+          keyword: PASSWORD
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'<even stronger password>'"
+  - statement_terminator: ;
+  - statement:
+      alter_master_key_statement:
+      - keyword: ALTER
+      - keyword: MASTER
+      - keyword: KEY
+      - keyword: ADD
+      - keyword: ENCRYPTION
+      - keyword: BY
+      - master_key_encryption_option:
+          keyword: PASSWORD
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'<even stronger password>'"
+  - statement_terminator: ;
+  - statement:
+      alter_master_key_statement:
+      - keyword: ALTER
+      - keyword: MASTER
+      - keyword: KEY
+      - keyword: ADD
+      - keyword: ENCRYPTION
+      - keyword: BY
+      - master_key_encryption_option:
+        - keyword: SERVICE
+        - keyword: MASTER
+        - keyword: KEY
+  - statement_terminator: ;
+  - statement:
+      alter_master_key_statement:
+      - keyword: ALTER
+      - keyword: MASTER
+      - keyword: KEY
+      - keyword: DROP
+      - keyword: ENCRYPTION
+      - keyword: BY
+      - master_key_encryption_option:
+          keyword: PASSWORD
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'<even stronger password>'"
+  - statement_terminator: ;
+  - statement:
+      drop_master_key_statement:
+      - keyword: DROP
+      - keyword: MASTER
+      - keyword: KEY
+  - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
fixes #5795
- https://learn.microsoft.com/en-us/sql/t-sql/statements/create-master-key-transact-sql
- https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-master-key-transact-sql
- https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-master-key-transact-sql

### Are there any other side effects of this change that we should be aware of?
no

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
