### PR TITLE
Bigquery: Support column level key definitions

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -323,6 +323,8 @@ bigquery_dialect.replace(
         Ref("SemiStructuredAccessorSegment"),
     ),
     BracketedSetExpressionGrammar=Bracketed(Ref("SetExpressionSegment")),
+    NotEnforcedGrammar=Sequence("NOT", "ENFORCED"),
+    ReferenceMatchGrammar=Nothing(),
 )
 
 

--- a/test/fixtures/dialects/bigquery/create_table_keys.sql
+++ b/test/fixtures/dialects/bigquery/create_table_keys.sql
@@ -19,3 +19,8 @@ CREATE TABLE t_table1
     _other STRING
 )
 ;
+
+CREATE TABLE `some_dataset.some_table` (
+    id STRING NOT NULL PRIMARY KEY NOT ENFORCED,
+    other_field STRING REFERENCES other_table(other_field) NOT ENFORCED
+);

--- a/test/fixtures/dialects/bigquery/create_table_keys.yml
+++ b/test/fixtures/dialects/bigquery/create_table_keys.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2e318327637f8ff0d1e4cbbe1c338b2d39724e040ffffd39dde1aa208cd310ea
+_hash: e4af7f29c06a83c2190d5fd2588bfe8558c9438902ff2587fdc5194747f96e62
 file:
 - statement:
     create_table_statement:
@@ -116,5 +116,43 @@ file:
           naked_identifier: _other
           data_type:
             data_type_identifier: STRING
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '`some_dataset.some_table`'
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+        - naked_identifier: id
+        - data_type:
+            data_type_identifier: STRING
+        - column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+        - column_constraint_segment:
+          - keyword: PRIMARY
+          - keyword: KEY
+          - keyword: NOT
+          - keyword: ENFORCED
+      - comma: ','
+      - column_definition:
+          naked_identifier: other_field
+          data_type:
+            data_type_identifier: STRING
+          column_constraint_segment:
+          - keyword: REFERENCES
+          - table_reference:
+              naked_identifier: other_table
+          - bracketed:
+              start_bracket: (
+              column_reference:
+                naked_identifier: other_field
+              end_bracket: )
+          - keyword: NOT
+          - keyword: ENFORCED
       - end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This allows for the column level definition for a key constraint e.g. `PRIMARY KEY NOT ENFORCED` or `REFERENCES table_name(column_name) NOT ENFORCED`
- fixes #6462

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
