### PR TITLE
ST11: Table and wildcard reference fixes

### DIFF
--- a/src/sqlfluff/rules/structure/ST11.py
+++ b/src/sqlfluff/rules/structure/ST11.py
@@ -102,7 +102,7 @@ class Rule_ST11(BaseRule):
         for table_reference in segment.recursive_crawl(
             "table_reference", no_recursive_seg_type="select_statement"
         ):
-            return table_reference.raw_upper
+            return table_reference.segments[-1].raw_upper
         # If we can't find a reference, just return an empty string
         # to signal that there isn't one. This could be a case of a
         # VALUES clause, or anything else selectable which hasn't
@@ -143,7 +143,6 @@ class Rule_ST11(BaseRule):
             for from_expression_elem in from_expression.get_children(
                 "from_expression_element"
             ):
-                # TODO: handle comma joins, these are CROSS joins
                 ref = self._extract_references_from_expression(from_expression_elem)
                 if ref:
                     joined_tables.append((ref, from_expression_elem))
@@ -262,7 +261,6 @@ class Rule_ST11(BaseRule):
         )
         for tbl_ref, segment in joined_tables:
             if tbl_ref not in table_references:
-                # if segment.is_type()
                 results.append(
                     LintResult(
                         anchor=segment,

--- a/src/sqlfluff/rules/structure/ST11.py
+++ b/src/sqlfluff/rules/structure/ST11.py
@@ -13,9 +13,6 @@ class UnqualifiedReferenceError(ValueError):
     """Custom exception for signalling when a reference is unqualified."""
 
 
-_START_TYPES = ["select_statement"]
-
-
 class Rule_ST11(BaseRule):
     """Joined table not referenced in query.
 
@@ -85,7 +82,7 @@ class Rule_ST11(BaseRule):
     name = "structure.unused_join"
     aliases = ()
     groups: Tuple[str, ...] = ("all", "structure")
-    crawl_behaviour = SegmentSeekerCrawler(set(_START_TYPES), allow_recurse=False)
+    crawl_behaviour = SegmentSeekerCrawler({"select_statement"})
     is_fix_compatible = False
 
     def _extract_references_from_expression(self, segment: BaseSegment) -> str:

--- a/test/fixtures/rules/std_rule_cases/ST11.yml
+++ b/test/fixtures/rules/std_rule_cases/ST11.yml
@@ -124,3 +124,49 @@ test_fail_subquery:
         FROM c
         WHERE c.other_column = a.col
     )
+
+test_pass_table_with_schema_6496:
+  pass_str: |
+    SELECT
+        t1.col1,
+        t2.col2
+    FROM
+        db1.t1
+    LEFT JOIN
+        t2
+        ON
+            t1.id = t2.id
+
+test_pass_wildcard_6511:
+  pass_str: |
+    select
+        simulation_source_data_reference.*,
+        sourcings.* exclude sourcing_job_id
+    from simulation_source_data_reference
+    left join sourcings
+        on simulation_source_data_reference.sourcing_job_id = sourcings.sourcing_job_id;
+  configs:
+    core:
+      dialect: snowflake
+
+test_pass_cross_join_6511:
+  pass_str: |
+    select
+        cast(fpids.value as integer) as party_id
+    from kyc_dossiers as kds,
+        lateral flatten(input => kds.party_ids) as fpids;
+  configs:
+    core:
+      dialect: snowflake
+
+test_pass_table_expression_function_6558:
+  pass_str: |
+    SELECT
+        ft.id,
+        n.generic_field
+    FROM fact_table AS ft
+    LEFT JOIN UNNEST(ft.generic_array) AS g
+    LEFT JOIN UNNEST(g.nested_array) AS n;
+  configs:
+    core:
+      dialect: bigquery

--- a/test/fixtures/rules/std_rule_cases/ST11.yml
+++ b/test/fixtures/rules/std_rule_cases/ST11.yml
@@ -125,6 +125,16 @@ test_fail_subquery:
         WHERE c.other_column = a.col
     )
 
+test_fail_inner_subquery:
+  fail_str: |
+    SELECT *
+    FROM (
+        SELECT t1.col1
+        FROM db1.t1
+        LEFT JOIN t2
+            ON t1.id = t2.id
+    );
+
 test_pass_table_with_schema_6496:
   pass_str: |
     SELECT


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This fixes a number of issues with ST11:
- wildcard usage
- table functions such as `UNNEST` or `LATERAL FLATTEN`
- implicit cross joins (legacy comma joins)

Issues:
- fixes #6496 
- fixes #6511 
- fixes #6558

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
