### PR TITLE
Add support for custom JinjaTracer implementations

### DIFF
--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -456,7 +456,7 @@ class JinjaTemplater(PythonTemplater):
         Derived classes can provide their own analyzers (e.g. to support custom Jinja
         tags).
         """
-        return JinjaAnalyzer(raw_str, env)
+        return JinjaAnalyzer(raw_str, env, config)
 
     def _apply_dbt_builtins(self, config: FluffConfig) -> bool:
         """Check if dbt builtins should be applied from the provided config object.

--- a/src/sqlfluff/core/templaters/slicers/tracer.py
+++ b/src/sqlfluff/core/templaters/slicers/tracer.py
@@ -14,7 +14,6 @@ import regex
 from jinja2 import Environment
 from jinja2.exceptions import TemplateSyntaxError
 
-from sqlfluff.core.config import FluffConfig
 from sqlfluff.core.templaters.base import RawFileSlice, TemplatedFileSlice
 
 # Instantiate the templater logger
@@ -52,7 +51,6 @@ class JinjaTracer:
         raw_slice_info: Dict[RawFileSlice, RawSliceInfo],
         sliced_file: List[TemplatedFileSlice],
         render_func: Callable[[str], str],
-        config: Optional[FluffConfig] = None,
     ):
         # Input
         self.raw_str = raw_str
@@ -264,13 +262,10 @@ class JinjaAnalyzer:
     re_open_tag = regex.compile(r"^\s*({[{%])[\+\-]?\s*")
     re_close_tag = regex.compile(r"\s*[\+\-]?([}%]})\s*$")
 
-    def __init__(
-        self, raw_str: str, env: Environment, config: Optional[FluffConfig]
-    ) -> None:
+    def __init__(self, raw_str: str, env: Environment) -> None:
         # Input
         self.raw_str: str = raw_str
         self.env = env
-        self.config = config
 
         # Output
         self.raw_sliced: List[RawFileSlice] = []
@@ -404,14 +399,13 @@ class JinjaAnalyzer:
         raw_slice_info: Dict[RawFileSlice, RawSliceInfo],
         sliced_file: List[TemplatedFileSlice],
         render_func: Callable[[str], str],
-        config: Optional[FluffConfig] = None,
     ) -> JinjaTracer:
         """Creates a new object derived from JinjaTracer.
 
         Derived classes can provide their own tracers with custom functionality.
         """
         return JinjaTracer(
-            raw_str, raw_sliced, raw_slice_info, sliced_file, render_func, config
+            raw_str, raw_sliced, raw_slice_info, sliced_file, render_func
         )
 
     def next_slice_id(self) -> str:
@@ -669,7 +663,6 @@ class JinjaAnalyzer:
             self.raw_slice_info,
             self.sliced_file,
             render_func,
-            self.config,
         )
 
     def track_templated(

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -992,7 +992,7 @@ def test__templater_jinja_slice_template(test, result, analyzer_class):
     templater = JinjaTemplater()
     env, _, render_func = templater.construct_render_func()
 
-    analyzer = analyzer_class(test, env)
+    analyzer = analyzer_class(test, env, FluffConfig(overrides={"dialect": "ansi"}))
     analyzer.analyze(render_func=render_func)
     resp = analyzer.raw_sliced
     # check contiguous (unless there's a comment in it)
@@ -1048,7 +1048,7 @@ class DerivedJinjaTemplater(JinjaTemplater):
     def _get_jinja_analyzer(
         self, raw_str: str, env: Environment, config: Optional[FluffConfig] = None
     ) -> JinjaAnalyzer:
-        return DerivedJinjaAnalyzer(raw_str, env)
+        return DerivedJinjaAnalyzer(raw_str, env, config)
 
 
 def _statement(*args, **kwargs):

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -9,7 +9,7 @@ loops and placeholders.
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import List, NamedTuple, Optional, Union
+from typing import List, NamedTuple, Union
 
 import pytest
 from jinja2 import Environment, nodes
@@ -992,7 +992,7 @@ def test__templater_jinja_slice_template(test, result, analyzer_class):
     templater = JinjaTemplater()
     env, _, render_func = templater.construct_render_func()
 
-    analyzer = analyzer_class(test, env, FluffConfig(overrides={"dialect": "ansi"}))
+    analyzer = analyzer_class(test, env)
     analyzer.analyze(render_func=render_func)
     resp = analyzer.raw_sliced
     # check contiguous (unless there's a comment in it)
@@ -1045,10 +1045,8 @@ class DerivedJinjaTemplater(JinjaTemplater):
         env.add_extension(DBMigrationExtension)
         return env
 
-    def _get_jinja_analyzer(
-        self, raw_str: str, env: Environment, config: Optional[FluffConfig] = None
-    ) -> JinjaAnalyzer:
-        return DerivedJinjaAnalyzer(raw_str, env, config)
+    def _get_jinja_analyzer(self, raw_str: str, env: Environment) -> JinjaAnalyzer:
+        return DerivedJinjaAnalyzer(raw_str, env)
 
 
 def _statement(*args, **kwargs):


### PR DESCRIPTION


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Currently, the JinjaAnalyzer implementation will directly construct an instance of JinjaTracer, making it difficult for users providing a derived JinjaAnalyzer to also have it return a derived JinjaTracer.

By moving the construction of JinjaTracer to a separate function, it is easy for plugin authors to override this function and provide their own tracer.

This approach is very similar to the one taken for allowing custom JinjaAnalyzer implementations in pull request #5543.


### Are there any other side effects of this change that we should be aware of?

No.  This is a small refactor that makes it easier to write derived classes.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
