### PR TITLE
Fix time travel clauses in Snowflake dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -640,6 +640,7 @@ snowflake_dialect.replace(
             Ref("MatchRecognizeClauseSegment"),
             Ref("ChangesClauseSegment"),
             Ref("ConnectByClauseSegment"),
+            Ref("FromAtExpressionSegment"),
             Ref("FromBeforeExpressionSegment"),
             Ref("FromPivotExpressionSegment"),
             AnyNumberOf(Ref("FromUnpivotExpressionSegment")),
@@ -1483,12 +1484,20 @@ class WithinGroupClauseSegment(BaseSegment):
 
 
 class FromExpressionElementSegment(ansi.FromExpressionElementSegment):
-    """A table expression."""
+    """A table expression.
+
+    https://docs.snowflake.com/en/sql-reference/constructs/from
+    """
 
     type = "from_expression_element"
     match_grammar = Sequence(
         Ref("PreTableFunctionKeywordsGrammar", optional=True),
         OptionallyBracketed(Ref("TableExpressionSegment")),
+        OneOf(
+            Ref("FromAtExpressionSegment"),
+            Ref("FromBeforeExpressionSegment"),
+            optional=True,
+        ),
         Ref(
             "AliasExpressionSegment",
             exclude=OneOf(

--- a/test/fixtures/dialects/snowflake/at_before_time_travel.sql
+++ b/test/fixtures/dialects/snowflake/at_before_time_travel.sql
@@ -1,0 +1,29 @@
+SELECT * FROM my_table AT ( TIMESTAMP => '2024-06-05 12:30:00'::TIMESTAMP_LTZ );
+
+SELECT * FROM my_table AT ( TIMESTAMP => '2024-06-05 12:30:00'::TIMESTAMP );
+
+SELECT * FROM my_table AT ( TIMESTAMP => '2024-06-05 12:30:00' );
+
+SELECT * FROM my_table AT ( TIMESTAMP => '2024-06-05 12:30:00' ) AS T;
+
+SELECT * FROM my_table BEFORE(STATEMENT => '8e5d0ca9-005e-44e6-b858-a8f5b37c5726');
+
+SELECT oldt.* ,newt.*
+   FROM my_table BEFORE(STATEMENT => '8e5d0ca9-005e-44e6-b858-a8f5b37c5726') AS oldt
+     FULL OUTER JOIN my_table AT(STATEMENT => '8e5d0ca9-005e-44e6-b858-a8f5b37c5726') AS newt
+     ON oldt.id = newt.id
+   WHERE oldt.id IS NULL OR newt.id IS NULL;
+
+ SELECT *
+   FROM db1.public.htt1
+     AT(TIMESTAMP => '2024-06-05 17:50:00'::TIMESTAMP_LTZ) h
+     JOIN db1.public.tt1
+     AT(TIMESTAMP => '2024-06-05 17:50:00'::TIMESTAMP_LTZ) t
+     ON h.c1=t.c1;
+
+
+-- https://github.com/sqlfluff/sqlfluff/issues/6070
+SELECT * FROM my_table AT (TIMESTAMP => TO_TIMESTAMP(DATEADD('DAY', -1, DATEADD('MONTH', -1, DATEADD('DAY', -1, CURRENT_DATE)))));
+
+-- https://github.com/sqlfluff/sqlfluff/issues/5570
+SELECT * FROM my_table AT(TIMESTAMP => 'Fri, 01 May 2015 16:20:00 -0700'::timestamp_tz);

--- a/test/fixtures/dialects/snowflake/at_before_time_travel.yml
+++ b/test/fixtures/dialects/snowflake/at_before_time_travel.yml
@@ -1,0 +1,412 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 13311cd8fbb14ef5ac53888617e465acfa8993e7dcee2f5751fef3a7afdfcf4a
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+            from_at_expression:
+              keyword: AT
+              bracketed:
+                start_bracket: (
+                keyword: TIMESTAMP
+                parameter_assigner: =>
+                expression:
+                  cast_expression:
+                    quoted_literal: "'2024-06-05 12:30:00'"
+                    casting_operator: '::'
+                    data_type:
+                      data_type_identifier: TIMESTAMP_LTZ
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+            from_at_expression:
+              keyword: AT
+              bracketed:
+                start_bracket: (
+                keyword: TIMESTAMP
+                parameter_assigner: =>
+                expression:
+                  cast_expression:
+                    quoted_literal: "'2024-06-05 12:30:00'"
+                    casting_operator: '::'
+                    data_type:
+                      keyword: TIMESTAMP
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+            from_at_expression:
+              keyword: AT
+              bracketed:
+                start_bracket: (
+                keyword: TIMESTAMP
+                parameter_assigner: =>
+                expression:
+                  quoted_literal: "'2024-06-05 12:30:00'"
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+            from_at_expression:
+              keyword: AT
+              bracketed:
+                start_bracket: (
+                keyword: TIMESTAMP
+                parameter_assigner: =>
+                expression:
+                  quoted_literal: "'2024-06-05 12:30:00'"
+                end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: T
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+            from_before_expression:
+              keyword: BEFORE
+              bracketed:
+                start_bracket: (
+                keyword: STATEMENT
+                parameter_assigner: =>
+                expression:
+                  quoted_literal: "'8e5d0ca9-005e-44e6-b858-a8f5b37c5726'"
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              naked_identifier: oldt
+              dot: .
+              star: '*'
+      - comma: ','
+      - select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              naked_identifier: newt
+              dot: .
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+            from_before_expression:
+              keyword: BEFORE
+              bracketed:
+                start_bracket: (
+                keyword: STATEMENT
+                parameter_assigner: =>
+                expression:
+                  quoted_literal: "'8e5d0ca9-005e-44e6-b858-a8f5b37c5726'"
+                end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: oldt
+          join_clause:
+          - keyword: FULL
+          - keyword: OUTER
+          - keyword: JOIN
+          - from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: my_table
+              from_at_expression:
+                keyword: AT
+                bracketed:
+                  start_bracket: (
+                  keyword: STATEMENT
+                  parameter_assigner: =>
+                  expression:
+                    quoted_literal: "'8e5d0ca9-005e-44e6-b858-a8f5b37c5726'"
+                  end_bracket: )
+              alias_expression:
+                keyword: AS
+                naked_identifier: newt
+          - join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - naked_identifier: oldt
+                - dot: .
+                - naked_identifier: id
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: newt
+                - dot: .
+                - naked_identifier: id
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: oldt
+          - dot: .
+          - naked_identifier: id
+        - keyword: IS
+        - null_literal: 'NULL'
+        - binary_operator: OR
+        - column_reference:
+          - naked_identifier: newt
+          - dot: .
+          - naked_identifier: id
+        - keyword: IS
+        - null_literal: 'NULL'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: db1
+              - dot: .
+              - naked_identifier: public
+              - dot: .
+              - naked_identifier: htt1
+            from_at_expression:
+              keyword: AT
+              bracketed:
+                start_bracket: (
+                keyword: TIMESTAMP
+                parameter_assigner: =>
+                expression:
+                  cast_expression:
+                    quoted_literal: "'2024-06-05 17:50:00'"
+                    casting_operator: '::'
+                    data_type:
+                      data_type_identifier: TIMESTAMP_LTZ
+                end_bracket: )
+            alias_expression:
+              naked_identifier: h
+          join_clause:
+            keyword: JOIN
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: db1
+                - dot: .
+                - naked_identifier: public
+                - dot: .
+                - naked_identifier: tt1
+              from_at_expression:
+                keyword: AT
+                bracketed:
+                  start_bracket: (
+                  keyword: TIMESTAMP
+                  parameter_assigner: =>
+                  expression:
+                    cast_expression:
+                      quoted_literal: "'2024-06-05 17:50:00'"
+                      casting_operator: '::'
+                      data_type:
+                        data_type_identifier: TIMESTAMP_LTZ
+                  end_bracket: )
+              alias_expression:
+                naked_identifier: t
+            join_on_condition:
+              keyword: 'ON'
+              expression:
+              - column_reference:
+                - naked_identifier: h
+                - dot: .
+                - naked_identifier: c1
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: c1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+            from_at_expression:
+              keyword: AT
+              bracketed:
+                start_bracket: (
+                keyword: TIMESTAMP
+                parameter_assigner: =>
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: TO_TIMESTAMP
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          function:
+                            function_name:
+                              function_name_identifier: DATEADD
+                            function_contents:
+                              bracketed:
+                              - start_bracket: (
+                              - expression:
+                                  quoted_literal: "'DAY'"
+                              - comma: ','
+                              - expression:
+                                  numeric_literal:
+                                    sign_indicator: '-'
+                                    numeric_literal: '1'
+                              - comma: ','
+                              - expression:
+                                  function:
+                                    function_name:
+                                      function_name_identifier: DATEADD
+                                    function_contents:
+                                      bracketed:
+                                      - start_bracket: (
+                                      - expression:
+                                          quoted_literal: "'MONTH'"
+                                      - comma: ','
+                                      - expression:
+                                          numeric_literal:
+                                            sign_indicator: '-'
+                                            numeric_literal: '1'
+                                      - comma: ','
+                                      - expression:
+                                          function:
+                                            function_name:
+                                              function_name_identifier: DATEADD
+                                            function_contents:
+                                              bracketed:
+                                              - start_bracket: (
+                                              - expression:
+                                                  quoted_literal: "'DAY'"
+                                              - comma: ','
+                                              - expression:
+                                                  numeric_literal:
+                                                    sign_indicator: '-'
+                                                    numeric_literal: '1'
+                                              - comma: ','
+                                              - expression:
+                                                  bare_function: CURRENT_DATE
+                                              - end_bracket: )
+                                      - end_bracket: )
+                              - end_bracket: )
+                        end_bracket: )
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: my_table
+            from_at_expression:
+              keyword: AT
+              bracketed:
+                start_bracket: (
+                keyword: TIMESTAMP
+                parameter_assigner: =>
+                expression:
+                  cast_expression:
+                    quoted_literal: "'Fri, 01 May 2015 16:20:00 -0700'"
+                    casting_operator: '::'
+                    data_type:
+                      data_type_identifier: timestamp_tz
+                end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
- [x] Included the time travel clauses in the `FromExpressionElementSegment`, as per the [Snowflake docs.](https://docs.snowflake.com/en/sql-reference/constructs/from)
- [x] Fixed missing `FromAtExpression` in `JoinLikeClauseGrammar`

- fixes #5570
- fixex #6070 


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
