### PR TITLE
SQLite: Specialize create view with support for temporary views.

### DIFF
--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -777,10 +777,18 @@ class UpdateStatementSegment(ansi.UpdateStatementSegment):
             optional=True,
         ),
         Ref("TableReferenceSegment"),
-        # SET is not a reserved word in all dialects (e.g. RedShift)
-        # So specifically exclude as an allowed implicit alias to avoid parsing errors
-        Ref("AliasExpressionSegment", exclude=Ref.keyword("SET"), optional=True),
-        Ref("SetClauseListSegment"),
+        Ref("AliasExpressionSegment", optional=True),
+        "SET",
+        Delimited(
+            Sequence(
+                OneOf(
+                    Ref("SingleIdentifierGrammar"),
+                    Ref("BracketedColumnReferenceListGrammar"),
+                ),
+                Ref("EqualsSegment"),
+                Ref("ExpressionSegment"),
+            ),
+        ),
         Ref("FromClauseSegment", optional=True),
         Ref("WhereClauseSegment", optional=True),
         Ref("ReturningClauseSegment", optional=True),

--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -765,6 +765,17 @@ class UpdateStatementSegment(ansi.UpdateStatementSegment):
     type = "update_statement"
     match_grammar: Matchable = Sequence(
         "UPDATE",
+        Sequence(
+            "OR",
+            OneOf(
+                "ABORT",
+                "FAIL",
+                "IGNORE",
+                "REPLACE",
+                "ROLLBACK",
+            ),
+            optional=True,
+        ),
         Ref("TableReferenceSegment"),
         # SET is not a reserved word in all dialects (e.g. RedShift)
         # So specifically exclude as an allowed implicit alias to avoid parsing errors

--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -702,6 +702,24 @@ class CreateTriggerStatementSegment(ansi.CreateTriggerStatementSegment):
     )
 
 
