### PR TITLE
LT01: Add default config for `match_condition` to touch

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -179,6 +179,9 @@ spacing_within = touch:inline
 [sqlfluff:layout:type:bracketed_arguments]
 spacing_before = touch:inline
 
+[sqlfluff:layout:type:match_condition]
+spacing_within = touch:inline
+
 [sqlfluff:layout:type:typed_struct_literal]
 spacing_within = touch
 

--- a/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
@@ -27,3 +27,36 @@ test_fail_parenthesis_block_not_isolated_templated:
 test_pass_parenthesis_function:
   pass_str: |
     SELECT foo(5) FROM T1;
+
+test_pass_snowflake_match_condition:
+  pass_str: |
+    select *
+    from table1
+    asof join table2 match_condition(t1 > t2) on pk1 = pk2;
+  configs:
+    core:
+      dialect: snowflake
+
+test_fail_snowflake_match_condition:
+  fail_str: |
+    select
+        table1.pk1,
+        table1.t1
+    from table1
+        asof join
+        table2
+        match_condition
+        (t1 > t2)
+        on table1.pk1 = table2.pk2;
+  fix_str: |
+    select
+        table1.pk1,
+        table1.t1
+    from table1
+        asof join
+        table2
+        match_condition(t1 > t2)
+        on table1.pk1 = table2.pk2;
+  configs:
+    core:
+      dialect: snowflake


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Removes the whitespace between `match_condition` and the `bracket` in LT01.
- fixes #5885

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
