### PR TITLE
Add volume syntax support for Databricks

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -319,6 +319,125 @@ class AlterDatabaseStatementSegment(sparksql.AlterDatabaseStatementSegment):
     )
 
 
+class VolumeReferenceSegment(ansi.ObjectReferenceSegment):
+    """Volume reference."""
+
+    type = "volume_reference"
+
+
+class AlterVolumeStatementSegment(BaseSegment):
+    """Alter Volume Statement.
+
+    https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-alter-volume.html
+    """
+
+    type = "alter_volume_statement"
+
+    match_grammar = Sequence(
+        "ALTER",
+        "VOLUME",
+        Ref("VolumeReferenceSegment"),
+        OneOf(
+            Sequence(
+                "RENAME",
+                "TO",
+                Ref("VolumeReferenceSegment"),
+            ),
+            Ref("SetOwnerGrammar"),
+            Ref("SetTagsGrammar"),
+            Ref("UnsetTagsGrammar"),
+        ),
+    )
+
+
+class CreateVolumeStatementSegment(BaseSegment):
+    """Create Volume Statement.
+
+    https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-create-volume.html
+    """
+
+    type = "create_volume_statement"
+
+    match_grammar = OneOf(
+        # You can create a non-external volume without a location
+        Sequence(
+            "CREATE",
+            "VOLUME",
+            Ref("IfNotExistsGrammar", optional=True),
+            Ref("VolumeReferenceSegment"),
+            Ref("CommentGrammar", optional=True),
+        ),
+        # Or you can create an external volume that must have a location
+        Sequence(
+            "CREATE",
+            "EXTERNAL",
+            "VOLUME",
+            Ref("IfNotExistsGrammar", optional=True),
+            Ref("VolumeReferenceSegment"),
+            Ref("LocationGrammar"),
+            Ref("CommentGrammar", optional=True),
+        ),
+    )
+
+
+class DescribeVolumeStatementSegment(BaseSegment):
+    """Describe Volume Statement.
+
+    https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-aux-describe-volume.html
+    """
+
+    type = "describe_volume_statement"
+
+    match_grammar = Sequence(
+        "DESCRIBE",
+        "VOLUME",
+        Ref("VolumeReferenceSegment"),
+    )
+
+
+class DropVolumeStatementSegment(BaseSegment):
+    """Drop Volume Statement.
+
+    https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-drop-volume.html
+    """
+
+    type = "drop_volume_statement"
+
+    match_grammar = Sequence(
+        "DROP",
+        "VOLUME",
+        Ref("IfExistsGrammar", optional=True),
+        Ref("VolumeReferenceSegment"),
+    )
+
+
+class ShowVolumesStatementSegment(BaseSegment):
+    """Show Volumes Statement.
+
+    https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-aux-show-volumes.html
+    """
+
+    type = "show_volume_statement"
+
+    match_grammar = Sequence(
+        "SHOW",
+        "VOLUMES",
+        Sequence(
+            Sequence(
+                OneOf("IN", "FROM"),
+                Ref("DatabaseReferenceSegment"),
+                optional=True,
+            ),
+            Sequence(
+                Ref.keyword("LIKE", optional=True),
+                Ref("QuotedLiteralSegment"),
+                optional=True,
+            ),
+            optional=True,
+        ),
+    )
+
+
 class MaskStatementSegment(BaseSegment):
     """A `MASK` statement.
 
@@ -717,6 +836,11 @@ class StatementSegment(sparksql.StatementSegment):
             Ref("CreateCatalogStatementSegment"),
             Ref("DropCatalogStatementSegment"),
             Ref("UseCatalogStatementSegment"),
+            Ref("AlterVolumeStatementSegment"),
+            Ref("CreateVolumeStatementSegment"),
+            Ref("DescribeVolumeStatementSegment"),
+            Ref("DropVolumeStatementSegment"),
+            Ref("ShowVolumesStatementSegment"),
             Ref("SetTimeZoneStatementSegment"),
             Ref("OptimizeTableStatementSegment"),
             Ref("CreateDatabricksFunctionStatementSegment"),

--- a/src/sqlfluff/dialects/dialect_databricks_keywords.py
+++ b/src/sqlfluff/dialects/dialect_databricks_keywords.py
@@ -40,5 +40,7 @@ UNRESERVED_KEYWORDS = [
     "SQL",
     "TAGS",
     "TIMESERIES",
+    "VOLUME",
+    "VOLUMES",
     "ZORDER",
 ]

--- a/test/fixtures/dialects/databricks/alter_volume.sql
+++ b/test/fixtures/dialects/databricks/alter_volume.sql
@@ -1,0 +1,16 @@
+-- Rename a volume
+ALTER VOLUME some_vol RENAME TO some_new_vol;
+
+-- Transfer ownership of the volume to another user
+ALTER VOLUME some_vol OWNER TO `alf@melmak.et`;
+ALTER VOLUME some_vol OWNER TO my_group;
+
+-- SET is allowed as an optional keyword
+ALTER VOLUME some_vol SET OWNER TO `alf@melmak.et`;
+ALTER VOLUME some_vol SET OWNER TO my_group;
+
+-- Set and unset volume tags
+ALTER VOLUME some_vol SET TAGS ('tag1'='value1');
+ALTER VOLUME some_vol SET TAGS ('tag2'='value2', 'tag3'='value3');
+ALTER VOLUME some_vol UNSET TAGS ('tag1');
+ALTER VOLUME some_vol UNSET TAGS ('tag2', 'tag3');

--- a/test/fixtures/dialects/databricks/alter_volume.yml
+++ b/test/fixtures/dialects/databricks/alter_volume.yml
@@ -1,0 +1,131 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 283c1e2e602131c3faecc9938bebae62abca9ec0fd1640f38e02cebfd56558e8
+file:
+- statement:
+    alter_volume_statement:
+    - keyword: ALTER
+    - keyword: VOLUME
+    - volume_reference:
+        naked_identifier: some_vol
+    - keyword: RENAME
+    - keyword: TO
+    - volume_reference:
+        naked_identifier: some_new_vol
+- statement_terminator: ;
+- statement:
+    alter_volume_statement:
+    - keyword: ALTER
+    - keyword: VOLUME
+    - volume_reference:
+        naked_identifier: some_vol
+    - keyword: OWNER
+    - keyword: TO
+    - quoted_identifier: '`alf@melmak.et`'
+- statement_terminator: ;
+- statement:
+    alter_volume_statement:
+    - keyword: ALTER
+    - keyword: VOLUME
+    - volume_reference:
+        naked_identifier: some_vol
+    - keyword: OWNER
+    - keyword: TO
+    - naked_identifier: my_group
+- statement_terminator: ;
+- statement:
+    alter_volume_statement:
+    - keyword: ALTER
+    - keyword: VOLUME
+    - volume_reference:
+        naked_identifier: some_vol
+    - keyword: SET
+    - keyword: OWNER
+    - keyword: TO
+    - quoted_identifier: '`alf@melmak.et`'
+- statement_terminator: ;
+- statement:
+    alter_volume_statement:
+    - keyword: ALTER
+    - keyword: VOLUME
+    - volume_reference:
+        naked_identifier: some_vol
+    - keyword: SET
+    - keyword: OWNER
+    - keyword: TO
+    - naked_identifier: my_group
+- statement_terminator: ;
+- statement:
+    alter_volume_statement:
+    - keyword: ALTER
+    - keyword: VOLUME
+    - volume_reference:
+        naked_identifier: some_vol
+    - keyword: SET
+    - keyword: TAGS
+    - bracketed:
+        start_bracket: (
+        property_name_identifier:
+          quoted_identifier: "'tag1'"
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'value1'"
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_volume_statement:
+    - keyword: ALTER
+    - keyword: VOLUME
+    - volume_reference:
+        naked_identifier: some_vol
+    - keyword: SET
+    - keyword: TAGS
+    - bracketed:
+      - start_bracket: (
+      - property_name_identifier:
+          quoted_identifier: "'tag2'"
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'value2'"
+      - comma: ','
+      - property_name_identifier:
+          quoted_identifier: "'tag3'"
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'value3'"
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_volume_statement:
+    - keyword: ALTER
+    - keyword: VOLUME
+    - volume_reference:
+        naked_identifier: some_vol
+    - keyword: UNSET
+    - keyword: TAGS
+    - bracketed:
+        start_bracket: (
+        property_name_identifier:
+          quoted_identifier: "'tag1'"
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_volume_statement:
+    - keyword: ALTER
+    - keyword: VOLUME
+    - volume_reference:
+        naked_identifier: some_vol
+    - keyword: UNSET
+    - keyword: TAGS
+    - bracketed:
+      - start_bracket: (
+      - property_name_identifier:
+          quoted_identifier: "'tag2'"
+      - comma: ','
+      - property_name_identifier:
+          quoted_identifier: "'tag3'"
+      - end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/databricks/create_volume.sql
+++ b/test/fixtures/dialects/databricks/create_volume.sql
@@ -1,0 +1,27 @@
+-- Create volume `customer_vol`.
+-- This throws exception if volume with name customer_vol already exists.
+CREATE VOLUME customer_vol;
+
+-- Create volume `customer_vol` only if volume with same name doesn't exist.
+CREATE VOLUME IF NOT EXISTS customer_vol;
+
+-- Create volume `customer_vol` only if volume with same name doesn't exist,
+-- with a comment.
+CREATE VOLUME IF NOT EXISTS customer_vol COMMENT 'This is customer volume';
+
+-- Create external volume `customer_vol_external`
+-- This throws exception if volume with name customer_vol_external
+-- already exists.
+CREATE EXTERNAL VOLUME customer_vol_external
+LOCATION 's3://s3-path/';
+
+-- Create external volume `customer_vol_external`
+-- only if volume with same name doesn't exist, with a location.
+CREATE EXTERNAL VOLUME IF NOT EXISTS customer_vol_external
+LOCATION 's3://s3-path/';
+
+-- Create external volume `customer_vol_external`
+-- only if volume with same name doesn't exist, with a location and a comment.
+CREATE EXTERNAL VOLUME IF NOT EXISTS customer_vol_external
+LOCATION 's3://s3-path/'
+COMMENT 'This is customer volume';

--- a/test/fixtures/dialects/databricks/create_volume.yml
+++ b/test/fixtures/dialects/databricks/create_volume.yml
@@ -1,0 +1,74 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: a2105a5218087ba3cbcdd279855c7fba2a2e35f4bf23b727a269df2c06d3eea7
+file:
+- statement:
+    create_volume_statement:
+    - keyword: CREATE
+    - keyword: VOLUME
+    - volume_reference:
+        naked_identifier: customer_vol
+- statement_terminator: ;
+- statement:
+    create_volume_statement:
+    - keyword: CREATE
+    - keyword: VOLUME
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - volume_reference:
+        naked_identifier: customer_vol
+- statement_terminator: ;
+- statement:
+    create_volume_statement:
+    - keyword: CREATE
+    - keyword: VOLUME
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - volume_reference:
+        naked_identifier: customer_vol
+    - keyword: COMMENT
+    - quoted_literal: "'This is customer volume'"
+- statement_terminator: ;
+- statement:
+    create_volume_statement:
+    - keyword: CREATE
+    - keyword: EXTERNAL
+    - keyword: VOLUME
+    - volume_reference:
+        naked_identifier: customer_vol_external
+    - keyword: LOCATION
+    - quoted_literal: "'s3://s3-path/'"
+- statement_terminator: ;
+- statement:
+    create_volume_statement:
+    - keyword: CREATE
+    - keyword: EXTERNAL
+    - keyword: VOLUME
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - volume_reference:
+        naked_identifier: customer_vol_external
+    - keyword: LOCATION
+    - quoted_literal: "'s3://s3-path/'"
+- statement_terminator: ;
+- statement:
+    create_volume_statement:
+    - keyword: CREATE
+    - keyword: EXTERNAL
+    - keyword: VOLUME
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - volume_reference:
+        naked_identifier: customer_vol_external
+    - keyword: LOCATION
+    - quoted_literal: "'s3://s3-path/'"
+    - keyword: COMMENT
+    - quoted_literal: "'This is customer volume'"
+- statement_terminator: ;

--- a/test/fixtures/dialects/databricks/describe_volume.sql
+++ b/test/fixtures/dialects/databricks/describe_volume.sql
@@ -1,0 +1,2 @@
+-- Desribe the volume
+DESCRIBE VOLUME VACCINE_VOLUME;

--- a/test/fixtures/dialects/databricks/describe_volume.yml
+++ b/test/fixtures/dialects/databricks/describe_volume.yml
@@ -1,0 +1,14 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: dbacf385e0fb479407d6131eac2f4426980a664462ae47a6d350179bc9e116dd
+file:
+  statement:
+    describe_statement:
+      keyword: DESCRIBE
+      table_reference:
+        naked_identifier: VOLUME
+      naked_identifier: VACCINE_VOLUME
+  statement_terminator: ;

--- a/test/fixtures/dialects/databricks/drop_volume.sql
+++ b/test/fixtures/dialects/databricks/drop_volume.sql
@@ -1,0 +1,5 @@
+-- Drop the volume
+DROP VOLUME vaccine_volume;
+
+-- Drop the volume using IF EXISTS.
+DROP VOLUME IF EXISTS vaccine_volume;

--- a/test/fixtures/dialects/databricks/drop_volume.yml
+++ b/test/fixtures/dialects/databricks/drop_volume.yml
@@ -1,0 +1,23 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: dfe9fe8a21ef3a2b447f823a1b8a437a16e71cea56fd657d1e6d9b1deddd76c5
+file:
+- statement:
+    drop_volume_statement:
+    - keyword: DROP
+    - keyword: VOLUME
+    - volume_reference:
+        naked_identifier: vaccine_volume
+- statement_terminator: ;
+- statement:
+    drop_volume_statement:
+    - keyword: DROP
+    - keyword: VOLUME
+    - keyword: IF
+    - keyword: EXISTS
+    - volume_reference:
+        naked_identifier: vaccine_volume
+- statement_terminator: ;

--- a/test/fixtures/dialects/databricks/show_volumes.sql
+++ b/test/fixtures/dialects/databricks/show_volumes.sql
@@ -1,0 +1,17 @@
+SHOW VOLUMES;
+
+SHOW VOLUMES IN sampledb;
+
+SHOW VOLUMES FROM sampledb;
+
+SHOW VOLUMES LIKE 'regex*';
+
+SHOW VOLUMES 'regex*';
+
+SHOW VOLUMES IN sampledb LIKE 'regex*';
+
+SHOW VOLUMES IN sampledb 'regex*';
+
+SHOW VOLUMES FROM sampledb LIKE 'regex*';
+
+SHOW VOLUMES FROM sampledb 'regex*';

--- a/test/fixtures/dialects/databricks/show_volumes.yml
+++ b/test/fixtures/dialects/databricks/show_volumes.yml
@@ -1,0 +1,79 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 495ea5c11ca120287d61034aaeac515e8bc37395ddb021692b1399e1090a3d8d
+file:
+- statement:
+    show_volume_statement:
+    - keyword: SHOW
+    - keyword: VOLUMES
+- statement_terminator: ;
+- statement:
+    show_volume_statement:
+    - keyword: SHOW
+    - keyword: VOLUMES
+    - keyword: IN
+    - database_reference:
+        naked_identifier: sampledb
+- statement_terminator: ;
+- statement:
+    show_volume_statement:
+    - keyword: SHOW
+    - keyword: VOLUMES
+    - keyword: FROM
+    - database_reference:
+        naked_identifier: sampledb
+- statement_terminator: ;
+- statement:
+    show_volume_statement:
+    - keyword: SHOW
+    - keyword: VOLUMES
+    - keyword: LIKE
+    - quoted_literal: "'regex*'"
+- statement_terminator: ;
+- statement:
+    show_volume_statement:
+    - keyword: SHOW
+    - keyword: VOLUMES
+    - quoted_literal: "'regex*'"
+- statement_terminator: ;
+- statement:
+    show_volume_statement:
+    - keyword: SHOW
+    - keyword: VOLUMES
+    - keyword: IN
+    - database_reference:
+        naked_identifier: sampledb
+    - keyword: LIKE
+    - quoted_literal: "'regex*'"
+- statement_terminator: ;
+- statement:
+    show_volume_statement:
+    - keyword: SHOW
+    - keyword: VOLUMES
+    - keyword: IN
+    - database_reference:
+        naked_identifier: sampledb
+    - quoted_literal: "'regex*'"
+- statement_terminator: ;
+- statement:
+    show_volume_statement:
+    - keyword: SHOW
+    - keyword: VOLUMES
+    - keyword: FROM
+    - database_reference:
+        naked_identifier: sampledb
+    - keyword: LIKE
+    - quoted_literal: "'regex*'"
+- statement_terminator: ;
+- statement:
+    show_volume_statement:
+    - keyword: SHOW
+    - keyword: VOLUMES
+    - keyword: FROM
+    - database_reference:
+        naked_identifier: sampledb
+    - quoted_literal: "'regex*'"
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Add support for VOLUME[S] syntax in Databricks. Fixes #6178 

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
