### PR TITLE
(WIP) Adds support for generated columns in mysql (in create statements)

### DIFF
--- a/test/fixtures/dialects/mysql/create_table_generated_columns.sql
+++ b/test/fixtures/dialects/mysql/create_table_generated_columns.sql
@@ -1,0 +1,7 @@
+
+CREATE TABLE emails (
+    email CHAR(100) NOT NULL,
+    email_domain CHAR(100) AS (SUBSTRING_INDEX(email, '@', -1)),
+    email_domain2 CHAR(100) GENERATED ALWAYS AS (SUBSTRING_INDEX(email, '@', -1)) STORED,
+    email_domain3 CHAR(100) GENERATED ALWAYS AS (SUBSTRING_INDEX(email, '@', -1)) VIRTUAL
+);


### PR DESCRIPTION

### Brief summary of the change made

This PR attempts to add support for generated columns in the mysql dialect.
Related: https://github.com/sqlfluff/sqlfluff/issues/4960

### Are there any other side effects of this change that we should be aware of?
Not that I know ... 

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.
    - [X] Added test file, will generate yml when I finish the implementation. 

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
