### PR TITLE
Trino: Fix rule interactions with lambda functions

### DIFF
--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -69,6 +69,7 @@ trino_dialect.insert_lexer_matchers(
 
 trino_dialect.add(
     RightArrowOperator=StringParser("->", SymbolSegment, type="binary_operator"),
+    LambdaArrowSegment=StringParser("->", SymbolSegment, type="lambda_arrow"),
     StartAngleBracketSegment=StringParser(
         "<", SymbolSegment, type="start_angle_bracket"
     ),
@@ -233,6 +234,10 @@ trino_dialect.replace(
     # match ANSI's naked identifier casefold, trino is case-insensitive.
     QuotedIdentifierSegment=TypedParser(
         "double_quote", IdentifierSegment, type="quoted_identifier", casefold=str.upper
+    ),
+    FunctionContentsExpressionGrammar=OneOf(
+        Ref("LambdaExpressionSegment"),
+        Ref("ExpressionSegment"),
     ),
 )
 
@@ -574,4 +579,18 @@ class CommentOnStatementSegment(BaseSegment):
             ),
             Sequence("IS", OneOf(Ref("QuotedLiteralSegment"), "NULL")),
         ),
+    )
+
+
+class LambdaExpressionSegment(BaseSegment):
+    """Lambda function used in a function."""
+
+    type = "lambda_function"
+    match_grammar = Sequence(
+        OneOf(
+            Ref("ParameterNameSegment"),
+            Bracketed(Delimited(Ref("ParameterNameSegment"))),
+        ),
+        Ref("LambdaArrowSegment"),
+        Ref("ExpressionSegment"),
     )

--- a/test/fixtures/dialects/trino/array.yml
+++ b/test/fixtures/dialects/trino/array.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d0bf6b8b24c65e7cdb438e4729eb7ce5c42cb21c0eacd859a76bfac0b021f319
+_hash: 1d356a551759ad8cc2f3f301276a9f1cbd1411488fe0c4c65098b545d442527b
 file:
 - statement:
     select_statement:
@@ -104,8 +104,8 @@ file:
               function_name_identifier: FILTER
             function_contents:
               bracketed:
-              - start_bracket: (
-              - expression:
+                start_bracket: (
+                expression:
                   typed_array_literal:
                     array_type:
                       keyword: ARRAY
@@ -121,17 +121,17 @@ file:
                     - comma: ','
                     - numeric_literal: '7'
                     - end_square_bracket: ']'
-              - comma: ','
-              - expression:
-                - column_reference:
-                    naked_identifier: x
-                - binary_operator: ->
-                - column_reference:
-                    naked_identifier: x
-                - comparison_operator:
-                    raw_comparison_operator: '>'
-                - numeric_literal: '0'
-              - end_bracket: )
+                comma: ','
+                lambda_function:
+                  parameter: x
+                  lambda_arrow: ->
+                  expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '>'
+                    numeric_literal: '0'
+                end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -143,8 +143,8 @@ file:
               function_name_identifier: ANY_MATCH
             function_contents:
               bracketed:
-              - start_bracket: (
-              - expression:
+                start_bracket: (
+                expression:
                   typed_array_literal:
                     array_type:
                       keyword: ARRAY
@@ -160,17 +160,17 @@ file:
                     - comma: ','
                     - numeric_literal: '7'
                     - end_square_bracket: ']'
-              - comma: ','
-              - expression:
-                - column_reference:
-                    naked_identifier: x
-                - binary_operator: ->
-                - column_reference:
-                    naked_identifier: x
-                - comparison_operator:
-                    raw_comparison_operator: '>'
-                - numeric_literal: '0'
-              - end_bracket: )
+                comma: ','
+                lambda_function:
+                  parameter: x
+                  lambda_arrow: ->
+                  expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '>'
+                    numeric_literal: '0'
+                end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:

--- a/test/fixtures/dialects/trino/regexp_replace_with_lambda.yml
+++ b/test/fixtures/dialects/trino/regexp_replace_with_lambda.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 95c2853fc6ace75fe1c436b6139f973024fb81a4d343674d203ebfb6859ba9a7
+_hash: 91356f5092bfd660feacc2acbd4548995cf183cbc49bd4a2188556a4fd2a56f6
 file:
   statement:
     select_statement:
@@ -22,40 +22,40 @@ file:
               - expression:
                   quoted_literal: "'(\\w)(\\w*)'"
               - comma: ','
-              - expression:
-                - column_reference:
-                    naked_identifier: x
-                - binary_operator: ->
-                - function:
-                    function_name:
-                      function_name_identifier: UPPER
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: x
-                          array_accessor:
-                            start_square_bracket: '['
-                            numeric_literal: '1'
-                            end_square_bracket: ']'
-                        end_bracket: )
-                - binary_operator:
-                  - pipe: '|'
-                  - pipe: '|'
-                - function:
-                    function_name:
-                      function_name_identifier: LOWER
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          column_reference:
-                            naked_identifier: x
-                          array_accessor:
-                            start_square_bracket: '['
-                            numeric_literal: '2'
-                            end_square_bracket: ']'
-                        end_bracket: )
+              - lambda_function:
+                  parameter: x
+                  lambda_arrow: ->
+                  expression:
+                  - function:
+                      function_name:
+                        function_name_identifier: UPPER
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: x
+                            array_accessor:
+                              start_square_bracket: '['
+                              numeric_literal: '1'
+                              end_square_bracket: ']'
+                          end_bracket: )
+                  - binary_operator:
+                    - pipe: '|'
+                    - pipe: '|'
+                  - function:
+                      function_name:
+                        function_name_identifier: LOWER
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: x
+                            array_accessor:
+                              start_square_bracket: '['
+                              numeric_literal: '2'
+                              end_square_bracket: ']'
+                          end_bracket: )
               - end_bracket: )
   statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -318,3 +318,13 @@ test_pass_tsql_nested_join_alias:
   configs:
     core:
       dialect: tsql
+
+test_pass_trino_lambda_expression:
+  pass_str: |
+    SELECT
+        a_column,
+        TRANSFORM(array_col, x -> x.example) AS array_col_example
+    FROM example_table;
+  configs:
+    core:
+      dialect: trino

--- a/test/fixtures/rules/std_rule_cases/RF03.yml
+++ b/test/fixtures/rules/std_rule_cases/RF03.yml
@@ -507,3 +507,13 @@ test_pass_postgres_named_arguments:
   configs:
     core:
       dialect: postgres
+
+test_pass_trino_lambda_expression:
+  pass_str: |
+    SELECT
+        a_column,
+        TRANSFORM(array_col, x -> x.example) AS array_col_example
+    FROM example_table;
+  configs:
+    core:
+      dialect: trino


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This fixes how some rules interact with lambda function and their parameters. Namely touches Trino, but also supports any of the dialects that use lambda functions/expressions
- fixes #6141

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
