### PR TITLE
Update link to diff-cover docs

### DIFF
--- a/docs/source/production/diff_quality.rst
+++ b/docs/source/production/diff_quality.rst
@@ -55,9 +55,9 @@ although the format is a little different. Note that ``diff-quality`` only lists
 the line _numbers_, not the character position. If you need the character
 position, you will need to run SQLFluff directly.
 
-For more information on ``diff-quality``, see the
-`documentation <https://diff-cover.readthedocs.io/en/latest/README.html>`_. It covers topics
-such as:
+For more information on ``diff-quality`` and the ``diff_cover`` package, see the
+`documentation <https://github.com/Bachmann1234/diff_cover>`_ on their github
+repository. It covers topics such as:
 
 * Generating HTML reports
 * Controlling which branch to compare against (i.e. to determine new/changed
@@ -65,7 +65,3 @@ such as:
 * Configuring ``diff-quality`` to return an error code if the quality is
   too low.
 * Troubleshooting
-
-You can also find out more about ``diff-quality`` and the ``diff_cover`` package
-on the `github repository <https://github.com/Bachmann1234/diff_cover>`_ for the
-project.

--- a/docs/source/production/diff_quality.rst
+++ b/docs/source/production/diff_quality.rst
@@ -56,7 +56,7 @@ the line _numbers_, not the character position. If you need the character
 position, you will need to run SQLFluff directly.
 
 For more information on ``diff-quality``, see the
-`documentation <https://diff-cover.readthedocs.io/en/latest/>`_. It covers topics
+`documentation <https://diff-cover.readthedocs.io/en/latest/README.html>`_. It covers topics
 such as:
 
 * Generating HTML reports
@@ -65,3 +65,7 @@ such as:
 * Configuring ``diff-quality`` to return an error code if the quality is
   too low.
 * Troubleshooting
+
+You can also find out more about ``diff-quality`` and the ``diff_cover`` package
+on the `github repository <https://github.com/Bachmann1234/diff_cover>`_ for the
+project.


### PR DESCRIPTION
The readthedocs.io page for diff quality seems to have become unlinked from the project, the link we have in the docs also doesn't work anyway. The project is still maintained and the docs were just a rendered copy of the README anyway, so this updates the link in the docs to just point at the github page.

I've let the folks at diff cover know: https://github.com/Bachmann1234/diff_cover/issues/420