### PR TITLE
pre-commit: Disable progress bar

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,9 @@
 - id: sqlfluff-lint
   name: sqlfluff-lint
   # Set `--processes 0` to use maximum parallelism
-  entry: sqlfluff lint --processes 0
+  #  - `--disable-progress-bar` pre-commit suppresses logging already
+  #      this can cause an unneeded slow down.
+  entry: sqlfluff lint --processes 0 --disable-progress-bar
   language: python
   description: "Lints sql files with `SQLFluff`"
   types: [sql]
@@ -13,8 +15,10 @@
   # Set a couple of default flags:
   #  - `--show-lint-violations` shows issues to not require running `sqlfluff lint`
   #  - `--processes 0` to use maximum parallelism
+  #  - `--disable-progress-bar` pre-commit suppresses logging already
+  #      this can cause an unneeded slow down.
   # By default, this hook applies all rules.
-  entry: sqlfluff fix --show-lint-violations --processes 0
+  entry: sqlfluff fix --show-lint-violations --processes 0 --disable-progress-bar
   language: python
   description: "Fixes sql lint errors with `SQLFluff`"
   types: [sql]


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This disables the pre-commit hooks from using the progress bar. Pre-commit doesn't print information to the terminal until after the hook completes. Disabling this in the hook improves performance.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
