### PR TITLE
BigQuery: Support various DROP statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -520,14 +520,20 @@ class StatementSegment(ansi.StatementSegment):
             Ref("AlterOrganizationStatementSegment"),
             Ref("AlterProjectStatementSegment"),
             Ref("CreateSearchIndexStatementSegment"),
+            Ref("DropSearchIndexStatementSegment"),
             Ref("CreateVectorIndexStatementSegment"),
+            Ref("DropVectorIndexStatementSegment"),
             Ref("CreateRowAccessPolicyStatementSegment"),
+            Ref("DropRowAccessPolicyStatementSegment"),
             Ref("AlterBiCapacityStatementSegment"),
             Ref("CreateCapacityStatementSegment"),
             Ref("AlterCapacityStatementSegment"),
+            Ref("DropCapacityStatementSegment"),
             Ref("CreateReservationStatementSegment"),
             Ref("AlterReservationStatementSegment"),
+            Ref("DropReservationStatementSegment"),
             Ref("CreateAssignmentStatementSegment"),
+            Ref("DropAssignmentStatementSegment"),
         ],
     )
 
@@ -2766,6 +2772,25 @@ class CreateSearchIndexStatementSegment(BaseSegment):
     )
 
 
+class DropSearchIndexStatementSegment(BaseSegment):
+    """A `DROP SEARCH INDEX` statement.
+
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_search_index
+    """
+
+    type = "drop_search_index_statement"
+
+    match_grammar: Matchable = Sequence(
+        "DROP",
+        "SEARCH",
+        "INDEX",
+        Ref("IfExistsGrammar", optional=True),
+        Ref("IndexReferenceSegment"),
+        "ON",
+        Ref("TableReferenceSegment"),
+    )
+
+
 class CreateVectorIndexStatementSegment(BaseSegment):
     """A `CREATE VECTOR INDEX` statement.
 
@@ -2788,6 +2813,25 @@ class CreateVectorIndexStatementSegment(BaseSegment):
             ),
         ),
         Ref("OptionsSegment"),
+    )
+
+
+class DropVectorIndexStatementSegment(BaseSegment):
+    """A `DROP VECTOR INDEX` statement.
+
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_vector_index
+    """
+
+    type = "drop_vector_index_statement"
+
+    match_grammar: Matchable = Sequence(
+        "DROP",
+        "VECTOR",
+        "INDEX",
+        Ref("IfExistsGrammar", optional=True),
+        Ref("IndexReferenceSegment"),
+        "ON",
+        Ref("TableReferenceSegment"),
     )
 
 
@@ -2815,6 +2859,26 @@ class CreateRowAccessPolicyStatementSegment(BaseSegment):
         Bracketed(
             Ref("ExpressionSegment"),
         ),
+    )
+
+
+class DropRowAccessPolicyStatementSegment(BaseSegment):
+    """A `DROP ROW ACCESS POLICY` statement.
+
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_row_access_policy_statement
+    """
+
+    type = "drop_row_access_policy_statement"
+
+    match_grammar: Matchable = Sequence(
+        "DROP",
+        "ROW",
+        "ACCESS",
+        "POLICY",
+        Ref("IfExistsGrammar", optional=True),
+        Ref("NakedIdentifierSegment"),
+        "ON",
+        Ref("TableReferenceSegment"),
     )
 
 
@@ -2868,6 +2932,22 @@ class AlterCapacityStatementSegment(BaseSegment):
     )
 
 
+class DropCapacityStatementSegment(BaseSegment):
+    """A `DROP CAPACITY` statement.
+
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_capacity_statement
+    """
+
+    type = "drop_capacity_statement"
+
+    match_grammar: Matchable = Sequence(
+        "DROP",
+        "CAPACITY",
+        Ref("IfExistsGrammar", optional=True),
+        Ref("TableReferenceSegment"),
+    )
+
+
 class CreateReservationStatementSegment(BaseSegment):
     """A `CREATE RESERVATION` statement.
 
@@ -2901,6 +2981,22 @@ class AlterReservationStatementSegment(BaseSegment):
     )
 
 
