### PR TITLE
Snowflake execute immediate from

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -6869,9 +6869,13 @@ class ExecuteImmediateClauseSegment(BaseSegment):
 
     EXECUTE IMMEDIATE $<session_variable>
         [ USING ( <bind_variable> [ , <bind_variable> ... ] ) ]
+
+    EXECUTE IMMEDIATE
+        FROM { absoluteFilePath | relativeFilePath }
     ```
 
     https://docs.snowflake.com/en/sql-reference/sql/execute-immediate
+    https://docs.snowflake.com/en/sql-reference/sql/execute-immediate-from
     """
 
     type = "execute_immediate_clause"
@@ -6879,9 +6883,11 @@ class ExecuteImmediateClauseSegment(BaseSegment):
     match_grammar = Sequence(
         "EXECUTE",
         "IMMEDIATE",
+        Ref.keyword("FROM", optional=True),
         OneOf(
             Ref("QuotedLiteralSegment"),
             Ref("ReferencedVariableNameSegment"),
+            Ref("StorageLocation"),
             Sequence(
                 Ref("ColonSegment"),
                 Ref("LocalVariableNameSegment"),

--- a/test/fixtures/dialects/snowflake/execute_immediate.sql
+++ b/test/fixtures/dialects/snowflake/execute_immediate.sql
@@ -19,3 +19,7 @@ EXECUTE IMMEDIATE $pie USING (one, two);
 SET three = 'select ? + ?';
 EXECUTE IMMEDIATE :three;
 EXECUTE IMMEDIATE :three USING (one, two);
+
+EXECUTE IMMEDIATE FROM './insert-inventory.sql';
+
+EXECUTE IMMEDIATE FROM @my_stage/scripts/create-inventory.sql;

--- a/test/fixtures/dialects/snowflake/execute_immediate.yml
+++ b/test/fixtures/dialects/snowflake/execute_immediate.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8e04c349292c858194d9339483207da94a5fdf7483fa466ba1eb05a2eae1efb6
+_hash: 63e7035b51a821c215f17c68f64f1c30d7da14b1c6aa549f64fa0d8ca1fd3ff2
 file:
 - statement:
     execute_immediate_clause:
@@ -92,4 +92,19 @@ file:
       - comma: ','
       - variable: two
       - end_bracket: )
+- statement_terminator: ;
+- statement:
+    execute_immediate_clause:
+    - keyword: EXECUTE
+    - keyword: IMMEDIATE
+    - keyword: FROM
+    - quoted_literal: "'./insert-inventory.sql'"
+- statement_terminator: ;
+- statement:
+    execute_immediate_clause:
+    - keyword: EXECUTE
+    - keyword: IMMEDIATE
+    - keyword: FROM
+    - storage_location:
+        stage_path: '@my_stage/scripts/create-inventory.sql'
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Closes https://github.com/sqlfluff/sqlfluff/issues/5694

### Are there any other side effects of this change that we should be aware of?
Snowflake technically treats `EXECUTE IMMEDIATE` and `EXECUTE IMMEDIATE FROM` as two commands, but I think they are close enough to parse together. If you want, I could separate them into two on our end though.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
