### PR TITLE
Refactor timestamp grammar

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -746,6 +746,11 @@ ansi_dialect.add(
     # Uses grammar for LT06 support
     ColumnsExpressionGrammar=Nothing(),
     ListComprehensionGrammar=Nothing(),
+    TimeWithTZGrammar=Sequence(
+        OneOf("TIME", "TIMESTAMP"),
+        Bracketed(Ref("NumericLiteralSegment"), optional=True),
+        Sequence(OneOf("WITH", "WITHOUT"), "TIME", "ZONE", optional=True),
+    ),
 )
 
 
@@ -955,11 +960,7 @@ class DatatypeSegment(BaseSegment):
 
     type = "data_type"
     match_grammar: Matchable = OneOf(
-        Sequence(
-            OneOf("TIME", "TIMESTAMP"),
-            Bracketed(Ref("NumericLiteralSegment"), optional=True),
-            Sequence(OneOf("WITH", "WITHOUT"), "TIME", "ZONE", optional=True),
-        ),
+        Ref("TimeWithTZGrammar"),
         Sequence(
             "DOUBLE",
             "PRECISION",

--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -214,7 +214,13 @@ athena_dialect.add(
         type="quoted_identifier",
         casefold=str.lower,
     ),
-    DatetimeWithTZSegment=Sequence(OneOf("TIMESTAMP", "TIME"), "WITH", "TIME", "ZONE"),
+    DatetimeWithTZSegment=Sequence(
+        OneOf("TIMESTAMP", "TIME"),
+        Bracketed(Ref("NumericLiteralSegment"), optional=True),
+        "WITH",
+        "TIME",
+        "ZONE",
+    ),
 )
 
 athena_dialect.replace(

--- a/src/sqlfluff/dialects/dialect_athena.py
+++ b/src/sqlfluff/dialects/dialect_athena.py
@@ -214,13 +214,6 @@ athena_dialect.add(
         type="quoted_identifier",
         casefold=str.lower,
     ),
-    DatetimeWithTZSegment=Sequence(
-        OneOf("TIMESTAMP", "TIME"),
-        Bracketed(Ref("NumericLiteralSegment"), optional=True),
-        "WITH",
-        "TIME",
-        "ZONE",
-    ),
 )
 
 athena_dialect.replace(
@@ -420,7 +413,7 @@ class DatatypeSegment(BaseSegment):
                 )
             ),
         ),
