### PR TITLE
Hive: Add 'ALTER VIEW' query grammar

### DIFF
--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -706,6 +706,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("MsckRepairTableStatementSegment"),
             Ref("MsckTableStatementSegment"),
             Ref("SetStatementSegment"),
+            Ref("AlterViewStatementSegment"),
         ],
         remove=[
             Ref("TransactionStatementSegment"),
@@ -1085,4 +1086,26 @@ class SortByClauseSegment(ansi.OrderByClauseSegment):
             terminators=["LIMIT", Ref("FrameClauseUnitGrammar")],
         ),
         Dedent,
+    )
+
+
+class AlterViewStatementSegment(BaseSegment):
+    """A `ALTER VIEW` statement to change the view schema or properties.
+
+    https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Create/Drop/AlterView
+    """
+
+    type = "alter_view_statement"
+
+    match_grammar = Sequence(
+        "ALTER",
+        "VIEW",
+        Ref("TableReferenceSegment"),
+        OneOf(
+            Sequence("SET", Ref("TablePropertiesGrammar")),
+            Sequence(
+                "AS",
+                OptionallyBracketed(Ref("SelectStatementSegment")),
+            ),
+        ),
     )

--- a/test/fixtures/dialects/hive/alter_view.sql
+++ b/test/fixtures/dialects/hive/alter_view.sql
@@ -1,0 +1,3 @@
+ALTER VIEW db.foo AS SELECT col1 FROM db.bar;
+
+ALTER VIEW foo SET TBLPROPERTIES ('bar' = '1', 'baz' = '2');

--- a/test/fixtures/dialects/hive/alter_view.yml
+++ b/test/fixtures/dialects/hive/alter_view.yml
@@ -1,0 +1,53 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 436d5a23d3827fc3338561a5192f73152eb735856639d5bc323f546db15d81fe
+file:
+- statement:
+    alter_view_statement:
+    - keyword: ALTER
+    - keyword: VIEW
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: foo
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: col1
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: db
+                - dot: .
+                - naked_identifier: bar
+- statement_terminator: ;
+- statement:
+    alter_view_statement:
+    - keyword: ALTER
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: foo
+    - keyword: SET
+    - keyword: TBLPROPERTIES
+    - bracketed:
+      - start_bracket: (
+      - quoted_literal: "'bar'"
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'1'"
+      - comma: ','
+      - quoted_literal: "'baz'"
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - quoted_literal: "'2'"
+      - end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Add 'ALTER VIEW' query for the two supported operations: 

1. updating schema via 'AS SELECT...',
2. setting table properties

Fixes #6476 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
