### PR TITLE
Support quoted psql parameters with `placeholder` templater

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -896,6 +896,9 @@ A few common styles are supported:
     -- (use with caution as more prone to false positives)
     WHERE bla = table:my_name
 
+    -- colon_optional_quotes
+    SELECT :"column" FROM :table WHERE bla = :'my_name'
+
     -- numeric_colon
     WHERE bla = :2
 

--- a/test/core/templaters/placeholder_test.py
+++ b/test/core/templaters/placeholder_test.py
@@ -81,6 +81,24 @@ def test__templater_raw():
         ),
         (
             """
+            SELECT user_mail, city_id, :"custom_column"
+            FROM users_data
+            WHERE userid = :user_id AND date > :'start_date'
+            """,
+            "colon_optional_quotes",
+            """
+            SELECT user_mail, city_id, "PascalCaseColumn"
+            FROM users_data
+            WHERE userid = 42 AND date > '2021-10-01'
+            """,
+            dict(
+                user_id="42",
+                custom_column="PascalCaseColumn",
+                start_date="2021-10-01",
+            ),
+        ),
+        (
+            """
             SELECT user_mail, city_id
             FROM users_data:table_suffix
             """,
@@ -317,6 +335,7 @@ def test__templater_raw():
         "colon_simple_substitution",
         "colon_accept_block_at_end",
         "colon_tuple_substitution",
+        "colon_quoted",
         "colon_nospaces",
         "colon_nospaces_double_colon_ignored",
         "question_mark",


### PR DESCRIPTION
Closes #5140, though that issue has a bit of maybe a misunderstanding of the problem

### Brief summary of the change made
psql sql interpolation supports colon followed by variable name, unquoted, single-quoted, or double-quoted, such as
```sql
 SELECT :"column" FROM :table WHERE user = :'name'
```

When invoked with `psql -c "SELECT ..." -v column=columnWithUppercase -v table=my_table -v user=my_name` renders to
```sql
SELECT "columnWithUppercase" FROM my_table WHERE user = 'my_name'
```

This implements a new `param_style` for `placeholder` templater to allow for this. If a name more specific to its use case (rather than a description of the style) would be useful, like `psql_colon`, let me know

### Are there any other side effects of this change that we should be aware of?
It does add a new capture group to the regex, and looks for this capture group in the generic placeholder code. Shouldn't cause issue now, but it is a bit of a deviation in code style and maybe deserves a more abstracted implementation

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.
**I believe so but let me know if more documentation or testing is needed**

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
