### PR TITLE
tsql: allow both on delete and on update in a `reference_constraint`

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -1830,13 +1830,11 @@ class ReferencesConstraintGrammar(BaseSegment):
         Ref("TableReferenceSegment"),
         # Foreign columns making up FOREIGN KEY constraint
         Ref("BracketedColumnReferenceListGrammar", optional=True),
-        Sequence(
-            "ON",
-            OneOf("DELETE", "UPDATE"),
-            Ref("ReferentialActionGrammar"),
-            optional=True,
+        AnySetOf(
+            Sequence("ON", "DELETE", Ref("ReferentialActionGrammar")),
+            Sequence("ON", "UPDATE", Ref("ReferentialActionGrammar")),
+            Sequence("NOT", "FOR", "REPLICATION"),
         ),
-        Sequence("NOT", "FOR", "REPLICATION", optional=True),
     )
 
 

--- a/test/fixtures/dialects/tsql/alter_table.sql
+++ b/test/fixtures/dialects/tsql/alter_table.sql
@@ -110,3 +110,10 @@ ALTER TABLE TestTable SET (DATA_DELETION = OFF(FILTER_COLUMN = ColumnName, RETEN
 ALTER TABLE dbo.Products ADD RetailValue AS [QtyAvailable] * UnitPrice * 1.5 PERSISTED; GO
 ALTER TABLE dbo.Products ADD RetailValue AS (QtyAvailable * [UnitPrice] * 1.5) PERSISTED NOT NULL; GO
 ALTER TABLE dbo.Products ADD InventoyDate AS CAST([InventoryTs] AS date); GO
+
+ALTER TABLE [HangFire].[JobParameter]
+ADD CONSTRAINT [FK_HangFire_JobParameter_Job]
+FOREIGN KEY ([JobId])
+REFERENCES [HangFire].[Job] ([Id])
+ON UPDATE CASCADE
+ON DELETE CASCADE; GO

--- a/test/fixtures/dialects/tsql/alter_table.yml
+++ b/test/fixtures/dialects/tsql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5da52c9b61f489951f21119b14a49acc58bf2903b00bbf3a79068df5dfe4f467
+_hash: d788dbfbeaf65337c5ad5d8914093c4be2db4ffa389f349383e6ddafc2d3622a
 file:
 - batch:
     statement:
@@ -899,6 +899,47 @@ file:
                 data_type:
                   data_type_identifier: date
                 end_bracket: )
+    statement_terminator: ;
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+        - quoted_identifier: '[HangFire]'
+        - dot: .
+        - quoted_identifier: '[JobParameter]'
+      - keyword: ADD
+      - table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            quoted_identifier: '[FK_HangFire_JobParameter_Job]'
+        - keyword: FOREIGN
+        - keyword: KEY
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              quoted_identifier: '[JobId]'
+            end_bracket: )
+        - references_constraint_grammar:
+          - keyword: REFERENCES
+          - table_reference:
+            - quoted_identifier: '[HangFire]'
+            - dot: .
+            - quoted_identifier: '[Job]'
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                quoted_identifier: '[Id]'
+              end_bracket: )
+          - keyword: 'ON'
+          - keyword: UPDATE
+          - keyword: CASCADE
+          - keyword: 'ON'
+          - keyword: DELETE
+          - keyword: CASCADE
     statement_terminator: ;
 - go_statement:
     keyword: GO


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This allows for both `ON DELETE` and `ON UPDATE` to exist on a single `reference_constraint_grammar` for tsql.
- fixes #6339

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
