### PR TITLE
AL07: Fix self-referencing table aliases

### DIFF
--- a/src/sqlfluff/core/rules/fix.py
+++ b/src/sqlfluff/core/rules/fix.py
@@ -100,14 +100,22 @@ class LintFix:
                 self.edit != self.anchor
             ), "Fix created which replaces segment with itself."
 
-    def is_just_source_edit(self) -> bool:
-        """Return whether this a valid source only edit."""
-        return (
+    def is_just_source_edit(self, single_source_fix: bool = False) -> bool:
+        """Return whether this a valid source only edit.
+
+        Args:
+        single_source_fix (:obj:`bool`): Check for a single source_fixes.
+        """
+        if (
             self.edit_type == "replace"
             and self.edit is not None
             and len(self.edit) == 1
             and self.edit[0].raw == self.anchor.raw
-        )
+        ):
+            if single_source_fix:
+                return len(self.edit[0].source_fixes) == 1
+            return True
+        return False
 
     def __repr__(self) -> str:
         if self.edit_type == "delete":
@@ -143,7 +151,9 @@ class LintFix:
                 "edit": "",
                 **_src_loc,
             }
-        elif self.edit_type == "replace" and self.is_just_source_edit():
+        elif self.edit_type == "replace" and self.is_just_source_edit(
+            single_source_fix=True
+        ):
             assert self.edit is not None
             assert len(self.edit) == 1
             assert len(self.edit[0].source_fixes) == 1

--- a/test/fixtures/rules/std_rule_cases/AL07.yml
+++ b/test/fixtures/rules/std_rule_cases/AL07.yml
@@ -489,3 +489,65 @@ test_fail_fix_command:
     rules:
       aliasing.forbid:
         force_enable: true
+
+test_fail_fix_self_aliased_table_5954:
+  fail_str: |
+    with
+    foo as (
+        select * from vee
+    ),
+
+    bar as (
+        select * from baz
+    ),
+
+    final as (
+        select
+            foo.col1,
+            foo.col2,
+            foo.col3,
+            bar.col4,
+            bar.col5,
+            bar.col6,
+            bar.col7
+        from
+            foo as foo
+        left join
+            bar
+            on
+                foo.col1 = bar.col2
+    )
+
+    select * from final
+  fix_str: |
+    with
+    foo as (
+        select * from vee
+    ),
+
+    bar as (
+        select * from baz
+    ),
+
+    final as (
+        select
+            foo.col1,
+            foo.col2,
+            foo.col3,
+            bar.col4,
+            bar.col5,
+            bar.col6,
+            bar.col7
+        from
+            foo
+        left join
+            bar
+            on
+                foo.col1 = bar.col2
+    )
+
+    select * from final
+  configs:
+    rules:
+      aliasing.forbid:
+        force_enable: true


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Validates the condition of the assertions for "replace" with `is_just_source_edit` in `LintFix.to_dict`
- Fixes #5954 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
