### PR TITLE
More dialect documentation

### DIFF
--- a/docs/source/reference/dialects.rst
+++ b/docs/source/reference/dialects.rst
@@ -36,7 +36,7 @@ current dialects available on your installation of SQLFluff.
     - Will the feature I'm adding break any *downstream* dependencies
       within dialects which inherit from this one?
 
-.. We define a shortcut to render double backticks here, which can 
+.. We define a shortcut to render double backticks here, which can
    then be referenced by individual dialects when they want to say
    how backtick quotes behave in that dialect. They would otherwise
    be interpreted as markup and so not shown as back quotes.

--- a/docs/source/reference/dialects.rst
+++ b/docs/source/reference/dialects.rst
@@ -36,4 +36,13 @@ current dialects available on your installation of SQLFluff.
     - Will the feature I'm adding break any *downstream* dependencies
       within dialects which inherit from this one?
 
+.. We define a shortcut to render double backticks here, which can 
+   then be referenced by individual dialects when they want to say
+   how backtick quotes behave in that dialect. They would otherwise
+   be interpreted as markup and so not shown as back quotes.
+
+.. |back_quotes| raw:: html
+
+    <code class="code docutils literal notranslate">``</code>
+
 .. include:: ../_partials/dialect_summaries.rst

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -68,7 +68,11 @@ ansi_dialect = Dialect(
     "ansi",
     root_segment_name="FileSegment",
     formatted_name="ANSI",
-    docstring="""This is the base dialect which holds most of the definitions of common
+    docstring="""**Default Casing**: ``UPPERCASE``
+
+**Quotes**: String Literals: ``''``, Identifiers: ``""``
+    
+This is the base dialect which holds most of the definitions of common
 SQL commands and structures. If the dialect which you're actually using
 isn't specifically implemented by SQLFluff, using this dialect is a good
 place to start.

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -71,7 +71,7 @@ ansi_dialect = Dialect(
     docstring="""**Default Casing**: ``UPPERCASE``
 
 **Quotes**: String Literals: ``''``, Identifiers: ``""``
-    
+
 This is the base dialect which holds most of the definitions of common
 SQL commands and structures. If the dialect which you're actually using
 isn't specifically implemented by SQLFluff, using this dialect is a good

--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -43,7 +43,7 @@ athena_dialect = ansi_dialect.copy_as(
 
 **Quotes**: String Literals: ``''``, ``""`` or |back_quotes|,
 Identifiers: ``""`` or |back_quotes|
-    
+
 The dialect for `Athena <https://aws.amazon.com/athena/>`_
 on Amazon Web Services (AWS).""",
 )

--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -39,7 +39,12 @@ ansi_dialect = load_raw_dialect("ansi")
 athena_dialect = ansi_dialect.copy_as(
     "athena",
     formatted_name="AWS Athena",
-    docstring="""The dialect for `Athena <https://aws.amazon.com/athena/>`_
+    docstring="""**Default Casing**: ``lowercase``
+
+**Quotes**: String Literals: ``''``, ``""`` or |back_quotes|,
+Identifiers: ``""`` or |back_quotes|
+    
+The dialect for `Athena <https://aws.amazon.com/athena/>`_
 on Amazon Web Services (AWS).""",
 )
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -53,7 +53,7 @@ quoted options, also supporting variants prefixes with ``r``/``R`` (for
 raw/regex expressions) or ``b``/``B`` (for byte strings)),
 Identifiers: ``""`` or |back_quotes|. Note that *unquoted* aliases are
 resolved case-insensitively but *rendered case-sensitively* in the result
-set. 
+set.
 
 The dialect for `BigQuery <https://cloud.google.com/bigquery/>`_
 on Google Cloud Platform (GCP).""",

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -46,7 +46,15 @@ ansi_dialect = load_raw_dialect("ansi")
 bigquery_dialect = ansi_dialect.copy_as(
     "bigquery",
     formatted_name="Google BigQuery",
-    docstring="""The dialect for `BigQuery <https://cloud.google.com/bigquery/>`_
+    docstring="""**Default Casing**: ``UPPERCASE``
+
+**Quotes**: String Literals: ``''``, ``""``, ``@`` or ``@@`` (with the
+quoted options, also supporting prefixes of `r`, `R`, `b` & `B`),
+Identifiers: ``""`` or |back_quotes|. Note that *unquoted* aliases are
+resolved case-insensitively but *rendered case-sensitively* in the result
+set. 
+   
+The dialect for `BigQuery <https://cloud.google.com/bigquery/>`_
 on Google Cloud Platform (GCP).""",
 )
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -54,7 +54,7 @@ raw/regex expressions) or ``b``/``B`` (for byte strings)),
 Identifiers: ``""`` or |back_quotes|. Note that *unquoted* aliases are
 resolved case-insensitively but *rendered case-sensitively* in the result
 set. 
-   
+
 The dialect for `BigQuery <https://cloud.google.com/bigquery/>`_
 on Google Cloud Platform (GCP).""",
 )

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -49,7 +49,8 @@ bigquery_dialect = ansi_dialect.copy_as(
     docstring="""**Default Casing**: ``UPPERCASE``
 
 **Quotes**: String Literals: ``''``, ``""``, ``@`` or ``@@`` (with the
-quoted options, also supporting prefixes of `r`, `R`, `b` & `B`),
+quoted options, also supporting variants prefixes with ``r``/``R`` (for
+raw/regex expressions) or ``b``/``B`` (for byte strings)),
 Identifiers: ``""`` or |back_quotes|. Note that *unquoted* aliases are
 resolved case-insensitively but *rendered case-sensitively* in the result
 set. 

--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -34,7 +34,17 @@ postgres_dialect = load_raw_dialect("postgres")
 duckdb_dialect = postgres_dialect.copy_as(
     "duckdb",
     formatted_name="DuckDB",
-    docstring="The dialect for `DuckDB <https://duckdb.org/>`_.",
+    docstring="""**Default Casing**: DuckDB stores all identifiers in the case
+they were defined, however all identifier resolution is case-insensitive (when
+unquoted, and more unusually, *also when quoted*). See the
+`DuckDB Identifiers Documentation`_ for more details.
+
+**Quotes**: String Literals: ``''``, Identifiers: ``""`` or ``''``
+   
+The dialect for `DuckDB <https://duckdb.org/>`_.
+
+.. _`DuckDB Identifiers Documentation`: https://duckdb.org/docs/sql/dialect/keywords_and_identifiers
+""",  # noqa: E501
 )
 
 duckdb_dialect.sets("reserved_keywords").update(

--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -40,7 +40,7 @@ unquoted, and more unusually, *also when quoted*). See the
 `DuckDB Identifiers Documentation`_ for more details.
 
 **Quotes**: String Literals: ``''``, Identifiers: ``""`` or ``''``
-   
+
 The dialect for `DuckDB <https://duckdb.org/>`_.
 
 .. _`DuckDB Identifiers Documentation`: https://duckdb.org/docs/sql/dialect/keywords_and_identifiers

--- a/src/sqlfluff/dialects/dialect_mariadb.py
+++ b/src/sqlfluff/dialects/dialect_mariadb.py
@@ -33,7 +33,7 @@ mariadb_dialect = mysql_dialect.copy_as(
 
 **Quotes**: String Literals: ``''``, ``""`` or ``@``,
 Identifiers: |back_quotes|.
-   
+
 The dialect for `MariaDB <https://www.mariadb.org/>`_.""",
 )
 mariadb_dialect.update_keywords_set_from_multiline_string(

--- a/src/sqlfluff/dialects/dialect_mariadb.py
+++ b/src/sqlfluff/dialects/dialect_mariadb.py
@@ -29,7 +29,12 @@ mysql_dialect = load_raw_dialect("mysql")
 mariadb_dialect = mysql_dialect.copy_as(
     "mariadb",
     formatted_name="MariaDB",
-    docstring="The dialect for `MariaDB <https://www.mariadb.org/>`_.",
+    docstring="""**Default Casing**: ``lowercase``
+
+**Quotes**: String Literals: ``''``, ``""`` or ``@``,
+Identifiers: |back_quotes|.
+   
+The dialect for `MariaDB <https://www.mariadb.org/>`_.""",
 )
 mariadb_dialect.update_keywords_set_from_multiline_string(
     "unreserved_keywords", mariadb_unreserved_keywords

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -44,7 +44,12 @@ ansi_dialect = load_raw_dialect("ansi")
 mysql_dialect = ansi_dialect.copy_as(
     "mysql",
     formatted_name="MySQL",
-    docstring="The dialect for `MySQL <https://www.mysql.com/>`_.",
+    docstring="""**Default Casing**: ``lowercase``
+
+**Quotes**: String Literals: ``''``, ``""`` or ``@``,
+Identifiers: |back_quotes|.
+   
+The dialect for `MySQL <https://www.mysql.com/>`_.""",
 )
 
 mysql_dialect.patch_lexer_matchers(

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -48,7 +48,7 @@ mysql_dialect = ansi_dialect.copy_as(
 
 **Quotes**: String Literals: ``''``, ``""`` or ``@``,
 Identifiers: |back_quotes|.
-   
+
 The dialect for `MySQL <https://www.mysql.com/>`_.""",
 )
 

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -50,7 +50,7 @@ postgres_dialect = ansi_dialect.copy_as(
     docstring="""**Default Casing**: ``lowercase``
 
 **Quotes**: String Literals: ``''``, Identifiers: ``""``.
-   
+
 This is based around the `PostgreSQL spec`_. Many other SQL
 dialects are often based on the PostreSQL syntax. If you're running an unsupported
 dialect, then this is often the dialect to use (until someone makes a specific

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -47,7 +47,11 @@ ansi_dialect = load_raw_dialect("ansi")
 postgres_dialect = ansi_dialect.copy_as(
     "postgres",
     formatted_name="PostgreSQL",
-    docstring="""This is based around the `PostgreSQL spec`_. Many other SQL
+    docstring="""**Default Casing**: ``lowercase``
+
+**Quotes**: String Literals: ``''``, Identifiers: ``""``.
+   
+This is based around the `PostgreSQL spec`_. Many other SQL
 dialects are often based on the PostreSQL syntax. If you're running an unsupported
 dialect, then this is often the dialect to use (until someone makes a specific
 dialect).
@@ -571,7 +575,9 @@ postgres_dialect.replace(
     ),
     QuotedIdentifierSegment=OneOf(
         TypedParser("double_quote", IdentifierSegment, type="quoted_identifier"),
-        TypedParser("unicode_double_quote", LiteralSegment, type="quoted_literal"),
+        TypedParser(
+            "unicode_double_quote", IdentifierSegment, type="quoted_identifier"
+        ),
     ),
     PostFunctionGrammar=AnyNumberOf(
         Ref("WithinGroupClauseSegment"),

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -38,8 +38,18 @@ ansi_dialect = load_raw_dialect("ansi")
 redshift_dialect = postgres_dialect.copy_as(
     "redshift",
     formatted_name="AWS Redshift",
-    docstring="""The dialect for `Redshift <https://aws.amazon.com/redshift/>`_
-on Amazon Web Services (AWS).""",
+    docstring="""**Default Casing**: ``lowercase`` (unless configured
+to be case sensitive with all identifiers using the
+:code:`enable_case_sensitive_identifier` configuration value, see
+the `Redshift Names & Identifiers Docs`_).
+
+**Quotes**: String Literals: ``''``, Identifiers: ``""``.
+   
+The dialect for `Redshift`_ on Amazon Web Services (AWS).
+
+.. _`Redshift`: https://aws.amazon.com/redshift/
+.. _`Redshift Names & Identifiers Docs`: https://spark.apache.org/docs/latest/sql-ref.html
+""",  # noqa: E501
 )
 
 # Set Keywords

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -44,7 +44,7 @@ to be case sensitive with all identifiers using the
 the `Redshift Names & Identifiers Docs`_).
 
 **Quotes**: String Literals: ``''``, Identifiers: ``""``.
-   
+
 The dialect for `Redshift`_ on Amazon Web Services (AWS).
 
 .. _`Redshift`: https://aws.amazon.com/redshift/

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -48,7 +48,7 @@ snowflake_dialect = ansi_dialect.copy_as(
     docstring="""**Default Casing**: ``UPPERCASE``
 
 **Quotes**: String Literals: ``''``, Identifiers: ``""``
-    
+
 The dialect for
 `Snowflake <https://docs.snowflake.com/en/sql-reference.html>`_,
 which has much of its syntax inherited from :ref:`postgres_dialect_ref`.""",

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -45,7 +45,11 @@ ansi_dialect = load_raw_dialect("ansi")
 snowflake_dialect = ansi_dialect.copy_as(
     "snowflake",
     formatted_name="Snowflake",
-    docstring="""The dialect for
+    docstring="""**Default Casing**: ``UPPERCASE``
+
+**Quotes**: String Literals: ``''``, Identifiers: ``""``
+    
+The dialect for
 `Snowflake <https://docs.snowflake.com/en/sql-reference.html>`_,
 which has much of its syntax inherited from :ref:`postgres_dialect_ref`.""",
 )

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -55,7 +55,13 @@ hive_dialect = load_raw_dialect("hive")
 sparksql_dialect = ansi_dialect.copy_as(
     "sparksql",
     formatted_name="Apache Spark SQL",
-    docstring="""The dialect for Apache `Spark SQL`_. This includes relevant
+    docstring="""**Default Casing**: SparkSQL is case insensitive with
+both quoted and unquoted identifiers (_"delimited"_ identifiers in
+Spark terminology). See the :ref:`Spark Identifiers` docs.
+
+**Quotes**: String Literals: ``''`` or ``""``, Identifiers: |back_quotes|.
+
+The dialect for Apache `Spark SQL`_. This includes relevant
 syntax from :ref:`hive_dialect_ref` for commands that permit Hive Format.
 Spark SQL extensions provided by the `Delta Lake`_ project are also implemented
 in this dialect.
@@ -68,7 +74,8 @@ Versions of Spark prior to 3.x will only support the Hive dialect.
 
 .. _`Spark SQL`: https://spark.apache.org/docs/latest/sql-ref.html
 .. _`Delta Lake`: https://docs.delta.io/latest/quick-start.html#set-up-apache-spark-with-delta-lake
-.. _`Ansi Compliant Mode`: https://spark.apache.org/docs/latest/sql-ref-ansi-compliance.html""",  # noqa: E501
+.. _`Ansi Compliant Mode`: https://spark.apache.org/docs/latest/sql-ref-ansi-compliance.html
+.. _`Spark Identifiers`: https://spark.apache.org/docs/latest/sql-ref-identifier.html""",  # noqa: E501
 )
 
 sparksql_dialect.patch_lexer_matchers(

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -57,7 +57,7 @@ sparksql_dialect = ansi_dialect.copy_as(
     formatted_name="Apache Spark SQL",
     docstring="""**Default Casing**: SparkSQL is case insensitive with
 both quoted and unquoted identifiers (_"delimited"_ identifiers in
-Spark terminology). See the :ref:`Spark Identifiers` docs.
+Spark terminology). See the `Spark Identifiers`_ docs.
 
 **Quotes**: String Literals: ``''`` or ``""``, Identifiers: |back_quotes|.
 

--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -40,7 +40,19 @@ ansi_dialect = load_raw_dialect("ansi")
 sqlite_dialect = ansi_dialect.copy_as(
     "sqlite",
     formatted_name="SQLite",
-    docstring="""The dialect for `SQLite <https://www.sqlite.org/>`_.""",
+    docstring="""**Default Casing**: Not specified in the docs,
+but through testing it appears that SQLite *stores* column names
+in whatever case they were defined, but is always *case-insensitive*
+when resolving those names.
+
+**Quotes**: String Literals: ``''`` (or  ``""`` if not otherwise resolved
+to an identifier), Identifiers: ``""``, ``[]`` or |back_quotes|. See the
+`SQLite Keywords Docs`_ for more details.
+    
+The dialect for `SQLite <https://www.sqlite.org/>`_.
+
+.. _`SQLite Keywords Docs`: https://sqlite.org/lang_keywords.html
+""",
 )
 
 sqlite_dialect.sets("reserved_keywords").clear()

--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -48,7 +48,7 @@ when resolving those names.
 **Quotes**: String Literals: ``''`` (or  ``""`` if not otherwise resolved
 to an identifier), Identifiers: ``""``, ``[]`` or |back_quotes|. See the
 `SQLite Keywords Docs`_ for more details.
-    
+
 The dialect for `SQLite <https://www.sqlite.org/>`_.
 
 .. _`SQLite Keywords Docs`: https://sqlite.org/lang_keywords.html

--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -36,7 +36,11 @@ ansi_dialect = load_raw_dialect("ansi")
 trino_dialect = ansi_dialect.copy_as(
     "trino",
     formatted_name="Trino",
-    docstring="""The dialect for `Trino <https://trino.io/docs/current/>`_.""",
+    docstring="""**Default Casing**: ``UPPERCASE``
+
+**Quotes**: String Literals: ``''``, Identifiers: ``""``
+    
+The dialect for `Trino <https://trino.io/docs/current/>`_.""",
 )
 
 # Set the bare functions: https://trino.io/docs/current/functions/datetime.html

--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -39,7 +39,7 @@ trino_dialect = ansi_dialect.copy_as(
     docstring="""**Default Casing**: ``UPPERCASE``
 
 **Quotes**: String Literals: ``''``, Identifiers: ``""``
-    
+
 The dialect for `Trino <https://trino.io/docs/current/>`_.""",
 )
 

--- a/test/fixtures/dialects/postgres/unicode_double_quote.yml
+++ b/test/fixtures/dialects/postgres/unicode_double_quote.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d00383d8995415732be5182002939807cff91562ee2d226861396d5a73b65210
+_hash: ad143aefeb187466b408788e03993f4e2e9a93074a58b458f5d9fb8cd8e88a27
 file:
 - statement:
     select_statement:
@@ -11,7 +11,7 @@ file:
         keyword: SELECT
         select_clause_element:
           column_reference:
-            quoted_literal: U&"a"
+            quoted_identifier: U&"a"
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -19,7 +19,7 @@ file:
         keyword: SELECT
         select_clause_element:
           column_reference:
-            quoted_literal: "U&\"aaaa\" UESCAPE '!'"
+            quoted_identifier: "U&\"aaaa\" UESCAPE '!'"
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -27,5 +27,5 @@ file:
         keyword: SELECT
         select_clause_element:
           column_reference:
-            quoted_literal: "U&\"aaaa\"\n\n UESCAPE\n '!'"
+            quoted_identifier: "U&\"aaaa\"\n\n UESCAPE\n '!'"
 - statement_terminator: ;


### PR DESCRIPTION
After #6153, it's more obvious that some of the dialects have more extensive documentation than others. This starts to flesh out that documentation. I originally wanted to be more complete here, but some dialects were much easier to test and find than others.

I've added details for as many dialects as I'm either familiar with or have direct access to for testing. I've also added links where I can, especially where dialects do interesting things.

I've also started a bit of a convention (which I hope other dialects will follow) on what kinds of things to document.

(I also fixed a bug in the Postgres dialect which I found on the way through)