### PR TITLE
Test cases for linter fails.

### DIFF
--- a/test/core/linter/linter_test.py
+++ b/test/core/linter/linter_test.py
@@ -15,6 +15,8 @@ from sqlfluff.core.errors import (
     SQLFluffUserError,
     SQLLexError,
     SQLLintError,
+    SQLParseError,
+    SQLTemplaterError,
 )
 from sqlfluff.core.linter import LintingResult, runner
 from sqlfluff.core.linter.runner import get_runner
@@ -428,11 +430,63 @@ def test__linter__linting_unexpected_error_handled_gracefully(
 
 
 def test__linter__empty_file():
-    """Test linter behaves nicely with an empty string."""
+    """Test linter behaves nicely with an empty string.
+
+    Much of this test is about making sure that ParsedString is
+    instantiated appropriately.
+    """
     lntr = Linter(dialect="ansi")
     # Make sure no exceptions raised and no violations found in empty file.
     parsed = lntr.parse_string("")
+    # There should still be a parsed variant
+    assert parsed.parsed_variants
+    assert len(parsed.parsed_variants) == 1
+    root_variant = parsed.parsed_variants[0]
+    # That root variant should still have a templated file and a parsed tree
+    # (although that parsed tree will likely just be an end of file marker).
+    assert root_variant.templated_file
+    assert root_variant.tree
+    # No violations
     assert not parsed.violations
+
+
+def test__linter__parse_fail():
+    """Test linter behaves as expected with an unparsable string.
+
+    Much of this test is about making sure that ParsedString is
+    instantiated appropriately.
+    """
+    lntr = Linter(dialect="ansi")
+    # Try and parse something which obviously isn't SQL
+    parsed = lntr.parse_string("THIS ISNT SQL")
+    # There should still be a parsed variant
+    assert parsed.parsed_variants
+    assert len(parsed.parsed_variants) == 1
+    root_variant = parsed.parsed_variants[0]
+    # That root variant should still have a templated file and a parsed tree...
+    assert root_variant.templated_file
+    assert root_variant.tree
+    # ...but that tree should contain an unparsable segment.
+    assert "unparsable" in root_variant.tree.type_set()
+    # There *should* be violations because there should be a parsing fail.
+    assert parsed.violations
+    assert any(isinstance(v, SQLParseError) for v in parsed.violations)
+
+
+def test__linter__templating_fail():
+    """Test linter behaves as expected with invalid jinja template.
+
+    Much of this test is about making sure that ParsedString is
+    instantiated appropriately.
+    """
+    lntr = Linter(dialect="ansi")
+    # Try and parse something which breaks Jinja templating.
+    parsed = lntr.parse_string("{% if foo %}")
+    # For a templating fail, there won't be a parsed variant.
+    assert not parsed.parsed_variants
+    # There *should* be violations because there should be a templating fail.
+    assert parsed.violations
+    assert any(isinstance(v, SQLTemplaterError) for v in parsed.violations)
 
 
 @pytest.mark.parametrize(

--- a/test/core/linter/linter_test.py
+++ b/test/core/linter/linter_test.py
@@ -458,7 +458,7 @@ def test__linter__parse_fail():
     """
     lntr = Linter(dialect="ansi")
     # Try and parse something which obviously isn't SQL
-    parsed = lntr.parse_string("THIS ISNT SQL")
+    parsed = lntr.parse_string("THIS IS NOT SQL")
     # There should still be a parsed variant
     assert parsed.parsed_variants
     assert len(parsed.parsed_variants) == 1


### PR DESCRIPTION
This is based on #5794 and #5810, and fleshes out what should happen in some of the failure cases.

This is entirely just additional coverage and clarity on exactly what should happen in each case. No logic changes.