### PR TITLE
SparkSQL/Databricks: Support for `VARIANT` type

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -956,6 +956,7 @@ class PrimitiveTypeSegment(BaseSegment):
         ),
         "BINARY",
         "INTERVAL",
+        "VARIANT",
     )
 
 

--- a/src/sqlfluff/dialects/dialect_sparksql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_sparksql_keywords.py
@@ -278,6 +278,7 @@ UNRESERVED_KEYWORDS = [
     "UPDATE",
     "USE",
     "VALUES",
+    "VARIANT",
     "VIEW",
     "VIEWS",
     "WRITE",

--- a/test/fixtures/dialects/sparksql/create_table_complex_datatypes.sql
+++ b/test/fixtures/dialects/sparksql/create_table_complex_datatypes.sql
@@ -13,3 +13,9 @@ CREATE TABLE table_identifier
 --Create Table with complex datatypes and quoted identifiers
 CREATE TABLE table_identifier
 ( a STRUCT<`b`: STRING, c: BOOLEAN>, `d` MAP<STRING, BOOLEAN>, e ARRAY<STRING>);
+
+
+CREATE TABLE my_table (
+    field_a STRING,
+    field_b VARIANT
+);

--- a/test/fixtures/dialects/sparksql/create_table_complex_datatypes.yml
+++ b/test/fixtures/dialects/sparksql/create_table_complex_datatypes.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9630e84f8a1e62373243524752cc6eb7ab25f89c00d9d3c3b29fa70b2f564a4c
+_hash: 9f527614b5a4b861011fe60a1a10ebfc27f51e8901876167006d8bb21e57f0ac
 file:
 - statement:
     create_table_statement:
@@ -285,5 +285,26 @@ file:
                 primitive_type:
                   keyword: STRING
               end_angle_bracket: '>'
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: my_table
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: field_a
+          data_type:
+            primitive_type:
+              keyword: STRING
+      - comma: ','
+      - column_definition:
+          naked_identifier: field_b
+          data_type:
+            primitive_type:
+              keyword: VARIANT
       - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Adds support for the `VARIANT` data type in SparkSQL (feature being added in 4.0.0) and Databricks.
- fixes #6120 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
