### PR TITLE
Add support for Snowflake Higher-Order Functions

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -8376,7 +8376,10 @@ class LambdaExpressionSegment(BaseSegment):
     type = "lambda_expression"
     match_grammar = Sequence(
         OneOf(
-            Ref("NakedIdentifierSegment"),
+            Sequence(
+                Ref("NakedIdentifierSegment"),
+                Ref("DatatypeSegment", optional=True),
+            ),
             Bracketed(
                 Delimited(
                     Sequence(

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -601,6 +601,7 @@ snowflake_dialect.replace(
         Ref("DatetimeUnitSegment"),
         Ref("NamedParameterExpressionSegment"),
         Ref("ReferencedVariableNameSegment"),
+        Ref("LambdaExpressionSegment"),
         Sequence(
             Ref("ExpressionSegment"),
             Sequence(OneOf("IGNORE", "RESPECT"), "NULLS", optional=True),
@@ -8363,4 +8364,28 @@ class ScriptingDeclareStatementSegment(BaseSegment):
         ),
         Dedent,
         Ref("ScriptingBlockStatementSegment"),
+    )
+
+
+class LambdaExpressionSegment(BaseSegment):
+    """A lambda expression.
+
+    https://docs.snowflake.com/en/user-guide/querying-semistructured#lambda-expressions
+    """
+
+    type = "lambda_expression"
+    match_grammar = Sequence(
+        OneOf(
+            Ref("NakedIdentifierSegment"),
+            Bracketed(
+                Delimited(
+                    Sequence(
+                        Ref("NakedIdentifierSegment"),
+                        Ref("DatatypeSegment"),
+                    )
+                )
+            ),
+        ),
+        Ref("FunctionAssignerSegment"),
+        Ref("ExpressionSegment"),
     )

--- a/test/fixtures/dialects/snowflake/select_higher_order_function.sql
+++ b/test/fixtures/dialects/snowflake/select_higher_order_function.sql
@@ -1,0 +1,10 @@
+SELECT
+    FILTER(ident, i -> i:value > 0) as sample_filter,
+    TRANSFORM(ident, j -> j:value) as sample_transform
+FROM ref;
+
+SELECT
+    FILTER("ident", (i INT, j VARIANT) -> (i:value is not null and j:value = 'some_literal')) as sample_filter,
+    TRANSFORM("ident", j -> j) as sample_transform,
+    some_other_function('unusual arguments', x -> 'still a lambda expression', true) as sample_other
+FROM ref;

--- a/test/fixtures/dialects/snowflake/select_higher_order_function.sql
+++ b/test/fixtures/dialects/snowflake/select_higher_order_function.sql
@@ -1,6 +1,7 @@
 SELECT
     FILTER(ident, i -> i:value > 0) as sample_filter,
-    TRANSFORM(ident, j -> j:value) as sample_transform
+    TRANSFORM(ident, j -> j:value) as sample_transform,
+    TRANSFORM(ident, k variant -> k:val) as sample_transform_with_type
 FROM ref;
 
 SELECT

--- a/test/fixtures/dialects/snowflake/select_higher_order_function.yml
+++ b/test/fixtures/dialects/snowflake/select_higher_order_function.yml
@@ -1,0 +1,177 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: beaa6427d3e3bd8c3f396f7c13bccb9b9598656024f3ab13139a3a8c9e007757
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: FILTER
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: ident
+                comma: ','
+                lambda_expression:
+                  naked_identifier: i
+                  function_assigner: ->
+                  expression:
+                    column_reference:
+                      naked_identifier: i
+                    semi_structured_expression:
+                      colon: ':'
+                      semi_structured_element: value
+                    comparison_operator:
+                      raw_comparison_operator: '>'
+                    numeric_literal: '0'
+                end_bracket: )
+          alias_expression:
+            keyword: as
+            naked_identifier: sample_filter
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: TRANSFORM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: ident
+                comma: ','
+                lambda_expression:
+                  naked_identifier: j
+                  function_assigner: ->
+                  expression:
+                    column_reference:
+                      naked_identifier: j
+                    semi_structured_expression:
+                      colon: ':'
+                      semi_structured_element: value
+                end_bracket: )
+          alias_expression:
+            keyword: as
+            naked_identifier: sample_transform
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: ref
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: FILTER
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    quoted_identifier: '"ident"'
+                comma: ','
+                lambda_expression:
+                  bracketed:
+                  - start_bracket: (
+                  - naked_identifier: i
+                  - data_type:
+                      data_type_identifier: INT
+                  - comma: ','
+                  - naked_identifier: j
+                  - data_type:
+                      data_type_identifier: VARIANT
+                  - end_bracket: )
+                  function_assigner: ->
+                  expression:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - column_reference:
+                          naked_identifier: i
+                      - semi_structured_expression:
+                          colon: ':'
+                          semi_structured_element: value
+                      - keyword: is
+                      - keyword: not
+                      - null_literal: 'null'
+                      - binary_operator: and
+                      - column_reference:
+                          naked_identifier: j
+                      - semi_structured_expression:
+                          colon: ':'
+                          semi_structured_element: value
+                      - comparison_operator:
+                          raw_comparison_operator: '='
+                      - quoted_literal: "'some_literal'"
+                      end_bracket: )
+                end_bracket: )
+          alias_expression:
+            keyword: as
+            naked_identifier: sample_filter
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: TRANSFORM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    quoted_identifier: '"ident"'
+                comma: ','
+                lambda_expression:
+                  naked_identifier: j
+                  function_assigner: ->
+                  expression:
+                    column_reference:
+                      naked_identifier: j
+                end_bracket: )
+          alias_expression:
+            keyword: as
+            naked_identifier: sample_transform
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: some_other_function
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'unusual arguments'"
+              - comma: ','
+              - lambda_expression:
+                  naked_identifier: x
+                  function_assigner: ->
+                  expression:
+                    quoted_literal: "'still a lambda expression'"
+              - comma: ','
+              - expression:
+                  boolean_literal: 'true'
+              - end_bracket: )
+          alias_expression:
+            keyword: as
+            naked_identifier: sample_other
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: ref
+- statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/select_higher_order_function.yml
+++ b/test/fixtures/dialects/snowflake/select_higher_order_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: beaa6427d3e3bd8c3f396f7c13bccb9b9598656024f3ab13139a3a8c9e007757
+_hash: 71c80712cfb3a38e60e9c54cc5f51d4964b755935534882de394ab33fffddada
 file:
 - statement:
     select_statement:
