### PR TITLE
Postgres: Add `CREATE FOREIGN DATA WRAPPER` statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -2612,27 +2612,6 @@ class AlterExtensionStatementSegment(BaseSegment):
     )
 
 
-class WrapperReferenceSegment(ansi.ObjectReferenceSegment):
-    """A Wrapper object reference."""
-
-    type = "wrapper_reference"
-    match_grammar: Matchable = Ref("SingleIdentifierGrammar")
-
-
-class HandlerReferenceSegment(ansi.ObjectReferenceSegment):
-    """A Handler object reference."""
-
-    type = "handler_reference"
-    match_grammar: Matchable = Ref("SingleIdentifierGrammar")
-
-
-class ValidatorReferenceSegment(ansi.ObjectReferenceSegment):
-    """A validator object reference."""
-
-    type = "validator_reference"
-    match_grammar: Matchable = Ref("SingleIdentifierGrammar")
-
-
 class CreateForeignDataWrapperStatementSegment(BaseSegment):
     """A CREATE FOREIGN DATA WRAPPER Statement.
 
@@ -2642,17 +2621,15 @@ class CreateForeignDataWrapperStatementSegment(BaseSegment):
     type = "create_foreign_data_wrapper"
     match_grammar: Matchable = Sequence(
         "CREATE",
-        "FOREIGN",
-        "DATA",
-        "WRAPPER",
-        Ref("WrapperReferenceSegment"),
+        Ref("ForeignDataWrapperGrammar"),
+        Ref("SingleIdentifierGrammar"),
         Indent,
         "HANDLER",
-        Ref("HandlerReferenceSegment"),
+        Ref("SingleIdentifierGrammar"),
         Dedent,
         Indent,
         "VALIDATOR",
-        Ref("ValidatorReferenceSegment"),
+        Ref("SingleIdentifierGrammar"),
         Dedent,
     )
 

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -2612,6 +2612,51 @@ class AlterExtensionStatementSegment(BaseSegment):
     )
 
 
+class WrapperReferenceSegment(ansi.ObjectReferenceSegment):
+    """A Wrapper object reference."""
+
+    type = "wrapper_reference"
+    match_grammar: Matchable = Ref("SingleIdentifierGrammar")
+
+
+class HandlerReferenceSegment(ansi.ObjectReferenceSegment):
+    """A Handler object reference."""
+
+    type = "handler_reference"
+    match_grammar: Matchable = Ref("SingleIdentifierGrammar")
+
+
+class ValidatorReferenceSegment(ansi.ObjectReferenceSegment):
+    """A validator object reference."""
+
+    type = "validator_reference"
+    match_grammar: Matchable = Ref("SingleIdentifierGrammar")
+
+
+class CreateForeignDataWrapperStatementSegment(BaseSegment):
+    """A CREATE FOREIGN DATA WRAPPER Statement.
+
+    Docs: https://fdw.dev/catalog/
+    """
+
+    type = "create_foreign_data_wrapper"
+    match_grammar: Matchable = Sequence(
+        "CREATE",
+        "FOREIGN",
+        "DATA",
+        "WRAPPER",
+        Ref("WrapperReferenceSegment"),
+        Indent,
+        "HANDLER",
+        Ref("HandlerReferenceSegment"),
+        Dedent,
+        Indent,
+        "VALIDATOR",
+        Ref("ValidatorReferenceSegment"),
+        Dedent,
+    )
+
+
 class SubscriptionReferenceSegment(ansi.ObjectReferenceSegment):
     """A subscription reference."""
 
@@ -4665,6 +4710,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("DropStatisticsStatementSegment"),
             Ref("ShowStatementSegment"),
             Ref("SetConstraintsStatementSegment"),
+            Ref("CreateForeignDataWrapperStatementSegment"),
         ],
     )
 

--- a/test/fixtures/dialects/postgres/create_foreign_wrapper.sql
+++ b/test/fixtures/dialects/postgres/create_foreign_wrapper.sql
@@ -1,0 +1,3 @@
+create foreign data wrapper stripe_wrapper
+    handler stripe_fdw_handler
+    validator stripe_fdw_validator;

--- a/test/fixtures/dialects/postgres/create_foreign_wrapper.yml
+++ b/test/fixtures/dialects/postgres/create_foreign_wrapper.yml
@@ -1,0 +1,22 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 8492c0ed2a5da63655520f0d850a1421a9dc2e5cda4cfa79473cc909a08ba1a0
+file:
+  statement:
+    create_foreign_data_wrapper:
+    - keyword: create
+    - keyword: foreign
+    - keyword: data
+    - keyword: wrapper
+    - wrapper_reference:
+        naked_identifier: stripe_wrapper
+    - keyword: handler
+    - handler_reference:
+        naked_identifier: stripe_fdw_handler
+    - keyword: validator
+    - validator_reference:
+        naked_identifier: stripe_fdw_validator
+  statement_terminator: ;

--- a/test/fixtures/dialects/postgres/create_foreign_wrapper.yml
+++ b/test/fixtures/dialects/postgres/create_foreign_wrapper.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8492c0ed2a5da63655520f0d850a1421a9dc2e5cda4cfa79473cc909a08ba1a0
+_hash: 43b2813d5760fc078d59ae11a7fe6bec905c4f1bfeacc37bfe302af38a9b5d02
 file:
   statement:
     create_foreign_data_wrapper:
@@ -11,12 +11,9 @@ file:
     - keyword: foreign
     - keyword: data
     - keyword: wrapper
-    - wrapper_reference:
-        naked_identifier: stripe_wrapper
+    - naked_identifier: stripe_wrapper
     - keyword: handler
-    - handler_reference:
-        naked_identifier: stripe_fdw_handler
+    - naked_identifier: stripe_fdw_handler
     - keyword: validator
-    - validator_reference:
-        naked_identifier: stripe_fdw_validator
+    - naked_identifier: stripe_fdw_validator
   statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds the `CREATE FOREIGN DATA WRAPPER` statement for the `postgres_fdw` extension.
- fixes #6027

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
