### PR TITLE
Snowflake allow double-quoted comments

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -244,7 +244,7 @@ snowflake_dialect.add(
         type="semi_structured_element",
     ),
     # Normally, double quotes can't be used for literals. But in a few
-    # cases they can (e.g. Tags).
+    # cases they can (e.g. Tags, Comments).
     DoubleQuotedLiteralSegment=TypedParser(
         "double_quote", LiteralSegment, type="quoted_literal"
     ),
@@ -2626,7 +2626,9 @@ class CommentEqualsClauseSegment(BaseSegment):
 
     type = "comment_equals_clause"
     match_grammar = Sequence(
-        "COMMENT", Ref("EqualsSegment"), Ref("QuotedLiteralSegment")
+        "COMMENT",
+        Ref("EqualsSegment"),
+        OneOf(Ref("QuotedLiteralSegment"), Ref("DoubleQuotedLiteralSegment")),
     )
 
 

--- a/test/fixtures/dialects/snowflake/create_schema.sql
+++ b/test/fixtures/dialects/snowflake/create_schema.sql
@@ -5,3 +5,5 @@ create schema mytestschema comment = 'My test schema.';
 create schema mytestschema tag (tag1 = 'foo', tag2 = 'bar');
 create schema mytestschema with managed access;
 create transient schema if not exists mytestschema default_ddl_collation = 'de_DE';
+CREATE SCHEMA MYDB.MYSCHEMA COMMENT = "Space for landing my data";
+CREATE SCHEMA IF NOT EXISTS MYDB.MYSCHEMA COMMENT = "Space for landing my data";

--- a/test/fixtures/dialects/snowflake/create_schema.yml
+++ b/test/fixtures/dialects/snowflake/create_schema.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 38085f5164101f2733456e16eefe8e735836e336b123116ba3f4ef4900b27dde
+_hash: 693e2baaeb5e33ed133910627941c4f129513d421c911e175422c580f1d9ab60
 file:
 - statement:
     create_clone_statement:
@@ -121,4 +121,37 @@ file:
         comparison_operator:
           raw_comparison_operator: '='
         quoted_literal: "'de_DE'"
+- statement_terminator: ;
+- statement:
+    create_schema_statement:
+    - keyword: CREATE
+    - keyword: SCHEMA
+    - schema_reference:
+      - naked_identifier: MYDB
+      - dot: .
+      - naked_identifier: MYSCHEMA
+    - schema_object_properties:
+        comment_equals_clause:
+          keyword: COMMENT
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: '"Space for landing my data"'
+- statement_terminator: ;
+- statement:
+    create_schema_statement:
+    - keyword: CREATE
+    - keyword: SCHEMA
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - schema_reference:
+      - naked_identifier: MYDB
+      - dot: .
+      - naked_identifier: MYSCHEMA
+    - schema_object_properties:
+        comment_equals_clause:
+          keyword: COMMENT
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: '"Space for landing my data"'
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Closes https://github.com/sqlfluff/sqlfluff/issues/6315
I ensured that `CREATE SCHEMA MYSCHEMA COMMENT = "Space for landing my data"` actually works in Snowflake.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
