### PR TITLE
Add zip and zip_strict dbt jinja2 functions

### DIFF
--- a/src/sqlfluff/core/templaters/builtins/dbt.py
+++ b/src/sqlfluff/core/templaters/builtins/dbt.py
@@ -57,4 +57,6 @@ DBT_BUILTINS = {
     # to be parsed TWICE if it uses this variable.
     "is_incremental": FunctionWrapper("is_incremental", lambda: True),
     "this": RelationEmulator(),
+    "zip_strict": zip,
+    "zip": lambda *args, default=None: zip(*args) if all(hasattr(arg, '__iter__') for arg in args) else default
 }

--- a/src/sqlfluff/core/templaters/builtins/dbt.py
+++ b/src/sqlfluff/core/templaters/builtins/dbt.py
@@ -57,6 +57,11 @@ DBT_BUILTINS = {
     # to be parsed TWICE if it uses this variable.
     "is_incremental": FunctionWrapper("is_incremental", lambda: True),
     "this": RelationEmulator(),
-    "zip_strict": zip,
-    "zip": lambda *args, default=None: zip(*args) if all(hasattr(arg, '__iter__') for arg in args) else default
+    "zip_strict": FunctionWrapper("zip_strict", zip),
+    "zip": FunctionWrapper(
+        "zip",
+        lambda *args, default=None: (
+            zip(*args) if all(hasattr(arg, "__iter__") for arg in args) else default
+        ),
+    ),
 }

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -759,7 +759,7 @@ def test__templater_full(subpath, code_only, include_meta, yaml_loader, caplog):
 
     assert_structure(
         yaml_loader,
-        "/home/phong/Projects/sqlfluff/test/fixtures/templater/" + subpath,
+        "test/fixtures/templater/" + subpath,
         code_only=code_only,
         include_meta=include_meta,
     )

--- a/test/core/templaters/jinja_test.py
+++ b/test/core/templaters/jinja_test.py
@@ -706,6 +706,8 @@ def assert_structure(yaml_loader, path, code_only=True, include_meta=False):
         ("jinja_c_dbt/dbt_builtins_this_callable", True, False),
         ("jinja_c_dbt/dbt_builtins_var_default", True, False),
         ("jinja_c_dbt/dbt_builtins_test", True, False),
+        ("jinja_c_dbt/dbt_builtins_zip", True, False),
+        ("jinja_c_dbt/dbt_builtins_zip_strict", True, False),
         # do directive
         ("jinja_e/jinja", True, False),
         # case sensitivity and python literals
@@ -757,7 +759,7 @@ def test__templater_full(subpath, code_only, include_meta, yaml_loader, caplog):
 
     assert_structure(
         yaml_loader,
-        "test/fixtures/templater/" + subpath,
+        "/home/phong/Projects/sqlfluff/test/fixtures/templater/" + subpath,
         code_only=code_only,
         include_meta=include_meta,
     )

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip.sql
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip.sql
@@ -1,0 +1,12 @@
+{% set cols = 'c1' %}
+{% set tables = ['t1', 't2'] %}
+
+{% for (c, t) in zip(cols, tables) %}
+select
+  {{ c }} as col
+from
+  {{ t }}
+{% if not loop.last %}
+  union all
+{% endif %}
+{% endfor %}

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip.sql
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip.sql
@@ -1,12 +1,6 @@
-{% set cols = 'c1' %}
-{% set tables = ['t1', 't2'] %}
+{% set not_iterable = 1 %}
+{% set iterable = ['a1', 'a2'] %}
+{% set result = zip(not_iterable, iterable) %}
 
-{% for (c, t) in zip(cols, tables) %}
 select
-  {{ c }} as col
-from
-  {{ t }}
-{% if not loop.last %}
-  union all
-{% endif %}
-{% endfor %}
+  {{ result }}

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip.yml
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip.yml
@@ -1,37 +1,8 @@
 file:
   - statement:
-      set_expression:
-      - select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              column_reference:
-                naked_identifier: c
-              alias_expression:
-                keyword: as
-                naked_identifier: col
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: t1
-      - set_operator:
-        - keyword: union
-        - keyword: all
-      - select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              numeric_literal: '1'
-              alias_expression:
-                keyword: as
-                naked_identifier: col
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: t2
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            column_reference:
+              naked_identifier: None

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip.yml
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip.yml
@@ -1,0 +1,37 @@
+file:
+  - statement:
+      set_expression:
+      - select_statement:
+          select_clause:
+            keyword: select
+            select_clause_element:
+              column_reference:
+                naked_identifier: c
+              alias_expression:
+                keyword: as
+                naked_identifier: col
+          from_clause:
+            keyword: from
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: t1
+      - set_operator:
+        - keyword: union
+        - keyword: all
+      - select_statement:
+          select_clause:
+            keyword: select
+            select_clause_element:
+              numeric_literal: '1'
+              alias_expression:
+                keyword: as
+                naked_identifier: col
+          from_clause:
+            keyword: from
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: t2

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip_strict.sql
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip_strict.sql
@@ -1,12 +1,7 @@
 {% set cols = ['c1', 'c2'] %}
-{% set tables = ['t1', 't2'] %}
+{% set aliases = ['a1', 'a2'] %}
 
-{% for (c, t) in zip(cols, tables) %}
 select
-  {{ c }} as col
-from
-  {{ t }}
-{% if not loop.last %}
-  union all
-{% endif %}
+{% for (col, alias) in zip_strict(cols, aliases) %}
+  {{ col }} as {{ alias }}{% if not loop.last %},{% endif %}
 {% endfor %}

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip_strict.sql
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip_strict.sql
@@ -1,0 +1,12 @@
+{% set cols = ['c1', 'c2'] %}
+{% set tables = ['t1', 't2'] %}
+
+{% for (c, t) in zip(cols, tables) %}
+select
+  {{ c }} as col
+from
+  {{ t }}
+{% if not loop.last %}
+  union all
+{% endif %}
+{% endfor %}

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip_strict.yml
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip_strict.yml
@@ -1,38 +1,18 @@
 file:
   - statement:
-      set_expression:
-      - select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              column_reference:
-                naked_identifier: c1
-              alias_expression:
-                keyword: as
-                naked_identifier: col
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: t1
-      - set_operator:
-        - keyword: union
-        - keyword: all
-      - select_statement:
-          select_clause:
-            keyword: select
-            select_clause_element:
-              column_reference:
-                naked_identifier: c2
-              alias_expression:
-                keyword: as
-                naked_identifier: col
-          from_clause:
-            keyword: from
-            from_expression:
-              from_expression_element:
-                table_expression:
-                  table_reference:
-                    naked_identifier: t2
+      select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            column_reference:
+              naked_identifier: c1
+            alias_expression:
+              keyword: as
+              naked_identifier: a1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: c2
+            alias_expression:
+              keyword: as
+              naked_identifier: a2

--- a/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip_strict.yml
+++ b/test/fixtures/templater/jinja_c_dbt/dbt_builtins_zip_strict.yml
@@ -1,0 +1,38 @@
+file:
+  - statement:
+      set_expression:
+      - select_statement:
+          select_clause:
+            keyword: select
+            select_clause_element:
+              column_reference:
+                naked_identifier: c1
+              alias_expression:
+                keyword: as
+                naked_identifier: col
+          from_clause:
+            keyword: from
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: t1
+      - set_operator:
+        - keyword: union
+        - keyword: all
+      - select_statement:
+          select_clause:
+            keyword: select
+            select_clause_element:
+              column_reference:
+                naked_identifier: c2
+              alias_expression:
+                keyword: as
+                naked_identifier: col
+          from_clause:
+            keyword: from
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: t2


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
- Add `zip` and `zip_strict` dbt built-in jinja2 functions.  (from the official doc: https://docs.getdbt.com/reference/dbt-jinja-functions/zip)


### Why
- These missing functions will break the linting even even when we configure `apply_dbt_builtins=true`
#### How to reproduce
```bash
sqlfluff lint --templater=jinja --dialect bigquery --ignore="templating, parsing" -<<EOF
{% set cols = ['c1', 'c2', 'c3'] %}
{% set tables = ['alice', 'bob', 'tim'] %}

{% for (c, t) in zip(cols, tables) %}
select
  {{ c }} as col
from
  {{ t }}
{% if not loop.last %}
  union all
{% endif %}
{% endfor %}
EOF
```

This will throw a `ValueError` because zip is not a built-in jinja2 function.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
