### PR TITLE
BigQuery: Support CREATE ROW ACCESS POLICY statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -512,6 +512,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("CreateMaterializedViewAsReplicaOfStatementSegment"),
             Ref("AlterMaterializedViewStatementSegment"),
             Ref("DropMaterializedViewStatementSegment"),
+            Ref("CreateRowAccessPolicyStatementSegment"),
         ],
     )
 
@@ -1559,6 +1560,24 @@ class DefaultCollateSegment(BaseSegment):
     )
 
 
+class GrantToSegment(BaseSegment):
+    """GRANT TO (grantee_list).
+
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_row_access_policy_statement
+    """
+
+    type = "grant_to_segment"
+    match_grammar: Matchable = Sequence(
+        "GRANT",
+        "TO",
+        Bracketed(
+            Delimited(
+                Ref("QuotedLiteralSegment"),
+            ),
+        ),
+    )
+
+
 class OptionsSegment(BaseSegment):
     """OPTIONS clause for a table."""
 
@@ -2433,5 +2452,32 @@ class RaiseStatementSegment(BaseSegment):
             Ref("EqualsSegment"),
             Ref("ExpressionSegment"),
             optional=True,
+        ),
+    )
+
+
+class CreateRowAccessPolicyStatementSegment(BaseSegment):
+    """A `CREATE ROW ACCESS POLICY` statement.
+
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_row_access_policy_statement
+    """
+
+    type = "create_row_access_policy_statement"
+
+    match_grammar: Matchable = Sequence(
+        "CREATE",
+        Ref("OrReplaceGrammar", optional=True),
+        "ROW",
+        "ACCESS",
+        "POLICY",
+        Ref("IfNotExistsGrammar", optional=True),
+        Ref("NakedIdentifierSegment"),  # row_access_policy_name
+        "ON",
+        Ref("TableReferenceSegment"),
+        Ref("GrantToSegment", optional=True),
+        "FILTER",
+        "USING",
+        Bracketed(
+            Ref("ExpressionSegment"),
         ),
     )