+class DropReservationStatementSegment(BaseSegment):
+    """A `DROP RESERVATION` statement.
+
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_reservation_statement
+    """
+
+    type = "drop_reservation_statement"
+
+    match_grammar: Matchable = Sequence(
+        "DROP",
+        "RESERVATION",
+        Ref("IfExistsGrammar", optional=True),
+        Ref("TableReferenceSegment"),
+    )
+
+
 class CreateAssignmentStatementSegment(BaseSegment):
     """A `CREATE ASSIGNMENT` statement.
 
@@ -2914,4 +3010,20 @@ class CreateAssignmentStatementSegment(BaseSegment):
         "ASSIGNMENT",
         Ref("TableReferenceSegment"),
         Ref("OptionsSegment"),
+    )
+
+
+class DropAssignmentStatementSegment(BaseSegment):
+    """A `DROP ASSIGNMENT` statement.
+
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_assignment_statement
+    """
+
+    type = "drop_assignment_statement"
+
+    match_grammar: Matchable = Sequence(
+        "DROP",
+        "ASSIGNMENT",
+        Ref("IfExistsGrammar", optional=True),
+        Ref("TableReferenceSegment"),
     )

--- a/test/fixtures/dialects/bigquery/drop_various_resources.sql
+++ b/test/fixtures/dialects/bigquery/drop_various_resources.sql
@@ -1,0 +1,11 @@
+DROP ROW ACCESS POLICY IF EXISTS example_policy_name ON example_dataset.example_table;
+
+DROP CAPACITY `example-project.region-us.example_commitment`;
+
+DROP RESERVATION IF EXISTS `example-project.region-us.example_reservation`;
+
+DROP ASSIGNMENT `example-project.region-us.example_reservation.example_assignment`;
+
+DROP SEARCH INDEX IF EXISTS example_index ON example_dataset.example_table;
+
+DROP VECTOR INDEX example_index ON example_dataset.example_table;

--- a/test/fixtures/dialects/bigquery/drop_various_resources.yml
+++ b/test/fixtures/dialects/bigquery/drop_various_resources.yml
@@ -1,0 +1,73 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 5f317b1b68df983826c410d4622980da88329aac869915c6c74c15064d3890a9
+file:
+- statement:
+    drop_row_access_policy_statement:
+    - keyword: DROP
+    - keyword: ROW
+    - keyword: ACCESS
+    - keyword: POLICY
+    - keyword: IF
+    - keyword: EXISTS
+    - naked_identifier: example_policy_name
+    - keyword: 'ON'
+    - table_reference:
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_table
+- statement_terminator: ;
+- statement:
+    drop_capacity_statement:
+    - keyword: DROP
+    - keyword: CAPACITY
+    - table_reference:
+        quoted_identifier: '`example-project.region-us.example_commitment`'
+- statement_terminator: ;
+- statement:
+    drop_reservation_statement:
+    - keyword: DROP
+    - keyword: RESERVATION
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        quoted_identifier: '`example-project.region-us.example_reservation`'
+- statement_terminator: ;
+- statement:
+    drop_assignment_statement:
+    - keyword: DROP
+    - keyword: ASSIGNMENT
+    - table_reference:
+        quoted_identifier: '`example-project.region-us.example_reservation.example_assignment`'
+- statement_terminator: ;
+- statement:
+    drop_search_index_statement:
+    - keyword: DROP
+    - keyword: SEARCH
+    - keyword: INDEX
+    - keyword: IF
+    - keyword: EXISTS
+    - index_reference:
+        naked_identifier: example_index
+    - keyword: 'ON'
+    - table_reference:
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_table
+- statement_terminator: ;
+- statement:
+    drop_vector_index_statement:
+    - keyword: DROP
+    - keyword: VECTOR
+    - keyword: INDEX
+    - index_reference:
+        naked_identifier: example_index
+    - keyword: 'ON'
+    - table_reference:
+      - naked_identifier: example_dataset
+      - dot: .
+      - naked_identifier: example_table
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

makes progress on #5789

The current BigQuery dialect does not correctly parse some DROP TABLE statements, so we try to fix them.

- https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_row_access_policy_statement
- https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_capacity_statement
- https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_reservation_statement
- https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_assignment_statement
- https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_search_index
- https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_vector_index

### Are there any other side effects of this change that we should be aware of?

None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
