### PR TITLE
Postgres: Fix Select statement ordering

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1670,6 +1670,26 @@ class ForClauseSegment(BaseSegment):
     )
 
 
+class FetchClauseSegment(ansi.FetchClauseSegment):
+    """A `FETCH` clause like in `SELECT."""
+
+    type = "fetch_clause"
+    match_grammar: Matchable = Sequence(
+        "FETCH",
+        OneOf(
+            "FIRST",
+            "NEXT",
+        ),
+        OneOf(
+            Ref("NumericLiteralSegment"),
+            Ref("ExpressionSegment", exclude=Ref.keyword("ROW")),
+            optional=True,
+        ),
+        OneOf("ROW", "ROWS"),
+        OneOf("ONLY", Sequence("WITH", "TIES")),
+    )
+
+
 class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
     """Overrides ANSI Statement, to allow for SELECT INTO statements."""
 
@@ -1688,19 +1708,20 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
 
 
 class SelectStatementSegment(ansi.SelectStatementSegment):
-    """Overrides ANSI as the parse grammar copy needs to be reapplied."""
+    """Overrides ANSI as the parse grammar copy needs to be reapplied.
+
+    As per https://www.postgresql.org/docs/current/sql-select.html
+    """
 
     # Inherit most of the parse grammar from the unordered version.
     match_grammar: Matchable = UnorderedSelectStatementSegment.match_grammar.copy(
         insert=[
+            Ref("NamedWindowSegment", optional=True),
             Ref("OrderByClauseSegment", optional=True),
             Ref("LimitClauseSegment", optional=True),
-            Ref("NamedWindowSegment", optional=True),
-        ]
-    ).copy(
-        insert=[Ref("ForClauseSegment", optional=True)],
-        before=Ref("LimitClauseSegment", optional=True),
-        # Overwrite the terminators, because we want to remove some.
+            Ref("FetchClauseSegment", optional=True),
+            Ref("ForClauseSegment", optional=True),
+        ],
         replace_terminators=True,
         terminators=[
             Ref("SetOperatorSegment"),

--- a/test/fixtures/dialects/postgres/select.sql
+++ b/test/fixtures/dialects/postgres/select.sql
@@ -78,8 +78,9 @@ SELECT col1, col2
 FROM mytable1
 JOIN mytable2 ON col1 = col2
 ORDER BY sync_time ASC
+LIMIT 1
 FOR SHARE OF mytable1, mytable2 SKIP LOCKED
-LIMIT 1;
+;
 
 Select * from foo TABLESAMPLE SYSTEM (10);
 
@@ -94,3 +95,14 @@ SELECT 1 /* hi hi /* foo */ ho ho */ AS bar;
 
 -- escape double quotes
 SELECT """t".col1 FROM tbl1 AS """t";
+
+SELECT
+    film_id,
+    title
+FROM
+    film
+ORDER BY
+    title
+FETCH FIRST 10 ROW ONLY;
+
+SELECT foo FROM bar LIMIT 1 FOR UPDATE;

--- a/test/fixtures/dialects/postgres/select.yml
+++ b/test/fixtures/dialects/postgres/select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 67e1713643ad1d884f3672640f2d755a6731920489c151d97e18eb148e71cf48
+_hash: 5345b0bcb3f5ac09c7500b419c2a23032d3c1385fa4db9212dcbd44134ad1e33
 file:
 - statement:
     select_statement:
@@ -785,6 +785,9 @@ file:
       - column_reference:
           naked_identifier: sync_time
       - keyword: ASC
+      limit_clause:
+        keyword: LIMIT
+        numeric_literal: '1'
       for_clause:
       - keyword: FOR
       - keyword: SHARE
@@ -796,9 +799,6 @@ file:
           naked_identifier: mytable2
       - keyword: SKIP
       - keyword: LOCKED
-      limit_clause:
-        keyword: LIMIT
-        numeric_literal: '1'
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -941,4 +941,55 @@ file:
             alias_expression:
               keyword: AS
               quoted_identifier: '"""t"'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: film_id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: title
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: film
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+          naked_identifier: title
+      fetch_clause:
+      - keyword: FETCH
+      - keyword: FIRST
+      - numeric_literal: '10'
+      - keyword: ROW
+      - keyword: ONLY
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: foo
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: bar
+      limit_clause:
+        keyword: LIMIT
+        numeric_literal: '1'
+      for_clause:
+      - keyword: FOR
+      - keyword: UPDATE
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #6425 

Also adds the fetch clause.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
