### PR TITLE
fix(clickhouse): add support for limit by and bracketed format

### DIFF
--- a/test/fixtures/dialects/clickhouse/cte.yml
+++ b/test/fixtures/dialects/clickhouse/cte.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5f5efb217212b97c6ea3f52e5a265c8dc25e078729131d82262c8a1cbd33285d
+_hash: a781900a4223eeddfdc1a86e4fe5570da0271324d600b31f793e0ec3035c7f66
 file:
 - statement:
     with_compound_statement:
@@ -285,7 +285,8 @@ file:
         - keyword: DESC
         limit_clause:
           keyword: LIMIT
-          numeric_literal: '10'
+          limit_clause_component:
+            numeric_literal: '10'
 - statement_terminator: ;
 - statement:
     with_compound_statement:

--- a/test/fixtures/dialects/clickhouse/limit_by.sql
+++ b/test/fixtures/dialects/clickhouse/limit_by.sql
@@ -1,0 +1,7 @@
+with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 1, 2 by id;
+
+with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 1 by id;
+
+with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 2 OFFSET 1 by id;
+
+with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 2, 1 by (id, name);

--- a/test/fixtures/dialects/clickhouse/limit_by.yml
+++ b/test/fixtures/dialects/clickhouse/limit_by.yml
@@ -1,0 +1,202 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: ac1e31885ec99f99cc12fb2e2a01a26801f4f0fed014c59a6c75a0d381cdbb3a
+file:
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        naked_identifier: toto
+        keyword: as
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                numeric_literal: '1'
+                alias_expression:
+                  keyword: as
+                  naked_identifier: id
+            - comma: ','
+            - select_clause_element:
+                quoted_literal: "'test'"
+                alias_expression:
+                  keyword: as
+                  naked_identifier: name
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: toto
+        limit_clause:
+        - keyword: LIMIT
+        - limit_clause_component:
+            numeric_literal: '1'
+        - comma: ','
+        - limit_clause_component:
+            numeric_literal: '2'
+        - keyword: by
+        - column_reference:
+            naked_identifier: id
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        naked_identifier: toto
+        keyword: as
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                numeric_literal: '1'
+                alias_expression:
+                  keyword: as
+                  naked_identifier: id
+            - comma: ','
+            - select_clause_element:
+                quoted_literal: "'test'"
+                alias_expression:
+                  keyword: as
+                  naked_identifier: name
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: toto
+        limit_clause:
+        - keyword: LIMIT
+        - limit_clause_component:
+            numeric_literal: '1'
+        - keyword: by
+        - column_reference:
+            naked_identifier: id
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        naked_identifier: toto
+        keyword: as
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                numeric_literal: '1'
+                alias_expression:
+                  keyword: as
+                  naked_identifier: id
+            - comma: ','
+            - select_clause_element:
+                quoted_literal: "'test'"
+                alias_expression:
+                  keyword: as
+                  naked_identifier: name
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: toto
+        limit_clause:
+        - keyword: LIMIT
+        - limit_clause_component:
+            numeric_literal: '2'
+        - keyword: OFFSET
+        - limit_clause_component:
+            numeric_literal: '1'
+        - keyword: by
+        - column_reference:
+            naked_identifier: id
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        naked_identifier: toto
+        keyword: as
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                numeric_literal: '1'
+                alias_expression:
+                  keyword: as
+                  naked_identifier: id
+            - comma: ','
+            - select_clause_element:
+                quoted_literal: "'test'"
+                alias_expression:
+                  keyword: as
+                  naked_identifier: name
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: toto
+        limit_clause:
+        - keyword: LIMIT
+        - limit_clause_component:
+            numeric_literal: '2'
+        - comma: ','
+        - limit_clause_component:
+            numeric_literal: '1'
+        - keyword: by
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: id
+          - comma: ','
+          - column_reference:
+              naked_identifier: name
+          - end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/clickhouse/limit_delimited.sql
+++ b/test/fixtures/dialects/clickhouse/limit_delimited.sql
@@ -1,0 +1,7 @@
+with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 1;
+
+with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 1 OFFSET 1;
+
+with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT 1, 2;
+
+with toto as (SELECT 1 as id, 'test' as name) SELECT * FROM toto LIMIT (1), (2);

--- a/test/fixtures/dialects/clickhouse/limit_delimited.yml
+++ b/test/fixtures/dialects/clickhouse/limit_delimited.yml
@@ -1,0 +1,190 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: d1e7ebf65dc7ba0f08fdb5ff4ef034216241ca80d587b3b9f96961cfb4cd5c12
+file:
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        naked_identifier: toto
+        keyword: as
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                numeric_literal: '1'
+                alias_expression:
+                  keyword: as
+                  naked_identifier: id
+            - comma: ','
+            - select_clause_element:
+                quoted_literal: "'test'"
+                alias_expression:
+                  keyword: as
+                  naked_identifier: name
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: toto
+        limit_clause:
+          keyword: LIMIT
+          limit_clause_component:
+            numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        naked_identifier: toto
+        keyword: as
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                numeric_literal: '1'
+                alias_expression:
+                  keyword: as
+                  naked_identifier: id
+            - comma: ','
+            - select_clause_element:
+                quoted_literal: "'test'"
+                alias_expression:
+                  keyword: as
+                  naked_identifier: name
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: toto
+        limit_clause:
+        - keyword: LIMIT
+        - limit_clause_component:
+            numeric_literal: '1'
+        - keyword: OFFSET
+        - limit_clause_component:
+            numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        naked_identifier: toto
+        keyword: as
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                numeric_literal: '1'
+                alias_expression:
+                  keyword: as
+                  naked_identifier: id
+            - comma: ','
+            - select_clause_element:
+                quoted_literal: "'test'"
+                alias_expression:
+                  keyword: as
+                  naked_identifier: name
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: toto
+        limit_clause:
+        - keyword: LIMIT
+        - limit_clause_component:
+            numeric_literal: '1'
+        - comma: ','
+        - limit_clause_component:
+            numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        naked_identifier: toto
+        keyword: as
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                numeric_literal: '1'
+                alias_expression:
+                  keyword: as
+                  naked_identifier: id
+            - comma: ','
+            - select_clause_element:
+                quoted_literal: "'test'"
+                alias_expression:
+                  keyword: as
+                  naked_identifier: name
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: toto
+        limit_clause:
+        - keyword: LIMIT
+        - limit_clause_component:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '1'
+              end_bracket: )
+        - comma: ','
+        - limit_clause_component:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '2'
+              end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
fixes #5494 adding support for limit by and limit 1,2 as well as LIMIT (1), (2) formats that are valid in Clickhouse

### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
