### PR TITLE
SparkSQL: Improved lexing and parsing of file literals

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -206,6 +206,10 @@ spacing_within = touch
 # NOTE: This is the spacing between the operator and the colon
 spacing_before = touch
 
+[sqlfluff:layout:type:slash]
+spacing_before = any
+spacing_after = any
+
 [sqlfluff:layout:type:comment]
 spacing_before = any
 spacing_after = any

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -2477,8 +2477,8 @@ class FileLiteralSegment(BaseSegment):
     """A path literal that isn't quoted.
 
     The regular expression will pickup any paths with a leading protocol, however to
-    prevent some division operators that may look like paths, we only parse them
-    after lexing here.
+    prevent some division operators that may look like paths, we only parse them here
+    **after** lexing.
     """
 
     type = "file_literal"

--- a/test/fixtures/dialects/sparksql/add_file.sql
+++ b/test/fixtures/dialects/sparksql/add_file.sql
@@ -8,5 +8,4 @@ ADD FILE "/path/to/some/directory";
 
 ADD FILES "/path with space/cde.txt" '/path with space/fgh.txt';
 
--- NB: Non-quoted paths are not supported in SQLFluff currently
---ADD FILE /tmp/test;
+ADD FILE /tmp/test;

--- a/test/fixtures/dialects/sparksql/add_file.yml
+++ b/test/fixtures/dialects/sparksql/add_file.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5e12d4826b7072fddd53e9e4c040cd96ae651d7999d1230aac1ae9466599d511
+_hash: 9fb033c7be6f39ac2f59ae9dc3797a52adf82ae1db6ecce433fe5cc7503a7021
 file:
 - statement:
     add_file_statement:
@@ -35,4 +35,14 @@ file:
     - file_keyword: FILES
     - quoted_literal: '"/path with space/cde.txt"'
     - quoted_literal: "'/path with space/fgh.txt'"
+- statement_terminator: ;
+- statement:
+    add_file_statement:
+      keyword: ADD
+      file_keyword: FILE
+      file_literal:
+      - slash: /
+      - path_segment: tmp
+      - slash: /
+      - path_segment: test
 - statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/add_jar.yml
+++ b/test/fixtures/dialects/sparksql/add_jar.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b7ba37b07b7588c894e6ad680fafcb954a373185f6623e703546834c8ad6990c
+_hash: 13da3d255c3b050efe435020197c5ed2042e917c230fbceff39062f3485b1967
 file:
 - statement:
     add_jar_statement:
@@ -58,23 +58,40 @@ file:
     add_jar_statement:
       keyword: ADD
       file_keyword: JAR
-      file_literal: ivy://group:module:version?exclude=group:module&transitive=true
+      file_literal:
+        literal: ivy://group:module:version?exclude=group:module&transitive=true
 - statement_terminator: ;
 - statement:
     add_jar_statement:
       keyword: ADD
       file_keyword: JAR
-      file_literal: /path/to/some.jar
+      file_literal:
+      - slash: /
+      - path_segment: path
+      - slash: /
+      - path_segment: to
+      - slash: /
+      - path_segment: some
+      - dot: .
+      - path_segment: jar
 - statement_terminator: ;
 - statement:
     add_jar_statement:
       keyword: ADD
       file_keyword: JAR
-      file_literal: path/to/some.jar
+      file_literal:
+      - path_segment: path
+      - slash: /
+      - path_segment: to
+      - slash: /
+      - path_segment: some
+      - dot: .
+      - path_segment: jar
 - statement_terminator: ;
 - statement:
     add_jar_statement:
       keyword: ADD
       file_keyword: JAR
-      file_literal: ivy://path/to/some.jar
+      file_literal:
+        literal: ivy://path/to/some.jar
 - statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/division_operator.sql
+++ b/test/fixtures/dialects/sparksql/division_operator.sql
@@ -1,0 +1,2 @@
+select t1.year_earn/t1.avg_cost/t1.rcp_cnt as fourth_cnt from dw.test t1;
+select t1.year_earn/t1.avg_cost/t1.jar as fourth_cnt from dw.test t1;

--- a/test/fixtures/dialects/sparksql/division_operator.yml
+++ b/test/fixtures/dialects/sparksql/division_operator.yml
@@ -1,0 +1,77 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 33d2661c8f540490df207db412d4dbf9a260c3b9055fdee5920b33e170437b82
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: t1
+            - dot: .
+            - naked_identifier: year_earn
+          - binary_operator: /
+          - column_reference:
+            - naked_identifier: t1
+            - dot: .
+            - naked_identifier: avg_cost
+          - binary_operator: /
+          - column_reference:
+            - naked_identifier: t1
+            - dot: .
+            - naked_identifier: rcp_cnt
+          alias_expression:
+            keyword: as
+            naked_identifier: fourth_cnt
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: dw
+              - dot: .
+              - naked_identifier: test
+            alias_expression:
+              naked_identifier: t1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          expression:
+          - column_reference:
+            - naked_identifier: t1
+            - dot: .
+            - naked_identifier: year_earn
+          - binary_operator: /
+          - column_reference:
+            - naked_identifier: t1
+            - dot: .
+            - naked_identifier: avg_cost
+          - binary_operator: /
+          - column_reference:
+            - naked_identifier: t1
+            - dot: .
+            - naked_identifier: jar
+          alias_expression:
+            keyword: as
+            naked_identifier: fourth_cnt
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: dw
+              - dot: .
+              - naked_identifier: test
+            alias_expression:
+              naked_identifier: t1
+- statement_terminator: ;

--- a/test/fixtures/dialects/sparksql/list_file.sql
+++ b/test/fixtures/dialects/sparksql/list_file.sql
@@ -8,5 +8,4 @@ LIST FILE "/path/to/some/directory";
 
 LIST FILES "/path with space/cde.txt" '/path with space/fgh.txt';
 
--- NB: Non-quoted paths are not supported in SQLFluff currently
---LIST FILE /tmp/test;
+LIST FILE /tmp/test;

--- a/test/fixtures/dialects/sparksql/list_file.yml
+++ b/test/fixtures/dialects/sparksql/list_file.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e38255cadfe8a5739a5c7b4264284692e1736042b948947ed0d05d422485d794
+_hash: 0dea32244f66bc206871bba68d8cc37fed2020bb9302eb167b369d7c6b53e267
 file:
 - statement:
     list_file_statement:
@@ -35,4 +35,14 @@ file:
     - file_keyword: FILES
     - quoted_literal: '"/path with space/cde.txt"'
     - quoted_literal: "'/path with space/fgh.txt'"
+- statement_terminator: ;
+- statement:
+    list_file_statement:
+      keyword: LIST
+      file_keyword: FILE
+      file_literal:
+      - slash: /
+      - path_segment: tmp
+      - slash: /
+      - path_segment: test
 - statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/LT01-operators.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-operators.yml
@@ -129,3 +129,9 @@ fail_bigquery_safe_prefix_function:
   configs:
     core:
       dialect: bigquery
+
+pass_sparksql_file_literal:
+  pass_str: ADD JAR path/to/some.jar;
+  configs:
+    core:
+      dialect: sparksql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This prevents some segments that use division without spaces from being lexed as a `file_literal`.
- fixes #6363 

### Are there any other side effects of this change that we should be aware of?
This changes the `file_literal` to have some sub-parts namely `path_segment` and `slash` (taken from the `clickhouse` dialect). This shouldn't have any impact but changes the parsing tree. 
Also `slash` now allows for `any` layout for before and after spacing as we shouldn't manipulate the filepath.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
