### PR TITLE
Standardise json operator spacing between dialects

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -95,6 +95,10 @@ line_position = trailing
 spacing_within = touch
 line_position = leading
 
+[sqlfluff:layout:type:column_path_operator]
+spacing_within = touch
+line_position = leading
+
 [sqlfluff:layout:type:statement_terminator]
 spacing_before = touch
 line_position = trailing

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -213,6 +213,12 @@ mysql_dialect.replace(
         ],
         at=0,
     ),
+    BinaryOperatorGrammar=ansi_dialect.get_grammar("BinaryOperatorGrammar").copy(
+        insert=[
+            Ref("ColumnPathOperatorSegment"),
+            Ref("InlinePathOperatorSegment"),
+        ]
+    ),
     ArithmeticBinaryOperatorGrammar=ansi_dialect.get_grammar(
         "ArithmeticBinaryOperatorGrammar"
     ).copy(
@@ -1276,8 +1282,8 @@ mysql_dialect.insert_lexer_matchers(
 
 mysql_dialect.insert_lexer_matchers(
     [
-        StringLexer("inline_path_operator", "->>", CodeSegment),
-        StringLexer("column_path_operator", "->", CodeSegment),
+        StringLexer("inline_path_operator", "->>", SymbolSegment),
+        StringLexer("column_path_operator", "->", SymbolSegment),
     ],
     before="greater_than",
 )
@@ -2852,30 +2858,6 @@ class DropTriggerStatementSegment(ansi.DropTriggerStatementSegment):
         "TRIGGER",
         Ref("IfExistsGrammar", optional=True),
         Ref("TriggerReferenceSegment"),
-    )
-
-
-class ColumnReferenceSegment(ansi.ColumnReferenceSegment):
-    """A reference to column, field or alias.
-
-    Also allows `column->path` and `column->>path` for JSON values.
-    https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#operator_json-column-path
-    """
-
-    match_grammar = ansi.ColumnReferenceSegment.match_grammar.copy(
-        insert=[
-            Sequence(
-                ansi.ColumnReferenceSegment.match_grammar.copy(),
-                OneOf(
-                    Ref("ColumnPathOperatorSegment"),
-                    Ref("InlinePathOperatorSegment"),
-                ),
-                OneOf(
-                    Ref("DoubleQuotedJSONPath"),
-                    Ref("SingleQuotedJSONPath"),
-                ),
-            ),
-        ]
     )
 
 

--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -483,18 +483,6 @@ class ColumnReferenceSegment(ansi.ColumnReferenceSegment):
                     Ref("BareFunctionSegment"),
                     Ref("LiteralGrammar"),
                 ),
-                # AnyNumberOf(
-                #     Sequence(
-                #         OneOf(
-                #             Ref("ColumnPathOperatorSegment"),
-                #             Ref("InlinePathOperatorSegment"),
-                #         ),
-                #         OneOf(
-                #             Ref("LiteralGrammar"),
-                #             Ref("QuotedIdentifierSegment"),
-                #         ),
-                #     )
-                # ),
             ),
         ]
     )

--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -247,6 +247,12 @@ sqlite_dialect.replace(
     MLTableExpressionSegment=Nothing(),
     MergeIntoLiteralGrammar=Nothing(),
     SamplingExpressionSegment=Nothing(),
+    BinaryOperatorGrammar=ansi_dialect.get_grammar("BinaryOperatorGrammar").copy(
+        insert=[
+            Ref("ColumnPathOperatorSegment"),
+            Ref("InlinePathOperatorSegment"),
+        ]
+    ),
     OrderByClauseTerminators=OneOf(
         "LIMIT",
         # For window functions
@@ -477,18 +483,18 @@ class ColumnReferenceSegment(ansi.ColumnReferenceSegment):
                     Ref("BareFunctionSegment"),
                     Ref("LiteralGrammar"),
                 ),
-                AnyNumberOf(
-                    Sequence(
-                        OneOf(
-                            Ref("ColumnPathOperatorSegment"),
-                            Ref("InlinePathOperatorSegment"),
-                        ),
-                        OneOf(
-                            Ref("LiteralGrammar"),
-                            Ref("QuotedIdentifierSegment"),
-                        ),
-                    )
-                ),
+                # AnyNumberOf(
+                #     Sequence(
+                #         OneOf(
+                #             Ref("ColumnPathOperatorSegment"),
+                #             Ref("InlinePathOperatorSegment"),
+                #         ),
+                #         OneOf(
+                #             Ref("LiteralGrammar"),
+                #             Ref("QuotedIdentifierSegment"),
+                #         ),
+                #     )
+                # ),
             ),
         ]
     )

