### PR TITLE
Fix ignored inline rule overrides (#5697)

### DIFF
--- a/src/sqlfluff/core/config.py
+++ b/src/sqlfluff/core/config.py
@@ -796,22 +796,7 @@ class FluffConfig:
             False if self._configs["core"].get("nocolor", False) else None
         )
         # Handle inputs which are potentially comma separated strings
-        for in_key, out_key in [
-            # Deal with potential ignore & warning parameters
-            ("ignore", "ignore"),
-            ("warnings", "warnings"),
-            ("rules", "rule_allowlist"),
-            # Allowlists and denylistsignore_words
-            ("exclude_rules", "rule_denylist"),
-        ]:
-            if self._configs["core"].get(in_key, None):
-                # Checking if key is string as can potentially be a list to
-                self._configs["core"][out_key] = split_comma_separated_string(
-                    self._configs["core"][in_key]
-                )
-            else:
-                self._configs["core"][out_key] = []
-
+        self._handle_comma_separated_values()
         # Dialect and Template selection.
         dialect: Optional[str] = self._configs["core"]["dialect"]
         self._initialise_dialect(dialect, require_dialect)
@@ -819,6 +804,20 @@ class FluffConfig:
         self._configs["core"]["templater_obj"] = self.get_templater(
             self._configs["core"]["templater"]
         )
+
+    def _handle_comma_separated_values(self):
+        for in_key, out_key in [
+            ("ignore", "ignore"),
+            ("warnings", "warnings"),
+            ("rules", "rule_allowlist"),
+            ("exclude_rules", "rule_denylist"),
+        ]:
+            if self._configs["core"].get(in_key, None):
+                self._configs["core"][out_key] = split_comma_separated_string(
+                    self._configs["core"][in_key]
+                )
+            else:
+                self._configs["core"][out_key] = []
 
     def _initialise_dialect(
         self, dialect: Optional[str], require_dialect: bool = True
@@ -1181,6 +1180,8 @@ class FluffConfig:
             if raw_line.startswith(("-- sqlfluff", "--sqlfluff")):
                 # Found a in-file config command
                 self.process_inline_config(raw_line, fname)
+        # Deal with potential list-like inputs.
+        self._handle_comma_separated_values()
 
 
 class ProgressBarConfiguration:

--- a/test/core/config_test.py
+++ b/test/core/config_test.py
@@ -598,3 +598,39 @@ def test__process_inline_config():
     # Check that Windows paths don't get mangled
     cfg.process_inline_config("-- sqlfluff:jinja:my_path:c:\\foo", "test.sql")
     assert cfg.get("my_path", section="jinja") == "c:\\foo"
+
+
+@pytest.mark.parametrize(
+    "raw_sql",
+    [
+        (
+            "-- sqlfluff:max_line_length:25\n"
+            "-- sqlfluff:rules:LT05,LT06\n"
+            "-- sqlfluff:exclude_rules:LT01,LT02\n"
+            "SELECT 1"
+        )
+    ],
+)
+def test__process_raw_file_for_config(raw_sql):
+    """Test the processing of a file inline directives."""
+    cfg = FluffConfig(config_b)
+
+    # verify initial attributes based on the preloaded configuration
+    assert cfg.get("max_line_length") == 80
+    assert cfg.get("rules") == "LT03"
+    assert cfg.get("exclude_rules") is None
+
+    # internal list attributes should have corresponding exploded list values
+    assert cfg.get("rule_allowlist") == ["LT03"]
+    assert cfg.get("rule_denylist") == []
+
+    cfg.process_raw_file_for_config(raw_sql, "test.sql")
+
+    # verify overrides based on the file inline directives
+    assert cfg.get("max_line_length") == 25
+    assert cfg.get("rules") == "LT05,LT06"
+    assert cfg.get("exclude_rules") == "LT01,LT02"
+
+    # internal list attributes should have overridden exploded list values
+    assert cfg.get("rule_allowlist") == ["LT05", "LT06"]
+    assert cfg.get("rule_denylist") == ["LT01", "LT02"]


### PR DESCRIPTION
### Brief summary of the change made

Fixes #5697

- The code parsing comma-separated input in the `FluffConfig` class constructor taken out into a separate internal method. This method is called from the `FluffConfig` class constructor to preserve the original use. In addition, it is now also called when inline directive processing on a file is done to ensure the comma-separated lists are exploded into internal variables.

- While this fixes the encountered issue, it does so within the existing facilities for the inline configuration directive parsing. These are however implemented differently from the rest of the configuration loading - the former as a set of method on `FluffConfig`, the latter via a dedicated `ConfigLoader` functions. It is possible that the correct way to fix the problem is to re-implement the inline directive handling via the `ConfigLoader`. However, I am not familiar enough with the code base to make this call.

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
