### PR TITLE
tsql: Allow leading dots in table references

### DIFF
--- a/test/fixtures/dialects/tsql/table_object_references.sql
+++ b/test/fixtures/dialects/tsql/table_object_references.sql
@@ -1,0 +1,7 @@
+select column_1 from ."#my_table"
+
+select column_1 from .[#my_table];
+
+select column_1 from ..[#my_table];
+
+select column_1 from ...[#my_table];

--- a/test/fixtures/dialects/tsql/table_object_references.yml
+++ b/test/fixtures/dialects/tsql/table_object_references.yml
@@ -1,0 +1,74 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 2279ed87a2eaac228ed9fca50f2829ef6989c0a3170357ee97c640507a3356a5
+file:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            column_reference:
+              naked_identifier: column_1
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  leading_dot: .
+                  quoted_identifier: '"#my_table"'
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            column_reference:
+              naked_identifier: column_1
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  leading_dot: .
+                  quoted_identifier: '[#my_table]'
+          statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            column_reference:
+              naked_identifier: column_1
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  leading_dot: .
+                  dot: .
+                  quoted_identifier: '[#my_table]'
+          statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            column_reference:
+              naked_identifier: column_1
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - leading_dot: .
+                - dot: .
+                - dot: .
+                - quoted_identifier: '[#my_table]'
+          statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This allows for leading dots in tsql's table references. This also adds grammar for a special leading dot for LT01 spacing.
- fixes #5571

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
