### PR TITLE
Utilize a deepcopy of the config object when parsing files

### DIFF
--- a/src/sqlfluff/core/config/fluffconfig.py
+++ b/src/sqlfluff/core/config/fluffconfig.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from copy import copy, deepcopy
 from itertools import chain
 from typing import (
     TYPE_CHECKING,
@@ -167,6 +168,17 @@ class FluffConfig:
         # NOTE: Likewise we don't reinstate the "templater_obj" config value
         # which should also only be used in the main thread rather than child
         # processes.
+
+    def copy(self) -> FluffConfig:
+        """Returns a copy of the FluffConfig.
+
+        This creates a shallow copy of most of the config, but with a deep copy of the
+        `_configs` dictionary.
+        """
+        configs_attribute_copy = deepcopy(self._configs)
+        config_copy = copy(self)
+        config_copy._configs = configs_attribute_copy
+        return config_copy
 
     @classmethod
     def from_root(

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -896,7 +896,7 @@ class Linter:
             self.formatter.dispatch_template_header(fname, self.config, config)
 
         # Just use the local config from here:
-        config = config or self.config
+        config = (config or self.config).copy()
 
         # Scan the raw file for config commands.
         config.process_raw_file_for_config(in_str, fname)

--- a/test/core/config/fluffconfig_test.py
+++ b/test/core/config/fluffconfig_test.py
@@ -5,6 +5,7 @@ import os
 
 import pytest
 
+import sqlfluff
 from sqlfluff.core import FluffConfig, Linter
 from sqlfluff.core.errors import SQLFluffUserError
 from sqlfluff.core.templaters import (
@@ -374,3 +375,15 @@ def test__process_raw_file_for_config(raw_sql):
     # internal list attributes should have overridden exploded list values
     assert cfg.get("rule_allowlist") == ["LT05", "LT06"]
     assert cfg.get("rule_denylist") == ["LT01", "LT02"]
+
+
+def test__api__immutable_config():
+    """Tests that a config is not mutated when parsing."""
+    config = FluffConfig.from_path(
+        "test/fixtures/api/config_path_test/extra_configs/.sqlfluff"
+    )
+    assert config.get("dialect") == "ansi"
+    sqlfluff.parse(
+        "-- sqlfluff:dialect: postgres\nSELECT * FROM table1\n", config=config
+    )
+    assert config.get("dialect") == "ansi"


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Uses a deepcopy of the FluffConfig when parsing files. This prevents the config from being mutated by file-level config overrides.

fixes #6343 


### Are there any other side effects of this change that we should be aware of?
Configs will no longer be mutated when parsing files, so file-level config overrides will now only apply to the file in which they are applied.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
