### PR TITLE
Remove dependency on coveralls.

### DIFF
--- a/.github/workflows/ci-test-dbt.yml
+++ b/.github/workflows/ci-test-dbt.yml
@@ -74,15 +74,6 @@ jobs:
       if: ${{ !inputs.coverage }}
       run: tox -e ${{ inputs.dbt-version }} -- plugins/sqlfluff-templater-dbt
 
-    - name: Coveralls Parallel (coveralls)
-      uses: coverallsapp/github-action@v2
-      if: ${{ inputs.coverage }}
-      with:
-        path-to-lcov: coverage.lcov
-        github-token: ${{ secrets.gh_token }}
-        flag-name: run-${{ inputs.dbt-version }}
-        parallel: true
-
     - name: Upload coverage data (github)
       uses: actions/upload-artifact@v4
       if: ${{ inputs.coverage }}

--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -80,15 +80,6 @@ jobs:
         echo "COVSUFFIX=$COVSUFFIX" >> $GITHUB_OUTPUT
         for file in .coverage.*; do mv "$file" "$file.$COVSUFFIX"; done;
 
-    - name: Coveralls Parallel (coveralls)
-      uses: coverallsapp/github-action@v2
-      if: ${{ inputs.coverage }}
-      with:
-        path-to-lcov: coverage.lcov
-        github-token: ${{ secrets.gh_token }}
-        flag-name: run-${{ inputs.python-version }}-${{ steps.cov_suffix.outputs.COVSUFFIX }}
-        parallel: true
-
     - name: Upload coverage data (github)
       uses: actions/upload-artifact@v4
       if: ${{ inputs.coverage }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -277,17 +277,6 @@ jobs:
       run: |
         sqlfluff lint --dialect=ansi <(echo "select 1")
 
-  coveralls_finish:
-    name: Finalise coveralls.
-    needs: [python-version-tests, dbt-tests, python-windows-tests, dialect-tests]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@v2
-      with:
-        github-token: ${{ secrets.github_token }}
-        parallel-finished: true
-
   coverage_check:
     name: Combine & check 100% coverage.
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![PyPi Status](https://img.shields.io/pypi/status/sqlfluff.svg?style=flat-square)](https://pypi.org/project/sqlfluff/)
 [![PyPi Downloads](https://img.shields.io/pypi/dm/sqlfluff?style=flat-square)](https://pypi.org/project/sqlfluff/)
 
-[![Coveralls](https://img.shields.io/coverallsCoverage/github/sqlfluff/sqlfluff?logo=coveralls&style=flat-square)](https://coveralls.io/github/sqlfluff/sqlfluff?branch=main)
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/sqlfluff/sqlfluff/.github/workflows/ci-tests.yml?logo=github&style=flat-square)](https://github.com/sqlfluff/sqlfluff/actions/workflows/ci-tests.yml?query=branch%3Amain)
 [![ReadTheDocs](https://img.shields.io/readthedocs/sqlfluff?style=flat-square&logo=Read%20the%20Docs)](https://sqlfluff.readthedocs.io)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat-square)](https://github.com/psf/black)


### PR DESCRIPTION
@greg-finley has identified that the coveralls jobs are failing, and that the repo doesn't seem to be updated anymore. All of our coverage jobs have already been migrated to github actions anyway, so this finishes the job and removes coveralls entirely.