### PR TITLE
Postgres: Add Support for PostGIS operators

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -110,6 +110,28 @@ postgres_dialect.insert_lexer_matchers(
             r"->>|#>>|->|#>|@>|<@|\?\||\?|\?&|#-",
             SymbolSegment,
         ),
+        # r"|".join(
+        #     re.escape(operator)
+        #     for operator in [
+        #         "&&&",
+        #         "&<|",
+        #         "<<|",
+        #         "@",
+        #         "|&>",
+        #         "|>>",
+        #         "~=",
+        #         "<->",
+        #         "|=|",
+        #         "<#>",
+        #         "<<->>",
+        #         "<<#>>",
+        #     ]
+        # )
+        RegexLexer(
+            "postgis_operator",
+            r"\&\&\&|\&<\||<<\||@|\|\&>|\|>>|\~=|<\->|\|=\||<\#>|<<\->>|<<\#>>",
+            SymbolSegment,
+        ),
         StringLexer("at", "@", CodeSegment),
         # https://www.postgresql.org/docs/current/sql-syntax-lexical.html
         RegexLexer(
@@ -288,6 +310,9 @@ postgres_dialect.add(
     JsonOperatorSegment=TypedParser(
         "json_operator", SymbolSegment, type="binary_operator"
     ),
+    PostgisOperatorSegment=TypedParser(
+        "postgis_operator", SymbolSegment, type="binary_operator"
+    ),
     SimpleGeometryGrammar=AnyNumberOf(Ref("NumericLiteralSegment")),
     # N.B. this MultilineConcatenateDelimiterGrammar is only created
     # to parse multiline-concatenated string literals
@@ -377,6 +402,7 @@ postgres_dialect.replace(
         Ref("NotExtendRightSegment"),
         Ref("NotExtendLeftSegment"),
         Ref("AdjacentSegment"),
+        Ref("PostgisOperatorSegment"),
     ),
     NakedIdentifierSegment=SegmentGenerator(
         # Generate the anti template from the set of reserved keywords

--- a/test/fixtures/dialects/postgres/postgres_postgis_operators.sql
+++ b/test/fixtures/dialects/postgres/postgres_postgis_operators.sql
@@ -1,0 +1,149 @@
+SELECT tbl1.column1, tbl2.column1, tbl1.column2 && tbl2.column2 AS overlap
+FROM ( VALUES
+	(1, 'LINESTRING(0 0, 3 3)'::geometry),
+	(2, 'LINESTRING(0 1, 0 5)'::geometry)) AS tbl1,
+( VALUES
+	(3, 'LINESTRING(1 2, 4 6)'::geometry)) AS tbl2;
+
+SELECT tbl1.column1, tbl2.column1, tbl1.column2 &&& tbl2.column2 AS overlaps_3d,
+			            tbl1.column2 && tbl2.column2 AS overlaps_2d
+FROM ( VALUES
+	(1, 'LINESTRING Z(0 0 1, 3 3 2)'::geometry),
+	(2, 'LINESTRING Z(1 2 0, 0 5 -1)'::geometry)) AS tbl1,
+( VALUES
+	(3, 'LINESTRING Z(1 2 1, 4 6 1)'::geometry)) AS tbl2;
+
+SELECT tbl1.column1, tbl2.column1, tbl1.column2 &< tbl2.column2 AS overleft
+FROM
+  ( VALUES
+	(1, 'LINESTRING(1 2, 4 6)'::geometry)) AS tbl1,
+  ( VALUES
+	(2, 'LINESTRING(0 0, 3 3)'::geometry),
+	(3, 'LINESTRING(0 1, 0 5)'::geometry),
+	(4, 'LINESTRING(6 0, 6 1)'::geometry)) AS tbl2;
+
+SELECT tbl1.column1, tbl2.column1, tbl1.column2 &<| tbl2.column2 AS overbelow
+FROM
+  ( VALUES
+	(1, 'LINESTRING(6 0, 6 4)'::geometry)) AS tbl1,
+  ( VALUES
+	(2, 'LINESTRING(0 0, 3 3)'::geometry),
+	(3, 'LINESTRING(0 1, 0 5)'::geometry),
+	(4, 'LINESTRING(1 2, 4 6)'::geometry)) AS tbl2;
+
+SELECT tbl1.column1, tbl2.column1, tbl1.column2 &> tbl2.column2 AS overright
+FROM
+  ( VALUES
+	(1, 'LINESTRING(1 2, 4 6)'::geometry)) AS tbl1,
+  ( VALUES
+	(2, 'LINESTRING(0 0, 3 3)'::geometry),
+	(3, 'LINESTRING(0 1, 0 5)'::geometry),
+	(4, 'LINESTRING(6 0, 6 1)'::geometry)) AS tbl2;
+
+SELECT tbl1.column1, tbl2.column1, tbl1.column2 << tbl2.column2 AS strict_left
+FROM
+  ( VALUES
+	(1, 'LINESTRING (1 2, 1 5)'::geometry)) AS tbl1,
+  ( VALUES
+	(2, 'LINESTRING (0 0, 4 3)'::geometry),
+	(3, 'LINESTRING (6 0, 6 5)'::geometry),
+	(4, 'LINESTRING (2 2, 5 6)'::geometry)) AS tbl2;
+
+SELECT tbl1.column1, tbl2.column1, tbl1.column2 <<| tbl2.column2 AS below
+FROM
+  ( VALUES
+	(1, 'LINESTRING (0 0, 4 3)'::geometry)) AS tbl1,
+  ( VALUES
+	(2, 'LINESTRING (1 4, 1 7)'::geometry),
+	(3, 'LINESTRING (6 1, 6 5)'::geometry),
+	(4, 'LINESTRING (2 3, 5 6)'::geometry)) AS tbl2;
+
+SELECT 'LINESTRING(0 0, 0 1, 1 0)'::geometry = 'LINESTRING(1 1, 0 0)'::geometry;
+
+SELECT tbl1.column1, tbl2.column1, tbl1.column2 >> tbl2.column2 AS strict_right
+FROM
+  ( VALUES
+	(1, 'LINESTRING (2 3, 5 6)'::geometry)) AS tbl1,
+  ( VALUES
+	(2, 'LINESTRING (1 4, 1 7)'::geometry),
+	(3, 'LINESTRING (6 1, 6 5)'::geometry),
+	(4, 'LINESTRING (0 0, 4 3)'::geometry)) AS tbl2;
+
+SELECT tbl1.column1, tbl2.column1, tbl1.column2 @ tbl2.column2 AS contained
+FROM
+  ( VALUES
+	(1, 'LINESTRING (1 1, 3 3)'::geometry)) AS tbl1,
+  ( VALUES
+	(2, 'LINESTRING (0 0, 4 4)'::geometry),
+	(3, 'LINESTRING (2 2, 4 4)'::geometry),
+	(4, 'LINESTRING (1 1, 3 3)'::geometry)) AS tbl2;
+
+SELECT tbl1.column1, tbl2.column1, tbl1.column2 |&> tbl2.column2 AS overabove
+FROM
+  ( VALUES
+	(1, 'LINESTRING(6 0, 6 4)'::geometry)) AS tbl1,
+  ( VALUES
+	(2, 'LINESTRING(0 0, 3 3)'::geometry),
+	(3, 'LINESTRING(0 1, 0 5)'::geometry),
+	(4, 'LINESTRING(1 2, 4 6)'::geometry)) AS tbl2;
+
+SELECT tbl1.column1, tbl2.column1, tbl1.column2 |>> tbl2.column2 AS above
+FROM
+  ( VALUES
+	(1, 'LINESTRING (1 4, 1 7)'::geometry)) AS tbl1,
+  ( VALUES
+	(2, 'LINESTRING (0 0, 4 2)'::geometry),
+	(3, 'LINESTRING (6 1, 6 5)'::geometry),
+	(4, 'LINESTRING (2 3, 5 6)'::geometry)) AS tbl2;
+
+SELECT tbl1.column1, tbl2.column1, tbl1.column2 ~ tbl2.column2 AS contains
+FROM
+  ( VALUES
+	(1, 'LINESTRING (0 0, 3 3)'::geometry)) AS tbl1,
+  ( VALUES
+	(2, 'LINESTRING (0 0, 4 4)'::geometry),
+	(3, 'LINESTRING (1 1, 2 2)'::geometry),
+	(4, 'LINESTRING (0 0, 3 3)'::geometry)) AS tbl2;
+
+select 'LINESTRING(0 0, 1 1)'::geometry ~= 'LINESTRING(0 1, 1 0)'::geometry as equality;
+
+SELECT st_distance(geom, 'SRID=3005;POINT(1011102 450541)'::geometry) as d,edabbr, vaabbr
+FROM va2005
+ORDER BY geom <-> 'SRID=3005;POINT(1011102 450541)'::geometry limit 10;
+
+SELECT track_id, dist FROM (
+  SELECT track_id, ST_DistanceCPA(tr,:qt) dist
+  FROM trajectories
+  ORDER BY tr |=| :qt
+  LIMIT 5
+) foo;
+
+SELECT *
+FROM (
+SELECT b.tlid, b.mtfcc,
+	b.geom <#> ST_GeomFromText('LINESTRING(746149 2948672,745954 2948576,
+		745787 2948499,745740 2948468,745712 2948438,
+		745690 2948384,745677 2948319)',2249) As b_dist,
+		ST_Distance(b.geom, ST_GeomFromText('LINESTRING(746149 2948672,745954 2948576,
+		745787 2948499,745740 2948468,745712 2948438,
+		745690 2948384,745677 2948319)',2249)) As act_dist
+    FROM bos_roads As b
+    ORDER BY b_dist, b.tlid
+    LIMIT 100) As foo
+    ORDER BY act_dist, tlid LIMIT 10;
+
+WITH index_query AS (
+  SELECT ST_Distance(geom, 'SRID=3005;POINT(1011102 450541)'::geometry) as d,edabbr, vaabbr
+	FROM va2005
+  ORDER BY geom <<->> 'SRID=3005;POINT(1011102 450541)'::geometry LIMIT 100)
+  SELECT *
+	FROM index_query
+  ORDER BY d limit 10;
+
+WITH index_query AS (
+  SELECT ST_Distance(geom, 'SRID=3005;POINT(1011102 450541)'::geometry) as d,edabbr, vaabbr
+	FROM va2005
+  ORDER BY geom <<#>> 'SRID=3005;POINT(1011102 450541)'::geometry LIMIT 100)
+  SELECT *
+	FROM index_query
+  ORDER BY d limit 10;

--- a/test/fixtures/dialects/postgres/postgres_postgis_operators.yml
+++ b/test/fixtures/dialects/postgres/postgres_postgis_operators.yml
@@ -1,0 +1,1734 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: f7b42488b29a51ad5707b39f317edfb1659ecf08badabde6e8c9628b07311f5f
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl1
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl2
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: tbl1
+            - dot: .
+            - naked_identifier: column2
+          - comparison_operator:
+            - ampersand: '&'
+            - ampersand: '&'
+          - column_reference:
+            - naked_identifier: tbl2
+            - dot: .
+            - naked_identifier: column2
+          alias_expression:
+            keyword: AS
+            naked_identifier: overlap
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(0 0, 3 3)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(0 1, 0 5)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl1
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                  keyword: VALUES
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '3'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(1 2, 4 6)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl1
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl2
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: tbl1
+            - dot: .
+            - naked_identifier: column2
+          - binary_operator: '&&&'
+          - column_reference:
+            - naked_identifier: tbl2
+            - dot: .
+            - naked_identifier: column2
+          alias_expression:
+            keyword: AS
+            naked_identifier: overlaps_3d
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: tbl1
+            - dot: .
+            - naked_identifier: column2
+          - comparison_operator:
+            - ampersand: '&'
+            - ampersand: '&'
+          - column_reference:
+            - naked_identifier: tbl2
+            - dot: .
+            - naked_identifier: column2
+          alias_expression:
+            keyword: AS
+            naked_identifier: overlaps_2d
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING Z(0 0 1, 3 3 2)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING Z(1 2 0, 0 5 -1)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl1
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                  keyword: VALUES
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '3'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING Z(1 2 1, 4 6 1)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl1
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl2
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: tbl1
+            - dot: .
+            - naked_identifier: column2
+          - comparison_operator:
+              ampersand: '&'
+              raw_comparison_operator: <
+          - column_reference:
+            - naked_identifier: tbl2
+            - dot: .
+            - naked_identifier: column2
+          alias_expression:
+            keyword: AS
+            naked_identifier: overleft
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                  keyword: VALUES
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(1 2, 4 6)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl1
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(0 0, 3 3)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '3'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(0 1, 0 5)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '4'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(6 0, 6 1)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl1
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl2
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: tbl1
+            - dot: .
+            - naked_identifier: column2
+          - binary_operator: '&<|'
+          - column_reference:
+            - naked_identifier: tbl2
+            - dot: .
+            - naked_identifier: column2
+          alias_expression:
+            keyword: AS
+            naked_identifier: overbelow
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                  keyword: VALUES
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(6 0, 6 4)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl1
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(0 0, 3 3)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '3'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(0 1, 0 5)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '4'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(1 2, 4 6)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl1
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl2
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: tbl1
+            - dot: .
+            - naked_identifier: column2
+          - comparison_operator:
+              ampersand: '&'
+              raw_comparison_operator: '>'
+          - column_reference:
+            - naked_identifier: tbl2
+            - dot: .
+            - naked_identifier: column2
+          alias_expression:
+            keyword: AS
+            naked_identifier: overright
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                  keyword: VALUES
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(1 2, 4 6)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl1
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(0 0, 3 3)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '3'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(0 1, 0 5)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '4'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(6 0, 6 1)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl1
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl2
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: tbl1
+            - dot: .
+            - naked_identifier: column2
+          - binary_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: <
+          - column_reference:
+            - naked_identifier: tbl2
+            - dot: .
+            - naked_identifier: column2
+          alias_expression:
+            keyword: AS
+            naked_identifier: strict_left
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                  keyword: VALUES
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (1 2, 1 5)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl1
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (0 0, 4 3)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '3'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (6 0, 6 5)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '4'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (2 2, 5 6)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl1
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl2
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: tbl1
+            - dot: .
+            - naked_identifier: column2
+          - binary_operator: <<|
+          - column_reference:
+            - naked_identifier: tbl2
+            - dot: .
+            - naked_identifier: column2
+          alias_expression:
+            keyword: AS
+            naked_identifier: below
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                  keyword: VALUES
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (0 0, 4 3)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl1
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (1 4, 1 7)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '3'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (6 1, 6 5)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '4'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (2 3, 5 6)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - cast_expression:
+              quoted_literal: "'LINESTRING(0 0, 0 1, 1 0)'"
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: geometry
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - cast_expression:
+              quoted_literal: "'LINESTRING(1 1, 0 0)'"
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: geometry
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl1
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl2
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: tbl1
+            - dot: .
+            - naked_identifier: column2
+          - binary_operator:
+            - raw_comparison_operator: '>'
+            - raw_comparison_operator: '>'
+          - column_reference:
+            - naked_identifier: tbl2
+            - dot: .
+            - naked_identifier: column2
+          alias_expression:
+            keyword: AS
+            naked_identifier: strict_right
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                  keyword: VALUES
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (2 3, 5 6)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl1
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (1 4, 1 7)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '3'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (6 1, 6 5)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '4'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (0 0, 4 3)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl1
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl2
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: tbl1
+            - dot: .
+            - naked_identifier: column2
+          - binary_operator: '@'
+          - column_reference:
+            - naked_identifier: tbl2
+            - dot: .
+            - naked_identifier: column2
+          alias_expression:
+            keyword: AS
+            naked_identifier: contained
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                  keyword: VALUES
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (1 1, 3 3)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl1
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (0 0, 4 4)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '3'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (2 2, 4 4)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '4'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (1 1, 3 3)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl1
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl2
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: tbl1
+            - dot: .
+            - naked_identifier: column2
+          - binary_operator: '|&>'
+          - column_reference:
+            - naked_identifier: tbl2
+            - dot: .
+            - naked_identifier: column2
+          alias_expression:
+            keyword: AS
+            naked_identifier: overabove
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                  keyword: VALUES
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(6 0, 6 4)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl1
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(0 0, 3 3)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '3'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(0 1, 0 5)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '4'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING(1 2, 4 6)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl1
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl2
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: tbl1
+            - dot: .
+            - naked_identifier: column2
+          - binary_operator: '|>>'
+          - column_reference:
+            - naked_identifier: tbl2
+            - dot: .
+            - naked_identifier: column2
+          alias_expression:
+            keyword: AS
+            naked_identifier: above
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                  keyword: VALUES
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (1 4, 1 7)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl1
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (0 0, 4 2)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '3'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (6 1, 6 5)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '4'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (2 3, 5 6)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl1
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: tbl2
+          - dot: .
+          - naked_identifier: column1
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: tbl1
+            - dot: .
+            - naked_identifier: column2
+          - like_operator: '~'
+          - column_reference:
+            - naked_identifier: tbl2
+            - dot: .
+            - naked_identifier: column2
+          alias_expression:
+            keyword: AS
+            naked_identifier: contains
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                  keyword: VALUES
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (0 0, 3 3)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl1
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                - keyword: VALUES
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (0 0, 4 4)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '3'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (1 1, 2 2)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                - comma: ','
+                - bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '4'
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'LINESTRING (0 0, 3 3)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+              end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: tbl2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          expression:
+          - cast_expression:
+              quoted_literal: "'LINESTRING(0 0, 1 1)'"
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: geometry
+          - binary_operator: ~=
+          - cast_expression:
+              quoted_literal: "'LINESTRING(0 1, 1 0)'"
+              casting_operator: '::'
+              data_type:
+                data_type_identifier: geometry
+          alias_expression:
+            keyword: as
+            naked_identifier: equality
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: st_distance
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  naked_identifier: geom
+            - comma: ','
+            - expression:
+                cast_expression:
+                  quoted_literal: "'SRID=3005;POINT(1011102 450541)'"
+                  casting_operator: '::'
+                  data_type:
+                    data_type_identifier: geometry
+            - end_bracket: )
+          alias_expression:
+            keyword: as
+            naked_identifier: d
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: edabbr
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: vaabbr
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: va2005
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - expression:
+          column_reference:
+            naked_identifier: geom
+          binary_operator: <->
+          cast_expression:
+            quoted_literal: "'SRID=3005;POINT(1011102 450541)'"
+            casting_operator: '::'
+            data_type:
+              data_type_identifier: geometry
+      limit_clause:
+        keyword: limit
+        numeric_literal: '10'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: track_id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: dist
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      column_reference:
+                        naked_identifier: track_id
+                  - comma: ','
+                  - select_clause_element:
+                      function:
+                        function_name:
+                          function_name_identifier: ST_DistanceCPA
+                        bracketed:
+                        - start_bracket: (
+                        - expression:
+                            column_reference:
+                              naked_identifier: tr
+                        - comma: ','
+                        - expression:
+                            psql_variable:
+                              colon: ':'
+                              parameter: qt
+                        - end_bracket: )
+                      alias_expression:
+                        naked_identifier: dist
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: trajectories
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: tr
+                      binary_operator: '|=|'
+                      psql_variable:
+                        colon: ':'
+                        parameter: qt
+                  limit_clause:
+                    keyword: LIMIT
+                    numeric_literal: '5'
+                end_bracket: )
+            alias_expression:
+              naked_identifier: foo
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                  - keyword: SELECT
+                  - select_clause_element:
+                      column_reference:
+                      - naked_identifier: b
+                      - dot: .
+                      - naked_identifier: tlid
+                  - comma: ','
+                  - select_clause_element:
+                      column_reference:
+                      - naked_identifier: b
+                      - dot: .
+                      - naked_identifier: mtfcc
+                  - comma: ','
+                  - select_clause_element:
+                      expression:
+                        column_reference:
+                        - naked_identifier: b
+                        - dot: .
+                        - naked_identifier: geom
+                        binary_operator: <#>
+                        function:
+                          function_name:
+                            function_name_identifier: ST_GeomFromText
+                          bracketed:
+                          - start_bracket: (
+                          - expression:
+                              quoted_literal: "'LINESTRING(746149 2948672,745954 2948576,\n\
+                                \t\t745787 2948499,745740 2948468,745712 2948438,\n\
+                                \t\t745690 2948384,745677 2948319)'"
+                          - comma: ','
+                          - expression:
+                              numeric_literal: '2249'
+                          - end_bracket: )
+                      alias_expression:
+                        keyword: As
+                        naked_identifier: b_dist
+                  - comma: ','
+                  - select_clause_element:
+                      function:
+                        function_name:
+                          function_name_identifier: ST_Distance
+                        bracketed:
+                        - start_bracket: (
+                        - expression:
+                            column_reference:
+                            - naked_identifier: b
+                            - dot: .
+                            - naked_identifier: geom
+                        - comma: ','
+                        - expression:
+                            function:
+                              function_name:
+                                function_name_identifier: ST_GeomFromText
+                              bracketed:
+                              - start_bracket: (
+                              - expression:
+                                  quoted_literal: "'LINESTRING(746149 2948672,745954\
+                                    \ 2948576,\n\t\t745787 2948499,745740 2948468,745712\
+                                    \ 2948438,\n\t\t745690 2948384,745677 2948319)'"
+                              - comma: ','
+                              - expression:
+                                  numeric_literal: '2249'
+                              - end_bracket: )
+                        - end_bracket: )
+                      alias_expression:
+                        keyword: As
+                        naked_identifier: act_dist
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: bos_roads
+                        alias_expression:
+                          keyword: As
+                          naked_identifier: b
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: b_dist
+                  - comma: ','
+                  - column_reference:
+                    - naked_identifier: b
+                    - dot: .
+                    - naked_identifier: tlid
+                  limit_clause:
+                    keyword: LIMIT
+                    numeric_literal: '100'
+                end_bracket: )
+            alias_expression:
+              keyword: As
+              naked_identifier: foo
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: act_dist
+      - comma: ','
+      - column_reference:
+          naked_identifier: tlid
+      limit_clause:
+        keyword: LIMIT
+        numeric_literal: '10'
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        naked_identifier: index_query
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                function:
+                  function_name:
+                    function_name_identifier: ST_Distance
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        naked_identifier: geom
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'SRID=3005;POINT(1011102 450541)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                alias_expression:
+                  keyword: as
+                  naked_identifier: d
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: edabbr
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: vaabbr
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: va2005
+            orderby_clause:
+            - keyword: ORDER
+            - keyword: BY
+            - expression:
+                column_reference:
+                  naked_identifier: geom
+                binary_operator: <<->>
+                cast_expression:
+                  quoted_literal: "'SRID=3005;POINT(1011102 450541)'"
+                  casting_operator: '::'
+                  data_type:
+                    data_type_identifier: geometry
+            limit_clause:
+              keyword: LIMIT
+              numeric_literal: '100'
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: index_query
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: d
+        limit_clause:
+          keyword: limit
+          numeric_literal: '10'
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        naked_identifier: index_query
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                function:
+                  function_name:
+                    function_name_identifier: ST_Distance
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        naked_identifier: geom
+                  - comma: ','
+                  - expression:
+                      cast_expression:
+                        quoted_literal: "'SRID=3005;POINT(1011102 450541)'"
+                        casting_operator: '::'
+                        data_type:
+                          data_type_identifier: geometry
+                  - end_bracket: )
+                alias_expression:
+                  keyword: as
+                  naked_identifier: d
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: edabbr
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: vaabbr
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: va2005
+            orderby_clause:
+            - keyword: ORDER
+            - keyword: BY
+            - expression:
+                column_reference:
+                  naked_identifier: geom
+                binary_operator: <<#>>
+                cast_expression:
+                  quoted_literal: "'SRID=3005;POINT(1011102 450541)'"
+                  casting_operator: '::'
+                  data_type:
+                    data_type_identifier: geometry
+            limit_clause:
+              keyword: LIMIT
+              numeric_literal: '100'
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: index_query
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: d
+        limit_clause:
+          keyword: limit
+          numeric_literal: '10'
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes #4260

Only by adding regex lexer for postgis operators as suggested in the discussions in the initial PR: https://github.com/sqlfluff/sqlfluff/pull/4824

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
