### PR TITLE
Resolve an oscillation bug with LT02

### DIFF
--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/models/my_new_project/indent_loop_4.sql
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/models/my_new_project/indent_loop_4.sql
@@ -1,0 +1,8 @@
+-- This file tests the indentation of line 6, which isn't rendered on the last pass.
+select
+    a,
+    {%- for i in range(1, 3) -%}
+        1 as b_{{ i }}
+    {% if not loop.last %},{% endif %}
+    {% endfor %}
+from {{ source("jaffle_shop", "orders") }}

--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/models/my_new_project/indent_loop_8.sql
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/dbt_project/models/my_new_project/indent_loop_8.sql
@@ -1,0 +1,8 @@
+-- This file tests the indentation of line 6, which isn't rendered on the last pass.
+select
+    a,
+    {%- for i in range(1, 3) -%}
+        1 as b_{{ i }}
+        {% if not loop.last %},{% endif %}
+    {% endfor %}
+from {{ source("jaffle_shop", "orders") }}

--- a/plugins/sqlfluff-templater-dbt/test/rules_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/rules_test.py
@@ -20,7 +20,9 @@ from sqlfluff.utils.testing.rules import assert_rule_raises_violations_in_file
         ("LT12", "models/my_new_project/multiple_trailing_newline.sql", [(3, 1)]),
     ],
 )
-def test__rules__std_file_dbt(rule, path, violations, project_dir, dbt_fluff_config):  # noqa
+def test__rules__std_file_dbt(
+    rule, path, violations, project_dir, dbt_fluff_config
+):  # noqa
     """Test linter finds the given errors in (and only in) the right places (DBT)."""
     assert_rule_raises_violations_in_file(
         rule=rule,

--- a/plugins/sqlfluff-templater-dbt/test/rules_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/rules_test.py
@@ -20,9 +20,7 @@ from sqlfluff.utils.testing.rules import assert_rule_raises_violations_in_file
         ("LT12", "models/my_new_project/multiple_trailing_newline.sql", [(3, 1)]),
     ],
 )
