### PR TITLE
Sparksql: Fix hint function for proper spacing

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -1968,19 +1968,7 @@ class HintFunctionSegment(BaseSegment):
 
     match_grammar = Sequence(
         Ref("FunctionNameSegment"),
-        Bracketed(
-            Delimited(
-                AnyNumberOf(
-                    Ref("SingleIdentifierGrammar"),
-                    Ref("NumericLiteralSegment"),
-                    Ref("TableReferenceSegment"),
-                    Ref("ColumnReferenceSegment"),
-                    min_times=1,
-                ),
-            ),
-            # May be Bare Function unique to Hints, i.e. REBALANCE
-            optional=True,
-        ),
+        Ref("FunctionContentsSegment", optional=True),
     )
 
 

--- a/test/fixtures/dialects/sparksql/insert_overwrite_directory.yml
+++ b/test/fixtures/dialects/sparksql/insert_overwrite_directory.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b19c5c1de0e98b801765c0fc5e50a61d9540e3ce8037ee021284b4fbd6d8bf1d
+_hash: 1a1d483f184ec0255394fd87cfc6cec2e5ee976d93fcb404ace2e41d2e76116c
 file:
 - statement:
     insert_overwrite_directory_statement:
@@ -242,10 +242,12 @@ file:
                 hint_function:
                   function_name:
                     function_name_identifier: COALESCE
-                  bracketed:
-                    start_bracket: (
-                    numeric_literal: '1'
-                    end_bracket: )
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        numeric_literal: '1'
+                      end_bracket: )
                 end_hint: '*/'
             select_clause_element:
               wildcard_expression:

--- a/test/fixtures/dialects/sparksql/select_hints.yml
+++ b/test/fixtures/dialects/sparksql/select_hints.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 17d210004cf1b2cc4a9861681dd50739ed79ac4a0172ae16ad8a18fd885c03cd
+_hash: b7a5f1a6d838148caf30c0057a70f0d07683f9d092086886c7001c28048731e3
 file:
 - statement:
     select_statement:
