### PR TITLE
Bugfix for LT07 with consumed newlines.

### DIFF
--- a/test/fixtures/rules/std_rule_cases/LT07.yml
+++ b/test/fixtures/rules/std_rule_cases/LT07.yml
@@ -7,6 +7,38 @@ test_pass_with_clause_closing_aligned:
         select 1
     ) select * from cte
 
+test_pass_with_clause_closing_aligned_whitespace_consumption_a:
+  pass_str: |
+    with cte as (
+        select 1
+        {{- ' from i_consume_whitespace ' -}}
+    ) select * from cte
+
+test_pass_with_clause_closing_aligned_whitespace_consumption_b:
+  pass_str: |
+    with cte as (
+        select 1
+        {#- I'm a comment which consumes whitespace -#}
+    ) select * from cte
+
+test_pass_with_clause_closing_aligned_whitespace_consumption_c:
+  pass_str: |
+    with cte as (
+        select 1
+        {%- if False -%}{%- endif -%}
+    ) select * from cte
+
+test_fix_with_clause_closing_aligned_whitespace_consumption_d:
+  fail_str: |
+    with cte as (
+        select 1
+        {%- if False -%}{%- endif -%}) select * from cte
+  fix_str: |
+    with cte as (
+        select 1
+        {%- if False -%}{%- endif -%}
+    ) select * from cte
+
 test_pass_with_clause_closing_oneline:
   # with statement oneline
   pass_str: with cte as (select 1) select * from cte


### PR DESCRIPTION
I noticed that LT07 is throwing false positives if a CTE ends with a whitespace-consuming jinja tag. this adds logic to handle that situation and react accordingly.