### PR TITLE
MySQL: Support DIV and MOD operators

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -187,6 +187,21 @@ mysql_dialect.replace(
             Ref("VariableAssignmentSegment"),
         ]
     ),
+    ArithmeticBinaryOperatorGrammar=OneOf(
+        Ref("PlusSegment"),
+        Ref("MinusSegment"),
+        Ref("DivideSegment"),
+        Ref("MultiplySegment"),
+        Ref("ModuloSegment"),
+        Ref("BitwiseAndSegment"),
+        Ref("BitwiseOrSegment"),
+        Ref("BitwiseXorSegment"),
+        Ref("BitwiseLShiftSegment"),
+        Ref("BitwiseRShiftSegment"),
+        # Add MySQL's DIV and MOD segment
+        Ref("DivOperatorSegment"),
+        Ref("ModOperatorSegment"),
+    ),
     DateTimeLiteralGrammar=Sequence(
         # MySQL does not require the keyword to be specified:
         # https://dev.mysql.com/doc/refman/8.0/en/date-and-time-literals.html
@@ -283,6 +298,8 @@ mysql_dialect.add(
         CodeSegment,
         type="system_variable",
     ),
+    DivOperatorSegment=StringParser("DIV", KeywordSegment, type="binary_operator"),
+    ModOperatorSegment=StringParser("MOD", KeywordSegment, type="binary_operator"),
     DoubleQuotedJSONPath=TypedParser(
         "double_quote",
         CodeSegment,

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -187,20 +187,13 @@ mysql_dialect.replace(
             Ref("VariableAssignmentSegment"),
         ]
     ),
-    ArithmeticBinaryOperatorGrammar=OneOf(
-        Ref("PlusSegment"),
-        Ref("MinusSegment"),
-        Ref("DivideSegment"),
-        Ref("MultiplySegment"),
-        Ref("ModuloSegment"),
-        Ref("BitwiseAndSegment"),
-        Ref("BitwiseOrSegment"),
-        Ref("BitwiseXorSegment"),
-        Ref("BitwiseLShiftSegment"),
-        Ref("BitwiseRShiftSegment"),
-        # Add MySQL's DIV and MOD segment
-        Ref("DivOperatorSegment"),
-        Ref("ModOperatorSegment"),
+    ArithmeticBinaryOperatorGrammar=ansi_dialect.get_grammar(
+        "ArithmeticBinaryOperatorGrammar"
+    ).copy(
+        insert=[
+            Ref("DivOperatorSegment"),
+            Ref("ModOperatorSegment"),
+        ],
     ),
     DateTimeLiteralGrammar=Sequence(
         # MySQL does not require the keyword to be specified:

--- a/test/fixtures/dialects/mysql/select_operators.sql
+++ b/test/fixtures/dialects/mysql/select_operators.sql
@@ -5,3 +5,5 @@ SELECT 1 XOR 1;
 SELECT 1 || 1;
 SELECT col_1 && 1;
 SELECT (col_1 = col_2) || col_3;
+SELECT 5 DIV 2;
+SELECT 5 MOD 2;

--- a/test/fixtures/dialects/mysql/select_operators.yml
+++ b/test/fixtures/dialects/mysql/select_operators.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d21bd7c1927fa694dafe5d0812e99cabeeffb6fd21b122189c8c7dbb79328f70
+_hash: 1cedf78417964649de92fb66c5035c6d7b5cf09c22b3f5b5232e2e233083c132
 file:
 - statement:
     select_statement:
@@ -84,4 +84,24 @@ file:
             binary_operator: '||'
             column_reference:
               naked_identifier: col_3
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '5'
+          - binary_operator: DIV
+          - numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - numeric_literal: '5'
+          - binary_operator: MOD
+          - numeric_literal: '2'
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

fixes #5868

The above problem was caused by the lack of implementation of MySQL-specific BinaryOperator, which is not defined in ANSI.
According to the documentation, `DIV` and `MOD` were needed, so I try to add them.

https://dev.mysql.com/doc/refman/8.0/ja/arithmetic-functions.html

### Are there any other side effects of this change that we should be aware of?

None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
