### PR TITLE
Allow to align all siblings when respacing

### DIFF
--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -240,6 +240,16 @@ def _determine_aligned_inline_spacing(
     for sibling in siblings[:]:
         _pos = sibling.pos_marker
         assert _pos
+
+        # We should purge any siblings on the same line as the target. This requires
+        # line no to match and line position to mismatch.
+        if (
+            _pos.working_line_no == next_pos.working_line_no
+            and _pos.working_line_pos != next_pos.working_line_pos
+        ):
+            siblings.remove(sibling)
+            continue
+
         _best_seen = _earliest_siblings.get(_pos.working_line_no, None)
         # If we've already seen an earlier sibling on this line, ignore the later one.
         if _best_seen is not None and _pos.working_line_pos > _best_seen:
@@ -247,12 +257,6 @@ def _determine_aligned_inline_spacing(
             continue
         # Update best seen
         _earliest_siblings[_pos.working_line_no] = _pos.working_line_pos
-
-        # We should also purge the sibling which matches the target.
-        if _pos.working_line_no == next_pos.working_line_no:
-            # Is it in the same position?
-            if _pos.working_line_pos != next_pos.working_line_pos:
-                siblings.remove(sibling)
 
     # If there's only one sibling, we have nothing to compare to. Default to a single
     # space.

--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -242,7 +242,7 @@ def _determine_aligned_inline_spacing(
         assert _pos
 
         # We should purge any siblings on the same line as the target. This requires
-        # line no to match and line position to mismatch.
+        # line number to match and line position to mismatch.
         if (
             _pos.working_line_no == next_pos.working_line_no
             and _pos.working_line_pos != next_pos.working_line_pos

--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -1,6 +1,7 @@
 """Static methods to support ReflowPoint.respace_point()."""
 
 import logging
+from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, cast
 
 from sqlfluff.core.errors import SQLFluffUserError
@@ -235,28 +236,38 @@ def _determine_aligned_inline_spacing(
     if next_seg.pos_marker:
         next_pos = next_seg.pos_marker
 
-    # Purge any siblings which are either self, or on the same line but after it.
-    _earliest_siblings: Dict[int, int] = {}
-    for sibling in siblings[:]:
+    # Purge any siblings which are either on the same line or on another line and
+    # have another index
+    siblings_by_line: Dict[int, List[BaseSegment]] = defaultdict(list)
+    for sibling in siblings:
         _pos = sibling.pos_marker
         assert _pos
+        siblings_by_line[_pos.working_line_no].append(sibling)
 
-        # We should purge any siblings on the same line as the target. This requires
-        # line number to match and line position to mismatch.
+    # Sort all segments by position to easily access index information
+    for line_siblings in siblings_by_line.values():
+        line_siblings.sort(
+            key=lambda s: cast(PositionMarker, s.pos_marker).working_line_pos
+        )
+
+    target_index = next(
+        idx
+        for idx, segment in enumerate(siblings_by_line[next_pos.working_line_no])
         if (
-            _pos.working_line_no == next_pos.working_line_no
-            and _pos.working_line_pos != next_pos.working_line_pos
-        ):
-            siblings.remove(sibling)
-            continue
+            cast(PositionMarker, segment.pos_marker).working_line_pos
+            == next_pos.working_line_pos
+        )
+    )
 
-        _best_seen = _earliest_siblings.get(_pos.working_line_no, None)
-        # If we've already seen an earlier sibling on this line, ignore the later one.
-        if _best_seen is not None and _pos.working_line_pos > _best_seen:
-            siblings.remove(sibling)
-            continue
-        # Update best seen
-        _earliest_siblings[_pos.working_line_no] = _pos.working_line_pos
+    # Now that we know the target index, we can extract the relevant segment from
+    # all lines
+    siblings = [
+        segment
+        for segments in siblings_by_line.values()
+        for segment in (
+            [segments[target_index]] if target_index < len(segments) else []
+        )
+    ]
 
     # If there's only one sibling, we have nothing to compare to. Default to a single
     # space.

--- a/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
@@ -197,13 +197,7 @@ test_align_multiple_multiple_lines_a:
 test_align_multiple_multiple_lines_b:
   # If there are multiple options only on one of several lines, still align
   # correctly, related to https://github.com/sqlfluff/sqlfluff/pull/5823
-  fail_str: |
-    CREATE TABLE foo (
-        x INT NOT NULL PRIMARY KEY,
-        y INT NULL,
-        z INT NULL
-    );
-  fix_str: |
+  pass_str: |
     CREATE TABLE foo (
         x INT NOT NULL PRIMARY KEY,
         y INT NULL,

--- a/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
@@ -2,11 +2,11 @@ rule: LT01
 
 test_excess_space_without_align_alias:
   fail_str: |
-    SELECT
-        a    AS first_column,
-        b      AS second_column,
-        (a + b) / 2 AS third_column
-    FROM foo
+        SELECT
+            a    AS first_column,
+            b      AS second_column,
+            (a + b) / 2 AS third_column
+        FROM foo
   fix_str: |
     SELECT
         a AS first_column,
@@ -24,11 +24,11 @@ test_excess_space_without_align_alias:
 test_excess_space_with_align_alias:
   # NOTE: The config here shouldn't move the table alias
   fail_str: |
-    SELECT
-        a    AS first_column,
-        b      AS second_column,
-        (a + b) / 2 AS third_column
-    FROM foo   AS bar
+        SELECT
+            a    AS first_column,
+            b      AS second_column,
+            (a + b) / 2 AS third_column
+        FROM foo   AS bar
   fix_str: |
     SELECT
         a           AS first_column,
@@ -45,11 +45,11 @@ test_excess_space_with_align_alias:
 
 test_missing_keyword_with_align_alias:
   fail_str: |
-    SELECT
-        a    first_column,
-        b      AS second_column,
-        (a + b) / 2 AS third_column
-    FROM foo
+        SELECT
+            a    first_column,
+            b      AS second_column,
+            (a + b) / 2 AS third_column
+        FROM foo
   fix_str: |
     SELECT
         a           first_column,
@@ -60,11 +60,11 @@ test_missing_keyword_with_align_alias:
 
 test_skip_alias_with_align_alias:
   fail_str: |
-    SELECT
-        a   ,
-        b   ,
-        (a   +   b) /   2
-    FROM foo
+        SELECT
+            a   ,
+            b   ,
+            (a   +   b) /   2
+        FROM foo
   fix_str: |
     SELECT
         a,

--- a/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
@@ -2,11 +2,11 @@ rule: LT01
 
 test_excess_space_without_align_alias:
   fail_str: |
-        SELECT
-            a    AS first_column,
-            b      AS second_column,
-            (a + b) / 2 AS third_column
-        FROM foo
+    SELECT
+        a    AS first_column,
+        b      AS second_column,
+        (a + b) / 2 AS third_column
+    FROM foo
   fix_str: |
     SELECT
         a AS first_column,
@@ -24,11 +24,11 @@ test_excess_space_without_align_alias:
 test_excess_space_with_align_alias:
   # NOTE: The config here shouldn't move the table alias
   fail_str: |
-        SELECT
-            a    AS first_column,
-            b      AS second_column,
-            (a + b) / 2 AS third_column
-        FROM foo   AS bar
+    SELECT
+        a    AS first_column,
+        b      AS second_column,
+        (a + b) / 2 AS third_column
+    FROM foo   AS bar
   fix_str: |
     SELECT
         a           AS first_column,
@@ -45,11 +45,11 @@ test_excess_space_with_align_alias:
 
 test_missing_keyword_with_align_alias:
   fail_str: |
-        SELECT
-            a    first_column,
-            b      AS second_column,
-            (a + b) / 2 AS third_column
-        FROM foo
+    SELECT
+        a    first_column,
+        b      AS second_column,
+        (a + b) / 2 AS third_column
+    FROM foo
   fix_str: |
     SELECT
         a           first_column,
@@ -60,11 +60,11 @@ test_missing_keyword_with_align_alias:
 
 test_skip_alias_with_align_alias:
   fail_str: |
-        SELECT
-            a   ,
-            b   ,
-            (a   +   b) /   2
-        FROM foo
+    SELECT
+        a   ,
+        b   ,
+        (a   +   b) /   2
+    FROM foo
   fix_str: |
     SELECT
         a,
@@ -158,6 +158,29 @@ test_align_multiple_b:
     create table tab (
         foo    varchar(25) not null,
         barbar int         not null unique
+    )
+  configs:
+    layout:
+      type:
+        data_type:
+          spacing_before: align
+          align_within: create_table_statement
+        column_constraint_segment:
+          spacing_before: align
+          align_within: create_table_statement
+
+test_align_multiple_three_columns:
+  fail_str: |
+    create table tab (
+        foo    varchar(25)  not null,
+        barbar int not null unique,
+        barbara varchar(5) not null primary key
+    )
+  fix_str: |
+    create table tab (
+        foo     varchar(25) not null,
+        barbar  int         not null unique,
+        barbara varchar(5)  not null primary key
     )
   configs:
     layout:

--- a/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
@@ -169,7 +169,9 @@ test_align_multiple_b:
           spacing_before: align
           align_within: create_table_statement
 
-test_align_multiple_three_columns:
+test_align_multiple_multiple_lines_a:
+  # If there are multiple options on several lines, always choose the first
+  # to align with, related to https://github.com/sqlfluff/sqlfluff/pull/5823
   fail_str: |
     create table tab (
         foo    varchar(25)  not null,
@@ -182,6 +184,31 @@ test_align_multiple_three_columns:
         barbar  int         not null unique,
         barbara varchar(5)  not null primary key
     )
+  configs:
+    layout:
+      type:
+        data_type:
+          spacing_before: align
+          align_within: create_table_statement
+        column_constraint_segment:
+          spacing_before: align
+          align_within: create_table_statement
+
+test_align_multiple_multiple_lines_b:
+  # If there are multiple options only on one of several lines, still align
+  # correctly, related to https://github.com/sqlfluff/sqlfluff/pull/5823
+  fail_str: |
+    CREATE TABLE foo (
+        x INT NOT NULL PRIMARY KEY,
+        y INT NULL,
+        z INT NULL,
+    );
+  fix_str: |
+    CREATE TABLE foo (
+        x INT NOT NULL PRIMARY KEY,
+        y INT NULL,
+        z INT NULL,
+    );
   configs:
     layout:
       type:

--- a/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
@@ -235,3 +235,25 @@ test_align_multiple_all:
         column_constraint_segment:
           spacing_before: align
           align_within: create_table_statement
+
+test_align_multiple_operators:
+  # Unrealistic but more stretching with several lines which
+  # have different numbers of the same target.
+  fail_str: |
+    select
+        1+123+12345 as foo,
+        123456+1+12+56 as bar,
+        1234+123456789 as baz
+    from t
+  fix_str: |
+    select
+        1      + 123 + 12345 as foo,
+        123456 + 1   + 12 + 56 as bar,
+        1234   + 123456789 as baz
+    from t
+  configs:
+    layout:
+      type:
+        binary_operator:
+          spacing_before: align
+          align_within: select_statement

--- a/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
@@ -212,3 +212,26 @@ test_align_multiple_multiple_lines_b:
         column_constraint_segment:
           spacing_before: align
           align_within: create_table_statement
+
+test_align_multiple_all:
+  fail_str: |
+    create table tab1 (
+        a    varchar(25)  not null,
+        b int not null unique references tab2(b),
+        c varchar(5) not null primary key references tab2(c)
+    )
+  fix_str: |
+    create table tab1 (
+        a varchar(25) not null,
+        b int         not null unique      references tab2 (b),
+        c varchar(5)  not null primary key references tab2 (c)
+    )
+  configs:
+    layout:
+      type:
+        data_type:
+          spacing_before: align
+          align_within: create_table_statement
+        column_constraint_segment:
+          spacing_before: align
+          align_within: create_table_statement

--- a/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
@@ -201,13 +201,13 @@ test_align_multiple_multiple_lines_b:
     CREATE TABLE foo (
         x INT NOT NULL PRIMARY KEY,
         y INT NULL,
-        z INT NULL,
+        z INT NULL
     );
   fix_str: |
     CREATE TABLE foo (
         x INT NOT NULL PRIMARY KEY,
         y INT NULL,
-        z INT NULL,
+        z INT NULL
     );
   configs:
     layout:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Extension of #5823. Fixes #5672 .

This allows to format

```sql
create table tab1 (
    a    varchar(25)  not null,
    b int not null unique references tab2(b),
    c varchar(5) not null primary key references tab2(c)
)
```

as

```sql
create table tab1 (
    a varchar(25) not null,
    b int         not null unique      references tab2 (b),
    c varchar(5)  not null primary key references tab2 (c)
)
```

rather than

```sql
create table tab1 (
    a varchar(25) not null,
    b int         not null unique references tab2 (b),
    c varchar(5)  not null primary key references tab2 (c)
)
```

which creates some more clarity.

### Are there any other side effects of this change that we should be aware of?

n/a

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
