### PR TITLE
TSQL: Add DATETRUC to date_part_function_name list

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -116,7 +116,7 @@ tsql_dialect.sets("datetime_units").update(
 
 tsql_dialect.sets("date_part_function_name").clear()
 tsql_dialect.sets("date_part_function_name").update(
-    ["DATEADD", "DATEDIFF", "DATEDIFF_BIG", "DATENAME", "DATEPART"]
+    ["DATEADD", "DATEDIFF", "DATEDIFF_BIG", "DATENAME", "DATEPART", "DATETRUNC"]
 )
 
 tsql_dialect.sets("date_format").clear()

--- a/test/fixtures/dialects/tsql/datetrunc.sql
+++ b/test/fixtures/dialects/tsql/datetrunc.sql
@@ -1,0 +1,4 @@
+SELECT DATETRUNC(YEAR, my_table.date) AS [beginningOfYear]
+, DATETRUNC(MONTH, my_table.date) AS [FirstOfMonth]
+, DATETRUNC(DAY, my_table.date) AS [Today]
+FROM my_table;

--- a/test/fixtures/dialects/tsql/datetrunc.yml
+++ b/test/fixtures/dialects/tsql/datetrunc.yml
@@ -1,0 +1,76 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 1d2660a2bcd5b736992a943afc9ba187718d7cd51060b990e25549a8bdd4cf22
+file:
+  batch:
+    statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: DATETRUNC
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  date_part: YEAR
+                  comma: ','
+                  expression:
+                    column_reference:
+                    - naked_identifier: my_table
+                    - dot: .
+                    - naked_identifier: date
+                  end_bracket: )
+            alias_expression:
+              keyword: AS
+              quoted_identifier: '[beginningOfYear]'
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: DATETRUNC
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  date_part: MONTH
+                  comma: ','
+                  expression:
+                    column_reference:
+                    - naked_identifier: my_table
+                    - dot: .
+                    - naked_identifier: date
+                  end_bracket: )
+            alias_expression:
+              keyword: AS
+              quoted_identifier: '[FirstOfMonth]'
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: DATETRUNC
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  date_part: DAY
+                  comma: ','
+                  expression:
+                    column_reference:
+                    - naked_identifier: my_table
+                    - dot: .
+                    - naked_identifier: date
+                  end_bracket: )
+            alias_expression:
+              keyword: AS
+              quoted_identifier: '[Today]'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: my_table
+          statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Fixes #6282 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
