### PR TITLE
Exasol - allow function calls in values clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_exasol.py
+++ b/src/sqlfluff/dialects/dialect_exasol.py
@@ -485,9 +485,17 @@ class ValuesRangeClauseSegment(BaseSegment):
     match_grammar = Sequence(
         "VALUES",
         "BETWEEN",
-        Ref("NumericLiteralSegment"),
+        OneOf(
+            Ref("NumericLiteralSegment"),
+            Ref("BareFunctionSegment"),
+            Ref("FunctionSegment"),
+        ),
         "AND",
-        Ref("NumericLiteralSegment"),
+        OneOf(
+            Ref("NumericLiteralSegment"),
+            Ref("BareFunctionSegment"),
+            Ref("FunctionSegment"),
+        ),
         Sequence("WITH", "STEP", Ref("NumericLiteralSegment"), optional=True),
     )
 

--- a/test/fixtures/dialects/exasol/select_statement.sql
+++ b/test/fixtures/dialects/exasol/select_statement.sql
@@ -147,6 +147,24 @@ SELECT v,
        5 * v AS five_times_table
 FROM VALUES BETWEEN 1 AND 9 AS v(v);
 --
+with
+    v as (
+        select
+            RANGE_VALUE
+        from
+            VALUES between 0 and days_between(current_date -6, current_date -1)
+    )
+select * from v;
+--
+with
+    v as (
+        select
+            RANGE_VALUE
+        from
+            VALUES between abs(-5) and days_between(current_date -6, current_date -1)
+    )
+select * from v;
+--
 SELECT 'abcd' LIKE 'a_d' AS res1, '%bcd' like '%%d' AS res2;
 --
 SELECT 'abcd' NOT LIKE 'a_d' AS res1, '%bcd' like '%%d' AS res2;

--- a/test/fixtures/dialects/exasol/select_statement.yml
+++ b/test/fixtures/dialects/exasol/select_statement.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 05ff3402b26b4e996a656e1f3509ca5faf788cd55285c4cf978fae2a7e58fe19
+_hash: 94a5fbf4619e3ecb9e25fab9d9caed53b87ba63398bf253b89c9ac116afe4762
 file:
 - statement:
     select_statement:
@@ -1813,6 +1813,128 @@ file:
                 identifier_list:
                   naked_identifier: v
                 end_bracket: )
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        naked_identifier: v
+        keyword: as
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                column_reference:
+                  naked_identifier: RANGE_VALUE
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    values_range_clause:
+                    - keyword: VALUES
+                    - keyword: between
+                    - numeric_literal: '0'
+                    - keyword: and
+                    - function:
+                        function_name:
+                          function_name_identifier: days_between
+                        function_contents:
+                          bracketed:
+                          - start_bracket: (
+                          - expression:
+                              bare_function: current_date
+                              binary_operator: '-'
+                              numeric_literal: '6'
+                          - comma: ','
+                          - expression:
+                              bare_function: current_date
+                              binary_operator: '-'
+                              numeric_literal: '1'
+                          - end_bracket: )
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: v
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        naked_identifier: v
+        keyword: as
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: select
+              select_clause_element:
+                column_reference:
+                  naked_identifier: RANGE_VALUE
+            from_clause:
+              keyword: from
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    values_range_clause:
+                    - keyword: VALUES
+                    - keyword: between
+                    - function:
+                        function_name:
+                          function_name_identifier: abs
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              numeric_literal:
+                                sign_indicator: '-'
+                                numeric_literal: '5'
+                            end_bracket: )
+                    - keyword: and
+                    - function:
+                        function_name:
+                          function_name_identifier: days_between
+                        function_contents:
+                          bracketed:
+                          - start_bracket: (
+                          - expression:
+                              bare_function: current_date
+                              binary_operator: '-'
+                              numeric_literal: '6'
+                          - comma: ','
+                          - expression:
+                              bare_function: current_date
+                              binary_operator: '-'
+                              numeric_literal: '1'
+                          - end_bracket: )
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: v
 - statement_terminator: ;
 - statement:
     select_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

The value range table clause also allows function calls which return integer values, as there are many possibilities to create integer values with different functions I added functions and bare functions besides numeric literals.


[Exasol Doc link](https://docs.exasol.com/db/latest/sql/select.htm)
> The arguments min_value and max_value in the VALUES BETWEEN clause must be constant expressions that evaluate to integers. The argument step_value must be a constant expression that evaluates to a positive integer.


### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
