### PR TITLE
Documentation and small overhaul of parametrized rule test cases

### DIFF
--- a/docs/source/guides/contributing/rules.rst
+++ b/docs/source/guides/contributing/rules.rst
@@ -29,12 +29,11 @@ only those tests:
 
 .. code-block:: sh
 
-   pytest -vv test/rules/yaml_test_cases_test.py --rule_id=RF01
    pytest -vv test/rules/ -k RF01
 
-The :code:`--rule_id` syntax relies on the name of the yaml file, and the :code:`-k`
-option simply searches for the content of the argument being in the name of the test.
-The latter is slightly less to type and so is generally the most frequently used.
+The :code:`-k` option simply searches for the content of the argument being in the name
+of the test, which will match any single or combo tests for that rule. By convention,
+any test cases for a rule should include the code for that rule.
 
 .. _`yaml`: https://yaml.org/
 .. _`yaml fixtures on github`: https://github.com/sqlfluff/sqlfluff/tree/main/test/fixtures/rules/std_rule_cases

--- a/plugins/sqlfluff-plugin-example/test/rules/rule_test_cases_test.py
+++ b/plugins/sqlfluff-plugin-example/test/rules/rule_test_cases_test.py
@@ -7,7 +7,6 @@ import pytest
 from sqlfluff.utils.testing.rules import (
     RuleTestCase,
     load_test_cases,
-    rules__test_helper,
 )
 
 ids, test_cases = load_test_cases(
@@ -19,5 +18,15 @@ ids, test_cases = load_test_cases(
 
 @pytest.mark.parametrize("test_case", test_cases, ids=ids)
 def test__rule_test_case(test_case: RuleTestCase):
-    """Run the tests."""
-    rules__test_helper(test_case)
+    """Evaluate the parameterized yaml test cases.
+
+    NOTE: The test cases are loaded using `load_test_cases` above
+    and then passed to this test case one by one. This allows fairly
+    detailed rule testing, but defined only in the yaml files without
+    any python overhead required.
+
+    For examples of what features are available for parametrized rule
+    testing, take a look at some of the test cases defined for the bundled
+    SQLFluff core rules.
+    """
+    test_case.evaluate()

--- a/plugins/sqlfluff-plugin-example/test/rules/rule_test_cases_test.py
+++ b/plugins/sqlfluff-plugin-example/test/rules/rule_test_cases_test.py
@@ -4,7 +4,11 @@ import os
 
 import pytest
 
-from sqlfluff.utils.testing.rules import load_test_cases, rules__test_helper
+from sqlfluff.utils.testing.rules import (
+    RuleTestCase,
+    load_test_cases,
+    rules__test_helper,
+)
 
 ids, test_cases = load_test_cases(
     test_cases_path=os.path.join(
@@ -14,6 +18,6 @@ ids, test_cases = load_test_cases(
 
 
 @pytest.mark.parametrize("test_case", test_cases, ids=ids)
-def test__rule_test_case(test_case):
+def test__rule_test_case(test_case: RuleTestCase):
     """Run the tests."""
     rules__test_helper(test_case)

--- a/src/sqlfluff/utils/testing/rules.py
+++ b/src/sqlfluff/utils/testing/rules.py
@@ -48,7 +48,12 @@ class RuleTestCase(NamedTuple):
 def load_test_cases(
     test_cases_path: str,
 ) -> Tuple[List[str], List[RuleTestCase]]:
-    """Load rule test cases from YAML files."""
+    """Load rule test cases from YAML files.
+
+    Args:
+        test_cases_path (str): A glob string specifying the files containing
+            test cases to load.
+    """
     ids = []
     test_cases = []
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -301,8 +301,3 @@ def test_verbosity_level(request):
     Has a verbosity level of 0
     """
     return request.config.getoption("verbose")
-
-
-def pytest_addoption(parser):
-    """Allow to run test/rules/yaml_test_cases_test.py for a specific rule_id."""
-    parser.addoption("--rule_id", action="store", default="*", help="Rule id to run")

--- a/test/rules/yaml_test_cases_test.py
+++ b/test/rules/yaml_test_cases_test.py
@@ -7,6 +7,7 @@ import pytest
 
 from sqlfluff.core.config import FluffConfig
 from sqlfluff.utils.testing.rules import (
+    RuleTestCase,
     get_rule_from_set,
     load_test_cases,
     rules__test_helper,
@@ -14,21 +15,32 @@ from sqlfluff.utils.testing.rules import (
 
 
 def pytest_generate_tests(metafunc):
-    """Generate tests, optionally by rule_id."""
-    rule_id = metafunc.config.getoption("rule_id")
+    """Generate yaml test cases from file.
+
+    This is a predefined pytest hook which allows us to parametrize all
+    other test cases defined in this module.
+    https://docs.pytest.org/en/stable/how-to/parametrize.html#pytest-generate-tests
+    """
     ids, test_cases = load_test_cases(
-        test_cases_path=os.path.join(
-            "test/fixtures/rules/std_rule_cases", f"{rule_id}.yml"
-        )
+        test_cases_path="test/fixtures/rules/std_rule_cases/*.yml"
     )
+    # Only parametrize methods which include `test_case` in their
+    # list of required fixtures.
     if "test_case" in metafunc.fixturenames:
         metafunc.parametrize("test_case", test_cases, ids=ids)
 
 
 @pytest.mark.integration
 @pytest.mark.rules_suite
-def test__rule_test_case(test_case, caplog):
-    """Run the tests."""
+def test__rule_test_case(test_case: RuleTestCase, caplog):
+    """Execute each of the rule test cases.
+
+    The cases themselves are parametrized using the above
+    `pytest_generate_tests` function, which both loads them
+    from the yaml files do generate `RuleTestCase` objects,
+    but also sets appropriate IDs for each test to improve the
+    user feedback.
+    """
     with caplog.at_level(logging.DEBUG, logger="sqlfluff.rules"):
         with caplog.at_level(logging.DEBUG, logger="sqlfluff.linter"):
             res = rules__test_helper(test_case)

--- a/test/rules/yaml_test_cases_test.py
+++ b/test/rules/yaml_test_cases_test.py
@@ -5,12 +5,9 @@ import os
 
 import pytest
 
-from sqlfluff.core.config import FluffConfig
 from sqlfluff.utils.testing.rules import (
     RuleTestCase,
-    get_rule_from_set,
     load_test_cases,
-    rules__test_helper,
 )
 
 
@@ -43,12 +40,7 @@ def test__rule_test_case(test_case: RuleTestCase, caplog):
     """
     with caplog.at_level(logging.DEBUG, logger="sqlfluff.rules"):
         with caplog.at_level(logging.DEBUG, logger="sqlfluff.linter"):
-            res = rules__test_helper(test_case)
-            if res is not None and res != test_case.fail_str:
-                cfg = FluffConfig(configs=test_case.configs)
-                rule = get_rule_from_set(test_case.rule, config=cfg)
-                assert rule.is_fix_compatible, f"Rule {test_case.rule} returned "
-                'fixes but does not specify "is_fix_compatible = True".'
+            test_case.evaluate()
 
 
 def test__rule_test_global_config():

--- a/test/testing_test.py
+++ b/test/testing_test.py
@@ -7,7 +7,6 @@ from sqlfluff.utils.testing.rules import (
     RuleTestCase,
     assert_rule_fail_in_sql,
     assert_rule_pass_in_sql,
-    rules__test_helper,
 )
 
 
@@ -39,15 +38,15 @@ def test_assert_rule_pass_in_sql_should_fail_when_there_are_violations():
     failed_test.match("Found LT01 failures in query which should pass")
 
 
-def test_rules__test_helper_skipped_when_test_case_skipped():
-    """Util rules__test_helper should skip the test when test case is "skipped"."""
+def test_rules_test_case_skipped_when_test_case_skipped():
+    """Test functionality of the `RuleTestCase` skip attribute."""
     rule_test_case = RuleTestCase(rule="CP01", skip="Skip this one for now")
     with pytest.raises(Skipped) as skipped_test:
-        rules__test_helper(rule_test_case)
+        rule_test_case.evaluate()
     skipped_test.match("Skip this one for now")
 
 
-def test_rules__test_helper_has_variable_introspection(test_verbosity_level):
+def test_rules_test_case_has_variable_introspection(test_verbosity_level):
     """Make sure the helper gives variable introspection information on failure."""
     rule_test_case = RuleTestCase(
         rule="LT02",
@@ -66,7 +65,7 @@ def test_rules__test_helper_has_variable_introspection(test_verbosity_level):
         """,
     )
     with pytest.raises(AssertionError) as skipped_test:
-        rules__test_helper(rule_test_case)
+        rule_test_case.evaluate()
     if test_verbosity_level >= 2:
         # Enough to check that a query diff is displayed
         skipped_test.match("select")


### PR DESCRIPTION
I'd like to do a bit of an overhaul of the yaml rule test cases to eventually support a wider range of features. In particular specifying multiple rules in one test.

Rather than do that in one big PR, I intend to do it bit by bit in more manageable pieces. This PR is the first one of those.

This PR:
* Is _mostly_ documentation and docstrings. A lot of the methods and classes in this part of the codebase aren't particularly well documented, and I've added most of this just to help _myself_ as I go further with the refactor because I didn't know what each method did.
* It moves the main entry point for rules testing to a method on the `RuleTestCase` called `.evaluate()`. It's currently just a thin shim onto `rules__test_helper()` but that will change in the next step.
* It removes the option to select rule test cases using `pytest --rule_id`. Using `pytest -k` instead works just as well, and is more generic. It also is more future proof to when we might have test cases with more than one rule. The `--rule_id` option also currently works if the rule test case is named exactly after the rule code (which is already not the case for some of the layout rules). Also as a nit, it's not the rule `id` anyway, it's the rule `code` :shrug:`. It's custom code that we don't need.
* The code which checked for `is_fix_compatible` wasn't being executed at all before this PR. It was stuck in a clause based on a function which always returned `None`. I've moved it into a place where it will actually get checked.