### PR TITLE
TSQL: allow `NEXT VALUE FOR` use as expression

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -6422,9 +6422,9 @@ class ExpressionSegment(BaseSegment):
 
     Extended for TSQL to include the `NEXT VALUE FOR` segment.
     """
+
     type = "expression"
-    
+
     match_grammar: Matchable = OneOf(
-        Ref("Expression_A_Grammar"),
-        Ref("NextValueSequenceSegment")
+        Ref("Expression_A_Grammar"), Ref("NextValueSequenceSegment")
     )

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -6415,3 +6415,16 @@ class DropMasterKeySegment(BaseSegment):
         "MASTER",
         "KEY",
     )
+
+
+class ExpressionSegment(BaseSegment):
+    """An expression, either arithmetic or boolean.
+
+    Extended for TSQL to include the `NEXT VALUE FOR` segment.
+    """
+    type = "expression"
+    
+    match_grammar: Matchable = OneOf(
+        Ref("Expression_A_Grammar"),
+        Ref("NextValueSequenceSegment")
+    )

--- a/test/fixtures/dialects/tsql/set_statements.sql
+++ b/test/fixtures/dialects/tsql/set_statements.sql
@@ -29,3 +29,7 @@ SET @param1 += 1,
     @param5 &= 7,
     @param5 |= 8
 ;
+
+-- Param with sequence in expression
+SET @param1 = (NEXT VALUE FOR [dbo].[SEQUENCE_NAME])
+;

--- a/test/fixtures/dialects/tsql/set_statements.yml
+++ b/test/fixtures/dialects/tsql/set_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8ff80c388ac8b168e59fdfdbfacafea0a6e3483c6c36156a99ea33dcae05c1c0
+_hash: ad529eb73bf8da610ceddcbb5d0a7f5cbfa86bc470a92596bf7c4c82704278c1
 file:
   batch:
   - statement:
@@ -138,3 +138,23 @@ file:
       - expression:
           numeric_literal: '8'
       - statement_terminator: ;
+  - statement:
+      set_segment:
+        keyword: SET
+        parameter: '@param1'
+        assignment_operator:
+          raw_comparison_operator: '='
+        expression:
+          bracketed:
+            start_bracket: (
+            expression:
+              sequence_next_value:
+              - keyword: NEXT
+              - keyword: VALUE
+              - keyword: FOR
+              - object_reference:
+                - quoted_identifier: '[dbo]'
+                - dot: .
+                - quoted_identifier: '[SEQUENCE_NAME]'
+            end_bracket: )
+        statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Extends `ExpressionSegment` in TSQL to include the `NEXT VALUE FOR` as an expression, as it returns a scalar value.

### Are there any other side effects of this change that we should be aware of?
No known side-effects

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
