### PR TITLE
DuckDB: Support functions with walrus operators

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -340,6 +340,21 @@ class ColumnsExpressionFunctionContentsSegment(
     )
 
 
+class NamedArgumentSegment(postgres.NamedArgumentSegment):
+    """Named argument to a function.
+
+    Some functions may use a `walrus operator`.
+    e.g. https://duckdb.org/docs/sql/functions/struct#struct_packname--any-
+    """
+
+    type = "named_argument"
+    match_grammar = Sequence(
+        Ref("NakedIdentifierSegment"),
+        OneOf(Ref("RightArrowSegment"), Ref("WalrusOperatorSegment")),
+        Ref("ExpressionSegment"),
+    )
+
+
 class LambdaExpressionSegment(BaseSegment):
     """Lambda function used in a function or columns expression.
 

--- a/test/fixtures/dialects/duckdb/walrus_operator_function.sql
+++ b/test/fixtures/dialects/duckdb/walrus_operator_function.sql
@@ -1,0 +1,11 @@
+create view v as
+select
+    t.id,
+    struct_pack(
+        val := t.val
+    ) as s
+from
+    t;
+
+
+select struct_insert({ 'a': 1 }, b := 2);

--- a/test/fixtures/dialects/duckdb/walrus_operator_function.yml
+++ b/test/fixtures/dialects/duckdb/walrus_operator_function.yml
@@ -1,0 +1,77 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 480c5087136613c302fb2099295205dd5a622604369fc76d2adb1eda444d1088
+file:
+- statement:
+    create_view_statement:
+    - keyword: create
+    - keyword: view
+    - table_reference:
+        naked_identifier: v
+    - keyword: as
+    - select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: t
+            - dot: .
+            - naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: struct_pack
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  named_argument:
+                    naked_identifier: val
+                    assignment_operator: :=
+                    expression:
+                      column_reference:
+                      - naked_identifier: t
+                      - dot: .
+                      - naked_identifier: val
+                  end_bracket: )
+            alias_expression:
+              keyword: as
+              naked_identifier: s
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: struct_insert
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  object_literal:
+                    start_curly_bracket: '{'
+                    object_literal_element:
+                      quoted_literal: "'a'"
+                      colon: ':'
+                      numeric_literal: '1'
+                    end_curly_bracket: '}'
+                comma: ','
+                named_argument:
+                  naked_identifier: b
+                  assignment_operator: :=
+                  expression:
+                    numeric_literal: '2'
+                end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds support for functions that use a `walrus operator` in DuckDB.
- fixes #6189

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
