### PR TITLE
Trino: Remove TemporaryTransientGrammar

### DIFF
--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -266,6 +266,7 @@ trino_dialect.replace(
         Ref("LambdaExpressionSegment"),
         Ref("ExpressionSegment"),
     ),
+    TemporaryTransientGrammar=Nothing(),
 )
 
 


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #5875

Temporary and Transient are both unsupported in Trino. I've tested this locally, and it now compiles.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
