### PR TITLE
Deprecate support for dbt 1.1-1.3

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -72,18 +72,10 @@ jobs:
     name: dbt Plugin Tests
     strategy:
       matrix:
-        dbt-version: [ dbt110, dbt120, dbt130, dbt140, dbt150, dbt160, dbt170, dbt180 ]
+        dbt-version: [ dbt140, dbt150, dbt160, dbt170, dbt180 ]
         include:
           # Default to python 3.12 for dbt tests.
           - python-version: "3.12"
-          # For the two oldest dbt versions, override to python 3.9.
-          - dbt-version: dbt110
-            python-version: "3.9"
-          - dbt-version: dbt120
-            python-version: "3.9"
-          # For dbt 1.3 override to python 3.10
-          - dbt-version: dbt130
-            python-version: "3.10"
           # For dbt 1.4 - 1.6 override to python 3.11
           - dbt-version: dbt140
             python-version: "3.11"

--- a/constraints/dbt110.txt
+++ b/constraints/dbt110.txt
@@ -1,2 +1,0 @@
-dbt-core~=1.1.0
-dbt-postgres~=1.1.0

--- a/constraints/dbt120.txt
+++ b/constraints/dbt120.txt
@@ -1,2 +1,0 @@
-dbt-core~=1.2.0
-dbt-postgres~=1.2.0

--- a/constraints/dbt130.txt
+++ b/constraints/dbt130.txt
@@ -1,2 +1,0 @@
-dbt-core~=1.3.0
-dbt-postgres~=1.3.0

--- a/constraints/dbt140.txt
+++ b/constraints/dbt140.txt
@@ -1,2 +1,2 @@
-dbt-core~=1.4.0
-dbt-postgres~=1.4.0
+dbt-core~=1.4.1
+dbt-postgres~=1.4.1

--- a/plugins/sqlfluff-templater-dbt/pyproject.toml
+++ b/plugins/sqlfluff-templater-dbt/pyproject.toml
@@ -53,7 +53,7 @@ keywords = [
 ]
 dependencies = [
     "sqlfluff==3.1.1",
-    "dbt-core>=1.4.0",
+    "dbt-core>=1.4.1",
     "jinja2-simple-tags>=0.3.1",
 ]
 

--- a/plugins/sqlfluff-templater-dbt/pyproject.toml
+++ b/plugins/sqlfluff-templater-dbt/pyproject.toml
@@ -53,7 +53,7 @@ keywords = [
 ]
 dependencies = [
     "sqlfluff==3.1.1",
-    "dbt-core>=1.0.0",
+    "dbt-core>=1.4.0",
     "jinja2-simple-tags>=0.3.1",
 ]
 

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -135,7 +135,7 @@ class DbtTemplater(JinjaTemplater):
         # First check whether we need to silence the logs. If a formatter
         # is present then assume that it's not a problem
         if not self.formatter:
- 
+
             if self.dbt_version_tuple >= (1, 8):
                 from dbt_common.events.event_manager_client import (
                     cleanup_event_logger,
@@ -231,7 +231,6 @@ class DbtTemplater(JinjaTemplater):
         # dbt 0.20.* and onward
         from dbt.parser.manifest import ManifestLoader
 
-        old_cwd = os.getcwd()
         _dbt_manifest = ManifestLoader.get_full_manifest(self.dbt_config)
 
         return _dbt_manifest

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -135,18 +135,17 @@ class DbtTemplater(JinjaTemplater):
         # First check whether we need to silence the logs. If a formatter
         # is present then assume that it's not a problem
         if not self.formatter:
-            try:
-                if self.dbt_version_tuple >= (1, 8):
-                    from dbt_common.events.event_manager_client import (
-                        cleanup_event_logger,
-                    )
+ 
+            if self.dbt_version_tuple >= (1, 8):
+                from dbt_common.events.event_manager_client import (
+                    cleanup_event_logger,
+                )
 
-                else:
-                    from dbt.events.functions import cleanup_event_logger
+            else:
+                from dbt.events.functions import cleanup_event_logger
 
-                cleanup_event_logger()
-            except ImportError:
-                pass
+            cleanup_event_logger()
+
 
     @cached_property
     def dbt_config(self):
@@ -233,19 +232,7 @@ class DbtTemplater(JinjaTemplater):
         from dbt.parser.manifest import ManifestLoader
 
         old_cwd = os.getcwd()
-        try:
-            # Changing cwd temporarily as dbt is not using project_dir to
-            # read/write `target/partial_parse.msgpack`. This can be undone when
-            # https://github.com/dbt-labs/dbt-core/issues/6055 is solved.
-            # For dbt 1.4+ this isn't necessary, but it is required for 1.3
-            # and before.
-            if self.dbt_version_tuple < (1, 4):
-                os.chdir(self.project_dir)
-            _dbt_manifest = ManifestLoader.get_full_manifest(self.dbt_config)
-
-        finally:
-            if self.dbt_version_tuple < (1, 4):
-                os.chdir(old_cwd)
+        _dbt_manifest = ManifestLoader.get_full_manifest(self.dbt_config)
 
         return _dbt_manifest
 
@@ -292,13 +279,7 @@ class DbtTemplater(JinjaTemplater):
         # still be available in those versions.
 
         from dbt import flags
-
-        # From dbt 1.3 onwards, the default_profiles_dir resolver is
-        # available. Before that version we use the flags module
-        try:
-            from dbt.cli.resolvers import default_profiles_dir
-        except ImportError:
-            default_profiles_dir = None
+        from dbt.cli.resolvers import default_profiles_dir
 
         default_dir = (
             default_profiles_dir()
@@ -633,16 +614,10 @@ class DbtTemplater(JinjaTemplater):
             and not getattr(v, "compiled", False)
         )
 
-        try:
-            # These are the names in dbt-core 1.4.1+
-            # https://github.com/dbt-labs/dbt-core/pull/6539
-            if self.dbt_version_tuple >= (1, 8):
-                from dbt_common.exceptions import UndefinedMacroError
-            else:
-                from dbt.exceptions import UndefinedMacroError
-        except ImportError:
-            # These are the historic names for older dbt-core versions
-            from dbt.exceptions import UndefinedMacroException as UndefinedMacroError
+        if self.dbt_version_tuple >= (1, 8):
+            from dbt_common.exceptions import UndefinedMacroError
+        else:
+            from dbt.exceptions import UndefinedMacroError
 
         with self.connection():
             # Apply the monkeypatch.

--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -146,7 +146,6 @@ class DbtTemplater(JinjaTemplater):
 
             cleanup_event_logger()
 
-
     @cached_property
     def dbt_config(self):
         """Loads the dbt config."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = generate-fixture-yml, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{38,39,310,311,312}, dbt{140,150,160,170,180}, cov-report, mypy, winpy, dbt{130,150,180}-winpy, yamllint
+envlist = generate-fixture-yml, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{38,39,310,311,312}, dbt{140,150,160,170,180}, cov-report, mypy, winpy, dbt{150,180}-winpy, yamllint
 min_version = 4.0  # Require 4.0+ for proper pyproject.toml support
 
 [testenv]
@@ -32,7 +32,7 @@ commands =
     # number pinned to the same version number of the main sqlfluff library
     # so it _must_ be installed second in the context of a version which isn't
     # yet released (and so not available on pypi).
-    dbt{110,120,130,140,150,160,170,180,}: python -m pip install {toxinidir}/plugins/sqlfluff-templater-dbt
+    dbt{140,150,160,170,180,}: python -m pip install {toxinidir}/plugins/sqlfluff-templater-dbt
     # Add the example plugin.
     # NOTE: The trailing comma is important because in the github test suite
     # the python version is not specified and instead the "py" environment

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = generate-fixture-yml, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{38,39,310,311,312}, dbt{110,120,130,140,150,160,170,180}, cov-report, mypy, winpy, dbt{130,150,180}-winpy, yamllint
+envlist = generate-fixture-yml, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{38,39,310,311,312}, dbt{140,150,160,170,180}, cov-report, mypy, winpy, dbt{130,150,180}-winpy, yamllint
 min_version = 4.0  # Require 4.0+ for proper pyproject.toml support
 
 [testenv]
@@ -20,7 +20,7 @@ deps =
     # we force the right installation version up front in each environment.
     # NOTE: This is a bit of a hack around tox, but it does achieve reasonably
     # consistent results.
-    dbt{110,120,130,140,150,160,170,180,}: -r {toxinidir}/constraints/{envname}.txt
+    dbt{140,150,160,170,180,}: -r {toxinidir}/constraints/{envname}.txt
 # Include any other steps necessary for testing below.
 # {posargs} is there to allow us to specify specific tests, which
 # can then be invoked from tox by calling e.g.


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
DBT 1.1 & 1.2 have been EOL for over 2 years, 1.3 has been EOL for almost 2 years. We are having to make exceptions for them - such as setuptools not supporting them any more. Thus, it's time to sunset them. This PR should trigger a minor release.

I've cleaned up some old paths in the templater. I've also pinned 1.4 to 1.4.1+ to allow another code path cleanup. Realistically, we could sunset 1.4, as it's also very old, so i'm not worried about pinning the patch.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