--- a/test/fixtures/dialects/mariadb/json.yml
+++ b/test/fixtures/dialects/mariadb/json.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cadae1c616686a0f4f018b1b299e471a96997250ca16d251d36958171baf25eb
+_hash: 026dd56f2e5866ab3be47c3e6425246b47e9df269672641dcfd2870f93dc4827
 file:
 - statement:
     create_table_statement:
@@ -49,10 +49,11 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            naked_identifier: sentence
+          expression:
+            column_reference:
+              naked_identifier: sentence
             column_path_operator: ->
-            json_path: '"$.mascot"'
+            quoted_literal: '"$.mascot"'
       from_clause:
         keyword: FROM
         from_expression:
@@ -66,10 +67,11 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            naked_identifier: sentence
+          expression:
+            column_reference:
+              naked_identifier: sentence
             column_path_operator: ->
-            json_path: "'$.mascot'"
+            quoted_literal: "'$.mascot'"
       from_clause:
         keyword: FROM
         from_expression:
@@ -83,10 +85,11 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            naked_identifier: sentence
+          expression:
+            column_reference:
+              naked_identifier: sentence
             column_path_operator: ->>
-            json_path: '"$.mascot"'
+            quoted_literal: '"$.mascot"'
       from_clause:
         keyword: FROM
         from_expression:
@@ -100,10 +103,11 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            naked_identifier: sentence
+          expression:
+            column_reference:
+              naked_identifier: sentence
             column_path_operator: ->>
-            json_path: "'$.mascot'"
+            quoted_literal: "'$.mascot'"
       from_clause:
         keyword: FROM
         from_expression:
@@ -138,8 +142,8 @@ file:
                 expression:
                   column_reference:
                     naked_identifier: sentence
-                    column_path_operator: ->
-                    json_path: '"$.mascot"'
+                  column_path_operator: ->
+                  quoted_literal: '"$.mascot"'
                 end_bracket: )
           comparison_operator:
             raw_comparison_operator: '='
@@ -164,8 +168,8 @@ file:
         expression:
           column_reference:
             naked_identifier: sentence
-            column_path_operator: ->
-            json_path: '"$.mascot"'
+          column_path_operator: ->
+          quoted_literal: '"$.mascot"'
           keyword: IS
           null_literal: 'NULL'
 - statement_terminator: ;

--- a/test/fixtures/dialects/mysql/json.yml
+++ b/test/fixtures/dialects/mysql/json.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cadae1c616686a0f4f018b1b299e471a96997250ca16d251d36958171baf25eb
+_hash: 026dd56f2e5866ab3be47c3e6425246b47e9df269672641dcfd2870f93dc4827
 file:
 - statement:
     create_table_statement:
@@ -49,10 +49,11 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            naked_identifier: sentence
+          expression:
+            column_reference:
+              naked_identifier: sentence
             column_path_operator: ->
-            json_path: '"$.mascot"'
+            quoted_literal: '"$.mascot"'
       from_clause:
         keyword: FROM
         from_expression:
@@ -66,10 +67,11 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            naked_identifier: sentence
+          expression:
+            column_reference:
+              naked_identifier: sentence
             column_path_operator: ->
-            json_path: "'$.mascot'"
+            quoted_literal: "'$.mascot'"
       from_clause:
         keyword: FROM
         from_expression:
@@ -83,10 +85,11 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            naked_identifier: sentence
+          expression:
+            column_reference:
+              naked_identifier: sentence
             column_path_operator: ->>