@@ -15,10 +15,12 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: COALESCE
-              bracketed:
-                start_bracket: (
-                numeric_literal: '3'
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '3'
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -49,10 +51,12 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: REPARTITION
-              bracketed:
-                start_bracket: (
-                numeric_literal: '3'
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '3'
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -83,10 +87,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: REPARTITION
-              bracketed:
-                start_bracket: (
-                naked_identifier: c
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: c
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -117,12 +124,16 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: REPARTITION
-              bracketed:
-                start_bracket: (
-                numeric_literal: '3'
-                comma: ','
-                naked_identifier: c
-                end_bracket: )
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '3'
+                - comma: ','
+                - expression:
+                    column_reference:
+                      naked_identifier: c
+                - end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -153,10 +164,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: REPARTITION_BY_RANGE
-              bracketed:
-                start_bracket: (
-                naked_identifier: c
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: c
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -187,12 +201,16 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: REPARTITION_BY_RANGE
-              bracketed:
-                start_bracket: (
-                numeric_literal: '3'
-                comma: ','
-                naked_identifier: c
-                end_bracket: )
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '3'
+                - comma: ','
+                - expression:
+                    column_reference:
+                      naked_identifier: c
+                - end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -253,10 +271,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: REBALANCE
-              bracketed:
-                start_bracket: (
-                naked_identifier: c
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: c
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -287,28 +308,36 @@ file:
           - hint_function:
               function_name:
                 function_name_identifier: REPARTITION
-              bracketed:
-                start_bracket: (
-                numeric_literal: '100'
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
           - comma: ','
           - hint_function:
               function_name:
                 function_name_identifier: COALESCE
-              bracketed:
-                start_bracket: (
-                numeric_literal: '500'
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '500'
+                  end_bracket: )
           - comma: ','
           - hint_function:
               function_name:
                 function_name_identifier: REPARTITION_BY_RANGE
-              bracketed:
-                start_bracket: (
-                numeric_literal: '3'
-                comma: ','
-                naked_identifier: c
-                end_bracket: )
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '3'
+                - comma: ','
+                - expression:
+                    column_reference:
+                      naked_identifier: c
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -339,10 +368,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: BROADCAST
-              bracketed:
-                start_bracket: (
-                naked_identifier: t1
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: t1
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -399,10 +431,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: BROADCASTJOIN
-              bracketed:
-                start_bracket: (
-                naked_identifier: t1
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: t1
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -459,10 +494,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: MAPJOIN
-              bracketed:
-                start_bracket: (
-                naked_identifier: t2
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: t2
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -519,10 +557,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: SHUFFLE_MERGE
-              bracketed:
-                start_bracket: (
-                naked_identifier: t1
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: t1
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -579,10 +620,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: MERGEJOIN
-              bracketed:
-                start_bracket: (
-                naked_identifier: t2
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: t2
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -639,10 +683,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: MERGE
-              bracketed:
-                start_bracket: (
-                naked_identifier: t1
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: t1
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -699,10 +746,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: SHUFFLE_HASH
-              bracketed:
-                start_bracket: (
-                naked_identifier: t1
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: t1
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -759,10 +809,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: SHUFFLE_REPLICATE_NL
-              bracketed:
-                start_bracket: (
-                naked_identifier: t1
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: t1
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -819,20 +872,28 @@ file:
           - hint_function:
               function_name:
                 function_name_identifier: BROADCAST
-              bracketed:
-                start_bracket: (
-                naked_identifier: t1
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: t1
+                  end_bracket: )
           - comma: ','
           - hint_function:
               function_name:
                 function_name_identifier: MERGE
-              bracketed:
-              - start_bracket: (
-              - naked_identifier: t1
-              - comma: ','
-              - naked_identifier: t2
-              - end_bracket: )
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: t1
+                - comma: ','
+                - expression:
+                    column_reference:
+                      naked_identifier: t2
+                - end_bracket: )
           - end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -889,13 +950,15 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: BROADCAST
-              bracketed:
-                start_bracket: (
-                table_reference:
-                - naked_identifier: db
-                - dot: .
-                - naked_identifier: t1
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                    - naked_identifier: db
+                    - dot: .
+                    - naked_identifier: t1
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:

--- a/test/fixtures/dialects/sparksql/select_sort_by.yml
+++ b/test/fixtures/dialects/sparksql/select_sort_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0123e607c738aa6e9bd1cc1d75eeaaf8d0f32ad4646bbe82e8ef2e7781a69915
+_hash: ac53a271e7f933adb38da8d484ae968ce808e415ab41a629cc1e5b326cfd5f1a
 file:
 - statement:
     select_statement:
@@ -15,10 +15,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: REPARTITION
-              bracketed:
-                start_bracket: (
-                naked_identifier: zip_code
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: zip_code
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -82,10 +85,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: REPARTITION
-              bracketed:
-                start_bracket: (
-                naked_identifier: zip_code
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: zip_code
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -147,10 +153,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: REPARTITION
-              bracketed:
-                start_bracket: (
-                naked_identifier: zip_code
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: zip_code
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -218,10 +227,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: REPARTITION
-              bracketed:
-                start_bracket: (
-                naked_identifier: zip_code
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: zip_code
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -287,10 +299,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: REPARTITION
-              bracketed:
-                start_bracket: (
-                naked_identifier: zip_code
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: zip_code
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:
@@ -360,10 +375,13 @@ file:
             hint_function:
               function_name:
                 function_name_identifier: REPARTITION
-              bracketed:
-                start_bracket: (
-                naked_identifier: zip_code
-                end_bracket: )
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: zip_code
+                  end_bracket: )
             end_hint: '*/'
       - select_clause_element:
           column_reference:

--- a/test/fixtures/rules/std_rule_cases/LT01-functions.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-functions.yml
@@ -26,3 +26,14 @@ test_pass_drop_function_go:
   configs:
     core:
       dialect: tsql
+
+test_pass_select_hint:
+  pass_str: |
+    select /*+ repartition(200) */
+        one,
+        two
+    from
+        mytable
+  configs:
+    core:
+      dialect: sparksql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #6428 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
