### PR TITLE
AM06: Ignore array expressions in BigQuery

### DIFF
--- a/src/sqlfluff/rules/ambiguous/AM06.py
+++ b/src/sqlfluff/rules/ambiguous/AM06.py
@@ -108,6 +108,15 @@ class Rule_AM06(BaseRule):
         if FunctionalContext(context).parent_stack.any(sp.is_type(*self._ignore_types)):
             return LintResult(memory=context.memory)
 
+        # Ignore Array expressions in BigQuery
+        # BigQuery doesn't support implicit ordering inside an array expression,
+        # these aren't going to be caught by ignoring any of the listed types
+        # above.
+        if context.dialect.name == "bigquery" and FunctionalContext(
+            context
+        ).parent_stack.any(sp.is_type("array_expression")):
+            return LintResult(memory=context.memory)
+
         # Look at child segments and map column references to either the implicit or
         # explicit category.
         # N.B. segment names are used as the numeric literal type is 'raw', so best to

--- a/test/fixtures/rules/std_rule_cases/AM06.yml
+++ b/test/fixtures/rules/std_rule_cases/AM06.yml
@@ -682,3 +682,22 @@ test_pass_array_agg_bigquery:
   configs:
     core:
       dialect: bigquery
+
+test_pass_array_expression_bigquery:
+  pass_str: |
+    SELECT
+      poi.country_code
+      , poi.po_id
+      , ARRAY(
+          SELECT STRUCT(
+              p.product_name
+              , p.sku_id
+              , p.created_at
+            ) AS products_purchased
+          FROM UNNEST(poi.products_purchased) AS p
+          ORDER BY p.created_at
+        ) AS products_purchased
+    FROM `my_project.my_dataset.purchase_orders_products` AS poi
+  configs:
+    core:
+      dialect: bigquery


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This makes AM06 ignore array expressions within the BigQuery dialect.
- fixes #5497

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
