### PR TITLE
LT04: Fix indentation conflict with LT02

### DIFF
--- a/src/sqlfluff/utils/reflow/rebreak.py
+++ b/src/sqlfluff/utils/reflow/rebreak.py
@@ -381,7 +381,8 @@ def rebreak_sequence(
                 # the _preceding_ point.
                 fixes.append(LintFix.delete(loc.target))
                 for seg in elem_buff[loc.prev.adj_pt_idx].segments:
-                    fixes.append(LintFix.delete(seg))
+                    if not seg.is_type("dedent"):
+                        fixes.append(LintFix.delete(seg))
 
                 # We always reinsert after the first point, but respace
                 # the inserted point to ensure it's the right size given

--- a/test/rules/std_LT02_LT04_test.py
+++ b/test/rules/std_LT02_LT04_test.py
@@ -1,0 +1,74 @@
+"""Tests the python routines within LT02 and LT04."""
+
+import pytest
+
+from sqlfluff.core import FluffConfig, Linter
+
+
+@pytest.mark.parametrize(
+    ["in_sql", "out_sql"],
+    [
+        (
+            """SELECT
+    acct_id,
+    date_x,
+    't' AS test,
+
+    CASE
+        WHEN condition_1 = '1' THEN ''
+        ELSE condition_1
+    END AS case_1,
+
+    CASE
+        WHEN condition_2 = '2' THEN ''
+        ELSE condition_2
+    END AS case_2,
+    dollar_amt,
+FROM
+    table_x""",
+            """SELECT
+    acct_id
+    , date_x
+    , 't' AS test
+
+    , CASE
+        WHEN condition_1 = '1' THEN ''
+        ELSE condition_1
+    END AS case_1
+
+    , CASE
+        WHEN condition_2 = '2' THEN ''
+        ELSE condition_2
+    END AS case_2
+    , dollar_amt,
+FROM
+    table_x""",
+        ),
+    ],
+)
+def test_rules_std_LT02_LT04_interaction_indentation_leading(in_sql, out_sql) -> None:
+    """Test interaction between LT02 and LT04.
+
+    Test sql with two newlines with trailing commas expecting leading.
+    """
+    # Lint expected rules.
+    cfg = FluffConfig.from_string(
+        """[sqlfluff]
+dialect = snowflake
+rules = LT02, LT04
+
+[sqlfluff:layout:type:comma]
+spacing_before = touch
+line_position = leading
+"""
+    )
+    linter = Linter(config=cfg)
+
+    # Return linted/fixed file.
+    linted_file = linter.lint_string(in_sql, fix=True)
+
+    # Check expected lint errors are raised.
+    assert set([v.rule.code for v in linted_file.violations]) == {"LT04"}
+
+    # Check file is fixed.
+    assert linted_file.fix_string()[0] == out_sql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This corrects the issue with LT04 removing `dedent` segments from the fix.
- fixes #5466

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
