### PR TITLE
Add postgres normalization operator support

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -376,6 +376,7 @@ ansi_dialect.add(
     NullLiteralSegment=StringParser("null", LiteralKeywordSegment, type="null_literal"),
     NanLiteralSegment=StringParser("nan", LiteralKeywordSegment, type="null_literal"),
     UnknownLiteralSegment=Nothing(),
+    NormalizedGrammar=Nothing(),
     TrueSegment=StringParser("true", LiteralKeywordSegment, type="boolean_literal"),
     FalseSegment=StringParser("false", LiteralKeywordSegment, type="boolean_literal"),
     # We use a GRAMMAR here not a Segment. Otherwise, we get an unnecessary layer
@@ -472,6 +473,7 @@ ansi_dialect.add(
         Ref("NanLiteralSegment"),
         Ref("UnknownLiteralSegment"),
         Ref("BooleanLiteralGrammar"),
+        Ref("NormalizedGrammar"),
     ),
     InOperatorGrammar=Sequence(
         Ref.keyword("NOT", optional=True),

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -700,6 +700,10 @@ postgres_dialect.replace(
     UnknownLiteralSegment=StringParser(
         "UNKNOWN", LiteralKeywordSegment, type="null_literal"
     ),
+    NormalizedGrammar=Sequence(
+        OneOf("NFC", "NFD", "NFKC", "NFKD", optional=True),
+        "NORMALIZED",
+    ),
 )
 
 

--- a/test/fixtures/dialects/postgres/string_normalization.sql
+++ b/test/fixtures/dialects/postgres/string_normalization.sql
@@ -1,0 +1,36 @@
+SELECT (test_column IS NORMALIZED) AS is_normalized FROM test_table;
+SELECT (test_column IS NFC NORMALIZED) AS is_normalized FROM test_table;
+SELECT (test_column IS NFD NORMALIZED) AS is_normalized FROM test_table;
+SELECT (test_column IS NFKC NORMALIZED) AS is_normalized FROM test_table;
+SELECT (test_column IS NFKD NORMALIZED) AS is_normalized FROM test_table;
+SELECT (test_column IS NOT NORMALIZED) AS is_normalized FROM test_table;
+SELECT (test_column IS NOT NFC NORMALIZED) AS is_normalized FROM test_table;
+SELECT (test_column IS NOT NFD NORMALIZED) AS is_normalized FROM test_table;
+SELECT (test_column IS NOT NFKC NORMALIZED) AS is_normalized FROM test_table;
+SELECT (test_column IS NOT NFKD NORMALIZED) AS is_normalized FROM test_table;
+
+CREATE DOMAIN text_default AS TEXT CHECK (VALUE IS NORMALIZED);
+CREATE DOMAIN text_nfc AS TEXT CHECK (VALUE IS NFC NORMALIZED);
+CREATE DOMAIN text_nfd AS TEXT CHECK (VALUE IS NFD NORMALIZED);
+CREATE DOMAIN text_nfkc AS TEXT CHECK (VALUE IS NFKC NORMALIZED);
+CREATE DOMAIN text_nfkd AS TEXT CHECK (VALUE IS NFKD NORMALIZED);
+CREATE DOMAIN text_default AS TEXT CHECK (VALUE IS NOT normalized);
+CREATE DOMAIN text_nfc AS TEXT CHECK (VALUE IS NOT NFC NORMALIZED);
+CREATE DOMAIN text_nfd AS TEXT CHECK (VALUE IS NOT NFD NORMALIZED);
+CREATE DOMAIN text_nfkc AS TEXT CHECK (VALUE IS NOT NFKC NORMALIZED);
+CREATE DOMAIN text_nfkd AS TEXT CHECK (VALUE IS NOT NFKD NORMALIZED);
+
+
+create table test_table (
+    test_column text primary key,
+    CONSTRAINT default_constraint CHECK (test_column IS NORMALIZED),
+    CONSTRAINT nfc_constraint CHECK (test_column IS NFC NORMALIZED),
+    CONSTRAINT nfd_constraint CHECK (test_column IS NFD NORMALIZED),
+    CONSTRAINT nfkc_constraint CHECK (test_column IS NFKC NORMALIZED),
+    CONSTRAINT nfkd_constraint CHECK (test_column IS NFKD NORMALIZED),
+    CONSTRAINT not_default_constraint CHECK (test_column IS NOT NORMALIZED),
+    CONSTRAINT not_nfc_constraint CHECK (test_column IS NOT NFC NORMALIZED),
+    CONSTRAINT not_nfd_constraint CHECK (test_column IS NOT NFD NORMALIZED),
+    CONSTRAINT not_nfkc_constraint CHECK (test_column IS NOT NFKC NORMALIZED),
+    CONSTRAINT not_nfkd_constraint CHECK (test_column IS NOT NFKD NORMALIZED)
+);

--- a/test/fixtures/dialects/postgres/string_normalization.yml
+++ b/test/fixtures/dialects/postgres/string_normalization.yml
@@ -1,0 +1,653 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 4ec62be0fe156066c9e6457c974676baa77581602dab7972e462bd68f2f1beef
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: test_column
+              - keyword: IS
+              - keyword: NORMALIZED
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: is_normalized
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: test_column
+              - keyword: IS
+              - keyword: NFC
+              - keyword: NORMALIZED
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: is_normalized
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: test_column
+              - keyword: IS
+              - keyword: NFD
+              - keyword: NORMALIZED
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: is_normalized
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: test_column
+              - keyword: IS
+              - keyword: NFKC
+              - keyword: NORMALIZED
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: is_normalized
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: test_column
+              - keyword: IS
+              - keyword: NFKD
+              - keyword: NORMALIZED
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: is_normalized
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: test_column
+              - keyword: IS
+              - keyword: NOT
+              - keyword: NORMALIZED
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: is_normalized
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: test_column
+              - keyword: IS
+              - keyword: NOT
+              - keyword: NFC
+              - keyword: NORMALIZED
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: is_normalized
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: test_column
+              - keyword: IS
+              - keyword: NOT
+              - keyword: NFD
+              - keyword: NORMALIZED
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: is_normalized
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: test_column
+              - keyword: IS
+              - keyword: NOT
+              - keyword: NFKC
+              - keyword: NORMALIZED
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: is_normalized
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: test_column
+              - keyword: IS
+              - keyword: NOT
+              - keyword: NFKD
+              - keyword: NORMALIZED
+              end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: is_normalized
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: test_table
+- statement_terminator: ;
+- statement:
+    create_domain_statement:
+    - keyword: CREATE
+    - keyword: DOMAIN
+    - object_reference:
+        naked_identifier: text_default
+    - keyword: AS
+    - data_type:
+        keyword: TEXT
+    - keyword: CHECK
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              naked_identifier: VALUE
+          - keyword: IS
+          - keyword: NORMALIZED
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_domain_statement:
+    - keyword: CREATE
+    - keyword: DOMAIN
+    - object_reference:
+        naked_identifier: text_nfc
+    - keyword: AS
+    - data_type:
+        keyword: TEXT
+    - keyword: CHECK
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              naked_identifier: VALUE
+          - keyword: IS
+          - keyword: NFC
+          - keyword: NORMALIZED
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_domain_statement:
+    - keyword: CREATE
+    - keyword: DOMAIN
+    - object_reference:
+        naked_identifier: text_nfd
+    - keyword: AS
+    - data_type:
+        keyword: TEXT
+    - keyword: CHECK
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              naked_identifier: VALUE
+          - keyword: IS
+          - keyword: NFD
+          - keyword: NORMALIZED
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_domain_statement:
+    - keyword: CREATE
+    - keyword: DOMAIN
+    - object_reference:
+        naked_identifier: text_nfkc
+    - keyword: AS
+    - data_type:
+        keyword: TEXT
+    - keyword: CHECK
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              naked_identifier: VALUE
+          - keyword: IS
+          - keyword: NFKC
+          - keyword: NORMALIZED
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_domain_statement:
+    - keyword: CREATE
+    - keyword: DOMAIN
+    - object_reference:
+        naked_identifier: text_nfkd
+    - keyword: AS
+    - data_type:
+        keyword: TEXT
+    - keyword: CHECK
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              naked_identifier: VALUE
+          - keyword: IS
+          - keyword: NFKD
+          - keyword: NORMALIZED
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_domain_statement:
+    - keyword: CREATE
+    - keyword: DOMAIN
+    - object_reference:
+        naked_identifier: text_default
+    - keyword: AS
+    - data_type:
+        keyword: TEXT
+    - keyword: CHECK
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              naked_identifier: VALUE
+          - keyword: IS
+          - keyword: NOT
+          - keyword: normalized
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_domain_statement:
+    - keyword: CREATE
+    - keyword: DOMAIN
+    - object_reference:
+        naked_identifier: text_nfc
+    - keyword: AS
+    - data_type:
+        keyword: TEXT
+    - keyword: CHECK
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              naked_identifier: VALUE
+          - keyword: IS
+          - keyword: NOT
+          - keyword: NFC
+          - keyword: NORMALIZED
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_domain_statement:
+    - keyword: CREATE
+    - keyword: DOMAIN
+    - object_reference:
+        naked_identifier: text_nfd
+    - keyword: AS
+    - data_type:
+        keyword: TEXT
+    - keyword: CHECK
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              naked_identifier: VALUE
+          - keyword: IS
+          - keyword: NOT
+          - keyword: NFD
+          - keyword: NORMALIZED
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_domain_statement:
+    - keyword: CREATE
+    - keyword: DOMAIN
+    - object_reference:
+        naked_identifier: text_nfkc
+    - keyword: AS
+    - data_type:
+        keyword: TEXT
+    - keyword: CHECK
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              naked_identifier: VALUE
+          - keyword: IS
+          - keyword: NOT
+          - keyword: NFKC
+          - keyword: NORMALIZED
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_domain_statement:
+    - keyword: CREATE
+    - keyword: DOMAIN
+    - object_reference:
+        naked_identifier: text_nfkd
+    - keyword: AS
+    - data_type:
+        keyword: TEXT
+    - keyword: CHECK
+    - expression:
+        bracketed:
+          start_bracket: (
+          expression:
+          - column_reference:
+              naked_identifier: VALUE
+          - keyword: IS
+          - keyword: NOT
+          - keyword: NFKD
+          - keyword: NORMALIZED
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: create
+    - keyword: table
+    - table_reference:
+        naked_identifier: test_table
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: test_column
+      - data_type:
+          keyword: text
+      - column_constraint_segment:
+        - keyword: primary
+        - keyword: key
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: default_constraint
+        - keyword: CHECK
+        - bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: test_column
+            - keyword: IS
+            - keyword: NORMALIZED
+            end_bracket: )
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: nfc_constraint
+        - keyword: CHECK
+        - bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: test_column
+            - keyword: IS
+            - keyword: NFC
+            - keyword: NORMALIZED
+            end_bracket: )
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: nfd_constraint
+        - keyword: CHECK
+        - bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: test_column
+            - keyword: IS
+            - keyword: NFD
+            - keyword: NORMALIZED
+            end_bracket: )
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: nfkc_constraint
+        - keyword: CHECK
+        - bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: test_column
+            - keyword: IS
+            - keyword: NFKC
+            - keyword: NORMALIZED
+            end_bracket: )
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: nfkd_constraint
+        - keyword: CHECK
+        - bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: test_column
+            - keyword: IS
+            - keyword: NFKD
+            - keyword: NORMALIZED
+            end_bracket: )
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: not_default_constraint
+        - keyword: CHECK
+        - bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: test_column
+            - keyword: IS
+            - keyword: NOT
+            - keyword: NORMALIZED
+            end_bracket: )
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: not_nfc_constraint
+        - keyword: CHECK
+        - bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: test_column
+            - keyword: IS
+            - keyword: NOT
+            - keyword: NFC
+            - keyword: NORMALIZED
+            end_bracket: )
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: not_nfd_constraint
+        - keyword: CHECK
+        - bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: test_column
+            - keyword: IS
+            - keyword: NOT
+            - keyword: NFD
+            - keyword: NORMALIZED
+            end_bracket: )
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: not_nfkc_constraint
+        - keyword: CHECK
+        - bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: test_column
+            - keyword: IS
+            - keyword: NOT
+            - keyword: NFKC
+            - keyword: NORMALIZED
+            end_bracket: )
+      - comma: ','
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: not_nfkd_constraint
+        - keyword: CHECK
+        - bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: test_column
+            - keyword: IS
+            - keyword: NOT
+            - keyword: NFKD
+            - keyword: NORMALIZED
+            end_bracket: )
+      - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
Fixes #6210


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

For postgres, allows use of normalization operators in expressions.

Syntax: 
```
text IS [NOT] [form] NORMALIZED
```
where `form` is:
```
{ NFC | NFD | NFKC | NFKD }
```


### Are there any other side effects of this change that we should be aware of?

Defines a new `NormalizedGrammar` in `dialect_ansi` which is not set for any dialects other than postgres.


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
