### PR TITLE
fix(dialect-trino): Trino ROW datatype definition in queries

### DIFF
--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -297,6 +297,7 @@ class RowTypeSchemaSegment(BaseSegment):
         )
     )
 
+
 class OverlapsClauseSegment(BaseSegment):
     """An `OVERLAPS` clause like in `SELECT."""
 

--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -260,12 +260,42 @@ class DatatypeSegment(BaseSegment):
         # Structural
         "ARRAY",
         "MAP",
-        "ROW",
+        Ref("RowTypeSegment"),
         # Others
         "IPADDRESS",
         "UUID",
     )
 
+
+class RowTypeSegment(ansi.StructTypeSegment):
+    """Expression to construct a ROW datatype."""
+
+    match_grammar = Sequence(
+        "ROW",
+        Ref("RowTypeSchemaSegment", optional=True),
+    )
+
+
+class RowTypeSchemaSegment(BaseSegment):
+    """Expression to construct the schema of a ROW datatype."""
+
+    type = "struct_type_schema"
+    match_grammar = Bracketed(
+        Delimited(  # Comma-separated list of field names/types
+            Sequence(
+                OneOf(
+                    # ParameterNames can look like Datatypes so can't use
+                    # Optional=True here and instead do a OneOf in order
+                    # with DataType only first, followed by both.
+                    Ref("DatatypeSegment"),
+                    Sequence(
+                        Ref("ParameterNameSegment"),
+                        Ref("DatatypeSegment"),
+                    ),
+                )
+            )
+        )
+    )
 
 class OverlapsClauseSegment(BaseSegment):
     """An `OVERLAPS` clause like in `SELECT."""

--- a/test/fixtures/dialects/trino/row_datatype.sql
+++ b/test/fixtures/dialects/trino/row_datatype.sql
@@ -1,0 +1,4 @@
+SELECT
+    name,
+    CAST(ROW(price, store) AS ROW(price REAL, store VARCHAR)) AS data_row
+FROM customers

--- a/test/fixtures/dialects/trino/row_datatype.yml
+++ b/test/fixtures/dialects/trino/row_datatype.yml
@@ -1,0 +1,61 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: b7898d09c48c4c4c7fde05ee5e305b1383740d944c650937456b1cf46f384938
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: name
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            bracketed:
+              start_bracket: (
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: ROW
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      column_reference:
+                        naked_identifier: price
+                  - comma: ','
+                  - expression:
+                      column_reference:
+                        naked_identifier: store
+                  - end_bracket: )
+              keyword: AS
+              data_type:
+                struct_type:
+                  keyword: ROW
+                  struct_type_schema:
+                    bracketed:
+                    - start_bracket: (
+                    - parameter: price
+                    - data_type:
+                        keyword: REAL
+                    - comma: ','
+                    - parameter: store
+                    - data_type:
+                        keyword: VARCHAR
+                    - end_bracket: )
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: data_row
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: customers


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

fixes https://github.com/sqlfluff/sqlfluff/issues/6084

Inspired by Bigqueries STRUCT definition. Using `ansi.StructTypeSegment` as base as Trino's ROW is essentially a STRUCT.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
