### PR TITLE
Snowflake: Support defining virtual columns

### DIFF
--- a/test/fixtures/dialects/snowflake/alter_table_column.sql
+++ b/test/fixtures/dialects/snowflake/alter_table_column.sql
@@ -1,4 +1,4 @@
--- Add column
+-- ADD column
 ---- Base cases
 ALTER TABLE my_table ADD COLUMN my_column INTEGER;
 ALTER TABLE my_table ADD COLUMN my_column VARCHAR(5000) NOT NULL;
@@ -36,32 +36,32 @@ ALTER TABLE empl_info RENAME COLUMN old_col_name TO new_col_name;
 -- Alter-modify column(s)
 ---- Base cases
 ------ Single column
-alter table t1 alter column c1 drop not null;
-alter table t1 alter c5 comment '50 character column';
+ALTER TABLE t1 alter column c1 drop not null;
+ALTER TABLE t1 alter c5 comment '50 character column';
 
 ------ Multiple columns/properties
-alter table t1 modify c2 drop default, c3 set default seq5.nextval ;
-alter table t1 alter c4 set data type varchar(50), column c4 drop default;
+ALTER TABLE t1 modify c2 drop default, c3 set default seq5.nextval ;
+ALTER TABLE t1 alter c4 set data type varchar(50), column c4 drop default;
 
 ---- Set Masking Policy
 ------ Single column
 ALTER TABLE xxxx.example_table MODIFY COLUMN employeeCode SET MASKING POLICY example_MASKING_POLICY;
 ALTER TABLE aschema.atable MODIFY COLUMN acolumn SET MASKING POLICY adatabase.aschema.apolicy;
-alter table empl_info modify column empl_id set masking policy mask_empl_id;
-alter table empl_info modify column empl_id set masking policy mask_empl_id using(empl_id, empl_id > 10);
+ALTER TABLE empl_info modify column empl_id set masking policy mask_empl_id;
+ALTER TABLE empl_info modify column empl_id set masking policy mask_empl_id using(empl_id, empl_id > 10);
 
 ------ Multiple columns
-alter table empl_info modify
+ALTER TABLE empl_info modify
     column empl_id set masking policy mask_empl_id
    , column empl_dob set masking policy mask_empl_dob
 ;
 
 ---- Unset masking policy
 ------ Single column
-alter table empl_info modify column empl_id unset masking policy;
+ALTER TABLE empl_info modify column empl_id unset masking policy;
 
 ------ Multiple columns
-alter table empl_info modify
+ALTER TABLE empl_info modify
     column empl_id unset masking policy
   , column empl_dob unset masking policy
 ;
@@ -93,4 +93,10 @@ ALTER TABLE IF EXISTS empl_info RENAME COLUMN old_col_name TO new_col_name;
 ALTER TABLE my_schema.my_table drop PRIMARY KEY;
 
 -- ADD PRIMARY KEY
-ALTER TABLE my_schema.my_table add PRIMARY KEY(TABLE_ID);
+ALTER TABLE my_schema.my_table ADD PRIMARY KEY(TABLE_ID);
+
+-- ADD Virtual/Calculated columns
+ALTER TABLE some_schema.some_table ADD some_column_upr VARCHAR AS UPPER(some_column) COMMENT 'This is a virtual column';
+ALTER TABLE some_schema.some_table ADD column IF NOT EXISTS some_other_column_upr VARCHAR AS UPPER(some_column) || 'some characters' || LOWER(some_column);
+ALTER TABLE some_schema.some_table ADD column IF NOT EXISTS some_column_upr VARCHAR AS (UPPER(some_column));
+ALTER TABLE some_schema.some_table ADD column IF NOT EXISTS some_event_date_time_utc TIMESTAMP AS (IFF(is_condition_true AND TRY_TO_NUMBER(some_text_value) IS NOT NULL, TO_TIMESTAMP(SUBSTR(some_text_value, 5, 13)), '1900-01-01'));

--- a/test/fixtures/dialects/snowflake/alter_table_column.yml
+++ b/test/fixtures/dialects/snowflake/alter_table_column.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 110682ed6417ece43633451219360808659071c4e2150ee382a95aca60168aff
+_hash: e8cff0c6e9a5a485ce01b7d111bde77e1c5d289980acbe73d286abe4591fb97d
 file:
 - statement:
     alter_table_statement:
@@ -353,8 +353,8 @@ file:
 - statement_terminator: ;
 - statement:
     alter_table_statement:
-    - keyword: alter
-    - keyword: table
+    - keyword: ALTER
+    - keyword: TABLE
     - table_reference:
         naked_identifier: t1
     - alter_table_table_column_action:
@@ -368,8 +368,8 @@ file:
 - statement_terminator: ;
 - statement:
     alter_table_statement:
-    - keyword: alter
-    - keyword: table
+    - keyword: ALTER
+    - keyword: TABLE
     - table_reference:
         naked_identifier: t1
     - alter_table_table_column_action:
@@ -382,8 +382,8 @@ file:
 - statement_terminator: ;
 - statement:
     alter_table_statement:
-    - keyword: alter
-    - keyword: table
+    - keyword: ALTER
+    - keyword: TABLE
     - table_reference:
         naked_identifier: t1
     - alter_table_table_column_action:
@@ -403,8 +403,8 @@ file:
 - statement_terminator: ;
 - statement:
     alter_table_statement:
-    - keyword: alter
-    - keyword: table
+    - keyword: ALTER
+    - keyword: TABLE
     - table_reference:
         naked_identifier: t1
     - alter_table_table_column_action:
@@ -472,8 +472,8 @@ file:
 - statement_terminator: ;
 - statement:
     alter_table_statement:
-    - keyword: alter
-    - keyword: table
+    - keyword: ALTER
+    - keyword: TABLE
     - table_reference:
         naked_identifier: empl_info
     - alter_table_table_column_action:
@@ -489,8 +489,8 @@ file:
 - statement_terminator: ;
 - statement:
     alter_table_statement:
-    - keyword: alter
-    - keyword: table
+    - keyword: ALTER
+    - keyword: TABLE
     - table_reference:
         naked_identifier: empl_info
     - alter_table_table_column_action:
@@ -519,8 +519,8 @@ file:
 - statement_terminator: ;
 - statement:
     alter_table_statement:
-    - keyword: alter
-    - keyword: table
+    - keyword: ALTER
+    - keyword: TABLE
     - table_reference:
         naked_identifier: empl_info
     - alter_table_table_column_action:
@@ -545,8 +545,8 @@ file:
 - statement_terminator: ;
 - statement:
     alter_table_statement:
-    - keyword: alter
-    - keyword: table
+    - keyword: ALTER
+    - keyword: TABLE
     - table_reference:
         naked_identifier: empl_info
     - alter_table_table_column_action:
@@ -560,8 +560,8 @@ file:
 - statement_terminator: ;
 - statement:
     alter_table_statement:
-    - keyword: alter
-    - keyword: table
+    - keyword: ALTER
+    - keyword: TABLE
     - table_reference:
         naked_identifier: empl_info
     - alter_table_table_column_action:
@@ -830,7 +830,7 @@ file:
       - dot: .
       - naked_identifier: my_table
     - alter_table_constraint_action:
-        keyword: add
+        keyword: ADD
         constraint_properties_segment:
         - keyword: PRIMARY
         - keyword: KEY
@@ -838,5 +838,196 @@ file:
             start_bracket: (
             column_reference:
               naked_identifier: TABLE_ID
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: some_schema
+      - dot: .
+      - naked_identifier: some_table
+    - alter_table_table_column_action:
+      - keyword: ADD
+      - column_reference:
+          naked_identifier: some_column_upr
+      - data_type:
+          data_type_identifier: VARCHAR
+      - keyword: AS
+      - expression:
+          function:
+            function_name:
+              function_name_identifier: UPPER
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: some_column
+                end_bracket: )
+      - comment_clause:
+          keyword: COMMENT
+          quoted_literal: "'This is a virtual column'"
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: some_schema
+      - dot: .
+      - naked_identifier: some_table
+    - alter_table_table_column_action:
+      - keyword: ADD
+      - keyword: column
+      - keyword: IF
+      - keyword: NOT
+      - keyword: EXISTS
+      - column_reference:
+          naked_identifier: some_other_column_upr
+      - data_type:
+          data_type_identifier: VARCHAR
+      - keyword: AS
+      - expression:
+        - function:
+            function_name:
+              function_name_identifier: UPPER
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: some_column
+                end_bracket: )
+        - binary_operator:
+          - pipe: '|'
+          - pipe: '|'
+        - quoted_literal: "'some characters'"
+        - binary_operator:
+          - pipe: '|'
+          - pipe: '|'
+        - function:
+            function_name:
+              function_name_identifier: LOWER
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: some_column
+                end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: some_schema
+      - dot: .
+      - naked_identifier: some_table
+    - alter_table_table_column_action:
+      - keyword: ADD
+      - keyword: column
+      - keyword: IF
+      - keyword: NOT
+      - keyword: EXISTS
+      - column_reference:
+          naked_identifier: some_column_upr
+      - data_type:
+          data_type_identifier: VARCHAR
+      - keyword: AS
+      - expression:
+          bracketed:
+            start_bracket: (
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: UPPER
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: some_column
+                    end_bracket: )
+            end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: some_schema
+      - dot: .
+      - naked_identifier: some_table
+    - alter_table_table_column_action:
+      - keyword: ADD
+      - keyword: column
+      - keyword: IF
+      - keyword: NOT
+      - keyword: EXISTS
+      - column_reference:
+          naked_identifier: some_event_date_time_utc
+      - data_type:
+          keyword: TIMESTAMP
+      - keyword: AS
+      - expression:
+          bracketed:
+            start_bracket: (
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: IFF
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                    - column_reference:
+                        naked_identifier: is_condition_true
+                    - binary_operator: AND
+                    - function:
+                        function_name:
+                          function_name_identifier: TRY_TO_NUMBER
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: some_text_value
+                            end_bracket: )
+                    - keyword: IS
+                    - keyword: NOT
+                    - null_literal: 'NULL'
+                  - comma: ','
+                  - expression:
+                      function:
+                        function_name:
+                          function_name_identifier: TO_TIMESTAMP
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              function:
+                                function_name:
+                                  function_name_identifier: SUBSTR
+                                function_contents:
+                                  bracketed:
+                                  - start_bracket: (
+                                  - expression:
+                                      column_reference:
+                                        naked_identifier: some_text_value
+                                  - comma: ','
+                                  - expression:
+                                      numeric_literal: '5'
+                                  - comma: ','
+                                  - expression:
+                                      numeric_literal: '13'
+                                  - end_bracket: )
+                            end_bracket: )
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'1900-01-01'"
+                  - end_bracket: )
             end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/create_table.sql
