### PR TITLE
ST06 - Fix union of CTE/Subquery

### DIFF
--- a/src/sqlfluff/rules/structure/ST06.py
+++ b/src/sqlfluff/rules/structure/ST06.py
@@ -86,35 +86,16 @@ class Rule_ST06(BaseRule):
         ]  # type: ignore
 
         assert context.segment.is_type("select_clause")
-        # Ignore select clauses which belong to:
-        # - set expression, which is most commonly a union
-        # - insert_statement
-        # - create table statement
-        #
-        # In each of these contexts, the order of columns in a select should
-        # be preserved.
-        if len(context.parent_stack) >= 2 and context.parent_stack[-2].is_type(
-            "insert_statement", "set_expression"
-        ):
-            return None
-        if (
-            len(context.parent_stack) >= 3
-            and context.parent_stack[-3].is_type("insert_statement", "set_expression")
-            and context.parent_stack[-2].is_type("with_compound_statement")
-        ):
-            return None
-        if len(context.parent_stack) >= 3 and context.parent_stack[-3].is_type(
-            "create_table_statement", "merge_statement"
-        ):
-            return None
-        if (
-            len(context.parent_stack) >= 4
-            and context.parent_stack[-4].is_type(
-                "create_table_statement", "merge_statement"
-            )
-            and context.parent_stack[-2].is_type("with_compound_statement")
-        ):
-            return None
+
+        for seg in reversed(context.parent_stack):
+            if seg.is_type(
+                "insert_statement",
+                "set_expression",
+                "with_compound_statement",
+                "create_table_statement",
+                "merge_statement",
+            ):
+                return None
 
         select_clause_segment = context.segment
         select_target_elements = context.segment.get_children("select_clause_element")

--- a/test/fixtures/rules/std_rule_cases/ST06.yml
+++ b/test/fixtures/rules/std_rule_cases/ST06.yml
@@ -217,7 +217,7 @@ test_fail_no_fix_implicit_column_references:
     FROM table_name
     GROUP BY 1, 2
 
-test_pass_cte:
+test_pass_cte_used_in_set:
   pass_str: |
     WITH T1 AS (
       SELECT
@@ -234,8 +234,36 @@ test_pass_cte:
     UNION ALL
     SELECT * FROM T2;
 
-test_pass_subquery:
+test_pass_subquery_used_in_set:
   pass_str: |
     SELECT * FROM (SELECT 'a'::varchar AS A, 1::bigint AS B)
     UNION ALL
     SELECT * FROM (SELECT CASE WHEN COL > 1 THEN 'x' ELSE 'y' END AS A, COL AS B FROM T);
+
+test_fail_cte_used_in_select:
+  fail_str: |
+    WITH T1 AS (
+      SELECT
+        'a'::varchar AS A,
+        1::bigint AS B
+    ),
+    T2 AS (
+      SELECT
+        CASE WHEN COL > 1 THEN 'x' ELSE 'y' END AS A,
+        COL AS B
+      FROM T
+    )
+    SELECT * FROM T1 INNER JOIN T2 ON T1.A = T2A;
+  fix_str: |
+    WITH T1 AS (
+      SELECT
+        'a'::varchar AS A,
+        1::bigint AS B
+    ),
+    T2 AS (
+      SELECT
+        COL AS B,
+        CASE WHEN COL > 1 THEN 'x' ELSE 'y' END AS A
+      FROM T
+    )
+    SELECT * FROM T1 INNER JOIN T2 ON T1.A = T2A;

--- a/test/fixtures/rules/std_rule_cases/ST06.yml
+++ b/test/fixtures/rules/std_rule_cases/ST06.yml
@@ -240,6 +240,38 @@ test_pass_subquery_used_in_set:
     UNION ALL
     SELECT * FROM (SELECT CASE WHEN COL > 1 THEN 'x' ELSE 'y' END AS A, COL AS B FROM T);
 
+test_fail_cte_used_in_set:
+  fail_str: |
+    WITH T1 AS (
+      SELECT
+        'a'::varchar AS A,
+        1::bigint AS B
+    ),
+    T2 AS (
+      SELECT
+        CASE WHEN COL > 1 THEN 'x' ELSE 'y' END AS A,
+        COL AS B
+      FROM T
+    )
+    SELECT A, B FROM T1
+    UNION ALL
+    SELECT A, B FROM T2;
+  fix_str: |
+    WITH T1 AS (
+      SELECT
+        'a'::varchar AS A,
+        1::bigint AS B
+    ),
+    T2 AS (
+      SELECT
+        COL AS B,
+        CASE WHEN COL > 1 THEN 'x' ELSE 'y' END AS A
+      FROM T
+    )
+    SELECT A, B FROM T1
+    UNION ALL
+    SELECT A, B FROM T2;
+
 test_fail_cte_used_in_select:
   fail_str: |
     WITH T1 AS (
@@ -253,7 +285,7 @@ test_fail_cte_used_in_select:
         COL AS B
       FROM T
     )
-    SELECT * FROM T1 INNER JOIN T2 ON T1.A = T2A;
+    SELECT * FROM T1 INNER JOIN T2 ON T1.A = T2.A;
   fix_str: |
     WITH T1 AS (
       SELECT
@@ -266,4 +298,4 @@ test_fail_cte_used_in_select:
         CASE WHEN COL > 1 THEN 'x' ELSE 'y' END AS A
       FROM T
     )
-    SELECT * FROM T1 INNER JOIN T2 ON T1.A = T2A;
+    SELECT * FROM T1 INNER JOIN T2 ON T1.A = T2.A;

--- a/test/fixtures/rules/std_rule_cases/ST06.yml
+++ b/test/fixtures/rules/std_rule_cases/ST06.yml
@@ -216,3 +216,26 @@ test_fail_no_fix_implicit_column_references:
         b_field
     FROM table_name
     GROUP BY 1, 2
+
+test_pass_cte:
+  pass_str: |
+    WITH T1 AS (
+      SELECT
+        'a'::varchar AS A,
+        1::bigint AS B
+    ),
+    T2 AS (
+      SELECT
+        CASE WHEN COL > 1 THEN 'x' ELSE 'y' END AS A,
+        COL AS B
+      FROM T
+    )
+    SELECT * FROM T1
+    UNION ALL
+    SELECT * FROM T2;
+
+test_pass_subquery:
+  pass_str: |
+    SELECT * FROM (SELECT 'a'::varchar AS A, 1::bigint AS B)
+    UNION ALL
+    SELECT * FROM (SELECT CASE WHEN COL > 1 THEN 'x' ELSE 'y' END AS A, COL AS B FROM T);


### PR DESCRIPTION
Add failing test cases, no fix yet.


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #5956


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
