### PR TITLE
Rebreak: Fix meta dedent segment order

### DIFF
--- a/src/sqlfluff/utils/reflow/rebreak.py
+++ b/src/sqlfluff/utils/reflow/rebreak.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import dataclass
 from typing import List, Tuple, Type, cast
 
-from sqlfluff.core.parser import BaseSegment
+from sqlfluff.core.parser import BaseSegment, RawSegment
 from sqlfluff.core.rules import LintFix, LintResult
 from sqlfluff.utils.reflow.elements import ReflowBlock, ReflowPoint, ReflowSequenceType
 from sqlfluff.utils.reflow.helpers import (
@@ -140,6 +140,28 @@ class _RebreakLocation:
             # If there is a newline on BOTH sides. That's ok.
             or newlines_on_both_sides
         )
+
+
+def first_create_anchor(
+    elem_buff: ReflowSequenceType, loc_range: range
+) -> Tuple[RawSegment, ...]:
+    """Handle the potential case of an empty point with the next point with segments.
+
+    While a reflow element's segments are empty, search for the next
+    available element with segments to anchor new element creation.
+    """
+    # https://github.com/sqlfluff/sqlfluff/issues/4184
+    try:
+        create_anchor = next(
+            elem_buff[i].segments for i in loc_range if elem_buff[i].segments
+        )
+    except StopIteration as exc:  # pragma: no cover
+        # NOTE: We don't test this because we *should* always find
+        # _something_ to anchor the creation on, even if we're
+        # unlucky enough not to find it on the first pass.
+        raise NotImplementedError("Could not find anchor for creation.") from exc
+
+    return create_anchor
 
 
 def identify_rebreak_spans(
@@ -372,19 +394,10 @@ def rebreak_sequence(
                     anchor_on="after",
                 )
 
-                # Handle the potential case of an empty point.
-                # https://github.com/sqlfluff/sqlfluff/issues/4184
-                for i in range(loc.next.pre_code_pt_idx):
-                    if elem_buff[loc.next.pre_code_pt_idx - i].segments:
-                        create_anchor = elem_buff[
-                            loc.next.pre_code_pt_idx - i
-                        ].segments[-1]
-                        break
-                else:  # pragma: no cover
-                    # NOTE: We don't test this because we *should* always find
-                    # _something_ to anchor the creation on, even if we're
-                    # unlucky enough not to find it on the first pass.
-                    raise NotImplementedError("Could not find anchor for creation.")
+                create_anchor = first_create_anchor(
+                    elem_buff,
+                    range(loc.next.pre_code_pt_idx, loc.next.adj_pt_idx - 1, -1),
+                )[-1]
 
                 fixes.append(
                     LintFix.create_after(
@@ -468,22 +481,9 @@ def rebreak_sequence(
                     anchor_on="before",
                 )
 
-                # Handle the potential case of an empty point.
-                try:
-                    lead_create_anchor = next(
-                        elem_buff[i].segments
-                        for i in range(
-                            loc.prev.pre_code_pt_idx, loc.prev.adj_pt_idx + 1
-                        )
-                        if elem_buff[i].segments
-                    )
-                except StopIteration as exc:  # pragma: no cover
-                    # NOTE: We don't test this because we *should* always find
-                    # _something_ to anchor the creation on, even if we're
-                    # unlucky enough not to find it on the first pass.
-                    raise NotImplementedError(
-                        "Could not find anchor for creation."
-                    ) from exc
+                lead_create_anchor = first_create_anchor(
+                    elem_buff, range(loc.prev.pre_code_pt_idx, loc.prev.adj_pt_idx + 1)
+                )
 
                 # Attempt to skip dedent elements on reinsertion. These are typically
                 # found at the end of segments, but we don't want to include the

--- a/test/fixtures/rules/std_rule_cases/LT04.yml
+++ b/test/fixtures/rules/std_rule_cases/LT04.yml
@@ -362,3 +362,13 @@ trailing_comma_fix_mixed_indent:
       type:
         comma:
           line_position: leading
+
+trailing_comma_no_space_comment:
+  fail_str: |
+    SELECT a--comment
+        , b
+    FROM t
+  fix_str: |
+    SELECT a,--comment
+        b
+    FROM t

--- a/test/rules/std_LT04_ST06_test.py
+++ b/test/rules/std_LT04_ST06_test.py
@@ -1,0 +1,112 @@
+"""Tests the python routines within LT04 and ST06."""
+
+import pytest
+
+from sqlfluff.core import FluffConfig, Linter
+
+
+@pytest.mark.parametrize(
+    ["in_sql", "out_sql"],
+    [
+        (
+            """SELECT COALESCE(a, 0) AS b
+
+    , COALESCE(c, 0) AS d
+    , e
+FROM t""",
+            """SELECT e,
+
+    COALESCE(a, 0) AS b,
+    COALESCE(c, 0) AS d
+FROM t""",
+        ),
+        (
+            """SELECT COALESCE(a, 0) AS b--comment
+
+    , COALESCE(c, 0) AS d
+    , e
+FROM t""",
+            """SELECT e,--comment
+
+    COALESCE(a, 0) AS b,
+    COALESCE(c, 0) AS d
+FROM t""",
+        ),
+        (
+            """with cte1 as (
+select "a"
+      ,"b"
+      ,coalesce("g1"
+               ,"g2"
+               ,"g3"
+       ) as "g_combined"
+
+      ,"i"
+      ,"j"
+  from test
+),
+
+cte2 as (
+select "col1"
+
+      ,'start: ' + "col2" as "new_col2"
+
+      ,'start2: ' + "col3" as "new_col3"
+
+      ,"col4"
+      ,"col5"
+from cte1
+),
+
+select * from cte2""",
+            """with cte1 as (
+select "a",
+      "b",
+      "i",
+
+      "j",
+      coalesce("g1",
+               "g2",
+               "g3"
+       ) as "g_combined"
+  from test
+),
+
+cte2 as (
+select "col1",
+
+      "col4",
+
+      "col5",
+
+      'start: ' + "col2" as "new_col2",
+      'start2: ' + "col3" as "new_col3"
+from cte1
+),
+
+select * from cte2""",
+        ),
+    ],
+)
+def test_rules_std_LT04_and_ST06_interaction_trailing(in_sql, out_sql) -> None:
+    """Test interaction between LT04 and ST06.
+
+    Test sql with two newlines with leading commas expecting trailing.
+    """
+    # Lint expected rules.
+    cfg = FluffConfig.from_string(
+        """[sqlfluff]
+dialect = ansi
+rules = LT04, ST06
+"""
+    )
+    linter = Linter(config=cfg)
+
+    # Return linted/fixed file.
+    linted_file = linter.lint_string(in_sql, fix=True)
+
+    # Check expected lint errors are raised.
+    assert set([v.rule.code for v in linted_file.violations]) == {"LT04", "ST06"}
+
+    # Check file is fixed.
+    assert linted_file.fix_string()[0] == out_sql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This fixes how rebreak recombines moved elements for the "Leading Tricky Case", namely `dedent` segments.
- Fixes #4882
- Fixes #5913

This also fixes when a rebreak doesn't have an anchor point and attempts to find the next element with segments.
- Fixes #5973

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
