### PR TITLE
fix: databricks describe volume recognition

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -253,7 +253,8 @@ databricks_dialect.replace(
                 "VOLUME",
                 Ref("VolumeReferenceSegment"),
             ),
-        ]
+        ],
+        at=0,
     ),
     FunctionContentsExpressionGrammar=OneOf(
         Ref("ExpressionSegment"),

--- a/test/fixtures/dialects/databricks/describe_volume.yml
+++ b/test/fixtures/dialects/databricks/describe_volume.yml
@@ -3,12 +3,12 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: dbacf385e0fb479407d6131eac2f4426980a664462ae47a6d350179bc9e116dd
+_hash: 2ea60f6943f16c260123e678dc8ec29433a13cd657484991939d8d56fe42d5e4
 file:
   statement:
     describe_statement:
-      keyword: DESCRIBE
-      table_reference:
-        naked_identifier: VOLUME
-      naked_identifier: VACCINE_VOLUME
+    - keyword: DESCRIBE
+    - keyword: VOLUME
+    - volume_reference:
+        naked_identifier: VACCINE_VOLUME
   statement_terminator: ;


### PR DESCRIPTION
fix: databricks describe volume recognition

### Brief summary of the change made

Added `at=0` so that the Databricks parser doesn't mistakenly recognize `Describe Volume` as a `Describe Table` query.`

### Are there any other side effects of this change that we should be aware of?

None that I am aware of.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
