### PR TITLE
Add note on 3.0.x to main docs page.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,10 @@ Notable releases:
   :code:`sqlfluff format` and removal of support for dbt versions pre `1.1`.
   Note, that this release brings with it some breaking changes to rule coding
   and configuration, see :ref:`upgrading_2_0`.
+* **3.0.x**: :code:`sqlfluff fix` now defaults to *not* asking for confirmation
+  and the `--force` option was removed. Richer information returned by the
+  :code:`sqlfluff lint` command (although in a different structure to previous
+  versions). See :ref:`upgrading_3_0`.
 
 For more detail on other releases, see our :ref:`releasenotes`.
 

--- a/docs/source/reference/releasenotes.rst
+++ b/docs/source/reference/releasenotes.rst
@@ -10,6 +10,8 @@ of each individual release, see the detailed changelog_.
 
 .. _changelog: https://github.com/sqlfluff/sqlfluff/blob/main/CHANGELOG.md
 
+.. _upgrading_3_0:
+
 Upgrading to 3.x
 ----------------
 


### PR DESCRIPTION
I noticed there's a note about 1.0.x and 2.0.x on the index of the docs, but nothing on 3.0.x (the current major version). This adds a brief note for completeness.