### PR TITLE
Replace types-pkg-resources with types-setuptools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         additional_dependencies:
           [
             types-toml,
-            types-pkg_resources,
+            types-setuptools,
             types-chardet,
             types-appdirs,
             types-colorama,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -19,7 +19,7 @@ pytest-xdist
 # MyPy
 mypy
 types-toml
-types-pkg_resources
+types-setuptools
 types-chardet
 types-appdirs
 types-colorama


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
The package `types-pkg-resources` has been yanked with a note to replace with `types-setuptools`

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
