### PR TITLE
Complete the support for PIVOT in Snowflake dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1718,7 +1718,10 @@ class FromBeforeExpressionSegment(BaseSegment):
 
 
 class FromPivotExpressionSegment(BaseSegment):
-    """A PIVOT expression."""
+    """A PIVOT expression.
+
+    https://docs.snowflake.com/en/sql-reference/constructs/pivot.html
+    """
 
     type = "from_pivot_expression"
     match_grammar = Sequence(
@@ -1728,7 +1731,16 @@ class FromPivotExpressionSegment(BaseSegment):
             "FOR",
             Ref("SingleIdentifierGrammar"),
             "IN",
-            Bracketed(Delimited(Ref("LiteralGrammar"))),
+            Bracketed(
+                OneOf(
+                    Delimited(Ref("LiteralGrammar")),
+                    Sequence("ANY", Ref("OrderByClauseSegment", optional=True)),
+                    Ref("SelectStatementSegment"),
+                )
+            ),
+            Sequence(
+                "DEFAULT", "ON", "NULL", Bracketed(Ref("LiteralGrammar")), optional=True
+            ),
         ),
     )
 

--- a/test/fixtures/dialects/snowflake/pivot.sql
+++ b/test/fixtures/dialects/snowflake/pivot.sql
@@ -17,3 +17,52 @@ from table_a
 unpivot (a for b in (col_1, col_2, col_3))
 unpivot (c for d in (col_a, col_b, col_c))
 ;
+
+-- from Snowflake's PIVOT docs
+SELECT *
+FROM quarterly_sales
+  PIVOT(SUM(amount) FOR quarter IN (ANY ORDER BY quarter))
+ORDER BY empid;
+
+
+-- from Snowflake's PIVOT docs
+SELECT *
+FROM quarterly_sales
+  PIVOT(SUM(amount) FOR quarter IN (
+    SELECT DISTINCT quarter
+      FROM ad_campaign_types_by_quarter
+      WHERE television = TRUE
+      ORDER BY quarter)
+  )
+ORDER BY empid;
+
+-- from Snowflake's PIVOT docs
+SELECT *
+FROM quarterly_sales
+  PIVOT(SUM(amount) FOR quarter IN (
+    '2023_Q1',
+    '2023_Q2',
+    '2023_Q3',
+    '2023_Q4')
+  ) AS p (empid_renamed, Q1, Q2, Q3, Q4)
+ORDER BY empid_renamed;
+
+-- from Snowflake's PIVOT docs
+SELECT *
+FROM quarterly_sales
+  PIVOT(SUM(amount)
+    FOR quarter IN (
+      '2023_Q1',
+      '2023_Q2',
+      '2023_Q3',
+      '2023_Q4',
+      '2024_Q1')
+    DEFAULT ON NULL (0)
+  )
+ORDER BY empid;
+
+
+-- https://github.com/sqlfluff/sqlfluff/issues/5876
+select *
+from to_pivot pivot(sum(val) for col in (any order by col))
+order by id;

--- a/test/fixtures/dialects/snowflake/pivot.yml
+++ b/test/fixtures/dialects/snowflake/pivot.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 08999c2dfbc20dda5139fbc1f40ef4518a16170975f0691dca45771711c548c3
+_hash: 56bfa91af39ff5f68aa1628e31776d244512b7fc07ca4bda598bbcb6c6abf43f
 file:
 - statement:
     select_statement:
@@ -201,4 +201,293 @@ file:
               - naked_identifier: col_c
               - end_bracket: )
             - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: quarterly_sales
