### PR TITLE
Add loader_search_path setting to Jinja templater

### DIFF
--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -395,7 +395,10 @@ class ConfigLoader:
                 v = coerce_value(val)
 
                 # Attempt to resolve paths
-                if name.lower() == "load_macros_from_path":
+                if (
+                    name.lower() == "load_macros_from_path"
+                    or name.lower() == "loader_search_path"
+                ):
                     # Comma-separated list of paths.
                     paths = split_comma_separated_string(val)
                     v_temp = []

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -740,6 +740,8 @@ def assert_structure(yaml_loader, path, code_only=True, include_meta=False):
         # Load all the macros
         ("jinja_q_multiple_path_macros/jinja", True, False),
         ("jinja_s_filters_in_library/jinja", True, False),
+        # Jinja loader search path, without also loading macros into global namespace
+        ("jinja_t_loader_search_path/jinja", True, False),
     ],
 )
 def test__templater_full(subpath, code_only, include_meta, yaml_loader, caplog):

--- a/test/fixtures/templater/jinja_t_loader_search_path/.sqlfluff
+++ b/test/fixtures/templater/jinja_t_loader_search_path/.sqlfluff
@@ -1,0 +1,3 @@
+[sqlfluff:templater:jinja]
+load_macros_from_path=macro_load
+loader_search_path=search_a,search_b

--- a/test/fixtures/templater/jinja_t_loader_search_path/jinja.sql
+++ b/test/fixtures/templater/jinja_t_loader_search_path/jinja.sql
@@ -1,0 +1,15 @@
+{% import 'search_a.sql' as search_a_pkg %}
+{% import 'subdir/search_a_subdir.sql' as search_a_subdir_pkg %}
+{% import 'search_b.sql' as search_b_pkg %}
+
+select
+    -- the second expression on each line should evaluate to nothing,
+    -- since these macros are not loaded into the global namespace.
+    {{ search_a_pkg.search_a() }} {{ search_a() }},
+    {{ search_a_subdir_pkg.search_a_subdir() }} {{ search_a_subdir() }},
+    {{ search_b_pkg.search_b() }} {{ search_b() }},
+
+    -- these are still being loaded from the global namespace
+    {{ macro_load() }},
+    {{ macro_load_subdir() }}
+from my_table

--- a/test/fixtures/templater/jinja_t_loader_search_path/jinja.yml
+++ b/test/fixtures/templater/jinja_t_loader_search_path/jinja.yml
@@ -1,0 +1,26 @@
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: select
+      - select_clause_element:
+          quoted_literal: "'search_a'"
+      - comma: ','
+      - select_clause_element:
+          quoted_literal: "'search_a_subdir'"
+      - comma: ','
+      - select_clause_element:
+          quoted_literal: "'search_b'"
+      - comma: ','
+      - select_clause_element:
+          quoted_literal: "'macro_load'"
+      - comma: ','
+      - select_clause_element:
+          quoted_literal: "'macro_load_subdir'"
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table

--- a/test/fixtures/templater/jinja_t_loader_search_path/macro_load/macro_load.sql
+++ b/test/fixtures/templater/jinja_t_loader_search_path/macro_load/macro_load.sql
@@ -1,0 +1,1 @@
+{%- macro macro_load() -%}'macro_load'{%- endmacro -%}

--- a/test/fixtures/templater/jinja_t_loader_search_path/macro_load/subdir/macro_load_subdir.sql
+++ b/test/fixtures/templater/jinja_t_loader_search_path/macro_load/subdir/macro_load_subdir.sql
@@ -1,0 +1,1 @@
+{%- macro macro_load_subdir() -%}'macro_load_subdir'{%- endmacro -%}

--- a/test/fixtures/templater/jinja_t_loader_search_path/search_a/search_a.sql
+++ b/test/fixtures/templater/jinja_t_loader_search_path/search_a/search_a.sql
@@ -1,0 +1,1 @@
+{%- macro search_a() -%}'search_a'{%- endmacro -%}

--- a/test/fixtures/templater/jinja_t_loader_search_path/search_a/subdir/search_a_subdir.sql
+++ b/test/fixtures/templater/jinja_t_loader_search_path/search_a/subdir/search_a_subdir.sql
@@ -1,0 +1,1 @@
+{%- macro search_a_subdir() -%}'search_a_subdir'{%- endmacro -%}

--- a/test/fixtures/templater/jinja_t_loader_search_path/search_b/search_b.sql
+++ b/test/fixtures/templater/jinja_t_loader_search_path/search_b/search_b.sql
@@ -1,0 +1,1 @@
+{%- macro search_b() -%}'search_b'{%- endmacro -%}


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Currently, in order to include a folder in the Jinja loader search path, one must specify it using the load_macros_from_path setting.  However, this setting carries a side effect, which may be unwanted in some scenarios: it will also load every single file in that directory (which is slow), and loads those macros into the global namespace (which may not be an accurate representation of the end-user application behavior). There is currently no option to avoid this additional behavior.

This commit adds a new loader_search_path setting, which is a simple way of specifying the Jinja loader's search path.  The behavior of the existing load_macros_from_path setting remains unchanged.  If both options are set, all directories are merged and included in the Jinja loader search path.

Further details of the change can be found in the updated documentation.

Fixes #4699 

<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?

None, this should be completely backwards compatible.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
