### PR TITLE
Revise dbt warnings when a file fails to compile

### DIFF
--- a/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
+++ b/plugins/sqlfluff-templater-dbt/sqlfluff_templater_dbt/templater.py
@@ -696,20 +696,13 @@ class DbtTemplater(JinjaTemplater):
                 # The explanation on the undefined macro error is already fairly
                 # explanatory, so just pass it straight through.
                 raise SQLTemplaterError(str(err))
-            except Exception as err:  # pragma: no cover
-                # NOTE: We use .error() here rather than .exception() because
-                # for most users, the trace which accompanies the latter isn't
-                # particularly helpful.
-                templater_logger.error(
-                    "Fatal dbt compilation error on %s. This occurs most often "
-                    "during incorrect sorting of ephemeral models before linting. "
-                    "Please report this error on github at "
-                    "https://github.com/sqlfluff/sqlfluff/issues, including "
-                    "both the raw and compiled sql for the model affected.",
-                    fname,
-                )
-                # Additional error logging in case we get a fatal dbt error.
-                raise SQLFluffSkipFile(  # pragma: no cover
+            except Exception as err:
+                # This happens if there's a fatal error at compile time. That
+                # can sometimes happen for SQLFluff related reasons (it used
+                # to happen if we tried to compile ephemeral models in the
+                # wrong order), but more often because a macro tries to query
+                # a table at compile time which doesn't exist.
+                raise SQLFluffSkipFile(
                     f"Skipped file {fname} because dbt raised a fatal "
                     f"exception during compilation: {err!s}"
                 )

--- a/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/error_models/compile_missing_table.sql
+++ b/plugins/sqlfluff-templater-dbt/test/fixtures/dbt/error_models/compile_missing_table.sql
@@ -1,0 +1,4 @@
+-- This Query triggers an expection at compilation time because it runs
+-- a query *at compile time*, which will fail.
+{% set results = run_query('select 1 from this_table_does_not_exist') %}
+select 1

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -569,9 +569,9 @@ def test__templater_dbt_handle_database_connection_failure(
         )
     )
     dbt_fluff_config_fail = deepcopy(dbt_fluff_config)
-    dbt_fluff_config_fail["templater"]["dbt"]["profiles_dir"] = (
-        "plugins/sqlfluff-templater-dbt/test/fixtures/dbt/profiles_yml_fail"
-    )
+    dbt_fluff_config_fail["templater"]["dbt"][
+        "profiles_dir"
+    ] = "plugins/sqlfluff-templater-dbt/test/fixtures/dbt/profiles_yml_fail"
     # We move the file that throws an error in and out of the project directory
     # as dbt throws an error if a node fails to parse while computing the DAG
     shutil.move(src_fpath, target_fpath)

--- a/plugins/sqlfluff-templater-dbt/test/templater_test.py
+++ b/plugins/sqlfluff-templater-dbt/test/templater_test.py
@@ -462,6 +462,14 @@ def test__templater_dbt_templating_absolute_path(
             "undefined. This can happen when calling a macro that does not exist.",
             SQLTemplaterError,
         ),
+        (
+            "compile_missing_table.sql",
+            # In the test suite we don't get a very helpful error message from dbt
+            # but in live testing, the inclusion of the triggering error sometimes
+            # gives us something much more useful.
+            "because dbt raised a fatal exception during compilation",
+            SQLFluffSkipFile,
+        ),
     ],
 )
 def test__templater_dbt_handle_exceptions(
@@ -561,9 +569,9 @@ def test__templater_dbt_handle_database_connection_failure(
         )
     )
     dbt_fluff_config_fail = deepcopy(dbt_fluff_config)
-    dbt_fluff_config_fail["templater"]["dbt"][
-        "profiles_dir"
-    ] = "plugins/sqlfluff-templater-dbt/test/fixtures/dbt/profiles_yml_fail"
+    dbt_fluff_config_fail["templater"]["dbt"]["profiles_dir"] = (
+        "plugins/sqlfluff-templater-dbt/test/fixtures/dbt/profiles_yml_fail"
+    )
     # We move the file that throws an error in and out of the project directory
     # as dbt throws an error if a node fails to parse while computing the DAG
     shutil.move(src_fpath, target_fpath)


### PR DESCRIPTION
There's a section in the dbt template which was marked as `# pragma: no cover`, but I managed to cover it recently! This adds a test case which triggers it - and also removes the old warning asking people to report it, because I don't think they need to anymore.