### PR TITLE
Clarify docs around subdir handling when loading macros

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -595,31 +595,31 @@ loaded from files or folders. This is specified in the config file:
 .. code-block:: cfg
 
     [sqlfluff:templater:jinja]
-    load_macros_from_path = my_macros
+    load_macros_from_path = my_macros,other_macros
 
 ``load_macros_from_path`` is a comma-separated list of :code:`.sql` files or
 folders. Locations are *relative to the config file*. For example, if the
 config file above was found at :code:`/home/my_project/.sqlfluff`, then
-SQLFluff will look for macros in the folder :code:`/home/my_project/my_macros/`
-(but not subfolders). Any macros defined in the config will always take
-precedence over a macro defined in the path.
+SQLFluff will look for macros in the folders :code:`/home/my_project/my_macros/`
+and  :code:`/home/my_project/other_macros/`, including any of their subfolders.
+Any macros defined in the config will always take precedence over a macro
+defined in the path.
 
-* :code:`.sql` files: Macros in these files are available in every :code:`.sql`
-  file without requiring a Jinja :code:`include` or :code:`import`.
-* Folders: To use macros from the :code:`.sql` files in folders, use Jinja
-  :code:`include` or :code:`import` as explained below.
+Macros loaded from these files are available in every :code:`.sql` file without
+requiring a Jinja :code:`include` or :code:`import`.  They are loaded into the
+`Jinja Global Namespace <https://jinja.palletsprojects.com/en/3.1.x/api/#global-namespace>`_.
 
 **Note:** The :code:`load_macros_from_path` setting also defines the search
 path for Jinja
-`include <https://jinja.palletsprojects.com/en/3.0.x/templates/#include>`_ or
-`import <https://jinja.palletsprojects.com/en/3.0.x/templates/#import>`_.
-Unlike with macros (as noted above), subdirectories are supported. For example,
+`include <https://jinja.palletsprojects.com/en/3.1.x/templates/#include>`_ or
+`import <https://jinja.palletsprojects.com/en/3.1.x/templates/#import>`_.
+As with loaded macros, subdirectories are also supported. For example,
 if :code:`load_macros_from_path` is set to :code:`my_macros`, and there is a
 file :code:`my_macros/subdir/my_file.sql`, you can do:
 
 .. code-block:: jinja
 
-   {% include 'subdir/include_comment.sql' %}
+   {% include 'subdir/my_file.sql' %}
 
 .. note::
 
@@ -798,7 +798,7 @@ mixture of several types:
 * ``str``
 * ``int``
 * ``list``
-* Jinja's ``Undefined`` `class <https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.Undefined>`_
+* Jinja's ``Undefined`` `class <https://jinja.palletsprojects.com/en/3.1.x/api/#jinja2.Undefined>`_
 
 Because the values behave like ``Undefined``, it's possible to replace them
 using Jinja's ``default()`` `filter <https://jinja.palletsprojects.com/en/3.1.x/templates/#jinja-filters.default>`_.

--- a/test/fixtures/templater/jinja_q_multiple_path_macros/even_more_macros/subdir/subdir_foo.sql
+++ b/test/fixtures/templater/jinja_q_multiple_path_macros/even_more_macros/subdir/subdir_foo.sql
@@ -1,0 +1,1 @@
+{%- macro foo4() -%}104{%- endmacro -%}

--- a/test/fixtures/templater/jinja_q_multiple_path_macros/jinja.sql
+++ b/test/fixtures/templater/jinja_q_multiple_path_macros/jinja.sql
@@ -1,5 +1,6 @@
 select
     {{ foo1() }},
     {{ foo2() }},
-    {{ foo3() }}
+    {{ foo3() }},
+    {{ foo4() }}
 from my_table

--- a/test/fixtures/templater/jinja_q_multiple_path_macros/jinja.yml
+++ b/test/fixtures/templater/jinja_q_multiple_path_macros/jinja.yml
@@ -11,6 +11,9 @@ file:
       - comma: ','
       - select_clause_element:
           numeric_literal: '103'
+      - comma: ','
+      - select_clause_element:
+          numeric_literal: '104'
       from_clause:
         keyword: from
         from_expression:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

The documentation erroneously states that SQLFluff will not look in subfolders when loading macros using the load_macros_from_path config. This is not actually the case: the JinjaTemplater._extract_macros_from_path function will recursively search subdirectories, and load those macros into the Jinja global namespace as well:

https://github.com/sqlfluff/sqlfluff/blob/06b22f56a89043683915886a63d19aa34a4f63ec/src/sqlfluff/core/templaters/jinja.py#L169-L177

This commit does the following:

1.  Amends one of the existing test cases to demonstrate that macros can be loaded from subdirectories.  No obvious existing test case seemed to meaningfully cover this scenario.

2.  Updates the documentation to state that subdirectories will be searched as well.

There is no actual change in behavior of the product.  To the end user, this is a doc correction.

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
