### PR TITLE
Strict typing for `sqlfluff.core.linter`

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -759,7 +759,9 @@ def lint(
     if not nofail:
         if not non_human_output:
             formatter.completion_message()
-        sys.exit(result.stats(EXIT_FAIL, EXIT_SUCCESS)["exit code"])
+        exit_code = result.stats(EXIT_FAIL, EXIT_SUCCESS)["exit code"]
+        assert isinstance(exit_code, int), "result.stats error code must be integer."
+        sys.exit(exit_code)
     else:
         sys.exit(EXIT_SUCCESS)
 

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -18,7 +18,7 @@ from sqlfluff.cli.helpers import (
 from sqlfluff.cli.outputstream import OutputStream
 from sqlfluff.core import FluffConfig, Linter, SQLBaseError, TimingSummary
 from sqlfluff.core.enums import Color
-from sqlfluff.core.linter import LintedFile, ParsedString
+from sqlfluff.core.linter import FormatterInterface, LintedFile, ParsedString
 
 
 def split_string_on_spaces(s: str, line_length: int = 100) -> List[str]:
@@ -65,7 +65,7 @@ def format_linting_result_header() -> str:
     return text_buffer.getvalue()
 
 
-class OutputStreamFormatter:
+class OutputStreamFormatter(FormatterInterface):
     """Formatter which writes to an OutputStream.
 
     On instantiation, this formatter accepts a function to

--- a/src/sqlfluff/core/linter/__init__.py
+++ b/src/sqlfluff/core/linter/__init__.py
@@ -1,11 +1,13 @@
 """Linter class and helper classes."""
 
 from sqlfluff.core.linter.common import ParsedString, RenderedFile, RuleTuple
+from sqlfluff.core.linter.formatter import FormatterInterface
 from sqlfluff.core.linter.linted_file import LintedFile
 from sqlfluff.core.linter.linter import Linter
 from sqlfluff.core.linter.linting_result import LintingResult
 
 __all__ = (
+    "FormatterInterface",
     "RuleTuple",
     "ParsedString",
     "LintedFile",

--- a/src/sqlfluff/core/linter/formatter.py
+++ b/src/sqlfluff/core/linter/formatter.py
@@ -1,0 +1,22 @@
+"""Defines the formatter interface which can be used by the CLI.
+
+The linter module provides an optional formatter input which effectively
+allows callbacks at various points of the linting process. This is primarily
+to allow printed output at various points by the CLI, but could also be used
+for logging our other processes looking to report back as the linting process
+continues.
+
+In this module we only define the interface. Any modules wishing to use the
+interface should override with their own implementation.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class FormatterInterface(ABC):
+    """Generic formatter interface."""
+
+    @abstractmethod
+    def dispatch_persist_filename(self, filename: str, result: str) -> None:
+        """Called after a formatted file as been persisted to disk."""
+        ...

--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -4,7 +4,7 @@ This stores the idea of a collection of linted files at a single start path
 
 """
 
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, TypedDict, Union
+from typing import Dict, Iterable, List, Optional, Tuple, Type, TypedDict, Union
 
 from sqlfluff.core.errors import (
     CheckTuple,
@@ -12,6 +12,7 @@ from sqlfluff.core.errors import (
     SQLBaseError,
     SQLLintError,
 )
+from sqlfluff.core.linter.formatter import FormatterInterface
 from sqlfluff.core.linter.linted_file import TMP_PRS_ERROR_TYPES, LintedFile
 from sqlfluff.core.parser.segments.base import BaseSegment
 
@@ -207,7 +208,9 @@ class LintedDir:
         }
 
     def persist_changes(
-        self, formatter: Any = None, fixed_file_suffix: str = ""
+        self,
+        formatter: Optional[FormatterInterface] = None,
+        fixed_file_suffix: str = "",
     ) -> Dict[str, Union[bool, str]]:
         """Persist changes to files in the given path.
 

--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -4,7 +4,7 @@ This stores the idea of a collection of linted files at a single start path
 
 """
 
-from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, TypedDict, Union
 
 from sqlfluff.core.errors import CheckTuple, SQLBaseError, SQLLintError
 from sqlfluff.core.linter.linted_file import TMP_PRS_ERROR_TYPES, LintedFile
@@ -164,9 +164,15 @@ class LintedDir:
             for file in self.files
         }
 
-    def num_violations(self, **kwargs) -> int:
+    def num_violations(
+        self,
+        types: Optional[Union[Type[SQLBaseError], Iterable[Type[SQLBaseError]]]] = None,
+        fixable: Optional[bool] = None,
+    ) -> int:
         """Count the number of violations in the path."""
-        return sum(file.num_violations(**kwargs) for file in self.files)
+        return sum(
+            file.num_violations(types=types, fixable=fixable) for file in self.files
+        )
 
     def get_violations(self, **kwargs) -> List[SQLBaseError]:
         """Return a list of violations in the path."""

--- a/src/sqlfluff/core/linter/linted_dir.py
+++ b/src/sqlfluff/core/linter/linted_dir.py
@@ -174,11 +174,13 @@ class LintedDir:
             file.num_violations(types=types, fixable=fixable) for file in self.files
         )
 
-    def get_violations(self, **kwargs) -> List[SQLBaseError]:
+    def get_violations(
+        self, rules: Optional[Union[str, Tuple[str, ...]]] = None
+    ) -> List[SQLBaseError]:
         """Return a list of violations in the path."""
         buff: List[SQLBaseError] = []
         for file in self.files:
-            buff += file.get_violations(**kwargs)
+            buff += file.get_violations(rules=rules)
         return buff
 
     def as_records(self) -> List[LintingRecord]:

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -166,12 +166,23 @@ class LintedFile(NamedTuple):
             violations += self.ignore_mask.generate_warnings_for_unused()
         return violations
 
-    def num_violations(self, **kwargs) -> int:
+    def num_violations(
+        self,
+        types: Optional[Union[Type[SQLBaseError], Iterable[Type[SQLBaseError]]]] = None,
+        filter_ignore: bool = True,
+        filter_warning: bool = True,
+        fixable: Optional[bool] = None,
+    ) -> int:
         """Count the number of violations.
 
         Optionally now with filters.
         """
-        violations = self.get_violations(**kwargs)
+        violations = self.get_violations(
+            types=types,
+            filter_ignore=filter_ignore,
+            filter_warning=filter_warning,
+            fixable=fixable,
+        )
         return len(violations)
 
     def is_clean(self) -> bool:

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -12,7 +12,7 @@ import stat
 import tempfile
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple, Type, Union
+from typing import Dict, Iterable, List, NamedTuple, Optional, Tuple, Type, Union
 
 from sqlfluff.core.errors import (
     CheckTuple,
@@ -21,6 +21,7 @@ from sqlfluff.core.errors import (
     SQLParseError,
     SQLTemplaterError,
 )
+from sqlfluff.core.linter.formatter import FormatterInterface
 from sqlfluff.core.linter.patch import FixPatch, generate_source_patches
 
 # Classes needed only for type checking
@@ -380,7 +381,9 @@ class LintedFile(NamedTuple):
                 str_buff += raw_source_string[source_slice]
         return str_buff
 
-    def persist_tree(self, suffix: str = "", formatter: Any = None) -> bool:
+    def persist_tree(
+        self, suffix: str = "", formatter: Optional[FormatterInterface] = None
+    ) -> bool:
         """Persist changes to the given path."""
         if self.num_violations(fixable=True) > 0:
             write_buff, success = self.fix_string()

--- a/src/sqlfluff/core/linter/linted_file.py
+++ b/src/sqlfluff/core/linter/linted_file.py
@@ -44,7 +44,7 @@ class FileTimings:
     # process this as we wish later.
     rule_timings: List[Tuple[str, str, float]]
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self) -> str:  # pragma: no cover
         return "<FileTimings>"
 
     def get_rule_timing_dict(self) -> Dict[str, float]:
@@ -398,7 +398,7 @@ class LintedFile(NamedTuple):
     @staticmethod
     def _safe_create_replace_file(
         input_path: str, output_path: str, write_buff: str, encoding: str
-    ):
+    ) -> None:
         # Write to a temporary file first, so in case of encoding or other
         # issues, we don't delete or corrupt the user's existing file.
 

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -6,16 +6,18 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    Iterable,
     List,
     Mapping,
     Optional,
     Set,
     Tuple,
+    Type,
     TypeVar,
     Union,
 )
 
-from sqlfluff.core.errors import CheckTuple
+from sqlfluff.core.errors import CheckTuple, SQLBaseError
 from sqlfluff.core.linter.linted_dir import LintedDir, LintingRecord
 from sqlfluff.core.timing import RuleTimingSummary, TimingSummary
 
@@ -84,9 +86,15 @@ class LintingResult:
             buff.update(path.check_tuples_by_path())
         return buff
 
-    def num_violations(self, **kwargs) -> int:
+    def num_violations(
+        self,
+        types: Optional[Union[Type[SQLBaseError], Iterable[Type[SQLBaseError]]]] = None,
+        fixable: Optional[bool] = None,
+    ) -> int:
         """Count the number of violations in the result."""
-        return sum(path.num_violations(**kwargs) for path in self.paths)
+        return sum(
+            path.num_violations(types=types, fixable=fixable) for path in self.paths
+        )
 
     def get_violations(self, **kwargs) -> list:
         """Return a list of violations in the result."""

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -96,11 +96,13 @@ class LintingResult:
             path.num_violations(types=types, fixable=fixable) for path in self.paths
         )
 
-    def get_violations(self, **kwargs) -> list:
+    def get_violations(
+        self, rules: Optional[Union[str, Tuple[str, ...]]] = None
+    ) -> list:
         """Return a list of violations in the result."""
         buff = []
         for path in self.paths:
-            buff += path.get_violations(**kwargs)
+            buff += path.get_violations(rules=rules)
         return buff
 
     def stats(self, fail_code: int, success_code: int) -> Dict[str, Any]:

--- a/src/sqlfluff/core/linter/linting_result.py
+++ b/src/sqlfluff/core/linter/linting_result.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 from sqlfluff.core.errors import CheckTuple, SQLBaseError
+from sqlfluff.core.linter.formatter import FormatterInterface
 from sqlfluff.core.linter.linted_dir import LintedDir, LintingRecord
 from sqlfluff.core.timing import RuleTimingSummary, TimingSummary
 
@@ -193,7 +194,7 @@ class LintingResult:
         )
 
     def persist_changes(
-        self, formatter, fixed_file_suffix: str = ""
+        self, formatter: Optional[FormatterInterface], fixed_file_suffix: str = ""
     ) -> Dict[str, Union[bool, str]]:
         """Run all the fixes for all the files and return a dict."""
         return combine_dicts(

--- a/src/sqlfluff/core/linter/patch.py
+++ b/src/sqlfluff/core/linter/patch.py
@@ -215,7 +215,7 @@ def _iter_templated_patches(
             )
 
 
-def _log_hints(patch: FixPatch, templated_file: TemplatedFile):
+def _log_hints(patch: FixPatch, templated_file: TemplatedFile) -> None:
     """Log hints for debugging during patch generation."""
     max_log_length = 10
     if patch.templated_slice.start >= max_log_length:

--- a/src/sqlfluff/core/rules/noqa.py
+++ b/src/sqlfluff/core/rules/noqa.py
@@ -3,7 +3,7 @@
 import fnmatch
 import logging
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Set, Tuple, cast
+from typing import Dict, List, Optional, Set, Tuple, Union, cast
 
 from sqlfluff.core.errors import SQLBaseError, SQLParseError, SQLUnusedNoQaWarning
 from sqlfluff.core.parser import BaseSegment, RawSegment, RegexLexer
@@ -56,7 +56,7 @@ class IgnoreMask:
     def __init__(self, ignores: List[NoQaDirective]):
         self._ignore_list = ignores
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self) -> str:  # pragma: no cover
         return "<IgnoreMask>"
 
     # ### Construction class methods.
@@ -67,7 +67,7 @@ class IgnoreMask:
         line_no: int,
         line_pos: int,
         reference_map: Dict[str, Set[str]],
-    ):
+    ) -> Union[NoQaDirective, SQLParseError, None]:
         """Extract ignore mask entries from a comment string."""
         # Also trim any whitespace afterward
 
@@ -144,7 +144,7 @@ class IgnoreMask:
         cls,
         comment: RawSegment,
         reference_map: Dict[str, Set[str]],
-    ):
+    ) -> Union[NoQaDirective, SQLParseError, None]:
         """Extract ignore mask entries from a comment segment."""
         # Also trim any whitespace
         comment_content = comment.raw_trimmed().strip()
@@ -219,7 +219,7 @@ class IgnoreMask:
     @staticmethod
     def _ignore_masked_violations_single_line(
         violations: List[SQLBaseError], ignore_mask: List[NoQaDirective]
-    ):
+    ) -> List[SQLBaseError]:
         """Filter a list of violations based on this single line noqa.
 
         The "ignore" list is assumed to ONLY contain NoQaDirectives with
@@ -268,7 +268,7 @@ class IgnoreMask:
     @classmethod
     def _ignore_masked_violations_line_range(
         cls, violations: List[SQLBaseError], ignore_mask: List[NoQaDirective]
-    ):
+    ) -> List[SQLBaseError]:
         """Returns whether to ignore error for line-range directives.
 
         The "ignore" list is assumed to ONLY contain NoQaDirectives where

--- a/test/core/config/fluffconfig_test.py
+++ b/test/core/config/fluffconfig_test.py
@@ -60,7 +60,7 @@ def test__config__nested_config_tests():
         config=FluffConfig(overrides=dict(exclude_rules="CP02", dialect="ansi"))
     )
     lnt = lntr.lint_path("test/fixtures/config/inheritance_b")
-    violations = lnt.check_tuples(by_path=True)
+    violations = lnt.check_tuples_by_path()
     for k in violations:
         if k.endswith("nested\\example.sql"):
             # CP01 is enabled in the .sqlfluff file and not excluded.
@@ -106,7 +106,7 @@ def test__config__glob_exclude_config_tests():
     """
     lntr = Linter(config=FluffConfig.from_path("test/fixtures/config/glob_exclude"))
     lnt = lntr.lint_path("test/fixtures/config/glob_exclude/test.sql")
-    violations = lnt.check_tuples(by_path=True)
+    violations = lnt.check_tuples_by_path()
     for k in violations:
         assert ("AM04", 12, 1) in violations[k]
         assert "RF02" not in [c[0] for c in violations[k]]
@@ -123,7 +123,7 @@ def test__config__glob_include_config_tests():
     """
     lntr = Linter(config=FluffConfig.from_path("test/fixtures/config/glob_include"))
     lnt = lntr.lint_path("test/fixtures/config/glob_include/test.sql")
-    violations = lnt.check_tuples(by_path=True)
+    violations = lnt.check_tuples_by_path()
     for k in violations:
         assert ("LT13", 1, 1) in violations[k]
         assert ("AM05", 14, 1) in violations[k]
@@ -141,7 +141,7 @@ def test__config__rules_set_to_none():
         config=FluffConfig.from_path("test/fixtures/config/rules_set_to_none")
     )
     lnt = lntr.lint_path("test/fixtures/config/rules_set_to_none/test.sql")
-    violations = lnt.check_tuples(by_path=True)
+    violations = lnt.check_tuples_by_path()
     for k in violations:
         assert ("LT13", 1, 1) in violations[k]
         assert ("AM04", 12, 1) in violations[k]
@@ -154,7 +154,7 @@ def test__config__rules_group_with_exclude():
         config=FluffConfig.from_path("test/fixtures/config/rules_group_with_exclude")
     )
     lnt = lntr.lint_path("test/fixtures/config/rules_group_with_exclude/test.sql")
-    violations = lnt.check_tuples(by_path=True)
+    violations = lnt.check_tuples_by_path()
     for k in violations:
         assert ("CP01", 15, 1) in violations[k]
         assert "LT04" not in [c[0] for c in violations[k]]

--- a/tox.ini
+++ b/tox.ini
@@ -117,10 +117,11 @@ commands = make -C {toxinidir}/docs html
 commands =
     # Standard MyPy on the main package
     mypy -p sqlfluff
-    # Strict MyPy on the parser, helpers & config
+    # Strict MyPy on the parser, linter, helpers & config
     mypy -p sqlfluff.core.helpers --strict
     mypy -p sqlfluff.core.config --strict
     mypy -p sqlfluff.core.parser --strict
+    mypy -p sqlfluff.core.linter --strict
 
 [testenv:build-dist]
 skip_install = true


### PR DESCRIPTION
This brings the `sqlfluff.core.linter` module up to strict mypy typing (and enforces that in CI).

A lot of this is just type annotations, however there are a few more interesting bits:
- The `linter` module now defines a `FormatterInterface` for the `cli.OutputStreamFormatter` to inherit from. This means that all of the `Linter` methods which allow a `formatter` argument have an interface to use for typing without importing the `cli` module.
- The `check_tuples` method on `LintedFile`, `LintedDir` and `LintingResult` no longer supports a `by_path` argument. Instead there's now a seperate method called `check_tuples_by_path` to replace that functionality. That makes the typing much cleaner (and removes a bunch of overloads).
- For the `runner` module, there's more use of `abstractmethod` for the stub methods, and rather than using `MAP_FUNCTION_NAME`, each of the subclasses now just redefine the `_map()` method directly to make the call. It's a little more verbose, but much clearer and more explicit for typing.

Aside from the `templater` module, this is most of the `core` module done. Supports #6220 