### PR TITLE
Dededuplicate rule ignore docs

### DIFF
--- a/docs/source/configuration/ignoring_configuration.rst
+++ b/docs/source/configuration/ignoring_configuration.rst
@@ -3,6 +3,8 @@
 Ignoring Errors & Files
 -----------------------
 
+.. _inline_ignoring_errors:
+
 Ignoring individual lines
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -21,7 +23,14 @@ be ignored by quoting their code or the category.
     -- Ignore all parsing errors
     SeLeCt from tBl ;       -- noqa: PRS
 
+.. note::
+   It should be noted that ignoring ``TMP`` and ``PRS`` errors can lead to
+   incorrect ``sqlfluff lint`` and ``sqfluff fix`` results as `SQLFluff` can
+   misinterpret the SQL being analysed.
+
 .. _`flake8's ignore`: https://flake8.pycqa.org/en/3.1.1/user/ignoring-errors.html#in-line-ignoring-errors
+
+.. _inline_ignoring_ranges:
 
 Ignoring line ranges
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/configuration/rule_configuration.rst
+++ b/docs/source/configuration/rule_configuration.rst
@@ -127,7 +127,8 @@ disabled by default. The rules that support this can be found in the
 
 The default values can be seen in :ref:`defaultconfig`.
 
-See also: :ref:`ignoreconfig`.
+See :ref:`ignoreconfig` for more information on how to turn ignore particular
+rules for specific lines, sections or files.
 
 Downgrading rules to warnings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/reference/rules.rst
+++ b/docs/source/reference/rules.rst
@@ -3,12 +3,16 @@
 Rules Reference
 ===============
 
-`Rules` in `SQLFluff` are implemented as `crawlers`. These are entities
-which work their way through the parsed structure of a query to evaluate
-a particular rule or set of rules. The intent is that the definition of
-each specific rule should be really streamlined and only contain the logic
-for the rule itself, with all the other mechanics abstracted away. To
-understand how rules are enabled and disabled see :ref:`ruleselection`.
+This page is an index of available rules which are bundled with SQLFluff.
+
+* For information on how to configure which rules are enabled for your
+  project see :ref:`ruleselection`.
+
+* If you just want to turn rules on or off for specific files, or specific
+  sections of files, see :ref:`ignoreconfig`.
+
+* For more information on how to configure the rules which you do enable
+  see :ref:`ruleconfig`.
 
 Core Rules
 ----------
@@ -33,67 +37,6 @@ and customize a rule set that best suites their organization.
 
 See the :ref:`config` section for more information on how to enable
 only :code:`core` rules by default.
-
-Inline Ignoring Errors
------------------------
-
-`SQLFluff` features inline error ignoring. For example, the following will
-ignore the lack of whitespace surrounding the ``*`` operator.
-
-.. code-block:: sql
-
-   a.a*a.b AS bad_1  -- noqa: LT01
-
-Multiple rules can be ignored by placing them in a comma-delimited list.
-
-.. code-block:: sql
-
-   a.a *  a.b AS bad_2,  -- noqa: LT01, LT03
-
-It is also possible to ignore non-rule based errors, and instead opt to
-ignore templating (``TMP``) & parsing (``PRS``) errors.
-
-.. code-block:: sql
-
-   WHERE
-     col1 = 2 AND
-     dt >= DATE_ADD(CURRENT_DATE(), INTERVAL -2 DAY) -- noqa: PRS
-
-.. note::
-   It should be noted that ignoring ``TMP`` and ``PRS`` errors can lead to
-   incorrect ``sqlfluff lint`` and ``sqfluff fix`` results as `SQLFluff` can
-   misinterpret the SQL being analysed.
-
-Should the need arise, not specifying specific rules to ignore will ignore
-all rules on the given line.
-
-.. code-block:: sql
-
-   a.a*a.b AS bad_3  -- noqa
-
-.. _inline_ignoring_errors:
-
-Ignoring line ranges
-^^^^^^^^^^^^^^^^^^^^
-
-Similar to `pylint's "pylint" directive"`_, ranges of lines can be ignored by
-adding :code:`-- noqa:disable=<rule>[,...] | all` to the line. Following this
-directive, specified rules (or all rules, if "all" was specified) will be
-ignored until a corresponding `-- noqa:enable=<rule>[,...] | all` directive.
-
-.. code-block:: sql
-
-    -- Ignore rule AL02 from this line forward
-    SELECT col_a a FROM foo -- noqa: disable=AL02
-
-    -- Ignore all rules from this line forward
-    SELECT col_a a FROM foo -- noqa: disable=all
-
-    -- Enforce all rules from this line forward
-    SELECT col_a a FROM foo -- noqa: enable=all
-
-
-.. _`pylint's "pylint" directive"`: http://pylint.pycqa.org/en/latest/user_guide/message-control.html
 
 Rule Index
 ----------


### PR DESCRIPTION
Currently there are two, almost identical sections on how to ignore specific rules:
- https://docs.sqlfluff.com/en/stable/reference/rules.html#inline-ignoring-errors
- https://docs.sqlfluff.com/en/stable/configuration/ignoring_configuration.html#ignoring-errors-files

This is unhelpful and confusing, especially given the information in each is slightly different.

This PR sets the one in `configuration` as the main one, and then just links to that from the rules references section.