### PR TITLE
Support blocked_words and ignore_words as lists of strings

### DIFF
--- a/src/sqlfluff/rules/capitalisation/CP01.py
+++ b/src/sqlfluff/rules/capitalisation/CP01.py
@@ -286,11 +286,12 @@ class Rule_CP01(BaseRule):
             if opt != "consistent"
         ]
         # Use str() as CP04 uses bools which might otherwise be read as bool
-        ignore_words_config = str(getattr(self, "ignore_words"))
+        ignore_words_config = getattr(self, "ignore_words")
+        if not isinstance(ignore_words_config, (str, list)):
+            ignore_words_config = str(ignore_words_config)
         if ignore_words_config and ignore_words_config != "None":
-            self.ignore_words_list = self.split_comma_separated_string(
-                ignore_words_config.lower()
-            )
+            words_list = self.split_comma_separated_string(ignore_words_config)
+            self.ignore_words_list = [str(word).lower() for word in words_list]
         else:
             self.ignore_words_list = []
         self.ignore_templated_areas = context.config.get("ignore_templated_areas")

--- a/src/sqlfluff/rules/convention/CV09.py
+++ b/src/sqlfluff/rules/convention/CV09.py
@@ -108,7 +108,7 @@ class Rule_CV09(BaseRule):
         blocked_words_config = getattr(self, "blocked_words")
         if not isinstance(blocked_words_config, (str, list)):
             blocked_words_config = str(blocked_words_config)
-        if blocked_words_config and blocked_words_config != "None":
+        if blocked_words_config:
             words_list = self.split_comma_separated_string(blocked_words_config)
             self.blocked_words_list = [str(word).upper() for word in words_list]
         else:  # pragma: no cover

--- a/src/sqlfluff/rules/references/RF02.py
+++ b/src/sqlfluff/rules/references/RF02.py
@@ -111,11 +111,13 @@ class Rule_RF02(Rule_AL04):
 
     def _init_ignore_words_list(self) -> List[str]:
         """Called first time rule is evaluated to fetch & cache the policy."""
-        ignore_words_config: str = str(getattr(self, "ignore_words"))
+        # Use str() in case bools are passed which might otherwise be read as bool
+        ignore_words_config = getattr(self, "ignore_words")
+        if not isinstance(ignore_words_config, (str, list)):
+            ignore_words_config = str(ignore_words_config)
         if ignore_words_config and ignore_words_config != "None":
-            self.ignore_words_list = self.split_comma_separated_string(
-                ignore_words_config.lower()
-            )
+            words_list = self.split_comma_separated_string(ignore_words_config)
+            self.ignore_words_list = [str(word).lower() for word in words_list]
         else:
             self.ignore_words_list = []
 

--- a/src/sqlfluff/rules/references/RF04.py
+++ b/src/sqlfluff/rules/references/RF04.py
@@ -115,11 +115,12 @@ class Rule_RF04(BaseRule):
     def _init_ignore_string(self) -> List[str]:
         """Called first time rule is evaluated to fetch & cache the ignore_words."""
         # Use str() in case bools are passed which might otherwise be read as bool
-        ignore_words_config = str(getattr(self, "ignore_words"))
+        ignore_words_config = getattr(self, "ignore_words")
+        if not isinstance(ignore_words_config, (str, list)):
+            ignore_words_config = str(ignore_words_config)
         if ignore_words_config and ignore_words_config != "None":
-            self.ignore_words_list = self.split_comma_separated_string(
-                ignore_words_config.lower()
-            )
+            words_list = self.split_comma_separated_string(ignore_words_config)
+            self.ignore_words_list = [str(word).lower() for word in words_list]
         else:
             self.ignore_words_list = []
 

--- a/src/sqlfluff/rules/references/RF05.py
+++ b/src/sqlfluff/rules/references/RF05.py
@@ -206,11 +206,13 @@ class Rule_RF05(BaseRule):
 
     def _init_ignore_words_list(self) -> List[str]:
         """Called first time rule is evaluated to fetch & cache the policy."""
-        ignore_words_config: str = str(getattr(self, "ignore_words"))
+        # Use str() in case bools are passed which might otherwise be read as bool
+        ignore_words_config = getattr(self, "ignore_words")
+        if not isinstance(ignore_words_config, (str, list)):
+            ignore_words_config = str(ignore_words_config)
         if ignore_words_config and ignore_words_config != "None":
