### PR TITLE
Remove duplicate timing columns from the timing records

### DIFF
--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -155,6 +155,8 @@ class LintingResult:
                     continue
                 rule_codes.update(record["timings"].keys())
 
+        rule_codes -= set(timing_fields)
+
         with open(filename, "w", newline="") as f:
             writer = csv.DictWriter(
                 # Metadata first, then step timings and then _sorted_ rule codes.


### PR DESCRIPTION
### Brief summary of the change made

The "templating", "lexing", "parsing" and "linting" columns appear twice in the timing records output, because their ordering both is configured explicitly, and because they still are included in the `rule_codes` set.

This fixes that by removing them from `rule_codes` so they only appear once in the resulting CSV file.


### Are there any other side effects of this change that we should be aware of?

None


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

This part of the code doesn't seem to have any tests, and I guess it's intended for SQLFluff developers only anyways, so probably isn't important enough for that.