### PR TITLE
T-SQL: Parameter assignment in SELECT vs alias

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -767,7 +767,9 @@ class AltAliasExpressionSegment(BaseSegment):
     type = "alias_expression"
     match_grammar = Sequence(
         OneOf(
-            Ref("SingleIdentifierGrammar"),
+            Ref("NakedIdentifierSegment"),
+            Ref("QuotedIdentifierSegment"),
+            Ref("BracketedIdentifierSegment"),
             Ref("SingleQuotedIdentifierSegment"),
         ),
         Ref("RawEqualsSegment"),

--- a/test/fixtures/dialects/tsql/create_function.yml
+++ b/test/fixtures/dialects/tsql/create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9ded27ea23a5a527e9a235ea24249e64b61d4711444cf4b648973734d3618169
+_hash: d8612863b373b7f10674220eca8fc92b453d187f6950759466a87071fba57e41
 file:
 - batch:
     statement:
@@ -436,13 +436,13 @@ file:
                   select_clause:
                     keyword: SELECT
                     select_clause_element:
-                      alias_expression:
-                        parameter: '@str'
-                        raw_comparison_operator: '='
                       expression:
-                        parameter: '@str'
-                        binary_operator: +
-                        column_reference:
+                      - parameter: '@str'
+                      - comparison_operator:
+                          raw_comparison_operator: '='
+                      - parameter: '@str'
+                      - binary_operator: +
+                      - column_reference:
                           quoted_identifier: '[item]'
                   from_clause:
                     keyword: FROM

--- a/test/fixtures/dialects/tsql/select_assign_parameter.sql
+++ b/test/fixtures/dialects/tsql/select_assign_parameter.sql
@@ -1,0 +1,11 @@
+select userid = c.id
+from
+	mydb.myschema.customer c
+where
+	c.name = 'drjwelch';
+
+select @userid_parameter = c.id
+from
+	mydb.myschema.customer c
+where
+	c.name = 'drjwelch';

--- a/test/fixtures/dialects/tsql/select_assign_parameter.yml
+++ b/test/fixtures/dialects/tsql/select_assign_parameter.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 999979dd7d906ba9e9bccc79bece1b8bbd07d2c0c35d8cccb376ae3bab452495
+_hash: f68e7dca9031c7e4c03e06b79a621336421c3716702697fa092af9aef5f274b5
 file:
   batch:
   - statement:
@@ -47,13 +47,14 @@ file:
         select_clause:
           keyword: select
           select_clause_element:
-            alias_expression:
+            expression:
               parameter: '@userid_parameter'
-              raw_comparison_operator: '='
-            column_reference:
-            - naked_identifier: c
-            - dot: .
-            - naked_identifier: id
+              comparison_operator:
+                raw_comparison_operator: '='
+              column_reference:
+              - naked_identifier: c
+              - dot: .
+              - naked_identifier: id
         from_clause:
           keyword: from
           from_expression:

--- a/test/fixtures/dialects/tsql/select_assign_parameter.yml
+++ b/test/fixtures/dialects/tsql/select_assign_parameter.yml
@@ -1,0 +1,80 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 999979dd7d906ba9e9bccc79bece1b8bbd07d2c0c35d8cccb376ae3bab452495
+file:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            alias_expression:
+              naked_identifier: userid
+              raw_comparison_operator: '='
+            column_reference:
+            - naked_identifier: c
+            - dot: .
+            - naked_identifier: id
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: mydb
+                - dot: .
+                - naked_identifier: myschema
+                - dot: .
+                - naked_identifier: customer
+              alias_expression:
+                naked_identifier: c
+        where_clause:
+          keyword: where
+          expression:
+            column_reference:
+            - naked_identifier: c
+            - dot: .
+            - naked_identifier: name
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'drjwelch'"
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            alias_expression:
+              parameter: '@userid_parameter'
+              raw_comparison_operator: '='
+            column_reference:
+            - naked_identifier: c
+            - dot: .
+            - naked_identifier: id
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: mydb
+                - dot: .
+                - naked_identifier: myschema
+                - dot: .
+                - naked_identifier: customer
+              alias_expression:
+                naked_identifier: c
+        where_clause:
+          keyword: where
+          expression:
+            column_reference:
+            - naked_identifier: c
+            - dot: .
+            - naked_identifier: name
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'drjwelch'"
+        statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #5678 

`AltAliasExpressionSegment` can be matched by `ParameterNameSegment` (i.e. a SELECT projection that looks like `@myparam = mycolumn`). Test AT09 tries to obtain `alias_identifier` from this segment, but it only looks for `naked_identifier` or `quoted_identifier` types and `ParameterNameSegment` is of type `parameter`. There are no matches and the resulting `alias_identifier` is `None` and fails the the assertion.

### Are there any other side effects of this change that we should be aware of?
Statement was wrongly classified and linted as an alias; this change fixes that without any other side effect. All tests pass.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`. **N/A**
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`). **YES**
  - Full autofix test cases in `test/fixtures/linter/autofix`. **N/A**
  - Other.
- Added appropriate documentation for the change.  **N/A - but have commented on issue**
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
