### PR TITLE
Clichouse prewhere

### DIFF
--- a/test/fixtures/dialects/clickhouse/prewhere.sql
+++ b/test/fixtures/dialects/clickhouse/prewhere.sql
@@ -1,0 +1,27 @@
+SELECT *
+FROM table as t
+PREWHERE event_date = 1;
+
+
+SELECT *
+FROM table as t
+PREWHERE event_date = 1
+ORDER BY t1;
+
+SELECT *
+FROM table as t
+PREWHERE c1 = 1 AND c2 = 2
+ORDER BY c1;
+
+SELECT *
+FROM table as t
+PREWHERE c1 = 1 AND c2 = 2
+WHERE c3 = 1
+ORDER BY c1;
+
+
+SELECT *
+FROM table as t
+PREWHERE c1 = 1 AND c2 = 2
+GROUP BY c1
+ORDER BY c1;

--- a/test/fixtures/dialects/clickhouse/prewhere.yml
+++ b/test/fixtures/dialects/clickhouse/prewhere.yml
@@ -1,0 +1,193 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e8c754d4a85ae1a659193f42674618de02859828f0a4af8f7371439802c53d05
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table
+            alias_expression:
+              keyword: as
+              naked_identifier: t
+      prewhere_clause:
+        keyword: PREWHERE
+        expression:
+          column_reference:
+            naked_identifier: event_date
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table
+            alias_expression:
+              keyword: as
+              naked_identifier: t
+      prewhere_clause:
+        keyword: PREWHERE
+        expression:
+          column_reference:
+            naked_identifier: event_date
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table
+            alias_expression:
+              keyword: as
+              naked_identifier: t
+      prewhere_clause:
+        keyword: PREWHERE
+        expression:
+        - column_reference:
+            naked_identifier: c1
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '1'
+        - binary_operator: AND
+        - column_reference:
+            naked_identifier: c2
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '2'
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: c1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table
+            alias_expression:
+              keyword: as
+              naked_identifier: t
+      prewhere_clause:
+        keyword: PREWHERE
+        expression:
+        - column_reference:
+            naked_identifier: c1
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '1'
+        - binary_operator: AND
+        - column_reference:
+            naked_identifier: c2
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '2'
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: c3
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: c1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table
+            alias_expression:
+              keyword: as
+              naked_identifier: t
+      prewhere_clause:
+        keyword: PREWHERE
+        expression:
+        - column_reference:
+            naked_identifier: c1
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '1'
+        - binary_operator: AND
+        - column_reference:
+            naked_identifier: c2
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '2'
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: c1
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: c1
+- statement_terminator: ;


### PR DESCRIPTION
In Clickhouse, there is such a thing as PREWHERE when requesting SELECT. This PR adds PREWHERE support

https://clickhouse.com/docs/en/sql-reference/statements/select/prewhere
### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
