### PR TITLE
BigQuery: Support unimplemented alter table and view statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1760,9 +1760,13 @@ class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
         Ref("TableReferenceSegment"),
         OneOf(
             # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_set_options_statement
+            # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_collate_statement
             Sequence(
                 "SET",
-                Ref("OptionsSegment"),
+                OneOf(
+                    Ref("OptionsSegment"),
+                    Ref("DefaultCollateSegment"),
+                ),
             ),
             # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_add_column_statement
             Delimited(
@@ -1843,6 +1847,24 @@ class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
                     "COLUMN",
                     Ref("IfExistsGrammar", optional=True),
                     Ref("SingleIdentifierGrammar"),  # Column name
+                ),
+            ),
+            # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_drop_constraint_statement
+            Delimited(
+                Sequence(
+                    "DROP",
+                    "CONSTRAINT",
+                    Ref("IfExistsGrammar", optional=True),
+                    Ref("SingleIdentifierGrammar"),  # Constraint name
+                ),
+            ),
+            # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_drop_primary_key_statement
+            Delimited(
+                Sequence(
+                    "DROP",
+                    "PRIMARY",
+                    "KEY",
+                    Ref("IfExistsGrammar", optional=True),
                 ),
             ),
             # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_column_set_options_statement
@@ -2011,6 +2033,7 @@ class AlterViewStatementSegment(BaseSegment):
     """A `ALTER VIEW` statement.
 
     https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_view_set_options_statement
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_column_set_options_statement
     """
 
     type = "alter_view_statement"
@@ -2020,8 +2043,22 @@ class AlterViewStatementSegment(BaseSegment):
         "VIEW",
         Ref("IfExistsGrammar", optional=True),
         Ref("TableReferenceSegment"),
-        "SET",
-        Ref("OptionsSegment"),
+        OneOf(
+            Sequence(
+                "SET",
+                Ref("OptionsSegment"),
+            ),
+            Delimited(
+                Sequence(
+                    "ALTER",
+                    "COLUMN",
+                    Ref("IfExistsGrammar", optional=True),
+                    Ref("SingleIdentifierGrammar"),  # Column name
+                    "SET",
+                    Ref("OptionsSegment"),
+                ),
+            ),
+        ),
     )
 
 

--- a/test/fixtures/dialects/bigquery/alter_table_drop_constraint.sql
+++ b/test/fixtures/dialects/bigquery/alter_table_drop_constraint.sql
@@ -1,0 +1,5 @@
+ALTER TABLE example_dataset.example_table
+DROP CONSTRAINT x;
+
+ALTER TABLE `example-project.example_dataset.example_table`
+DROP CONSTRAINT IF EXISTS x;

--- a/test/fixtures/dialects/bigquery/alter_table_drop_constraint.yml
+++ b/test/fixtures/dialects/bigquery/alter_table_drop_constraint.yml
@@ -1,0 +1,31 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 445077d18e2a7bae420bfe4d94b8023f1f5046d052c5eba77761550fe7e63886
+file:
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_table
+    - keyword: DROP
+    - keyword: CONSTRAINT
+    - naked_identifier: x
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`example-project.example_dataset.example_table`'
+    - keyword: DROP
+    - keyword: CONSTRAINT
+    - keyword: IF
+    - keyword: EXISTS
+    - naked_identifier: x
+- statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/alter_table_drop_key.sql
+++ b/test/fixtures/dialects/bigquery/alter_table_drop_key.sql
@@ -1,0 +1,5 @@
+ALTER TABLE example_dataset.example_table
+DROP PRIMARY KEY;
+
+ALTER TABLE `example-project.example_dataset.example_table`
+DROP PRIMARY KEY IF EXISTS;

--- a/test/fixtures/dialects/bigquery/alter_table_drop_key.yml
+++ b/test/fixtures/dialects/bigquery/alter_table_drop_key.yml
@@ -1,0 +1,31 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9997aaefc952eb9b0bf6a7b4fb603e8249cd40f4563c324036c459cc56f6407f
+file:
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_table
+    - keyword: DROP
+    - keyword: PRIMARY
+    - keyword: KEY
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`example-project.example_dataset.example_table`'
+    - keyword: DROP
+    - keyword: PRIMARY
+    - keyword: KEY
+    - keyword: IF
+    - keyword: EXISTS
+- statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/alter_table_set_default_collate.sql
+++ b/test/fixtures/dialects/bigquery/alter_table_set_default_collate.sql
@@ -1,0 +1,2 @@
+ALTER TABLE example_dataset.example_table
+SET DEFAULT COLLATE "und:ci";

--- a/test/fixtures/dialects/bigquery/alter_table_set_default_collate.yml
+++ b/test/fixtures/dialects/bigquery/alter_table_set_default_collate.yml
@@ -1,0 +1,21 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 2ee9007f6e23966d7c7ec32afc2cdc3ffaa1e220b4485d1908ad5828c656ce98
+file:
+  statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_table
+    - keyword: SET
+    - default_collate:
+      - keyword: DEFAULT
+      - keyword: COLLATE
+      - quoted_literal: '"und:ci"'
+  statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/alter_view_alter_column.sql
+++ b/test/fixtures/dialects/bigquery/alter_view_alter_column.sql
@@ -1,0 +1,5 @@
+ALTER VIEW example_dataset.example_view
+ALTER COLUMN x SET OPTIONS(description="example");
+
+ALTER VIEW IF EXISTS `example-project.example_dataset.example_view`
+ALTER COLUMN IF EXISTS x SET OPTIONS(description="example");

--- a/test/fixtures/dialects/bigquery/alter_view_alter_column.yml
+++ b/test/fixtures/dialects/bigquery/alter_view_alter_column.yml
@@ -1,0 +1,53 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: c167b04f3ded45c772a70e6508643a28f1105cda17d6be72967b9e07d8ce1c97
+file:
+- statement:
+    alter_view_statement:
+    - keyword: ALTER
+    - keyword: VIEW
+    - table_reference:
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_view
+    - keyword: ALTER
+    - keyword: COLUMN
+    - naked_identifier: x
+    - keyword: SET
+    - options_segment:
+        keyword: OPTIONS
+        bracketed:
+          start_bracket: (
+          parameter: description
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: '"example"'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_view_statement:
+    - keyword: ALTER
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        quoted_identifier: '`example-project.example_dataset.example_view`'
+    - keyword: ALTER
+    - keyword: COLUMN
+    - keyword: IF
+    - keyword: EXISTS
+    - naked_identifier: x
+    - keyword: SET
+    - options_segment:
+        keyword: OPTIONS
+        bracketed:
+          start_bracket: (
+          parameter: description
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: '"example"'
+          end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

makes progress on #5789

The current BigQuery dialect does not correctly parse some `ALTER TABLE` and `ALTER VIEW` statements, so we try to fix them.

- ALTER TABLE DROP CONSTRAINT statement
  - https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_drop_constraint_statement
- ALTER TABLE DROP PRIMARY KEY statement
  - https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_drop_primary_key_statement
- ALTER TABLE SET DEFAULT COLLATE statement
  - https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_table_collate_statement
- ALTER COLUMN SET OPTIONS statement with ALTER VIEW
  - https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#alter_column_set_options_statement


### Are there any other side effects of this change that we should be aware of?

None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
