### PR TITLE
Remove old deps for dbt templater

### DIFF
--- a/constraints/dbt150-winpy.txt
+++ b/constraints/dbt150-winpy.txt
@@ -1,3 +1,2 @@
 dbt-core~=1.5.0
 dbt-postgres~=1.5.0
-markupsafe<=2.0.1

--- a/plugins/sqlfluff-templater-dbt/setup.cfg
+++ b/plugins/sqlfluff-templater-dbt/setup.cfg
@@ -67,10 +67,6 @@ install_requires =
     sqlfluff==3.1.0
     dbt-core>=1.0.0
     jinja2-simple-tags>=0.3.1
-    markupsafe
-    pydantic
-    rich
-    ruamel.yaml
 
 [options.packages.find]
 include =


### PR DESCRIPTION
Based on slack conversation, I think we have some old and unnecessary dependencies in the `setup.cfg` file for the dbt templater.

Those constraints were previously altered:
- `markupsafe` pinned in #2685 to fix #2684, which is linked to dbt-core 1.0 and python 3.8. dbt-core 1.0 doesn't compile anymore (see #4442).
- `markupsafe` unpinned in #3967 (but dependency not removed).
- `ruamel.yaml`, `pydantic` and `rich` were added as dependencies as part of #3976, but then the code that was added was removed in #4273 (but didn't remove the dependencies).

I think it's safe to nuke them now.