### PR TITLE
Postgres : Allow Extensions with Special Characters in Name

### DIFF
--- a/src/sqlfluff/rules/references/RF05.py
+++ b/src/sqlfluff/rules/references/RF05.py
@@ -126,6 +126,19 @@ class Rule_RF05(BaseRule):
             ):
                 return LintResult(memory=context.memory)
 
+            # PostgreSQL Extension allows the use of extensions.
+            #
+            # These extensions are often qutoed identifiers.
+            # (https://www.postgresql.org/docs/current/contrib.html)
+            #
+            # Allow quoted identifiers in extension references
+            if (
+                context.dialect.name in ["postgres"]
+                and context.parent_stack
+                and context.parent_stack[-1].is_type("extension_reference")
+            ):
+                return None
+
             # BigQuery table references are quoted in back ticks so allow dots
             #
             # It also allows a star at the end of table_references for wildcards

--- a/test/fixtures/rules/std_rule_cases/RF05.yml
+++ b/test/fixtures/rules/std_rule_cases/RF05.yml
@@ -382,6 +382,18 @@ test_pass_ignore_words_regex_unquoted:
       references.special_chars:
         ignore_words_regex: lias\$$
 
+test_pass_create_extension_reference_quoted:
+  pass_str: CREATE EXTENSION IF NOT EXISTS "quoted-extension";
+  configs:
+    core:
+      dialect: postgres
+
+test_pass_drop_extension_reference_quoted:
+  pass_str: DROP EXTENSION IF EXISTS "quoted-extension";
+  configs:
+    core:
+      dialect: postgres
+
 test_pass_ignore_words_regex_quoted:
   pass_str: SELECT a as 'aliashash#'
   configs:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

This code snippet bypasses the `RF05` rule for PostgreSQL dialects when an `extension_reference` type is detected in the parent stack. If the current SQL dialect is PostgreSQL and the parent stack contains an `extension_reference`, the function will return `None`, effectively ignoring the `RF05` rule in this specific context. 

- fix #4935 

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  
  ```
  test_pass_create_extension_reference_quoted:
    pass_str: CREATE EXTENSION IF NOT EXISTS "quoted-extension";
    configs:
      core:
        dialect: postgres

  test_pass_drop_extension_reference_quoted:
    pass_str: DROP EXTENSION IF EXISTS "quoted-extension";
    configs:
      core:
        dialect: postgres
  ```
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
