### PR TITLE
BigQuery: Add support for concatenating in `EXECUTE IMMEDIATE`

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1605,6 +1605,7 @@ class ExecuteImmediateSegment(BaseSegment):
                 Ref("SingleIdentifierFullGrammar"),  # Variable
                 Ref("FunctionSegment"),  # Function
                 Ref("CaseExpressionSegment"),  # Conditional Expression
+                Ref("ExpressionSegment"),  # Expression
                 Bracketed(Ref("SelectableGrammar")),  # Expression Subquery
             )
         ),

--- a/test/fixtures/dialects/bigquery/create_procedure.sql
+++ b/test/fixtures/dialects/bigquery/create_procedure.sql
@@ -190,3 +190,24 @@ BEGIN
     --end try
     END;
 END;
+
+CREATE
+OR REPLACE PROCEDURE `kkk.dynamic_table_creator` (
+    IN table_suffix STRING, IN num_rows INT64
+)
+BEGIN
+    DECLARE table_name STRING;
+
+    SET
+    table_name = 'my_table_' || table_suffix;
+
+    EXECUTE IMMEDIATE '''
+    CREATE OR REPLACE TABLE `my_dataset.''' || table_name || '''` AS
+    SELECT
+        GENERATE_UUID() AS id,
+        RAND() AS random_value
+    FROM
+        UNNEST(GENERATE_ARRAY(1, ''' || num_rows || ''')) AS num
+    ''';
+
+END;

--- a/test/fixtures/dialects/bigquery/create_procedure.yml
+++ b/test/fixtures/dialects/bigquery/create_procedure.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 6a450ddfea76187e4c305b5fa118cee72a2995a09a62ff249df2605ddaddf871
+_hash: 445d689e251f3f067ff5dca8da0f86d1d55f6de176450608b24539221aa38857
 file:
 - multi_statement_segment:
     create_procedure_statement:
@@ -926,6 +926,79 @@ file:
                 keyword: RAISE
           - statement_terminator: ;
           - keyword: END
+      - statement_terminator: ;
+      - keyword: END
+- statement_terminator: ;
+- multi_statement_segment:
+    create_procedure_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: PROCEDURE
+    - procedure_name:
+        procedure_name_identifier: '`kkk.dynamic_table_creator`'
+    - procedure_parameter_list:
+        bracketed:
+        - start_bracket: (
+        - keyword: IN
+        - parameter: table_suffix
+        - data_type:
+            data_type_identifier: STRING
+        - comma: ','
+        - keyword: IN
+        - parameter: num_rows
+        - data_type:
+            data_type_identifier: INT64
+        - end_bracket: )
+    - begin_statement:
+      - keyword: BEGIN
+      - statement:
+          declare_segment:
+            keyword: DECLARE
+            naked_identifier: table_name
+            data_type:
+              data_type_identifier: STRING
+      - statement_terminator: ;
+      - statement:
+          set_segment:
+            keyword: SET
+            naked_identifier: table_name
+            comparison_operator:
+              raw_comparison_operator: '='
+            expression:
+              quoted_literal: "'my_table_'"
+              binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+              column_reference:
+                naked_identifier: table_suffix
+      - statement_terminator: ;
+      - statement:
+          execute_immediate:
+          - keyword: EXECUTE
+          - keyword: IMMEDIATE
+          - expression:
+            - quoted_literal: "'''\n    CREATE OR REPLACE TABLE `my_dataset.'''"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - column_reference:
+                naked_identifier: table_name
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "'''` AS\n    SELECT\n        GENERATE_UUID() AS id,\n\
+                \        RAND() AS random_value\n    FROM\n        UNNEST(GENERATE_ARRAY(1,\
+                \ '''"
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - column_reference:
+                naked_identifier: num_rows
+            - binary_operator:
+              - pipe: '|'
+              - pipe: '|'
+            - quoted_literal: "''')) AS num\n    '''"
       - statement_terminator: ;
       - keyword: END
 - statement_terminator: ;

--- a/test/fixtures/dialects/bigquery/execute_immediate.yml
+++ b/test/fixtures/dialects/bigquery/execute_immediate.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: aa7aa84b500d55d783c542751c59bf97e628be782c6921c2b8f4c16a9b5d277e
+_hash: 38ccd9866f40e2ff07dfbcf1afae3c5f4c41bc6d817505c8ffdfeb3f28daa668
 file:
 - statement:
     declare_segment:
@@ -212,28 +212,29 @@ file:
           - keyword: immediate
           - bracketed:
               start_bracket: (
-              select_statement:
-                select_clause:
-                  keyword: select
-                  select_clause_element:
-                    function:
-                      function_name:
-                        function_name_identifier: format
-                      function_contents:
-                        bracketed:
-                        - start_bracket: (
-                        - expression:
-                            column_reference:
-                              naked_identifier: var_2
-                        - comma: ','
-                        - expression:
-                            column_reference:
-                              naked_identifier: var_1
-                        - comma: ','
-                        - expression:
-                            column_reference:
-                              naked_identifier: var_1
-                        - end_bracket: )
+              expression:
+                select_statement:
+                  select_clause:
+                    keyword: select
+                    select_clause_element:
+                      function:
+                        function_name:
+                          function_name_identifier: format
+                        function_contents:
+                          bracketed:
+                          - start_bracket: (
+                          - expression:
+                              column_reference:
+                                naked_identifier: var_2
+                          - comma: ','
+                          - expression:
+                              column_reference:
+                                naked_identifier: var_1
+                          - comma: ','
+                          - expression:
+                              column_reference:
+                                naked_identifier: var_1
+                          - end_bracket: )
               end_bracket: )
       - statement_terminator: ;
       - statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds support for concatenation in an `EXECUTE IMMEDIATE` statement.
- fixes #5405 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
