### PR TITLE
Strict typing in `config` and `helpers`.

### DIFF
--- a/src/sqlfluff/core/config/__init__.py
+++ b/src/sqlfluff/core/config/__init__.py
@@ -32,7 +32,7 @@ __all__ = (
 )
 
 
-def clear_config_caches():
+def clear_config_caches() -> None:
     """Clear any of the cached config methods.
 
     This is primarily used during testing where the cache may be be rendered unreliable

--- a/src/sqlfluff/core/config/file.py
+++ b/src/sqlfluff/core/config/file.py
@@ -61,7 +61,7 @@ def _resolve_path(filepath: str, val: str) -> str:
 
 def _resolve_paths_in_config(
     config: ConfigMappingType, filepath: str, logging_reference: Optional[str] = None
-):
+) -> None:
     """Attempt to resolve any paths found in the config file.
 
     NOTE: This method is recursive to crawl the whole config object,

--- a/src/sqlfluff/core/config/fluffconfig.py
+++ b/src/sqlfluff/core/config/fluffconfig.py
@@ -61,7 +61,7 @@ class FluffConfig:
         # it might only be set in nested .sqlfluff config files, so allow it
         # to be not required.
         require_dialect: bool = True,
-    ):
+    ) -> None:
         self._extra_config_path = (
             extra_config_path  # We only store this for child configs
         )
@@ -101,7 +101,7 @@ class FluffConfig:
             self._configs["core"]["templater"]
         )
 
