### PR TITLE
Snowflake: fix scriptless stored procedure parsing

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -2992,14 +2992,17 @@ class CreateProcedureStatementSegment(BaseSegment):
             Sequence("EXECUTE", "AS", OneOf("CALLER", "OWNER"), optional=True),
             optional=True,
         ),
-        "AS",
-        OneOf(
-            # Either a foreign programming language UDF...
-            Ref("DoubleQuotedUDFBody"),
-            Ref("SingleQuotedUDFBody"),
-            Ref("DollarQuotedUDFBody"),
-            # ...or a SQL UDF
-            Ref("ScriptingBlockStatementSegment"),
+        Sequence(
+            "AS",
+            OneOf(
+                # Either a foreign programming language UDF...
+                Ref("DoubleQuotedUDFBody"),
+                Ref("SingleQuotedUDFBody"),
+                Ref("DollarQuotedUDFBody"),
+                # ...or a SQL UDF
+                Ref("ScriptingBlockStatementSegment"),
+            ),
+            optional=True,
         ),
     )
 

--- a/test/fixtures/dialects/snowflake/create_procedure.sql
+++ b/test/fixtures/dialects/snowflake/create_procedure.sql
@@ -155,3 +155,15 @@ select 3;
 select 4;
 return 5;
 END;
+
+
+CREATE OR REPLACE PROCEDURE MY_PROCEDURE(hello_world VARCHAR(10000))
+COPY GRANTS
+RETURNS TABLE ()
+LANGUAGE PYTHON
+RUNTIME_VERSION = '3.11'
+PACKAGES = ('snowflake-snowpark-python')
+HANDLER = 'my.path.func_formula_parser_test_script_runner_proc'
+IMPORTS = ('@MIRROR.PYTHON_SCRIPTS/script.py')
+EXECUTE AS OWNER
+;

--- a/test/fixtures/dialects/snowflake/create_procedure.yml
+++ b/test/fixtures/dialects/snowflake/create_procedure.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a1e78aed2e96871f7bea75234bcc4cf6d20cb79dacfcbc8df61eed5f658719a7
+_hash: 041eb20639e0550e0740668d735d02046748fbc7c432b731fae5f4e0882238ff
 file:
 - statement:
     create_procedure_statement:
@@ -410,4 +410,63 @@ file:
               numeric_literal: '5'
       - statement_terminator: ;
       - keyword: END
+- statement_terminator: ;
+- statement:
+    create_procedure_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: PROCEDURE
+    - function_name:
+        function_name_identifier: MY_PROCEDURE
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          parameter: hello_world
+          data_type:
+            data_type_identifier: VARCHAR
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '10000'
+                end_bracket: )
+          end_bracket: )
+    - keyword: COPY
+    - keyword: GRANTS
+    - keyword: RETURNS
+    - data_type:
+        data_type_identifier: TABLE
+        bracketed_arguments:
+          bracketed:
+            start_bracket: (
+            end_bracket: )
+    - keyword: LANGUAGE
+    - keyword: PYTHON
+    - keyword: RUNTIME_VERSION
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'3.11'"
+    - keyword: PACKAGES
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+        start_bracket: (
+        quoted_literal: "'snowflake-snowpark-python'"
+        end_bracket: )
+    - keyword: HANDLER
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'variablecalculator.formulaparser_proc.func_formula_parser_test_script_runner_proc'"
+    - keyword: IMPORTS
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+      - start_bracket: (
+      - quoted_literal: "'@MIRROR.PYTHON_SCRIPTS/DATA.py'"
+      - comma: ','
+      - quoted_literal: "'@MIRROR.PYTHON_SCRIPTS/variablecalculator.zip'"
+      - end_bracket: )
+    - keyword: EXECUTE
+    - keyword: AS
+    - keyword: OWNER
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/create_procedure.yml
+++ b/test/fixtures/dialects/snowflake/create_procedure.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 041eb20639e0550e0740668d735d02046748fbc7c432b731fae5f4e0882238ff
+_hash: 091f4618f445b7b9a8b1f7cf9b5e131f873ee2b2bdb980453121da2f1095e5a1
 file:
 - statement:
     create_procedure_statement:
@@ -456,16 +456,14 @@ file:
     - keyword: HANDLER
     - comparison_operator:
         raw_comparison_operator: '='
-    - quoted_literal: "'variablecalculator.formulaparser_proc.func_formula_parser_test_script_runner_proc'"
+    - quoted_literal: "'my.path.func_formula_parser_test_script_runner_proc'"
     - keyword: IMPORTS
     - comparison_operator:
         raw_comparison_operator: '='
     - bracketed:
-      - start_bracket: (
-      - quoted_literal: "'@MIRROR.PYTHON_SCRIPTS/DATA.py'"
-      - comma: ','
-      - quoted_literal: "'@MIRROR.PYTHON_SCRIPTS/variablecalculator.zip'"
-      - end_bracket: )
+        start_bracket: (
+        quoted_literal: "'@MIRROR.PYTHON_SCRIPTS/script.py'"
+        end_bracket: )
     - keyword: EXECUTE
     - keyword: AS
     - keyword: OWNER


### PR DESCRIPTION
### Brief summary of the change made

The parser was not able to correctly parse a fully working CREATE PROCEDURE statement in Snowflake where a script was not part of the statement. Example: 

```
CREATE OR REPLACE PROCEDURE MY_PROCEDURE(hello_world VARCHAR(10000))
COPY GRANTS
RETURNS TABLE ()
LANGUAGE PYTHON
RUNTIME_VERSION = '3.11'
PACKAGES = ('snowflake-snowpark-python')
HANDLER = 'my.path.func_formula_parser_test_script_runner_proc'
IMPORTS = ('@MIRROR.PYTHON_SCRIPTS/script.py')
EXECUTE AS OWNER
;
```


### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- Included test case in test/fixtures/dialects/snowflake/create_procedure.sql
