### PR TITLE
Rule names in warnings logic

### DIFF
--- a/docs/source/configuration/rule_configuration.rst
+++ b/docs/source/configuration/rule_configuration.rst
@@ -162,6 +162,8 @@ This is particularly useful as a transitional tool when considering
 the introduction on new rules on a project where you might want to
 make users aware of issues without blocking their workflow (yet).
 
+You can use either rule code or rule name for this setting.
+
 Layout & Spacing Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/sqlfluff/core/errors.py
+++ b/src/sqlfluff/core/errors.py
@@ -37,6 +37,7 @@ class SQLBaseError(ValueError):
     """Base Error Class for all violations."""
 
     _code: Optional[str] = None
+    _name: Optional[str] = None
     _identifier = "base"
     _warning = False  # The default value for `warning`
 
@@ -90,6 +91,10 @@ class SQLBaseError(ValueError):
         """Fetch the code of the rule which cause this error."""
         return self._code or "????"
 
+    def rule_name(self) -> str:
+        """Fetch the name of the rule which cause this error."""
+        return self._name or "????"
+
     def desc(self) -> str:
         """Fetch a description of this violation."""
         if self.description:
@@ -141,7 +146,7 @@ class SQLBaseError(ValueError):
         Returns:
             None
         """
-        if self.rule_code() in warning_iterable:
+        if self.rule_code() in warning_iterable or self.rule_name() in warning_iterable:
             self.warning = True
 
 
@@ -336,6 +341,10 @@ class SQLLintError(SQLBaseError):
     def rule_code(self) -> str:
         """Fetch the code of the rule which cause this error."""
         return self.rule.code
+
+    def rule_name(self) -> str:
+        """Fetch the name of the rule which cause this error."""
+        return self.rule.name
 
     def source_signature(self) -> Tuple[Any, ...]:
         """Return hashable source signature for deduplication.

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -830,6 +830,33 @@ def test__cli__command_lint_warning():
     )
 
 
+def test__cli__command_lint_warning_name_rule():
+    """Test that configuring warnings works.
+
+    For this test the warnings are configured using
+    inline config in the file. That's more for simplicity
+    however the code paths should be the same if it's
+    configured in a file.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        lint,
+        [
+            "test/fixtures/cli/warning_name_a.sql",
+        ],
+    )
+    # Because we're only warning. The command should pass.
+    assert result.exit_code == 0
+    # The output should still say PASS.
+    assert "PASS" in result.output.strip()
+    # But should also contain the warnings.
+    # NOTE: Not including the whole description because it's too long.
+    assert (
+        "L:   4 | P:   9 | LT01 | WARNING: Expected single whitespace"
+        in result.output.strip()
+    )
+
+
 def test__cli__command_versioning():
     """Check version command."""
     # Get the package version info

--- a/test/fixtures/cli/warning_name_a.sql
+++ b/test/fixtures/cli/warning_name_a.sql
@@ -1,0 +1,4 @@
+-- This file should fail _only_ for spacing around +
+-- We explicit configure that rule to only warn.
+-- sqlfluff:warnings:layout.spacing
+SELECT 1+2


### PR DESCRIPTION
### Brief summary of the change made

According to the official documentation, rules can be downgraded to warnings by specifying their rule codes. However, there is IHMO an inconsistency in how rules are handled for exclusions versus warnings. Currently:

- Rules can be excluded using either rule code or rule name.
- Rules can only be downgraded to warnings using rule code.

This PR addresses this inconsistency by extending the configuration to allow warnings to be specified via both rule code and rule name. This aligns the handling of warnings with the existing behavior for `exclude_rules`.


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
