### PR TITLE
ST08: Ignore `DISTINCT`s with subqueries

### DIFF
--- a/src/sqlfluff/rules/structure/ST08.py
+++ b/src/sqlfluff/rules/structure/ST08.py
@@ -82,6 +82,8 @@ class Rule_ST08(BaseRule):
                 not function_name
                 or function_name[0].raw_upper != "DISTINCT"
                 or not bracketed
+                # If the DISTINCT has a subquery, don't remove the brackets
+                or bracketed.recursive_crawl("select_statement", recurse_into=False)
             ):
                 return None
             # Using ReflowSequence here creates an unneeded space between CONCAT

--- a/test/fixtures/rules/std_rule_cases/ST08.yml
+++ b/test/fixtures/rules/std_rule_cases/ST08.yml
@@ -56,3 +56,15 @@ test_fail_distinct_concat_inside_count:
     SELECT COUNT(DISTINCT(CONCAT(col1, '-', col2, '-', col3)))
   fix_str: |
     SELECT COUNT(DISTINCT CONCAT(col1, '-', col2, '-', col3))
+
+test_pass_distinct_subquery_inside_count:
+  pass_str: |
+    SELECT
+        COUNT(
+            DISTINCT(
+                SELECT ANY_VALUE(id)
+                FROM UNNEST(tag) t
+            )
+        )
+    FROM
+        dataset_name.table_name;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This ignores `DISTINCT`s with brackets which contain subquery expressions for ST08.
- fixes #6142

### Are there any other side effects of this change that we should be aware of?
None, performance hit _should_ be minimal.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
