### PR TITLE
Snowflake: fix connect by prior selects

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1102,19 +1102,40 @@ class ConnectByClauseSegment(BaseSegment):
     """
 
     type = "connectby_clause"
-    match_grammar = Sequence(
-        "START",
-        "WITH",
-        Ref("ExpressionSegment"),
-        "CONNECT",
-        "BY",
-        Delimited(
+    match_grammar = OneOf(
+        Sequence(
+            "START",
+            "WITH",
+            Ref("ExpressionSegment"),
+            "CONNECT",
+            "BY",
+            Delimited(
+                Sequence(
+                    Ref.keyword("PRIOR", optional=True),
+                    Ref("ColumnReferenceSegment"),
+                    Ref("EqualsSegment"),
+                    Ref.keyword("PRIOR", optional=True),
+                    Ref("ColumnReferenceSegment"),
+                ),
+            ),
+        ),
+        Sequence(
+            "CONNECT",
+            "BY",
+            Delimited(
+                Sequence(
+                    Ref.keyword("PRIOR", optional=True),
+                    Ref("ColumnReferenceSegment"),
+                    Ref("EqualsSegment"),
+                    Ref("ColumnReferenceSegment"),
+                ),
+                delimiter="AND",
+            ),
             Sequence(
-                Ref.keyword("PRIOR", optional=True),
-                Ref("ColumnReferenceSegment"),
-                Ref("EqualsSegment"),
-                Ref.keyword("PRIOR", optional=True),
-                Ref("ColumnReferenceSegment"),
+                "START",
+                "WITH",
+                Ref("ExpressionSegment"),
+                optional=True,
             ),
         ),
     )

--- a/test/fixtures/dialects/snowflake/connect_by.sql
+++ b/test/fixtures/dialects/snowflake/connect_by.sql
@@ -32,3 +32,13 @@ start with title = 'President'
 connect by
     manager_id = prior employee_id
 order by employee_id;
+
+select
+  description,
+  quantity,
+  component_id,
+  parent_component_id,
+  component_type
+from components c
+connect by prior c.parent_component_id = c.component_id AND PRIOR c.component_type = c.component_type
+order by quantity;

--- a/test/fixtures/dialects/snowflake/connect_by.yml
+++ b/test/fixtures/dialects/snowflake/connect_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b2ea3dbc494b78abe541194309260d24ae0a2a77bf63f9da74da0b73cdb74e19
+_hash: 6cf317f99f2d83dd1f2fa16620d22f7640c0da6447e2991be8b07f194ce94671
 file:
 - statement:
     select_statement:
@@ -231,4 +231,68 @@ file:
       - keyword: by
       - column_reference:
           naked_identifier: employee_id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: select
+      - select_clause_element:
+          column_reference:
+            naked_identifier: description
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: quantity
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: component_id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: parent_component_id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: component_type
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: components
+            alias_expression:
+              naked_identifier: c
+          connectby_clause:
+          - keyword: connect
+          - keyword: by
+          - keyword: prior
+          - column_reference:
+            - naked_identifier: c
+            - dot: .
+            - naked_identifier: parent_component_id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: c
+            - dot: .
+            - naked_identifier: component_id
+          - keyword: AND
+          - keyword: PRIOR
+          - column_reference:
+            - naked_identifier: c
+            - dot: .
+            - naked_identifier: component_type
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: c
+            - dot: .
+            - naked_identifier: component_type
+      orderby_clause:
+      - keyword: order
+      - keyword: by
+      - column_reference:
+          naked_identifier: quantity
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Fixes parsing of CONNECT BY PRIOR in SELECT statements where START WITH is not used.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