-        Ref("DatetimeWithTZSegment"),
+        Ref("TimeWithTZGrammar"),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -795,11 +795,7 @@ class DateTimeTypeIdentifier(BaseSegment):
     type = "datetime_type_identifier"
     match_grammar = OneOf(
         "DATE",
-        Sequence(
-            OneOf("TIME", "TIMESTAMP"),
-            Bracketed(Ref("NumericLiteralSegment"), optional=True),
-            Sequence(OneOf("WITH", "WITHOUT"), "TIME", "ZONE", optional=True),
-        ),
+        Ref("TimeWithTZGrammar"),
         Sequence(
             OneOf("INTERVAL", "TIMETZ", "TIMESTAMPTZ"),
             Bracketed(Ref("NumericLiteralSegment"), optional=True),

--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -338,10 +338,7 @@ class DateTimeTypeIdentifier(BaseSegment):
     match_grammar = OneOf(
         "DATE",
         "DATETIME",
-        Sequence(
-            OneOf("TIME", "TIMESTAMP"),
-            Sequence(OneOf("WITH", "WITHOUT"), "TIME", "ZONE", optional=True),
-        ),
+        Ref("TimeWithTZGrammar"),
         OneOf("TIMETZ", "TIMESTAMPTZ"),
         # INTERVAL types are not Datetime types under Redshift:
         # https://docs.aws.amazon.com/redshift/latest/dg/r_Datetime_types.html

--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -275,11 +275,7 @@ class DatatypeSegment(BaseSegment):
         "JSON",
         # Date and time
         "DATE",
-        Sequence(
-            OneOf("TIME", "TIMESTAMP"),
-            Ref("BracketedArguments", optional=True),
-            Sequence(OneOf("WITH", "WITHOUT"), "TIME", "ZONE", optional=True),
-        ),
+        Ref("TimeWithTZGrammar"),
         # Structural
         Ref("ArrayTypeSegment"),
         "MAP",

--- a/src/sqlfluff/dialects/dialect_vertica.py
+++ b/src/sqlfluff/dialects/dialect_vertica.py
@@ -1664,11 +1664,7 @@ class DatatypeSegment(ansi.DatatypeSegment):
     match_grammar: Matchable = Sequence(
         OneOf(
             # Date / Datetime
-            Sequence(
-                OneOf("TIME", "TIMESTAMP"),
-                Bracketed(Ref("NumericLiteralSegment"), optional=True),
-                Sequence(OneOf("WITH", "WITHOUT"), "TIME", "ZONE", optional=True),
-            ),
+            Ref("TimeWithTZGrammar"),
             "DATE",
             "DATETIME",
             "SMALLDATETIME",

--- a/test/fixtures/dialects/athena/select_cast_withtimezone.sql
+++ b/test/fixtures/dialects/athena/select_cast_withtimezone.sql
@@ -1,4 +1,5 @@
 SELECT
  cast(field_1 as time with time zone),
- cast(field_2 as timestamp with time zone)
+ cast(field_2 as timestamp with time zone),
+ CAST(CURRENT_TIMESTAMP AS TIMESTAMP(6) WITH TIME ZONE) AS _log_time,
 FROM my_table;

--- a/test/fixtures/dialects/athena/select_cast_withtimezone.yml
+++ b/test/fixtures/dialects/athena/select_cast_withtimezone.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 131af2ba78d428f8d35dcc47f98a4feb5dee6622bebb1d6e9c79b5af4d9a4982
+_hash: e1f1add5999a73e226c754a91e2563fff6e68676f50c0e0ca4ecaf5430821f2d
 file:
   statement:
     select_statement:
@@ -44,6 +44,31 @@ file:
                 - keyword: time
                 - keyword: zone
                 end_bracket: )
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CAST
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  bare_function: CURRENT_TIMESTAMP
+                keyword: AS
+                data_type:
+                - keyword: TIMESTAMP
+                - bracketed:
+                    start_bracket: (
+                    numeric_literal: '6'
+                    end_bracket: )
+                - keyword: WITH
+                - keyword: TIME
+                - keyword: ZONE
+                end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: _log_time
+      - comma: ','
       from_clause:
         keyword: FROM
         from_expression:

--- a/test/fixtures/dialects/trino/timestamp_resolutions.yml
+++ b/test/fixtures/dialects/trino/timestamp_resolutions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 527eb45c1823188bfa72246ef8fe36a48a9f0fa49f353f2aee7fd16cb406eece
+_hash: 699d11828a301f7ec379190090174237936718109c98145185885fe748fcb821
 file:
 - statement:
     select_statement:
@@ -49,11 +49,10 @@ file:
                 keyword: AS
                 data_type:
                   keyword: TIMESTAMP
-                  bracketed_arguments:
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '0'
-                      end_bracket: )
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '0'
+                    end_bracket: )
                 end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -77,11 +76,10 @@ file:
                 keyword: AS
                 data_type:
                   keyword: TIMESTAMP
-                  bracketed_arguments:
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '12'
-                      end_bracket: )
+                  bracketed:
+                    start_bracket: (
+                    numeric_literal: '12'
+                    end_bracket: )
                 end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -157,11 +155,10 @@ file:
                 keyword: AS
                 data_type:
                 - keyword: TIMESTAMP
-                - bracketed_arguments:
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '6'
-                      end_bracket: )
+                - bracketed:
+                    start_bracket: (
+                    numeric_literal: '6'
+                    end_bracket: )
                 - keyword: WITH
                 - keyword: TIME
                 - keyword: ZONE
@@ -188,11 +185,10 @@ file:
                 keyword: AS
                 data_type:
                 - keyword: TIMESTAMP
-                - bracketed_arguments:
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '6'
-                      end_bracket: )
+                - bracketed:
+                    start_bracket: (
+                    numeric_literal: '6'
+                    end_bracket: )
                 - keyword: WITHOUT
                 - keyword: TIME
                 - keyword: ZONE


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Closes https://github.com/sqlfluff/sqlfluff/issues/6330 but also reduces the same implementation in many dialects of the same thing

### Are there any other side effects of this change that we should be aware of?
It could have been solved more simply per the first commit, but I think this reduction in duplication is good. And dialects can override `TimeWithTZGrammar` if desired.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
