### PR TITLE
RF01: refine support for dialects with dot access syntax

### DIFF
--- a/src/sqlfluff/rules/references/RF01.py
+++ b/src/sqlfluff/rules/references/RF01.py
@@ -71,6 +71,7 @@ class Rule_RF01(BaseRule):
     # because they will more accurately process any internal references.
     crawl_behaviour = SegmentSeekerCrawler(set(_START_TYPES), allow_recurse=False)
     _dialects_disabled_by_default = [
+        "athena",
         "bigquery",
         "databricks",
         "hive",

--- a/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -328,3 +328,13 @@ test_pass_trino_lambda_expression:
   configs:
     core:
       dialect: trino
+
+test_athena_ignore_rule:
+  pass_str: |
+    select
+        a.complex.key,
+        a.complex.structure.val
+    from sch.t1
+  configs:
+    core:
+      dialect: athena

--- a/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -329,12 +329,47 @@ test_pass_trino_lambda_expression:
     core:
       dialect: trino
 
-test_athena_ignore_rule:
+test_athena_ignore_rule_if_single_table:
   pass_str: |
     select
         a.complex.key,
         a.complex.structure.val
     from sch.t1
+  configs:
+    core:
+      dialect: athena
+
+test_athena_apply_rule_if_single_table_and_force_enable:
+  fail_str: |
+    select
+        a.complex.key,
+        a.complex.structure.val
+    from sch.t1
+  configs:
+    core:
+      dialect: athena
+    rules:
+      references.from:
+        force_enable: true
+
+test_athena_apply_rule_if_multiple_tables:
+  fail_str: |
+    select
+        a.complex.key,
+        a.complex.structure.val
+    from sch.table1 as t1
+    left join sch.table2 as t2
+    on t1.id = t2.id
+  configs:
+    core:
+      dialect: athena
+
+test_athena_apply_rule_if_one_aliased_table:
+  fail_str: |
+    select
+        a.complex.key,
+        a.complex.structure.val
+    from sch.table1 as t1
   configs:
     core:
       dialect: athena

--- a/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -373,3 +373,54 @@ test_athena_apply_rule_if_one_aliased_table:
   configs:
     core:
       dialect: athena
+
+test_sqlite_create_trigger_after_insert_reference:
+  # https://github.com/sqlfluff/sqlfluff/issues/6402
+  # https://www.sqlite.org/lang_createtrigger.html
+  pass_str: |
+    CREATE TRIGGER x
+    AFTER INSERT
+    ON y
+    BEGIN
+    SELECT 1 WHERE new.xyz = 3;
+    END
+  configs:
+    core:
+      dialect: sqlite
+
+test_sqlite_create_trigger_after_delete_reference:
+  # https://github.com/sqlfluff/sqlfluff/issues/6402
+  # https://www.sqlite.org/lang_createtrigger.html
+  pass_str: |
+    CREATE TRIGGER x
+    AFTER DELETE
+    ON y
+    BEGIN
+    SELECT 1 WHERE old.xyz = 3;
+    END
+  configs:
+    core:
+      dialect: sqlite
+
+test_sqlite_create_trigger_after_update_reference:
+  # https://github.com/sqlfluff/sqlfluff/issues/6402
+  # https://www.sqlite.org/lang_createtrigger.html
+  pass_str: |
+    CREATE TRIGGER x
+    AFTER UPDATE
+    ON y
+    BEGIN
+    SELECT 1 WHERE old.xyz != new.xyz;
+    END;
+  configs:
+    core:
+      dialect: sqlite
+
+test_sqlite_outside_of_trigger:
+  # https://github.com/sqlfluff/sqlfluff/issues/6402
+  # https://www.sqlite.org/lang_createtrigger.html
+  fail_str: |
+    SELECT foo FROM bar WHERE old.xyz != new.xyz;
+  configs:
+    core:
+      dialect: sqlite


### PR DESCRIPTION
### Brief summary of the change made
- if only one table unaliased is referenced in query and dialect supports dot-struct-access, skip check
- add ability to inject _implicit_ references, implement them for sqlite triggers
- fixes #6033 and #6402

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
