### PR TITLE
DuckDB: Support `CREATE TYPE` statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -78,7 +78,7 @@ duckdb_dialect.replace(
         r"[A-Z_][A-Z0-9_$]*",
         CodeSegment,
         type="function_name_identifier",
-        anti_template=r"^(STRUCT)$",
+        anti_template=r"^(STRUCT|UNION|ENUM)$",
     ),
     DivideSegment=OneOf(
         StringParser("//", BinaryOperatorSegment),
@@ -769,5 +769,25 @@ class CreateFunctionStatementSegment(postgres.CreateFunctionStatementSegment):
         OneOf(
             Sequence("TABLE", Indent, Ref("SelectableGrammar"), Dedent),
             Ref("ExpressionSegment"),
+        ),
+    )
+
+
+class CreateTypeStatementSegment(postgres.CreateTypeStatementSegment):
+    """A `CREATE TYPE` statement.
+
+    https://duckdb.org/docs/sql/statements/create_type.html
+    """
+
+    match_grammar = Sequence(
+        "CREATE",
+        "TYPE",
+        Ref("DatatypeIdentifierSegment"),
+        "AS",
+        OneOf(
+            Ref("DatatypeIdentifierSegment"),
+            Sequence("ENUM", Bracketed(Delimited(Ref("QuotedLiteralSegment")))),
+            Ref("StructTypeSegment"),
+            Sequence("UNION", Ref("StructTypeSchemaSegment")),
         ),
     )

--- a/test/fixtures/dialects/duckdb/create_type.sql
+++ b/test/fixtures/dialects/duckdb/create_type.sql
@@ -1,0 +1,4 @@
+CREATE TYPE mood AS ENUM ('happy', 'sad', 'curious');
+CREATE TYPE many_things AS STRUCT(k integer, l varchar);
+CREATE TYPE one_thing AS UNION (number integer, string varchar);
+CREATE TYPE x_index AS integer;

--- a/test/fixtures/dialects/duckdb/create_type.yml
+++ b/test/fixtures/dialects/duckdb/create_type.yml
@@ -1,0 +1,70 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 64bba70a49a42bc0cff6c4071a0c97478a2f84dd80bf03db7a2afb0ea6ae6ad3
+file:
+- statement:
+    create_type_statement:
+    - keyword: CREATE
+    - keyword: TYPE
+    - data_type_identifier: mood
+    - keyword: AS
+    - keyword: ENUM
+    - bracketed:
+      - start_bracket: (
+      - quoted_literal: "'happy'"
+      - comma: ','
+      - quoted_literal: "'sad'"
+      - comma: ','
+      - quoted_literal: "'curious'"
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_type_statement:
+    - keyword: CREATE
+    - keyword: TYPE
+    - data_type_identifier: many_things
+    - keyword: AS
+    - struct_type:
+        keyword: STRUCT
+        struct_type_schema:
+          bracketed:
+          - start_bracket: (
+          - parameter: k
+          - data_type:
+              keyword: integer
+          - comma: ','
+          - parameter: l
+          - data_type:
+              keyword: varchar
+          - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_type_statement:
+    - keyword: CREATE
+    - keyword: TYPE
+    - data_type_identifier: one_thing
+    - keyword: AS
+    - keyword: UNION
+    - struct_type_schema:
+        bracketed:
+        - start_bracket: (
+        - parameter: number
+        - data_type:
+            keyword: integer
+        - comma: ','
+        - parameter: string
+        - data_type:
+            keyword: varchar
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_type_statement:
+    - keyword: CREATE
+    - keyword: TYPE
+    - data_type_identifier: x_index
+    - keyword: AS
+    - data_type_identifier: integer
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds support for `CREATE TYPE` in DuckDB. Namely `STRUCT` and `UNION` types.
- fixes #6200

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
