### PR TITLE
TSQL: Add `WITH ROLLUP` option for `GROUP BY`

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -4241,7 +4241,19 @@ class GroupByClauseSegment(BaseSegment):
                 Ref("ExpressionSegment"),
             ),
         ),
+        Ref("WithRollupClauseSegment", optional=True),
         Dedent,
+    )
+
+
+class WithRollupClauseSegment(BaseSegment):
+    """A `WITH ROLLUP` clause after the `GROUP BY` clause."""
+
+    type = "with_rollup_clause"
+
+    match_grammar = Sequence(
+        "WITH",
+        "ROLLUP",
     )
 
 

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -547,6 +547,7 @@ UNRESERVED_KEYWORDS = [
     "RETURNS",
     "ROBUST",
     "ROLE",
+    "ROLLUP",
     "ROOT",
     "ROUND_ROBIN",  # Azure Synapse Analytics specific
     "ROW_NUMBER",

--- a/test/fixtures/dialects/tsql/group_by.sql
+++ b/test/fixtures/dialects/tsql/group_by.sql
@@ -11,3 +11,6 @@ FROM #n t
 GROUP BY    t.ActionDTS;
 
 DROP  TABLE #n;
+
+SELECT st, count(*), count(DISTINCT id) FROM #3
+GROUP BY st WITH ROLLUP;

--- a/test/fixtures/dialects/tsql/group_by.yml
+++ b/test/fixtures/dialects/tsql/group_by.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ad0814659a8258c79cbd4ff066216c7f4d839397e4f567760a5bf98387b5c454
+_hash: 185300b83b1779585e6206cc559146785c004722e829ea7e464a52efed7de5ac
 file:
   batch:
   - statement:
@@ -76,3 +76,49 @@ file:
       - table_reference:
           hash_identifier: '#n'
       - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: st
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: count
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  star: '*'
+                  end_bracket: )
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: count
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  keyword: DISTINCT
+                  expression:
+                    column_reference:
+                      naked_identifier: id
+                  end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  hash_identifier: '#3'
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            naked_identifier: st
+        - with_rollup_clause:
+          - keyword: WITH
+          - keyword: ROLLUP
+        statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds the `WITH ROLLUP` keywords for tsql dialect.
- fixes #6524

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
