### PR TITLE
Postgres: Fix lexing some JSON operators

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -112,7 +112,7 @@ postgres_dialect.insert_lexer_matchers(
         ),
         RegexLexer(
             "json_operator",
-            r"->>|#>>|->|#>|@>|<@|\?\||\?|\?&|#-",
+            r"->>?|#>>?|@[>@?]|<@|\?[|&]?|#-",
             SymbolSegment,
         ),
         # r"|".join(

--- a/test/fixtures/dialects/postgres/json_operators.sql
+++ b/test/fixtures/dialects/postgres/json_operators.sql
@@ -15,3 +15,13 @@ SELECT '{"a":1,"b":2}'::json->>'b';
 SELECT '{"a": {"b":{"c": "foo"}}}'::json#>'{a,b}';
 -- Get JSON object at the specified path as text
 SELECT '{"a":[1,2,3],"b":[4,5,6]}'::json#>>'{a,2}';
+
+SELECT
+    '{"a":1, "b":2}'::jsonb @> '{"b":2}'::jsonb,
+    '{"b":2}'::jsonb <@ '{"a":1, "b":2}'::jsonb,
+    '{"a":1, "b":2}'::jsonb ? 'b',
+    '{"a":1, "b":2, "c":3}'::jsonb ?| array['b', 'd'],
+    '["a", "b", "c"]'::jsonb ?& array['a', 'b'],
+    '["a", {"b":1}]'::jsonb #- '{1,b}',
+    '{"a":[1,2,3,4,5]}'::jsonb @? '$.a[*] ? (@ > 2)',
+    '{"a":[1,2,3,4,5]}'::jsonb @@ '$.a[*] > 2';

--- a/test/fixtures/dialects/postgres/json_operators.yml
+++ b/test/fixtures/dialects/postgres/json_operators.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 523aa9b63c310f2a06987dffad7a60892a46e43c765efe10a96cb82ce3fd1bff
+_hash: 947fce13543180fe3b7fce322f22c12f2f6a180eaa92f5e0ad5a6b6db113d2a6
 file:
 - statement:
     select_statement:
@@ -129,4 +129,112 @@ file:
                 keyword: json
             binary_operator: '#>>'
             quoted_literal: "'{a,2}'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+          - cast_expression:
+              quoted_literal: "'{\"a\":1, \"b\":2}'"
+              casting_operator: '::'
+              data_type:
+                keyword: jsonb
+          - binary_operator: '@>'
+          - cast_expression:
+              quoted_literal: "'{\"b\":2}'"
+              casting_operator: '::'
+              data_type:
+                keyword: jsonb
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - cast_expression:
+              quoted_literal: "'{\"b\":2}'"
+              casting_operator: '::'
+              data_type:
+                keyword: jsonb
+          - binary_operator: <@
+          - cast_expression:
+              quoted_literal: "'{\"a\":1, \"b\":2}'"
+              casting_operator: '::'
+              data_type:
+                keyword: jsonb
+      - comma: ','
+      - select_clause_element:
+          expression:
+            cast_expression:
+              quoted_literal: "'{\"a\":1, \"b\":2}'"
+              casting_operator: '::'
+              data_type:
+                keyword: jsonb
+            binary_operator: '?'
+            quoted_literal: "'b'"
+      - comma: ','
+      - select_clause_element:
+          expression:
+            cast_expression:
+              quoted_literal: "'{\"a\":1, \"b\":2, \"c\":3}'"
+              casting_operator: '::'
+              data_type:
+                keyword: jsonb
+            binary_operator: ?|
+            typed_array_literal:
+              array_type:
+                keyword: array
+              array_literal:
+              - start_square_bracket: '['
+              - quoted_literal: "'b'"
+              - comma: ','
+              - quoted_literal: "'d'"
+              - end_square_bracket: ']'
+      - comma: ','
+      - select_clause_element:
+          expression:
+            cast_expression:
+              quoted_literal: "'[\"a\", \"b\", \"c\"]'"
+              casting_operator: '::'
+              data_type:
+                keyword: jsonb
+            binary_operator: ?&
+            typed_array_literal:
+              array_type:
+                keyword: array
+              array_literal:
+              - start_square_bracket: '['
+              - quoted_literal: "'a'"
+              - comma: ','
+              - quoted_literal: "'b'"
+              - end_square_bracket: ']'
+      - comma: ','
+      - select_clause_element:
+          expression:
+            cast_expression:
+              quoted_literal: "'[\"a\", {\"b\":1}]'"
+              casting_operator: '::'
+              data_type:
+                keyword: jsonb
+            binary_operator: '#-'
+            quoted_literal: "'{1,b}'"
+      - comma: ','
+      - select_clause_element:
+          expression:
+            cast_expression:
+              quoted_literal: "'{\"a\":[1,2,3,4,5]}'"
+              casting_operator: '::'
+              data_type:
+                keyword: jsonb
+            binary_operator: '@?'
+            quoted_literal: "'$.a[*] ? (@ > 2)'"
+      - comma: ','
+      - select_clause_element:
+          expression:
+            cast_expression:
+              quoted_literal: "'{\"a\":[1,2,3,4,5]}'"
+              casting_operator: '::'
+              data_type:
+                keyword: jsonb
+            binary_operator: '@@'
+            quoted_literal: "'$.a[*] > 2'"
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This fixes the ordering of lexing some of the JSON operators in the postgres dialect. This was preventing some operators from being lexed properly.
- fixes #6321

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
