### PR TITLE
Tighten up the return from .process()

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -744,6 +744,9 @@ class Linter:
                 if len(templated_variants) >= variant_limit:
                     # Stop if we hit the limit.
                     break
+        except SQLTemplaterError as templater_err:
+            # Fatal templating error. Capture it and don't generate a variant.
+            templater_violations.append(templater_err)
         except SQLFluffSkipFile as skip_file_err:  # pragma: no cover
             linter_logger.warning(str(skip_file_err))
 

--- a/src/sqlfluff/core/templaters/base.py
+++ b/src/sqlfluff/core/templaters/base.py
@@ -519,12 +519,11 @@ class RawTemplater:
         fname: str,
         config: Optional[FluffConfig] = None,
         formatter=None,
-    ) -> Tuple[Optional[TemplatedFile], List[SQLTemplaterError]]:
+    ) -> Tuple[TemplatedFile, List[SQLTemplaterError]]:
         """Process a string and return a TemplatedFile.
 
-        Note that the arguments are enforced as keywords
-        because Templaters can have differences in their
-        `process` method signature.
+        Note that the arguments are enforced as keywords because Templaters
+        can have differences in their `process` method signature.
         A Templater that only supports reading from a file
         would need the following signature:
             process(*, fname, in_str=None, config=None)
@@ -538,13 +537,22 @@ class RawTemplater:
                 templating operation. Only necessary for some templaters.
             formatter (:obj:`CallbackFormatter`): Optional object for output.
 
+        Returns:
+            :obj:`tuple` of :obj:`TemplatedFile` and a list of SQLTemplaterError
+            if templating was successful enough that we may move to attempt parsing.
+
+        Raises:
+            SQLTemplaterError: If templating fails fatally, then this method
+                should raise a :obj:`SQLTemplaterError` instead which will be
+                caught and displayed appropriately.
+
         """
         return TemplatedFile(in_str, fname=fname), []
 
     @large_file_check
     def process_with_variants(
         self, *, in_str: str, fname: str, config=None, formatter=None
-    ) -> Iterator[Tuple[Optional[TemplatedFile], List[SQLTemplaterError]]]:
+    ) -> Iterator[Tuple[TemplatedFile, List[SQLTemplaterError]]]:
         """Extended version of `process` which returns multiple variants.
 
         Unless explicitly defined, this simply yields the result of .process().

--- a/src/sqlfluff/core/templaters/placeholder.py
+++ b/src/sqlfluff/core/templaters/placeholder.py
@@ -1,7 +1,7 @@
 """Defines the placeholder template."""
 
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 import regex
 
@@ -115,7 +115,7 @@ class PlaceholderTemplater(RawTemplater):
     @large_file_check
     def process(
         self, *, in_str: str, fname: str, config=None, formatter=None
-    ) -> Tuple[Optional[TemplatedFile], List[SQLTemplaterError]]:
+    ) -> Tuple[TemplatedFile, List[SQLTemplaterError]]:
         """Process a string and return a TemplatedFile.
 
         Note that the arguments are enforced as keywords

--- a/src/sqlfluff/core/templaters/python.py
+++ b/src/sqlfluff/core/templaters/python.py
@@ -226,7 +226,7 @@ class PythonTemplater(RawTemplater):
     @large_file_check
     def process(
         self, *, in_str: str, fname: str, config=None, formatter=None
-    ) -> Tuple[Optional[TemplatedFile], List[SQLTemplaterError]]:
+    ) -> Tuple[TemplatedFile, List[SQLTemplaterError]]:
         """Process a string and return a TemplatedFile.
 
         Note that the arguments are enforced as keywords

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -594,26 +594,32 @@ def test__templater_jinja_error_syntax():
     """Test syntax problems in the jinja templater."""
     t = JinjaTemplater()
     instr = "SELECT {{foo} FROM jinja_error\n"
-    outstr, vs = t.process(
-        in_str=instr, fname="test", config=FluffConfig(overrides={"dialect": "ansi"})
-    )
-    # Check we just skip templating.
-    assert str(outstr) == instr
-    # Check we have violations.
-    assert len(vs) > 0
-    # Check one of them is a templating error on line 1
-    assert any(v.rule_code() == "TMP" and v.line_no == 1 for v in vs)
+    with pytest.raises(SQLTemplaterError) as excinfo:
+        t.process(
+            in_str=instr,
+            fname="test",
+            config=FluffConfig(overrides={"dialect": "ansi"}),
+        )
+    templater_exception = excinfo.value
+    assert templater_exception.rule_code() == "TMP"
+    assert templater_exception.line_no == 1
+    assert "Failed to parse Jinja syntax" in str(templater_exception)
 
 
 def test__templater_jinja_error_catastrophic():
     """Test error handling in the jinja templater."""
     t = JinjaTemplater(override_context=dict(blah=7))
     instr = JINJA_STRING
-    outstr, vs = t.process(
-        in_str=instr, fname="test", config=FluffConfig(overrides={"dialect": "ansi"})
-    )
-    assert not outstr
-    assert len(vs) > 0
+    with pytest.raises(SQLTemplaterError) as excinfo:
+        t.process(
+            in_str=instr,
+            fname="test",
+            config=FluffConfig(overrides={"dialect": "ansi"}),
+        )
+    templater_exception = excinfo.value
+    assert templater_exception.rule_code() == "TMP"
+    assert templater_exception.line_no == 1
+    assert "Unrecoverable failure in Jinja templating" in str(templater_exception)
 
 
 def test__templater_jinja_error_macro_path_does_not_exist():


### PR DESCRIPTION
Related to #5794. We've been fairly inconsistent in whether we raise issues or return `None` from the templater `.process()` methods. This PR tightens that up a bit.

Previously the methods could optionally return `None`, this PR prevents that - and instead for fatal templating errors requires the process method to explicitly raise a `SQLTemplaterError` which is then caught in the linter.

While it's not a massive change - it does modify the interface for the templater slightly. The upside of all of this is that it reduces the number of different scenarios that we need to handle outside the templater so simplify processing.