### PR TITLE
Trino: Add some support to `json_query` functions

### DIFF
--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -74,6 +74,11 @@ trino_dialect.add(
         "<", SymbolSegment, type="start_angle_bracket"
     ),
     EndAngleBracketSegment=StringParser(">", SymbolSegment, type="end_angle_bracket"),
+    FormatJsonEncodingGrammar=Sequence(
+        "FORMAT",
+        "JSON",
+        Sequence("ENCODING", OneOf("UTF8", "UTF16", "UTF32"), optional=True),
+    ),
 )
 
 trino_dialect.bracket_sets("angle_bracket_pairs").update(
@@ -216,6 +221,24 @@ trino_dialect.replace(
                 Ref("QuotedLiteralSegment"),
                 Ref("SingleIdentifierGrammar"),
                 Ref("ColumnReferenceSegment"),
+            ),
+        ),
+        # For JSON_QUERY function
+        # https://trino.io/docs/current/functions/json.html#json-query
+        Sequence(
+            Ref("ExpressionSegment"),  # json_input
+            Ref("FormatJsonEncodingGrammar", optional=True),
+            Ref("CommaSegment"),
+            Ref("ExpressionSegment"),  # json_path
+            OneOf(
+                Sequence("WITHOUT", Ref.keyword("ARRAY", optional=True), "WRAPPER"),
+                Sequence(
+                    "WITH",
+                    OneOf("CONDITIONAL", "UNCONDITIONAL", optional=True),
+                    Ref.keyword("ARRAY", optional=True),
+                    "WRAPPER",
+                ),
+                optional=True,
             ),
         ),
         Ref("IgnoreRespectNullsGrammar"),

--- a/test/fixtures/dialects/trino/json_functions.sql
+++ b/test/fixtures/dialects/trino/json_functions.sql
@@ -1,0 +1,7 @@
+select
+    json_query(payload format json, 'lax $.unstructured.abcd[*].field?(@ > 0.5)' with array wrapper),
+    json_query(payload format json encoding utf8, 'lax $.unstructured.abcd[*].field?(@ > 0.5)' without array wrapper),
+    json_query(payload format json encoding utf16, 'lax $.unstructured.abcd[*].field?(@ > 0.5)' with conditional wrapper),
+    json_query(payload format json encoding utf32, 'lax $.unstructured.abcd[*].field?(@ > 0.5)' with unconditional array wrapper),
+    json_query(payload format json, 'lax $.unstructured.abcd[*].field?(@ > 0.5)')
+;

--- a/test/fixtures/dialects/trino/json_functions.yml
+++ b/test/fixtures/dialects/trino/json_functions.yml
@@ -1,0 +1,115 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 3b84c13819bb113d18d08ab0e1c0e79e12df6d37748794356b8bd9ab2a4da956
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: select
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: json_query
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    naked_identifier: payload
+              - keyword: format
+              - keyword: json
+              - comma: ','
+              - expression:
+                  quoted_literal: "'lax $.unstructured.abcd[*].field?(@ > 0.5)'"
+              - keyword: with
+              - keyword: array
+              - keyword: wrapper
+              - end_bracket: )
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: json_query
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    naked_identifier: payload
+              - keyword: format
+              - keyword: json
+              - keyword: encoding
+              - keyword: utf8
+              - comma: ','
+              - expression:
+                  quoted_literal: "'lax $.unstructured.abcd[*].field?(@ > 0.5)'"
+              - keyword: without
+              - keyword: array
+              - keyword: wrapper
+              - end_bracket: )
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: json_query
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    naked_identifier: payload
+              - keyword: format
+              - keyword: json
+              - keyword: encoding
+              - keyword: utf16
+              - comma: ','
+              - expression:
+                  quoted_literal: "'lax $.unstructured.abcd[*].field?(@ > 0.5)'"
+              - keyword: with
+              - keyword: conditional
+              - keyword: wrapper
+              - end_bracket: )
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: json_query
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    naked_identifier: payload
+              - keyword: format
+              - keyword: json
+              - keyword: encoding
+              - keyword: utf32
+              - comma: ','
+              - expression:
+                  quoted_literal: "'lax $.unstructured.abcd[*].field?(@ > 0.5)'"
+              - keyword: with
+              - keyword: unconditional
+              - keyword: array
+              - keyword: wrapper
+              - end_bracket: )
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: json_query
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    naked_identifier: payload
+              - keyword: format
+              - keyword: json
+              - comma: ','
+              - expression:
+                  quoted_literal: "'lax $.unstructured.abcd[*].field?(@ > 0.5)'"
+              - end_bracket: )
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds _some_ of the specifics for `json_query` in Trino. There are still a number of options that have not been added, but covers the use case defined in the listed issue.
- fixes #5975

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
