### PR TITLE
Better documentation on how to cross reference rules and fix a few.

### DIFF
--- a/docs/source/_ext/sqlfluff_domain.py
+++ b/docs/source/_ext/sqlfluff_domain.py
@@ -15,9 +15,17 @@ class SQLFluffRule(ObjectDescription):
     .. code-block:: rst
 
         .. sqlfluff:rule:: AM01
-                        ambiguous.distinct
+                           ambiguous.distinct
 
             Write the documentation for the rule here.
+
+    To cross reference (i.e. refer to) objects defined like this
+    both the code and name reference is available:
+
+    .. code-block:: rst
+
+        :sqlfluff:ref:`CP02`
+        :sqlfluff:ref:`capitalisation.identifiers`
 
     """
 

--- a/src/sqlfluff/rules/aliasing/AL06.py
+++ b/src/sqlfluff/rules/aliasing/AL06.py
@@ -25,7 +25,7 @@ class Rule_AL06(BaseRule):
 
     Avoid aliases. Avoid short aliases when aliases are necessary.
 
-    See also: :class:`Rule_AL07`.
+    See also: :sqlfluff:ref:`AL07`.
 
     .. code-block:: sql
 

--- a/src/sqlfluff/rules/aliasing/AL07.py
+++ b/src/sqlfluff/rules/aliasing/AL07.py
@@ -33,7 +33,7 @@ class Rule_AL07(BaseRule):
        neither realistic nor desirable. In particular for BigQuery due to the
        complexity of backtick requirements and determining whether a name refers
        to a project or dataset so automated fixes can potentially break working
-       SQL code. For most users :class:`Rule_AL06` is likely a more appropriate
+       SQL code. For most users :sqlfluff:ref:`AL06` is likely a more appropriate
        linting rule to drive a sensible behaviour around aliasing.
 
        The stricter treatment of aliases in this rule may be useful for more


### PR DESCRIPTION
The docs for AL06 and AL07 have (in theory) links to other rule docs in them. Those links are currently broken, but not surprisingly because the details on how to cross reference rules is poorly documented.

This PR fixes the links and improves the documentation.