-def test__rules__std_file_dbt(
-    rule, path, violations, project_dir, dbt_fluff_config
-):  # noqa
+def test__rules__std_file_dbt(rule, path, violations, project_dir, dbt_fluff_config):  # noqa
     """Test linter finds the given errors in (and only in) the right places (DBT)."""
     assert_rule_raises_violations_in_file(
         rule=rule,
@@ -74,3 +72,31 @@ def test__rules__order_by(project_dir, dbt_fluff_config):  # noqa
 
     violations = lnt.check_tuples()
     assert len(violations) == 0
+
+
+def test__rules__indent_oscillate(project_dir, dbt_fluff_config):  # noqa
+    """Verify that we don't get oscillations with LT02 and dbt."""
+    # This *should* be the wrong format
+    path_1 = "models/my_new_project/indent_loop_4.sql"
+    # This *should* be the correct format
+    path_2 = "models/my_new_project/indent_loop_8.sql"
+    # Get the content of the latter
+    with open(os.path.join(project_dir, path_2), "r") as f:
+        path_2_content = f.read()
+    linter = Linter(
+        config=FluffConfig(configs=dbt_fluff_config, overrides={"rules": "LT02"})
+    )
+    # Check the wrong one first (path_1)
+    linted_dir = linter.lint_path(os.path.join(project_dir, path_1), fix=True)
+    linted_file = linted_dir.files[0]
+    assert linted_file.check_tuples() == [("LT02", 6, 1)]
+    fixed_file_1, _ = linted_file.fix_string()
+    assert (
+        fixed_file_1 == path_2_content
+    ), "indent_loop_4.sql should match indent_loop_8.sql post fix"
+    # Check the correct one second, we shouldn't get any issues.
+    # NOTE: This also checks that the fixed version of the first one wouldn't
+    # change again.
+    linted_dir = linter.lint_path(os.path.join(project_dir, path_2), fix=True)
+    linted_file = linted_dir.files[0]
+    assert linted_file.check_tuples() == []  # Should find no issues.

--- a/src/sqlfluff/utils/reflow/elements.py
+++ b/src/sqlfluff/utils/reflow/elements.py
@@ -320,6 +320,17 @@ class ReflowPoint(ReflowElement):
             return consumed_whitespace.split("\n")[-1]
         return seg.raw if seg else ""
 
+    def get_indent_segment_vals(self, exclude_block_indents=False) -> List[int]:
+        """Iterate through any indent segments and extract their values."""
+        values = []
+        for seg in self.segments:
+            if seg.is_type("indent"):
+                indent_seg = cast(Indent, seg)
+                if exclude_block_indents and indent_seg.block_uuid:
+                    continue
+                values.append(indent_seg.indent_val)
+        return values
+
     @staticmethod
     def _generate_indent_stats(
         segments: Sequence[RawSegment],

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -673,8 +673,8 @@ def _revise_skipped_source_lines(
     # Slice to avoid copying
     for idx, line in enumerate(lines[:]):
         # Find lines which _start_ with a placeholder
-        seg = next(line.iter_block_segments(elements))
-        if not seg.is_type("placeholder"):
+        seg = next(line.iter_block_segments(elements), None)
+        if not seg or not seg.is_type("placeholder"):
             continue
         template_seg = cast(TemplateSegment, seg)
         if template_seg.block_type != "block_start":

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -665,8 +665,11 @@ def _revise_skipped_source_lines(
     # Slice to avoid copying
     for idx, line in enumerate(lines[:]):
         # Find lines which _start_ with a placeholder
-        seg = next(line.iter_block_segments(elements), None)
-        if not seg or not seg.is_type("placeholder"):
+        try:
+            seg = next(line.iter_block_segments(elements))
+        except StopIteration:
+            continue
+        if not seg.is_type("placeholder"):
             continue
         template_seg = cast(TemplateSegment, seg)
         if template_seg.block_type != "block_start":

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -485,7 +485,8 @@ def _revise_templated_lines(
                 if last_group_line:
                     _inner_lines = list(range(last_group_line + 1, idx))
                     reflow_logger.debug(
-                        "      Extending Intermediates with %s", _inner_lines
+                        "      Extending Intermediates with rendered indices %s",
+                        _inner_lines,
                     )
                     inner_lines.extend(_inner_lines)
                 # if we have a temp balance - crystallise it
@@ -523,18 +524,38 @@ def _revise_templated_lines(
                         # NOTE: We set it temporarily here, because if we're going
                         # to pass an outer template loop then we should discard it.
                         # i.e. only count intervals within inner loops.
-                        _this_through = net_balance + ip.indent_trough
-                        temp_balance_trough = (
-                            _this_through
-                            if temp_balance_trough is None
-                            else min(temp_balance_trough, _this_through)
-                        )
-                        reflow_logger.debug(
-                            "      Stash Trough: %s (min = %s) @ %s",
-                            _this_through,
-                            temp_balance_trough,
-                            idx,
-                        )
+
+                        # We also abort if there's nothing rendered after it
+                        # (i.e. the only thing between us and a group line is
+                        # unrendered).
+                        _stash = True
+                        if idx + 1 in group_lines:
+                            for elem in elements[
+                                ip.idx + 1 : lines[idx].indent_points[-1].idx
+                            ]:
+                                if all(
+                                    seg.is_type("placeholder") for seg in elem.segments
+                                ):
+                                    continue
+                            else:
+                                reflow_logger.debug(
+                                    "This is really a trailing point. Don't stash."
+                                )
+                                _stash = False
+
+                        if _stash:
+                            _this_through = net_balance + ip.indent_trough
+                            temp_balance_trough = (
+                                _this_through
+                                if temp_balance_trough is None
+                                else min(temp_balance_trough, _this_through)
+                            )
+                            reflow_logger.debug(
+                                "      Stash Trough: %s (min = %s) @ %s",
+                                _this_through,
+                                temp_balance_trough,
+                                idx,
+                            )
                     # NOTE: We update net_balance _after_ the clause above.
                     net_balance += ip.indent_impulse
 

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -204,7 +204,7 @@ class _IndentLine:
         )
 
         reflow_logger.debug(
-            "Desired Indent Calculation: IB: %s, RUI: %s, UIL: %s, "
+            "    Desired Indent Calculation: IB: %s, RUI: %s, UIL: %s, "
             "iII: %s, iIT: %s. = %s",
             self.initial_indent_balance,
             relevant_untaken_indents,
@@ -1138,11 +1138,15 @@ def _lint_line_starting_indent(
                 reflow_logger.debug("    Indent is bigger than required. OK.")
                 return []
 
+    # NOTE: If the reindent code is flagging an indent change here that you
+    # don't agree with for a line with templated elements, especially in a
+    # loop, it's very likely that the fix shouldn't be here but much earlier
+    # in the code as part of `_revise_templated_lines()`.
     reflow_logger.debug(
-        "    Correcting indent @ line %s. Existing indent: %r -> %r",
+        "    Correcting indent @ line %s. Expected: %r. Found %r",
         elements[initial_point_idx + 1].segments[0].pos_marker.working_line_no,
-        current_indent,
         desired_starting_indent,
+        current_indent,
     )
 
     # Initial point gets special handling if it has no newlines.
@@ -1427,7 +1431,10 @@ def _lint_line_buffer_indents(
     allow generation of LintResult objects directly from them.
     """
     reflow_logger.info(
-        "    Line #%s [source line #%s]. idx=%s:%s. FI %s. UPI: %s.",
+        # NOTE: We add a little extra ## here because it's effectively
+        # the start of linting a single line and so the point to start
+        # interpreting the any debug logging from.
+        "## Evaluate Rendered Line #%s [source line #%s]. idx=%s:%s.",
         elements[indent_line.indent_points[0].idx + 1]
         .segments[0]
         .pos_marker.working_line_no,
@@ -1436,11 +1443,9 @@ def _lint_line_buffer_indents(
         .pos_marker.source_position()[0],
         indent_line.indent_points[0].idx,
         indent_line.indent_points[-1].idx,
-        forced_indents,
-        imbalanced_indent_locs,
     )
     reflow_logger.debug(
-        "   Line Content: %s",
+        "  Line Content: %s",
         [
             repr(elem.raw)
             for elem in elements[
@@ -1448,7 +1453,9 @@ def _lint_line_buffer_indents(
             ]
         ],
     )
-    reflow_logger.debug("  Evaluate Line: %s. FI %s", indent_line, forced_indents)
+    reflow_logger.debug("  Indent Line: %s", indent_line)
+    reflow_logger.debug("  Forced Indents: %s", forced_indents)
+    reflow_logger.debug("  Imbalanced Indent Locs: %s", imbalanced_indent_locs)
     results = []
 
     # First, handle starting indent.

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -524,31 +524,23 @@ def _revise_templated_lines(
                         # We also abort if there's nothing rendered after it
                         # (i.e. the only thing between us and a group line is
                         # unrendered).
-                        _stash = True
-                        if idx + 1 in group_lines:
+                        if idx + 1 not in group_lines or all(
+                            seg.is_type("placeholder")
                             for elem in elements[
                                 ip.idx + 1 : lines[idx].indent_points[-1].idx
-                            ]:
-                                if all(
-                                    seg.is_type("placeholder") for seg in elem.segments
-                                ):
-                                    continue
-                            else:
-                                reflow_logger.debug(
-                                    "This is really a trailing point. Don't stash."
-                                )
-                                _stash = False
-
-                        if _stash:
-                            _this_through = net_balance + ip.indent_trough
+                            ]
+                            for seg in elem.segments
+                        ):
+                            # Update the balance trough if stashing is ok
+                            _this_trough = net_balance + ip.indent_trough
                             temp_balance_trough = (
-                                _this_through
-                                if temp_balance_trough is None
-                                else min(temp_balance_trough, _this_through)
+                                min(temp_balance_trough, _this_trough)
+                                if temp_balance_trough
+                                else _this_trough
                             )
                             reflow_logger.debug(
                                 "      Stash Trough: %s (min = %s) @ %s",
-                                _this_through,
+                                _this_trough,
                                 temp_balance_trough,
                                 idx,
                             )

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -686,9 +686,9 @@ def _revise_comment_lines(
                     "  Comment Only Line: %s. Anchoring to %s", comment_line_idx, idx
                 )
                 # Mutate reference lines to match this one.
-                lines[
-                    comment_line_idx
-                ].initial_indent_balance = line.initial_indent_balance
+                lines[comment_line_idx].initial_indent_balance = (
+                    line.initial_indent_balance
+                )
             # Reset the buffer
             comment_line_buffer = []
 

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -148,11 +148,6 @@ class _IndentLine:
             if isinstance(element, ReflowBlock):
                 yield element
 
-    def iter_points(self, elements: ReflowSequenceType) -> Iterator[ReflowPoint]:
-        for element in self.iter_elements(elements):
-            if isinstance(element, ReflowPoint):
-                yield element
-
     def iter_block_segments(self, elements: ReflowSequenceType) -> Iterator[RawSegment]:
         for block in self.iter_blocks(elements):
             yield from block.segments

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -715,9 +715,9 @@ def _revise_comment_lines(
                     "  Comment Only Line: %s. Anchoring to %s", comment_line_idx, idx
                 )
                 # Mutate reference lines to match this one.
-                lines[
-                    comment_line_idx
-                ].initial_indent_balance = line.initial_indent_balance
+                lines[comment_line_idx].initial_indent_balance = (
+                    line.initial_indent_balance
+                )
             # Reset the buffer
             comment_line_buffer = []
 

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -391,26 +391,13 @@ def _revise_templated_lines(
                 # Indents can usually be shuffled a bit around unrendered
                 # elements.
                 # NOTE: We're starting with the current line.
-                _block_depth = 0
                 _forward_indent_balance = line.initial_indent_balance
                 for check_line in lines[idx:]:
                     _forward_indent_balance = check_line.initial_indent_balance
-                    _break_1 = False
-                    for blk in check_line.iter_blocks(elements):
-                        _break_2 = False
-                        for _seg in blk.segments:
-                            if not _seg.is_type("placeholder"):
-                                _break_2 = True
-                                break
-                            _block_type = cast(TemplateSegment, _seg).block_type
-                            if _block_type == "block_start":
-                                _block_depth += 1
-                            elif _block_type == "block_end":
-                                _block_depth -= 1
-                        if _break_2:
-                            _break_1 = True
-                            break
-                    if _break_1:
+                    if not all(
+                        _seg.is_type("placeholder")
+                        for _seg in check_line._iter_block_segments(elements)
+                    ):
                         break
 
                 if _forward_indent_balance > line.initial_indent_balance:

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2298,24 +2298,3 @@ test_pass_loop_indent_4:
             {%- endif -%}
         {% endfor %}
     from foo
-
-test_pass_loop_indent_5:
-  pass_str: |
-    select
-        {% for i in range(1, 3) %}
-            {% if not loop.first %},{% endif %}
-            1
-        {% endfor %}
-    from foo
-
-test_pass_loop_indent_6:
-  pass_str: |
-    select
-        {% for i in range(1, 3) %}
-            {% if not loop.first %},{% endif %}
-            {% for j in range(1, 3) %}
-                {% if not loop.first %},{% endif %}
-                1
-            {% endfor %}
-        {% endfor %}
-    from foo

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2269,14 +2269,6 @@ test_pass_loop_indent_1:
         {% endfor %}
     from foo
 
-test_pass_loop_indent_2:
-  pass_str: |
-    select
-        {% for i in range(1, 3) %}
-            1 {% if not loop.last %},{% endif %}
-        {% endfor %}
-    from foo
-
 test_pass_loop_indent_3:
   pass_str: |
     select

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2267,11 +2267,14 @@ test_pass_loop_indent_1:
     from foo
 
 test_pass_loop_indent_2:
+  # NOTE: I think this test case is wrong, but it is at least passable
+  # and not a ridiculous outcome.
+  # TODO: This should be refined in the logic.
   pass_str: |
     select
-        {% for i in range(1, 3) %}
-            1 {% if not loop.last %},{% endif %}
-        {% endfor %}
+    {% for i in range(1, 3) %}
+        1 {% if not loop.last %},{% endif %}
+    {% endfor %}
     from foo
 
 test_pass_loop_indent_3:

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2298,3 +2298,13 @@ test_pass_loop_indent_4:
             {%- endif -%}
         {% endfor %}
     from foo
+
+test_pass_loop_indent_5:
+  # I DEFINITELY DON'T LIKE THIS
+  pass_str: |
+    select
+    {% for i in range(1, 3) %}
+            {% if not loop.first %},{% endif %}
+            1
+    {% endfor %}
+    from foo

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2304,6 +2304,15 @@ test_pass_loop_indent_5:
     select
         {% for i in range(1, 3) %}
             {% if not loop.first %},{% endif %}
+            1
+        {% endfor %}
+    from foo
+
+test_pass_loop_indent_6:
+  pass_str: |
+    select
+        {% for i in range(1, 3) %}
+            {% if not loop.first %},{% endif %}
             {% for j in range(1, 3) %}
                 {% if not loop.first %},{% endif %}
                 1

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2267,14 +2267,11 @@ test_pass_loop_indent_1:
     from foo
 
 test_pass_loop_indent_2:
-  # NOTE: I think this test case is wrong, but it is at least passable
-  # and not a ridiculous outcome.
-  # TODO: This should be refined in the logic.
   pass_str: |
     select
-    {% for i in range(1, 3) %}
-        1 {% if not loop.last %},{% endif %}
-    {% endfor %}
+        {% for i in range(1, 3) %}
+            1 {% if not loop.last %},{% endif %}
+        {% endfor %}
     from foo
 
 test_pass_loop_indent_3:
@@ -2300,11 +2297,10 @@ test_pass_loop_indent_4:
     from foo
 
 test_pass_loop_indent_5:
-  # I DEFINITELY DON'T LIKE THIS
   pass_str: |
     select
-    {% for i in range(1, 3) %}
+        {% for i in range(1, 3) %}
             {% if not loop.first %},{% endif %}
             1
-    {% endfor %}
+        {% endfor %}
     from foo

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2243,6 +2243,20 @@ test_inconsistent_indent:
     )
     SELECT * FROM x
 
+test_pass_loop_indent_0:
+  # NOTE: This biguqery test is designed to be a kind of base case
+  # for the next few cases. Bigquery allows a trailing comma in a
+  # select so is a good candidate for this.
+  pass_str: |
+    select
+        {% for i in range(1, 3) %}
+            1,
+        {% endfor %}
+    from foo
+  configs:
+    core:
+      dialect: bigquery  
+
 test_pass_loop_indent_1:
   pass_str: |
     select

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2242,3 +2242,20 @@ test_inconsistent_indent:
         FROM o
     )
     SELECT * FROM x
+
+test_pass_loop_indent_1:
+  pass_str: |
+    select
+        {% for i in range(1, 3) %}
+            1
+            {% if not loop.last %},{% endif %}
+        {% endfor %}
+    from foo
+
+test_pass_loop_indent_2:
+  pass_str: |
+    select
+        {% for i in range(1, 3) %}
+            1 {% if not loop.last %},{% endif %}
+        {% endfor %}
+    from foo

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2273,3 +2273,25 @@ test_pass_loop_indent_2:
             1 {% if not loop.last %},{% endif %}
         {% endfor %}
     from foo
+
+test_pass_loop_indent_3:
+  pass_str: |
+    select
+        {% for i in range(1, 3) %}
+            1
+            {% if not loop.last %}
+                ,
+            {% endif %}
+        {% endfor %}
+    from foo
+
+test_pass_loop_indent_4:
+  pass_str: |
+    select
+        {% for i in range(1, 3) %}
+            1
+            {%- if not loop.last -%}
+                ,
+            {%- endif -%}
+        {% endfor %}
+    from foo

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2261,7 +2261,10 @@ test_pass_loop_indent_1:
   pass_str: |
     select
         {% for i in range(1, 3) %}
-            1
+            {% for j in range(1, 3) %}
+                1
+                {% if not loop.last %},{% endif %}
+            {% endfor %}
             {% if not loop.last %},{% endif %}
         {% endfor %}
     from foo
@@ -2301,6 +2304,9 @@ test_pass_loop_indent_5:
     select
         {% for i in range(1, 3) %}
             {% if not loop.first %},{% endif %}
-            1
+            {% for j in range(1, 3) %}
+                {% if not loop.first %},{% endif %}
+                1
+            {% endfor %}
         {% endfor %}
     from foo

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2255,7 +2255,7 @@ test_pass_loop_indent_0:
     from foo
   configs:
     core:
-      dialect: bigquery  
+      dialect: bigquery
 
 test_pass_loop_indent_1:
   pass_str: |


### PR DESCRIPTION
I originally found this bug while working with the `dbt` templater and a query which reduces to this:

```jinja
select
    {% for i in range(1, 3) %}
        1
        {% if not loop.last %},{% endif %}
    {% endfor %}
from foo
```

The `{% if not loop.last %},{% endif %}` would get shuffled between 4 and 8 indents on successive linting runs. The issue was that it was actually getting linted twice, twice when it was rendered in the middle of the loop and once at the end. The latter case was distorted around the indent tokens because it didn't contain any rendered code and was being treated as whitespace.

I found a few other bugs with the indentation logic here too, but this PR was getting too big with all of them (and I haven't managed to solve all of them yet). So I'm putting this one up in it's current state.