-    def _handle_comma_separated_values(self):
+    def _handle_comma_separated_values(self) -> None:
         for in_key, out_key in [
             ("ignore", "ignore"),
             ("warnings", "warnings"),

--- a/src/sqlfluff/core/config/ini.py
+++ b/src/sqlfluff/core/config/ini.py
@@ -4,7 +4,7 @@ This includes `.sqlfluff` and `tox.ini` files.
 """
 
 import configparser
-from typing import Any, List, Tuple
+from typing import List, Tuple
 
 from sqlfluff.core.config.types import ConfigMappingType, ConfigValueType
 from sqlfluff.core.helpers.dict import NestedDictRecord, records_to_nested_dict
@@ -14,8 +14,9 @@ def coerce_value(val: str) -> ConfigValueType:
     """Try to coerce to a more specific type."""
     # Try to coerce it to a more specific type,
     # otherwise just make it a string.
+    v: ConfigValueType
     try:
-        v: Any = int(val)
+        v = int(val)
     except ValueError:
         try:
             v = float(val)

--- a/src/sqlfluff/core/config/removed.py
+++ b/src/sqlfluff/core/config/removed.py
@@ -174,7 +174,7 @@ def validate_config_dict_for_removed(
     logging_reference: str,
     removed_config: NestedStringDict[_RemovedConfig] = REMOVED_CONFIG_MAP,
     root_config_ref: Optional[ConfigMappingType] = None,
-):
+) -> None:
     """Validates a config dict against removed values.
 
     Where a value can be updated or translated, it mutates the config object.

--- a/src/sqlfluff/core/config/toml.py
+++ b/src/sqlfluff/core/config/toml.py
@@ -1,6 +1,7 @@
 """Methods for loading config from pyproject.toml files."""
 
 import sys
+from typing import Any, Dict, TypeVar
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -14,13 +15,37 @@ from sqlfluff.core.helpers.dict import (
     records_to_nested_dict,
 )
 
+T = TypeVar("T")
 
-def _condense_rule_record(record: NestedDictRecord) -> NestedDictRecord:
+
+def _condense_rule_record(record: NestedDictRecord[T]) -> NestedDictRecord[T]:
     """Helper function to condense the rule section of a toml config."""
     key, value = record
     if len(key) > 2:
         key = (".".join(key[:-1]), key[-1])
     return key, value
+
+
+def _validate_structure(raw_config: Dict[str, Any]) -> ConfigMappingType:
+    """Helper function to narrow types for use by SQLFluff.
+
+    This is a recursive function on any dict keys found.
+    """
+    validated_config: ConfigMappingType = {}
+    for key, value in raw_config.items():
+        if isinstance(value, dict):
+            validated_config[key] = _validate_structure(value)
+        elif isinstance(value, list):
+            # Coerce all list items to strings, to be in line
+            # with the behaviour of ini configs.
+            validated_config[key] = [str(item) for item in value]
+        elif isinstance(value, (str, int, float, bool)) or value is None:
+            validated_config[key] = value
+        else:  # pragma: no cover
+            # Whatever we found, make it into a string.
+            # This is very unlikely to happen and is more for completeness.
+            validated_config[key] = str(value)
+    return validated_config
 
 
 def load_toml_file_config(filepath: str) -> ConfigMappingType:
@@ -30,22 +55,26 @@ def load_toml_file_config(filepath: str) -> ConfigMappingType:
     section of the toml file format is `tool.sqlfluff.core`.
     """
     with open(filepath, mode="r") as file:
-        config = tomllib.loads(file.read())
-    raw_config = config.get("tool", {}).get("sqlfluff", {})
+        toml_dict = tomllib.loads(file.read())
+    config_dict = _validate_structure(toml_dict.get("tool", {}).get("sqlfluff", {}))
 
     # NOTE: For the "rules" section of the sqlfluff config,
     # rule names are often qualified with a dot ".". In the
     # toml scenario this can get interpreted as a nested
     # section, and we resolve that edge case here.
-    if "rules" not in raw_config:
+    if "rules" not in config_dict:
         # No rules section, so no need to resolve.
-        return raw_config
+        return config_dict
 
-    rules_section = raw_config["rules"]
+    rules_section = config_dict["rules"]
+    assert isinstance(rules_section, dict), (
+        "Expected to find section in `rules` section of config, "
+        f"but instead found {rules_section}"
+    )
     # Condense the rules section.
-    raw_config["rules"] = records_to_nested_dict(
+    config_dict["rules"] = records_to_nested_dict(
         _condense_rule_record(record)
         for record in iter_records_from_nested_dict(rules_section)
     )
 
-    return raw_config
+    return config_dict

--- a/src/sqlfluff/core/config/types.py
+++ b/src/sqlfluff/core/config/types.py
@@ -5,6 +5,12 @@ from typing import List, Union
 from sqlfluff.core.helpers.dict import NestedDictRecord, NestedStringDict
 
 ConfigValueType = Union[int, float, bool, None, str]
-ConfigValueOrListType = Union[ConfigValueType, List[ConfigValueType]]
+# NOTE: We allow lists in the config types, but only lists
+# of strings. Lists of other things are not allowed and should
+# be rejected on load (or converted to strings). Given most
+# config loading starts as strings, it's more likely that we
+# just don't _try_ to convert lists from anything other than
+# strings.
+ConfigValueOrListType = Union[ConfigValueType, List[str]]
 ConfigMappingType = NestedStringDict[ConfigValueOrListType]
 ConfigRecordType = NestedDictRecord[ConfigValueOrListType]

--- a/src/sqlfluff/core/helpers/dict.py
+++ b/src/sqlfluff/core/helpers/dict.py
@@ -149,9 +149,9 @@ def records_to_nested_dict(
     ... )
     {'foo': {'bar': {'baz': 'a', 'biz': 'b'}}}
     """
-    result: NestedStringDict = {}
+    result: NestedStringDict[T] = {}
     for key, val in records:
-        ref: NestedStringDict = result
+        ref: NestedStringDict[T] = result
         for step in key[:-1]:
             # If the subsection isn't there, make it.
             if step not in ref:

--- a/tox.ini
+++ b/tox.ini
@@ -117,7 +117,9 @@ commands = make -C {toxinidir}/docs html
 commands =
     # Standard MyPy on the main package
     mypy -p sqlfluff
-    # Strict MyPy on the parser
+    # Strict MyPy on the parser, helpers & config
+    mypy -p sqlfluff.core.helpers --strict
+    mypy -p sqlfluff.core.config --strict
     mypy -p sqlfluff.core.parser --strict
 
 [testenv:build-dist]


### PR DESCRIPTION
This brings the `core.helpers` and `core.config` modules up to string mypy typing. Also helpfully it does a little bit of type narrowing so that any lists in config mappings can only contain strings. Practically this doesn't change downstream functionality (as they should only be lists anyway), but it makes type handling downstream simpler.