-            self.ignore_words_list = self.split_comma_separated_string(
-                ignore_words_config.lower()
-            )
+            words_list = self.split_comma_separated_string(ignore_words_config)
+            self.ignore_words_list = [str(word).lower() for word in words_list]
         else:
             self.ignore_words_list = []
 

--- a/src/sqlfluff/rules/references/RF06.py
+++ b/src/sqlfluff/rules/references/RF06.py
@@ -232,11 +232,13 @@ class Rule_RF06(BaseRule):
 
     def _init_ignore_words_list(self) -> List[str]:
         """Called first time rule is evaluated to fetch & cache the policy."""
-        ignore_words_config: str = str(getattr(self, "ignore_words"))
+        # Use str() in case bools are passed which might otherwise be read as bool
+        ignore_words_config = getattr(self, "ignore_words")
+        if not isinstance(ignore_words_config, (str, list)):
+            ignore_words_config = str(ignore_words_config)
         if ignore_words_config and ignore_words_config != "None":
-            self.ignore_words_list = self.split_comma_separated_string(
-                ignore_words_config.lower()
-            )
+            words_list = self.split_comma_separated_string(ignore_words_config)
+            self.ignore_words_list = [str(word).lower() for word in words_list]
         else:
             self.ignore_words_list = []
 

--- a/test/fixtures/rules/std_rule_cases/CP01.yml
+++ b/test/fixtures/rules/std_rule_cases/CP01.yml
@@ -97,6 +97,26 @@ test_pass_ignore_words:
         capitalisation_policy: upper
         ignore_words: select,from
 
+test_pass_ignore_words_as_list:
+  pass_str: SeleCT 1 From blah
+  configs:
+    rules:
+      capitalisation.keywords:
+        capitalisation_policy: upper
+        ignore_words:
+          - select
+          - from
+
+test_fail_ignore_words_as_list:
+  fail_str: SeleCT 1 From blah
+  fix_str: SELECT 1 From blah
+  configs:
+    rules:
+      capitalisation.keywords:
+        capitalisation_policy: upper
+        ignore_words:
+          - from
+
 test_pass_ignore_words_regex_simple:
   pass_str: SeleCT 1
   configs:

--- a/test/fixtures/rules/std_rule_cases/CP02.yml
+++ b/test/fixtures/rules/std_rule_cases/CP02.yml
@@ -253,6 +253,26 @@ test_pass_ignore_word:
         capitalisation_policy: upper
         ignore_words: b
 
+test_pass_ignore_word_as_list:
+  pass_str: SELECT A, b, c
+  configs:
+    rules:
+      capitalisation.identifiers:
+        capitalisation_policy: upper
+        ignore_words:
+          - b
+          - c
+
+test_fail_ignore_word_as_list:
+  fail_str: SELECT A, b, c
+  fix_str: SELECT A, b, C
+  configs:
+    rules:
+      capitalisation.identifiers:
+        capitalisation_policy: upper
+        ignore_words:
+          - b
+
 test_pass_consistent_capitalisation_properties_naked_identifier:
   pass_str: SHOW TBLPROPERTIES customer (created.by.user)
   configs:

--- a/test/fixtures/rules/std_rule_cases/CP03.yml
+++ b/test/fixtures/rules/std_rule_cases/CP03.yml
@@ -54,6 +54,34 @@ test_pass_ignore_word:
       capitalisation.functions:
         ignore_words: min
 
+test_pass_ignore_multiple_words:
+  pass_str: SELECT max(id), min(id) FROM TABLE1
+  configs:
+    rules:
+      capitalisation.functions:
+        extended_capitalisation_policy: upper
+        ignore_words: max, min
+
+test_pass_ignore_multiple_words_as_list:
+  pass_str: SELECT max(id), min(id) FROM TABLE1
+  configs:
+    rules:
+      capitalisation.functions:
+        extended_capitalisation_policy: upper
+        ignore_words:
+          - max
+          - min
+
+test_fail_ignore_multiple_words_as_list:
+  fail_str: SELECT max(id), min(id) FROM TABLE1
+  fix_str: SELECT max(id), MIN(id) FROM TABLE1
+  configs:
+    rules:
+      capitalisation.functions:
+        extended_capitalisation_policy: upper
+        ignore_words:
+          - max
+
 test_pass_ignore_templated_code_true:
   pass_str: |
     SELECT