-            json_path: '"$.mascot"'
+            quoted_literal: '"$.mascot"'
       from_clause:
         keyword: FROM
         from_expression:
@@ -100,10 +103,11 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            naked_identifier: sentence
+          expression:
+            column_reference:
+              naked_identifier: sentence
             column_path_operator: ->>
-            json_path: "'$.mascot'"
+            quoted_literal: "'$.mascot'"
       from_clause:
         keyword: FROM
         from_expression:
@@ -138,8 +142,8 @@ file:
                 expression:
                   column_reference:
                     naked_identifier: sentence
-                    column_path_operator: ->
-                    json_path: '"$.mascot"'
+                  column_path_operator: ->
+                  quoted_literal: '"$.mascot"'
                 end_bracket: )
           comparison_operator:
             raw_comparison_operator: '='
@@ -164,8 +168,8 @@ file:
         expression:
           column_reference:
             naked_identifier: sentence
-            column_path_operator: ->
-            json_path: '"$.mascot"'
+          column_path_operator: ->
+          quoted_literal: '"$.mascot"'
           keyword: IS
           null_literal: 'NULL'
 - statement_terminator: ;

--- a/test/fixtures/dialects/sqlite/json_operators.yml
+++ b/test/fixtures/dialects/sqlite/json_operators.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: eff30e30bae7b32c67734b7def65d8b5a248fa36fed14e34481c1b102ea82083
+_hash: b524b0d670b1517bea87f9b60f90d34fd5fab741612b4d276c14e67e80ebee4c
 file:
 - statement:
     select_statement:
@@ -24,13 +24,12 @@ file:
       where_clause:
         keyword: WHERE
         expression:
-          column_reference:
-            quoted_identifier: "'{\"x\": \"y\"}'"
-            column_path_operator: ->>
-            quoted_literal: "'$.x'"
-          comparison_operator:
+        - quoted_literal: "'{\"x\": \"y\"}'"
+        - column_path_operator: ->>
+        - quoted_literal: "'$.x'"
+        - comparison_operator:
             raw_comparison_operator: '='
-          quoted_literal: "'y'"
+        - quoted_literal: "'y'"
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -51,99 +50,99 @@ file:
       where_clause:
         keyword: WHERE
         expression:
-          column_reference:
-            function:
-              function_name:
-                function_name_identifier: Upper
-              function_contents:
-                bracketed:
-                  start_bracket: (
-                  expression:
-                    quoted_literal: "'{\"x\": \"y\"}'"
-                  end_bracket: )
-            column_path_operator: ->>
-            quoted_literal: "'$.x'"
-          comparison_operator:
+        - function:
+            function_name:
+              function_name_identifier: Upper
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  quoted_literal: "'{\"x\": \"y\"}'"
+                end_bracket: )
+        - column_path_operator: ->>
+        - quoted_literal: "'$.x'"
+        - comparison_operator:
             raw_comparison_operator: '='
-          quoted_literal: "'y'"
+        - quoted_literal: "'y'"
 - statement_terminator: ;
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            quoted_identifier: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
-            column_path_operator: ->
-            quoted_literal: "'$'"
-- statement_terminator: ;
-- statement:
-    select_statement:
-      select_clause:
-        keyword: SELECT
-        select_clause_element:
-          column_reference:
-          - quoted_identifier: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
+          expression:
+          - quoted_literal: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
           - column_path_operator: ->
-          - quoted_identifier: '"$"'
+          - quoted_literal: "'$'"
 - statement_terminator: ;
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            quoted_identifier: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
+          expression:
+            quoted_literal: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
             column_path_operator: ->
