### PR TITLE
enable default values when creating databricks tables

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -585,6 +585,7 @@ class MaskStatementSegment(BaseSegment):
         ),
     )
 
+
 class ColumnFieldDefinitionSegment(ansi.ColumnDefinitionSegment):
     """A column field definition, e.g. for CREATE TABLE or ALTER TABLE.
 
@@ -598,7 +599,7 @@ class ColumnFieldDefinitionSegment(ansi.ColumnDefinitionSegment):
         Bracketed(Anything(), optional=True),  # For types like VARCHAR(100)
         AnyNumberOf(
             Ref("ColumnConstraintSegment", optional=True),
-            Ref("ColumnDefaultGrammar", optional=True), # For default values
+            Ref("ColumnDefaultGrammar", optional=True),  # For default values
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -119,7 +119,10 @@ databricks_dialect.add(
     ),
     ColumnDefaultGrammar=Sequence(
         "DEFAULT",
-        Ref("LiteralGrammar"),
+        OneOf(
+            Ref("LiteralGrammar"),
+            Ref("FunctionSegment"),
+        ),
     ),
     ConstraintOptionGrammar=Sequence(
         Sequence("ENABLE", "NOVALIDATE", optional=True),
@@ -579,6 +582,23 @@ class MaskStatementSegment(BaseSegment):
                 ),
             ),
             optional=True,
+        ),
+    )
+
+class ColumnFieldDefinitionSegment(ansi.ColumnDefinitionSegment):
+    """A column field definition, e.g. for CREATE TABLE or ALTER TABLE.
+
+    This supports the iceberg syntax and allows for iceberg syntax such
+    as ADD COLUMN a.b.
+    """
+
+    match_grammar: Matchable = Sequence(
+        Ref("ColumnReferenceSegment"),  # Column name
+        Ref("DatatypeSegment"),  # Column type
+        Bracketed(Anything(), optional=True),  # For types like VARCHAR(100)
+        AnyNumberOf(
+            Ref("ColumnConstraintSegment", optional=True),
+            Ref("ColumnDefaultGrammar", optional=True), # For default values
         ),
     )
 

--- a/test/fixtures/dialects/databricks/create_table.sql
+++ b/test/fixtures/dialects/databricks/create_table.sql
@@ -59,3 +59,19 @@ CREATE OR REPLACE TABLE TABLE1 (
     CONSTRAINT DATE_CONSTRAINT
     FOREIGN KEY REFERENCES TABLE2
 );
+
+-- Create a table with a column with default value
+CREATE TABLE student (id INT, name STRING DEFAULT 'bobby tables', age INT);
+
+-- Create a table with non nullable column with default value
+CREATE TABLE student (id INT, name STRING NOT NULL DEFAULT 'bobby tables', age INT);
+
+-- Create a table with a default timestamp 
+CREATE TABLE clock (
+    which_time TIMESTAMP DEFAULT current_timestamp()
+);
+
+-- Create a table with mixing default value and constraints
+CREATE TABLE clock (
+    which_time TIMESTAMP CONSTRAINT clock_pk PRIMARY KEY DEFAULT current_timestamp() NOT NULL
+);

--- a/test/fixtures/dialects/databricks/create_table.sql
+++ b/test/fixtures/dialects/databricks/create_table.sql
@@ -66,7 +66,7 @@ CREATE TABLE student (id INT, name STRING DEFAULT 'bobby tables', age INT);
 -- Create a table with non nullable column with default value
 CREATE TABLE student (id INT, name STRING NOT NULL DEFAULT 'bobby tables', age INT);
 
--- Create a table with a default timestamp 
+-- Create a table with a default timestamp
 CREATE TABLE clock (
     which_time TIMESTAMP DEFAULT current_timestamp()
 );

--- a/test/fixtures/dialects/databricks/create_table.yml
+++ b/test/fixtures/dialects/databricks/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d505be32cbb519e6de1746ab542bd37646b0abf36f6dddb921b82b9e572878c9
+_hash: 7ee77c6e9b81bfcf5f60df9cfd5b6268885971bda49cf9cffd71918479b53a35
 file:
 - statement:
     create_table_statement:
@@ -490,5 +490,129 @@ file:
           - keyword: REFERENCES
           - table_reference:
               naked_identifier: TABLE2
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: student
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          column_reference:
+            naked_identifier: id
+          data_type:
+            primitive_type:
+              keyword: INT
+      - comma: ','
+      - column_definition:
+          column_reference:
+            naked_identifier: name
+          data_type:
+            primitive_type:
+              keyword: STRING
+          keyword: DEFAULT
+          quoted_literal: "'bobby tables'"
+      - comma: ','
+      - column_definition:
+          column_reference:
+            naked_identifier: age
+          data_type:
+            primitive_type:
+              keyword: INT
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: student
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          column_reference:
+            naked_identifier: id
+          data_type:
+            primitive_type:
+              keyword: INT
+      - comma: ','
+      - column_definition:
+          column_reference:
+            naked_identifier: name
+          data_type:
+            primitive_type:
+              keyword: STRING
+          column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+          keyword: DEFAULT
+          quoted_literal: "'bobby tables'"
+      - comma: ','
+      - column_definition:
+          column_reference:
+            naked_identifier: age
+          data_type:
+            primitive_type:
+              keyword: INT
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: clock
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          column_reference:
+            naked_identifier: which_time
+          data_type:
+            primitive_type:
+              keyword: TIMESTAMP
+          keyword: DEFAULT
+          function:
+            function_name:
+              function_name_identifier: current_timestamp
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: clock
+    - bracketed:
+        start_bracket: (
+        column_definition:
+        - column_reference:
+            naked_identifier: which_time
+        - data_type:
+            primitive_type:
+              keyword: TIMESTAMP
+        - column_constraint_segment:
+          - keyword: CONSTRAINT
+          - object_reference:
+              naked_identifier: clock_pk
+          - keyword: PRIMARY
+          - keyword: KEY
+        - keyword: DEFAULT
+        - function:
+            function_name:
+              function_name_identifier: current_timestamp
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+        - column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
         end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

fixes #6361

Databricks support adding default values to columns when creating tables, e.g.

```
CREATE TABLE test (
   value STRING DEFAULT "test"
);
``` 

The default values can either be a literal or a function, such as `current_timestamp()`.

### Are there any other side effects of this change that we should be aware of?

There are some false negatives with this change, such as 

```
CREATE TABLE test (
   value STRING DEFAULT "test" DEFAULT "fail"
);
``` 

which passes the checks but is invalid SQL. Though this kind of false positives already exist on main with e.g. 

```
CREATE TABLE test (
   value STRING NOT NULL NOT NULL
);
``` 

which also passes a sqlfluff check but fails to execute in databricks sql.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
