### PR TITLE
sparksql: Allow `INSERT OVERWRITE` after a CTE

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -459,6 +459,9 @@ sparksql_dialect.replace(
         Ref("ExpressionSegment"),
         Ref("StarSegment"),
     ),
+    NonWithNonSelectableGrammar=ansi_dialect.get_grammar(
+        "NonWithNonSelectableGrammar"
+    ).copy(insert=[Ref("InsertOverwriteDirectorySegment")]),
 )
 
 sparksql_dialect.add(

--- a/test/fixtures/dialects/sparksql/insert_overwrite_directory.sql
+++ b/test/fixtures/dialects/sparksql/insert_overwrite_directory.sql
@@ -19,3 +19,21 @@ INSERT OVERWRITE DIRECTORY '/tmp/destination'
 USING PARQUET
 OPTIONS (col1 1, col2 2, col3 'test')
 SELECT a FROM test_table;
+
+WITH cte AS (
+     SELECT
+        *
+     FROM test_table
+)
+
+INSERT OVERWRITE DIRECTORY 'destination_dir/path_to'
+USING CSV
+OPTIONS (
+    sep '\t',
+    header 'true',
+    compression 'none',
+    emptyValue ''
+)
+
+SELECT /*+ COALESCE(1) */ *
+FROM cte;

--- a/test/fixtures/dialects/sparksql/insert_overwrite_directory.yml
+++ b/test/fixtures/dialects/sparksql/insert_overwrite_directory.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1693594c7c492caa9efe94c8fdd1a42c392020ee78aea06c6b922bf4e444652a
+_hash: b19c5c1de0e98b801765c0fc5e50a61d9540e3ce8037ee021284b4fbd6d8bf1d
 file:
 - statement:
     insert_overwrite_directory_statement:
@@ -182,4 +182,80 @@ file:
               table_expression:
                 table_reference:
                   naked_identifier: test_table
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        naked_identifier: cte
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: test_table
+          end_bracket: )
+      insert_overwrite_directory_statement:
+      - keyword: INSERT
+      - keyword: OVERWRITE
+      - keyword: DIRECTORY
+      - quoted_literal: "'destination_dir/path_to'"
+      - keyword: USING
+      - data_source_format:
+          keyword: CSV
+      - keyword: OPTIONS
+      - bracketed:
+        - start_bracket: (
+        - property_name_identifier:
+            properties_naked_identifier: sep
+        - quoted_literal: "'\\t'"
+        - comma: ','
+        - property_name_identifier:
+            properties_naked_identifier: header
+        - quoted_literal: "'true'"
+        - comma: ','
+        - property_name_identifier:
+            properties_naked_identifier: compression
+        - quoted_literal: "'none'"
+        - comma: ','
+        - property_name_identifier:
+            properties_naked_identifier: emptyValue
+        - quoted_literal: "''"
+        - end_bracket: )
+      - select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_modifier:
+              select_hint:
+                start_hint: /*+
+                hint_function:
+                  function_name:
+                    function_name_identifier: COALESCE
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '1'
+                    end_bracket: )
+                end_hint: '*/'
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: cte
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Add support for an `INSERT OVERWRITE DIRECTORY` statement after a CTE.
- fixes #5901

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
