### PR TITLE
Don't indent invisible template slices

### DIFF
--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -825,7 +825,17 @@ def _crawl_indent_points(
 
             # Is the next element a comment? If so - delay the decision until we've
             # got any indents from after the comment too.
-            if "comment" in elements[idx + 1].class_types:
+            #
+            # Also, some templaters might insert custom marker slices that are of zero
+            # source string length as a way of marking locations in the middle of
+            # templated output.  These don't correspond to real source code, so we
+            # can't meaningfully indent before them.  We can safely handle them similar
+            # to the comment case.
+            if "comment" in elements[idx + 1].class_types or (
+                "placeholder" in elements[idx + 1].class_types
+                and cast(TemplateSegment, elements[idx + 1].segments[0]).source_str
+                == ""
+            ):
                 cached_indent_stats = indent_stats
                 # Create parts of a point to use later.
                 cached_point = indent_point

--- a/test/utils/reflow/reindent_test.py
+++ b/test/utils/reflow/reindent_test.py
@@ -7,11 +7,18 @@ Specifically:
 """
 
 import logging
+import sys
+from typing import Callable, List, Tuple, Type
 
 import pytest
 
-from sqlfluff.core import Linter
+from sqlfluff.core import FluffConfig, Linter
 from sqlfluff.core.linter.fix import apply_fixes, compute_anchor_edit_info
+from sqlfluff.core.plugin import hookimpl
+from sqlfluff.core.plugin.host import get_plugin_manager, purge_plugin_manager
+from sqlfluff.core.templaters import RawTemplater
+from sqlfluff.core.templaters.base import RawFileSlice, TemplatedFileSlice
+from sqlfluff.core.templaters.jinja import JinjaTemplater
 from sqlfluff.utils.reflow.helpers import deduce_line_indent, fixes_from_results
 from sqlfluff.utils.reflow.reindent import (
     _crawl_indent_points,
@@ -26,6 +33,49 @@ def parse_ansi_string(sql, config):
     """Parse an ansi sql string for testing."""
     linter = Linter(config=config)
     return linter.parse_string(sql).tree
+
+
+class SpecialMarkerInserter(JinjaTemplater):
+    """Inserts special marker slices in a sliced file.
+
+    Some templater plugins might insert custom marker slices that are of zero source
+    string length, including an empty source string.  This mock templater simulates
+    this behavior by adding a marker slice like this after every block_start slice.
+    """
+
+    name = "special_marker_inserter"
+
+    def slice_file(
+        self, raw_str: str, render_func: Callable[[str], str], config=None, **kwargs
+    ) -> Tuple[List[RawFileSlice], List[TemplatedFileSlice], str]:
+        """Patch a sliced file returned by the superclass."""
+        raw_sliced, sliced_file, templated_str = super().slice_file(
+            raw_str, render_func, config, **kwargs
+        )
+
+        patched_sliced_file = []
+        for templated_slice in sliced_file:
+            patched_sliced_file.append(templated_slice)
+            # Add an EMPTY special_marker slice after every block_start.
+            if templated_slice.slice_type == "block_start":
+                # Note that both the source_slice AND the templated_slice are empty.
+                source_pos = templated_slice.source_slice.stop
+                templated_pos = templated_slice.templated_slice.stop
+                patched_sliced_file.append(
+                    TemplatedFileSlice(
+                        "special_marker",
+                        slice(source_pos, source_pos),
+                        slice(templated_pos, templated_pos),
+                    )
+                )
+
+        return raw_sliced, patched_sliced_file, templated_str
+
+
+@hookimpl
+def get_templaters() -> List[Type[RawTemplater]]:
+    """Return templaters provided by this test module."""
+    return [SpecialMarkerInserter]
 
 
 @pytest.mark.parametrize(
@@ -128,11 +178,12 @@ def test_reflow__deduce_line_indent(
 
 
 @pytest.mark.parametrize(
-    "raw_sql_in,points_out",
+    "raw_sql_in,templater,points_out",
     [
         # Trivial
         (
             "select 1",
+            "raw",
             [
                 # No point at the start.
                 # Point after select (not newline)
@@ -159,6 +210,7 @@ def test_reflow__deduce_line_indent(
         ),
         (
             "\nselect 1\n",
+            "raw",
             [
                 # Start point
                 _IndentPoint(
@@ -194,6 +246,7 @@ def test_reflow__deduce_line_indent(
         ),
         (
             "select\n1",
+            "raw",
             [
                 # No point at the start.
                 # Point after select (not newline)
@@ -222,6 +275,7 @@ def test_reflow__deduce_line_indent(
         (
             "SELECT\n    r.a,\n    s.b\nFROM r\nJOIN s\n    "
             "ON\n        r.a = s.a\n        AND true",
+            "raw",
             [
                 # No point at the start.
                 # After SELECT
@@ -335,6 +389,7 @@ def test_reflow__deduce_line_indent(
         ),
         (
             "SELECT *\nFROM t1\nJOIN t2 ON true\nAND true",
+            "raw",
             [
                 # No point at the start.
                 # NOTE: Abbreviated notation given much is the same as above.
@@ -365,6 +420,40 @@ def test_reflow__deduce_line_indent(
                 _IndentPoint(19, -2, -2, 2, 15, False, (1, 2)),
             ],
         ),
+        # Trailing comment case: delays indent until after the comment
+        (
+            "SELECT -- comment\n    1;",
+            "raw",
+            [
+                # No point at the start.
+                # After SELECT
+                _IndentPoint(1, 0, 0, 0, None, False, ()),
+                # After comment
+                _IndentPoint(3, 1, 0, 0, None, True, ()),
+                # After 1
+                _IndentPoint(5, -1, -1, 1, 3, False, ()),
+                # After ;
+                _IndentPoint(7, 0, 0, 0, 3, False, ()),
+            ],
+        ),
+        # Two trailing comments
+        (
+            "SELECT /* first comment */ /* second comment */\n    1;",
+            "raw",
+            [
+                # No point at the start.
+                # After SELECT
+                _IndentPoint(1, 0, 0, 0, None, False, ()),
+                # After first comment
+                _IndentPoint(3, 0, 0, 0, None, False, ()),
+                # After second comment
+                _IndentPoint(5, 1, 0, 0, None, True, ()),
+                # After 1
+                _IndentPoint(7, -1, -1, 1, 5, False, ()),
+                # After ;
+                _IndentPoint(9, 0, 0, 0, 5, False, ()),
+            ],
+        ),
         # Templated case
         (
             "SELECT\n"
@@ -372,6 +461,7 @@ def test_reflow__deduce_line_indent(
             "    {% for c in ['d', 'e'] %}\n"
             "    ,{{ c }}_val\n"
             "    {% endfor %}\n",
+            "jinja",
             [
                 # No initial indent (this is the first newline).
                 _IndentPoint(1, 1, 0, 0, None, True, ()),
@@ -396,6 +486,7 @@ def test_reflow__deduce_line_indent(
             "FROM some_table\n"
             "{{ 'UNION ALL\n' if not loop.last }}\n"
             "{%- endfor %}",
+            "jinja",
             [
                 # No initial indent (this is the first newline).
                 # Importantly this first point - IS a newline
@@ -433,6 +524,7 @@ def test_reflow__deduce_line_indent(
         # Templated case (with templated newline and indent)
         (
             "SELECT\n  {{'1 \n, 2'}}\nFROM foo",
+            "jinja",
             [
                 # After SELECT
                 _IndentPoint(1, 1, 0, 0, None, True, ()),
@@ -445,13 +537,44 @@ def test_reflow__deduce_line_indent(
                 _IndentPoint(11, -1, -1, 1, 7, False, (1,)),
             ],
         ),
+        # Templated case (with special marker slice that has no source string)
+        (
+            # The invisible special marker slice will be inserted immediately after
+            # the first normal template section.
+            "{% if True %}\n    SELECT 1;\n{% endif %}\n",
+            "special_marker_inserter",
+            [
+                # No point at the start.
+                # After the {% if True %} block: this should not yet indent because
+                # there's still the upcoming zero-length special_marker
+                # TemplateSegment.  This is handled similar to the trailing comment
+                # test case.
+                _IndentPoint(1, 0, 0, 0, None, False, ()),
+                # After the zero-length special_marker TemplateSegment inserted by
+                # the special templater: only after this do we want to indent.
+                _IndentPoint(3, 1, 0, 0, None, True, ()),
+                # After SELECT
+                _IndentPoint(5, 1, 0, 1, 3, False, ()),
+                # After 1
+                _IndentPoint(7, -1, -1, 2, 3, False, (2,)),
+                # After ;
+                _IndentPoint(9, -1, -1, 1, 3, True, ()),
+                # After {% endif %}
+                _IndentPoint(11, 0, 0, 0, 9, True, ()),
+            ],
+        ),
     ],
 )
-def test_reflow__crawl_indent_points(raw_sql_in, points_out, default_config, caplog):
+def test_reflow__crawl_indent_points(raw_sql_in, templater, points_out, caplog):
     """Test _crawl_indent_points directly."""
-    root = parse_ansi_string(raw_sql_in, default_config)
+    # Register the mock templater in this module.
+    purge_plugin_manager()
+    get_plugin_manager().register(sys.modules[__name__], name="reindent_test")
+
+    config = FluffConfig(overrides={"dialect": "ansi", "templater": templater})
+    root = parse_ansi_string(raw_sql_in, config)
     print(root.stringify())
-    seq = ReflowSequence.from_root(root, config=default_config)
+    seq = ReflowSequence.from_root(root, config=config)
     with caplog.at_level(logging.DEBUG, logger="sqlfluff.rules.reflow"):
         points = list(_crawl_indent_points(seq.elements))
     assert points == points_out


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Some custom templater plugins might emit special zero-length marker template slices with a special slice type, as previously described in #4708.  These are transformed into a meta TemplateSegment with an empty source string, which mostly works great.  However, the LT02 indention rule will attempt to indent these meta nodes, which is impossible because there is no `source_str` that the indention would affect, and thus it is impossible to resolve this lint violation.

For example, suppose the parse tree looks like this:

```
[META] placeholder: [Type: 'block_start', Raw: "{% up 'Do nothing' %}", Block: 'f142fe']
[META] indent:      [Block: 'f142fe']
[META] placeholder: [Type: 'migration_up', Raw: '']
newline:            '\n'
whitespace:         '    '
```

The indention rule will perceive a violation and try to fix it by inserting a newline and whitespace prior to the second placeholder:

```
[META] placeholder: [Type: 'block_start', Raw: "{% up 'Do nothing' %}", Block: 'f142fe']
[META] indent:      [Block: 'f142fe']
newline:            '\n'
whitespace:         '    '
[META] placeholder: [Type: 'migration_up', Raw: '']
newline:            '\n'
whitespace:         '    '
```

However, this second placeholder doesn't have any source string.  When the file is reparsed, the templater will again result in a parse tree as seen in the original snippet above, and thus the violation is effectively unfixable.

This commit fixes the issue by treating these cases identically to trailing comments at the end of a line.  For example, the following template has a trailing comment that delays the indention requirement:

```
{% if True %} -- I don't need to put a trailing comment on the next line
    SELECT 1;
```

By treating the zero-length marker placeholder the same as a trailing comment, we can avoid trying to indent them.

Note that this commit also adds test cases to the `reindent_test` for trailing comments.  Previously, there was no direct test coverage for that branch of code.


### Are there any other side effects of this change that we should be aware of?

No, there shouldn't be.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
