### PR TITLE
TSQL: handle nested joins, RF01 better aliasing

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1562,6 +1562,7 @@ class FromExpressionElementSegment(BaseSegment):
     _base_from_expression_element = Sequence(
         Ref("PreTableFunctionKeywordsGrammar", optional=True),
         OptionallyBracketed(Ref("TableExpressionSegment")),
+        Ref("TemporalQuerySegment", optional=True),
         Ref(
             "AliasExpressionSegment",
             exclude=OneOf(
@@ -1618,6 +1619,10 @@ class FromExpressionElementSegment(BaseSegment):
 
         # Handle any aliases
         alias_expression = self.get_child("alias_expression")
+        if not alias_expression:  # pragma: no cover
+            _bracketed = self.get_child("bracketed")
+            if _bracketed:
+                alias_expression = _bracketed.get_child("alias_expression")
         if alias_expression:
             # If it has an alias, return that
             segment = alias_expression.get_child("identifier")
@@ -4357,6 +4362,17 @@ class SamplingExpressionSegment(BaseSegment):
             optional=True,
         ),
     )
+
+
+class TemporalQuerySegment(BaseSegment):
+    """A segment that allows Temporal Queries to be run.
+
+    https://learn.microsoft.com/en-us/sql/relational-databases/tables/temporal-tables
+    """
+
+    type = "temporal_query"
+
+    match_grammar: Matchable = Nothing()
 
 
 class LocalAliasSegment(BaseSegment):

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -4171,29 +4171,6 @@ class FromClauseSegment(ansi.FromClauseSegment):
     )
 
 
-class FromExpressionElementSegment(ansi.FromExpressionElementSegment):
-    """FROM Expression Element Segment.
-
-    Overriding ANSI to add Temporal Query.
-    """
-
-    match_grammar = (
-        ansi.FromExpressionElementSegment._base_from_expression_element.copy(
-            insert=[
-                Ref("TemporalQuerySegment", optional=True),
-            ],
-            before=Ref(
-                "AliasExpressionSegment",
-                exclude=OneOf(
-                    Ref("SamplingExpressionSegment"),
-                    Ref("JoinLikeClauseGrammar"),
-                ),
-                optional=True,
-            ),
-        )
-    )
-
-
 class TableExpressionSegment(BaseSegment):
     """The main table expression e.g. within a FROM clause.
 
@@ -5596,7 +5573,7 @@ class SamplingExpressionSegment(ansi.SamplingExpressionSegment):
     )
 
 
-class TemporalQuerySegment(BaseSegment):
+class TemporalQuerySegment(ansi.TemporalQuerySegment):
     """A segment that allows Temporal Queries to be run.
 
     https://learn.microsoft.com/en-us/sql/relational-databases/tables/temporal-tables

--- a/test/fixtures/dialects/tsql/nested_joins.sql
+++ b/test/fixtures/dialects/tsql/nested_joins.sql
@@ -26,3 +26,11 @@ LEFT OUTER JOIN (
         ON I.Pcd = P.Iid
 ) ON BA.Iid = I.Bcd;
 GO
+
+SELECT
+    tst1.Name, tst2.OtherName
+FROM dbo.Test1 AS tst1
+    LEFT OUTER JOIN (dbo.Test2       AS tst2
+                          INNER JOIN dbo.FilterTable AS fltr1
+                              ON tst2.Id = fltr1.Id)
+        ON tst1.id = tst2.id;

--- a/test/fixtures/dialects/tsql/nested_joins.yml
+++ b/test/fixtures/dialects/tsql/nested_joins.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4a50c74940284dee3625bff8670f76ab21e7190c7110fe32c190f411e852c1a3
+_hash: b27020b480d914870f45713849ab63c9749457f35299ef6506cd2bfdf5ef78c6
 file:
 - batch:
     statement:
@@ -294,3 +294,86 @@ file:
           statement_terminator: ;
 - go_statement:
     keyword: GO
+- batch:
+    statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: tst1
+            - dot: .
+            - naked_identifier: Name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: tst2
+            - dot: .
+            - naked_identifier: OtherName
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: dbo
+                - dot: .
+                - naked_identifier: Test1
+              alias_expression:
+                keyword: AS
+                naked_identifier: tst1
+            join_clause:
+            - keyword: LEFT
+            - keyword: OUTER
+            - keyword: JOIN
+            - from_expression_element:
+                bracketed:
+                  start_bracket: (
+                  table_expression:
+                    table_reference:
+                    - naked_identifier: dbo
+                    - dot: .
+                    - naked_identifier: Test2
+                  alias_expression:
+                    keyword: AS
+                    naked_identifier: tst2
+                  join_clause:
+                  - keyword: INNER
+                  - keyword: JOIN
+                  - from_expression_element:
+                      table_expression:
+                        table_reference:
+                        - naked_identifier: dbo
+                        - dot: .
+                        - naked_identifier: FilterTable
+                      alias_expression:
+                        keyword: AS
+                        naked_identifier: fltr1
+                  - join_on_condition:
+                      keyword: 'ON'
+                      expression:
+                      - column_reference:
+                        - naked_identifier: tst2
+                        - dot: .
+                        - naked_identifier: Id
+                      - comparison_operator:
+                          raw_comparison_operator: '='
+                      - column_reference:
+                        - naked_identifier: fltr1
+                        - dot: .
+                        - naked_identifier: Id
+                  end_bracket: )
+            - join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - naked_identifier: tst1
+                  - dot: .
+                  - naked_identifier: id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: tst2
+                  - dot: .
+                  - naked_identifier: id
+          statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -305,3 +305,16 @@ test_pass_postgres_merge_with_alias:
   configs:
     core:
       dialect: tsql
+
+test_pass_tsql_nested_join_alias:
+  pass_str: |
+    SELECT
+        tst1.Name, tst2.OtherName
+    FROM dbo.Test1 AS tst1
+        LEFT OUTER JOIN (dbo.Test2       AS tst2
+                              INNER JOIN dbo.FilterTable AS fltr1
+                                  ON tst2.Id = fltr1.Id)
+            ON tst1.id = tst2.id
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds supported for bracketed nested joins in tsql.
Also fixes how aliases of bracketed `table_expression` detect aliases
- fixes #6137

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
