### PR TITLE
dbt templater `pyproject.toml` nits

### DIFF
--- a/plugins/sqlfluff-templater-dbt/pyproject.toml
+++ b/plugins/sqlfluff-templater-dbt/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Utilities",
     "Topic :: Software Development :: Quality Assurance",
@@ -70,4 +71,4 @@ Chat = "https://github.com/sqlfluff/sqlfluff#sqlfluff-on-slack"
 sqlfluff_templater_dbt = "sqlfluff_templater_dbt"
 
 [tool.setuptools.packages.find]
-include = ["sqlfluff_templater_dbt", "sqlfluff_templater_dbt.osmosis"]
+include = ["sqlfluff_templater_dbt"]


### PR DESCRIPTION
Two tiny nits I found. Added py3.12 support to the tags for the dbt templater, and removed the reference to the dbt_osmosis package in the `[tool.setuptools.packages.find]` section.