### PR TITLE
Select Analysis: Don't recursively crawl merge subselects

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -1013,7 +1013,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
         self,
         *seg_type: str,
         recurse_into: bool = True,
-        no_recursive_seg_type: Optional[str] = None,
+        no_recursive_seg_type: Optional[Union[str, List[str]]] = None,
         allow_self: bool = True,
     ) -> Iterator[BaseSegment]:
         """Recursively crawl for segments of a given type.
@@ -1023,13 +1023,16 @@ class BaseSegment(metaclass=SegmentMetaclass):
                 to look for.
             recurse_into: :obj:`bool`: When an element of type "seg_type" is
                 found, whether to recurse into it.
-            no_recursive_seg_type: :obj:`str`: a type of segment
+            no_recursive_seg_type: :obj:`Union[str, List[str]]`: a type of segment
                 not to recurse further into. It is highly recommended
                 to set this argument where possible, as it can significantly
                 narrow the search pattern.
             allow_self: :obj:`bool`: Whether to allow the initial segment this
                 is called on to be one of the results.
         """
+        if isinstance(no_recursive_seg_type, str):
+            no_recursive_seg_type = [no_recursive_seg_type]
+
         # Assuming there is a segment to be found, first check self (if allowed):
         if allow_self and self.is_type(*seg_type):
             match = True
@@ -1050,7 +1053,7 @@ class BaseSegment(metaclass=SegmentMetaclass):
                 # recurse into.
                 # NOTE: Setting no_recursive_seg_type can significantly
                 # improve performance in many cases.
-                if not no_recursive_seg_type or not seg.is_type(no_recursive_seg_type):
+                if not no_recursive_seg_type or not seg.is_type(*no_recursive_seg_type):
                     yield from seg.recursive_crawl(
                         *seg_type,
                         recurse_into=recurse_into,

--- a/src/sqlfluff/utils/analysis/select.py
+++ b/src/sqlfluff/utils/analysis/select.py
@@ -30,7 +30,8 @@ def _get_object_references(segment: BaseSegment) -> List[ObjectReferenceSegment]
     return list(
         cast(ObjectReferenceSegment, _seg)
         for _seg in segment.recursive_crawl(
-            "object_reference", no_recursive_seg_type="select_statement"
+            "object_reference",
+            no_recursive_seg_type=["select_statement", "merge_statement"],
         )
     )
 

--- a/test/fixtures/rules/std_rule_cases/RF03.yml
+++ b/test/fixtures/rules/std_rule_cases/RF03.yml
@@ -325,3 +325,57 @@ fail_but_dont_fix_templated_table_name_qualified:
     rules:
       references.consistent:
         single_table_references: qualified
+
+pass_tsql_subselect_merge_statement:
+  pass_str: |
+    INSERT INTO [DIL].[md_GLAccount_HIST] (
+      [ChartOfAccounts_KEY]
+      , [GLAccount_KEY]
+      , [ValidFrom]
+      , [ValidTo]
+      , [GLAccount_DESC_short]
+    )
+    SELECT
+      MRG.[ChartOfAccounts_KEY]
+      , MRG.[GLAccount_KEY]
+      , MRG.[ValidFrom]
+      , MRG.[ValidTo]
+      , MRG.[GLAccount_DESC_short]
+    FROM (
+      MERGE [DIL].[md_GLAccount_HIST] WITH (TABLOCK) t
+      USING [INTERNAL_MERGE].[DIL_md_GLAccount_HIST] s
+        ON (
+          t.[ChartOfAccounts_KEY] = s.[ChartOfAccounts_KEY]
+          AND t.[GLAccount_KEY] = s.[GLAccount_KEY]
+        )
+      WHEN NOT MATCHED BY TARGET
+        THEN
+        INSERT (
+          [ChartOfAccounts_KEY]
+          , [GLAccount_KEY]
+          , [ValidFrom]
+          , [ValidTo]
+          , [GLAccount_DESC_short]
+        )
+        VALUES (
+          s.[ChartOfAccounts_KEY]
+          , s.[GLAccount_KEY]
+          , '19900101'
+          , '99991231'
+          , s.[GLAccount_DESC_short]
+        )
+      OUTPUT
+        $ACTION AS [Action_OUT]
+        , s.[ChartOfAccounts_KEY]
+        , s.[GLAccount_KEY]
+        , '19900101'
+        , '99991231'
+        , s.[GLAccount_DESC_short]
+    ) MRG
+    WHERE
+      MRG.Action_OUT = 'UPDATE'
+      AND MRG.[ChartOfAccounts_KEY] IS NOT NULL
+      AND MRG.[GLAccount_KEY] IS NOT NULL;
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Allows multiple types for `BaseSegment.recursive_crawl`'s `no_recursive_seg_type`
Don't analyze merge statements that may be present in subselects for object references
- Fixes #5980 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
