### PR TITLE
Duckdb: Add support for list comprehensions

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -739,6 +739,7 @@ ansi_dialect.add(
     ColumnsExpressionNameGrammar=Nothing(),
     # Uses grammar for LT06 support
     ColumnsExpressionGrammar=Nothing(),
+    ListComprehensionGrammar=Nothing(),
 )
 
 
@@ -2282,6 +2283,7 @@ ansi_dialect.add(
                 ),
             ),
             Ref("LocalAliasSegment"),
+            Ref("ListComprehensionGrammar"),
             terminators=[Ref("CommaSegment")],
         ),
         Ref("AccessorGrammar", optional=True),

--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -119,6 +119,7 @@ duckdb_dialect.replace(
     SingleQuotedIdentifierSegment=TypedParser(
         "single_quote", IdentifierSegment, type="quoted_identifier", casefold=str.lower
     ),
+    ListComprehensionGrammar=Ref("ListComprehensionExpressionSegment"),
 )
 
 duckdb_dialect.insert_lexer_matchers(
@@ -344,6 +345,24 @@ class LambdaExpressionSegment(BaseSegment):
         ),
         Ref("LambdaArrowSegment"),
         Ref("ExpressionSegment"),
+    )
+
+
+class ListComprehensionExpressionSegment(BaseSegment):
+    """A list comprehension expression in duckdb.
+
+    https://duckdb.org/docs/sql/functions/list#list-comprehension
+    """
+
+    type = "list_comprehension"
+    match_grammar = Bracketed(
+        Ref("ExpressionSegment"),
+        "FOR",
+        Ref("ParameterNameSegment"),
+        "IN",
+        Ref("ExpressionSegment"),
+        Sequence("IF", Ref("ExpressionSegment"), optional=True),
+        bracket_type="square",
     )
 
 

--- a/test/fixtures/dialects/duckdb/list_comprehension.sql
+++ b/test/fixtures/dialects/duckdb/list_comprehension.sql
@@ -1,0 +1,5 @@
+SELECT [lower(x) FOR x IN strings]
+FROM (VALUES (['Hello', '', 'World'])) t(strings);
+
+SELECT [upper(x) FOR x IN strings IF len(x) > 0]
+FROM (VALUES (['Hello', '', 'World'])) t(strings);

--- a/test/fixtures/dialects/duckdb/list_comprehension.yml
+++ b/test/fixtures/dialects/duckdb/list_comprehension.yml
@@ -1,0 +1,134 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: c9984ae559b1e1d2289012be9644998fa963a9d523fbb5e6534659ca77201196
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            list_comprehension:
+            - start_square_bracket: '['
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: lower
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: x
+                      end_bracket: )
+            - keyword: FOR
+            - parameter: x
+            - keyword: IN
+            - expression:
+                column_reference:
+                  naked_identifier: strings
+            - end_square_bracket: ']'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                  keyword: VALUES
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      array_literal:
+                      - start_square_bracket: '['
+                      - quoted_literal: "'Hello'"
+                      - comma: ','
+                      - quoted_literal: "''"
+                      - comma: ','
+                      - quoted_literal: "'World'"
+                      - end_square_bracket: ']'
+                    end_bracket: )
+              end_bracket: )
+            alias_expression:
+              naked_identifier: t
+              bracketed:
+                start_bracket: (
+                identifier_list:
+                  naked_identifier: strings
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            list_comprehension:
+            - start_square_bracket: '['
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: upper
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: x
+                      end_bracket: )
+            - keyword: FOR
+            - parameter: x
+            - keyword: IN
+            - expression:
+                column_reference:
+                  naked_identifier: strings
+            - keyword: IF
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: len
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: x
+                      end_bracket: )
+                comparison_operator:
+                  raw_comparison_operator: '>'
+                numeric_literal: '0'
+            - end_square_bracket: ']'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            bracketed:
+              start_bracket: (
+              table_expression:
+                values_clause:
+                  keyword: VALUES
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      array_literal:
+                      - start_square_bracket: '['
+                      - quoted_literal: "'Hello'"
+                      - comma: ','
+                      - quoted_literal: "''"
+                      - comma: ','
+                      - quoted_literal: "'World'"
+                      - end_square_bracket: ']'
+                    end_bracket: )
+              end_bracket: )
+            alias_expression:
+              naked_identifier: t
+              bracketed:
+                start_bracket: (
+                identifier_list:
+                  naked_identifier: strings
+                end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds list comprehensions to the duckdb dialect.
- fixes #6157

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
