### PR TITLE
Fix Jinja variant location correction

### DIFF
--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -1854,6 +1854,9 @@ def test__templater_lint_unreached_code(sql_path: str, expected_renderings):
         assert additional_slicing == root_slicing
     # Check that the final source slices also line up in the templated files.
     # NOTE: Clearly the `templated_slice` values _won't_ be the same.
+    # We're doing the _final_ slice, because it's very likely to be the same
+    # _type_ and if it's in the right place, we can assume that all of the
+    # others probably are.
     root_final_slice = final_source_slices[0]
     for additional_final_slice in final_source_slices[1:]:
         assert additional_final_slice == root_final_slice

--- a/test/fixtures/templater/jinja_lint_unreached_code/inline_select.sql
+++ b/test/fixtures/templater/jinja_lint_unreached_code/inline_select.sql
@@ -1,0 +1,1 @@
+select {% if 1 > 2 %}1{% else %}2{% endif %}


### PR DESCRIPTION
This fixes #5803 . It actually corrects something from #5339, which was originally taken from #5202.

The code to correct the source slices of variant `TemplatedFileSlices` wasn't working as expected. This PR takes a totally different approach to that correction which I think is more robust.

Rather than trying to use the old locations in a lookup (which I don't think would work), this instead keeps track of the lengths of adjustments and uses them to shift the locations of the slices.

Added more test coverage to make sure it works too.