+          from_pivot_expression:
+            keyword: PIVOT
+            bracketed:
+            - start_bracket: (
+            - function:
+                function_name:
+                  function_name_identifier: SUM
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: amount
+                    end_bracket: )
+            - keyword: FOR
+            - naked_identifier: quarter
+            - keyword: IN
+            - bracketed:
+                start_bracket: (
+                keyword: ANY
+                orderby_clause:
+                - keyword: ORDER
+                - keyword: BY
+                - column_reference:
+                    naked_identifier: quarter
+                end_bracket: )
+            - end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: empid
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: quarterly_sales
+          from_pivot_expression:
+            keyword: PIVOT
+            bracketed:
+            - start_bracket: (
+            - function:
+                function_name:
+                  function_name_identifier: SUM
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: amount
+                    end_bracket: )
+            - keyword: FOR
+            - naked_identifier: quarter
+            - keyword: IN
+            - bracketed:
+                start_bracket: (
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_modifier:
+                      keyword: DISTINCT
+                    select_clause_element:
+                      column_reference:
+                        naked_identifier: quarter
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: ad_campaign_types_by_quarter
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                      column_reference:
+                        naked_identifier: television
+                      comparison_operator:
+                        raw_comparison_operator: '='
+                      boolean_literal: 'TRUE'
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: quarter
+                end_bracket: )
+            - end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: empid
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: quarterly_sales
+          from_pivot_expression:
+            keyword: PIVOT
+            bracketed:
+            - start_bracket: (
+            - function:
+                function_name:
+                  function_name_identifier: SUM
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: amount
+                    end_bracket: )
+            - keyword: FOR
+            - naked_identifier: quarter
+            - keyword: IN
+            - bracketed:
+              - start_bracket: (
+              - quoted_literal: "'2023_Q1'"
+              - comma: ','
+              - quoted_literal: "'2023_Q2'"
+              - comma: ','
+              - quoted_literal: "'2023_Q3'"
+              - comma: ','
+              - quoted_literal: "'2023_Q4'"
+              - end_bracket: )
+            - end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: p
+            bracketed:
+              start_bracket: (
+              identifier_list:
+              - naked_identifier: empid_renamed
+              - comma: ','
+              - naked_identifier: Q1
+              - comma: ','
+              - naked_identifier: Q2
+              - comma: ','
+              - naked_identifier: Q3
+              - comma: ','
+              - naked_identifier: Q4
+              end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: empid_renamed
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: quarterly_sales
+          from_pivot_expression:
+            keyword: PIVOT
+            bracketed:
+            - start_bracket: (
+            - function:
+                function_name:
+                  function_name_identifier: SUM
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: amount
+                    end_bracket: )
+            - keyword: FOR
+            - naked_identifier: quarter
+            - keyword: IN
+            - bracketed:
+              - start_bracket: (
+              - quoted_literal: "'2023_Q1'"
+              - comma: ','
+              - quoted_literal: "'2023_Q2'"
+              - comma: ','
+              - quoted_literal: "'2023_Q3'"
+              - comma: ','
+              - quoted_literal: "'2023_Q4'"
+              - comma: ','
+              - quoted_literal: "'2024_Q1'"
+              - end_bracket: )
+            - keyword: DEFAULT
+            - keyword: 'ON'
+            - keyword: 'NULL'
+            - bracketed:
+                start_bracket: (
+                numeric_literal: '0'
+                end_bracket: )
+            - end_bracket: )
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: empid
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: to_pivot
+          from_pivot_expression:
+            keyword: pivot
+            bracketed:
+            - start_bracket: (
+            - function:
+                function_name:
+                  function_name_identifier: sum
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: val
+                    end_bracket: )
+            - keyword: for
+            - naked_identifier: col
+            - keyword: in
+            - bracketed:
+                start_bracket: (
+                keyword: any
+                orderby_clause:
+                - keyword: order
+                - keyword: by
+                - column_reference:
+                    naked_identifier: col
+                end_bracket: )
+            - end_bracket: )
+      orderby_clause:
+      - keyword: order
+      - keyword: by
+      - column_reference:
+          naked_identifier: id
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

The previous implementation did not allow subqueries, ANY [ORDER BY ...], and 'DEFAULT ON NULL'. I've completed it following the [Snowflake docs.](https://docs.snowflake.com/en/sql-reference/constructs/pivot)

- fixes #5876 

### Are there any other side effects of this change that we should be aware of?
There should be no side effects with this change.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
