### PR TITLE
Add perma-links for rules

### DIFF
--- a/docs/generate-rule-docs.py
+++ b/docs/generate-rule-docs.py
@@ -1,5 +1,6 @@
 """Generate rule documentation automatically."""
 
+import json
 from collections import defaultdict
 from pathlib import Path
 
@@ -27,10 +28,17 @@ table_header = f"""
 # Extract all the rules.
 print("Rule Docs Generation: Reading Rules...")
 rule_bundles = defaultdict(list)
+rule_list = []
 for plugin_rules in get_plugin_manager().hook.get_rules():
     for rule in plugin_rules:
         _bundle_name = rule.name.split(".")[0]
         rule_bundles[_bundle_name].append(rule)
+        rule_list.append((rule.code, rule.name))
+
+# Write them into a json file for use by redirects.
+print("Rule Docs Generation: Writing Rule JSON...")
+with open(base_path / "source/_partials/rule_list.json", "w", encoding="utf8") as f:
+    json.dump(rule_list, f)
 
 # Write them into the table. Bundle by bundle.
 print("Rule Docs Generation: Writing Rule Table...")

--- a/docs/source/_partials/.gitignore
+++ b/docs/source/_partials/.gitignore
@@ -1,2 +1,3 @@
 rule_table.rst
 rule_summaries.rst
+rule_list.json

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -148,7 +148,8 @@ redirects = {
     **{
         f"perma/rule/{code}": (
             f"../../reference/rules.html#sqlfluff.rules.sphinx.Rule_{code}"
-        ) for code, _ in rule_list
+        )
+        for code, _ in rule_list
     },
     # These are legacy links which used to exist in different parts of the
     # SQLFluff code base, and which we continue to support so those links

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,6 +5,7 @@ list see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
+import json
 import os
 import sys
 
@@ -110,6 +111,10 @@ html_theme_options = {
 # -- Options for redirects ---------------------------------------------
 # https://documatt.gitlab.io/sphinx-reredirects/usage.html
 
+# Load the rule lists to generate rule permalinks
+with open("_partials/rule_list.json", "r") as rule_file:
+    rule_list = json.load(rule_file)
+
 redirects = {
     # Where there are references to the docs in any of the codebase (whether in
     # places like the README or in error messages), they should all reference
@@ -139,6 +144,12 @@ redirects = {
     "perma/why": "../why_sqlfluff.html",
     "perma/plugin_dev": "../development/plugins.html",
     "perma/variables": "../configuration/templating/index.html",
+    # Add permalinks for rule codes
+    **{
+        f"perma/rule/{code}": (
+            f"../../reference/rules.html#sqlfluff.rules.sphinx.Rule_{code}"
+        ) for code, _ in rule_list
+    },
     # These are legacy links which used to exist in different parts of the
     # SQLFluff code base, and which we continue to support so those links
     # aren't dead ends. They should redirect to permalinks.
@@ -149,6 +160,9 @@ redirects = {
     "layout": "perma/layout.html",
     "releasenotes": "perma/releasenotes.html",
     "realworld": "perma/why.html",
+    # This is a legacy link to support older versions of the VSCode plugin.
+    # https://github.com/sqlfluff/vscode-sqlfluff/blob/master/src/features/providers/linter/actions/hover.ts
+    "rules": "perma/rules.html",
 }
 
 


### PR DESCRIPTION
Unfortunately, #6052 will break the VSCode docs link, by moving the rules again. However I now have a better solution so that we never need to break them again!

**RULE PERMALINKS**.

This PR adds permanent links to the rules which can then internally redirect. e.g. the VSCode plugin would be able to point at `/perma/rule/RF01.html` and be internally redirected by the docs to the appropriate location - in this case `/reference/rules.html#sqlfluff.rules.sphinx.Rule_RF01`.

I'll make a PR for the VSCode plugin shortly.