### PR TITLE
SparkSQL + Databricks: Add support for raw string literals

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -131,6 +131,16 @@ sparksql_dialect.patch_lexer_matchers(
 sparksql_dialect.insert_lexer_matchers(
     [
         RegexLexer(
+            "raw_single_quote",
+            r"[rR]'([^'\\]|\\.)*'",
+            CodeSegment,
+        ),
+        RegexLexer(
+            "raw_double_quote",
+            r'[rR]"([^"\\]|\\.)*"',
+            CodeSegment,
+        ),
+        RegexLexer(
             "bytes_single_quote",
             r"X'([^'\\]|\\.)*'",
             CodeSegment,
@@ -292,6 +302,7 @@ sparksql_dialect.replace(
     ),
     LiteralGrammar=ansi_dialect.get_grammar("LiteralGrammar").copy(
         insert=[
+            Ref("RawQuotedLiteralSegment"),
             Ref("BytesQuotedLiteralSegment"),
         ]
     ),
@@ -669,6 +680,18 @@ sparksql_dialect.add(
     ),
     TablePropertiesGrammar=Sequence(
         "TBLPROPERTIES", Ref("BracketedPropertyListGrammar")
+    ),
+    RawQuotedLiteralSegment=OneOf(
+        TypedParser(
+            "raw_single_quote",
+            LiteralSegment,
+            type="raw_quoted_literal",
+        ),
+        TypedParser(
+            "raw_double_quote",
+            LiteralSegment,
+            type="raw_quoted_literal",
+        ),
     ),
     BytesQuotedLiteralSegment=OneOf(
         TypedParser(

--- a/test/fixtures/dialects/sparksql/raw_literal.sql
+++ b/test/fixtures/dialects/sparksql/raw_literal.sql
@@ -1,0 +1,4 @@
+SELECT r'foo\nbar' AS col;
+SELECT r"foo\nbar" AS col;
+SELECT R'foo\nbar' AS col;
+SELECT R"foo\nbar" AS col;

--- a/test/fixtures/dialects/sparksql/raw_literal.yml
+++ b/test/fixtures/dialects/sparksql/raw_literal.yml
@@ -1,0 +1,47 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 88dd43cfdf808026b0bda8c6aa9c968bdd85134ece1d6a9a578d26a6b427c0d1
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          raw_quoted_literal: "r'foo\\nbar'"
+          alias_expression:
+            keyword: AS
+            naked_identifier: col
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          raw_quoted_literal: r"foo\nbar"
+          alias_expression:
+            keyword: AS
+            naked_identifier: col
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          raw_quoted_literal: "R'foo\\nbar'"
+          alias_expression:
+            keyword: AS
+            naked_identifier: col
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          raw_quoted_literal: R"foo\nbar"
+          alias_expression:
+            keyword: AS
+            naked_identifier: col
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Add support for raw string literals to SparkSQL and Databricks.
See: https://spark.apache.org/docs/latest/sql-ref-literals.html#string-literal


### Are there any other side effects of this change that we should be aware of?
None.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
