### PR TITLE
Guides for custom rules and for troubleshooting

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -143,6 +143,7 @@ redirects = {
     "perma/releasenotes": "../reference/releasenotes.html",
     "perma/why": "../why_sqlfluff.html",
     "perma/plugin_dev": "../guides/contributing/plugins.html",
+    "perma/plugin_guide": "../guides/setup/developing_custom_rules.html",
     "perma/variables": "../configuration/templating/index.html",
     "perma/python_templating": "../configuration/templating/python.html",
     "perma/guides": "../guides/index.html",

--- a/docs/source/guides/contributing/architecture.rst
+++ b/docs/source/guides/contributing/architecture.rst
@@ -121,8 +121,9 @@ Stage 4, the linter
 
 Given the complete parse tree, rule classes check for linting errors by
 traversing the tree, looking for segments and patterns of concern. If
-the rule discovers a violation, it returns a :code:`LintResult` pointing
-to the segment which caused the violation.
+the rule discovers a violation, it returns a
+:py:class:`~sqlfluff.core.rules.base.LintResult` pointing to the segment
+which caused the violation.
 
 Some rules are able to *fix* the problems they find. If this is the case,
 the rule will return a list of fixes, which describe changes to be made to

--- a/docs/source/guides/contributing/dialect.rst
+++ b/docs/source/guides/contributing/dialect.rst
@@ -1,3 +1,5 @@
+.. _contributing_dialect_changes:
+
 Contributing dialect changes
 ============================
 

--- a/docs/source/guides/index.rst
+++ b/docs/source/guides/index.rst
@@ -13,13 +13,16 @@ Setting up SQLFluff
    :maxdepth: 1
 
    setup/teamrollout
+   setup/developing_custom_rules
 
-..
-    NOTE: Eventually we should add a troubleshooting section here too,
-    but that doesn't have any content yet.
+Troubleshooting SQLFluff
+------------------------
 
-    Troubleshooting SQLFluff
-    ------------------------
+.. toctree::
+   :maxdepth: 1
+
+   troubleshooting/how_to_troubleshoot
+   troubleshooting/common_errors
 
 .. _development:
 

--- a/docs/source/guides/index.rst
+++ b/docs/source/guides/index.rst
@@ -21,8 +21,7 @@ Troubleshooting SQLFluff
 .. toctree::
    :maxdepth: 1
 
-   troubleshooting/how_to_troubleshoot
-   troubleshooting/common_errors
+   troubleshooting/how_to
 
 .. _development:
 

--- a/docs/source/guides/setup/developing_custom_rules.rst
+++ b/docs/source/guides/setup/developing_custom_rules.rst
@@ -1,0 +1,134 @@
+.. _developing_custom_rules:
+
+Developing Custom Rules
+=======================
+
+It's quite common to have organisation-, or project-specific norms and
+conventions you might want to enforce using SQLFluff. With a little bit
+of python knowledge this is very achievable with SQLFluff, and there's
+a plugin architecture to support that.
+
+This guide should be read alongside the code for the
+`SQLFluff example plugin`_ and the more technical documentation for
+:ref:`developingpluginsref`.
+
+What Plugin do I need?
+----------------------
+
+When thinking about developing a rule, the following thought process will
+help you decide what to develop:
+
+1. When do I want this rule to show a warning, when should it definitely
+   **not** show one? What information do I need when evaluating whether
+   a the rule has been followed or not? This information will tell you
+   about the two important *locations* in the parse tree which will become
+   important.
+
+   * The *trigger* location: i.e. when should the rule be *called* for
+     evaluation. e.g. :sqlfluff:ref:`CP01` triggers on keywords, because
+     it only needs the information about that keyword to run, but
+     :sqlfluff:ref:`LT08` triggers on ``WITH`` statements even though it's
+     only interested in specific pieces of whitespace, because it needs the
+     full context of the statement to evaluate. You may with to examine the
+     parse structure of some example queries you'd want to handle by using
+     ``sqlfluff parse my_file.sql`` to identify the right segment. This is
+     then specified using the ``crawl_behaviour`` attribute on the rule.
+    
+   * The *anchor* location: i.e. which position will show up in the CLI
+     readout back to the user. To continue the example of above, while
+     :sqlfluff:ref:`LT08` *triggers* on a ``WITH`` statement, it *anchors*
+     on a more specific segment just after where it expected whitespace.
+     It specifies this using the ``anchor`` argument to the
+     :py:class:`~sqlfluff.core.rules.base.LintResult` object.
+
+2. How should the rule evaluate and should I implement an auto-fix? For
+   the simplest rules, it the logic to evaluate whether there's an issue
+   can be *very simple*. For example in the `SQLFluff example plugin`_,
+   we are just checking the name of an element isn't in a configured list.
+   Typically we recommend that for organisation-specific rules, **KEEP IT**
+   **SIMPLE**. Some of the rules bundled with SQLFluff contain a lot of
+   complexity for handling how to automatically fix lots of edge cases,
+   but for your organisation it's probably not worth the overhead unless
+   you're a **very big team** or **come across a huge amount of poorly**
+   **formatted SQL**. 
+
+   * Consider the information not just to *trigger*, but also whether a
+     custom error message would be appropriate and how to get the information
+     to construct that too. The default error message will be the first
+     line of the rule docstring_. Custom messages can be configured by
+     setting the ``description`` argument of the
+     :py:class:`~sqlfluff.core.rules.base.LintResult` object.
+
+   * Do use the existing SQLFluff core rules as examples of what is possible
+     and how to achieve various things - but remember that many of them
+     implement a level of complexity and edge case handling which may not
+     be necessary for your organisation.
+
+3. How am I going to roll out my rule to the team? Thinking through this
+   aspect of rule development is just as important as the technical aspect.
+   Spending a lot of time on rule development for it to be rejected by
+   the end users of it is both a waste of time and also counterproductive.
+
+   * Consider manually fixing any pre-existing issues in your project which
+     would trigger the rule before rollout.
+    
+   * Seek consensus on how strictly the rule will be enforced and what the
+     step by step pathway is to strict enforcement.
+    
+   * Consider *beta-testing* your new rule with a smaller group of users
+     who are more engaged with SQLFluff or code quality in general.
+
+.. _docstring:  https://en.wikipedia.org/wiki/Docstring
+
+Plugin Discovery
+----------------
+
+One of most common questions asked with respect to custom plugins is
+*discovery*, or *"how do I tell SQLFluff where my plugin is"*. SQLFluff
+uses pluggy_ as it's plugin architecture (developed by the folks at pytest_).
+Pluggy uses the python packaging metadata for plugin discovery. This means
+that **your plugin must be installed as a python package for discovery**.
+Specifically, it must define an `entry point`_ for SQLFluff.
+When SQLFluff runs, it inspects installed python packages for this entry
+point and then can run any which define one. For example you'll see in the
+`SQLFluff example plugin`_ that the ``pyproject.toml`` file has the
+following section:
+
+.. code-block:: toml
+
+   [project.entry-points.sqlfluff]
+   # Change this name in your plugin, e.g. company name or plugin purpose.
+   sqlfluff_example = "sqlfluff_plugin_example"
+
+You can find equivalent examples for ``setup.cfg`` and ``setup.py`` in the
+python docs for `entry point`_. This information is registered
+*on install* of your plugin, (i.e. when running `pip install`, or equivalent
+if you're using a different package manager) so if you change it later, you
+may need to re-install your plugin.
+
+You can test whether your rule has been successfully discovered by running
+``sqlfluff rules`` and reviewing whether your new rule has been included in
+the readout.
+
+.. note::
+    If you're struggling with rule discovery, **use the example plugin**.
+    It can be much easier to take a known working example and then modify
+    from there:
+
+    1. Copy the code from the `SQLFluff example plugin`_ into a local
+       folder.
+    
+    2. Run `pip install -e /path/to/where/you/put/it`.
+
+    3. Run `sqlfluff rules`, to confirm that the example plugin is present
+       to demonstrate to yourself that discovery is functional.
+
+    4. Then edit the example plugin to do what you want now that discovery
+       isn't an issue. You may have to re-run `pip install ...` if you
+       change anything in the rule metadata (like the entry point, filenames
+       or plugin location).
+
+.. _pluggy: https://pluggy.readthedocs.io/en/latest/
+.. _pytest: https://docs.pytest.org/en/stable/
+.. _`entry point`: https://setuptools.pypa.io/en/stable/userguide/entry_point.html
+.. _`SQLFluff example plugin`: https://github.com/sqlfluff/sqlfluff/tree/main/plugins/sqlfluff-plugin-example

--- a/docs/source/guides/setup/developing_custom_rules.rst
+++ b/docs/source/guides/setup/developing_custom_rules.rst
@@ -33,7 +33,7 @@ help you decide what to develop:
      parse structure of some example queries you'd want to handle by using
      ``sqlfluff parse my_file.sql`` to identify the right segment. This is
      then specified using the ``crawl_behaviour`` attribute on the rule.
-    
+
    * The *anchor* location: i.e. which position will show up in the CLI
      readout back to the user. To continue the example of above, while
      :sqlfluff:ref:`LT08` *triggers* on a ``WITH`` statement, it *anchors*
@@ -50,7 +50,7 @@ help you decide what to develop:
    complexity for handling how to automatically fix lots of edge cases,
    but for your organisation it's probably not worth the overhead unless
    you're a **very big team** or **come across a huge amount of poorly**
-   **formatted SQL**. 
+   **formatted SQL**.
 
    * Consider the information not just to *trigger*, but also whether a
      custom error message would be appropriate and how to get the information
@@ -71,10 +71,10 @@ help you decide what to develop:
 
    * Consider manually fixing any pre-existing issues in your project which
      would trigger the rule before rollout.
-    
+
    * Seek consensus on how strictly the rule will be enforced and what the
      step by step pathway is to strict enforcement.
-    
+
    * Consider *beta-testing* your new rule with a smaller group of users
      who are more engaged with SQLFluff or code quality in general.
 
@@ -117,7 +117,7 @@ the readout.
 
     1. Copy the code from the `SQLFluff example plugin`_ into a local
        folder.
-    
+
     2. Run `pip install -e /path/to/where/you/put/it`.
 
     3. Run `sqlfluff rules`, to confirm that the example plugin is present

--- a/docs/source/guides/troubleshooting/how_to.rst
+++ b/docs/source/guides/troubleshooting/how_to.rst
@@ -87,7 +87,7 @@ See :ref:`ignoreconfig`.
 Configuration Issues
 ^^^^^^^^^^^^^^^^^^^^
 
-If you're getting ether error unexpected behaviour with your config or errors
+If you're getting ether unexpected behaviour with your config, or errors
 because config values haven't been set correctly, it's often due to config
 file discovery (i.e. whether SQLFluff can find your config file, and what
 order it's combining config files).

--- a/docs/source/guides/troubleshooting/how_to.rst
+++ b/docs/source/guides/troubleshooting/how_to.rst
@@ -1,0 +1,144 @@
+How to Troubleshoot SQLFluff
+============================
+
+It can at times be tricky to troubleshoot SQLFluff as it exists within
+an ecosystem of other tools, and can be deployed in wide range of ways.
+
+This step by step guide can help you narrow down what's likely going wrong
+and point you toward the swiftest resolution.
+
+1. Common Errors
+----------------
+
+There are a few error messages you may get which have relatively
+straightforward resolution paths.
+
+Parsing Errors
+^^^^^^^^^^^^^^
+
+SQLFluff needs to be able to parse your SQL to understand it's structure.
+That means if it fails to parse the SQL it will give you an error message.
+The intent is that if SQLFluff cannot parse the SQL, then it should mean
+the SQL is also invalid and help you understand where and why.
+
+For example, this is a simple query which is not valid SQL:
+
+.. code-block:: sql
+
+   select 1 2 3
+   from my_table
+
+When running ``sqlfluff lint`` or ``sqlfluff parse`` we get the following
+error message::
+
+    ==== parsing violations ====
+    L:   1 | P:  10 |  PRS | Line 1, Position 10: Found unparsable section: '2 3'
+
+Furthermore if we look at the full parsing output we can see an unparsable
+section in the parse tree:
+
+.. code-block::
+   :emphasize-lines: 12,13,14,15
+
+   [L:  1, P:  1]      |file:
+   [L:  1, P:  1]      |    statement:
+   [L:  1, P:  1]      |        select_statement:
+   [L:  1, P:  1]      |            select_clause:
+   [L:  1, P:  1]      |                keyword:                                      'select'
+   [L:  1, P:  7]      |                [META] indent:
+   [L:  1, P:  7]      |                whitespace:                                   ' '
+   [L:  1, P:  8]      |                select_clause_element:
+   [L:  1, P:  8]      |                    numeric_literal:                          '1'
+   [L:  1, P:  9]      |                [META] dedent:
+   [L:  1, P:  9]      |                whitespace:                                   ' '
+   [L:  1, P: 10]      |                unparsable:                                   !! Expected: 'Nothing here.'
+   [L:  1, P: 10]      |                    numeric_literal:                          '2'
+   [L:  1, P: 11]      |                    whitespace:                               ' '
+   [L:  1, P: 12]      |                    numeric_literal:                          '3'
+   [L:  1, P: 13]      |            newline:                                          '\n'
+   [L:  2, P:  1]      |            from_clause:
+   [L:  2, P:  1]      |                keyword:                                      'from'
+   [L:  2, P:  5]      |                whitespace:                                   ' '
+   [L:  2, P:  6]      |                from_expression:
+   [L:  2, P:  6]      |                    [META] indent:
+   [L:  2, P:  6]      |                    from_expression_element:
+   [L:  2, P:  6]      |                        table_expression:
+   [L:  2, P:  6]      |                            table_reference:
+   [L:  2, P:  6]      |                                naked_identifier:             'my_table'
+   [L:  2, P: 14]      |                    [META] dedent:
+   [L:  2, P: 14]      |    newline:                                                  '\n'
+   [L:  3, P:  1]      |    [META] end_of_file:
+
+SQLFluff maintains it's own version of each SQL dialect, and this may not be
+exhaustive for some of the dialects which are newer to SQLFluff or which are
+in very active development themselves. This means in some scenarios you may
+find a query which runs fine in your environment, but cannot be parsed by
+SQLFluff. This is not a *"bug"* per-se, but is an indicator of a gap in the
+SQLFluff dialect.
+
+Many of the issues raised on GitHub relate to parsing errors like this, but
+it's also a great way to support the project if you feel able to contribute
+a dialect improvement yourself. We have a short guide on
+:ref:`contributing_dialect_changes` to walk you through the process. In the
+short term you can also ignore specific files from your overall project so
+that this specific file doesn't become a blocker for the rest.
+See :ref:`ignoreconfig`.
+
+Configuration Issues
+^^^^^^^^^^^^^^^^^^^^
+
+If you're getting ether error unexpected behaviour with your config or errors
+because config values haven't been set correctly, it's often due to config
+file discovery (i.e. whether SQLFluff can find your config file, and what
+order it's combining config files).
+
+For a more general guide to this topic see :ref:`setting_config`.
+
+To help troubleshoot issues, if you run ``sqlfluff`` with a more verbose
+logging setting (e.g. ``sqlfluff lint /my/model.sql -v``, or ``-vv``, or
+``-vvvvvv``) you'll get a readout of the root config that SQLFluff is using.
+This can help debug which values are being used.
+
+2. Isolating SQLFluff
+---------------------
+
+If you're still getting strange errors, then the next most useful thing you
+can do, both to help narrow down the cause, but also to assist with fixing
+a bug if you have found one, is to isolate SQLFluff from any other tools
+you're using in parallel:
+
+1. If you're using SQLFluff with the :ref:`dbt_templater`, then try and
+   recreate the error with the :ref:`jinja_templater` to remove the influence
+   of ``dbt`` and any database connection related issues.
+
+2. If you're getting an error in a remote CI suite (for example on GitHub
+   actions, or a server like Jenkins), try and recreate the issue locally
+   on your machine using the same tools.
+
+3. If you're :ref:`using-pre-commit`, :ref:`diff-quality` or the
+   `VSCode extension`_ try to recreate the issue by running the SQLFluff
+   :ref:`cliref` directly. Often this can make debugging significantly
+   easier because some of these tools hide some of the error messages
+   which SQLFluff gives the user to help debugging errors.
+
+.. _`VSCode extension`: https://github.com/sqlfluff/vscode-sqlfluff
+
+3. Minimise the Query
+---------------------
+
+Often SQL scripts can get very long, and if you're getting an error on a very
+long script, then it can be extremely difficult to work out what the issue is.
+To assist with this we recommend iteratively cutting down the file (or
+alternatively, iteratively building a file back up) until you have the smallest
+file which still exhibits the issue. Often after this step, the issue can
+become obvious.
+
+1. If your file has multiple statements in it (i.e. statements separated
+   by ``;``), then remove ones until SQLFluff no longer shows the issue. When
+   you get to that point, add the offending one back in and remove all the
+   others.
+
+2. Simplify individual statements. For example in a ``SELECT`` statement, if
+   you suspect the issue is coming from a particular column, then remove the
+   others, or remove CTEs, until you've got the simplest query which still
+   shows the issue.

--- a/plugins/sqlfluff-plugin-example/README.md
+++ b/plugins/sqlfluff-plugin-example/README.md
@@ -1,7 +1,50 @@
 # Example rules plugin
 
-This example plugin showcases the ability to setup
-installable rule plugins.
+This example plugin showcases the ability to setup installable rule plugins.
 
-This interface is supported from version `0.4.0` of
-SQLFluff onwards.
+This interface is supported from version `0.4.0` of SQLFluff onwards.
+
+For a step by step guide on using custom rule plugins, see the
+[guide in the docs](https://docs.sqlfluff.com/en/stable/perma/plugin_guide.html),
+or the more technical docs on [developing plugins](https://docs.sqlfluff.com/en/stable/perma/plugin_dev.html).
+
+## Discovery
+
+SQLFluff plugins use [pluggy](https://pluggy.readthedocs.io/en/latest/) to
+enable plugin discovery. This relies on the python packaging metadata, and
+therefore your plugin *must be installed as a python package* to be found
+by SQLFluff. This doesn't mean that you need to make your plugin *public*
+because you can install from a local path or private git repo (or any
+other location that you can `pip install` from). See the docs links
+above for more details.
+
+## Plugin structure
+
+This plugin follows the structure we recommend for any custom plugin:
+
+* `pyproject.toml` defines all the package metadata, including importantly
+  the `entry_point` configuration which allows SQLFluff to find your
+  plugin once installed. See the [python docs](https://setuptools.pypa.io/en/stable/userguide/entry_point.html)
+  for more detail and examples for `setup.cfg` or `setup.py` if you prefer
+  that format instead.
+
+* `MANIFEST.in` defines any *non-python* files to include when the package
+  is installed. This specifies that we should also include the bundled
+  config file for the rule. If you don't specify any new config keys for
+  your rule you don't need this.
+
+* `/src/sqlfluff_plugin_example` contains the main source code for the
+  plugin. You should change the name to an appropriate one for your plugin
+  and ensure that it matches the configuration in `pyproject.toml`. Within
+  that folder you should find most of the methods are individually
+  documented so you can understand what does what.
+
+* `/test` contains a test suite for this rule. We recommend that you *do*
+  create tests for your rule, and so we include an example `pytest` suite
+  for our example rule here. This folder is not *necessary* for the rule
+  to function, and so the level of test coverage you implement is up to
+  you. The test suite can be invoked by running [pytest](https://docs.pytest.org/en/stable/)
+  on this folder. Great tests for your rules not only ensure consistent
+  functionality over time, but can also be a great tool during initial
+  development and serve as examples of how the rule operates to share with
+  colleagues when rolling out your rule.


### PR DESCRIPTION
This adds two more guides in the guides section:

- One on how to troubleshoot SQLFluff (this one probably needs extending at some point, but I think it's probably a good starting set of steps).
- One on how to develop custom rules (where I've also fleshed out the `README.md` file for the example plugin).

I think the latter should resolve #5655 and resolve #2352.