### PR TITLE
Support dbt 1.8

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -72,7 +72,7 @@ jobs:
     name: dbt Plugin Tests
     strategy:
       matrix:
-        dbt-version: [ dbt110, dbt120, dbt130, dbt140, dbt150, dbt160, dbt170 ]
+        dbt-version: [ dbt110, dbt120, dbt130, dbt140, dbt150, dbt160, dbt170, dbt180 ]
         include:
           # Default to python 3.11 for dbt tests. dbt doesn't support py 3.12 yet.
           - python-version: "3.11"

--- a/constraints/dbt180.txt
+++ b/constraints/dbt180.txt
@@ -1,0 +1,2 @@
+dbt-core~=1.8.0
+dbt-postgres~=1.8.0

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -188,7 +188,14 @@ class DbtTemplater(JinjaTemplater):
                 threads=1,
             )
         )
-        register_adapter(self.dbt_config)
+
+        if self.dbt_version_tuple >= (1, 8):
+            from dbt.mp_context import get_mp_context
+
+            register_adapter(self.dbt_config, get_mp_context())
+        else:
+            register_adapter(self.dbt_config)
+
         return self.dbt_config
 
     @cached_property
@@ -459,7 +466,12 @@ class DbtTemplater(JinjaTemplater):
         try:
             # These are the names in dbt-core 1.4.1+
             # https://github.com/dbt-labs/dbt-core/pull/6539
-            from dbt.exceptions import CompilationError, FailedToConnectError
+            from dbt.exceptions import CompilationError
+
+            if self.dbt_version_tuple >= (1, 8):
+                from dbt.adapters.exceptions import FailedToConnectError
+            else:
+                from dbt.exceptions import FailedToConnectError
         except ImportError:
             # These are the historic names for older dbt-core versions
             from dbt.exceptions import CompilationException as CompilationError

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = generate-fixture-yml, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{38,39,310,311,312}, dbt{110,120,130,140,150,160,170}, cov-report, mypy, winpy, dbt{130,150}-winpy, yamllint
+envlist = generate-fixture-yml, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{38,39,310,311,312}, dbt{110,120,130,140,150,160,170,180}, cov-report, mypy, winpy, dbt{130,150}-winpy, yamllint
 min_version = 4.0  # Require 4.0+ for proper pyproject.toml support
 
 [testenv]
@@ -20,7 +20,7 @@ deps =
     # we force the right installation version up front in each environment.
     # NOTE: This is a bit of a hack around tox, but it does achieve reasonably
     # consistent results.
-    dbt{110,120,130,140,150,160,170,}: -r {toxinidir}/constraints/{envname}.txt
+    dbt{110,120,130,140,150,160,170,180,}: -r {toxinidir}/constraints/{envname}.txt
 # Include any other steps necessary for testing below.
 # {posargs} is there to allow us to specify specific tests, which
 # can then be invoked from tox by calling e.g.
@@ -32,7 +32,7 @@ commands =
     # number pinned to the same version number of the main sqlfluff library
     # so it _must_ be installed second in the context of a version which isn't
     # yet released (and so not available on pypi).
-    dbt{110,120,130,140,150,160,170,}: python -m pip install {toxinidir}/plugins/sqlfluff-templater-dbt
+    dbt{110,120,130,140,150,160,170,180,}: python -m pip install {toxinidir}/plugins/sqlfluff-templater-dbt
     # Add the example plugin.
     # NOTE: The trailing comma is important because in the github test suite
     # the python version is not specified and instead the "py" environment
@@ -40,7 +40,7 @@ commands =
     # still installs the relevant plugins.
     {py,winpy}{38,39,310,311,312,}: python -m pip install {toxinidir}/plugins/sqlfluff-plugin-example
     # For the dbt test cases install dependencies.
-    dbt{110,120,130,140,150,160,170,}: dbt deps --project-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project --profiles-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt
+    dbt{110,120,130,140,150,160,170,180,}: dbt deps --project-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project --profiles-dir {toxinidir}/plugins/sqlfluff-templater-dbt/test/fixtures/dbt
     # Clean up from previous tests
     python {toxinidir}/util.py clean-tests
     # Run tests


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


fixes https://github.com/sqlfluff/sqlfluff/issues/5877

Changes are almost same as https://github.com/sqlfluff/sqlfluff/pull/5842 , and I added support for some breaking changes in dbt 1.8.

Note that I'm a newbie to both dbt and sqlfluff core, please review carefully. Feel free for other developers to edit this branch directly if necessary.

## Current Status

I haven't fully resolved the issue yet.
It seems there are two problems that sqlfluff itself can't solve. I made direct edits to dbt's code in my local environment to fix the two issues described below, and run `sqlfluff lint` , it worked.

If we can address these points internally, such as by passing certain arguments into the `DbtRuntimeConfig` , that would be ideal. If you have any ideas, please advise me. Otherwise, we would need to raise an issue in dbt-core.

### 1. get_invocation_context

After the code fixes in this PR, if we run `sqlfluff lint` with dbt 1.8, it fails like this.

