### PR TITLE
Details on debugging and setup for diff-quality

### DIFF
--- a/docs/source/production/diff_quality.rst
+++ b/docs/source/production/diff_quality.rst
@@ -78,7 +78,7 @@ position, you will need to run SQLFluff directly.
    robust setup. If each is rooted in different paths if can be very
    difficult to achieve the same result, and the resulting behaviour
    can be difficult to debug.
-   
+
    To debug any issues relating to this setup, we recommend occasionally
    running ``sqlfluff`` directly using the main cli (i.e. calling
    :code:`sqlfluff lint my/project/path`) and check whether that route

--- a/docs/source/production/diff_quality.rst
+++ b/docs/source/production/diff_quality.rst
@@ -25,7 +25,7 @@ Adding ``diff-quality`` to your builds
 In your CI build script:
 
 1. Set the current working directory to the ``git`` repository containing the
-SQL code to be checked.
+   SQL code to be checked.
 
 2. Run ``diff-quality``, specifying SQLFluff as the underlying tool:
 
@@ -55,13 +55,44 @@ although the format is a little different. Note that ``diff-quality`` only lists
 the line _numbers_, not the character position. If you need the character
 position, you will need to run SQLFluff directly.
 
+.. note::
+   When using ``diff-quality`` with ``.sqlfluff`` :ref:`config-files`, and
+   especially together with the :ref:`dbt_templater`, it can be really easy
+   to run into issues with file discovery. There are a few steps you can
+   take to make it much less likely that this will happen:
+
+   1. ``diff-quality`` needs to be run from the root of your ``git``
+      repository (so that it can find the ``git`` metadata).
+
+   2. SQLFluff works best if the bulk of the configuration is done from a
+      single ``.sqlfluff`` file, which should be in the root of your
+      ``git`` repository.
+
+   3. If using :ref:`dbt_templater`, then either place your ``dbt_project.yml``
+      file in the same root folder, or if you put it in a subfolder, then
+      only invoke ``diff-quality`` and ``sqlfluff`` from the root and define
+      the subfolder that the ``dbt`` project lives in using the ``.sqlfluff``
+      config file.
+
+   By aligning the paths of all three, you should be able to achieve a
+   robust setup. If each is rooted in different paths if can be very
+   difficult to achieve the same result, and the resulting behaviour
+   can be difficult to debug.
+   
+   To debug any issues relating to this setup, we recommend occasionally
+   running ``sqlfluff`` directly using the main cli (i.e. calling
+   :code:`sqlfluff lint my/project/path`) and check whether that route
+   gives you the results you expect. ``diff-quality`` should behave as
+   though it's calling the SQLFluff CLI *from the same path that you*
+   *invoke* ``diff-quality``.
+
 For more information on ``diff-quality`` and the ``diff_cover`` package, see the
 `documentation <https://github.com/Bachmann1234/diff_cover>`_ on their github
 repository. It covers topics such as:
 
 * Generating HTML reports
 * Controlling which branch to compare against (i.e. to determine new/changed
-  lines). The default is `origin/master`.
+  lines). The default is ``origin/main``.
 * Configuring ``diff-quality`` to return an error code if the quality is
   too low.
 * Troubleshooting

--- a/docs/source/production/pre_commit.rst
+++ b/docs/source/production/pre_commit.rst
@@ -17,8 +17,8 @@ only linting/fixing the files that changed.
 
 SQLFluff comes with two `pre-commit`_ hooks:
 
-* sqlfluff-lint: returns linting errors.
-* sqlfluff-fix: attempts to fix rule violations.
+* ``sqlfluff-lint``: returns linting errors.
+* ``sqlfluff-fix``: attempts to fix rule violations.
 
 .. warning::
    For safety reasons, ``sqlfluff-fix`` by default will not make any fixes in
@@ -34,7 +34,7 @@ SQLFluff comes with two `pre-commit`_ hooks:
    always be sure to review any fixes applied to files with templating or parse
    errors to verify they are okay.*
 
-You should create a file named `.pre-commit-config.yaml`
+You should create a file named ``.pre-commit-config.yaml``
 at the root of your git project, which should look
 like this:
 


### PR DESCRIPTION
This helps tie off #2848 .

This PR contains a few formatting improvements for the docs relating to `diff-quality` and `pre-commit`. It mostly clarifies best practice when using `diff-quality` to avoid issues with file discovery.