### PR TITLE
Change evaluation order of literals before column refs in bracketed, delimited expressions

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2215,13 +2215,13 @@ ansi_dialect.add(
                     Ref("ExpressionSegment"),
                     Ref("SelectableGrammar"),
                     Delimited(
+                        Ref("LiteralGrammar"),  # WHERE (a, 2) IN (SELECT b, c FROM ...)
                         Ref(
                             "ColumnReferenceSegment"
                         ),  # WHERE (a,b,c) IN (select a,b,c FROM...)
                         Ref(
                             "FunctionSegment"
                         ),  # WHERE (a, substr(b,1,3)) IN (select c,d FROM...)
-                        Ref("LiteralGrammar"),  # WHERE (a, 2) IN (SELECT b, c FROM ...)
                         Ref("LocalAliasSegment"),  # WHERE (LOCAL.a, LOCAL.b) IN (...)
                     ),
                 ),

--- a/test/fixtures/dialects/clickhouse/tuple_datatype.yml
+++ b/test/fixtures/dialects/clickhouse/tuple_datatype.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 932b62c5844873fe012d2c850c255ac21b107d5261ba67f85277e37098d9fe13
+_hash: 2e4a5aaa753e255388556599da5a2815dc96db426e4ef4ed480dcec274d396be
 file:
 - statement:
     select_statement:
@@ -16,11 +16,9 @@ file:
               - start_bracket: (
               - numeric_literal: '1'
               - comma: ','
-              - column_reference:
-                  quoted_identifier: "'two'"
+              - quoted_literal: "'two'"
               - comma: ','
-              - column_reference:
-                  quoted_identifier: "'2024-01-01'"
+              - quoted_literal: "'2024-01-01'"
               - end_bracket: )
               casting_operator: '::'
               data_type:
@@ -56,11 +54,9 @@ file:
               - start_bracket: (
               - numeric_literal: '1'
               - comma: ','
-              - column_reference:
-                  quoted_identifier: "'two'"
+              - quoted_literal: "'two'"
               - comma: ','
-              - column_reference:
-                  quoted_identifier: "'2024-01-01'"
+              - quoted_literal: "'2024-01-01'"
               - end_bracket: )
               casting_operator: '::'
               data_type:
@@ -96,11 +92,9 @@ file:
               - start_bracket: (
               - numeric_literal: '1'
               - comma: ','
-              - column_reference:
-                  quoted_identifier: "'two'"
+              - quoted_literal: "'two'"
               - comma: ','
-              - column_reference:
-                  quoted_identifier: "'2024-01-01'"
+              - quoted_literal: "'2024-01-01'"
               - end_bracket: )
               casting_operator: '::'
               data_type:

--- a/test/fixtures/dialects/sparksql/select_like_clause.yml
+++ b/test/fixtures/dialects/sparksql/select_like_clause.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 349068b86aa827ffccae2cceb5577c0a2b0806df07a4ee7ef3ad2c797de3cdbd
+_hash: a10e144284905c4683bcedb17f02ecc2afdfdafd69ac81ec1097400a26d7e633
 file:
 - statement:
     select_statement:
@@ -217,11 +217,9 @@ file:
         - keyword: ALL
         - bracketed:
           - start_bracket: (
-          - column_reference:
-              quoted_identifier: "'%an%'"
+          - quoted_literal: "'%an%'"
           - comma: ','
-          - column_reference:
-              quoted_identifier: "'%an'"
+          - quoted_literal: "'%an'"
           - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -251,11 +249,9 @@ file:
         - keyword: ANY
         - bracketed:
           - start_bracket: (
-          - column_reference:
-              quoted_identifier: "'%an%'"
+          - quoted_literal: "'%an%'"
           - comma: ','
-          - column_reference:
-              quoted_identifier: "'%an'"
+          - quoted_literal: "'%an'"
           - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -285,11 +281,9 @@ file:
         - keyword: SOME
         - bracketed:
           - start_bracket: (
-          - column_reference:
-              quoted_identifier: "'%an%'"
+          - quoted_literal: "'%an%'"
           - comma: ','
-          - column_reference:
-              quoted_identifier: "'%an'"
+          - quoted_literal: "'%an'"
           - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -320,11 +314,9 @@ file:
         - keyword: ALL
         - bracketed:
           - start_bracket: (
-          - column_reference:
-              quoted_identifier: "'%an%'"
+          - quoted_literal: "'%an%'"
           - comma: ','
-          - column_reference:
-              quoted_identifier: "'%an'"
+          - quoted_literal: "'%an'"
           - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -355,11 +347,9 @@ file:
         - keyword: ANY
         - bracketed:
           - start_bracket: (
-          - column_reference:
-              quoted_identifier: "'%an%'"
+          - quoted_literal: "'%an%'"
           - comma: ','
-          - column_reference:
-              quoted_identifier: "'%an'"
+          - quoted_literal: "'%an'"
           - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -390,11 +380,9 @@ file:
         - keyword: SOME
         - bracketed:
           - start_bracket: (
-          - column_reference:
-              quoted_identifier: "'%an%'"
+          - quoted_literal: "'%an%'"
           - comma: ','
-          - column_reference:
-              quoted_identifier: "'%an'"
+          - quoted_literal: "'%an'"
           - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -420,11 +408,9 @@ file:
         - keyword: ALL
         - bracketed:
           - start_bracket: (
-          - column_reference:
-              quoted_identifier: "'%oO%'"
+          - quoted_literal: "'%oO%'"
           - comma: ','
-          - column_reference:
-              quoted_identifier: "'%Go%'"
+          - quoted_literal: "'%Go%'"
           - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -450,13 +436,10 @@ file:
         - keyword: ANY
         - bracketed:
           - start_bracket: (
-          - column_reference:
-              quoted_identifier: "'%oo%'"
+          - quoted_literal: "'%oo%'"
           - comma: ','
-          - column_reference:
-              quoted_identifier: "'%IN'"
+          - quoted_literal: "'%IN'"
           - comma: ','
-          - column_reference:
-              quoted_identifier: "'fA%'"
+          - quoted_literal: "'fA%'"
           - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This fixes an issue where some bracketed, delimited expressions were resolving to delimited column references instead of the literal values that they should have been.
- Fixes #6040

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
