### PR TITLE
Snowflake Create Table allow inline foreign key with on delete …

### DIFF
--- a/test/fixtures/dialects/snowflake/create_table.sql
+++ b/test/fixtures/dialects/snowflake/create_table.sql
@@ -212,3 +212,30 @@ CREATE TABLE some_schema.some_table
   , some_event_date_time_utc VARCHAR AS (TO_TIMESTAMP(SUBSTR(some_text_value, 5, 13)))
   , some_other_event_date_time_utc TIMESTAMP AS (IFF(is_condition_true AND TRY_TO_NUMBER(some_text_value) IS NOT NULL, TO_TIMESTAMP(SUBSTR(some_text_value, 5, 13)), '1900-01-01')) COMMENT 'The date and time of the other event'
 );
+
+
+CREATE OR REPLACE TABLE some_table (
+  id INTEGER NOT NULL,
+  CONSTRAINT MY_FK FOREIGN KEY (id) REFERENCES another_table(id) MATCH SIMPLE ON DELETE RESTRICT
+);
+
+CREATE OR REPLACE TABLE some_table (
+  id INTEGER NOT NULL,
+  CONSTRAINT MY_FK FOREIGN KEY (id) REFERENCES another_table MATCH FULL ON DELETE RESTRICT
+);
+
+
+CREATE OR REPLACE TABLE some_table (
+    ID INTEGER NOT NULL CONSTRAINT MY_FK
+    FOREIGN KEY REFERENCES another_table (id)
+    MATCH PARTIAL
+    ON DELETE RESTRICT
+    ON UPDATE SET DEFAULT
+);
+
+CREATE OR REPLACE TABLE some_table (
+    ID INTEGER NOT NULL,
+    CONSTRAINT MY_FK FOREIGN KEY (ID) REFERENCES another_table (id)
+    MATCH SIMPLE
+    ON DELETE CASCADE
+);

--- a/test/fixtures/dialects/snowflake/create_table.yml
+++ b/test/fixtures/dialects/snowflake/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 74de85b93e5227b9ab1271d01a558b6ca2e844a1d05659c33297c0d5e51b08a9
+_hash: a337f8d00263c86575e132b7e2950c189c27f0a2af8ac5ff264c25ca6f7aea3c
 file:
 - statement:
     create_table_statement:
@@ -1757,4 +1757,169 @@ file:
           keyword: COMMENT
           quoted_literal: "'The date and time of the other event'"
       - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: some_table
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          naked_identifier: id
+          data_type:
+            data_type_identifier: INTEGER
+          column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+        comma: ','
+        constraint_properties_segment:
+        - keyword: CONSTRAINT
+        - naked_identifier: MY_FK
+        - keyword: FOREIGN
+        - keyword: KEY
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: id
+            end_bracket: )
+        - keyword: REFERENCES
+        - table_reference:
+            naked_identifier: another_table
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: id
+            end_bracket: )
+        - keyword: MATCH
+        - keyword: SIMPLE
+        - keyword: 'ON'
+        - keyword: DELETE
+        - keyword: RESTRICT
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: some_table
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          naked_identifier: id
+          data_type:
+            data_type_identifier: INTEGER
+          column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+        comma: ','
+        constraint_properties_segment:
+        - keyword: CONSTRAINT
+        - naked_identifier: MY_FK
+        - keyword: FOREIGN
+        - keyword: KEY
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: id
+            end_bracket: )
+        - keyword: REFERENCES
+        - table_reference:
+            naked_identifier: another_table
+        - keyword: MATCH
+        - keyword: FULL
+        - keyword: 'ON'
+        - keyword: DELETE
+        - keyword: RESTRICT
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: some_table
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          naked_identifier: ID
+          data_type:
+            data_type_identifier: INTEGER
+          column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+          - constraint_properties_segment:
+            - keyword: CONSTRAINT
+            - naked_identifier: MY_FK
+            - keyword: FOREIGN
+            - keyword: KEY
+            - keyword: REFERENCES
+            - table_reference:
+                naked_identifier: another_table
+            - bracketed:
+                start_bracket: (
+                column_reference:
+                  naked_identifier: id
+                end_bracket: )
+            - keyword: MATCH
+            - keyword: PARTIAL
+            - keyword: 'ON'
+            - keyword: DELETE
+            - keyword: RESTRICT
+            - keyword: 'ON'
+            - keyword: UPDATE
+            - keyword: SET
+            - keyword: DEFAULT
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: some_table
+    - bracketed:
+        start_bracket: (
+        column_definition:
+          naked_identifier: ID
+          data_type:
+            data_type_identifier: INTEGER
+          column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+        comma: ','
+        constraint_properties_segment:
+        - keyword: CONSTRAINT
+        - naked_identifier: MY_FK
+        - keyword: FOREIGN
+        - keyword: KEY
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: ID
+            end_bracket: )
+        - keyword: REFERENCES
+        - table_reference:
+            naked_identifier: another_table
+        - bracketed:
+            start_bracket: (
+            column_reference:
+              naked_identifier: id
+            end_bracket: )
+        - keyword: MATCH
+        - keyword: SIMPLE
+        - keyword: 'ON'
+        - keyword: DELETE
+        - keyword: CASCADE
+        end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes #6485 

The Inline and Out Of Line Constraints for Create Table and Alter Table have a slightly different format. For Inline constraints we do not need specify the column that contains the foreign key in the table e.g.

```
CREATE OR REPLACE TABLE SOME_TABLE1 (
    ID INTEGER NOT NULL 
    CONSTRAINT MY_FK FOREIGN KEY REFERENCES ADDRESSES (ADDRESS)
    MATCH SIMPLE
    ON DELETE CASCADE
);
```
but for an Out of Line constrain we do

```
CREATE OR REPLACE TABLE SOME_TABLE2 (
    ID INTEGER NOT NULL,
    CONSTRAINT MY_FK FOREIGN KEY (ID) REFERENCES ADDRESSES (ADDRESS)
    MATCH SIMPLE
    ON DELETE CASCADE
);
```
The latter having the column reference in brackets. 

I looked at ways to do this with the previous implementation of `ConstraintPropertiesSegment` by making the bracketed section optional however this meant we could get invalid SQL linting successfully. I opted to create separate `OutOfLineConstraintPropertiesSegment` and `InlineConstraintPropertiesSegment`


### Are there any other side effects of this change that we should be aware of?

None 

### Pull Request checklist
- [*] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