@@ -61,6 +61,33 @@ file:
           alias_expression:
             keyword: as
             naked_identifier: sample_transform
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: TRANSFORM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: ident
+                comma: ','
+                lambda_expression:
+                  naked_identifier: k
+                  data_type:
+                    data_type_identifier: variant
+                  function_assigner: ->
+                  expression:
+                    column_reference:
+                      naked_identifier: k
+                    semi_structured_expression:
+                      colon: ':'
+                      semi_structured_element: val
+                end_bracket: )
+          alias_expression:
+            keyword: as
+            naked_identifier: sample_transform_with_type
       from_clause:
         keyword: FROM
         from_expression:


### PR DESCRIPTION
### Brief summary of the change made

fixes #5977 and #6122

This change introduces support for Higher-Order Functions - see https://docs.snowflake.com/en/user-guide/querying-semistructured#filter-and-transform-data-with-snowflake-higher-order-functions

Based on a bit of testing, I've found that Snowflake will parse a lambda expression (`x -> x:value`) anywhere it appears as long as it's within a function. Meaning - it _won't_ parse a lambda expression outside of a function, but also it _will_ parse a lambda expression even when it's in an unrelated function (or in an incorrect position). I've chosen to replicate that logic as a result, assuming that will better match any changes in Snowflake going forwards as well.


### Are there any other side effects of this change that we should be aware of?

None identified

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
