### PR TITLE
BigQuery: Fix EXPORT DATA statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -2415,13 +2415,28 @@ class ExportStatementSegment(BaseSegment):
                             type="export_option",
                         ),
                         StringParser(
+                            "header",
+                            CodeSegment,
+                            type="export_option",
+                        ),
+                        StringParser(
+                            "overwrite",
+                            CodeSegment,
+                            type="export_option",
+                        ),
+                        StringParser(
                             "uri",
+                            CodeSegment,
+                            type="export_option",
+                        ),
+                        StringParser(
+                            "use_avro_logical_types",
                             CodeSegment,
                             type="export_option",
                         ),
                     ),
                     Ref("EqualsSegment"),
-                    Ref("QuotedLiteralSegment"),
+                    Ref("BaseExpressionElementGrammar"),
                 ),
                 # Bool options
                 # Note: adding as own type, rather than keywords as convention with

--- a/test/fixtures/dialects/bigquery/export_statement.sql
+++ b/test/fixtures/dialects/bigquery/export_statement.sql
@@ -63,3 +63,11 @@ WITH cte AS (
 )
 SELECT *
 FROM cte;
+
+EXPORT DATA OPTIONS
+(uri=CONCAT("gs://bucket/","/file_*.csv"),
+  format='CSV',
+  overwrite=true,
+  header=true,
+  field_delimiter=',')
+as SELECT col1,col2 FROM thetable;

--- a/test/fixtures/dialects/bigquery/export_statement.yml
+++ b/test/fixtures/dialects/bigquery/export_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ff4d2fa69759372f4d3bc11a761c5120bd908dffde43fcec59efbf422f874dcc
+_hash: 7d10b2ff48fefa01c60d89e3bb631de6f679dfe38608a25a5e339c6d7435ef1f
 file:
 - statement:
     export_statement:
@@ -33,12 +33,12 @@ file:
       - export_option: overwrite
       - comparison_operator:
           raw_comparison_operator: '='
-      - keyword: 'true'
+      - boolean_literal: 'true'
       - comma: ','
       - export_option: header
       - comparison_operator:
           raw_comparison_operator: '='
-      - keyword: 'true'
+      - boolean_literal: 'true'
       - comma: ','
       - export_option: field_delimiter
       - comparison_operator:
@@ -95,12 +95,12 @@ file:
       - export_option: overwrite
       - comparison_operator:
           raw_comparison_operator: '='
-      - keyword: 'true'
+      - boolean_literal: 'true'
       - comma: ','
       - export_option: header
       - comparison_operator:
           raw_comparison_operator: '='
-      - keyword: 'true'
+      - boolean_literal: 'true'
       - comma: ','
       - export_option: field_delimiter
       - comparison_operator:
@@ -153,12 +153,12 @@ file:
       - export_option: overwrite
       - comparison_operator:
           raw_comparison_operator: '='
-      - keyword: 'true'
+      - boolean_literal: 'true'
       - comma: ','
       - export_option: header
       - comparison_operator:
           raw_comparison_operator: '='
-      - keyword: 'true'
+      - boolean_literal: 'true'
       - comma: ','
       - export_option: field_delimiter
       - comparison_operator:
@@ -214,12 +214,12 @@ file:
       - export_option: overwrite
       - comparison_operator:
           raw_comparison_operator: '='
-      - keyword: 'true'
+      - boolean_literal: 'true'
       - comma: ','
       - export_option: header
       - comparison_operator:
           raw_comparison_operator: '='
-      - keyword: 'true'
+      - boolean_literal: 'true'
       - comma: ','
       - export_option: field_delimiter
       - comparison_operator:
@@ -326,7 +326,7 @@ file:
       - export_option: overwrite
       - comparison_operator:
           raw_comparison_operator: '='
-      - keyword: 'true'
+      - boolean_literal: 'true'
       - end_bracket: )
     - keyword: AS
     - select_statement:
@@ -377,12 +377,12 @@ file:
       - export_option: overwrite
       - comparison_operator:
           raw_comparison_operator: '='
-      - keyword: 'true'
+      - boolean_literal: 'true'
       - comma: ','
       - export_option: header
       - comparison_operator:
           raw_comparison_operator: '='
-      - keyword: 'true'
+      - boolean_literal: 'true'
       - comma: ','
       - export_option: field_delimiter
       - comparison_operator:
@@ -439,4 +439,65 @@ file:
                 table_expression:
                   table_reference:
                     naked_identifier: cte
+- statement_terminator: ;
+- statement:
+    export_statement:
+    - keyword: EXPORT
+    - keyword: DATA
+    - keyword: OPTIONS
+    - bracketed:
+      - start_bracket: (
+      - export_option: uri
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - function:
+          function_name:
+            function_name_identifier: CONCAT
+          bracketed:
+          - start_bracket: (
+          - expression:
+              quoted_literal: '"gs://bucket/"'
+          - comma: ','
+          - expression:
+              quoted_literal: '"/file_*.csv"'
+          - end_bracket: )
+      - comma: ','
+      - export_option: format
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'CSV'"
+      - comma: ','
+      - export_option: overwrite
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - boolean_literal: 'true'
+      - comma: ','
+      - export_option: header
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - boolean_literal: 'true'
+      - comma: ','
+      - export_option: field_delimiter
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "','"
+      - end_bracket: )
+    - keyword: as
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: col1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: col2
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: thetable
 - statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/handle_exception.yml
+++ b/test/fixtures/dialects/bigquery/handle_exception.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1b4e7316d947b3082776f2b5d29aa85448671a8fc632f1dda2e4c83325bea6d2
+_hash: 83eadb0af7c00b07530eb74d400051a77c647a005c49b78e4cb54bbabc5096bd
 file:
 - multi_statement_segment:
     begin_statement:
@@ -168,12 +168,12 @@ file:
           - export_option: overwrite
           - comparison_operator:
               raw_comparison_operator: '='
-          - keyword: 'true'
+          - boolean_literal: 'true'
           - comma: ','
           - export_option: header
           - comparison_operator:
               raw_comparison_operator: '='
-          - keyword: 'true'
+          - boolean_literal: 'true'
           - comma: ','
           - export_option: field_delimiter
           - comparison_operator:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

fixes #5409

The parsing logic for `EXPORT DATA` was implemented, but lacked consideration of some option items and the case where an expression was specified for the value, so we try to fix it.

https://cloud.google.com/bigquery/docs/reference/standard-sql/other-statements#export_data_statement

### Are there any other side effects of this change that we should be aware of?

None


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
