### PR TITLE
MySQL: Fix variable handlings inside expressions

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2191,6 +2191,15 @@ ansi_dialect.add(
         Ref("ShorthandCastSegment"),
         terminators=[Ref("CommaSegment")],
     ),
+    Expression_D_Potential_Select_Statement_Without_Brackets=OneOf(
+        Ref("SelectStatementSegment"),
+        Ref("LiteralGrammar"),
+        Ref("IntervalExpressionSegment"),
+        Ref("TypedStructLiteralSegment"),
+        Ref("ArrayExpressionSegment"),
+        Ref("ColumnReferenceSegment"),
+        Ref("OverlapsClauseSegment"),
+    ),
     # Expression_D_Grammar
     # https://www.cockroachlabs.com/docs/v20.2/sql-grammar.htm#d_expr
     Expression_D_Grammar=Sequence(
@@ -2217,13 +2226,7 @@ ansi_dialect.add(
                 parse_mode=ParseMode.GREEDY,
             ),
             # Allow potential select statement without brackets
-            Ref("SelectStatementSegment"),
-            Ref("LiteralGrammar"),
-            Ref("IntervalExpressionSegment"),
-            Ref("TypedStructLiteralSegment"),
-            Ref("ArrayExpressionSegment"),
-            Ref("ColumnReferenceSegment"),
-            Ref("OverlapsClauseSegment"),
+            Ref("Expression_D_Potential_Select_Statement_Without_Brackets"),
             # For triggers, we allow "NEW.*" but not just "*" nor "a.b.*"
             # So can't use WildcardIdentifierSegment nor WildcardExpressionSegment
             Sequence(

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -195,6 +195,14 @@ mysql_dialect.replace(
             Ref("VariableAssignmentSegment"),
         ]
     ),
+    Expression_D_Potential_Select_Statement_Without_Brackets=ansi_dialect.get_grammar(
+        "Expression_D_Potential_Select_Statement_Without_Brackets"
+    ).copy(
+        insert=[
+            Ref("SessionVariableNameSegment"),
+        ],
+        at=0,
+    ),
     ArithmeticBinaryOperatorGrammar=ansi_dialect.get_grammar(
         "ArithmeticBinaryOperatorGrammar"
     ).copy(

--- a/test/fixtures/dialects/mysql/call_statement.yml
+++ b/test/fixtures/dialects/mysql/call_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a11cc392fec28fb4460d4da8a14fab9bd4c712a5875e482371d32f38255b29bf
+_hash: b976170556023f001f8ee857f5a302503bc1d90e0bc76eeb09c2033eafa7f05c
 file:
 - statement:
     call_statement:
@@ -48,8 +48,7 @@ file:
             quoted_literal: "'test'"
         - comma: ','
         - expression:
-            column_reference:
-              variable: '@test1'
+            variable: '@test1'
         - comma: ','
         - expression:
             column_reference:

--- a/test/fixtures/dialects/mysql/create_trigger.yml
+++ b/test/fixtures/dialects/mysql/create_trigger.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3ac600fa9db5bca6f4e64fd5a6141a57ea55630707bd387061e56299e0a5430d
+_hash: a421a80640fe4e013133432ce6fccf9e145397ba3c8bedcc36d8b1da64981e17
 file:
 - statement:
     create_trigger:
@@ -120,10 +120,9 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           expression:
-          - column_reference:
-              variable: '@sum'
-          - binary_operator: +
-          - column_reference:
+            variable: '@sum'
+            binary_operator: +
+            column_reference:
             - naked_identifier: NEW
             - dot: .
             - naked_identifier: amount
@@ -389,10 +388,9 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           expression:
-          - column_reference:
-              variable: '@sum'
-          - binary_operator: +
-          - column_reference:
+            variable: '@sum'
+            binary_operator: +
+            column_reference:
             - naked_identifier: NEW
             - dot: .
             - naked_identifier: amount
@@ -424,10 +422,9 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           expression:
-          - column_reference:
-              variable: '@sum'
-          - binary_operator: +
-          - column_reference:
+            variable: '@sum'
+            binary_operator: +
+            column_reference:
             - naked_identifier: NEW
             - dot: .
             - naked_identifier: amount

--- a/test/fixtures/dialects/mysql/if_session_variable.yml
+++ b/test/fixtures/dialects/mysql/if_session_variable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1bdf0414cbba1a35240b81866b84e72279f68cb5939e807fc5b26a1b1f0ff60a
+_hash: 04481051b789d4b6ce1abee734b0296efed481cf1423dd700556e432038b23b0
 file:
 - statement:
     if_then_statement:
@@ -12,8 +12,7 @@ file:
         bracketed:
           start_bracket: (
           expression:
-            column_reference:
-              variable: '@x'
+            variable: '@x'
             comparison_operator:
               raw_comparison_operator: '='
             numeric_literal: '0'

--- a/test/fixtures/dialects/mysql/load_data.yml
+++ b/test/fixtures/dialects/mysql/load_data.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2d0a01865822c5dbbf9fc9d91f606ad76c05ede0b97e42f286267cb7c58df743
+_hash: 2e054931718eeab266f22b5254bab24824e76c0cc4e83dc5b54ecb69ace9f538
 file:
 - statement:
     load_data_statement:
@@ -206,8 +206,7 @@ file:
         naked_identifier: column2
     - comparison_operator:
         raw_comparison_operator: '='
-    - column_reference:
-        variable: '@var1'
+    - variable: '@var1'
     - binary_operator: /
     - numeric_literal: '100'
 - statement_terminator: ;

--- a/test/fixtures/dialects/mysql/repeat_label.yml
+++ b/test/fixtures/dialects/mysql/repeat_label.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a2053c708738b674f2b1964f16358678e7df43a8662d2d38373a7ad02d693267
+_hash: 6202885f33bcd0a346d2436056aa723837e6127704fddff948205986aad344dc
 file:
 - statement:
     repeat_statement:
@@ -17,8 +17,7 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           expression:
-            column_reference:
-              variable: '@a'
+            variable: '@a'
             binary_operator: +
             numeric_literal: '1'
 - statement_terminator: ;
@@ -26,8 +25,7 @@ file:
     repeat_statement:
     - keyword: until
     - expression:
-        column_reference:
-          variable: '@a'
+        variable: '@a'
         comparison_operator:
           raw_comparison_operator: '>'
         numeric_literal: '5'

--- a/test/fixtures/dialects/mysql/repeat_multiple_statements.yml
+++ b/test/fixtures/dialects/mysql/repeat_multiple_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: be84d375c2033cff7370f20ceaa9409da3f9a700c02a210850a2634b48bbe207
+_hash: d51657630a73b8ae3d1fb36fe5494b43d57b3da9ba2fa3be71f3e3ddae4bea06
 file:
 - statement:
     repeat_statement:
@@ -15,8 +15,7 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           expression:
-            column_reference:
-              variable: '@a'
+            variable: '@a'
             binary_operator: +
             numeric_literal: '1'
 - statement_terminator: ;
@@ -31,8 +30,7 @@ file:
     repeat_statement:
     - keyword: until
     - expression:
-      - column_reference:
-          variable: '@a'
+      - variable: '@a'
       - comparison_operator:
           raw_comparison_operator: '>'
       - numeric_literal: '5'

--- a/test/fixtures/dialects/mysql/repeat_no_label.yml
+++ b/test/fixtures/dialects/mysql/repeat_no_label.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1626c026e42da9255c25bbd14de7039094f647001ae594a00274a1377c3c240b
+_hash: a907fbb417b57c4bcd31c689236a595b55b81c6367bf4c1bead609bf102f5568
 file:
 - statement:
     repeat_statement:
@@ -15,8 +15,7 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           expression:
-            column_reference:
-              variable: '@a'
+            variable: '@a'
             binary_operator: +
             numeric_literal: '1'
 - statement_terminator: ;
@@ -24,8 +23,7 @@ file:
     repeat_statement:
     - keyword: until
     - expression:
-        column_reference:
-          variable: '@a'
+        variable: '@a'
         comparison_operator:
           raw_comparison_operator: '>'
         numeric_literal: '5'

--- a/test/fixtures/rules/std_rule_cases/RF02.yml
+++ b/test/fixtures/rules/std_rule_cases/RF02.yml
@@ -217,6 +217,19 @@ test_pass_column_and_alias_same_name_2_mysql:
     core:
       dialect: mysql
 
+test_pass_variable_reference_in_where_clause_mysql:
+  pass_str: |
+    SET @someVar = 1;
+    SELECT
+        Table1.Col1,
+        Table2.Col2
+    FROM Table1
+    LEFT JOIN Table2 ON Table1.Join1 = Table2.Join1
+    WHERE Table1.FilterCol = @someVar;
+  configs:
+    core:
+      dialect: mysql
+
 test_pass_qualified_references_multi_table_statements_tsql:
   pass_str: |
     SELECT foo.a, vee.b


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

fixes: https://github.com/sqlfluff/sqlfluff/issues/5479

Change what was parsed as:

```yaml
- column_reference:
    variable: '@a'
```
 in many places in the MySQL dialect to be parsed as:

```yaml
- variable: '@a'
```

As a result, we can resolve the false match in the lint rule that requires a variable to be qualified for a non-column variable, as shown in the above issue.

### Are there any other side effects of this change that we should be aware of?

This change may affect existing MySQL grammars. Since variable is not a column, this change should result in more accurate parsing results than the current implementation. However, if existing syntaxes handle variables and columns indistinguishably, the parsing results may be incorrect because it is no longer be wrapped in a `column_reference`.
At the very least, the effect of this change is limited to the MySQL dialect. The ansi dialect has not been changed beyond a refactoring that preserves its behavior.

There might be another approach to modify RF02 so that it can handle variables even if they are still wrapped in a column_reference. If a better approach seems possible, I will close this PR.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
