### PR TITLE
Postgres: Support `SET` with double quoted identifiers

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -4991,6 +4991,7 @@ class SetStatementSegment(BaseSegment):
                     Delimited(
                         Ref("LiteralGrammar"),
                         Ref("NakedIdentifierSegment"),
+                        Ref("QuotedIdentifierSegment"),
                         # https://github.com/postgres/postgres/blob/4380c2509d51febad34e1fac0cfaeb98aaa716c5/src/backend/parser/gram.y#L1810-L1815
                         Ref("OnKeywordAsIdentifierSegment"),
                     ),

--- a/test/fixtures/dialects/postgres/set.sql
+++ b/test/fixtures/dialects/postgres/set.sql
@@ -13,3 +13,5 @@ SET SCHEMA  'public';
 SET ROLE my_role;
 SET ROLE "my role";
 SET ROLE NONE;
+SET LOCAL search_path = schema_name;
+SET LOCAL search_path = "schema_name";

--- a/test/fixtures/dialects/postgres/set.yml
+++ b/test/fixtures/dialects/postgres/set.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1f838a5987921dc5b619c4bd6293baa5f135cd12fa558d2f18a6198dc6578d3d
+_hash: cb0dc63cad87d359306fe882a446dcfaa69e1d67b89a691307fa98cbe277415b
 file:
 - statement:
     set_statement:
@@ -123,4 +123,22 @@ file:
     - keyword: SET
     - keyword: ROLE
     - keyword: NONE
+- statement_terminator: ;
+- statement:
+    set_statement:
+    - keyword: SET
+    - keyword: LOCAL
+    - parameter: search_path
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - naked_identifier: schema_name
+- statement_terminator: ;
+- statement:
+    set_statement:
+    - keyword: SET
+    - keyword: LOCAL
+    - parameter: search_path
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_identifier: '"schema_name"'
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This allows for double quoted identifiers to be used in a `SET` statement in postgres.
- fixes #6234

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
