### PR TITLE
Snowflake: Allow literals in match_by_column_name

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -4054,7 +4054,12 @@ class CopyOptionsSegment(BaseSegment):
         Sequence(
             "MATCH_BY_COLUMN_NAME",
             Ref("EqualsSegment"),
-            OneOf("CASE_SENSITIVE", "CASE_INSENSITIVE", "NONE", Ref("QuotedLiteralSegment")),
+            OneOf(
+                "CASE_SENSITIVE",
+                "CASE_INSENSITIVE",
+                "NONE",
+                Ref("QuotedLiteralSegment"),
+            ),
         ),
         Sequence(
             "INCLUDE_METADATA",

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -4054,7 +4054,7 @@ class CopyOptionsSegment(BaseSegment):
         Sequence(
             "MATCH_BY_COLUMN_NAME",
             Ref("EqualsSegment"),
-            OneOf("CASE_SENSITIVE", "CASE_INSENSITIVE", "NONE"),
+            OneOf("CASE_SENSITIVE", "CASE_INSENSITIVE", "NONE", Ref("QuotedLiteralSegment")),
         ),
         Sequence(
             "INCLUDE_METADATA",

--- a/test/fixtures/dialects/snowflake/copy_into_table.sql
+++ b/test/fixtures/dialects/snowflake/copy_into_table.sql
@@ -81,3 +81,8 @@ MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE
 FILE_FORMAT = (TYPE = JSON)
 INCLUDE_METADATA = (
     ingestdate = METADATA$START_SCAN_TIME, filename = METADATA$FILENAME);
+
+COPY INTO test.transactions_all
+FROM @rawdata.STITCH_STAGE_NETSUITE/transactions/
+FILE_FORMAT = rawdata.json_format
+MATCH_BY_COLUMN_NAME = 'case_insensitive';

--- a/test/fixtures/dialects/snowflake/copy_into_table.yml
+++ b/test/fixtures/dialects/snowflake/copy_into_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c66235d23458e18428aca8c525fb3575b4c9fac1fe207f2008f4b9dea6b251b3
+_hash: 040e7069446054b29b50495660eaf946f067ce1ef76fdbdb0654ff313f51fb2b
 file:
 - statement:
     copy_into_table_statement:
@@ -463,4 +463,28 @@ file:
           raw_comparison_operator: '='
       - keyword: METADATA$FILENAME
       - end_bracket: )
+- statement_terminator: ;
+- statement:
+    copy_into_table_statement:
+    - keyword: COPY
+    - keyword: INTO
+    - table_reference:
+      - naked_identifier: test
+      - dot: .
+      - naked_identifier: transactions_all
+    - keyword: FROM
+    - storage_location:
+        stage_path: '@rawdata.STITCH_STAGE_NETSUITE/transactions/'
+    - keyword: FILE_FORMAT
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - file_format_segment:
+        object_reference:
+        - naked_identifier: rawdata
+        - dot: .
+        - naked_identifier: json_format
+    - keyword: MATCH_BY_COLUMN_NAME
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'case_insensitive'"
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #6419

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
