### PR TITLE
Snowflake: Support bracketed lambda functions without datatypes

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -8483,7 +8483,7 @@ class LambdaExpressionSegment(BaseSegment):
                 Delimited(
                     Sequence(
                         Ref("NakedIdentifierSegment"),
-                        Ref("DatatypeSegment"),
+                        Ref("DatatypeSegment", optional=True),
                     )
                 )
             ),

--- a/test/fixtures/dialects/snowflake/select_higher_order_function.sql
+++ b/test/fixtures/dialects/snowflake/select_higher_order_function.sql
@@ -9,3 +9,5 @@ SELECT
     TRANSFORM("ident", j -> j) as sample_transform,
     some_other_function('unusual arguments', x -> 'still a lambda expression', true) as sample_other
 FROM ref;
+
+SELECT REDUCE([1,2,3], 0, (acc, val) -> acc + val);

--- a/test/fixtures/dialects/snowflake/select_higher_order_function.yml
+++ b/test/fixtures/dialects/snowflake/select_higher_order_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 71c80712cfb3a38e60e9c54cc5f51d4964b755935534882de394ab33fffddada
+_hash: b010934e6f9b8805d2002e3c436aa7cde66fe9ca7a6c1c0a1a7ee2dfdd67c862
 file:
 - statement:
     select_statement:
@@ -201,4 +201,44 @@ file:
             table_expression:
               table_reference:
                 naked_identifier: ref
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: REDUCE
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '1'
+                  - comma: ','
+                  - numeric_literal: '2'
+                  - comma: ','
+                  - numeric_literal: '3'
+                  - end_square_bracket: ']'
+              - comma: ','
+              - expression:
+                  numeric_literal: '0'
+              - comma: ','
+              - lambda_expression:
+                  bracketed:
+                  - start_bracket: (
+                  - naked_identifier: acc
+                  - comma: ','
+                  - naked_identifier: val
+                  - end_bracket: )
+                  function_assigner: ->
+                  expression:
+                  - column_reference:
+                      naked_identifier: acc
+                  - binary_operator: +
+                  - column_reference:
+                      naked_identifier: val
+              - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This makes the datatype in a bracketed lambda function optional for the snowflake dialect.
- fixes #6386 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
