### PR TITLE
DuckDB: Fixed `DatatypeSegment` references

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -782,10 +782,10 @@ class CreateTypeStatementSegment(postgres.CreateTypeStatementSegment):
     match_grammar = Sequence(
         "CREATE",
         "TYPE",
-        Ref("DatatypeIdentifierSegment"),
+        Ref("DatatypeSegment"),
         "AS",
         OneOf(
-            Ref("DatatypeIdentifierSegment"),
+            Ref("DatatypeSegment"),
             Sequence("ENUM", Bracketed(Delimited(Ref("QuotedLiteralSegment")))),
             Ref("StructTypeSegment"),
             Sequence("UNION", Ref("StructTypeSchemaSegment")),

--- a/test/fixtures/dialects/duckdb/create_type.sql
+++ b/test/fixtures/dialects/duckdb/create_type.sql
@@ -2,3 +2,6 @@ CREATE TYPE mood AS ENUM ('happy', 'sad', 'curious');
 CREATE TYPE many_things AS STRUCT(k integer, l varchar);
 CREATE TYPE one_thing AS UNION (number integer, string varchar);
 CREATE TYPE x_index AS integer;
+CREATE TYPE myschema.mytype AS int;
+CREATE TYPE "myschema".mytype2 AS int;
+CREATE TYPE myschema.mytype3 AS myschema.mytype2;

--- a/test/fixtures/dialects/duckdb/create_type.yml
+++ b/test/fixtures/dialects/duckdb/create_type.yml
@@ -3,13 +3,14 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 64bba70a49a42bc0cff6c4071a0c97478a2f84dd80bf03db7a2afb0ea6ae6ad3
+_hash: 7773898b6d4416f6d35f1ca9f143892e4ee3abe36db1297eaa157e9521c9f3b9
 file:
 - statement:
     create_type_statement:
     - keyword: CREATE
     - keyword: TYPE
-    - data_type_identifier: mood
+    - data_type:
+        data_type_identifier: mood
     - keyword: AS
     - keyword: ENUM
     - bracketed:
@@ -25,27 +26,30 @@ file:
     create_type_statement:
     - keyword: CREATE
     - keyword: TYPE
-    - data_type_identifier: many_things
+    - data_type:
+        data_type_identifier: many_things
     - keyword: AS
-    - struct_type:
-        keyword: STRUCT
-        struct_type_schema:
-          bracketed:
-          - start_bracket: (
-          - parameter: k
-          - data_type:
-              keyword: integer
-          - comma: ','
-          - parameter: l
-          - data_type:
-              keyword: varchar
-          - end_bracket: )
+    - data_type:
+        struct_type:
+          keyword: STRUCT
+          struct_type_schema:
+            bracketed:
+            - start_bracket: (
+            - parameter: k
+            - data_type:
+                keyword: integer
+            - comma: ','
+            - parameter: l
+            - data_type:
+                keyword: varchar
+            - end_bracket: )
 - statement_terminator: ;
 - statement:
     create_type_statement:
     - keyword: CREATE
     - keyword: TYPE
-    - data_type_identifier: one_thing
+    - data_type:
+        data_type_identifier: one_thing
     - keyword: AS
     - keyword: UNION
     - struct_type_schema:
@@ -64,7 +68,47 @@ file:
     create_type_statement:
     - keyword: CREATE
     - keyword: TYPE
-    - data_type_identifier: x_index
+    - data_type:
+        data_type_identifier: x_index
     - keyword: AS
-    - data_type_identifier: integer
+    - data_type:
+        keyword: integer
+- statement_terminator: ;
+- statement:
+    create_type_statement:
+    - keyword: CREATE
+    - keyword: TYPE
+    - data_type:
+        naked_identifier: myschema
+        dot: .
+        data_type_identifier: mytype
+    - keyword: AS
+    - data_type:
+        keyword: int
+- statement_terminator: ;
+- statement:
+    create_type_statement:
+    - keyword: CREATE
+    - keyword: TYPE
+    - data_type:
+        quoted_identifier: '"myschema"'
+        dot: .
+        data_type_identifier: mytype2
+    - keyword: AS
+    - data_type:
+        keyword: int
+- statement_terminator: ;
+- statement:
+    create_type_statement:
+    - keyword: CREATE
+    - keyword: TYPE
+    - data_type:
+        naked_identifier: myschema
+        dot: .
+        data_type_identifier: mytype3
+    - keyword: AS
+    - data_type:
+        naked_identifier: myschema
+        dot: .
+        data_type_identifier: mytype2
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Originally, I pointed to the wrong segment type for data types in `CREATE TYPE`. This corrects this to use `DatatypeSegments`.
- fixes #6225 

### Are there any other side effects of this change that we should be aware of?
none

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
