### PR TITLE
BigQuery: Support ALTER TABLE ADD KEY statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1774,6 +1774,50 @@ class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
                 ),
                 allow_trailing=True,
             ),
+            # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_add_foreign_key_statement
+            # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_add_primary_key_statement
+            Delimited(
+                OneOf(
+                    Sequence(
+                        "ADD",
+                        Sequence(
+                            "CONSTRAINT",
+                            Ref("IfNotExistsGrammar", optional=True),
+                            Ref("SingleIdentifierGrammar"),
+                            optional=True,
+                        ),
+                        "FOREIGN",
+                        "KEY",
+                        Bracketed(
+                            Delimited(
+                                Ref("SingleIdentifierGrammar"),
+                            ),
+                        ),
+                        "REFERENCES",
+                        Ref("TableReferenceSegment"),
+                        Bracketed(
+                            Delimited(
+                                Ref("SingleIdentifierGrammar"),
+                            ),
+                        ),
+                        "NOT",
+                        "ENFORCED",
+                    ),
+                    Sequence(
+                        "ADD",
+                        "PRIMARY",
+                        "KEY",
+                        Bracketed(
+                            Delimited(
+                                Ref("SingleIdentifierGrammar"),
+                            ),
+                        ),
+                        "NOT",
+                        "ENFORCED",
+                    ),
+                ),
+                allow_trailing=True,
+            ),
             # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_rename_to_statement
             Sequence(
                 "RENAME",

--- a/test/fixtures/dialects/bigquery/alter_table_add_key.sql
+++ b/test/fixtures/dialects/bigquery/alter_table_add_key.sql
@@ -1,0 +1,11 @@
+ALTER TABLE example_dataset.example_table2
+ADD CONSTRAINT my_fk_name FOREIGN KEY (x)
+REFERENCES example_dataset.example_table(x) NOT ENFORCED;
+
+ALTER TABLE `example_dataset.example_table`
+ADD PRIMARY KEY (`x`) NOT ENFORCED;
+
+ALTER TABLE fk_table
+ADD PRIMARY KEY (x,y) NOT ENFORCED,
+ADD CONSTRAINT fk FOREIGN KEY (u, v) REFERENCES pk_table(x, y) NOT ENFORCED,
+ADD CONSTRAINT `fk2` FOREIGN KEY (`i`, `j`) REFERENCES `pk_table`(`x`, `y`) NOT ENFORCED;

--- a/test/fixtures/dialects/bigquery/alter_table_add_key.yml
+++ b/test/fixtures/dialects/bigquery/alter_table_add_key.yml
@@ -1,0 +1,116 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 7e3f74ec53c1b37238306efed683b139d7a014b2d315032fb6aab8da8952f161
+file:
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_table2
+    - keyword: ADD
+    - keyword: CONSTRAINT
+    - naked_identifier: my_fk_name
+    - keyword: FOREIGN
+    - keyword: KEY
+    - bracketed:
+        start_bracket: (
+        naked_identifier: x
+        end_bracket: )
+    - keyword: REFERENCES
+    - table_reference:
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_table
+    - bracketed:
+        start_bracket: (
+        naked_identifier: x
+        end_bracket: )
+    - keyword: NOT
+    - keyword: ENFORCED
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`example_dataset.example_table`'
+    - keyword: ADD
+    - keyword: PRIMARY
+    - keyword: KEY
+    - bracketed:
+        start_bracket: (
+        quoted_identifier: '`x`'
+        end_bracket: )
+    - keyword: NOT
+    - keyword: ENFORCED
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: fk_table
+    - keyword: ADD
+    - keyword: PRIMARY
+    - keyword: KEY
+    - bracketed:
+      - start_bracket: (
+      - naked_identifier: x
+      - comma: ','
+      - naked_identifier: y
+      - end_bracket: )
+    - keyword: NOT
+    - keyword: ENFORCED
+    - comma: ','
+    - keyword: ADD
+    - keyword: CONSTRAINT
+    - naked_identifier: fk
+    - keyword: FOREIGN
+    - keyword: KEY
+    - bracketed:
+      - start_bracket: (
+      - naked_identifier: u
+      - comma: ','
+      - naked_identifier: v
+      - end_bracket: )
+    - keyword: REFERENCES
+    - table_reference:
+        naked_identifier: pk_table
+    - bracketed:
+      - start_bracket: (
+      - naked_identifier: x
+      - comma: ','
+      - naked_identifier: y
+      - end_bracket: )
+    - keyword: NOT
+    - keyword: ENFORCED
+    - comma: ','
+    - keyword: ADD
+    - keyword: CONSTRAINT
+    - quoted_identifier: '`fk2`'
+    - keyword: FOREIGN
+    - keyword: KEY
+    - bracketed:
+      - start_bracket: (
+      - quoted_identifier: '`i`'
+      - comma: ','
+      - quoted_identifier: '`j`'
+      - end_bracket: )
+    - keyword: REFERENCES
+    - table_reference:
+        quoted_identifier: '`pk_table`'
+    - bracketed:
+      - start_bracket: (
+      - quoted_identifier: '`x`'
+      - comma: ','
+      - quoted_identifier: '`y`'
+      - end_bracket: )
+    - keyword: NOT
+    - keyword: ENFORCED
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

makes progress on #5789

The current BigQuery dialect does not correctly parse `ALTER TABLE ADD KEY` statements, so we try to fix them.

https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_add_foreign_key_statement
https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_add_primary_key_statement

### Are there any other side effects of this change that we should be aware of?

None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
