### PR TITLE
[fix_clickhouse] Temporary Table Create AS SELECT

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -38,7 +38,6 @@ ansi_dialect = load_raw_dialect("ansi")
 clickhouse_dialect = ansi_dialect.copy_as("clickhouse")
 clickhouse_dialect.sets("unreserved_keywords").update(UNRESERVED_KEYWORDS)
 
-
 clickhouse_dialect.insert_lexer_matchers(
     # https://clickhouse.com/docs/en/sql-reference/functions#higher-order-functions---operator-and-lambdaparams-expr-function
     [StringLexer("lambda", r"->", SymbolSegment)],
@@ -744,63 +743,121 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
 
     type = "create_table_statement"
 
-    match_grammar: Matchable = Sequence(
-        "CREATE",
-        OneOf(
-            Ref("OrReplaceGrammar"),
-            Ref.keyword("TEMPORARY"),
-            optional=True,
-        ),
-        "TABLE",
-        Ref("IfNotExistsGrammar", optional=True),
-        Ref("TableReferenceSegment"),
-        Ref("OnClusterClauseSegment", optional=True),
-        OneOf(
-            # CREATE TABLE (...):
-            Sequence(
-                Bracketed(
-                    Delimited(
-                        OneOf(
-                            Ref("TableConstraintSegment"),
-                            Ref("ColumnDefinitionSegment"),
-                            Ref("ColumnConstraintSegment"),
+    match_grammar: Matchable = OneOf(
+        Sequence(
+            "CREATE",
+            Ref("OrReplaceGrammar", optional=True),
+            "TABLE",
+            Ref("IfNotExistsGrammar", optional=True),
+            Ref("TableReferenceSegment"),
+            Ref("OnClusterClauseSegment", optional=True),
+            OneOf(
+                # CREATE TABLE (...):
+                Sequence(
+                    Bracketed(
+                        Delimited(
+                            OneOf(
+                                Ref("TableConstraintSegment"),
+                                Ref("ColumnDefinitionSegment"),
+                                Ref("ColumnConstraintSegment"),
+                            ),
                         ),
+                        # Column definition may be missing if using AS SELECT
+                        optional=True,
                     ),
-                    # Column definition may be missing if using AS SELECT
-                    optional=True,
+                    Ref("TableEngineSegment"),
+                    # CREATE TABLE (...) AS SELECT:
+                    Sequence(
+                        "AS",
+                        Ref("SelectableGrammar"),
+                        optional=True,
+                    ),
                 ),
-                Ref("TableEngineSegment"),
-                # CREATE TABLE (...) AS SELECT:
+                # CREATE TABLE AS other_table:
+                Sequence(
+                    "AS",
+                    Ref("TableReferenceSegment"),
+                    Ref("TableEngineSegment", optional=True),
+                ),
+                # CREATE TABLE AS table_function():
+                Sequence(
+                    "AS",
+                    Ref("FunctionSegment"),
+                ),
+            ),
+            AnySetOf(
+                Sequence(
+                    "COMMENT",
+                    OneOf(
+                        Ref("SingleIdentifierGrammar"),
+                        Ref("QuotedIdentifierSegment"),
+                    ),
+                ),
+                Ref("TableTTLSegment"),
+                optional=True,
+            ),
+            Ref("TableEndClauseSegment", optional=True),
+        ),
+        # CREATE TEMPORARY TABLE
+        Sequence(
+            "CREATE",
+            Ref.keyword("TEMPORARY"),
+            "TABLE",
+            Ref("IfNotExistsGrammar", optional=True),
+            Ref("TableReferenceSegment"),
+            OneOf(
+                # CREATE TEMPORARY TABLE (...):
+                Sequence(
+                    Bracketed(
+                        Delimited(
+                            OneOf(
+                                Ref("TableConstraintSegment"),
+                                Ref("ColumnDefinitionSegment"),
+                                Ref("ColumnConstraintSegment"),
+                            ),
+                        ),
+                        # Column definition may be missing if using AS SELECT
+                        optional=True,
+                    ),
+                    Ref("TableEngineSegment"),
+                    # CREATE TEMPORARY TABLE (...) AS SELECT:
+                    Sequence(
+                        "AS",
+                        Ref("SelectableGrammar"),
+                        optional=True,
+                    ),
+                ),
+                # CREATE TEMPORARY TABLE AS other_table:
+                Sequence(
+                    "AS",
+                    Ref("TableReferenceSegment"),
+                    Ref("TableEngineSegment", optional=True),
+                ),
+                # CREATE TEMPORARY TABLE AS table_function():
+                Sequence(
+                    "AS",
+                    Ref("FunctionSegment"),
+                ),
+                # CREATE TEMPORARY TABLE AS
                 Sequence(
                     "AS",
                     Ref("SelectableGrammar"),
                     optional=True,
                 ),
             ),
-            # CREATE TABLE AS other_table:
-            Sequence(
-                "AS",
-                Ref("TableReferenceSegment"),
-                Ref("TableEngineSegment", optional=True),
-            ),
-            # CREATE TABLE AS table_function():
-            Sequence(
-                "AS",
-                Ref("FunctionSegment"),
-            ),
-        ),
-        AnySetOf(
-            Sequence(
-                "COMMENT",
-                OneOf(
-                    Ref("SingleIdentifierGrammar"),
-                    Ref("QuotedIdentifierSegment"),
+            AnySetOf(
+                Sequence(
+                    "COMMENT",
+                    OneOf(
+                        Ref("SingleIdentifierGrammar"),
+                        Ref("QuotedIdentifierSegment"),
+                    ),
                 ),
+                Ref("TableTTLSegment"),
+                optional=True,
             ),
-            Ref("TableTTLSegment"),
-            optional=True,
+            Ref("TableEndClauseSegment", optional=True),
         ),
-        Ref("TableEndClauseSegment", optional=True),
     )
 
 

--- a/test/fixtures/dialects/clickhouse/create_temporary_table.sql
+++ b/test/fixtures/dialects/clickhouse/create_temporary_table.sql
@@ -1,0 +1,10 @@
+CREATE TEMPORARY TABLE xt0 AS SELECT * FROM x;
+CREATE TEMPORARY TABLE IF NOT EXISTS t2
+(
+    ty String,
+    t2 String,
+    c_date_time DateTime32
+)
+ENGINE = MergeTree
+ORDER BY (ty,t2)
+TTL c_date_time + INTERVAL  1 DAY

--- a/test/fixtures/dialects/clickhouse/create_temporary_table.yml
+++ b/test/fixtures/dialects/clickhouse/create_temporary_table.yml
@@ -1,0 +1,84 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 8fab8176123d3063d83e53cc60e50bb312fc5eaeaac89cb9c50d73489f4635d5
+file:
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TEMPORARY
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: xt0
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: x
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TEMPORARY
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: t2
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: ty
+          data_type:
+            data_type_identifier: String
+      - comma: ','
+      - column_definition:
+          naked_identifier: t2
+          data_type:
+            data_type_identifier: String
+      - comma: ','
+      - column_definition:
+          naked_identifier: c_date_time
+          data_type:
+            data_type_identifier: DateTime32
+      - end_bracket: )
+    - engine:
+      - keyword: ENGINE
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - table_engine_function:
+          function_name:
+            function_name_identifier: MergeTree
+      - keyword: ORDER
+      - keyword: BY
+      - bracketed:
+        - start_bracket: (
+        - column_reference:
+            naked_identifier: ty
+        - comma: ','
+        - column_reference:
+            naked_identifier: t2
+        - end_bracket: )
+    - table_ttl_segment:
+        keyword: TTL
+        expression:
+          column_reference:
+            naked_identifier: c_date_time
+          binary_operator: +
+          interval_expression:
+            keyword: INTERVAL
+            numeric_literal: '1'
+            date_part: DAY


### PR DESCRIPTION
### Brief summary of the change made
I have made changes to the Clickhouse dialect. The changes are related to the creation of a Temporary TABLE, they have become more rigid, and also added the ability to AS SELECT for a TEMPORARY TABLE

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [ x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
