### PR TITLE
Bugfix: ST02 - Compare entire condition expression

### DIFF
--- a/src/sqlfluff/rules/structure/ST02.py
+++ b/src/sqlfluff/rules/structure/ST02.py
@@ -194,10 +194,25 @@ class Rule_ST02(BaseRule):
                     .children(sp.is_type("column_reference"))
                     .get()
                 )
+                array_accessor_segment = (
+                    Segments(condition_expression)
+                    .children(sp.is_type("array_accessor"))
+                    .get()
+                )
 
                 # Return None if none found (this condition does not apply to functions)
                 if not column_reference_segment:
                     return None
+
+                if array_accessor_segment:
+                    column_reference_segment_raw_upper = (
+                        column_reference_segment.raw_upper
+                        + array_accessor_segment.raw_upper
+                    )
+                else:
+                    column_reference_segment_raw_upper = (
+                        column_reference_segment.raw_upper
+                    )
 
                 if else_clauses:
                     else_expression = else_clauses.children(sp.is_type("expression"))[0]
@@ -205,13 +220,15 @@ class Rule_ST02(BaseRule):
                     # function.
                     if (
                         not is_not_prefix
-                        and condition_expression.raw_upper == else_expression.raw_upper
+                        and column_reference_segment_raw_upper
+                        == else_expression.raw_upper
                     ):
                         coalesce_arg_1 = else_expression
                         coalesce_arg_2 = then_expression
                     elif (
                         is_not_prefix
-                        and condition_expression.raw_upper == then_expression.raw_upper
+                        and column_reference_segment_raw_upper
+                        == then_expression.raw_upper
                     ):
                         coalesce_arg_1 = then_expression
                         coalesce_arg_2 = else_expression

--- a/src/sqlfluff/rules/structure/ST02.py
+++ b/src/sqlfluff/rules/structure/ST02.py
@@ -205,14 +205,14 @@ class Rule_ST02(BaseRule):
                     # function.
                     if (
                         not is_not_prefix
-                        and column_reference_segment.raw_upper
+                        and condition_expression_segments_raw
                         == else_expression.raw_upper
                     ):
                         coalesce_arg_1 = else_expression
                         coalesce_arg_2 = then_expression
                     elif (
                         is_not_prefix
-                        and column_reference_segment.raw_upper
+                        and condition_expression_segments_raw
                         == then_expression.raw_upper
                     ):
                         coalesce_arg_1 = then_expression

--- a/src/sqlfluff/rules/structure/ST02.py
+++ b/src/sqlfluff/rules/structure/ST02.py
@@ -205,14 +205,14 @@ class Rule_ST02(BaseRule):
                     # function.
                     if (
                         not is_not_prefix
-                        and condition_expression_segments_raw
+                        and condition_expression.raw_upper
                         == else_expression.raw_upper
                     ):
                         coalesce_arg_1 = else_expression
                         coalesce_arg_2 = then_expression
                     elif (
                         is_not_prefix
-                        and condition_expression_segments_raw
+                        and condition_expression.raw_upper
                         == then_expression.raw_upper
                     ):
                         coalesce_arg_1 = then_expression

--- a/src/sqlfluff/rules/structure/ST02.py
+++ b/src/sqlfluff/rules/structure/ST02.py
@@ -205,15 +205,13 @@ class Rule_ST02(BaseRule):
                     # function.
                     if (
                         not is_not_prefix
-                        and condition_expression.raw_upper
-                        == else_expression.raw_upper
+                        and condition_expression.raw_upper == else_expression.raw_upper
                     ):
                         coalesce_arg_1 = else_expression
                         coalesce_arg_2 = then_expression
                     elif (
                         is_not_prefix
-                        and condition_expression.raw_upper
-                        == then_expression.raw_upper
+                        and condition_expression.raw_upper == then_expression.raw_upper
                     ):
                         coalesce_arg_1 = then_expression
                         coalesce_arg_2 = else_expression

--- a/test/fixtures/rules/std_rule_cases/ST02.yml
+++ b/test/fixtures/rules/std_rule_cases/ST02.yml
@@ -107,6 +107,19 @@ test_pass_case_cannot_be_reduced_13:
   configs:
     core:
       dialect: postgres
+test_pass_array_accessors:
+  pass_str: |
+    SELECT
+    CASE
+        WHEN genres[0] IS NULL
+           THEN 'x'
+        ELSE genres
+    END
+    AS g
+    FROM table_t
+  configs:
+    core:
+      dialect: snowflake
 test_fail_unnecessary_case_1:
   fail_str: |
     select


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #5844 
The comparison was previously ignoring array accessors, and just comparing the column reference

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
