### PR TITLE
Fix docs for CP04 config and add test cases

### DIFF
--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -333,6 +333,16 @@ class RuleMetaclass(type):
                 class_dict["groups"] = base.groups
                 break
 
+        # If the rule doesn't itself define `config_keywords`, check the parent
+        # classes for them. If we don't do this then they'll still be available to
+        # the rule, but they won't appear in the docs.
+        for base in reversed(bases):
+            if "config_keywords" in class_dict:
+                break
+            elif base.config_keywords:
+                class_dict["config_keywords"] = base.config_keywords
+                break
+
         class_dict = RuleMetaclass._populate_docstring(name, class_dict)
         # Don't try and infer code and description for the base classes
         if name not in ("BaseRule",):

--- a/test/fixtures/rules/std_rule_cases/CP04.yml
+++ b/test/fixtures/rules/std_rule_cases/CP04.yml
@@ -1,8 +1,12 @@
 rule: CP04
 
-test_fail_inconsistent_boolean_capitalisation:
+test_fail_inconsistent_boolean_capitalisation_1:
   fail_str: SeLeCt true, FALSE, NULL
   fix_str: SeLeCt true, false, null
+
+test_fail_inconsistent_boolean_capitalisation_2:
+  fail_str: SeLeCt TRUE, false, NULL
+  fix_str: SeLeCt TRUE, FALSE, NULL
 
 test_pass_ignore_word:
   pass_str: SELECT true, FALSE, NULL
@@ -10,3 +14,19 @@ test_pass_ignore_word:
     rules:
       capitalisation.literals:
         ignore_words: true
+
+test_fail_upper_boolean_capitalisation:
+  fail_str: SeLeCt true, FALSE, NULL
+  fix_str: SeLeCt TRUE, FALSE, NULL
+  configs:
+    rules:
+      capitalisation.literals:
+        capitalisation_policy: upper
+
+test_fail_lower_boolean_capitalisation:
+  fail_str: SeLeCt TRUE, false, NULL
+  fix_str: SeLeCt true, false, null
+  configs:
+    rules:
+      capitalisation.literals:
+        capitalisation_policy: lower


### PR DESCRIPTION
Very minor bugfix. The current rule docs for CP04 don't show any configuration values. That's not because they're not there, but it's because they're totally inherited. That also means it's ambiguous as to which capitalisation policy that rule uses (as I found out on a project recently 🤦 ).

This fixes the docs, and add more test cases for CP04 to show it uses the root capitalisation policy.

No actual functionality changes here.