### PR TITLE
fix(clickhouse): add support for tuple() and ENGINE MergeTree

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -271,6 +271,24 @@ class FormatClauseSegment(BaseSegment):
     )
 
 
+class MergeTreesOrderByClauseSegment(BaseSegment):
+    """A `ORDER BY` clause for the MergeTree family engine."""
+
+    type = "merge_tree_order_by_clause"
+    match_grammar: Matchable = Sequence(
+        "ORDER",
+        "BY",
+        OneOf(
+            Sequence(
+                "TUPLE",
+                Bracketed(),  # tuple() not tuple
+            ),
+            Ref("BracketedColumnReferenceListGrammar"),
+            Ref("ColumnReferenceSegment"),
+        ),
+    )
+
+
 class PreWhereClauseSegment(BaseSegment):
     """A `PREWHERE` clause like in `SELECT` or `INSERT`."""
 
@@ -647,18 +665,11 @@ class TableEngineSegment(BaseSegment):
     type = "engine"
     match_grammar = Sequence(
         "ENGINE",
-        Ref("EqualsSegment"),
+        Ref("EqualsSegment", optional=True),
         Sequence(
             Ref("TableEngineFunctionSegment"),
             AnySetOf(
-                Sequence(
-                    "ORDER",
-                    "BY",
-                    OneOf(
-                        Ref("BracketedColumnReferenceListGrammar"),
-                        Ref("ColumnReferenceSegment"),
-                    ),
-                ),
+                Ref("MergeTreesOrderByClauseSegment"),
                 Sequence(
                     "PARTITION",
                     "BY",
@@ -724,15 +735,7 @@ class DatabaseEngineSegment(BaseSegment):
         Sequence(
             Ref("DatabaseEngineFunctionSegment"),
             AnySetOf(
-                Sequence(
-                    "ORDER",
-                    "BY",
-                    OneOf(
-                        Ref("BracketedColumnReferenceListGrammar"),
-                        Ref("ColumnReferenceSegment"),
-                    ),
-                    optional=True,
-                ),
+                Ref("MergeTreesOrderByClauseSegment"),
                 Sequence(
                     "PARTITION",
                     "BY",

--- a/test/fixtures/dialects/clickhouse/create_materialized_view.sql
+++ b/test/fixtures/dialects/clickhouse/create_materialized_view.sql
@@ -48,3 +48,8 @@ AS
         column1,
         column2
     FROM table_kafka;
+
+CREATE MATERIALIZED VIEW db.mv_table
+ENGINE MergeTree
+ORDER BY ()
+AS SELECT * FROM db.table;

--- a/test/fixtures/dialects/clickhouse/create_materialized_view.yml
+++ b/test/fixtures/dialects/clickhouse/create_materialized_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b2c3cc157211631bf681fb486c2acfbe8a05f377b12eef199b5f5fe7e89d1653
+_hash: 5ae9466354f14bd27c81ab733286658cf0954d0eefe200aeb4b58895acadcd7e
 file:
 - statement:
     create_materialized_view_statement:
@@ -225,4 +225,42 @@ file:
               table_expression:
                 table_reference:
                   naked_identifier: table_kafka
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: mv_table
+    - engine:
+        keyword: ENGINE
+        table_engine_function:
+          function_name:
+            function_name_identifier: MergeTree
+        merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - bracketed:
+            start_bracket: (
+            end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: db
+                - dot: .
+                - naked_identifier: table
 - statement_terminator: ;

--- a/test/fixtures/dialects/clickhouse/create_table.yml
+++ b/test/fixtures/dialects/clickhouse/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0d8c06d7b85df995a48a26ffd92efdb9082f25001adda4393383ef373b2dd2b9
+_hash: 4609a345d1662797a81f7a236eaacc1bf251053128d52bdb972cfc24a9078026
 file:
 - statement:
     create_table_statement:
@@ -24,25 +24,26 @@ file:
             data_type_identifier: String
       - end_bracket: )
     - engine:
-      - keyword: engine
-      - comparison_operator:
+        keyword: engine
+        comparison_operator:
           raw_comparison_operator: '='
-      - table_engine_function:
+        table_engine_function:
           function_name:
             function_name_identifier: MergeTree
           bracketed:
             start_bracket: (
             end_bracket: )
-      - keyword: order
-      - keyword: by
-      - bracketed:
-        - start_bracket: (
-        - column_reference:
-            naked_identifier: a
-        - comma: ','
-        - column_reference:
-            naked_identifier: b
-        - end_bracket: )
+        merge_tree_order_by_clause:
+        - keyword: order
+        - keyword: by
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: a
+          - comma: ','
+          - column_reference:
+              naked_identifier: b
+          - end_bracket: )
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -77,16 +78,17 @@ file:
           bracketed:
             start_bracket: (
             end_bracket: )
-      - keyword: ORDER
-      - keyword: BY
-      - bracketed:
-        - start_bracket: (
-        - column_reference:
-            naked_identifier: CounterID
-        - comma: ','
-        - column_reference:
-            naked_identifier: EventDate
-        - end_bracket: )
+      - merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: CounterID
+          - comma: ','
+          - column_reference:
+              naked_identifier: EventDate
+          - end_bracket: )
       - keyword: PARTITION
       - keyword: BY
       - expression:
@@ -201,16 +203,17 @@ file:
       - expression:
           column_reference:
             naked_identifier: date
-      - keyword: ORDER
-      - keyword: BY
-      - bracketed:
-        - start_bracket: (
-        - column_reference:
-            naked_identifier: UserId
-        - comma: ','
-        - column_reference:
-            naked_identifier: EventType
-        - end_bracket: )
+      - merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: UserId
+          - comma: ','
+          - column_reference:
+              naked_identifier: EventType
+          - end_bracket: )
       - settings_clause:
           keyword: SETTINGS
           naked_identifier: index_granularity
@@ -441,16 +444,17 @@ file:
               - end_bracket: )
         end_bracket: )
     - engine:
-      - keyword: ENGINE
-      - comparison_operator:
+        keyword: ENGINE
+        comparison_operator:
           raw_comparison_operator: '='
-      - table_engine_function:
+        table_engine_function:
           function_name:
             function_name_identifier: MergeTree
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
-          naked_identifier: x
+        merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: x
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -475,16 +479,17 @@ file:
             data_type_identifier: String
       - end_bracket: )
     - engine:
-      - keyword: ENGINE
-      - comparison_operator:
+        keyword: ENGINE
+        comparison_operator:
           raw_comparison_operator: '='
-      - table_engine_function:
+        table_engine_function:
           function_name:
             function_name_identifier: MergeTree
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
-          naked_identifier: n
+        merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: n
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -514,16 +519,17 @@ file:
               end_bracket: )
       - end_bracket: )
     - engine:
