### PR TITLE
BigQuery: Add support for `SET` with system variables

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -72,7 +72,7 @@ bigquery_dialect.insert_lexer_matchers(
         ),
         RegexLexer(
             "double_at_sign_literal",
-            r"@@[a-zA-Z_][\w]*",
+            r"@@[a-zA-Z_][\w\.]*",
             LiteralSegment,
             segment_kwargs={"trim_chars": ("@@",)},
         ),
@@ -1564,6 +1564,7 @@ class SetStatementSegment(BaseSegment):
         OneOf(
             Ref("NakedIdentifierSegment"),
             Bracketed(Delimited(Ref("NakedIdentifierSegment"))),
+            Ref("SystemVariableSegment"),
         ),
         Ref("EqualsSegment"),
         Delimited(

--- a/test/fixtures/dialects/bigquery/handle_exception.yml
+++ b/test/fixtures/dialects/bigquery/handle_exception.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 83aeafe3c949c957183a9384ce83e20d4730afae8ec43f63a8689af5ad50a674
+_hash: 9acf9e7e8ebd6abee20641493d56d4af4ffb5d0e1a7c12de20d4d4f41defbd16
 file:
 - multi_statement_segment:
     begin_statement:
@@ -138,10 +138,7 @@ file:
                 - comma: ','
                 - expression:
                     system_variable:
-                      double_at_sign_literal: '@@error'
-                    semi_structured_expression:
-                      dot: .
-                      naked_identifier: message
+                      double_at_sign_literal: '@@error.message'
                 - end_bracket: )
     - statement_terminator: ;
     - keyword: END
@@ -263,10 +260,7 @@ file:
                 - comma: ','
                 - expression:
                     system_variable:
-                      double_at_sign_literal: '@@error'
-                    semi_structured_expression:
-                      dot: .
-                      naked_identifier: message
+                      double_at_sign_literal: '@@error.message'
                 - end_bracket: )
     - statement_terminator: ;
     - statement:

--- a/test/fixtures/dialects/bigquery/set_variable_single.sql
+++ b/test/fixtures/dialects/bigquery/set_variable_single.sql
@@ -1,2 +1,3 @@
 set var1 = 5;
 set var1 = ['one', 'two'];
+set @@query_label = 'text';

--- a/test/fixtures/dialects/bigquery/set_variable_single.yml
+++ b/test/fixtures/dialects/bigquery/set_variable_single.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5b73183ebf8033c3781e1134e79dda3300baf1a5b990595c27be20e9a23b764f
+_hash: 68bf2c7424c20a4e477ccae3fafe51a21ccff4ae1665262c0778d2d1a277bb3d
 file:
 - statement:
     set_segment:
@@ -25,4 +25,13 @@ file:
       - comma: ','
       - quoted_literal: "'two'"
       - end_square_bracket: ']'
+- statement_terminator: ;
+- statement:
+    set_segment:
+      keyword: set
+      system_variable:
+        double_at_sign_literal: '@@query_label'
+      comparison_operator:
+        raw_comparison_operator: '='
+      quoted_literal: "'text'"
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds support for system variables in a `SET` statement. Also allows for system variables with dots.
- fixes #5404

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