+class CreateViewStatementSegment(BaseSegment):
+    """A `CREATE VIEW` statement."""
+
+    type = "create_view_statement"
+    # https://www.sqlite.org/lang_createview.html
+    match_grammar: Matchable = Sequence(
+        "CREATE",
+        Ref("TemporaryGrammar", optional=True),
+        "VIEW",
+        Ref("IfNotExistsGrammar", optional=True),
+        Ref("TableReferenceSegment"),
+        # Optional list of column names
+        Ref("BracketedColumnReferenceListGrammar", optional=True),
+        "AS",
+        OptionallyBracketed(Ref("SelectableGrammar")),
+    )
+
+
 class UnorderedSelectStatementSegment(BaseSegment):
     """A `SELECT` statement without any ORDER clauses or later.
 

--- a/test/fixtures/dialects/sqlite/create_trigger.yml
+++ b/test/fixtures/dialects/sqlite/create_trigger.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a6c6cd83844198daf4513a642932e69466dd2c90d887929b24e9d6577e8d120c
+_hash: d6e8c372e879f121ab751b63422e04ffdd820bed050b5dafa6f676096a9e017a
 file:
 - statement:
     create_trigger:
@@ -20,21 +20,19 @@ file:
         naked_identifier: customers
     - keyword: BEGIN
     - update_statement:
-        keyword: UPDATE
-        table_reference:
+      - keyword: UPDATE
+      - table_reference:
           naked_identifier: orders
-        set_clause_list:
-          keyword: SET
-          set_clause:
-          - column_reference:
-              naked_identifier: address
-          - comparison_operator:
-              raw_comparison_operator: '='
-          - column_reference:
-            - naked_identifier: new
-            - dot: .
-            - naked_identifier: address
-        where_clause:
+      - keyword: SET
+      - naked_identifier: address
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - expression:
+          column_reference:
+          - naked_identifier: new
+          - dot: .
+          - naked_identifier: address
+      - where_clause:
           keyword: WHERE
           expression:
           - column_reference:
@@ -65,21 +63,19 @@ file:
         naked_identifier: customer_address
     - keyword: BEGIN
     - update_statement:
-        keyword: UPDATE
-        table_reference:
+      - keyword: UPDATE
+      - table_reference:
           naked_identifier: customer
-        set_clause_list:
-          keyword: SET
-          set_clause:
-          - column_reference:
-              naked_identifier: cust_addr
-          - comparison_operator:
-              raw_comparison_operator: '='
-          - column_reference:
-            - naked_identifier: NEW
-            - dot: .
-            - naked_identifier: cust_addr
-        where_clause:
+      - keyword: SET
+      - naked_identifier: cust_addr
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - expression:
+          column_reference:
+          - naked_identifier: NEW
+          - dot: .
+          - naked_identifier: cust_addr
+      - where_clause:
           keyword: WHERE
           expression:
           - column_reference:

--- a/test/fixtures/dialects/sqlite/create_view.sql
+++ b/test/fixtures/dialects/sqlite/create_view.sql
@@ -1,0 +1,11 @@
+CREATE TEMPORARY VIEW IF NOT EXISTS temp_table AS
+SELECT * FROM tab
+WHERE col = 'value';
+
+
+CREATE VIEW Test.Data (id, name, age)
+AS
+SELECT id, name, age
+FROM temp_table
+WHERE age > 18
+AND name = 'John';

--- a/test/fixtures/dialects/sqlite/create_view.yml
+++ b/test/fixtures/dialects/sqlite/create_view.yml
@@ -1,0 +1,97 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e9c58f578649c26507df6eeeec6dd6ff15e1bb7b03cefd4ba99f2383023d680e
+file:
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: TEMPORARY
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: temp_table
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tab
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: col
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'value'"
+- statement_terminator: ;
+- statement:
+    create_view_statement:
+    - keyword: CREATE
+    - keyword: VIEW
+    - table_reference:
+      - naked_identifier: Test
+      - dot: .
+      - naked_identifier: Data
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: id
+      - comma: ','
+      - column_reference:
+          naked_identifier: name
+      - comma: ','
+      - column_reference:
+          naked_identifier: age
+      - end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: age
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: temp_table
+        where_clause:
+          keyword: WHERE
+          expression:
+          - column_reference:
+              naked_identifier: age
+          - comparison_operator:
+              raw_comparison_operator: '>'
+          - numeric_literal: '18'
+          - binary_operator: AND
+          - column_reference:
+              naked_identifier: name
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - quoted_literal: "'John'"
+- statement_terminator: ;

--- a/test/fixtures/dialects/sqlite/update.sql
+++ b/test/fixtures/dialects/sqlite/update.sql
@@ -13,3 +13,5 @@ UPDATE OR FAIL table_name SET column1 = value1, column2 = value2 WHERE a=1;
 UPDATE OR REPLACE table_name SET column1 = value1, column2 = value2 WHERE a=1;
 
 UPDATE OR ROLLBACK table_name SET column1 = value1, column2 = value2 WHERE a=1;
+
+UPDATE table_name SET (context, country) = (SELECT context, country FROM Nations);

--- a/test/fixtures/dialects/sqlite/update.sql
+++ b/test/fixtures/dialects/sqlite/update.sql
@@ -3,3 +3,13 @@ UPDATE table_name SET column1 = value1, column2 = value2 WHERE a=1;
 UPDATE table_name SET column1 = value1, column2 = value2 WHERE a=1 RETURNING *;
 
 UPDATE table_name SET column1 = value1, column2 = value2 WHERE a=1 RETURNING id foo, id_2 AS bar;
+
+UPDATE OR IGNORE table_name SET column1 = value1, column2 = value2 WHERE a=1;
+
+UPDATE OR ABORT table_name SET column1 = value1, column2 = value2 WHERE a=1;
+
+UPDATE OR FAIL table_name SET column1 = value1, column2 = value2 WHERE a=1;
+
+UPDATE OR REPLACE table_name SET column1 = value1, column2 = value2 WHERE a=1;
+
+UPDATE OR ROLLBACK table_name SET column1 = value1, column2 = value2 WHERE a=1;

--- a/test/fixtures/dialects/sqlite/update.yml
+++ b/test/fixtures/dialects/sqlite/update.yml
@@ -3,31 +3,28 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a67271c01489077e2dc69e06e43d808f65bffd15decc4dc631f1b876343d73ed
+_hash: 3f382641c211d3e442174e8d53fadb4ed7ca713b0a59897392f15668a846bc2d
 file:
 - statement:
     update_statement:
-      keyword: UPDATE
-      table_reference:
+    - keyword: UPDATE
+    - table_reference:
         naked_identifier: table_name
-      set_clause_list:
-      - keyword: SET
-      - set_clause:
-        - column_reference:
-            naked_identifier: column1
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value1
-      - comma: ','
-      - set_clause:
-        - column_reference:
-            naked_identifier: column2
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value2
-      where_clause:
+    - keyword: SET
+    - naked_identifier: column1
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value1
+    - comma: ','
+    - naked_identifier: column2
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value2
+    - where_clause:
         keyword: WHERE
         expression:
           column_reference:
@@ -38,27 +35,24 @@ file:
 - statement_terminator: ;
 - statement:
     update_statement:
-      keyword: UPDATE
-      table_reference:
+    - keyword: UPDATE
+    - table_reference:
         naked_identifier: table_name
-      set_clause_list:
-      - keyword: SET
-      - set_clause:
-        - column_reference:
-            naked_identifier: column1
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value1
-      - comma: ','
-      - set_clause:
-        - column_reference:
-            naked_identifier: column2
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value2
-      where_clause:
+    - keyword: SET
+    - naked_identifier: column1
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value1
+    - comma: ','
+    - naked_identifier: column2
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value2
+    - where_clause:
         keyword: WHERE
         expression:
           column_reference:
@@ -66,7 +60,7 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           numeric_literal: '1'
-      returning_clause:
+    - returning_clause:
         keyword: RETURNING
         wildcard_expression:
           wildcard_identifier:
@@ -74,27 +68,24 @@ file:
 - statement_terminator: ;
 - statement:
     update_statement:
-      keyword: UPDATE
-      table_reference:
+    - keyword: UPDATE
+    - table_reference:
         naked_identifier: table_name
-      set_clause_list:
-      - keyword: SET
-      - set_clause:
-        - column_reference:
-            naked_identifier: column1
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value1
-      - comma: ','
-      - set_clause:
-        - column_reference:
-            naked_identifier: column2
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value2
-      where_clause:
+    - keyword: SET
+    - naked_identifier: column1
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value1
+    - comma: ','
+    - naked_identifier: column2
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value2
+    - where_clause:
         keyword: WHERE
         expression:
           column_reference:
@@ -102,7 +93,7 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           numeric_literal: '1'
-      returning_clause:
+    - returning_clause:
       - keyword: RETURNING
       - expression:
           column_reference:
@@ -124,23 +115,20 @@ file:
     - keyword: IGNORE
     - table_reference:
         naked_identifier: table_name
-    - set_clause_list:
-      - keyword: SET
-      - set_clause:
-        - column_reference:
-            naked_identifier: column1
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value1
-      - comma: ','
-      - set_clause:
-        - column_reference:
-            naked_identifier: column2
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value2
+    - keyword: SET
+    - naked_identifier: column1
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value1
+    - comma: ','
+    - naked_identifier: column2
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value2
     - where_clause:
         keyword: WHERE
         expression:
@@ -157,23 +145,20 @@ file:
     - keyword: ABORT
     - table_reference:
         naked_identifier: table_name
-    - set_clause_list:
-      - keyword: SET
-      - set_clause:
-        - column_reference:
-            naked_identifier: column1
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value1
-      - comma: ','
-      - set_clause:
-        - column_reference:
-            naked_identifier: column2
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value2
+    - keyword: SET
+    - naked_identifier: column1
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value1
+    - comma: ','
+    - naked_identifier: column2
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value2
     - where_clause:
         keyword: WHERE
         expression:
@@ -190,23 +175,20 @@ file:
     - keyword: FAIL
     - table_reference:
         naked_identifier: table_name
-    - set_clause_list:
-      - keyword: SET
-      - set_clause:
-        - column_reference:
-            naked_identifier: column1
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value1
-      - comma: ','
-      - set_clause:
-        - column_reference:
-            naked_identifier: column2
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value2
+    - keyword: SET
+    - naked_identifier: column1
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value1
+    - comma: ','
+    - naked_identifier: column2
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value2
     - where_clause:
         keyword: WHERE
         expression:
@@ -223,23 +205,20 @@ file:
     - keyword: REPLACE
     - table_reference:
         naked_identifier: table_name
-    - set_clause_list:
-      - keyword: SET
-      - set_clause:
-        - column_reference:
-            naked_identifier: column1
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value1
-      - comma: ','
-      - set_clause:
-        - column_reference:
-            naked_identifier: column2
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value2
+    - keyword: SET
+    - naked_identifier: column1
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value1
+    - comma: ','
+    - naked_identifier: column2
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value2
     - where_clause:
         keyword: WHERE
         expression:
@@ -256,23 +235,20 @@ file:
     - keyword: ROLLBACK
     - table_reference:
         naked_identifier: table_name
-    - set_clause_list:
-      - keyword: SET
-      - set_clause:
-        - column_reference:
-            naked_identifier: column1
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value1
-      - comma: ','
-      - set_clause:
-        - column_reference:
-            naked_identifier: column2
-        - comparison_operator:
-            raw_comparison_operator: '='
-        - column_reference:
-            naked_identifier: value2
+    - keyword: SET
+    - naked_identifier: column1
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value1
+    - comma: ','
+    - naked_identifier: column2
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        column_reference:
+          naked_identifier: value2
     - where_clause:
         keyword: WHERE
         expression:
@@ -281,4 +257,42 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    update_statement:
+    - keyword: UPDATE
+    - table_reference:
+        naked_identifier: table_name
+    - keyword: SET
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: context
+      - comma: ','
+      - column_reference:
+          naked_identifier: country
+      - end_bracket: )
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - expression:
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: context
+            - comma: ','
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: country
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: Nations
+          end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/sqlite/update.yml
+++ b/test/fixtures/dialects/sqlite/update.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ae5a79c638d3c45f8d9c1f249cb7f74c6bb5e70786f1b26407e8894e6e77d7ba
+_hash: a67271c01489077e2dc69e06e43d808f65bffd15decc4dc631f1b876343d73ed
 file:
 - statement:
     update_statement:
@@ -116,4 +116,169 @@ file:
       - alias_expression:
           keyword: AS
           naked_identifier: bar
+- statement_terminator: ;
+- statement:
+    update_statement:
+    - keyword: UPDATE
+    - keyword: OR
+    - keyword: IGNORE
+    - table_reference:
+        naked_identifier: table_name
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+        - column_reference:
+            naked_identifier: column1
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+            naked_identifier: value1
+      - comma: ','
+      - set_clause:
+        - column_reference:
+            naked_identifier: column2
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+            naked_identifier: value2
+    - where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    update_statement:
+    - keyword: UPDATE
+    - keyword: OR
+    - keyword: ABORT
+    - table_reference:
+        naked_identifier: table_name
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+        - column_reference:
+            naked_identifier: column1
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+            naked_identifier: value1
+      - comma: ','
+      - set_clause:
+        - column_reference:
+            naked_identifier: column2
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+            naked_identifier: value2
+    - where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    update_statement:
+    - keyword: UPDATE
+    - keyword: OR
+    - keyword: FAIL
+    - table_reference:
+        naked_identifier: table_name
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+        - column_reference:
+            naked_identifier: column1
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+            naked_identifier: value1
+      - comma: ','
+      - set_clause:
+        - column_reference:
+            naked_identifier: column2
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+            naked_identifier: value2
+    - where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    update_statement:
+    - keyword: UPDATE
+    - keyword: OR
+    - keyword: REPLACE
+    - table_reference:
+        naked_identifier: table_name
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+        - column_reference:
+            naked_identifier: column1
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+            naked_identifier: value1
+      - comma: ','
+      - set_clause:
+        - column_reference:
+            naked_identifier: column2
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+            naked_identifier: value2
+    - where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    update_statement:
+    - keyword: UPDATE
+    - keyword: OR
+    - keyword: ROLLBACK
+    - table_reference:
+        naked_identifier: table_name
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+        - column_reference:
+            naked_identifier: column1
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+            naked_identifier: value1
+      - comma: ','
+      - set_clause:
+        - column_reference:
+            naked_identifier: column2
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+            naked_identifier: value2
+    - where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: a
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
* Support SQLite specific create view (https://www.sqlite.org/lang_createview.html)
* Add OR clause to UPDATE as per https://www.sqlite.org/lang_update.html
* Support column-name-list in update https://www.sqlite.org/lang_update.html


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
