### PR TITLE
Fix patch will anchor on first buffer insertion point

### DIFF
--- a/src/sqlfluff/core/linter/patch.py
+++ b/src/sqlfluff/core/linter/patch.py
@@ -121,6 +121,7 @@ def _iter_templated_patches(
         source_idx = segment.pos_marker.source_slice.start
         templated_idx = segment.pos_marker.templated_slice.start
         insert_buff = ""
+        first_segment_pos = None
         for seg in segments:
             # First check for insertions.
             # At this stage, everything should have a position.
@@ -131,6 +132,8 @@ def _iter_templated_patches(
                 # Add it to the insertion buffer if it has length:
                 if seg.raw:
                     insert_buff += seg.raw
+                    # We want to capture the first position where we have a point.
+                    first_segment_pos = first_segment_pos or seg.pos_marker
                     linter_logger.debug(
                         "Appending insertion buffer. %r @idx: %s",
                         insert_buff,
@@ -152,7 +155,7 @@ def _iter_templated_patches(
                 # For the start of the next segment, we need the position of the
                 # first raw, not the pos marker of the whole thing. That accounts
                 # better for loops.
-                first_segment_pos = seg.raw_segments[0].pos_marker
+                first_segment_pos = first_segment_pos or seg.pos_marker
                 yield FixPatch(
                     # Whether the source slice is zero depends on the start_diff.
                     # A non-zero start diff implies a deletion, or more likely
@@ -173,6 +176,8 @@ def _iter_templated_patches(
                     source_str="",
                 )
 
+                # Reset the first position so we can move the pointer forward.
+                first_segment_pos = None
                 insert_buff = ""
 
             # Now we deal with any changes *within* the segment itself.

--- a/test/fixtures/linter/autofix/ansi/028_leading_comma_with_jinja/after.sql
+++ b/test/fixtures/linter/autofix/ansi/028_leading_comma_with_jinja/after.sql
@@ -1,0 +1,10 @@
+{% set isENTER = true %}
+SELECT
+    myt.c1
+    {% if isENTER %}
+        , myt.c2
+    {% endif %}
+    , myt.dt,
+    coalesce(myt.c3, 0) as c3,
+    coalesce(myt.c4, 0) as c4
+from myt

--- a/test/fixtures/linter/autofix/ansi/028_leading_comma_with_jinja/before.sql
+++ b/test/fixtures/linter/autofix/ansi/028_leading_comma_with_jinja/before.sql
@@ -1,0 +1,10 @@
+{% set isENTER = true %}
+SELECT
+    myt.c1
+    {% if isENTER %}
+        , myt.c2
+    {% endif %}
+    , coalesce(myt.c3, 0) as c3
+    , coalesce(myt.c4, 0) as c4
+    , myt.dt
+from myt

--- a/test/fixtures/linter/autofix/ansi/028_leading_comma_with_jinja/test-config.yml
+++ b/test/fixtures/linter/autofix/ansi/028_leading_comma_with_jinja/test-config.yml
@@ -1,0 +1,4 @@
+test-config:
+  rules:
+    - LT04
+    - ST06

--- a/test/fixtures/linter/autofix/ansi/029_indentation_join_reorder_LT02_ST09/.sqlfluff
+++ b/test/fixtures/linter/autofix/ansi/029_indentation_join_reorder_LT02_ST09/.sqlfluff
@@ -1,0 +1,9 @@
+[sqlfluff:indentation]
+indent_unit = space
+tab_space_size = 2
+indented_joins = true
+indented_using_on = true
+template_blocks_indent = false
+
+[sqlfluff:templater:jinja:macros]
+snapshot_date = {% macro snapshot_date(delta_days=0, format_as="DATE") %}{% if format_as == 'DATE' %}{{ "CAST('2022-09-23' AS DATE)" }}{% else %}{{ "CAST('2022-09-23T00-00' AS TIMESTAMP)" }}{% endif %}{% endmacro %}

--- a/test/fixtures/linter/autofix/ansi/029_indentation_join_reorder_LT02_ST09/after.sql
+++ b/test/fixtures/linter/autofix/ansi/029_indentation_join_reorder_LT02_ST09/after.sql
@@ -1,0 +1,6 @@
+SELECT table_a.*
+FROM schema.table_a
+  INNER JOIN schema.table_b
+    ON
+      table_a.col_a = table_b.col_a
+      AND table_b.col_b = {{ snapshot_date() }}

--- a/test/fixtures/linter/autofix/ansi/029_indentation_join_reorder_LT02_ST09/before.sql
+++ b/test/fixtures/linter/autofix/ansi/029_indentation_join_reorder_LT02_ST09/before.sql
@@ -1,0 +1,5 @@
+SELECT table_a.*
+FROM schema.table_a
+  INNER JOIN schema.table_b
+    ON table_b.col_a = table_a.col_a
+      AND table_b.col_b = {{ snapshot_date() }}

--- a/test/fixtures/linter/autofix/ansi/029_indentation_join_reorder_LT02_ST09/test-config.yml
+++ b/test/fixtures/linter/autofix/ansi/029_indentation_join_reorder_LT02_ST09/test-config.yml
@@ -1,0 +1,4 @@
+test-config:
+  rules:
+    - LT02
+    - ST09


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This fixes how the patcher applies the patches in order. Originally this anchor was on the first raw sub-segment in a segment, this now captures the first point where an insertion buffer has data appended to it and uses that position to build out where the next patch is applied. Once that point has been inserted into the fixed string, we reset the `first_segment_pos` anchor.
- fixes #6048 
- fixes #5641

### Are there any other side effects of this change that we should be aware of?
There should be no side effects with this change, but obviously testing was limited to the examples that were failing and current test continue to be applied appropriately. All in all this should be more correct than before.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
