### PR TITLE
MySQL: AL09 handle double quoted identifiers

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -308,6 +308,10 @@ mysql_dialect.add(
         type="quoted_literal",
         trim_chars=('"',),
     ),
+    # MySQL allows the usage of a double quoted identifier for an alias.
+    DoubleQuotedIdentifierSegment=TypedParser(
+        "double_quote", IdentifierSegment, type="quoted_identifier"
+    ),
     AtSignLiteralSegment=TypedParser(
         "at_sign_literal",
         LiteralSegment,
@@ -347,7 +351,8 @@ class AliasExpressionSegment(BaseSegment):
         Ref.keyword("AS", optional=True),
         OneOf(
             Ref("SingleIdentifierGrammar"),
-            Ref("QuotedLiteralSegment"),
+            Ref("SingleQuotedIdentifierSegment"),
+            Ref("DoubleQuotedIdentifierSegment"),
         ),
         Dedent,
     )

--- a/test/fixtures/dialects/mariadb/column_alias.sql
+++ b/test/fixtures/dialects/mariadb/column_alias.sql
@@ -1,3 +1,4 @@
 SELECT 1 AS `one`;
 SELECT 2 AS 'two';
 SELECT 3 AS "three";
+SELECT 4 AS "four""_with_escaped_double_quotes";

--- a/test/fixtures/dialects/mariadb/column_alias.yml
+++ b/test/fixtures/dialects/mariadb/column_alias.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c9775a3b31f10dbd2195648c11645df65acb8dd428e41c317fbbd0c2941c615e
+_hash: 29a79d6c1125d4e917fd2e01274c4a2a09beb4225c95aa1cb3ba9c744e9db414
 file:
 - statement:
     select_statement:
@@ -23,7 +23,7 @@ file:
           numeric_literal: '2'
           alias_expression:
             keyword: AS
-            quoted_literal: "'two'"
+            quoted_identifier: "'two'"
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -33,5 +33,15 @@ file:
           numeric_literal: '3'
           alias_expression:
             keyword: AS
-            quoted_literal: '"three"'
+            quoted_identifier: '"three"'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: '4'
+          alias_expression:
+            keyword: AS
+            quoted_identifier: '"four""_with_escaped_double_quotes"'
 - statement_terminator: ;

--- a/test/fixtures/dialects/mysql/column_alias.sql
+++ b/test/fixtures/dialects/mysql/column_alias.sql
@@ -1,3 +1,4 @@
 SELECT 1 AS `one`;
 SELECT 2 AS 'two';
 SELECT 3 AS "three";
+SELECT 4 AS "four""_with_escaped_double_quotes";

--- a/test/fixtures/dialects/mysql/column_alias.yml
+++ b/test/fixtures/dialects/mysql/column_alias.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c9775a3b31f10dbd2195648c11645df65acb8dd428e41c317fbbd0c2941c615e
+_hash: 29a79d6c1125d4e917fd2e01274c4a2a09beb4225c95aa1cb3ba9c744e9db414
 file:
 - statement:
     select_statement:
@@ -23,7 +23,7 @@ file:
           numeric_literal: '2'
           alias_expression:
             keyword: AS
-            quoted_literal: "'two'"
+            quoted_identifier: "'two'"
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -33,5 +33,15 @@ file:
           numeric_literal: '3'
           alias_expression:
             keyword: AS
-            quoted_literal: '"three"'
+            quoted_identifier: '"three"'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: '4'
+          alias_expression:
+            keyword: AS
+            quoted_identifier: '"four""_with_escaped_double_quotes"'
 - statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/AL09.yml
+++ b/test/fixtures/rules/std_rule_cases/AL09.yml
@@ -96,3 +96,15 @@ test_pass_self_alias_case_sensitive:
             col_a as "col_a",
             col_b as new_col_b
         from foo
+
+test_pass_mysql_quoted_identifiers:
+    pass_str: |
+        SELECT
+            users.email AS "Email_in_double_quotes",
+            users.email AS "Email""with_escaped_double_quotes",
+            users.email AS `Email_in_backticks`,
+            users.email AS 'Email_in_single_quotes'
+        FROM users;
+    configs:
+        core:
+            dialect: mysql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This corrects the exception raised by AL09 when using double quoted aliases in MySQL or MariaDB.
- fixes #6218

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
