### PR TITLE
BigQuery: Support Tuple syntax in other locations

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2263,6 +2263,9 @@ ansi_dialect.add(
                             "FunctionSegment"
                         ),  # WHERE (a, substr(b,1,3)) IN (select c,d FROM...)
                         Ref("LocalAliasSegment"),  # WHERE (LOCAL.a, LOCAL.b) IN (...)
+                        Ref(
+                            "ExpressionSegment"
+                        ),  # SELECT (1*1, 2) IN (STRUCT(1 AS a, 2 AS b));
                     ),
                 ),
                 parse_mode=ParseMode.GREEDY,

--- a/test/fixtures/dialects/bigquery/select_struct.sql
+++ b/test/fixtures/dialects/bigquery/select_struct.sql
@@ -55,3 +55,5 @@ FROM table;
 SELECT
   TO_JSON(STRUCT()) AS col
 FROM table;
+
+SELECT (1*1, 2) IN (STRUCT(1 AS a, 2 AS b));

--- a/test/fixtures/dialects/bigquery/select_struct.yml
+++ b/test/fixtures/dialects/bigquery/select_struct.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3acc157fb75d3edb209a0c9061717e9c7f824017883552a119bfc2f2d6201cbe
+_hash: 85ce3a90c011dd304cbbf6a7e53be86927685f2c597e877a42ca92431054f08f
 file:
 - statement:
     select_statement:
@@ -359,4 +359,40 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: table
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - bracketed:
+              start_bracket: (
+              expression:
+              - numeric_literal: '1'
+              - binary_operator: '*'
+              - numeric_literal: '1'
+              comma: ','
+              numeric_literal: '2'
+              end_bracket: )
+          - keyword: IN
+          - bracketed:
+              start_bracket: (
+              typed_struct_literal:
+                struct_type:
+                  keyword: STRUCT
+                struct_literal:
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '1'
+                  - alias_expression:
+                      keyword: AS
+                      naked_identifier: a
+                  - comma: ','
+                  - numeric_literal: '2'
+                  - alias_expression:
+                      keyword: AS
+                      naked_identifier: b
+                  - end_bracket: )
+              end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This allows for expressions to be in bracketed expressions. Namely used by BigQuery and the tuple syntax.
- fixes #6015

### Are there any other side effects of this change that we should be aware of?
None, as far as I can tell

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
