### PR TITLE
Make dbt `RelationEmulator` safely callable

### DIFF
--- a/src/sqlfluff/core/templaters/jinja.py
+++ b/src/sqlfluff/core/templaters/jinja.py
@@ -61,9 +61,8 @@ class UndefinedRecorder:
     """Similar to jinja2.StrictUndefined, but remembers, not fails."""
 
     # Tell Jinja this object is safe to call and does not alter data.
-    # https://jinja.palletsprojects.com/en/2.9.x/sandbox/#jinja2.sandbox.SandboxedEnvironment.is_safe_callable
-    unsafe_callable = False
     # https://jinja.palletsprojects.com/en/3.0.x/sandbox/#jinja2.sandbox.SandboxedEnvironment.is_safe_callable
+    unsafe_callable = False
     alters_data = False
 
     def __init__(self, name: str, undefined_set: Set[str]) -> None:
@@ -316,6 +315,11 @@ class JinjaTemplater(PythonTemplater):
 
         class RelationEmulator:
             """A class which emulates the `this` class from dbt."""
+
+            # Tell Jinja this object is safe to call and does not alter data.
+            # https://jinja.palletsprojects.com/en/3.0.x/sandbox/#jinja2.sandbox.SandboxedEnvironment.is_safe_callable
+            unsafe_callable = False
+            alters_data = False
 
             identifier = "this_model"
             schema = "this_schema"

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -703,6 +703,7 @@ def assert_structure(yaml_loader, path, code_only=True, include_meta=False):
         ("jinja_c_dbt/dbt_builtins_ref", True, False),
         ("jinja_c_dbt/dbt_builtins_source", True, False),
         ("jinja_c_dbt/dbt_builtins_this", True, False),
+        ("jinja_c_dbt/dbt_builtins_this_callable", True, False),
         ("jinja_c_dbt/dbt_builtins_var_default", True, False),
         ("jinja_c_dbt/dbt_builtins_test", True, False),
         # do directive

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins_this.sql
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins_this.sql
@@ -1,2 +1,5 @@
 SELECT col1
-FROM {{ this }}
+FROM {{ this }};
+
+SELECT col1
+FROM {{ this.render() }};

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins_this.sql
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins_this.sql
@@ -1,5 +1,2 @@
 SELECT col1
-FROM {{ this }};
-
-SELECT col1
-FROM {{ this.render() }};
+FROM {{ this }}

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins_this_callable.sql
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins_this_callable.sql
@@ -1,2 +1,2 @@
 SELECT col1
-FROM {{ this }}
+FROM {{ this.render() }}

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins_this_callable.sql
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins_this_callable.sql
@@ -1,0 +1,2 @@
+SELECT col1
+FROM {{ this }}

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins_this_callable.yml
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins_this_callable.yml
@@ -1,0 +1,15 @@
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: this_model


### PR DESCRIPTION
### Brief summary of the change made
Make the dbt `RelationEmulator` safely callable.

Fixes #6357.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.