### PR TITLE
Bugfix for JJ01 in parallel mode

### DIFF
--- a/plugins/sqlfluff-templater-dbt/test/conftest.py
+++ b/plugins/sqlfluff-templater-dbt/test/conftest.py
@@ -62,7 +62,9 @@ def profiles_dir(dbt_fluff_config):
 @pytest.fixture()
 def dbt_templater():
     """Returns an instance of the DbtTemplater."""
-    return FluffConfig(overrides={"dialect": "ansi"}).get_templater("dbt")
+    return FluffConfig(
+        overrides={"dialect": "ansi", "templater": "dbt"}
+    ).get_templater()
 
 
 @pytest.fixture(scope="session")

--- a/src/sqlfluff/core/config/fluffconfig.py
+++ b/src/sqlfluff/core/config/fluffconfig.py
@@ -97,9 +97,7 @@ class FluffConfig:
         dialect: Optional[str] = self._configs["core"]["dialect"]
         self._initialise_dialect(dialect, require_dialect)
 
-        self._configs["core"]["templater_obj"] = self.get_templater(
-            self._configs["core"]["templater"]
-        )
+        self._configs["core"]["templater_obj"] = self.get_templater()
 
     def _handle_comma_separated_values(self) -> None:
         for in_key, out_key in [
@@ -153,7 +151,10 @@ class FluffConfig:
         del state["_plugin_manager"]
         # The dbt templater doesn't pickle well, but isn't required
         # within threaded operations. If it was, it could easily be
-        # rehydrated within the thread.
+        # rehydrated within the thread. For rules which want to determine
+        # the type of a templater in their context, use
+        # `get_templater_class()` instead, which avoids instantiating
+        # a new templater instance.
         state["_configs"]["core"].pop("templater_obj", None)
         return state
 
@@ -298,20 +299,27 @@ class FluffConfig:
 
         return cls(overrides=overrides, require_dialect=require_dialect)
 
-    def get_templater(
-        self, templater_name: str = "jinja", **kwargs: Any
-    ) -> "RawTemplater":
-        """Fetch a templater by name."""
+    def get_templater_class(self) -> Type["RawTemplater"]:
+        """Get the configured templater class.
+
+        NOTE: This is mostly useful to call directly when rules want to determine
+        the *type* of a templater without (in particular to work out if it's a
+        derivative of the jinja templater), without needing to instantiate a
+        full templater. Instantiated templaters don't pickle well, so aren't
+        automatically passed around between threads/processes.
+        """
         templater_lookup: Dict[str, Type["RawTemplater"]] = {
             templater.name: templater
             for templater in chain.from_iterable(
                 self._plugin_manager.hook.get_templaters()
             )
         }
+        # Fetch the config value.
+        templater_name = self._configs["core"].get("templater", "<no value set>")
         try:
             cls = templater_lookup[templater_name]
             # Instantiate here, optionally with kwargs
-            return cls(**kwargs)
+            return cls
         except KeyError:
             if templater_name == "dbt":  # pragma: no cover
                 config_logger.warning(
@@ -323,6 +331,10 @@ class FluffConfig:
                 "Requested templater {!r} which is not currently available. Try one of "
                 "{}".format(templater_name, ", ".join(templater_lookup.keys()))
             )
+
+    def get_templater(self, **kwargs: Any) -> "RawTemplater":
+        """Instantiate the configured templater."""
+        return self.get_templater_class()(**kwargs)
 
     def make_child_from_path(self, path: str) -> FluffConfig:
         """Make a child config at a path but pass on overrides and extra_config_path."""

--- a/src/sqlfluff/core/config/fluffconfig.py
+++ b/src/sqlfluff/core/config/fluffconfig.py
@@ -318,7 +318,8 @@ class FluffConfig:
         templater_name = self._configs["core"].get("templater", "<no value set>")
         try:
             cls = templater_lookup[templater_name]
-            # Instantiate here, optionally with kwargs
+            # Return class. Do not instantiate yet. That happens in `get_templater()`
+            # for situations which require it.
             return cls
         except KeyError:
             if templater_name == "dbt":  # pragma: no cover

--- a/src/sqlfluff/rules/jinja/JJ01.py
+++ b/src/sqlfluff/rules/jinja/JJ01.py
@@ -127,9 +127,12 @@ class Rule_JJ01(BaseRule):
 
         # We also only work with setups which use the jinja templater
         # or a derivative of that. Otherwise return empty.
-        _templater = context.config.get("templater_obj")
-        if not isinstance(_templater, JinjaTemplater):
-            self.logger.debug(f"Detected non-jinja templater: {_templater}")
+        # NOTE: The `templater_obj` is not available in parallel operations
+        # and we don't really want to rehydrate a templater just to check
+        # what type it is, so use `get_templater_class()`.
+        _templater_class = context.config.get_templater_class()
+        if not issubclass(_templater_class, JinjaTemplater):
+            self.logger.debug(f"Detected non-jinja templater: {_templater_class.name}")
             return []
 
         results = []

--- a/test/core/config/fluffconfig_test.py
+++ b/test/core/config/fluffconfig_test.py
@@ -85,17 +85,27 @@ def test__config__nested_config_tests():
             assert "LT02" not in [c[0] for c in violations[k]]
 
 
-def test__config__templater_selection():
+@pytest.mark.parametrize(
+    "templater_name,templater_class,raises_error",
+    [
+        ("raw", RawTemplater, False),
+        ("jinja", JinjaTemplater, False),
+        ("python", PythonTemplater, False),
+        ("placeholder", PlaceholderTemplater, False),
+        ("afefhlsakufe", None, True),
+        ("", None, True),
+        (None, None, True),
+    ],
+)
+def test__config__templater_selection(templater_name, templater_class, raises_error):
     """Test template selection by name."""
-    cfg = FluffConfig(overrides={"dialect": "ansi"})
-    assert cfg.get_templater().__class__ is JinjaTemplater
-    assert cfg.get_templater("raw").__class__ is RawTemplater
-    assert cfg.get_templater("python").__class__ is PythonTemplater
-    assert cfg.get_templater("jinja").__class__ is JinjaTemplater
-    assert cfg.get_templater("placeholder").__class__ is PlaceholderTemplater
-
-    with pytest.raises(ValueError):
-        cfg.get_templater("afefhlsakufe")
+    if raises_error:
+        with pytest.raises(SQLFluffUserError):
+            FluffConfig(overrides={"dialect": "ansi", "templater": templater_name})
+    else:
+        cfg = FluffConfig(overrides={"dialect": "ansi", "templater": templater_name})
+        assert cfg.get_templater().__class__ is templater_class
+        assert cfg._configs["core"]["templater_obj"].__class__ is templater_class
 
 
 def test__config__glob_exclude_config_tests():


### PR DESCRIPTION
I noticed a _really wierd bug_ with JJ01. It basically doesn't work in parallel mode at the moment.

On debugging, the cause seems to be that when it checks for the presence of a jinja templater (or subclass), and it's using `context.config.get("templater_obj")` which intentionally isn't rehydrated when the `FluffConfig` object is pickled/unpickled. Instantiating a new templater object seems overkill, but we do still need a way of checking the class.

This PR allows a new method `get_templater_class()` which rules can use to find out if they're in a jinja-like environment. That one does work in parallel mode.

In doing that, I've changed the type signature of the original `get_templater()` method to use the config value rather than the argument. I think it's cleaner and safer.