--- a/src/sqlfluff/dialects/dialect_bigquery_keywords.py
+++ b/src/sqlfluff/dialects/dialect_bigquery_keywords.py
@@ -102,7 +102,8 @@ WITHIN"""
 
 # Note BigQuery doesn't have a list of Unreserved Keywords
 # so these are just ones we need to allow parsing to work
-bigquery_unreserved_keywords = """ACCOUNT
+bigquery_unreserved_keywords = """ACCESS
+ACCOUNT
 ADD
 ADMIN
 AFTER

--- a/test/fixtures/dialects/bigquery/create_row_access_policy.sql
+++ b/test/fixtures/dialects/bigquery/create_row_access_policy.sql
@@ -1,0 +1,27 @@
+CREATE ROW ACCESS POLICY
+row_access_policy_name ON example_dataset.example_table
+FILTER USING (TRUE);
+
+CREATE OR REPLACE ROW ACCESS POLICY
+row_access_policy_name ON example_dataset.example_table
+GRANT TO ("user:someone@example.com")
+FILTER USING (x = y);
+
+CREATE ROW ACCESS POLICY IF NOT EXISTS
+row_access_policy_name ON example_dataset.example_table
+GRANT TO (
+   "serviceAccount:example@example-project.iam.gserviceaccount.com",
+   "group:some_group@example.com",
+   "domain:example.com"
+)
+FILTER USING (email_column_name = SESSION_USER());
+
+CREATE OR REPLACE ROW ACCESS POLICY IF NOT EXISTS
+row_access_policy_name ON example_dataset.example_table
+GRANT TO ("allAuthenticatedUsers")
+FILTER USING (SESSION_USER() IN ("foo", "bar"));
+
+CREATE ROW ACCESS POLICY
+row_access_policy_name ON example_dataset.example_table
+GRANT TO ("allUsers")
+FILTER USING (example_dataset.exampleFunction(x, y));

--- a/test/fixtures/dialects/bigquery/create_row_access_policy.yml
+++ b/test/fixtures/dialects/bigquery/create_row_access_policy.yml
@@ -1,0 +1,189 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: bceadfcc2e3aaafb5def62f48dbdfb315fcb41b776861ca60ee27a30ae879b24
+file:
+- statement:
+    create_row_access_policy_statement:
+    - keyword: CREATE
+    - keyword: ROW
+    - keyword: ACCESS
+    - keyword: POLICY
+    - naked_identifier: row_access_policy_name
+    - keyword: 'ON'
+    - table_reference:
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_table
+    - keyword: FILTER
+    - keyword: USING
+    - bracketed:
+        start_bracket: (
+        expression:
+          boolean_literal: 'TRUE'
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_row_access_policy_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: ROW
+    - keyword: ACCESS
+    - keyword: POLICY
+    - naked_identifier: row_access_policy_name
+    - keyword: 'ON'
+    - table_reference:
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_table
+    - grant_to_segment:
+      - keyword: GRANT
+      - keyword: TO
+      - bracketed:
+          start_bracket: (
+          quoted_literal: '"user:someone@example.com"'
+          end_bracket: )
+    - keyword: FILTER
+    - keyword: USING
+    - bracketed:
+        start_bracket: (
+        expression:
+        - column_reference:
+            naked_identifier: x
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+            naked_identifier: y
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_row_access_policy_statement:
+    - keyword: CREATE
+    - keyword: ROW
+    - keyword: ACCESS
+    - keyword: POLICY
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - naked_identifier: row_access_policy_name
+    - keyword: 'ON'
+    - table_reference:
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_table
+    - grant_to_segment:
+      - keyword: GRANT
+      - keyword: TO
+      - bracketed:
+        - start_bracket: (
+        - quoted_literal: '"serviceAccount:example@example-project.iam.gserviceaccount.com"'
+        - comma: ','
+        - quoted_literal: '"group:some_group@example.com"'
+        - comma: ','
+        - quoted_literal: '"domain:example.com"'
+        - end_bracket: )
+    - keyword: FILTER
+    - keyword: USING
+    - bracketed:
+        start_bracket: (
+        expression:
+          column_reference:
+            naked_identifier: email_column_name
+          comparison_operator:
+            raw_comparison_operator: '='
+          function:
+            function_name:
+              function_name_identifier: SESSION_USER
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_row_access_policy_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: ROW
+    - keyword: ACCESS
+    - keyword: POLICY
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - naked_identifier: row_access_policy_name
+    - keyword: 'ON'
+    - table_reference:
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_table
+    - grant_to_segment:
+      - keyword: GRANT
+      - keyword: TO
+      - bracketed:
+          start_bracket: (
+          quoted_literal: '"allAuthenticatedUsers"'
+          end_bracket: )
+    - keyword: FILTER
+    - keyword: USING
+    - bracketed:
+        start_bracket: (
+        expression:
+          function:
+            function_name:
+              function_name_identifier: SESSION_USER
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+          keyword: IN
+          bracketed:
+          - start_bracket: (
+          - quoted_literal: '"foo"'
+          - comma: ','
+          - quoted_literal: '"bar"'
+          - end_bracket: )
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_row_access_policy_statement:
+    - keyword: CREATE
+    - keyword: ROW
+    - keyword: ACCESS
+    - keyword: POLICY
+    - naked_identifier: row_access_policy_name
+    - keyword: 'ON'
+    - table_reference:
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_table
+    - grant_to_segment:
+      - keyword: GRANT
+      - keyword: TO
+      - bracketed:
+          start_bracket: (
+          quoted_literal: '"allUsers"'
+          end_bracket: )
+    - keyword: FILTER
+    - keyword: USING
+    - bracketed:
+        start_bracket: (
+        expression:
+          function:
+            function_name:
+              naked_identifier: example_dataset
+              dot: .
+              function_name_identifier: exampleFunction
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  naked_identifier: x
+            - comma: ','
+            - expression:
+                column_reference:
+                  naked_identifier: y
+            - end_bracket: )
+        end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

related: #5789

The current BigQuery dialect does not correctly parse `CREATE ROW ACCESS POLICY` statements, so we will attempt to fix this.


https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_row_access_policy_statement

### Are there any other side effects of this change that we should be aware of?

None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
