### PR TITLE
Add DuckDB to RF01 filter for dialects with dot-access

### DIFF
--- a/src/sqlfluff/rules/references/RF01.py
+++ b/src/sqlfluff/rules/references/RF01.py
@@ -37,7 +37,7 @@ class Rule_RF01(BaseRule):
 
     .. note::
 
-       This rule is disabled by default for BigQuery, Databricks, Hive,
+       This rule is disabled by default for Athena, BigQuery, Databricks, DuckDB, Hive,
        Redshift, SOQL and SparkSQL due to the support of things like
        structs and lateral views which trigger false positives. It can be
        enabled with the ``force_enable = True`` flag.
@@ -269,6 +269,8 @@ class Rule_RF01(BaseRule):
         # https://cloud.google.com/bigquery/docs/reference/standard-sql/operators#field_access_operator
         # Databricks:
         # https://docs.databricks.com/en/sql/language-manual/functions/dotsign.html
+        # DuckDB:
+        # https://duckdb.org/docs/sql/data_types/struct#retrieving-from-structs
         # Redshift:
         # https://docs.aws.amazon.com/redshift/latest/dg/query-super.html
         # TODO: all doc links to all referenced dialects
@@ -276,6 +278,7 @@ class Rule_RF01(BaseRule):
             "athena",
             "bigquery",
             "databricks",
+            "duckdb",
             "hive",
             "redshift",
             "soql",

--- a/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -36,7 +36,7 @@ test_pass_object_referenced_3:
     SELECT * FROM db.sc.tbl2
     WHERE a NOT IN (SELECT tbl2.a FROM db.sc.tbl1)
 
-test_pass_object_referenced_4:
+test_pass_object_referenced_4a:
   # Test ambiguous column reference caused by use of BigQuery structure fields.
   # Here, 'et2' could either be a schema name or a table name.
   # https://github.com/sqlfluff/sqlfluff/issues/1079
@@ -49,6 +49,17 @@ test_pass_object_referenced_4:
     rules:
       references.from:
         force_enable: true
+
+test_pass_object_referenced_4b:
+  # DuckDB allows dot-access to its MAP objects, which requires special handling
+  # to ensure `ex.x` is not interpreted as `{table}.{field}` instead of
+  # `{schema}.{table}`. The following returns `'there'` if executed.
+  pass_str: |
+    SELECT ex.x.hi
+    FROM (SELECT { 'hi': 'there' } AS x) AS ex
+  configs:
+    core:
+      dialect: duckdb
 
 test_pass_object_referenced_5a:
   # Test ambiguous column reference caused by use of BigQuery structure fields.


### PR DESCRIPTION
### Brief summary of the change made
fixes #6551 

DuckDB, as described [on their page about the DuckDB struct type
](https://duckdb.org/docs/sql/data_types/struct#retrieving-from-structs), allows for "dot"-based access to struct fields. 

For example, the following query returns 'there' when executed by DuckDB:

```sql
SELECT ex.x.hi
FROM (SELECT { 'hi': 'there' } AS x) AS ex
```

### Are there any other side effects of this change that we should be aware of?

Effectively disables non-trivial RF01 checks for all DuckDB queries. As far as I can tell, this is in-line with our current strategy for other languages that allow "dot"-based access, since otherwise we generate far too many false-positives to be useful.


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
