### PR TITLE
RF02: Ignore alias references that are self-inner

### DIFF
--- a/src/sqlfluff/rules/references/RF02.py
+++ b/src/sqlfluff/rules/references/RF02.py
@@ -63,7 +63,13 @@ class Rule_RF02(Rule_AL04):
             )
             if parent_select_info:
                 # If we are looking at a subquery, include any table references
-                table_aliases += parent_select_info.table_aliases
+                for table_alias in parent_select_info.table_aliases:
+                    if table_alias.from_expression_element.path_to(
+                        rule_context.segment
+                    ):
+                        # Skip the subquery alias itself
+                        continue
+                    table_aliases.append(table_alias)
 
         # Do we have more than one? If so, all references should be qualified.
         if len(table_aliases) <= 1:

--- a/test/fixtures/rules/std_rule_cases/RF02.yml
+++ b/test/fixtures/rules/std_rule_cases/RF02.yml
@@ -441,3 +441,8 @@ test_pass_referenced_subquery_column:
     SELECT a
     FROM foo
     WHERE a IN (SELECT bar.a FROM bar)
+
+test_pass_referenced_subquery_is_self:
+  pass_str: |
+    SELECT *
+    FROM (SELECT a FROM table)


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This removes including the parent table alias of a subquery. These cases would be referencing the subquery itself.
- fixes #6231

### Are there any other side effects of this change that we should be aware of?
none

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
