### PR TITLE
Databricks: Add support for GROUP BY ALL

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -1900,7 +1900,7 @@ class SelectStatementSegment(ansi.SelectStatementSegment):
 
 
 class GroupByClauseSegment(ansi.GroupByClauseSegment):
-    """Enhance `GROUP BY` clause like in `SELECT` for 'CUBE' and 'ROLLUP`.
+    """Enhance `GROUP BY` clause like in `SELECT` for `CUBE` and `ROLLUP`.
 
     https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-groupby.html
     """
@@ -1911,12 +1911,12 @@ class GroupByClauseSegment(ansi.GroupByClauseSegment):
         Indent,
         OneOf(
             Delimited(
+                Ref("CubeRollupClauseSegment"),
+                Ref("GroupingSetsClauseSegment"),
                 Ref("ColumnReferenceSegment"),
                 # Can `GROUP BY 1`
                 Ref("NumericLiteralSegment"),
                 # Can `GROUP BY coalesce(col, 1)`
-                Ref("CubeRollupClauseSegment"),
-                Ref("GroupingSetsClauseSegment"),
                 Ref("ExpressionSegment"),
             ),
             Sequence(
@@ -1928,7 +1928,8 @@ class GroupByClauseSegment(ansi.GroupByClauseSegment):
                     Ref("ExpressionSegment"),
                 ),
                 OneOf(
-                    Ref("WithCubeRollupClauseSegment"), Ref("GroupingSetsClauseSegment")
+                    Ref("WithCubeRollupClauseSegment"),
+                    Ref("GroupingSetsClauseSegment"),
                 ),
             ),
         ),

--- a/test/fixtures/dialects/databricks/select_group_by.sql
+++ b/test/fixtures/dialects/databricks/select_group_by.sql
@@ -1,0 +1,140 @@
+-- Sum of quantity per dealership. Group by `id`.
+SELECT
+    id,
+    sum(quantity) AS sum_quantity
+FROM dealer GROUP BY id ORDER BY id;
+
+-- Use column position in GROUP by clause.
+SELECT
+    id,
+    sum(quantity) AS sum_quantity
+FROM dealer GROUP BY 1 ORDER BY 1;
+
+-- Multiple aggregations.
+-- 1. Sum of quantity per dealership.
+-- 2. Max quantity per dealership.
+SELECT
+    id,
+    sum(quantity) AS sum_quantity,
+    max(quantity) AS max_quantity
+FROM dealer GROUP BY id ORDER BY id;
+
+-- Count the number of distinct dealer cities per car_model.
+SELECT
+    car_model,
+    count(DISTINCT city) AS count_distinct_city
+FROM dealer GROUP BY car_model;
+
+-- Sum of only 'Honda Civic' and 'Honda CRV' quantities per dealership.
+SELECT
+    id,
+    sum(quantity) FILTER (
+        WHERE car_model IN ('Honda Civic', 'Honda CRV')
+    ) AS `sum(quantity)` FROM dealer
+GROUP BY id ORDER BY id;
+
+-- Aggregations using multiple sets of grouping columns in a single statement.
+-- Following performs aggregations based on four sets of grouping columns.
+-- 1. city, car_model
+-- 2. city
+-- 3. car_model
+-- 4. Empty grouping set. Returns quantities for all city and car models.
+SELECT
+    city,
+    car_model,
+    sum(quantity) AS sum_quantity
+FROM dealer
+GROUP BY GROUPING SETS ((city, car_model), (city), (car_model), ())
+ORDER BY city;
+
+SELECT
+    city,
+    car_model,
+    sum(quantity) AS sum_quantity
+FROM dealer
+GROUP BY city, car_model GROUPING SETS ((city, car_model), (city), (car_model), ())
+ORDER BY city;
+
+SELECT
+    city,
+    car_model,
+    sum(quantity) AS sum_quantity
+FROM dealer
+GROUP BY city, car_model, GROUPING SETS ((city, car_model), (city), (car_model), ())
+ORDER BY city;
+
+-- Group by processing with `ROLLUP` clause.
+-- Equivalent GROUP BY GROUPING SETS ((city, car_model), (city), ())
+SELECT
+    city,
+    car_model,
+    sum(quantity) AS sum_quantity
+FROM dealer
+GROUP BY city, car_model WITH ROLLUP
+ORDER BY city, car_model;
+
+-- Group by processing with `CUBE` clause.
+-- Equivalent GROUP BY:
+-- GROUPING SETS ((city, car_model), (city), (car_model), ())
+SELECT
+    city,
+    car_model,
+    sum(quantity) AS sum_quantity
+FROM dealer
+GROUP BY city, car_model WITH CUBE
+ORDER BY city, car_model;
+
+-- Select the first row in column age
+-- Implicit GROUP BY
+SELECT first(age) FROM person;
+
+-- Implicit GROUP BY
+SELECT
+    first(age IGNORE NULLS) AS first_age,
+    last(id) AS last_id,
+    sum(id) AS sum_id
+FROM person;
+
+-- CUBE within GROUP BY clause
+SELECT
+    name,
+    age,
+    count(*) AS record_count
+FROM people
+GROUP BY cube(name, age);
+
+-- CUBE within GROUP BY clause with single clause on newline
+SELECT
+    name,
+    count(*) AS record_count
+FROM people
+GROUP BY cube(
+    name
+);
+
+-- CUBE within GROUP BY clause with multiple clauses on newline
+SELECT
+    name,
+    age,
+    count(*) AS record_count
+FROM people
+GROUP BY cube(
+    name,
+    age
+);
+
+-- ROLLUP within GROUP BY clause
+SELECT
+    name,
+    age,
+    count(*) AS record_count
+FROM people
+GROUP BY rollup(name, age);
+
+-- GROUP BY ALL
+SELECT
+    name,
+    age,
+    count(*) AS record_count
+FROM people
+GROUP BY ALL;

--- a/test/fixtures/dialects/databricks/select_group_by.yml
+++ b/test/fixtures/dialects/databricks/select_group_by.yml
@@ -1,0 +1,863 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 40c5bb2051b0965431559f09e5a017f3bd129a4dbcb5a93df18239c8ac66ccee
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: sum
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: quantity
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: sum_quantity
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dealer
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: id
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: sum
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: quantity
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: sum_quantity
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dealer
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - numeric_literal: '1'
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: sum
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: quantity
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: sum_quantity
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: max
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: quantity
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: max_quantity
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dealer
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: id
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: car_model
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            bracketed:
+              start_bracket: (
+              keyword: DISTINCT
+              expression:
+                column_reference:
+                  naked_identifier: city
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: count_distinct_city
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dealer
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: car_model
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          function:
+          - function_name:
+              function_name_identifier: sum
+          - bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: quantity
+              end_bracket: )
+          - keyword: FILTER
+          - bracketed:
+              start_bracket: (
+              keyword: WHERE
+              expression:
+                column_reference:
+                  naked_identifier: car_model
+                keyword: IN
+                bracketed:
+                - start_bracket: (
+                - quoted_literal: "'Honda Civic'"
+                - comma: ','
+                - quoted_literal: "'Honda CRV'"
+                - end_bracket: )
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            quoted_identifier: '`sum(quantity)`'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dealer
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: id
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: city
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: car_model
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: sum
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: quantity
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: sum_quantity
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dealer
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - grouping_sets_clause:
+        - keyword: GROUPING
+        - keyword: SETS
+        - bracketed:
+            start_bracket: (
+            grouping_expression_list:
+            - expression:
+                bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: city
+                - comma: ','
+                - column_reference:
+                    naked_identifier: car_model
+                - end_bracket: )
+            - comma: ','
+            - expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: city
+                  end_bracket: )
+            - comma: ','
+            - expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: car_model
+                  end_bracket: )
+            - comma: ','
+            - expression:
+                bracketed:
+                  start_bracket: (
+                  end_bracket: )
+            end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: city
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: city
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: car_model
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: sum
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: quantity
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: sum_quantity
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dealer
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: city
+      - comma: ','
+      - column_reference:
+          naked_identifier: car_model
+      - grouping_sets_clause:
+        - keyword: GROUPING
+        - keyword: SETS
+        - bracketed:
+            start_bracket: (
+            grouping_expression_list:
+            - expression:
+                bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: city
+                - comma: ','
+                - column_reference:
+                    naked_identifier: car_model
+                - end_bracket: )
+            - comma: ','
+            - expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: city
+                  end_bracket: )
+            - comma: ','
+            - expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: car_model
+                  end_bracket: )
+            - comma: ','
+            - expression:
+                bracketed:
+                  start_bracket: (
+                  end_bracket: )
+            end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: city
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: city
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: car_model
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: sum
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: quantity
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: sum_quantity
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dealer
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: city
+      - comma: ','
+      - column_reference:
+          naked_identifier: car_model
+      - comma: ','
+      - grouping_sets_clause:
+        - keyword: GROUPING
+        - keyword: SETS
+        - bracketed:
+            start_bracket: (
+            grouping_expression_list:
+            - expression:
+                bracketed:
+                - start_bracket: (
+                - column_reference:
+                    naked_identifier: city
+                - comma: ','
+                - column_reference:
+                    naked_identifier: car_model
+                - end_bracket: )
+            - comma: ','
+            - expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: city
+                  end_bracket: )
+            - comma: ','
+            - expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: car_model
+                  end_bracket: )
+            - comma: ','
+            - expression:
+                bracketed:
+                  start_bracket: (
+                  end_bracket: )
+            end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: city
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: city
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: car_model
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: sum
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: quantity
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: sum_quantity
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dealer
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: city
+      - comma: ','
+      - column_reference:
+          naked_identifier: car_model
+      - with_cube_rollup_clause:
+        - keyword: WITH
+        - keyword: ROLLUP
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: city
+      - comma: ','
+      - column_reference:
+          naked_identifier: car_model
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: city
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: car_model
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: sum
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: quantity
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: sum_quantity
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: dealer
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - column_reference:
+          naked_identifier: city
+      - comma: ','
+      - column_reference:
+          naked_identifier: car_model
+      - with_cube_rollup_clause:
+        - keyword: WITH
+        - keyword: CUBE
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: city
+      - comma: ','
+      - column_reference:
+          naked_identifier: car_model
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: first
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: age
+              end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: first
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  naked_identifier: age
+            - keyword: IGNORE
+            - keyword: NULLS
+            - end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: first_age
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: last
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: id
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: last_id
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: sum
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: id
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: sum_id
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: person
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            bracketed:
+              start_bracket: (
+              star: '*'
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: record_count
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: people
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - cube_rollup_clause:
+          function_name:
+            function_name_identifier: cube
+          bracketed:
+            start_bracket: (
+            grouping_expression_list:
+            - column_reference:
+                naked_identifier: name
+            - comma: ','
+            - column_reference:
+                naked_identifier: age
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            bracketed:
+              start_bracket: (
+              star: '*'
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: record_count
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: people
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - cube_rollup_clause:
+          function_name:
+            function_name_identifier: cube
+          bracketed:
+            start_bracket: (
+            grouping_expression_list:
+              column_reference:
+                naked_identifier: name
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            bracketed:
+              start_bracket: (
+              star: '*'
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: record_count
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: people
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - cube_rollup_clause:
+          function_name:
+            function_name_identifier: cube
+          bracketed:
+            start_bracket: (
+            grouping_expression_list:
+            - column_reference:
+                naked_identifier: name
+            - comma: ','
+            - column_reference:
+                naked_identifier: age
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            bracketed:
+              start_bracket: (
+              star: '*'
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: record_count
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: people
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - cube_rollup_clause:
+          function_name:
+            function_name_identifier: rollup
+          bracketed:
+            start_bracket: (
+            grouping_expression_list:
+            - column_reference:
+                naked_identifier: name
+            - comma: ','
+            - column_reference:
+                naked_identifier: age
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: age
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: count
+            bracketed:
+              start_bracket: (
+              star: '*'
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: record_count
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: people
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - keyword: ALL
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Add support for GROUP BY ALL to the Databricks dialect. This syntax is not yet supported by the SparkSQL dialect, so I've added a new GroupByClauseSegment to the Databricks grammar. I have also replicated the tests from SparkSQL, adding a test for GROUP BY ALL at the end.

### Are there any other side effects of this change that we should be aware of?
None for now. When SparkSQL supports GROUP BY ALL, we can simply move this change to the SparkSQL dialect.
I have also cleaned up the GroupByClauseSegment for SparkSQL, but this should have no impact to parsing, as demonstrated by the unchanged fixture YML files.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
