### PR TITLE
Improve heuristics for inline config

### DIFF
--- a/test/core/config/fluffconfig_test.py
+++ b/test/core/config/fluffconfig_test.py
@@ -340,6 +340,14 @@ def test__process_inline_config():
     cfg.process_inline_config("-- sqlfluff:jinja:my_path:c:\\foo", "test.sql")
     assert cfg.get("my_path", section="jinja") == "c:\\foo"
 
+    # Check that JSON objects are not mangled
+    cfg.process_inline_config('-- sqlfluff:jinja:my_dict:{"k":"v"}', "test.sql")
+    assert cfg.get("my_dict", section="jinja") == '{"k":"v"}'
+
+    # Check that JSON arrays are not mangled
+    cfg.process_inline_config('-- sqlfluff:jinja:my_dict:[{"k":"v"}]', "test.sql")
+    assert cfg.get("my_dict", section="jinja") == '[{"k":"v"}]'
+
 
 @pytest.mark.parametrize(
     "raw_sql",


### PR DESCRIPTION
Support JSON values, sometimes used in Jinja context.


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #6370


### Are there any other side effects of this change that we should be aware of?
Hopefully not.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
