### PR TITLE
Sparksql: Fix ordering of create table options

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -890,18 +890,11 @@ sparksql_dialect.add(
             Ref("OptionsGrammar"),
             Ref("PartitionSpecGrammar"),
             Ref("BucketSpecGrammar"),
-            optional=True,
+            Ref("LocationGrammar"),
+            Ref("CommentGrammar"),
+            Ref("TablePropertiesGrammar"),
+            Sequence("CLUSTER", "BY", Ref("BracketedColumnReferenceListGrammar")),
         ),
-        Indent,
-        AnyNumberOf(
-            Ref("LocationGrammar", optional=True),
-            Ref("CommentGrammar", optional=True),
-            Ref("TablePropertiesGrammar", optional=True),
-        ),
-        Sequence(
-            "CLUSTER", "BY", Ref("BracketedColumnReferenceListGrammar"), optional=True
-        ),
-        Dedent,
         # Create AS syntax:
         Sequence(
             Ref.keyword("AS", optional=True),

--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -894,6 +894,7 @@ sparksql_dialect.add(
             Ref("CommentGrammar"),
             Ref("TablePropertiesGrammar"),
             Sequence("CLUSTER", "BY", Ref("BracketedColumnReferenceListGrammar")),
+            optional=True,
         ),
         # Create AS syntax:
         Sequence(

--- a/test/fixtures/dialects/sparksql/create_table_datasource.sql
+++ b/test/fixtures/dialects/sparksql/create_table_datasource.sql
@@ -49,3 +49,11 @@ USING CSV
 COMMENT "this is a comment"
 PARTITIONED BY (age)
 STORED AS PARQUET;
+
+create table if not exists my_table_space.my_test_table (
+    test_value string,
+    activity_date_partition date
+)
+using DELTA
+location 's3://some-bucket/test-data/'
+partitioned by (activity_date_partition);

--- a/test/fixtures/dialects/sparksql/create_table_datasource.yml
+++ b/test/fixtures/dialects/sparksql/create_table_datasource.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5bc3f9f743008498f010caf756e019fd94e291ae34b442841ec58512d149e6ca
+_hash: 42a6bbcae0324aa0b2d7c7256c7fe61e894c5948ec2dc94c2bc7985135eb189d
 file:
 - statement:
     create_table_statement:
@@ -398,4 +398,45 @@ file:
     - keyword: STORED
     - keyword: AS
     - keyword: PARQUET
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: create
+    - keyword: table
+    - keyword: if
+    - keyword: not
+    - keyword: exists
+    - table_reference:
+      - naked_identifier: my_table_space
+      - dot: .
+      - naked_identifier: my_test_table
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          column_reference:
+            naked_identifier: test_value
+          data_type:
+            primitive_type:
+              keyword: string
+      - comma: ','
+      - column_definition:
+          column_reference:
+            naked_identifier: activity_date_partition
+          data_type:
+            primitive_type:
+              keyword: date
+      - end_bracket: )
+    - using_clause:
+        keyword: using
+        data_source_format:
+          keyword: DELTA
+    - keyword: location
+    - quoted_literal: "'s3://some-bucket/test-data/'"
+    - keyword: partitioned
+    - keyword: by
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: activity_date_partition
+        end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #5769

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
