### PR TITLE
TSQL: Allow for empty catch block in try-catch

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3910,9 +3910,7 @@ class TryCatchSegment(BaseSegment):
         Ref("DelimiterGrammar", optional=True),
         Indent,
         # A catch block may be empty
-        AnyNumberOf(
-            Ref("StatementAndDelimiterGrammar"),
-        ),
+        AnyNumberOf(Ref("StatementAndDelimiterGrammar")),
         Dedent,
         "END",
         "CATCH",

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3909,7 +3909,10 @@ class TryCatchSegment(BaseSegment):
         "CATCH",
         Ref("DelimiterGrammar", optional=True),
         Indent,
-        Ref("OneOrMoreStatementsGrammar"),
+        # A catch block may be empty
+        AnyNumberOf(
+            Ref("StatementAndDelimiterGrammar"),
+        ),
         Dedent,
         "END",
         "CATCH",

--- a/test/fixtures/dialects/tsql/try_catch.sql
+++ b/test/fixtures/dialects/tsql/try_catch.sql
@@ -13,3 +13,9 @@ END CATCH
 GO
 
 THROW 50005, N'an error occurred', 1;
+
+BEGIN TRY
+    EXEC spSomeProc
+END TRY
+BEGIN CATCH
+END CATCH;

--- a/test/fixtures/dialects/tsql/try_catch.yml
+++ b/test/fixtures/dialects/tsql/try_catch.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 447bb3cd044ffe26c65e01f60557358411e66ad25287f132fca88e45957cc33c
+_hash: bdac659c03275e49ffb67b94dd21aa2cfd1cce3826c88270c2fb73aa3f3d78f0
 file:
 - batch:
     statement:
@@ -64,7 +64,7 @@ file:
 - go_statement:
     keyword: GO
 - batch:
-    statement:
+  - statement:
       throw_statement:
       - keyword: THROW
       - numeric_literal: '50005'
@@ -72,4 +72,20 @@ file:
       - quoted_literal: "N'an error occurred'"
       - comma: ','
       - numeric_literal: '1'
-    statement_terminator: ;
+  - statement_terminator: ;
+  - statement:
+      try_catch:
+      - keyword: BEGIN
+      - keyword: TRY
+      - statement:
+          execute_script_statement:
+            keyword: EXEC
+            object_reference:
+              naked_identifier: spSomeProc
+      - keyword: END
+      - keyword: TRY
+      - keyword: BEGIN
+      - keyword: CATCH
+      - keyword: END
+      - keyword: CATCH
+  - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This allows for the catch block to be empty.
- fixes #6114 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
