### PR TITLE
Allow double quotes to be escaped by writing twice

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -122,7 +122,7 @@ ansi_dialect.set_lexer_matchers(
         ),
         RegexLexer(
             "double_quote",
-            r'"([^"\\]|\\.)*"',
+            r'"(""|[^"\\]|\\.)*"',
             CodeSegment,
             segment_kwargs={
                 "quoted_value": (r'"((?:[^"\\]|\\.)*)"', 1),

--- a/test/fixtures/dialects/ansi/double_quote_escapes.sql
+++ b/test/fixtures/dialects/ansi/double_quote_escapes.sql
@@ -1,0 +1,10 @@
+select
+    1 as foo,
+    2 as "foo",
+    3 as """foo""",
+    4 as """""foo""""",
+    bar,
+    "bar",
+    """bar""",
+    """""bar"""""
+from """""a"""""."""""b"""""."""""c"""""

--- a/test/fixtures/dialects/ansi/double_quote_escapes.yml
+++ b/test/fixtures/dialects/ansi/double_quote_escapes.yml
@@ -1,0 +1,61 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: ae71a202bbe935777772d21fa220c7d04baf22912bf0d1a9335bc4ec9ac3f52c
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: select
+      - select_clause_element:
+          numeric_literal: '1'
+          alias_expression:
+            keyword: as
+            naked_identifier: foo
+      - comma: ','
+      - select_clause_element:
+          numeric_literal: '2'
+          alias_expression:
+            keyword: as
+            quoted_identifier: '"foo"'
+      - comma: ','
+      - select_clause_element:
+          numeric_literal: '3'
+          alias_expression:
+            keyword: as
+            quoted_identifier: '"""foo"""'
+      - comma: ','
+      - select_clause_element:
+          numeric_literal: '4'
+          alias_expression:
+            keyword: as
+            quoted_identifier: '"""""foo"""""'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: bar
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            quoted_identifier: '"bar"'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            quoted_identifier: '"""bar"""'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            quoted_identifier: '"""""bar"""""'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - quoted_identifier: '"""""a"""""'
+              - dot: .
+              - quoted_identifier: '"""""b"""""'
+              - dot: .
+              - quoted_identifier: '"""""c"""""'

--- a/test/fixtures/dialects/snowflake/double_quote_escapes.sql
+++ b/test/fixtures/dialects/snowflake/double_quote_escapes.sql
@@ -1,0 +1,10 @@
+select
+    1 as foo,
+    2 as "foo",
+    3 as """foo""",
+    4 as """""foo""""",
+    bar,
+    "bar",
+    """bar""",
+    """""bar"""""
+from """""a"""""."""""b"""""."""""c"""""

--- a/test/fixtures/dialects/snowflake/double_quote_escapes.yml
+++ b/test/fixtures/dialects/snowflake/double_quote_escapes.yml
@@ -1,0 +1,61 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: ae71a202bbe935777772d21fa220c7d04baf22912bf0d1a9335bc4ec9ac3f52c
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: select
+      - select_clause_element:
+          numeric_literal: '1'
+          alias_expression:
+            keyword: as
+            naked_identifier: foo
+      - comma: ','
+      - select_clause_element:
+          numeric_literal: '2'
+          alias_expression:
+            keyword: as
+            quoted_identifier: '"foo"'
+      - comma: ','
+      - select_clause_element:
+          numeric_literal: '3'
+          alias_expression:
+            keyword: as
+            quoted_identifier: '"""foo"""'
+      - comma: ','
+      - select_clause_element:
+          numeric_literal: '4'
+          alias_expression:
+            keyword: as
+            quoted_identifier: '"""""foo"""""'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: bar
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            quoted_identifier: '"bar"'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            quoted_identifier: '"""bar"""'
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            quoted_identifier: '"""""bar"""""'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - quoted_identifier: '"""""a"""""'
+              - dot: .
+              - quoted_identifier: '"""""b"""""'
+              - dot: .
+              - quoted_identifier: '"""""c"""""'


### PR DESCRIPTION
I found this issue on snowflake, but I checked the postgres docs, and I think it's fairly widespread, as such I'm adding it to the `ansi` dialect.

It turns out that this is valid SQL (don't ask how I found out 🫨 ):

```sql
select
    1 as foo,
    2 as "foo",
    3 as """foo""",
    4 as """""foo""""",
    bar,
    "bar",
    """bar""",
    """""bar"""""
from """""a"""""."""""b"""""."""""c"""""
```

This is because double quotes can be escaped by doubling them. I've confirmed this on snowflake live, and it's in the postgres docs:

> To include the escape character in the identifier literally, write it twice.

https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS