### PR TITLE
RF03: Fixed some subquery reference scenarios

### DIFF
--- a/src/sqlfluff/rules/references/RF03.py
+++ b/src/sqlfluff/rules/references/RF03.py
@@ -99,13 +99,21 @@ class Rule_RF03(BaseRule):
         # Recursively visit and check each query in the tree.
         return list(self._visit_queries(query, visited))
 
-    def _iter_available_targets(self, query) -> Iterator[str]:
+    def _iter_available_targets(
+        self, query: Query, subquery: Optional[Query] = None
+    ) -> Iterator[AliasInfo]:
         """Iterate along a list of valid alias targets."""
         for selectable in query.selectables:
             select_info = selectable.select_info
-            for alias in select_info.table_aliases:
-                if alias.ref_str:
-                    yield alias.ref_str
+            if select_info:
+                for alias in select_info.table_aliases:
+                    if subquery and alias.from_expression_element.path_to(
+                        subquery.selectables[0].selectable
+                    ):
+                        # Skip the subquery alias itself
+                        continue
+                    if (subquery and not alias.object_reference) or alias.ref_str:
+                        yield alias
 
     def _visit_queries(self, query: Query, visited: set) -> Iterator[LintResult]:
         select_info: Optional[SelectStatementColumnsAndTables] = None
@@ -117,11 +125,12 @@ class Rule_RF03(BaseRule):
                 fixable = True
                 # :TRICKY: Subqueries in the column list of a SELECT can see tables
                 # in the FROM list of the containing query. Thus, count tables at
-                # the *parent* query level.
+                # the *parent* query level. Only check if it is a subquery of the
+                # parent.
                 possible_ref_tables = list(self._iter_available_targets(query))
-                if query.parent:
+                if query.parent and query.is_subquery:
                     possible_ref_tables += list(
-                        self._iter_available_targets(query.parent)
+                        self._iter_available_targets(query.parent, query)
                     )
                 if len(possible_ref_tables) > 1:
                     # If more than one table name is visible, check for and report
@@ -268,13 +277,16 @@ def _validate_one_reference(
 
     # If not, it's the wrong type and we should handle it.
     if single_table_references == "unqualified":
+        # If unqualified and not fixable, there is no error.
+        if not fixable:
+            return None
         # If this is qualified we must have a "table", "."" at least
-        fixes = [LintFix.delete(el) for el in ref.segments[:2]] if fixable else None
         return LintResult(
             anchor=ref,
-            fixes=fixes,
-            description="{} reference {!r} found in single table "
-            "select.".format(this_ref_type.capitalize(), ref.raw),
+            fixes=[LintFix.delete(el) for el in ref.segments[:2]],
+            description="{} reference {!r} found in single table select.".format(
+                this_ref_type.capitalize(), ref.raw
+            ),
         )
 
     fixes = None
@@ -295,6 +307,7 @@ def _validate_one_reference(
     return LintResult(
         anchor=ref,
         fixes=fixes,
-        description="{} reference {!r} found in single table "
-        "select.".format(this_ref_type.capitalize(), ref.raw),
+        description="{} reference {!r} found in single table select.".format(
+            this_ref_type.capitalize(), ref.raw
+        ),
     )

--- a/src/sqlfluff/utils/analysis/query.py
+++ b/src/sqlfluff/utils/analysis/query.py
@@ -181,6 +181,7 @@ class Query(Generic[T]):
     subqueries: List[T] = field(default_factory=list)
     cte_definition_segment: Optional[BaseSegment] = field(default=None)
     cte_name_segment: Optional[BaseSegment] = field(default=None)
+    is_subquery: Optional[bool] = None
 
     def __post_init__(self):
         # Once instantiated, set the `parent` attribute of any
@@ -188,6 +189,8 @@ class Query(Generic[T]):
         # we'll reset them anyway here.
         for subquery in self.subqueries:
             subquery.parent = self
+            # We set this here to prevent a potential recursion error in RF03.
+            subquery.is_subquery = True
         # NOTE: In normal operation, CTEs are typically set after
         # instantiation, and so for this method there aren't normally
         # any present. It is included here for completeness but not

--- a/test/fixtures/rules/std_rule_cases/RF03.yml
+++ b/test/fixtures/rules/std_rule_cases/RF03.yml
@@ -379,3 +379,123 @@ pass_tsql_subselect_merge_statement:
   configs:
     core:
       dialect: tsql
+
+test_pass_subselect_unqualified_one_reference_3987:
+  pass_str: |
+    SELECT 1
+    FROM mydataset.table1 AS a
+    WHERE EXISTS (
+        SELECT 1
+        FROM mydataset.table2
+        WHERE a.id = id
+    );
+  configs:
+    rules:
+      references.consistent:
+        single_table_references: unqualified
+
+test_pass_subselect_unqualified_two_references_3987:
+  pass_str: |
+    SELECT 1
+    FROM mydataset.table1 AS a
+    WHERE EXISTS (
+        SELECT 1
+        FROM mydataset.table2 AS b
+        WHERE a.id = b.id
+    );
+  configs:
+    rules:
+      references.consistent:
+        single_table_references: unqualified
+
+test_pass_subselect_qualified_reference_5599:
+  pass_str: |
+    insert into dim.clients
+    (
+        data_source
+    )
+    select s.data_source
+    from
+        dim.clients_stg as s
+    where
+        not exists (
+            select 1 from dim.clients as t
+            where s.id = t.id
+        )
+    ;
+  configs:
+    rules:
+      references.consistent:
+        single_table_references: qualified
+
+test_fail_no_fix_unqualified_correlated_subquery_5983:
+  fail_str: |
+    SELECT
+        *,
+        (
+          SELECT C.JobId FROM customer AS C WHERE C.Id = CustomerId LIMIT 1
+        ) AS CustomerId
+    FROM (
+    SELECT
+        F.*,
+        B.*
+    FROM
+        foo AS F
+        LEFT JOIN bar AS B ON P.Id = B.ParentId
+    );
+
+test_fail_cte_qualified_to_unqualified_6014:
+  fail_str: |
+    with
+    final as (
+        select
+            my_table.first,
+            second
+        from my_table
+    )
+
+    select *
+    from final
+  fix_str: |
+    with
+    final as (
+        select
+            first,
+            second
+        from my_table
+    )
+
+    select *
+    from final
+  configs:
+    rules:
+      references.consistent:
+        single_table_references: unqualified
+
+test_fail_cte_unqualified_to_qualified_6014:
+  fail_str: |
+    with
+    final as (
+        select
+            my_table.first,
+            second
+        from my_table
+    )
+
+    select *
+    from final
+  fix_str: |
+    with
+    final as (
+        select
+            my_table.first,
+            my_table.second
+        from my_table
+    )
+
+    select *
+    from final
+  configs:
+    rules:
+      references.consistent:
+        single_table_references: qualified


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This fixes a number of edge cases with subqueries with RF03.
- fixes #3987
- fixes #5599 
- fixes #5983
- fixes #6014

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
