### PR TITLE
Allow expressions in ORDER BY for clickhouse

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -351,7 +351,12 @@ class MergeTreesOrderByClauseSegment(BaseSegment):
                 "TUPLE",
                 Bracketed(),  # tuple() not tuple
             ),
-            Ref("BracketedColumnReferenceListGrammar"),
+            Bracketed(
+                Delimited(
+                    Ref("ColumnReferenceSegment"),
+                    Ref("ExpressionSegment"),
+                ),
+            ),
             Ref("ColumnReferenceSegment"),
         ),
     )

--- a/test/fixtures/dialects/clickhouse/order_by_expression.sql
+++ b/test/fixtures/dialects/clickhouse/order_by_expression.sql
@@ -1,0 +1,10 @@
+CREATE TABLE foodb.events ON CLUSTER '{cluster}' (
+        timestamp DateTime,
+        mt_id UInt32,
+        event VARCHAR,
+        uuid UUID,
+        value Int32
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/{cluster}/databases/{database}/all/tables/{table}', '{replica}')
+ORDER BY (mt_id, toStartOfDay(timestamp), event, uuid)
+SETTINGS index_granularity = 8192;

--- a/test/fixtures/dialects/clickhouse/order_by_expression.yml
+++ b/test/fixtures/dialects/clickhouse/order_by_expression.yml
@@ -1,0 +1,95 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 63bd924b9380fd28d05fa31d2354a139ec77353b2edcdc2c130305ecadbe257d
+file:
+  statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: foodb
+      - dot: .
+      - naked_identifier: events
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - quoted_identifier: "'{cluster}'"
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: timestamp
+          data_type:
+            data_type_identifier: DateTime
+      - comma: ','
+      - column_definition:
+          naked_identifier: mt_id
+          data_type:
+            data_type_identifier: UInt32
+      - comma: ','
+      - column_definition:
+          naked_identifier: event
+          data_type:
+            data_type_identifier: VARCHAR
+      - comma: ','
+      - column_definition:
+          naked_identifier: uuid
+          data_type:
+            data_type_identifier: UUID
+      - comma: ','
+      - column_definition:
+          naked_identifier: value
+          data_type:
+            data_type_identifier: Int32
+      - end_bracket: )
+    - engine:
+        keyword: ENGINE
+        comparison_operator:
+          raw_comparison_operator: '='
+        table_engine_function:
+          function_name:
+            function_name_identifier: ReplicatedMergeTree
+          function_contents:
+            bracketed:
+            - start_bracket: (
+            - expression:
+                quoted_literal: "'/clickhouse/{cluster}/databases/{database}/all/tables/{table}'"
+            - comma: ','
+            - expression:
+                quoted_literal: "'{replica}'"
+            - end_bracket: )
+        merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: mt_id
+          - comma: ','
+          - expression:
+              function:
+                function_name:
+                  function_name_identifier: toStartOfDay
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      column_reference:
+                        naked_identifier: timestamp
+                    end_bracket: )
+          - comma: ','
+          - column_reference:
+              naked_identifier: event
+          - comma: ','
+          - column_reference:
+              naked_identifier: uuid
+          - end_bracket: )
+        settings_clause:
+          keyword: SETTINGS
+          naked_identifier: index_granularity
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '8192'
+  statement_terminator: ;


### PR DESCRIPTION
As raised on slack. This enabled expressions in the `ORDER BY` clause for clickhouse.