### PR TITLE
Snowflake: fixes drop column if exists parsing rules

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -2171,7 +2171,12 @@ class AlterTableTableColumnActionSegment(BaseSegment):
         Sequence(
             "DROP",
             Ref.keyword("COLUMN", optional=True),
-            Delimited(Ref("ColumnReferenceSegment")),
+            Delimited(
+                Sequence(
+                    Ref("IfExistsGrammar", optional=True),
+                    Ref("ColumnReferenceSegment"),
+                )
+            ),
         ),
         # @TODO: Drop columns
         # vvvvv COPIED FROM ANSI vvvvv

--- a/test/fixtures/dialects/snowflake/alter_table_column.sql
+++ b/test/fixtures/dialects/snowflake/alter_table_column.sql
@@ -75,6 +75,12 @@ ALTER TABLE empl_info DROP COLUMN my_column;
 ALTER TABLE some_schema.empl_info DROP COLUMN my_column;
 ALTER TABLE my_table DROP COLUMN column_1, column_2, column_3;
 
+-- Drop column if exists
+ALTER TABLE demo_db.public DROP column IF EXISTS public_name, IF EXISTS description_text, IF EXISTS type_alias;
+ALTER TABLE demo_db.public DROP column public_name,  description_text,  type_alias;
+ALTER TABLE demo_db.public DROP public_name,  description_text,  type_alias;
+ALTER TABLE demo_db.public DROP IF EXISTS public_name, IF EXISTS description_text, IF EXISTS type_alias;
+
 -- IF EXISTS
 ALTER TABLE IF EXISTS my_table ADD COLUMN my_column INTEGER;
 ALTER TABLE IF EXISTS empl_info DROP COLUMN my_column;

--- a/test/fixtures/dialects/snowflake/alter_table_column.yml
+++ b/test/fixtures/dialects/snowflake/alter_table_column.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5d13fc0e5461c17cc822abce14e000655fc3eb1b319d5dfcf4d669eb375b2e62
+_hash: c85d9c9b4e7809f2ce4267b0c22a559222502108af30d8658cee5612afc58e7f
 file:
 - statement:
     alter_table_statement:
@@ -611,6 +611,96 @@ file:
       - comma: ','
       - column_reference:
           naked_identifier: column_3
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: demo_db
+      - dot: .
+      - naked_identifier: public
+    - alter_table_table_column_action:
+      - keyword: DROP
+      - keyword: column
+      - keyword: IF
+      - keyword: EXISTS
+      - column_reference:
+          naked_identifier: public_name
+      - comma: ','
+      - keyword: IF
+      - keyword: EXISTS
+      - column_reference:
+          naked_identifier: description_text
+      - comma: ','
+      - keyword: IF
+      - keyword: EXISTS
+      - column_reference:
+          naked_identifier: type_alias
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: demo_db
+      - dot: .
+      - naked_identifier: public
+    - alter_table_table_column_action:
+      - keyword: DROP
+      - keyword: column
+      - column_reference:
+          naked_identifier: public_name
+      - comma: ','
+      - column_reference:
+          naked_identifier: description_text
+      - comma: ','
+      - column_reference:
+          naked_identifier: type_alias
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: demo_db
+      - dot: .
+      - naked_identifier: public
+    - alter_table_table_column_action:
+      - keyword: DROP
+      - column_reference:
+          naked_identifier: public_name
+      - comma: ','
+      - column_reference:
+          naked_identifier: description_text
+      - comma: ','
+      - column_reference:
+          naked_identifier: type_alias
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: demo_db
+      - dot: .
+      - naked_identifier: public
+    - alter_table_table_column_action:
+      - keyword: DROP
+      - keyword: IF
+      - keyword: EXISTS
+      - column_reference:
+          naked_identifier: public_name
+      - comma: ','
+      - keyword: IF
+      - keyword: EXISTS
+      - column_reference:
+          naked_identifier: description_text
+      - comma: ','
+      - keyword: IF
+      - keyword: EXISTS
+      - column_reference:
+          naked_identifier: type_alias
 - statement_terminator: ;
 - statement:
     alter_table_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Adds parsing fixes to `ALTER TABLE ... DROP COLUMN IF EXISTS` special cases: 
- `DROP IF EXISTS column1, IF EXISTS column2`
- `DROP COLUMN IF EXISTS column1, IF EXISTS column2` 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