-            quoted_literal: "'$.c'"
+            column_reference:
+              quoted_identifier: '"$"'
 - statement_terminator: ;
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            quoted_identifier: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
-            column_path_operator: ->
-            quoted_literal: "'c'"
+          expression:
+          - quoted_literal: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
+          - column_path_operator: ->
+          - quoted_literal: "'$.c'"
 - statement_terminator: ;
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            quoted_identifier: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
-            column_path_operator: ->
-            quoted_literal: "'$.c[2]'"
+          expression:
+          - quoted_literal: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
+          - column_path_operator: ->
+          - quoted_literal: "'c'"
 - statement_terminator: ;
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            quoted_identifier: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
-            column_path_operator: ->
-            quoted_literal: "'$.c[2].f'"
+          expression:
+          - quoted_literal: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
+          - column_path_operator: ->
+          - quoted_literal: "'$.c[2]'"
 - statement_terminator: ;
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            quoted_identifier: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
-            column_path_operator: ->>
-            quoted_literal: "'$.c[2].f'"
+          expression:
+          - quoted_literal: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
+          - column_path_operator: ->
+          - quoted_literal: "'$.c[2].f'"
 - statement_terminator: ;
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-          - quoted_identifier: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
+          expression:
+          - quoted_literal: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
+          - column_path_operator: ->>
+          - quoted_literal: "'$.c[2].f'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+          - quoted_literal: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
           - column_path_operator: ->
           - quoted_literal: "'c'"
           - column_path_operator: ->
@@ -156,28 +155,28 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            quoted_identifier: "'{\"a\":2,\"c\":[4,5],\"f\":7}'"
-            column_path_operator: ->
-            quoted_literal: "'$.c[#-1]'"
+          expression:
+          - quoted_literal: "'{\"a\":2,\"c\":[4,5],\"f\":7}'"
+          - column_path_operator: ->
+          - quoted_literal: "'$.c[#-1]'"
 - statement_terminator: ;
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            quoted_identifier: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
-            column_path_operator: ->
-            quoted_literal: "'$.x'"
+          expression:
+          - quoted_literal: "'{\"a\":2,\"c\":[4,5,{\"f\":7}]}'"
+          - column_path_operator: ->
+          - quoted_literal: "'$.x'"
 - statement_terminator: ;
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            quoted_identifier: "'[11,22,33,44]'"
+          expression:
+            quoted_literal: "'[11,22,33,44]'"
             column_path_operator: ->
             numeric_literal: '3'
 - statement_terminator: ;
@@ -186,8 +185,8 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            quoted_identifier: "'[11,22,33,44]'"
+          expression:
+            quoted_literal: "'[11,22,33,44]'"
             column_path_operator: ->>
             numeric_literal: '3'
 - statement_terminator: ;
@@ -196,38 +195,38 @@ file:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            quoted_identifier: "'{\"a\":\"xyz\"}'"
-            column_path_operator: ->
-            quoted_literal: "'$.a'"
+          expression:
+          - quoted_literal: "'{\"a\":\"xyz\"}'"
+          - column_path_operator: ->
+          - quoted_literal: "'$.a'"
 - statement_terminator: ;
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            quoted_identifier: "'{\"a\":\"xyz\"}'"
-            column_path_operator: ->>
-            quoted_literal: "'$.a'"
+          expression:
+          - quoted_literal: "'{\"a\":\"xyz\"}'"
+          - column_path_operator: ->>
+          - quoted_literal: "'$.a'"
 - statement_terminator: ;
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            quoted_identifier: "'{\"a\":null}'"
-            column_path_operator: ->
-            quoted_literal: "'$.a'"
+          expression:
+          - quoted_literal: "'{\"a\":null}'"
+          - column_path_operator: ->
+          - quoted_literal: "'$.a'"
 - statement_terminator: ;
 - statement:
     select_statement:
       select_clause:
         keyword: SELECT
         select_clause_element:
-          column_reference:
-            quoted_identifier: "'{\"a\":null}'"
-            column_path_operator: ->>
-            quoted_literal: "'$.a'"
+          expression:
+          - quoted_literal: "'{\"a\":null}'"
+          - column_path_operator: ->>
+          - quoted_literal: "'$.a'"
 - statement_terminator: ;

--- a/test/fixtures/rules/std_rule_cases/LT01-operators.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-operators.yml
@@ -135,3 +135,9 @@ pass_sparksql_file_literal:
   configs:
     core:
       dialect: sparksql
+
+pass_sqlite_column_path_operator:
+  pass_str: SELECT a -> 'b';
+  configs:
+    core:
+      dialect: sqlite


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #6404

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
