### PR TITLE
5944: Add support for databricks named parameters

### DIFF
--- a/test/fixtures/dialects/databricks/named_argument.sql
+++ b/test/fixtures/dialects/databricks/named_argument.sql
@@ -1,0 +1,7 @@
+--https://docs.databricks.com/en/sql/language-manual/sql-ref-function-invocation.html#named-parameter-invocation
+
+select my_function(arg1 => 3, arg2 => 4) from dual;
+
+select my_function(3, arg2 => 4) from dual;
+
+select my_function(arg1 => 3, 4) from dual;

--- a/test/fixtures/dialects/databricks/named_argument.yml
+++ b/test/fixtures/dialects/databricks/named_argument.yml
@@ -1,0 +1,91 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 96a8a90d5cb19753570b96e0b15c0390b1676bb54dd1a8c226a75f998e31ea54
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: my_function
+            bracketed:
+            - start_bracket: (
+            - named_argument:
+                naked_identifier: arg1
+                right_arrow: =>
+                expression:
+                  numeric_literal: '3'
+            - comma: ','
+            - named_argument:
+                naked_identifier: arg2
+                right_arrow: =>
+                expression:
+                  numeric_literal: '4'
+            - end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dual
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: my_function
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '3'
+              comma: ','
+              named_argument:
+                naked_identifier: arg2
+                right_arrow: =>
+                expression:
+                  numeric_literal: '4'
+              end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dual
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: my_function
+            bracketed:
+              start_bracket: (
+              named_argument:
+                naked_identifier: arg1
+                right_arrow: =>
+                expression:
+                  numeric_literal: '3'
+              comma: ','
+              expression:
+                numeric_literal: '4'
+              end_bracket: )
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dual
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fixes #5944 by adding support for Databricks named parameters.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
