### PR TITLE
CV11: Remove rogue print statement

### DIFF
--- a/src/sqlfluff/rules/convention/CV11.py
+++ b/src/sqlfluff/rules/convention/CV11.py
@@ -265,7 +265,6 @@ class Rule_CV11(BaseRule):
                         functional_context.segment
                     )
 
-                    print(previous_skipped)
                     fixes = self._cast_fix_list(
                         context,
                         [expression_datatype_segment[0]],


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Removes the print statement found in CV11.
- fixes #4850

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
