### PR TITLE
Add support for Oracle SQL*Plus substitution variable `&`.

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -230,6 +230,7 @@ oracle_dialect.replace(
     ).copy(
         insert=[
             Ref("ConnectByRootGrammar"),
+            Ref("SqlplusSubstitutionVariableSegment"),
         ]
     ),
     Expression_D_Grammar=Sequence(
@@ -289,6 +290,7 @@ oracle_dialect.replace(
                 ),
             ),
             Ref("LocalAliasSegment"),
+            Ref("SqlplusSubstitutionVariableSegment"),
             terminators=[Ref("CommaSegment")],
         ),
         Ref("AccessorGrammar", optional=True),
@@ -305,6 +307,11 @@ oracle_dialect.replace(
     PreTableFunctionKeywordsGrammar=OneOf("LATERAL"),
     ConditionalCrossJoinKeywordsGrammar=Nothing(),
     UnconditionalCrossJoinKeywordsGrammar=Ref.keyword("CROSS"),
+    SingleIdentifierGrammar=ansi_dialect.get_grammar("SingleIdentifierGrammar").copy(
+        insert=[
+            Ref("SqlplusSubstitutionVariableSegment"),
+        ]
+    ),
 )
 
 
@@ -982,4 +989,29 @@ class FunctionNameSegment(BaseSegment):
             delimiter=Ref("AtSignSegment"),
         ),
         allow_gaps=False,
+    )
+
+
+class SqlplusSubstitutionVariableSegment(BaseSegment):
+    """SQLPlus Substitution Variables &thing.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/21/sqpug/using-substitution-variables-sqlplus.html
+    """
+
+    type = "sqlplus_variable"
+
+    match_grammar = Sequence(
+        Ref("AmpersandSegment"),
+        Ref("AmpersandSegment", optional=True),
+        Ref("SingleIdentifierGrammar"),
+    )
+
+
+class TableExpressionSegment(ansi.TableExpressionSegment):
+    """The main table expression e.g. within a FROM clause."""
+
+    match_grammar = ansi.TableExpressionSegment.match_grammar.copy(
+        insert=[
+            Ref("SqlplusSubstitutionVariableSegment"),
+        ]
     )

--- a/test/fixtures/dialects/oracle/substitution_variable.sql
+++ b/test/fixtures/dialects/oracle/substitution_variable.sql
@@ -1,0 +1,19 @@
+grant select on my_table to &REGISTRY;
+
+SELECT &SORTCOL, SALARY
+FROM &MYTABLE
+WHERE SALARY>12000;
+
+select employee_id from employees where last_name = '&myv';
+
+select * from employees where employee_id = &myv;
+
+SELECT SALARY FROM EMP_DETAILS_VIEW WHERE EMPLOYEE_ID='&X.5';
+
+SELECT &GROUP_COL, MAX(&NUMBER_COL) MAXIMUM
+FROM &TABLE
+GROUP BY &GROUP_COL;
+
+select * from employees where employee_id = &&myv;
+
+insert into mytable values (&myv);

--- a/test/fixtures/dialects/oracle/substitution_variable.yml
+++ b/test/fixtures/dialects/oracle/substitution_variable.yml
@@ -1,0 +1,205 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 6f27a1d7f5eab2da90914282e3976d71d89614ce5cde8883ebe506af5605c108
+file:
+- statement:
+    access_statement:
+    - keyword: grant
+    - keyword: select
+    - keyword: 'on'
+    - object_reference:
+        naked_identifier: my_table
+    - keyword: to
+    - role_reference:
+        sqlplus_variable:
+          ampersand: '&'
+          naked_identifier: REGISTRY
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+            sqlplus_variable:
+              ampersand: '&'
+              naked_identifier: SORTCOL
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: SALARY
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              sqlplus_variable:
+                ampersand: '&'
+                naked_identifier: MYTABLE
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: SALARY
+          comparison_operator:
+            raw_comparison_operator: '>'
+          numeric_literal: '12000'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          column_reference:
+            naked_identifier: employee_id
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: employees
+      where_clause:
+        keyword: where
+        expression:
+          column_reference:
+            naked_identifier: last_name
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'&myv'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: employees
+      where_clause:
+        keyword: where
+        expression:
+          column_reference:
+            naked_identifier: employee_id
+          comparison_operator:
+            raw_comparison_operator: '='
+          sqlplus_variable:
+            ampersand: '&'
+            naked_identifier: myv
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: SALARY
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: EMP_DETAILS_VIEW
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: EMPLOYEE_ID
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'&X.5'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+            sqlplus_variable:
+              ampersand: '&'
+              naked_identifier: GROUP_COL
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: MAX
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  sqlplus_variable:
+                    ampersand: '&'
+                    naked_identifier: NUMBER_COL
+                end_bracket: )
+          alias_expression:
+            naked_identifier: MAXIMUM
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              sqlplus_variable:
+                ampersand: '&'
+                naked_identifier: TABLE
+      groupby_clause:
+      - keyword: GROUP
+      - keyword: BY
+      - expression:
+          sqlplus_variable:
+            ampersand: '&'
+            naked_identifier: GROUP_COL
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: employees
+      where_clause:
+        keyword: where
+        expression:
+          column_reference:
+            naked_identifier: employee_id
+          comparison_operator:
+            raw_comparison_operator: '='
+          sqlplus_variable:
+          - ampersand: '&'
+          - ampersand: '&'
+          - naked_identifier: myv
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: insert
+    - keyword: into
+    - table_reference:
+        naked_identifier: mytable
+    - values_clause:
+        keyword: values
+        bracketed:
+          start_bracket: (
+          expression:
+            sqlplus_variable:
+              ampersand: '&'
+              naked_identifier: myv
+          end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
Closes #6569.

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
