### PR TITLE
Update Docs and tests for CP02

### DIFF
--- a/src/sqlfluff/rules/capitalisation/CP02.py
+++ b/src/sqlfluff/rules/capitalisation/CP02.py
@@ -11,6 +11,25 @@ from sqlfluff.utils.identifers import identifiers_policy_applicable
 class Rule_CP02(Rule_CP01):
     """Inconsistent capitalisation of unquoted identifiers.
 
+    This rule applies to all unquoted identifiers, whether references
+    or aliases, and whether they refer to columns or other objects (such
+    as tables or schemas).
+
+    .. note::
+
+       In **most** dialects, unquoted identifiers are treated as case-insensitive
+       and so the fixes proposed by this rule do not change the interpretation
+       of the query. **HOWEVER**, some databases (notably :ref:`bigquery_dialect_ref`
+       and :ref:`clickhouse_dialect_ref`) do take the casing of *unquoted*
+       identifiers into account when determining the casing of the column heading
+       in the *result*.
+
+       As this feature is only present in a few dialects, and not widely understood
+       by users, we regard it as *an antipattern*. It is more widely understood that
+       if the case of an identifier *matters*, then it should be quoted. If you, or
+       your organisation, do wish to rely on this feature, we recommend that you
+       disabled this rule (see :ref:`ruleselection`).
+
     **Anti-pattern**
 
     In this example, unquoted identifier ``a`` is in lower-case but
@@ -23,6 +42,17 @@ class Rule_CP02(Rule_CP01):
             B
         from foo
 
+    In this more complicated example, there are a mix of capitalisations
+    in both reference and aliases of columns and tables. That inconsistency
+    is acceptable when those identifiers are quoted, but not when unquoted.
+
+    .. code-block:: sql
+
+        select
+            col_1 + Col_2 as COL_3,
+            "COL_4" as Col_5
+        from Foo as BAR
+
     **Best practice**
 
     Ensure all unquoted identifiers are either in upper-case or in lower-case.
@@ -32,14 +62,21 @@ class Rule_CP02(Rule_CP01):
         select
             a,
             b
-        from foo
+        from foo;
 
-        -- Also good
+        -- ...also good...
 
         select
             A,
             B
-        from foo
+        from foo;
+
+        --- ...or for comparison with our more complex example, this too:
+
+        select
+            col_1 + col_2 as col_3,
+            "COL_4" as col_5
+        from foo as bar
 
     """
 
@@ -71,7 +108,8 @@ class Rule_CP02(Rule_CP01):
             return None
 
         if identifiers_policy_applicable(
-            self.unquoted_identifiers_policy, context.parent_stack  # type: ignore
+            self.unquoted_identifiers_policy,
+            context.parent_stack,  # type: ignore
         ):
             return super()._eval(context=context)
         else:

--- a/src/sqlfluff/rules/capitalisation/CP02.py
+++ b/src/sqlfluff/rules/capitalisation/CP02.py
@@ -108,8 +108,8 @@ class Rule_CP02(Rule_CP01):
             return None
 
         if identifiers_policy_applicable(
-            self.unquoted_identifiers_policy,
-            context.parent_stack,  # type: ignore
+            self.unquoted_identifiers_policy,  # type: ignore
+            context.parent_stack,
         ):
             return super()._eval(context=context)
         else:

--- a/test/fixtures/rules/std_rule_cases/CP02.yml
+++ b/test/fixtures/rules/std_rule_cases/CP02.yml
@@ -31,14 +31,20 @@ test_fail_consistent_capitalisation_with_multiple_words_with_numbers:
 test_pass_consistent_capitalisation_with_leading_underscore:
   pass_str: SELECT _a, b
 
-test_fail_inconsistent_capitalisation_lower_case:
-  # Test that fixes are consistent
-  fail_str: SELECT a,   B
-  fix_str: SELECT a,   b
+test_fail_inconsistent_capitalisation_lowercase_1:
+  # Test that fixes are consistent, and that we capture
+  # table names and aliases.
+  fail_str: SELECT a, B AS C FROM FOO AS BAR
+  fix_str: SELECT a, b AS c FROM foo AS bar
 
-test_fail_inconsistent_capitalisation_2:
-  fail_str: SELECT B,   a
-  fix_str: SELECT B,   A
+test_fail_inconsistent_capitalisation_lowercase_2:
+  # Test that consistency between columns and tables still counts.
+  fail_str: SELECT a FROM FOO
+  fix_str: SELECT a FROM foo
+
+test_fail_inconsistent_capitalisation_uppercase:
+  fail_str: SELECT B, a FROM foo
+  fix_str: SELECT B, A FROM FOO
 
 # PascalCase tests are based on this comment by @alanmcruickshank:
 # https://github.com/sqlfluff/sqlfluff/issues/820#issuecomment-787050507


### PR DESCRIPTION
As part of resolving the conflict around RF06 and AL09, there's some influence from CP02. The docs for this rule were fairly poor, but the functionality is good I think.

This PR significantly updates the docs and adds/improves a few of the test cases.