### PR TITLE
Exclude templated casts from CV11

### DIFF
--- a/src/sqlfluff/rules/convention/CV11.py
+++ b/src/sqlfluff/rules/convention/CV11.py
@@ -205,6 +205,14 @@ class Rule_CV11(BaseRule):
         if context.dialect.name == "teradata":
             return None
 
+        # If we're in a templated section, don't consider the current location.
+        # (i.e. if a cast happens in a macro, the end user writing the current
+        # query may not know that or have control over it, so we should just
+        # skip it).
+        if context.segment.pos_marker:
+            if not context.segment.pos_marker.is_literal():
+                return None
+
         # Construct segment type casting
         if context.segment.is_type("function"):
             function_name = context.segment.get_child("function_name")
@@ -397,7 +405,6 @@ class Rule_CV11(BaseRule):
                         expression_datatype_segment[2:],
                     )
             elif self.preferred_type_casting_style == "shorthand":
-
                 bracketed = functional_context.segment.children(
                     sp.is_type("function_contents")
                 ).children(sp.is_type("bracketed"))

--- a/test/fixtures/rules/std_rule_cases/CV11.yml
+++ b/test/fixtures/rules/std_rule_cases/CV11.yml
@@ -382,3 +382,17 @@ test_fail_snowflake_semi_structured_cast_4453:
     rules:
       convention.casting_style:
         preferred_type_casting_style: cast
+
+test_pass_macro_cast:
+  # If a cast is in a templated section, it shouldn't
+  # mean the ones in the file are inconsistent.
+  pass_str: |
+    {% macro cast_macro(col) %}
+        CAST(col as int)
+    {% endmacro %}
+
+    select
+        a,
+        {{ cast_macro('b') }},
+        c::date as d
+    from tbl


### PR DESCRIPTION
I found this bug earlier today. Consider the following query (although it would be better to imagine that the macro is defined somewhere else in the codebase entirely):

```sql
{% macro cast_macro(col) %}
    CAST(col as int)
{% endmacro %}

select
    a,
    {{ cast_macro('b') }},
    c::date as d
from tbl
```

The casting style is definitely inconsistent (there's an explicit `CAST()` and there's also an implicit `::date` operation). However for the user writing the final query they may now know (or have control over) the macro they're calling (over `cast_macro`). As such I don't think it should be an error if `::date` is inconsistent with the casting inside the `cast_macro`. This PR excludes any templated sections from being considered for `CV11`.