### PR TITLE
SQLite: Add conflict_clause to unique table constraint

### DIFF
--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -757,6 +757,7 @@ class TableConstraintSegment(ansi.TableConstraintSegment):
                 "UNIQUE",
                 Ref("BracketedColumnReferenceListGrammar"),
                 # Later add support for index_parameters?
+                Ref("ConflictClauseSegment", optional=True),
             ),
             Sequence(  # PRIMARY KEY ( column_name [, ... ] ) index_parameters
                 Ref("PrimaryKeyGrammar"),

--- a/test/fixtures/dialects/sqlite/conflict_clause.sql
+++ b/test/fixtures/dialects/sqlite/conflict_clause.sql
@@ -4,3 +4,9 @@ CREATE TABLE users (
 );
 
 ALTER TABLE users ADD COLUMN name TEXT UNIQUE ON CONFLICT FAIL;
+
+create table imap_boxes (
+    account_id integer not null,
+    box_name text not null,
+    unique (account_id, box_name) on conflict replace
+);

--- a/test/fixtures/dialects/sqlite/conflict_clause.yml
+++ b/test/fixtures/dialects/sqlite/conflict_clause.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d5d2a2c34404e3fb22e85dbbb556e4170ef4080beeb62fc5220de978e41e5c40
+_hash: ad491a3736ca6192fa02974d8ebb4fecb73b54637c6299f2b8284dfe52b0e0b1
 file:
 - statement:
     create_table_statement:
@@ -56,4 +56,44 @@ file:
           - keyword: 'ON'
           - keyword: CONFLICT
           - keyword: FAIL
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: create
+    - keyword: table
+    - table_reference:
+        naked_identifier: imap_boxes
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: account_id
+          data_type:
+            data_type_identifier: integer
+          column_constraint_segment:
+          - keyword: not
+          - keyword: 'null'
+      - comma: ','
+      - column_definition:
+          naked_identifier: box_name
+          data_type:
+            data_type_identifier: text
+          column_constraint_segment:
+          - keyword: not
+          - keyword: 'null'
+      - comma: ','
+      - table_constraint:
+          keyword: unique
+          bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: account_id
+          - comma: ','
+          - column_reference:
+              naked_identifier: box_name
+          - end_bracket: )
+          conflict_clause:
+          - keyword: 'on'
+          - keyword: conflict
+          - keyword: replace
+      - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #3872 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
