### PR TITLE
RF02: Handle subquery column qualification

### DIFF
--- a/src/sqlfluff/rules/aliasing/AL04.py
+++ b/src/sqlfluff/rules/aliasing/AL04.py
@@ -73,6 +73,7 @@ class Rule_AL04(BaseRule):
         col_aliases: List[ColumnAliasInfo],
         using_cols: List[BaseSegment],
         parent_select: Optional[BaseSegment],
+        rule_context: RuleContext,
     ) -> Optional[List[LintResult]]:
         """Check whether any aliases are duplicates.
 
@@ -129,4 +130,5 @@ class Rule_AL04(BaseRule):
             select_info.col_aliases,
             select_info.using_cols,
             parent_select,
+            context,
         )

--- a/test/fixtures/rules/std_rule_cases/RF02.yml
+++ b/test/fixtures/rules/std_rule_cases/RF02.yml
@@ -30,8 +30,11 @@ test_fail_unqualified_references_multi_table_statements_subquery:
         LEFT JOIN vee ON vee.a = foo.a
     )
 
-test_pass_qualified_references_multi_table_statements_subquery_mix:
-  pass_str: |
+test_fail_qualified_references_multi_table_statements_subquery_mix:
+  # This test should fail because the `c` reference _should_ be from `bar`, but
+  # if the `bar` table does not contain the `c` column, this query will produce
+  # incorrect results.
+  fail_str: |
     SELECT foo.a, vee.b
     FROM (
         SELECT c
@@ -424,3 +427,17 @@ test_pass_redshift_convert:
   configs:
     core:
       dialect: redshift
+
+test_fail_unreferenced_subquery_column:
+  # Issue 6067
+  fail_str: |
+    SELECT a
+    FROM foo
+    WHERE a IN (SELECT a FROM bar)
+
+test_pass_referenced_subquery_column:
+  # Issue 6067
+  pass_str: |
+    SELECT a
+    FROM foo
+    WHERE a IN (SELECT bar.a FROM bar)


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This handles finding column references within subqueries.
- fixes #6067

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
