### PR TITLE
Introducing SQLFluff Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![ReadTheDocs](https://img.shields.io/readthedocs/sqlfluff?style=flat-square&logo=Read%20the%20Docs)](https://sqlfluff.readthedocs.io)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat-square)](https://github.com/psf/black)
 [![Docker Pulls](https://img.shields.io/docker/pulls/sqlfluff/sqlfluff?logo=docker&style=flat-square)](https://hub.docker.com/r/sqlfluff/sqlfluff)
+[![](https://img.shields.io/badge/Gurubase-Ask%20SQLFluff%20Guru-006BFF)](https://gurubase.io/g/sqlfluff)
 
 **SQLFluff** is a dialect-flexible and configurable SQL linter. Designed
 with ELT applications in mind, **SQLFluff** also works with Jinja templating

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![ReadTheDocs](https://img.shields.io/readthedocs/sqlfluff?style=flat-square&logo=Read%20the%20Docs)](https://sqlfluff.readthedocs.io)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat-square)](https://github.com/psf/black)
 [![Docker Pulls](https://img.shields.io/docker/pulls/sqlfluff/sqlfluff?logo=docker&style=flat-square)](https://hub.docker.com/r/sqlfluff/sqlfluff)
-[![](https://img.shields.io/badge/Gurubase-Ask%20SQLFluff%20Guru-006BFF)](https://gurubase.io/g/sqlfluff)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20SQLFluff%20Guru-006BFF?style=flat-square)](https://gurubase.io/g/sqlfluff)
 
 **SQLFluff** is a dialect-flexible and configurable SQL linter. Designed
 with ELT applications in mind, **SQLFluff** also works with Jinja templating


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [SQLFluff Guru](https://gurubase.io/g/sqlfluff) to Gurubase. SQLFluff Guru uses the data from this repo and data from the [docs](https://docs.sqlfluff.com/en/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "SQLFluff Guru" badge, which highlights that SQLFluff now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable SQLFluff Guru in Gurubase, just let me know that's totally fine.