### PR TITLE
[docs] Update missing convention whitespace for CV10

### DIFF
--- a/src/sqlfluff/rules/convention/__init__.py
+++ b/src/sqlfluff/rules/convention/__init__.py
@@ -50,7 +50,7 @@ def get_configs_info() -> Dict[str, Any]:
             "validation": ["consistent", "single_quotes", "double_quotes"],
             "definition": (
                 "Preferred quoting style to use for the quoted literals. If set to "
-                "``consistent`` quoting style is derived from the first quoted literal"
+                "``consistent`` quoting style is derived from the first quoted literal "
                 "in the file."
             ),
         },


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
- teensy docs whitespace change
- "literalin the file" -> "literal in the file" 

Missing whitespace was below: 
<img width="683" alt="image" src="https://github.com/user-attachments/assets/34ecfb95-4d31-4154-98cc-9bc65492c031" />

Note: I haven't built / tested this locally but it looks pretty shallow.. 

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