-      - keyword: ENGINE
-      - comparison_operator:
+        keyword: ENGINE
+        comparison_operator:
           raw_comparison_operator: '='
-      - table_engine_function:
+        table_engine_function:
           function_name:
             function_name_identifier: MergeTree
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
-          naked_identifier: n
+        merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: n
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -701,10 +707,11 @@ file:
                 column_reference:
                   naked_identifier: d
               end_bracket: )
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
-          naked_identifier: d
+      - merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: d
 - statement_terminator: ;
 - statement:
     create_table_statement:
@@ -743,10 +750,11 @@ file:
                 column_reference:
                   naked_identifier: d
               end_bracket: )
-      - keyword: ORDER
-      - keyword: BY
-      - column_reference:
-          naked_identifier: d
+      - merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: d
     - table_ttl_segment:
       - keyword: TTL
       - expression:

--- a/test/fixtures/dialects/clickhouse/create_temporary_table.yml
+++ b/test/fixtures/dialects/clickhouse/create_temporary_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8fab8176123d3063d83e53cc60e50bb312fc5eaeaac89cb9c50d73489f4635d5
+_hash: 51d346a915d0f87f6d66889eb8169b3d44ac5f87f62588a851beb4fca8e6c52b
 file:
 - statement:
     create_table_statement:
@@ -56,22 +56,23 @@ file:
             data_type_identifier: DateTime32
       - end_bracket: )
     - engine:
-      - keyword: ENGINE
-      - comparison_operator:
+        keyword: ENGINE
+        comparison_operator:
           raw_comparison_operator: '='
-      - table_engine_function:
+        table_engine_function:
           function_name:
             function_name_identifier: MergeTree
-      - keyword: ORDER
-      - keyword: BY
-      - bracketed:
-        - start_bracket: (
-        - column_reference:
-            naked_identifier: ty
-        - comma: ','
-        - column_reference:
-            naked_identifier: t2
-        - end_bracket: )
+        merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: ty
+          - comma: ','
+          - column_reference:
+              naked_identifier: t2
+          - end_bracket: )
     - table_ttl_segment:
         keyword: TTL
         expression:


### PR DESCRIPTION
### Brief summary of the change made
Fixes #5749 - the support for create materialized view is ok but needed to be more lenient in regarde to the following syntaxes : 
```
ENGINE = MergeTree()
-- equivalent to
ENGINE MergeTree
```
and 
```
ORDER BY (col1, col2)
-- or if you don't care what to pick using a MergeTree engine 
ORDER BY tuple() -- the parenthesis being mandatory
```



### Are there any other side effects of this change that we should be aware of?
Nope

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).