### PR TITLE
Parent dir config search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/packages.yml
 # VSCode
 .vscode
 *.code-workspace
+
+# Emacs
+*~

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -135,11 +135,14 @@ steps overriding those from earlier:
    above in the main :ref:`config` section. If multiple are present, they will
    *patch*/*override* each other in the order above.
 2. It will look for the same files in the user's home directory (~).
-3. It will look for the same files in the current working directory.
-4. *[if parsing a file in a subdirectory of the current working directory]*
+3. It will look for the same files in all directories between the user's home
+   directory (~), and the current working directory (this does nothing if the
+   current working directory is not a sub directory of the home directory).
+4. It will look for the same files in the current working directory.
+5. *[if parsing a file in a subdirectory of the current working directory]*
    It will look for the same files in every subdirectory between the
    current working dir and the file directory.
-5. It will look for the same files in the directory containing the file
+6. It will look for the same files in the directory containing the file
    being linted.
 
 This whole structure leads to efficient configuration, in particular

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -135,11 +135,9 @@ steps overriding those from earlier:
    above in the main :ref:`config` section. If multiple are present, they will
    *patch*/*override* each other in the order above.
 2. It will look for the same files in the user's home directory (~).
-3. It will look for the same files in all directories between the
-   user's home directory (~), and the current working directory, but
-   only use the first file it finds closest to the current working
-   directory (this does nothing if the current working directory is
-   not a sub directory of the home directory).
+3. *[if the current working directory is a subdirectory of the user's home directory (~)]*
+   It will look for the same files in all directories between the
+   user's home directory (~), and the current working directory.
 4. It will look for the same files in the current working directory.
 5. *[if parsing a file in a subdirectory of the current working directory]*
    It will look for the same files in every subdirectory between the

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -135,9 +135,11 @@ steps overriding those from earlier:
    above in the main :ref:`config` section. If multiple are present, they will
    *patch*/*override* each other in the order above.
 2. It will look for the same files in the user's home directory (~).
-3. It will look for the same files in all directories between the user's home
-   directory (~), and the current working directory (this does nothing if the
-   current working directory is not a sub directory of the home directory).
+3. It will look for the same files in all directories between the
+   user's home directory (~), and the current working directory, but
+   only use the first file it finds closest to the current working
+   directory (this does nothing if the current working directory is
+   not a sub directory of the home directory).
 4. It will look for the same files in the current working directory.
 5. *[if parsing a file in a subdirectory of the current working directory]*
    It will look for the same files in every subdirectory between the

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -685,6 +685,17 @@ class ConfigLoader:
             self.load_user_appdir_config() if not ignore_local_config else {}
         )
         user_config = self.load_user_config() if not ignore_local_config else {}
+        parent_config_paths = (
+            iter_intermediate_paths(Path(path).absolute(), Path(os.path.expanduser("~")))
+            if not ignore_local_config
+            else {}
+        )
+        parent_config_stack = (
+            [self.load_config_at_path(p) for p in reversed(list(parent_config_paths))]
+            if not ignore_local_config
+            else []
+        )
+        parent_config_stack = [config for config in parent_config_stack if config][:1]
         config_paths = (
             iter_intermediate_paths(Path(path).absolute(), Path.cwd())
             if not ignore_local_config
@@ -699,7 +710,7 @@ class ConfigLoader:
             self.load_extra_config(extra_config_path) if extra_config_path else {}
         )
         return nested_combine(
-            user_appdir_config, user_config, *config_stack, extra_config
+            user_appdir_config, user_config, *parent_config_stack, *config_stack, extra_config
         )
 
     @classmethod

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -702,11 +702,7 @@ class ConfigLoader:
             # here
             parent_config_paths = parent_config_paths[1:-1]
             parent_config_stack = [
-                self.load_config_at_path(p) for p in reversed(list(parent_config_paths))
-            ]
-            # Taking the first non-empty config (of the reversed list)
-            parent_config_stack = [config for config in parent_config_stack if config][
-                :1
+                self.load_config_at_path(p) for p in list(parent_config_paths)
             ]
 
             config_paths = iter_intermediate_paths(Path(path).absolute(), Path.cwd())

--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -693,30 +693,33 @@ class ConfigLoader:
             # but depending on the user's setup, this might result in
             # permissions errors.
             parent_config_paths = list(
-                iter_intermediate_paths(Path(path).absolute(),
-                                        Path(os.path.expanduser("~")))
+                iter_intermediate_paths(
+                    Path(path).absolute(), Path(os.path.expanduser("~"))
+                )
             )
             # Stripping off the home directory and the current working
             # directory, since they are both covered by other code
             # here
             parent_config_paths = parent_config_paths[1:-1]
-            parent_config_stack = (
-                [self.load_config_at_path(p) for p in reversed(list(parent_config_paths))]
-            )
+            parent_config_stack = [
+                self.load_config_at_path(p) for p in reversed(list(parent_config_paths))
+            ]
             # Taking the first non-empty config (of the reversed list)
-            parent_config_stack = [config for config in parent_config_stack if config][:1]
+            parent_config_stack = [config for config in parent_config_stack if config][
+                :1
+            ]
 
-            config_paths = (
-                iter_intermediate_paths(Path(path).absolute(), Path.cwd())
-            )
-            config_stack = (
-                [self.load_config_at_path(p) for p in config_paths]
-            )
+            config_paths = iter_intermediate_paths(Path(path).absolute(), Path.cwd())
+            config_stack = [self.load_config_at_path(p) for p in config_paths]
         extra_config = (
             self.load_extra_config(extra_config_path) if extra_config_path else {}
         )
         return nested_combine(
-            user_appdir_config, user_config, *parent_config_stack, *config_stack, extra_config
+            user_appdir_config,
+            user_config,
+            *parent_config_stack,
+            *config_stack,
+            extra_config,
         )
 
     @classmethod

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -129,8 +129,12 @@ def change_dir(path):
         os.chdir(original_dir)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Seems test is not executed under home directory on Windows",
+)
 def test__config__load_parent():
-    """Test nested overwrite and order of precedence of config files."""
+    """Test that config is loaded from parent directory of current working directory."""
     c = ConfigLoader()
     with change_dir(
         os.path.join("test", "fixtures", "config", "inheritance_a", "nested")

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import sys
+from contextlib import contextmanager
 from unittest.mock import call, patch
 
 import appdirs
@@ -105,6 +106,36 @@ def test__config__load_nested():
             "test", "fixtures", "config", "inheritance_a", "nested", "blah.sql"
         )
     )
+    assert cfg == {
+        "core": {
+            "dialect": "mysql",
+            "testing_val": "foobar",
+            "testing_int": 1,
+            "testing_bar": 7.698,
+        },
+        "bar": {"foo": "foobar"},
+        "fnarr": {"fnarr": {"foo": "foobar"}},
+    }
+
+
+@contextmanager
+def change_dir(path):
+    """Set the current working directory to `path` for the duration of the context."""
+    original_dir = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(original_dir)
+
+
+def test__config__load_parent():
+    """Test nested overwrite and order of precedence of config files."""
+    c = ConfigLoader()
+    with change_dir(
+        os.path.join("test", "fixtures", "config", "inheritance_a", "nested")
+    ):
+        cfg = c.load_config_up_to_path("blah.sql")
     assert cfg == {
         "core": {
             "dialect": "mysql",


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
When searching for configuration files, this PR adds a step that looks for configuration files between the users home directory and the current working directory. This makes it possible to execute sqlfluff in subdirectories of a project where the sqlfluff config is in the root of the project, making it simpler to configure linting in editors.
Fixes #5957 (at least its a possible solution)

## Open questions
- Would it be better to but this feature behind a feature or cli flag (i.e. make it not default)?
- In this PR, if there are several directories between home and cwd that contains a config, it will only take the config closest to cwd, and ignore all other configs. Wondering if it should just include all of them?

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes in `test/core/config_test.py`.
- Added appropriate documentation for the change.
