### PR TITLE
Teradata order of VOLATILE and MULTISET

### DIFF
--- a/src/sqlfluff/dialects/dialect_teradata.py
+++ b/src/sqlfluff/dialects/dialect_teradata.py
@@ -11,6 +11,7 @@ Teradata Database SQL Data Definition Language Syntax and Examples
 from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
     AnyNumberOf,
+    AnySetOf,
     Anything,
     BaseSegment,
     Bracketed,
@@ -644,9 +645,11 @@ class CreateTableStatementSegment(BaseSegment):
     match_grammar = Sequence(
         "CREATE",
         Ref("OrReplaceGrammar", optional=True),
-        # Adding Teradata specific [MULTISET| SET]
-        OneOf("SET", "MULTISET", optional=True),
-        OneOf(Sequence("GLOBAL", "TEMPORARY"), "VOLATILE", optional=True),
+        AnySetOf(
+            OneOf("SET", "MULTISET"),
+            OneOf(Sequence("GLOBAL", "TEMPORARY"), "VOLATILE"),
+            optional=True,
+        ),
         "TABLE",
         Ref("IfNotExistsGrammar", optional=True),
         Ref("TableReferenceSegment"),

--- a/test/fixtures/dialects/teradata/create_table.sql
+++ b/test/fixtures/dialects/teradata/create_table.sql
@@ -27,3 +27,6 @@ comment on column sandbox_db.Org_Descendant.Entity_Code is 'Owning entity code';
 comment on column sandbox_db.Org_Descendant.Parent_Org_Unit_Code is 'Organisational unit code';
 comment on column sandbox_db.Org_Descendant.Parent_Org_Unit_Type is 'The type of organization such as branch, region, team, call center';
 comment on column sandbox_db.Org_Descendant.Parent_Entity_Code is 'Owning entity code parent';
+
+CREATE VOLATILE MULTISET TABLE date_control (calculation_date DATE FORMAT 'yyyy-mm-dd' ) PRIMARY INDEX (calculation_date);
+CREATE MULTISET VOLATILE TABLE date_control (calculation_date DATE FORMAT 'yyyy-mm-dd' ) PRIMARY INDEX (calculation_date);

--- a/test/fixtures/dialects/teradata/create_table.yml
+++ b/test/fixtures/dialects/teradata/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3badd344b1e26c3368e9102fa001ff4302206b72fb4594f4dda4a6611a08fd32
+_hash: 59b0eb5d79df53e409dd8d590d6fe535a03a428635a518c14c138f0261656625
 file:
 - statement:
     create_table_statement:
@@ -312,4 +312,56 @@ file:
       - naked_identifier: Parent_Entity_Code
     - keyword: is
     - quoted_literal: "'Owning entity code parent'"
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: VOLATILE
+    - keyword: MULTISET
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: date_control
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          column_reference:
+            naked_identifier: calculation_date
+          data_type:
+            data_type_identifier: DATE
+            keyword: FORMAT
+            quoted_literal: "'yyyy-mm-dd'"
+        end_bracket: )
+    - td_table_constraint:
+      - keyword: PRIMARY
+      - keyword: INDEX
+      - bracketed:
+          start_bracket: (
+          naked_identifier: calculation_date
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: MULTISET
+    - keyword: VOLATILE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: date_control
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          column_reference:
+            naked_identifier: calculation_date
+          data_type:
+            data_type_identifier: DATE
+            keyword: FORMAT
+            quoted_literal: "'yyyy-mm-dd'"
+        end_bracket: )
+    - td_table_constraint:
+      - keyword: PRIMARY
+      - keyword: INDEX
+      - bracketed:
+          start_bracket: (
+          naked_identifier: calculation_date
+          end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Closes https://github.com/sqlfluff/sqlfluff/issues/6232

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
