### PR TITLE
Add upsert clause support to SQLite dialect

### DIFF
--- a/test/fixtures/dialects/sqlite/upsert.sql
+++ b/test/fixtures/dialects/sqlite/upsert.sql
@@ -1,0 +1,19 @@
+INSERT INTO t1 (a, b) VALUES (1, 2) ON CONFLICT DO NOTHING;
+
+INSERT INTO t1 (a, b) VALUES (1, 2) ON CONFLICT (a, b) DO NOTHING;
+
+INSERT INTO t1 (a, b)
+VALUES (1, 2)
+ON CONFLICT (a, b) DO UPDATE SET
+a = excluded.a;
+
+INSERT INTO t1 (a, b)
+VALUES (1, 2)
+ON CONFLICT (a, b) DO UPDATE SET
+a = excluded.a WHERE a < 10;
+
+INSERT INTO t1 (a, b)
+VALUES (1, 2)
+ON CONFLICT (a, b) DO UPDATE SET
+a = excluded.a WHERE a < 10
+RETURNING *;

--- a/test/fixtures/dialects/sqlite/upsert.yml
+++ b/test/fixtures/dialects/sqlite/upsert.yml
@@ -1,0 +1,247 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: f20fb63140dbf48d70b1e52b4db30324a332968e7e33b62144d994727ef3e6d5
+file:
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - end_bracket: )
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - end_bracket: )
+    - upsert_clause:
+      - keyword: 'ON'
+      - keyword: CONFLICT
+      - keyword: DO
+      - keyword: NOTHING
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - end_bracket: )
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - end_bracket: )
+    - upsert_clause:
+      - keyword: 'ON'
+      - keyword: CONFLICT
+      - conflict_target:
+          index_column_definition:
+            expression:
+              bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: a
+              - comma: ','
+              - column_reference:
+                  naked_identifier: b
+              - end_bracket: )
+      - keyword: DO
+      - keyword: NOTHING
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - end_bracket: )
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - end_bracket: )
+    - upsert_clause:
+      - keyword: 'ON'
+      - keyword: CONFLICT
+      - conflict_target:
+          index_column_definition:
+            expression:
+              bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: a
+              - comma: ','
+              - column_reference:
+                  naked_identifier: b
+              - end_bracket: )
+      - keyword: DO
+      - keyword: UPDATE
+      - keyword: SET
+      - naked_identifier: a
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - expression:
+          column_reference:
+          - naked_identifier: excluded
+          - dot: .
+          - naked_identifier: a
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - end_bracket: )
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - end_bracket: )
+    - upsert_clause:
+      - keyword: 'ON'
+      - keyword: CONFLICT
+      - conflict_target:
+          index_column_definition:
+            expression:
+              bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: a
+              - comma: ','
+              - column_reference:
+                  naked_identifier: b
+              - end_bracket: )
+      - keyword: DO
+      - keyword: UPDATE
+      - keyword: SET
+      - naked_identifier: a
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - expression:
+          column_reference:
+          - naked_identifier: excluded
+          - dot: .
+          - naked_identifier: a
+      - keyword: WHERE
+      - expression:
+          column_reference:
+            naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: <
+          numeric_literal: '10'
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: a
+      - comma: ','
+      - column_reference:
+          naked_identifier: b
+      - end_bracket: )
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '2'
+        - end_bracket: )
+    - upsert_clause:
+      - keyword: 'ON'
+      - keyword: CONFLICT
+      - conflict_target:
+          index_column_definition:
+            expression:
+              bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: a
+              - comma: ','
+              - column_reference:
+                  naked_identifier: b
+              - end_bracket: )
+      - keyword: DO
+      - keyword: UPDATE
+      - keyword: SET
+      - naked_identifier: a
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - expression:
+          column_reference:
+          - naked_identifier: excluded
+          - dot: .
+          - naked_identifier: a
+      - keyword: WHERE
+      - expression:
+          column_reference:
+            naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: <
+          numeric_literal: '10'
+    - returning_clause:
+        keyword: RETURNING
+        wildcard_expression:
+          wildcard_identifier:
+            star: '*'
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
This adds `upsert` clause support with `on conflict` to the sqlite dialect, as described [here](https://sqlite.org/lang_upsert.html).
Makes progress on #3872, but that still needs https://www.sqlite.org/lang_conflict.html to be implemented which requires overriding `ansi.ColumnConstraintSegment` entirely, which I'm hoping to do in another PR as in comparison this PR is relatively straightforward.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [X] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
