### PR TITLE
Add option for allowing only a subset of rules for noqa

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -304,6 +304,11 @@ def core_options(f: Callable) -> Callable:
         help="Set this flag to ignore inline noqa comments.",
     )(f)
     f = click.option(
+        "--allowed-noqa",
+        default=None,
+        help="Ignore all but the listed rules to ignore inline noqa comments.",
+    )(f)
+    f = click.option(
         "--library-path",
         default=None,
         help=(

--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -304,9 +304,9 @@ def core_options(f: Callable) -> Callable:
         help="Set this flag to ignore inline noqa comments.",
     )(f)
     f = click.option(
-        "--allowed-noqa",
+        "--disable-noqa-except",
         default=None,
-        help="Ignore all but the listed rules to ignore inline noqa comments.",
+        help="Ignore all but the listed rules inline noqa comments.",
     )(f)
     f = click.option(
         "--library-path",

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -33,7 +33,7 @@ encoding = autodetect
 disable_noqa = False
 # Ignore inline overrides except those listed.
 # This take priority over `disabled_noqa`.
-allowed_noqa = None
+disable_noqa_except = None
 # Comma separated list of file extensions to lint
 # NB: This config will only apply in the root folder
 sql_file_exts = .sql,.sql.j2,.dml,.ddl

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -31,6 +31,9 @@ ignore_templated_areas = True
 encoding = autodetect
 # Ignore inline overrides (e.g. to test if still required)
 disable_noqa = False
+# Ignore inline overrides except those listed.
+# This take priority over `disabled_noqa`.
+allowed_noqa = None
 # Comma separated list of file extensions to lint
 # NB: This config will only apply in the root folder
 sql_file_exts = .sql,.sql.j2,.dml,.ddl

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -392,10 +392,10 @@ class Linter:
             formatter.dispatch_lint_header(fname, sorted(rule_pack.codes()))
 
         # Look for comment segments which might indicate lines to ignore.
-        allowed_noqa: Optional[str] = config.get("allowed_noqa")
-        if not config.get("disable_noqa") or allowed_noqa:
+        disable_noqa_except: Optional[str] = config.get("disable_noqa_except")
+        if not config.get("disable_noqa") or disable_noqa_except:
             allowed_rules_ref_map = cls.allowed_rule_ref_map(
-                rule_pack.reference_map, allowed_noqa
+                rule_pack.reference_map, disable_noqa_except
             )
             ignore_mask, ivs = IgnoreMask.from_tree(tree, allowed_rules_ref_map)
             initial_linting_errors += ivs
@@ -676,8 +676,10 @@ class Linter:
         # or templating fails.
         else:
             rule_timings = []
-            allowed_noqa: Optional[str] = parsed.config.get("allowed_noqa")
-            if parsed.config.get("disable_noqa") and not allowed_noqa:
+            disable_noqa_except: Optional[str] = parsed.config.get(
+                "disable_noqa_except"
+            )
+            if parsed.config.get("disable_noqa") and not disable_noqa_except:
                 # NOTE: This path is only accessible if there is no valid `tree`
                 # which implies that there was a fatal templating fail. Even an
                 # unparsable file will still have a valid tree.
@@ -688,7 +690,7 @@ class Linter:
                 # requires access to the parse tree, and because of the failure,
                 # we don't have a parse tree).
                 allowed_rules_ref_map = cls.allowed_rule_ref_map(
-                    rule_pack.reference_map, allowed_noqa
+                    rule_pack.reference_map, disable_noqa_except
                 )
                 ignore_mask, ignore_violations = IgnoreMask.from_source(
                     parsed.source_str,
@@ -740,23 +742,23 @@ class Linter:
 
     @classmethod
     def allowed_rule_ref_map(
-        cls, reference_map: Dict[str, Set[str]], allowed_noqa: Optional[str]
+        cls, reference_map: Dict[str, Set[str]], disable_noqa_except: Optional[str]
     ) -> Dict[str, Set[str]]:
         """Generate a noqa rule reference map."""
-        # allowed_noqa is not set, return the entire map.
-        if not allowed_noqa:
+        # disable_noqa_except is not set, return the entire map.
+        if not disable_noqa_except:
             return reference_map
         output_map = reference_map
-        # Add the special rules so they can be disallowed for `allowed noqa`` usage
+        # Add the special rules so they can be excluded for `disable_noqa_except` usage
         for special_rule in ["PRS", "LXR", "TMP"]:
             output_map[special_rule] = set([special_rule])
         # Expand glob usage of rules
-        unexpanded_rules = tuple(r.strip() for r in allowed_noqa.split(","))
+        unexpanded_rules = tuple(r.strip() for r in disable_noqa_except.split(","))
         noqa_set = set()
         for r in unexpanded_rules:
             for x in fnmatch.filter(output_map.keys(), r):
                 noqa_set |= output_map.get(x, set())
-        # Return a new map with only the allowed noqa rules
+        # Return a new map with only the excluded rules
         return {k: v.intersection(noqa_set) for k, v in output_map.items()}
 
     @classmethod

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -1,11 +1,13 @@
 """Defines the linter class."""
 
+import fnmatch
 import logging
 import os
 import time
 from typing import (
     TYPE_CHECKING,
     Any,
+    Dict,
     Iterator,
     List,
     Optional,
@@ -390,8 +392,12 @@ class Linter:
             formatter.dispatch_lint_header(fname, sorted(rule_pack.codes()))
 
         # Look for comment segments which might indicate lines to ignore.
-        if not config.get("disable_noqa"):
-            ignore_mask, ivs = IgnoreMask.from_tree(tree, rule_pack.reference_map)
+        allowed_noqa: Optional[str] = config.get("allowed_noqa")
+        if not config.get("disable_noqa") or allowed_noqa:
+            allowed_rules_ref_map = cls.allowed_rule_ref_map(
+                rule_pack.reference_map, allowed_noqa
+            )
+            ignore_mask, ivs = IgnoreMask.from_tree(tree, allowed_rules_ref_map)
             initial_linting_errors += ivs
         else:
             ignore_mask = None
@@ -670,7 +676,8 @@ class Linter:
         # or templating fails.
         else:
             rule_timings = []
-            if parsed.config.get("disable_noqa"):
+            allowed_noqa: Optional[str] = parsed.config.get("allowed_noqa")
+            if parsed.config.get("disable_noqa") and not allowed_noqa:
                 # NOTE: This path is only accessible if there is no valid `tree`
                 # which implies that there was a fatal templating fail. Even an
                 # unparsable file will still have a valid tree.
@@ -680,6 +687,9 @@ class Linter:
                 # comments (the normal path for identifying these comments
                 # requires access to the parse tree, and because of the failure,
                 # we don't have a parse tree).
+                allowed_rules_ref_map = cls.allowed_rule_ref_map(
+                    rule_pack.reference_map, allowed_noqa
+                )
                 ignore_mask, ignore_violations = IgnoreMask.from_source(
                     parsed.source_str,
                     [
@@ -687,7 +697,7 @@ class Linter:
                         for lm in parsed.config.get("dialect_obj").lexer_matchers
                         if lm.name == "inline_comment"
                     ][0],
-                    rule_pack.reference_map,
+                    allowed_rules_ref_map,
                 )
                 violations += ignore_violations
 
@@ -727,6 +737,27 @@ class Linter:
                 formatter.dispatch_dialect_warning(parsed.config.get("dialect"))
 
         return linted_file
+
+    @classmethod
+    def allowed_rule_ref_map(
+        cls, reference_map: Dict[str, Set[str]], allowed_noqa: Optional[str]
+    ) -> Dict[str, Set[str]]:
+        """Generate a noqa rule reference map."""
+        # allowed_noqa is not set, return the entire map.
+        if not allowed_noqa:
+            return reference_map
+        output_map = reference_map
+        # Add the special rules so they can be disallowed for `allowed noqa`` usage
+        for special_rule in ["PRS", "LXR", "TMP"]:
+            output_map[special_rule] = set([special_rule])
+        # Expand glob usage of rules
+        unexpanded_rules = tuple(r.strip() for r in allowed_noqa.split(","))
+        noqa_set = set()
+        for r in unexpanded_rules:
+            for x in fnmatch.filter(output_map.keys(), r):
+                noqa_set |= output_map.get(x, set())
+        # Return a new map with only the allowed noqa rules
+        return {k: v.intersection(noqa_set) for k, v in output_map.items()}
 
     @classmethod
     def lint_rendered(

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1976,6 +1976,41 @@ def test_cli_disable_noqa_flag():
     )
 
 
+def test_cli_allowed_noqa_flag():
+    """Test that --allowed-noqa flag ignores inline noqa comments."""
+    result = invoke_assert_code(
+        ret_code=1,
+        args=[
+            lint,
+            [
+                "test/fixtures/cli/disable_noqa_test.sql",
+                "--allowed-noqa",
+                "CP01",
+            ],
+        ],
+        # Linting error is raised even though it is inline ignored.
+        assert_output_contains=r"L:   8 | P:   5 | CP03 |",
+    )
+    assert r"L:   6 | P:  11 | CP01 |" not in result.output
+
+
+def test_cli_allowed_noqa_non_rules_flag():
+    """Test that --allowed-noqa flag ignores all inline noqa comments."""
+    invoke_assert_code(
+        ret_code=1,
+        args=[
+            lint,
+            [
+                "test/fixtures/cli/disable_noqa_test.sql",
+                "--allowed-noqa",
+                "None",
+            ],
+        ],
+        # Linting error is raised even though it is inline ignored.
+        assert_output_contains=r"L:   6 | P:  11 | CP01 |",
+    )
+
+
 def test_cli_warn_unused_noqa_flag():
     """Test that --warn-unused-ignores flag works."""
     invoke_assert_code(

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1976,15 +1976,15 @@ def test_cli_disable_noqa_flag():
     )
 
 
-def test_cli_allowed_noqa_flag():
-    """Test that --allowed-noqa flag ignores inline noqa comments."""
+def test_cli_disable_noqa_except_flag():
+    """Test that --disable-noqa-except flag ignores inline noqa comments."""
     result = invoke_assert_code(
         ret_code=1,
         args=[
             lint,
             [
                 "test/fixtures/cli/disable_noqa_test.sql",
-                "--allowed-noqa",
+                "--disable-noqa-except",
                 "CP01",
             ],
         ],
@@ -1994,15 +1994,15 @@ def test_cli_allowed_noqa_flag():
     assert r"L:   6 | P:  11 | CP01 |" not in result.output
 
 
-def test_cli_allowed_noqa_non_rules_flag():
-    """Test that --allowed-noqa flag ignores all inline noqa comments."""
+def test_cli_disable_noqa_except_non_rules_flag():
+    """Test that --disable-noqa-except flag ignores all inline noqa comments."""
     invoke_assert_code(
         ret_code=1,
         args=[
             lint,
             [
                 "test/fixtures/cli/disable_noqa_test.sql",
-                "--allowed-noqa",
+                "--disable-noqa-except",
                 "None",
             ],
         ],

--- a/test/core/rules/noqa_test.py
+++ b/test/core/rules/noqa_test.py
@@ -557,29 +557,30 @@ def test_linter_noqa_disable():
     assert violations_noqa_disabled[0].rule.code == "AL02"
 
 
-def test_linter_noqa_allowed():
+def test_linter_disable_noqa_except():
     """Test "noqa" comments can be disabled via the config."""
-    lntr_noqa_allowed_al02 = Linter(
+    lntr_disable_noqa_except_al02 = Linter(
         config=FluffConfig(
             overrides={
-                "allowed_noqa": "AL02",
+                "disable_noqa_except": "AL02",
                 "rules": "AL02, CP01",
                 "dialect": "ansi",
             }
         )
     )
-    lntr_noqa_allowed_core = Linter(
+    lntr_disable_noqa_except_core = Linter(
         config=FluffConfig(
             overrides={
-                "allowed_noqa": "core",
+                "disable_noqa_except": "core",
                 "rules": "AL02, CP01",
                 "dialect": "ansi",
             }
         )
     )
-    # This query raises AL02, but it is being suppressed by the inline noqa comment.
-    # We can ignore this comment by setting disable_noqa = True in the config
-    # or by using the --disable-noqa flag in the CLI.
+    # This query raises AL02 and CP01 but it is being suppressed by the inline noqa
+    # comments. We can partially ignore these comment by setting
+    # disable_noqa_except = rule_list in the config or by using the
+    # --disable-noqa-except option in the CLI.
     sql = """
     SELECT
     col_a a, --noqa: AL02
@@ -587,13 +588,18 @@ def test_linter_noqa_allowed():
     from foo; --noqa: CP01
     """
 
-    # Verify that noqa comment is ignored with allowed_noqa = AL02 (base rule name).
-    result_noqa_allowed_al02 = lntr_noqa_allowed_al02.lint_string(sql)
-    violations_noqa_allowed_al02 = result_noqa_allowed_al02.get_violations()
-    assert len(violations_noqa_allowed_al02) == 1
-    assert violations_noqa_allowed_al02[0].rule.code == "CP01"
+    # Verify that noqa comment is ignored with
+    # disable_noqa_except = AL02 (base rule name).
+    result_disable_noqa_except_al02 = lntr_disable_noqa_except_al02.lint_string(sql)
+    violations_disable_noqa_except_al02 = (
+        result_disable_noqa_except_al02.get_violations()
+    )
+    assert len(violations_disable_noqa_except_al02) == 1
+    assert violations_disable_noqa_except_al02[0].rule.code == "CP01"
 
-    # Verify that noqa works as expected with allowed_noqa = core (rule alias).
-    result_noqa_allowed_core = lntr_noqa_allowed_core.lint_string(sql)
-    violations_noqa_allowed_core = result_noqa_allowed_core.get_violations()
-    assert len(violations_noqa_allowed_core) == 0
+    # Verify that noqa works as expected with disable_noqa_except = core (rule alias).
+    result_disable_noqa_except_core = lntr_disable_noqa_except_core.lint_string(sql)
+    violations_disable_noqa_except_core = (
+        result_disable_noqa_except_core.get_violations()
+    )
+    assert len(violations_disable_noqa_except_core) == 0

--- a/test/fixtures/cli/disable_noqa_test.sql
+++ b/test/fixtures/cli/disable_noqa_test.sql
@@ -3,5 +3,8 @@
 -- NOTE: two noqas so that we can also test --warn-unused-ignores
 SELECT
     col_a AS a,  --noqa: CP01
-    col_b as b  --noqa: CP01
+    col_b as b,  --noqa: CP01
+    UPPER(col_b) as c, --noqa: CP01
+    lower(col_b) as d,  --noqa: CP01, CP03
+    lower(col_b) as e  --noqa: core
 FROM t;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Adds an option to allow only a subset of rules when a line is marked with `--noqa: rule_id`
- fixes #6097 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
