### PR TITLE
Resolve collision between ST02 and LT01

### DIFF
--- a/src/sqlfluff/rules/structure/ST02.py
+++ b/src/sqlfluff/rules/structure/ST02.py
@@ -14,6 +14,24 @@ from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.utils.functional import FunctionalContext, Segments, sp
 
 
+class FunctionNameSegment(BaseSegment):
+    """Function name, including any prefix bits, e.g. project or schema.
+
+    NOTE: This is a minimal segment definition to allow appropriate fixing.
+    """
+
+    type = "function_name"
+
+
+class FunctionContentsSegment(BaseSegment):
+    """Function Contents.
+
+    NOTE: This is a minimal segment definition to allow appropriate fixing.
+    """
+
+    type = "function_contents"
+
+
 class Rule_ST02(BaseRule):
     """Unnecessary ``CASE`` statement.
 
@@ -92,13 +110,19 @@ class Rule_ST02(BaseRule):
         """Generate list of fixes to convert CASE statement to COALESCE function."""
         # Add coalesce and opening parenthesis.
         edits = [
-            WordSegment("coalesce", type="function_name_identifier"),
-            SymbolSegment("(", type="start_bracket"),
-            coalesce_arg_1,
-            SymbolSegment(",", type="comma"),
-            WhitespaceSegment(),
-            coalesce_arg_2,
-            SymbolSegment(")", type="end_bracket"),
+            FunctionNameSegment(
+                segments=(WordSegment("coalesce", type="function_name_identifier"),)
+            ),
+            FunctionContentsSegment(
+                segments=(
+                    SymbolSegment("(", type="start_bracket"),
+                    coalesce_arg_1,
+                    SymbolSegment(",", type="comma"),
+                    WhitespaceSegment(),
+                    coalesce_arg_2,
+                    SymbolSegment(")", type="end_bracket"),
+                )
+            ),
         ]
 
         if preceding_not:

--- a/test/rules/std_LT01_ST02_test.py
+++ b/test/rules/std_LT01_ST02_test.py
@@ -1,0 +1,49 @@
+"""Tests the python routines within LT04 and ST06."""
+
+import pytest
+
+from sqlfluff.core import FluffConfig, Linter
+
+
+@pytest.mark.parametrize(
+    ["in_sql", "out_sql"],
+    [
+        (
+            """
+select
+    case
+        when ended_at is null or date(ended_at) > current_date()
+        then true else false
+    end as is_active
+from foo
+""",
+            """
+select
+    coalesce(ended_at is null or date(ended_at) > current_date(), false) as is_active
+from foo
+""",
+        ),
+    ],
+)
+def test_rules_std_LT01_and_ST02_interaction(in_sql, out_sql) -> None:
+    """Test interaction between LT04 and ST06.
+
+    Test sql with two newlines with leading commas expecting trailing.
+    """
+    # Lint expected rules.
+    cfg = FluffConfig.from_string(
+        """[sqlfluff]
+dialect = ansi
+rules = LT01,ST02
+"""
+    )
+    linter = Linter(config=cfg)
+
+    # Return linted/fixed file.
+    linted_file = linter.lint_string(in_sql, fix=True)
+
+    # Check expected lint errors are raised.
+    assert set([v.rule.code for v in linted_file.violations]) == {"ST02"}
+
+    # Check file is fixed.
+    assert linted_file.fix_string()[0] == out_sql


### PR DESCRIPTION
This fixes #6359, which it looks like was caused by #5809. The fix created by ST02 didn't have the expected structure from the rest of the dialect and so was being created with the wrong typing.