### PR TITLE
DuckDB: Support `STRUCT` datatype

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -830,6 +830,7 @@ class DatatypeSegment(ansi.DatatypeSegment):
         OneOf(
             Ref("WellKnownTextGeometrySegment"),
             Ref("DateTimeTypeIdentifier"),
+            Ref("StructTypeSegment"),
             Sequence(
                 OneOf(
                     # numeric types

--- a/test/fixtures/dialects/duckdb/create_table.sql
+++ b/test/fixtures/dialects/duckdb/create_table.sql
@@ -68,7 +68,7 @@ CREATE TABLE t5 (id INTEGER UNIQUE, j VARCHAR);
 CREATE TABLE t6 (
     id INTEGER PRIMARY KEY,
     t5_id INTEGER,
-    FOREIGN KEY (t5_id) REFERENCES t5(id)
+    FOREIGN KEY (t5_id) REFERENCES t5 (id)
 );
 
 -- The simplest syntax for a generated column.
@@ -84,3 +84,19 @@ CREATE TABLE t_values AS VALUES (1);
 CREATE TABLE t_dflt_int (id INTEGER DEFAULT 0);
 
 CREATE OR REPLACE TABLE t_dflt_dt (dt DATE DEFAULT CURRENT_DATE);
+
+CREATE TABLE t (
+    s STRUCT(
+        val STRING
+    )
+);
+
+CREATE TABLE t (
+    s STRUCT(
+        val STRING,
+        s1 STRUCT(
+            ival INT,
+            jval INT
+        )
+    )
+);

--- a/test/fixtures/dialects/duckdb/create_table.yml
+++ b/test/fixtures/dialects/duckdb/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ca5f225dd7eee6d74cfbd3101b6d193a4297346057cbc213244cc7fea57867e4
+_hash: ec9ccc0fa7f44a937ce3cc21f7ba141415e751452c9354e7a28ee8e0d5422809
 file:
 - statement:
     create_table_statement:
@@ -704,5 +704,65 @@ file:
           keyword: DEFAULT
           expression:
             bare_function: CURRENT_DATE
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: s
+        data_type:
+          struct_type:
+            keyword: STRUCT
+            struct_type_schema:
+              bracketed:
+                start_bracket: (
+                parameter: val
+                data_type:
+                  data_type_identifier: STRING
+                end_bracket: )
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: s
+        data_type:
+          struct_type:
+            keyword: STRUCT
+            struct_type_schema:
+              bracketed:
+              - start_bracket: (
+              - parameter: val
+              - data_type:
+                  data_type_identifier: STRING
+              - comma: ','
+              - parameter: s1
+              - data_type:
+                  struct_type:
+                    keyword: STRUCT
+                    struct_type_schema:
+                      bracketed:
+                      - start_bracket: (
+                      - parameter: ival
+                      - data_type:
+                          keyword: INT
+                      - comma: ','
+                      - parameter: jval
+                      - data_type:
+                          keyword: INT
+                      - end_bracket: )
+              - end_bracket: )
         end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/duckdb/structs.sql
+++ b/test/fixtures/dialects/duckdb/structs.sql
@@ -1,0 +1,3 @@
+SELECT a::STRUCT(y INTEGER) AS b
+FROM
+    (SELECT {'x': 42} AS a);

--- a/test/fixtures/dialects/duckdb/structs.yml
+++ b/test/fixtures/dialects/duckdb/structs.yml
@@ -1,0 +1,53 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9732e9b750cc75eec8a510455feaad16022fca24154cc54954a2c066d04cba61
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            cast_expression:
+              column_reference:
+                naked_identifier: a
+              casting_operator: '::'
+              data_type:
+                struct_type:
+                  keyword: STRUCT
+                  struct_type_schema:
+                    bracketed:
+                      start_bracket: (
+                      parameter: y
+                      data_type:
+                        keyword: INTEGER
+                      end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: b
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      object_literal:
+                        start_curly_bracket: '{'
+                        object_literal_element:
+                          quoted_literal: "'x'"
+                          colon: ':'
+                          numeric_literal: '42'
+                        end_curly_bracket: '}'
+                      alias_expression:
+                        keyword: AS
+                        naked_identifier: a
+                end_bracket: )
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Adds support for `STRUCT` datatype in DuckDB
- fixes #6195

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
