### PR TITLE
TSQL: Fix `MERGE` without a target alias

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -4849,7 +4849,7 @@ class MergeStatementSegment(ansi.MergeStatementSegment):
             ),
             optional=True,
         ),
-        Ref("AliasExpressionSegment", optional=True),
+        Ref("AliasExpressionSegment", optional=True, exclude=Ref.keyword("USING")),
         Dedent,
         "USING",
         Indent,

--- a/test/fixtures/dialects/tsql/merge.sql
+++ b/test/fixtures/dialects/tsql/merge.sql
@@ -194,3 +194,9 @@ MERGE INTO Production.ProductInventory WITH (ROWLOCK, INDEX(myindex, myindex2)) 
     OUTPUT $action, Inserted.ProductID, Inserted.LocationID,
         Inserted.Quantity AS NewQty, Deleted.Quantity AS PreviousQty;
 GO
+
+MERGE INTO dbo.target
+USING  (	SELECT 1 AS i	) AS source
+ON source.i = target.i
+WHEN MATCHED
+THEN  UPDATE SET target.i = source.i;

--- a/test/fixtures/dialects/tsql/merge.yml
+++ b/test/fixtures/dialects/tsql/merge.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: eb17e69e8ece3ab2b5aa93963e9600bdb40ff950e699568cb74561db7e339b76
+_hash: 605fa1b9e7edd1e43e68c0a1745d650c5b7982305d241b31cc166ab10a86e19d
 file:
 - batch:
     statement:
@@ -1446,3 +1446,62 @@ file:
     statement_terminator: ;
 - go_statement:
     keyword: GO
+- batch:
+    statement:
+      merge_statement:
+      - keyword: MERGE
+      - keyword: INTO
+      - table_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: target
+      - keyword: USING
+      - bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                numeric_literal: '1'
+                alias_expression:
+                  keyword: AS
+                  naked_identifier: i
+          end_bracket: )
+      - alias_expression:
+          keyword: AS
+          naked_identifier: source
+      - join_on_condition:
+          keyword: 'ON'
+          expression:
+          - column_reference:
+            - naked_identifier: source
+            - dot: .
+            - naked_identifier: i
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: target
+            - dot: .
+            - naked_identifier: i
+      - merge_match:
+          merge_when_matched_clause:
+          - keyword: WHEN
+          - keyword: MATCHED
+          - keyword: THEN
+          - merge_update_clause:
+              keyword: UPDATE
+              set_clause_list:
+                keyword: SET
+                set_clause:
+                  column_reference:
+                  - naked_identifier: target
+                  - dot: .
+                  - naked_identifier: i
+                  assignment_operator:
+                    raw_comparison_operator: '='
+                  expression:
+                    column_reference:
+                    - naked_identifier: source
+                    - dot: .
+                    - naked_identifier: i
+    statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This correct the issue when a merge statement does not include an alias on the target table.
- fixes #5989

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