+++ b/test/fixtures/dialects/snowflake/create_table.sql
@@ -204,3 +204,11 @@ CREATE OR REPLACE TABLE myschema.mytable (
   id INTEGER NOT NULL
   , CONSTRAINT mytable_pk PRIMARY KEY (id) NOT ENFORCED NOVALIDATE NORELY
 );
+
+CREATE TABLE some_schema.some_table
+(
+  is_condition_true BOOLEAN
+  , some_text_value VARCHAR(100)
+  , some_event_date_time_utc VARCHAR AS (TO_TIMESTAMP(SUBSTR(some_text_value, 5, 13)))
+  , some_other_event_date_time_utc TIMESTAMP AS (IFF(is_condition_true AND TRY_TO_NUMBER(some_text_value) IS NOT NULL, TO_TIMESTAMP(SUBSTR(some_text_value, 5, 13)), '1900-01-01')) COMMENT 'The date and time of the other event'
+);

--- a/test/fixtures/dialects/snowflake/create_table.yml
+++ b/test/fixtures/dialects/snowflake/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 46c10f7370c6d9b7f5b7ab3dd08db364056fc4f750e9529a6af6ff3a384dd8f3
+_hash: 74de85b93e5227b9ab1271d01a558b6ca2e844a1d05659c33297c0d5e51b08a9
 file:
 - statement:
     create_table_statement:
@@ -1633,4 +1633,128 @@ file:
         - keyword: NOVALIDATE
         - keyword: NORELY
         end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: some_schema
+      - dot: .
+      - naked_identifier: some_table
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: is_condition_true
+          data_type:
+            data_type_identifier: BOOLEAN
+      - comma: ','
+      - column_definition:
+          naked_identifier: some_text_value
+          data_type:
+            data_type_identifier: VARCHAR
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '100'
+                end_bracket: )
+      - comma: ','
+      - naked_identifier: some_event_date_time_utc
+      - data_type:
+          data_type_identifier: VARCHAR
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          expression:
+            function:
+              function_name:
+                function_name_identifier: TO_TIMESTAMP
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    function:
+                      function_name:
+                        function_name_identifier: SUBSTR
+                      function_contents:
+                        bracketed:
+                        - start_bracket: (
+                        - expression:
+                            column_reference:
+                              naked_identifier: some_text_value
+                        - comma: ','
+                        - expression:
+                            numeric_literal: '5'
+                        - comma: ','
+                        - expression:
+                            numeric_literal: '13'
+                        - end_bracket: )
+                  end_bracket: )
+          end_bracket: )
+      - comma: ','
+      - naked_identifier: some_other_event_date_time_utc
+      - data_type:
+          keyword: TIMESTAMP
+      - keyword: AS
+      - bracketed:
+          start_bracket: (
+          expression:
+            function:
+              function_name:
+                function_name_identifier: IFF
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                  - column_reference:
+                      naked_identifier: is_condition_true
+                  - binary_operator: AND
+                  - function:
+                      function_name:
+                        function_name_identifier: TRY_TO_NUMBER
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: some_text_value
+                          end_bracket: )
+                  - keyword: IS
+                  - keyword: NOT
+                  - null_literal: 'NULL'
+                - comma: ','
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: TO_TIMESTAMP
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            function:
+                              function_name:
+                                function_name_identifier: SUBSTR
+                              function_contents:
+                                bracketed:
+                                - start_bracket: (
+                                - expression:
+                                    column_reference:
+                                      naked_identifier: some_text_value
+                                - comma: ','
+                                - expression:
+                                    numeric_literal: '5'
+                                - comma: ','
+                                - expression:
+                                    numeric_literal: '13'
+                                - end_bracket: )
+                          end_bracket: )
+                - comma: ','
+                - expression:
+                    quoted_literal: "'1900-01-01'"
+                - end_bracket: )
+          end_bracket: )
+      - comment_clause:
+          keyword: COMMENT
+          quoted_literal: "'The date and time of the other event'"
+      - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

This change adds the ability to define [virtual/calculated columns](https://snowflakewiki.medium.com/virtual-column-in-snowflake-the-complete-guide-50c1a224ffd0) using `CREATE TABLE` and `ALTER TABLE ... ADD COLUMN` statements.

### Are there any other side effects of this change that we should be aware of?
This is an extension of the dialect. The existing unit tests show that none of the existing functionalities in the Snowflake dialect are impacted adversely.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
