### PR TITLE
Exasol: add REGEXP_LIKE

### DIFF
--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -235,7 +235,7 @@ exasol_dialect.replace(
         CodeSegment,
         type="parameter",
     ),
-    LikeGrammar=Ref.keyword("LIKE"),
+    LikeGrammar=OneOf("LIKE", "REGEXP_LIKE"),
     NanLiteralSegment=Nothing(),
     SelectClauseTerminatorGrammar=OneOf(
         "FROM",

--- a/test/fixtures/dialects/exasol/select_statement.sql
+++ b/test/fixtures/dialects/exasol/select_statement.sql
@@ -146,3 +146,15 @@ SELECT v,
        DATE'2020-10-26' + v * INTERVAL'7'DAY AS late_2020_mondays,
        5 * v AS five_times_table
 FROM VALUES BETWEEN 1 AND 9 AS v(v);
+--
+SELECT 'abcd' LIKE 'a_d' AS res1, '%bcd' like '%%d' AS res2;
+--
+SELECT 'abcd' NOT LIKE 'a_d' AS res1, '%bcd' like '%%d' AS res2;
+--
+SELECT 'My mail address is my_mail@exasol.com'
+       REGEXP_LIKE '(?i).*[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}.*'
+       AS contains_email;
+--
+SELECT 'My mail address is my_mail@exasol.com'
+       NOT REGEXP_LIKE '(?i).*[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}.*'
+       AS contains_email;

--- a/test/fixtures/dialects/exasol/select_statement.yml
+++ b/test/fixtures/dialects/exasol/select_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: db5ec62e466fde8b17b5e49d240ef94c936848af9ed48ce964bb3663a0204256
+_hash: 1b5fd3bd0d3c91581cd2ee9f167c2a4607a98296c43717424aa44d4dba77243f
 file:
 - statement:
     select_statement:
@@ -1796,4 +1796,76 @@ file:
                 identifier_list:
                   naked_identifier: v
                 end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+          - quoted_literal: "'abcd'"
+          - keyword: LIKE
+          - quoted_literal: "'a_d'"
+          alias_expression:
+            keyword: AS
+            naked_identifier: res1
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - quoted_literal: "'%bcd'"
+          - keyword: like
+          - quoted_literal: "'%%d'"
+          alias_expression:
+            keyword: AS
+            naked_identifier: res2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+          - quoted_literal: "'abcd'"
+          - keyword: NOT
+          - keyword: LIKE
+          - quoted_literal: "'a_d'"
+          alias_expression:
+            keyword: AS
+            naked_identifier: res1
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - quoted_literal: "'%bcd'"
+          - keyword: like
+          - quoted_literal: "'%%d'"
+          alias_expression:
+            keyword: AS
+            naked_identifier: res2
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - quoted_literal: "'My mail address is my_mail@exasol.com'"
+          - keyword: REGEXP_LIKE
+          - quoted_literal: "'(?i).*[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,4}.*'"
+          alias_expression:
+            keyword: AS
+            naked_identifier: contains_email
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - quoted_literal: "'My mail address is my_mail@exasol.com'"
+          - keyword: NOT
+          - keyword: REGEXP_LIKE
+          - quoted_literal: "'(?i).*[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,4}.*'"
+          alias_expression:
+            keyword: AS
+            naked_identifier: contains_email
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Add support for REGEXP_LIKE 
https://docs.exasol.com/db/latest/sql_references/predicates/not_regexp_like.htm

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
