### PR TITLE
Add support for `grant monitor on user ...` in Snowflake dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -2918,6 +2918,7 @@ class AccessStatementSegment(BaseSegment):
                 "INTEGRATION",
                 "SCHEMA",
                 "ROLE",
+                "USER",
                 Sequence("ALL", "SCHEMAS", "IN", "DATABASE"),
                 Sequence("FUTURE", "SCHEMAS", "IN", "DATABASE"),
                 _schema_object_types,

--- a/test/fixtures/dialects/snowflake/grant_revoke.sql
+++ b/test/fixtures/dialects/snowflake/grant_revoke.sql
@@ -90,6 +90,8 @@ grant import share on account to role my_role;
 grant manage grants on account to role my_role;
 grant monitor execution on account to role my_role;
 grant monitor usage on account to role my_role;
+grant monitor on user some_user to role my_role;
+revoke monitor on user some_user from role my_role;
 grant override share restrictions on account to role my_role;
 grant create account on account to role my_role;
 grant create share on account to role my_role;

--- a/test/fixtures/dialects/snowflake/grant_revoke.yml
+++ b/test/fixtures/dialects/snowflake/grant_revoke.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 60742b98d9081885cbf3076cd3802c9bac4507c6570fa9d6b285a77debb0e290
+_hash: 0690310e2a4a48fecf5d8d49f8582c255f4213bdee32884a53db83c73b2baa08
 file:
 - statement:
     access_statement:
@@ -1084,6 +1084,32 @@ file:
     - keyword: to
     - keyword: role
     - role_reference:
+        naked_identifier: my_role
+- statement_terminator: ;
+- statement:
+    access_statement:
+    - keyword: grant
+    - keyword: monitor
+    - keyword: 'on'
+    - keyword: user
+    - object_reference:
+        naked_identifier: some_user
+    - keyword: to
+    - keyword: role
+    - role_reference:
+        naked_identifier: my_role
+- statement_terminator: ;
+- statement:
+    access_statement:
+    - keyword: revoke
+    - keyword: monitor
+    - keyword: 'on'
+    - keyword: user
+    - object_reference:
+        naked_identifier: some_user
+    - keyword: from
+    - keyword: role
+    - object_reference:
         naked_identifier: my_role
 - statement_terminator: ;
 - statement:


### PR DESCRIPTION
### Brief summary of the change made
Added support for `grant monitor on user ...` in Snowflake dialect.

Fixes #6308.

### Are there any other side effects of this change that we should be aware of?
Not to my knowledge.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