```
> sqlfluff lint example.sql
...
  File "/Users/kzosabe/ws/dev/oss/python/sqlfluff/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py", line 252, in dbt_manifest
    self.dbt_manifest = ManifestLoader.get_full_manifest(self.dbt_config)
  File "/Users/kzosabe/ws/dev/oss/python/sqlfluff/.venv/lib/python3.8/site-packages/dbt/parser/manifest.py", line 330, in get_full_manifest
    manifest = loader.load()
  File "/Users/kzosabe/ws/dev/oss/python/sqlfluff/.venv/lib/python3.8/site-packages/dbt/parser/manifest.py", line 384, in load
    project_parser_files = self.safe_update_project_parser_files_partially(
  File "/Users/kzosabe/ws/dev/oss/python/sqlfluff/.venv/lib/python3.8/site-packages/dbt/parser/manifest.py", line 536, in safe_update_project_parser_files_partially
    self.partial_parser = PartialParsing(self.saved_manifest, self.manifest.files)  # type: ignore[arg-type]
  File "/Users/kzosabe/ws/dev/oss/python/sqlfluff/.venv/lib/python3.8/site-packages/dbt/parser/partial.py", line 86, in __init__
    self.build_file_diff()
  File "/Users/kzosabe/ws/dev/oss/python/sqlfluff/.venv/lib/python3.8/site-packages/dbt/parser/partial.py", line 165, in build_file_diff
    if get_invocation_context().env.get("DBT_PP_TEST"):
  File "/Users/kzosabe/ws/dev/oss/python/sqlfluff/.venv/lib/python3.8/site-packages/dbt_common/context.py", line 53, in get_invocation_context
    ctx = invocation_var.get()
LookupError: <ContextVar name='DBT_INVOCATION_CONTEXT_VAR' at 0x1064ffa90>
```

```python
        if get_invocation_context().env.get("DBT_PP_TEST"):
            fire_event(event, level=EventLevel.INFO)
```

It seems that calling `get_invocation_context()` inside the sqlfluff context isn't working properly. 
This line was introduced below. If we revert this line to`if os.environ.get("DBT_PP_TEST"):`, no errors occur.

https://github.com/dbt-labs/dbt-core/commit/ef03ea26973b6776d280aa00501cc16f32041a4f#diff-2fd42940aaee0e200a257863155b747faf735f6b49ae49ac9229c17be33db82aR165


### 2. REQUIRE_RESOURCE_NAMES_WITHOUT_SPACES

If we fixed `1.` and run  `sqlfluff lint` again, it fails like this.

```
> sqlfluff lint example.sql
...
  File "/Users/kzosabe/ws/dev/oss/python/sqlfluff/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py", line 252, in dbt_manifest
    self.dbt_manifest = ManifestLoader.get_full_manifest(self.dbt_config)
  File "/Users/kzosabe/ws/dev/oss/python/sqlfluff/.venv/lib/python3.8/site-packages/dbt/parser/manifest.py", line 330, in get_full_manifest
    manifest = loader.load()
  File "/Users/kzosabe/ws/dev/oss/python/sqlfluff/.venv/lib/python3.8/site-packages/dbt/parser/manifest.py", line 528, in load
    self.check_for_spaces_in_resource_names()
  File "/Users/kzosabe/ws/dev/oss/python/sqlfluff/.venv/lib/python3.8/site-packages/dbt/parser/manifest.py", line 641, in check_for_spaces_in_resource_names
    if self.root_project.args.REQUIRE_RESOURCE_NAMES_WITHOUT_SPACES
AttributeError: 'DbtConfigArgs' object has no attribute 'REQUIRE_RESOURCE_NAMES_WITHOUT_SPACES'
```

```python
        level = (
            EventLevel.ERROR
            if self.root_project.args.REQUIRE_RESOURCE_NAMES_WITHOUT_SPACES
            else EventLevel.WARN
        )
```

This line was introduced below.
https://github.com/dbt-labs/dbt-core/commit/a36057d6e9da02d8a9ff359f85dc0b94b674f90a#diff-a25a77362db78f4ddc0675bcbd4775e158631076c9918ce5b64cfcd9f6db6bceR641

If we make it like below, no errors occur.

```python
        level = (
            EventLevel.ERROR
            if (
                hasattr(self.root_project.args, "REQUIRE_RESOURCE_NAMES_WITHOUT_SPACES") and
                self.root_project.args.REQUIRE_RESOURCE_NAMES_WITHOUT_SPACES
            )
            else EventLevel.WARN
        )
```

I'm not sure if this change is  a good way. 
It's possible that they expected a default value for `REQUIRE_RESOURCE_NAMES_WITHOUT_SPACES` and it was missed during implementation. I'm not familiar with dbt's codebase, I couldn't confirm that.

### Are there any other side effects of this change that we should be aware of?

Since I've made changes intended to affect only inside the branch of `dbt_version_tuple >= (1, 8)` , there should be no side effects, but it needs to be checked carefully.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
