### PR TITLE
Remove typing_extensions requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,6 @@ dependencies = [
     "toml; python_version < '3.11'",
     # For handling progress bars
     "tqdm",
-    # Literals and TypedDicts
-    "typing_extensions",
 ]
 
 [project.urls]

--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -4,9 +4,7 @@ This stores the idea of a collection of linted files at a single start path
 
 """
 
-from typing import Any, Dict, List, Optional, Tuple, Union, overload
-
-from typing_extensions import Literal, TypedDict
+from typing import Any, Dict, List, Literal, Optional, Tuple, TypedDict, Union, overload
 
 from sqlfluff.core.errors import CheckTuple, SQLLintError
 from sqlfluff.core.linter.linted_file import TMP_PRS_ERROR_TYPES, LintedFile

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -2,9 +2,18 @@
 
 import csv
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union, overload
-
-from typing_extensions import Literal
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    overload,
+)
 
 from sqlfluff.core.errors import CheckTuple
 from sqlfluff.core.linter.linted_dir import LintedDir, LintingRecord

--- a/src/sqlfluff/utils/functional/segments.py
+++ b/src/sqlfluff/utils/functional/segments.py
@@ -7,11 +7,10 @@ from typing import (
     Iterator,
     List,
     Optional,
+    SupportsIndex,
     Union,
     overload,
 )
-
-from typing_extensions import SupportsIndex  # NOTE: Required for py37
 
 from sqlfluff.core.parser import BaseSegment
 from sqlfluff.core.templaters.base import TemplatedFile


### PR DESCRIPTION
`Literal`, `SupportsIndex` and `TypedDict` were added in `typing` in Python 3.8.