### PR TITLE
fix RF06 issue in postgres naked identifier regex

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -412,9 +412,9 @@ postgres_dialect.replace(
     NakedIdentifierSegment=SegmentGenerator(
         # Generate the anti template from the set of reserved keywords
         lambda dialect: RegexParser(
-            # Can’t begin with $, must only contain digits, letters, underscore it $ but
-            # can’t be all digits.
-            r"([A-Z_]+|[0-9]+[A-Z_$])[A-Z0-9_$]*",
+            # Can’t begin with $ or digits,
+            # must only contain digits, letters, underscore or $
+            r"[A-Z_][A-Z0-9_$]*",
             IdentifierSegment,
             type="naked_identifier",
             anti_template=r"^(" + r"|".join(dialect.sets("reserved_keywords")) + r")$",

--- a/test/fixtures/rules/std_rule_cases/RF06.yml
+++ b/test/fixtures/rules/std_rule_cases/RF06.yml
@@ -10,6 +10,7 @@ test_pass_default:
       "case_specific_reference",
       "REFERENCE WITH SPACE",
       "I-c@nn0t-be~un-quoted",
+      "1_starts_with_digit",
       "SELECT",  -- Keyword as identifier
       another as "Case_Specific_Alias"
     from my_schema.my_table


### PR DESCRIPTION
### Fixes regex for naked identifier in postgres dialect
Per the new changes auto-enforcing RF06, I've run into issues of `fix` making invalid sql, centered around that postgres naked identifiers cannot begin with digits.

If you run `sqlfluff lint file.sql --dialect postgres` with no other config using sqlfluff 3.2.0 on
```sql
SELECT
    regular,
    "1a"
FROM
    my_schema.mytable
```

`"1a"` is flagged as a violation. However, the correction is invalid sql - identifiers beginning with a digit must be quoted. Running sql violating this returns `ERROR: trailing junk after numeric literal at or near "1a"`

I didn't create a linked issue for this problem, let me know if that's preferred to a standalone PR

### Are there any other side effects of this change that we should be aware of?
A little concerned of other unintended consequences, I'm not hugely familiar with this codebase, but this seems relatively specific. We'll see what tests look like

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
