### PR TITLE
BigQuery: Support OPTIONS in CREATE FUNCTION statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1063,6 +1063,7 @@ class FunctionDefinitionGrammar(ansi.FunctionDefinitionGrammar):
                     ),
                 ),
             ),
+            Ref("OptionsSegment", optional=True),
         )
     )
 

--- a/test/fixtures/dialects/bigquery/create_function_no_args.sql
+++ b/test/fixtures/dialects/bigquery/create_function_no_args.sql
@@ -2,4 +2,13 @@ CREATE FUNCTION add() RETURNS integer
     AS 'select $1 + $2;'
     LANGUAGE SQL;
 
-DROP FUNCTION myproject.mydataset.addfunc;
+CREATE FUNCTION example_dataset.exampleFunction() RETURNS STRING
+AS ("example")
+OPTIONS(description="example");
+
+CREATE TEMP FUNCTION exampleFunction() RETURNS FLOAT64
+AS (1.234 * 5.678);
+
+CREATE TEMPORARY FUNCTION exampleFunction() RETURNS BOOL
+AS (TRUE)
+OPTIONS();

--- a/test/fixtures/dialects/bigquery/create_function_with_args.sql
+++ b/test/fixtures/dialects/bigquery/create_function_with_args.sql
@@ -1,0 +1,16 @@
+CREATE FUNCTION example_dataset.exampleFunction(x FLOAT64)
+RETURNS FLOAT64
+AS (x * x);
+
+CREATE OR REPLACE FUNCTION `example-project.example_dataset.exampleFunction`(x INTEGER, y INTEGER)
+RETURNS INTEGER
+AS (x * y)
+OPTIONS(description="foo");
+
+CREATE TEMPORARY FUNCTION exampleFunction(x BIGNUMERIC)
+AS (x + x);
+
+CREATE TEMP FUNCTION exampleFunction(x STRING)
+RETURNS STRING
+AS (CONCAT(x, x))
+OPTIONS();

--- a/test/fixtures/dialects/bigquery/create_function_with_args.yml
+++ b/test/fixtures/dialects/bigquery/create_function_with_args.yml
@@ -3,27 +3,8 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b97d342bce0a8626ad54b1635ea0aa457b01fc4bd34c73f8f2af63fb27121d98
+_hash: 601a1a6b4b2d7983cc36a108a3aa4bee136513a1763124ccef9b1f1b7f2361bd
 file:
-- statement:
-    create_function_statement:
-    - keyword: CREATE
-    - keyword: FUNCTION
-    - function_name:
-        function_name_identifier: add
-    - function_parameter_list:
-        bracketed:
-          start_bracket: (
-          end_bracket: )
-    - keyword: RETURNS
-    - data_type:
-        data_type_identifier: integer
-    - function_definition:
-      - keyword: AS
-      - udf_body: "'select $1 + $2;'"
-      - keyword: LANGUAGE
-      - naked_identifier: SQL
-- statement_terminator: ;
 - statement:
     create_function_statement:
     - keyword: CREATE
@@ -35,37 +16,9 @@ file:
     - function_parameter_list:
         bracketed:
           start_bracket: (
-          end_bracket: )
-    - keyword: RETURNS
-    - data_type:
-        data_type_identifier: STRING
-    - function_definition:
-        keyword: AS
-        bracketed:
-          start_bracket: (
-          expression:
-            quoted_literal: '"example"'
-          end_bracket: )
-        options_segment:
-          keyword: OPTIONS
-          bracketed:
-            start_bracket: (
-            parameter: description
-            comparison_operator:
-              raw_comparison_operator: '='
-            quoted_literal: '"example"'
-            end_bracket: )
-- statement_terminator: ;
-- statement:
-    create_function_statement:
-    - keyword: CREATE
-    - keyword: TEMP
-    - keyword: FUNCTION
-    - function_name:
-        function_name_identifier: exampleFunction
-    - function_parameter_list:
-        bracketed:
-          start_bracket: (
+          parameter: x
+          data_type:
+            data_type_identifier: FLOAT64
           end_bracket: )
     - keyword: RETURNS
     - data_type:
@@ -75,10 +28,55 @@ file:
         bracketed:
           start_bracket: (
           expression:
-          - numeric_literal: '1.234'
+          - column_reference:
+              naked_identifier: x
           - binary_operator: '*'
-          - numeric_literal: '5.678'
+          - column_reference:
+              naked_identifier: x
           end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: '`example-project.example_dataset.exampleFunction`'
+    - function_parameter_list:
+        bracketed:
+        - start_bracket: (
+        - parameter: x
+        - data_type:
+            data_type_identifier: INTEGER
+        - comma: ','
+        - parameter: y
+        - data_type:
+            data_type_identifier: INTEGER
+        - end_bracket: )
+    - keyword: RETURNS
+    - data_type:
+        data_type_identifier: INTEGER
+    - function_definition:
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              naked_identifier: x
+          - binary_operator: '*'
+          - column_reference:
+              naked_identifier: y
+          end_bracket: )
+        options_segment:
+          keyword: OPTIONS
+          bracketed:
+            start_bracket: (
+            parameter: description
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: '"foo"'
+            end_bracket: )
 - statement_terminator: ;
 - statement:
     create_function_statement:
@@ -90,16 +88,57 @@ file:
     - function_parameter_list:
         bracketed:
           start_bracket: (
+          parameter: x
+          data_type:
+            data_type_identifier: BIGNUMERIC
           end_bracket: )
-    - keyword: RETURNS
-    - data_type:
-        data_type_identifier: BOOL
     - function_definition:
         keyword: AS
         bracketed:
           start_bracket: (
           expression:
-            boolean_literal: 'TRUE'
+          - column_reference:
+              naked_identifier: x
+          - binary_operator: +
+          - column_reference:
+              naked_identifier: x
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_function_statement:
+    - keyword: CREATE
+    - keyword: TEMP
+    - keyword: FUNCTION
+    - function_name:
+        function_name_identifier: exampleFunction
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          parameter: x
+          data_type:
+            data_type_identifier: STRING
+          end_bracket: )
+    - keyword: RETURNS
+    - data_type:
+        data_type_identifier: STRING
+    - function_definition:
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          expression:
+            function:
+              function_name:
+                function_name_identifier: CONCAT
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+              - comma: ','
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+              - end_bracket: )
           end_bracket: )
         options_segment:
           keyword: OPTIONS

--- a/test/fixtures/dialects/bigquery/drop_function.sql
+++ b/test/fixtures/dialects/bigquery/drop_function.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION myproject.mydataset.addfunc;

--- a/test/fixtures/dialects/bigquery/drop_function.yml
+++ b/test/fixtures/dialects/bigquery/drop_function.yml
@@ -1,0 +1,18 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e518c1e3191ebea388a2e1d5b2ad6828a3a9481ff0945f3b0ba280eb60d0d92a
+file:
+  statement:
+    drop_function_statement:
+    - keyword: DROP
+    - keyword: FUNCTION
+    - function_name:
+      - naked_identifier: myproject
+      - dot: .
+      - naked_identifier: mydataset
+      - dot: .
+      - function_name_identifier: addfunc
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

related: https://github.com/sqlfluff/sqlfluff/issues/5789

The current BigQuery dialect does not correctly parse `CREATE FUNCTION` statements with `OPTIONS` segment, so we try to fix this.
And refactor and add some test cases.

### Are there any other side effects of this change that we should be aware of?

None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