--- a/test/fixtures/rules/std_rule_cases/CP04.yml
+++ b/test/fixtures/rules/std_rule_cases/CP04.yml
@@ -10,3 +10,19 @@ test_pass_ignore_word:
     rules:
       capitalisation.literals:
         ignore_words: true
+
+test_pass_ignore_multiple_words:
+  pass_str: SELECT True, false, NULL
+  configs:
+    rules:
+      capitalisation.literals:
+        ignore_words: true, false
+
+test_pass_ignore_multiple_words_as_list:
+  pass_str: SELECT true, FALSE, NULL
+  configs:
+    rules:
+      capitalisation.literals:
+        ignore_words:
+          - true
+          - false

--- a/test/fixtures/rules/std_rule_cases/CP05.yml
+++ b/test/fixtures/rules/std_rule_cases/CP05.yml
@@ -154,7 +154,7 @@ test_pass_bigquery_struct_params:
         extended_capitalisation_policy: upper
 
 # See https://github.com/sqlfluff/sqlfluff/issues/3277
-test_pass_typless_structs_dont_trigger_rule:
+test_pass_typeless_structs_dont_trigger_rule:
   pass_str: |
     SELECT
         STRUCT(
@@ -168,3 +168,31 @@ test_pass_typless_structs_dont_trigger_rule:
     rules:
       capitalisation.types:
         extended_capitalisation_policy: upper
+
+test_pass_ignore_words:
+  pass_str: CREATE TABLE table1 (account_id BiGinT, ts TimE);
+  configs:
+    rules:
+      capitalisation.types:
+        extended_capitalisation_policy: upper
+        ignore_words: bigint, time
+
+test_pass_ignore_words_as_list:
+  pass_str: CREATE TABLE table1 (account_id BiGinT, ts TimE);
+  configs:
+    rules:
+      capitalisation.types:
+        extended_capitalisation_policy: upper
+        ignore_words:
+          - bigint
+          - time
+
+test_fail_ignore_words_as_list:
+  fail_str: CREATE TABLE table1 (account_id BiGinT, ts TimE);
+  fix_str: CREATE TABLE table1 (account_id BiGinT, ts TIME);
+  configs:
+    rules:
+      capitalisation.types:
+        extended_capitalisation_policy: upper
+        ignore_words:
+          - bigint

--- a/test/fixtures/rules/std_rule_cases/CV09.yml
+++ b/test/fixtures/rules/std_rule_cases/CV09.yml
@@ -12,6 +12,14 @@ test_fail_deny_word:
       convention.blocked_words:
         blocked_words: deprecated_table
 
+test_fail_deny_bool:
+  fail_str: |
+    SELECT false
+  configs:
+    rules:
+      convention.blocked_words:
+        blocked_words: false
+
 test_fail_deny_word_case_difference1:
   fail_str: |
     SELECT col1 FROM deprecated_table
@@ -43,6 +51,26 @@ test_fail_multiple_deny_words2:
     rules:
       convention.blocked_words:
         blocked_words: deprecated_table,myoldFunction
+
+test_pass_multiple_deny_words_as_list:
+  pass_str: |
+    SELECT col1 FROM table1
+  configs:
+    rules:
+      convention.blocked_words:
+        blocked_words:
+          - deprecated_table
+          - myoldFunction
+
+test_fail_multiple_deny_words_as_list:
+  fail_str: |
+    SELECT myOldFunction(col1) FROM table1
+  configs:
+    rules:
+      convention.blocked_words:
+        blocked_words:
+          - deprecated_table
+          - myoldFunction
 
 test_pass_not_complete_match:
   pass_str: |

--- a/test/fixtures/rules/std_rule_cases/RF02.yml
+++ b/test/fixtures/rules/std_rule_cases/RF02.yml
@@ -342,6 +342,39 @@ test_pass_ignore_words_column_name:
       references.qualification:
         ignore_words: test1,test2
 
+test_pass_ignore_words_column_name_as_list:
+  pass_str: |
+    SELECT test1, test2
+    FROM t_table1
+    LEFT JOIN t_table_2
+        ON TRUE
+  configs:
+    rules:
+      references.qualification:
+        ignore_words:
+          - test1
+          - test2
+
+test_fail_ignore_words_column_name_as_list:
+  fail_str: |
+    SELECT test1, test2
+    FROM t_table1
+    LEFT JOIN t_table_2
+        ON TRUE
+  configs:
+    rules:
+      references.qualification:
+        ignore_words:
+          - test1
+
+test_pass_ignore_words_column_name_as_bool:
+  pass_str: |
+    SELECT "false" FROM foo
+  configs:
+    rules:
+      references.qualification:
+        ignore_words: false
+
 test_pass_ignore_words_regex_column_name:
   pass_str: |
     SELECT _test1, _test2

--- a/test/fixtures/rules/std_rule_cases/RF04.yml
+++ b/test/fixtures/rules/std_rule_cases/RF04.yml
@@ -122,7 +122,6 @@ test_pass_ignore_word1:
       references.keywords:
         ignore_words: create
 
-
 test_pass_ignore_word2:
   pass_str: SELECT col1 AS date FROM table1
   configs:
@@ -130,13 +129,36 @@ test_pass_ignore_word2:
       references.keywords:
         ignore_words: date
 
+test_pass_ignore_word3:
+  pass_str: SELECT false.col1 AS false FROM table1 AS false
+  configs:
+    rules:
+      references.keywords:
+        ignore_words: false
+
+test_pass_ignore_multiple_words_as_list:
+  pass_str: SELECT col1 AS date, col2 AS parameter FROM table1
+  configs:
+    rules:
+      references.keywords:
+        ignore_words:
+          - date
+          - parameter
+
+test_fail_ignore_multiple_words_as_list:
+  fail_str: SELECT col1 AS date, col2 AS parameter FROM table1
+  configs:
+    rules:
+      references.keywords:
+        ignore_words:
+          - date
+
 test_pass_ignore_words_regex1:
   pass_str: CREATE TABLE artist(create TEXT)
   configs:
     rules:
       references.keywords:
         ignore_words_regex: ^cr
-
 
 test_pass_ignore_words_regex2:
   pass_str: SELECT col1 AS date FROM table1

--- a/test/fixtures/rules/std_rule_cases/RF05.yml
+++ b/test/fixtures/rules/std_rule_cases/RF05.yml
@@ -349,9 +349,44 @@ test_pass_ignore_lists_quoted:
       references.special_chars:
         ignore_words: aliashash#
 
-test_pass_ignore_lists_quoted_fail:
+test_fail_ignore_lists_quoted:
   fail_str:
     SELECT a as 'aliashash#'
+
+test_fail_ignore_lists_quoted2:
+  fail_str:
+    SELECT a as 'aliashash#', b as 'alias$'
+  configs:
+    rules:
+      references.special_chars:
+        ignore_words: false
+
+test_pass_ignore_lists_multiple_quoted:
+  pass_str:
+    SELECT a as 'aliashash#', b as 'alias$'
+  configs:
+    rules:
+      references.special_chars:
+        ignore_words: aliashash#, alias$
+
+test_pass_ignore_lists_multiple_quoted_as_list:
+  pass_str:
+    SELECT a as 'aliashash#', b as 'alias$'
+  configs:
+    rules:
+      references.special_chars:
+        ignore_words:
+          - aliashash#
+          - alias$
+
+test_fail_ignore_lists_multiple_quoted_as_list:
+  fail_str:
+    SELECT a as 'aliashash#', b as 'alias$'
+  configs:
+    rules:
+      references.special_chars:
+        ignore_words:
+          - aliashash#
 
 test_pass_ignore_lists_quoted_mixed_case:
   pass_str:
@@ -371,7 +406,7 @@ test_pass_ignore_lists_unquoted:
       references.special_chars:
         ignore_words: alias$
 
-test_pass_ignore_lists_unquoted_fail:
+test_fail_ignore_lists_unquoted:
   fail_str:
     SELECT a as alias$
   configs:

--- a/test/fixtures/rules/std_rule_cases/RF06.yml
+++ b/test/fixtures/rules/std_rule_cases/RF06.yml
@@ -416,6 +416,80 @@ test_pass_ignore_lists_tsql:
       references.quoting:
         ignore_words: foo
 
+test_pass_ignore_lists_multiple:
+  pass_str:
+    SELECT 123 AS "foo", 456 AS "bar";
+  configs:
+    rules:
+      references.quoting:
+        ignore_words: foo, bar
+
+test_fail_ignore_lists_multiple:
+  fail_str:
+    SELECT 123 AS "foo", 456 AS "bar";
+  fix_str:
+    SELECT 123 AS foo, 456 AS bar;
+  configs:
+    rules:
+      references.quoting:
+        ignore_words: false
+
+test_pass_ignore_lists_multiple_tsql:
+  pass_str:
+    SELECT 123 AS [foo], 456 AS [bar];
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      references.quoting:
+        ignore_words: foo, bar
+
+test_pass_ignore_lists_multiple_as_list:
+  pass_str:
+    SELECT 123 AS "foo", 456 AS "bar";
+  configs:
+    rules:
+      references.quoting:
+        ignore_words:
+          - foo
+          - bar
+
+test_pass_ignore_lists_multiple_as_list_tsql:
+  pass_str:
+    SELECT 123 AS [foo], 456 AS [bar];
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      references.quoting:
+        ignore_words:
+          - foo
+          - bar
+
+test_fail_ignore_lists_multiple_as_list:
+  fail_str:
+    SELECT 123 AS "foo", 456 AS "bar";
+  fix_str:
+    SELECT 123 AS "foo", 456 AS bar;
+  configs:
+    rules:
+      references.quoting:
+        ignore_words:
+          - foo
+
+test_fail_ignore_lists_multiple_as_list_tsql:
+  fail_str:
+    SELECT 123 AS [foo], 456 AS [bar];
+  fix_str:
+    SELECT 123 AS [foo], 456 AS bar;
+  configs:
+    core:
+      dialect: tsql
+    rules:
+      references.quoting:
+        ignore_words:
+          - foo
+
 test_pass_ignore_lists_mixed_case:
   pass_str:
     SELECT 123 AS "Foo";


### PR DESCRIPTION
### Brief summary of the change made
This PR allows configuring blocked_words and ignore_words using a list of strings.
This is an alternative to the current configuration, which requires a single string with comma-separated values.

This change affects the following rules by standardizing the way comma-delimited configs are handled:
- CV09 - convention.blocked_words
- CP01 - capitalisation.keywords
- CP02 - capitalisation.identifiers
- CP03 - capitalisation.functions
- CP04 - capitalisation.literals
- CP05 - capitalisation.types
- RF02 - references.qualification
- RF04 - references.keywords
- RF05 - references.special_chars
- RF06 - references.quoting

The reason for this PR is that CV09's was the only configuration that threw me off when adding SQLFluff to a project last week.
I expected blocked_words to receive a list of strings in pyproject.toml, but that produced the following error when I tried:

```
CRITICAL   [CV09] Applying rule CV09 to 'path/to/file.sql' threw an Exception: 'list' object has no attribute 'upper'                                           
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.10/site-packages/sqlfluff/rules/convention/CV09.py", line 75, in _eval
    blocked_words_list = self.blocked_words_list
AttributeError: 'Rule_CV09' object has no attribute 'blocked_words_list'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/.local/lib/python3.10/site-packages/sqlfluff/core/rules/base.py", line 507, in crawl
    res = self._eval(context=context)
  File "/home/user/.local/lib/python3.10/site-packages/sqlfluff/rules/convention/CV09.py", line 79, in _eval
    blocked_words_list = self._init_blocked_words()
  File "/home/user/.local/lib/python3.10/site-packages/sqlfluff/rules/convention/CV09.py", line 110, in _init_blocked_words
    blocked_words_config.upper()
AttributeError: 'list' object has no attribute 'upper'
== [path/to/file.sql] FAIL                                                                                                                                      
L:   1 | P:   1 | CV09 | Unexpected exception: 'list' object has no attribute
                       | 'upper';
Could you open an issue at
                       | https://github.com/sqlfluff/sqlfluff/issues ?
You can
                       | ignore this exception for now, by adding '-- noqa: CV09'
                       | at the end
of line 1

                       | [convention.blocked_words]
```

It took me several minutes to realize that I should use a single string of comma-separated values. This PR supports both options.


### Are there any other side effects of this change that we should be aware of?
No, the original settings should continue working fine, as demonstrated by the tests.
We could update the docs to mention that both options work, but I think it's not necessary. Whatever the user tries, it'll work.


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
