### PR TITLE
Postgres: Support identifiers in `ALTER DATABASE SET`

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -3287,7 +3287,12 @@ class AlterDatabaseStatementSegment(BaseSegment):
                 OneOf(
                     Sequence(
                         OneOf("TO", Ref("EqualsSegment")),
-                        OneOf("DEFAULT", Ref("LiteralGrammar")),
+                        OneOf(
+                            "DEFAULT",
+                            Ref("LiteralGrammar"),
+                            Ref("NakedIdentifierSegment"),
+                            Ref("QuotedIdentifierSegment"),
+                        ),
                     ),
                     Sequence("FROM", "CURRENT"),
                 ),

--- a/test/fixtures/dialects/postgres/alter_database.sql
+++ b/test/fixtures/dialects/postgres/alter_database.sql
@@ -26,6 +26,8 @@ ALTER DATABASE db SET parameter1 = 1;
 ALTER DATABASE db SET parameter1 = 'some_value';
 ALTER DATABASE db SET parameter1 = DEFAULT;
 ALTER DATABASE db SET parameter1 FROM CURRENT;
+ALTER DATABASE db SET search_path TO my_schema;
+ALTER DATABASE db SET search_path TO "my_schema";
 
 ALTER USER some_user SET default_transaction_read_only = ON;
 

--- a/test/fixtures/dialects/postgres/alter_database.yml
+++ b/test/fixtures/dialects/postgres/alter_database.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b5ca029c5ff1a0e82e534f264dfe874a5dadb9863c930dc8118f51b94e818f3b
+_hash: 6930f3b7548edd340ea078833ff2846a5c77fd88c8f4352d9623a9348ebe7ff6
 file:
 - statement:
     alter_database_statement:
@@ -277,6 +277,28 @@ file:
     - parameter: parameter1
     - keyword: FROM
     - keyword: CURRENT
+- statement_terminator: ;
+- statement:
+    alter_database_statement:
+    - keyword: ALTER
+    - keyword: DATABASE
+    - database_reference:
+        naked_identifier: db
+    - keyword: SET
+    - parameter: search_path
+    - keyword: TO
+    - naked_identifier: my_schema
+- statement_terminator: ;
+- statement:
+    alter_database_statement:
+    - keyword: ALTER
+    - keyword: DATABASE
+    - database_reference:
+        naked_identifier: db
+    - keyword: SET
+    - parameter: search_path
+    - keyword: TO
+    - quoted_identifier: '"my_schema"'
 - statement_terminator: ;
 - statement:
     alter_role_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds support for identifiers in a `ALTER DATABASE ... SET` statement.
- fixes #6374

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
