### PR TITLE
Snowflake: Allow for additional `CONNECT BY` expressions that may use `PRIOR`

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -685,6 +685,7 @@ snowflake_dialect.replace(
             # Allow use of CONNECT_BY_ROOT pseudo-columns.
             # https://docs.snowflake.com/en/sql-reference/constructs/connect-by.html#:~:text=Snowflake%20supports%20the%20CONNECT_BY_ROOT,the%20Examples%20section%20below.
             Sequence("CONNECT_BY_ROOT", Ref("ColumnReferenceSegment")),
+            Sequence("PRIOR", Ref("ColumnReferenceSegment")),
         ],
         before=Ref("LiteralGrammar"),
     ),
@@ -1165,27 +1166,13 @@ class ConnectByClauseSegment(BaseSegment):
             "CONNECT",
             "BY",
             Delimited(
-                Sequence(
-                    Ref.keyword("PRIOR", optional=True),
-                    Ref("ColumnReferenceSegment"),
-                    Ref("EqualsSegment"),
-                    Ref.keyword("PRIOR", optional=True),
-                    Ref("ColumnReferenceSegment"),
-                ),
+                OptionallyBracketed(Ref("ExpressionSegment")),
             ),
         ),
         Sequence(
             "CONNECT",
             "BY",
-            Delimited(
-                Sequence(
-                    Ref.keyword("PRIOR", optional=True),
-                    Ref("ColumnReferenceSegment"),
-                    Ref("EqualsSegment"),
-                    Ref("ColumnReferenceSegment"),
-                ),
-                delimiter="AND",
-            ),
+            OptionallyBracketed(Ref("ExpressionSegment")),
             Sequence(
                 "START",
                 "WITH",

--- a/test/fixtures/dialects/snowflake/connect_by.sql
+++ b/test/fixtures/dialects/snowflake/connect_by.sql
@@ -42,3 +42,16 @@ select
 from components c
 connect by prior c.parent_component_id = c.component_id AND PRIOR c.component_type = c.component_type
 order by quantity;
+
+with tbl as (
+    select 'A' as foo, 'B' as bar
+    union all
+    select 'B' as foo, 'C' as bar
+)
+
+select
+    *,
+    connect_by_root bar as connect_by_root,
+    sys_connect_by_path(bar, '') as path
+from tbl
+connect by prior foo = bar and not contains(prior path, bar);

--- a/test/fixtures/dialects/snowflake/connect_by.yml
+++ b/test/fixtures/dialects/snowflake/connect_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f7fb309134f715fa9db2152b58edb39c7e9945c453bfd0ec7647b0c4c5127b68
+_hash: e14025f4c73fa53449dcd09a84dd1f56407ecfa362d611a04ff98af56aebcef5
 file:
 - statement:
     select_statement:
@@ -38,13 +38,14 @@ file:
               quoted_literal: "'President'"
           - keyword: connect
           - keyword: by
-          - column_reference:
-              naked_identifier: manager_id
-          - comparison_operator:
-              raw_comparison_operator: '='
-          - keyword: prior
-          - column_reference:
-              naked_identifier: employee_id
+          - expression:
+            - column_reference:
+                naked_identifier: manager_id
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - keyword: prior
+            - column_reference:
+                naked_identifier: employee_id
       orderby_clause:
       - keyword: order
       - keyword: by
@@ -99,13 +100,14 @@ file:
               quoted_literal: "'President'"
           - keyword: connect
           - keyword: by
-          - column_reference:
-              naked_identifier: manager_id
-          - comparison_operator:
-              raw_comparison_operator: '='
-          - keyword: prior
-          - column_reference:
-              naked_identifier: employee_id
+          - expression:
+            - column_reference:
+                naked_identifier: manager_id
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - keyword: prior
+            - column_reference:
+                naked_identifier: employee_id
       orderby_clause:
       - keyword: order
       - keyword: by
@@ -167,13 +169,14 @@ file:
               numeric_literal: '1'
           - keyword: connect
           - keyword: by
-          - column_reference:
-              naked_identifier: parent_component_id
-          - comparison_operator:
-              raw_comparison_operator: '='
-          - keyword: prior
-          - column_reference:
-              naked_identifier: component_id
+          - expression:
+            - column_reference:
+                naked_identifier: parent_component_id
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - keyword: prior
+            - column_reference:
+                naked_identifier: component_id
       orderby_clause:
       - keyword: order
       - keyword: by
@@ -221,13 +224,14 @@ file:
               quoted_literal: "'President'"
           - keyword: connect
           - keyword: by
-          - column_reference:
-              naked_identifier: manager_id
-          - comparison_operator:
-              raw_comparison_operator: '='
-          - keyword: prior
-          - column_reference:
-              naked_identifier: employee_id
+          - expression:
+            - column_reference:
+                naked_identifier: manager_id
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - keyword: prior
+            - column_reference:
+                naked_identifier: employee_id
       orderby_clause:
       - keyword: order
       - keyword: by
@@ -269,32 +273,143 @@ file:
           connectby_clause:
           - keyword: connect
           - keyword: by
-          - keyword: prior
-          - column_reference:
-            - naked_identifier: c
-            - dot: .
-            - naked_identifier: parent_component_id
-          - comparison_operator:
-              raw_comparison_operator: '='
-          - column_reference:
-            - naked_identifier: c
-            - dot: .
-            - naked_identifier: component_id
-          - keyword: AND
-          - keyword: PRIOR
-          - column_reference:
-            - naked_identifier: c
-            - dot: .
-            - naked_identifier: component_type
-          - comparison_operator:
-              raw_comparison_operator: '='
-          - column_reference:
-            - naked_identifier: c
-            - dot: .
-            - naked_identifier: component_type
+          - expression:
+            - keyword: prior
+            - column_reference:
+              - naked_identifier: c
+              - dot: .
+              - naked_identifier: parent_component_id
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - column_reference:
+              - naked_identifier: c
+              - dot: .
+              - naked_identifier: component_id
+            - binary_operator: AND
+            - keyword: PRIOR
+            - column_reference:
+              - naked_identifier: c
+              - dot: .
+              - naked_identifier: component_type
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - column_reference:
+              - naked_identifier: c
+              - dot: .
+              - naked_identifier: component_type
       orderby_clause:
       - keyword: order
       - keyword: by
       - column_reference:
           naked_identifier: quantity
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        naked_identifier: tbl
+        keyword: as
+        bracketed:
+          start_bracket: (
+          set_expression:
+          - select_statement:
+              select_clause:
+              - keyword: select
+              - select_clause_element:
+                  quoted_literal: "'A'"
+                  alias_expression:
+                    keyword: as
+                    naked_identifier: foo
+              - comma: ','
+              - select_clause_element:
+                  quoted_literal: "'B'"
+                  alias_expression:
+                    keyword: as
+                    naked_identifier: bar
+          - set_operator:
+            - keyword: union
+            - keyword: all
+          - select_statement:
+              select_clause:
+              - keyword: select
+              - select_clause_element:
+                  quoted_literal: "'B'"
+                  alias_expression:
+                    keyword: as
+                    naked_identifier: foo
+              - comma: ','
+              - select_clause_element:
+                  quoted_literal: "'C'"
+                  alias_expression:
+                    keyword: as
+                    naked_identifier: bar
+          end_bracket: )
+      select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        - comma: ','
+        - select_clause_element:
+            keyword: connect_by_root
+            column_reference:
+              naked_identifier: bar
+            alias_expression:
+              keyword: as
+              naked_identifier: connect_by_root
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: sys_connect_by_path
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: bar
+                - comma: ','
+                - expression:
+                    quoted_literal: "''"
+                - end_bracket: )
+            alias_expression:
+              keyword: as
+              naked_identifier: path
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tbl
+            connectby_clause:
+            - keyword: connect
+            - keyword: by
+            - expression:
+              - keyword: prior
+              - column_reference:
+                  naked_identifier: foo
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                  naked_identifier: bar
+              - binary_operator: and
+              - keyword: not
+              - function:
+                  function_name:
+                    function_name_identifier: contains
+                  function_contents:
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        keyword: prior
+                        column_reference:
+                          naked_identifier: path
+                    - comma: ','
+                    - expression:
+                        column_reference:
+                          naked_identifier: bar
+                    - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This allows for expressions in a `CONNECT BY` clause which may use the `PRIOR` keyword before a column name, but may be inside another expression in snowflake.
- fixes #5863

### Are there any other side effects of this change that we should be aware of?
This opens up parsing to be like a `join_on_condition` like the snowflake docs indicate. While potentially allowing for some non-runnable sql, it more correctly handles the parsing.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
