### PR TITLE
Postgres: Support walrus operator named arguments

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -380,21 +380,6 @@ class ColumnsExpressionFunctionContentsSegment(
     )
 
 
-class NamedArgumentSegment(postgres.NamedArgumentSegment):
-    """Named argument to a function.
-
-    Some functions may use a `walrus operator`.
-    e.g. https://duckdb.org/docs/sql/functions/struct#struct_packname--any-
-    """
-
-    type = "named_argument"
-    match_grammar = Sequence(
-        Ref("NakedIdentifierSegment"),
-        OneOf(Ref("RightArrowSegment"), Ref("WalrusOperatorSegment")),
-        Ref("ExpressionSegment"),
-    )
-
-
 class LambdaExpressionSegment(BaseSegment):
     """Lambda function used in a function or columns expression.
 

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -6047,7 +6047,7 @@ class NamedArgumentSegment(BaseSegment):
     type = "named_argument"
     match_grammar = Sequence(
         Ref("NakedIdentifierSegment"),
-        Ref("RightArrowSegment"),
+        OneOf(Ref("RightArrowSegment"), Ref("WalrusOperatorSegment")),
         Ref("ExpressionSegment"),
     )
 

--- a/test/fixtures/dialects/postgres/table_functions.yml
+++ b/test/fixtures/dialects/postgres/table_functions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ff47a1913e0a5d7ef2272660de07f3c6e23aebf80fb751f498cc3a44457e2780
+_hash: 44e5601cc593b38c3a1d0743827b4ea56cae885023b0c0767d1e4cd33b2bf217
 file:
 - statement:
     select_statement:
@@ -179,15 +179,14 @@ file:
               function_name_identifier: make_interval
             function_contents:
               bracketed:
-              - start_bracket: (
-              - expression:
-                  column_reference:
-                    naked_identifier: mins
-              - expression:
+                start_bracket: (
+                named_argument:
+                  naked_identifier: mins
                   assignment_operator: :=
-                  column_reference:
-                    naked_identifier: activity_dur_mnt
-              - end_bracket: )
+                  expression:
+                    column_reference:
+                      naked_identifier: activity_dur_mnt
+                end_bracket: )
         - keyword: BETWEEN
         - cast_expression:
             quoted_literal: "'2024-01-07T00:00:00'"

--- a/test/fixtures/rules/std_rule_cases/RF03.yml
+++ b/test/fixtures/rules/std_rule_cases/RF03.yml
@@ -499,3 +499,11 @@ test_fail_cte_unqualified_to_qualified_6014:
     rules:
       references.consistent:
         single_table_references: qualified
+
+test_pass_postgres_named_arguments:
+  pass_str: |
+    select t1.b
+    from __test__(a := 1) t1;
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds support for walrus named arguments in a postgres function. As duckdb now matches postgres' named arguments, this has been dropped.
- fixes #6290

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
