### PR TITLE
TSQL: allow `UPDATE` to be a function name

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -466,7 +466,7 @@ tsql_dialect.replace(
             type="function_name_identifier",
             anti_template=r"^("
             + r"|".join(
-                dialect.sets("reserved_keywords")
+                dialect.sets("reserved_keywords").difference({"UPDATE"})
                 | dialect.sets("future_reserved_keywords")
             )
             + r")$",

--- a/test/fixtures/dialects/tsql/triggers.sql
+++ b/test/fixtures/dialects/tsql/triggers.sql
@@ -127,3 +127,13 @@ ON Sales.Customer
 AFTER INSERT, UPDATE
 AS RAISERROR ('Notify Customer Relations', 16, 10);
 GO
+
+CREATE TRIGGER reminder
+ON person.address
+AFTER UPDATE
+AS
+IF (UPDATE(stateprovinceid) OR UPDATE(postalcode))
+    BEGIN
+        RAISERROR (50009, 16, 10)
+    END;
+GO

--- a/test/fixtures/dialects/tsql/triggers.yml
+++ b/test/fixtures/dialects/tsql/triggers.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9c667932554dd99405cd329846504296aa7e39d0c8309d43abf91399de5af4e9
+_hash: 3764b2f327435897bc418cc9f255a1ac748670db020f99ce704f3da49cb82de8
 file:
 - batch:
     statement:
@@ -667,5 +667,68 @@ file:
             - numeric_literal: '10'
             - end_bracket: )
       - statement_terminator: ;
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      create_trigger:
+      - keyword: CREATE
+      - keyword: TRIGGER
+      - trigger_reference:
+          naked_identifier: reminder
+      - keyword: 'ON'
+      - table_reference:
+        - naked_identifier: person
+        - dot: .
+        - naked_identifier: address
+      - keyword: AFTER
+      - keyword: UPDATE
+      - keyword: AS
+      - statement:
+          if_then_statement:
+            if_clause:
+              keyword: IF
+              expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                  - function:
+                      function_name:
+                        function_name_identifier: UPDATE
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: stateprovinceid
+                          end_bracket: )
+                  - binary_operator: OR
+                  - function:
+                      function_name:
+                        function_name_identifier: UPDATE
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: postalcode
+                          end_bracket: )
+                  end_bracket: )
+            statement:
+              begin_end_block:
+              - keyword: BEGIN
+              - statement:
+                  raiserror_statement:
+                    keyword: RAISERROR
+                    bracketed:
+                    - start_bracket: (
+                    - numeric_literal: '50009'
+                    - comma: ','
+                    - numeric_literal: '16'
+                    - comma: ','
+                    - numeric_literal: '10'
+                    - end_bracket: )
+              - keyword: END
+            statement_terminator: ;
 - go_statement:
     keyword: GO


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This allows for the `UPDATE` keyword to a be function in the tsql dialect.
- fixes #5960

### Are there any other side effects of this change that we should be aware of?
None.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
