### PR TITLE
Snowflake: Added `INTERVAL`s to Frame Clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -7889,6 +7889,7 @@ class FrameClauseSegment(ansi.FrameClauseSegment):
             OneOf(
                 Ref("NumericLiteralSegment"),
                 Ref("ReferencedVariableNameSegment"),
+                Sequence("INTERVAL", Ref("QuotedLiteralSegment")),
                 "UNBOUNDED",
             ),
             OneOf("PRECEDING", "FOLLOWING"),

--- a/test/fixtures/dialects/snowflake/frame_clause.sql
+++ b/test/fixtures/dialects/snowflake/frame_clause.sql
@@ -8,3 +8,11 @@ SELECT
   ) AS vehicle_type_id_last_value
 FROM foo
 ;
+
+SELECT
+  account_id
+  , SUM(amount)
+    OVER (ORDER BY date_created RANGE BETWEEN INTERVAL '7 DAYS' PRECEDING AND CURRENT ROW)
+    AS trailing_7d_sum_amount
+FROM my_database.my_schema.my_table
+;

--- a/test/fixtures/dialects/snowflake/frame_clause.yml
+++ b/test/fixtures/dialects/snowflake/frame_clause.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0e1728a3d30a3a0255a6e7c3669cb5d0b83b21017da070cd60e71bc62ffb179c
+_hash: c89852b04abe9a288de0c64e9a3a373a9cef353c1f1c359e2babff075f6ac76d
 file:
-  statement:
+- statement:
     select_statement:
       select_clause:
       - keyword: SELECT
@@ -61,4 +61,57 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: foo
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: account_id
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: SUM
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  naked_identifier: amount
+              end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: date_created
+                  frame_clause:
+                  - keyword: RANGE
+                  - keyword: BETWEEN
+                  - keyword: INTERVAL
+                  - quoted_literal: "'7 DAYS'"
+                  - keyword: PRECEDING
+                  - keyword: AND
+                  - keyword: CURRENT
+                  - keyword: ROW
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: trailing_7d_sum_amount
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: my_database
+              - dot: .
+              - naked_identifier: my_schema
+              - dot: .
+              - naked_identifier: my_table
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Adds support for the `INTERVAL` keyword within a `frame_clause`
- fixes #6092

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
