### PR TITLE
Enable AM02 for snowflake and trino by default.

### DIFF
--- a/src/sqlfluff/rules/ambiguous/AM02.py
+++ b/src/sqlfluff/rules/ambiguous/AM02.py
@@ -16,7 +16,8 @@ class Rule_AM02(BaseRule):
     .. note::
        This rule is only enabled for dialects that support ``UNION`` and
        ``UNION DISTINCT`` (``ansi``, ``bigquery``, ``clickhouse``,
-       ``databricks``, ``db2``, ``hive``, ``mysql``, and ``redshift``).
+       ``databricks``, ``db2``, ``hive``, ``mysql``, ``redshift``,
+       ``snowflake``, and ``trino``).
 
     **Anti-pattern**
 
@@ -67,6 +68,8 @@ class Rule_AM02(BaseRule):
             "hive",
             "mysql",
             "redshift",
+            "snowflake",
+            "trino",
         ]:
             return LintResult()
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Based on conversation in https://github.com/sqlfluff/sqlfluff/pull/6337#issuecomment-2417433407 and in https://github.com/sqlfluff/sqlfluff/issues/5964#issuecomment-2192409972, this PR expands coverage of the [ambiguous union rule](https://docs.sqlfluff.com/en/stable/reference/rules.html#rule-ambiguous.union) (AM02) to Snowflake and Trino.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist

- [x] Ran linter and tox check for this rule, AM02

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
