### PR TITLE
ST03: Handle quotes in CTE names

### DIFF
--- a/src/sqlfluff/rules/structure/ST03.py
+++ b/src/sqlfluff/rules/structure/ST03.py
@@ -57,7 +57,7 @@ class Rule_ST03(BaseRule):
         # Work through all the references in the file, checking off CTES as the
         # are referenced.
         for reference in context.segment.recursive_crawl("table_reference"):
-            remaining_ctes.pop(reference.raw.upper(), None)
+            remaining_ctes.pop(reference.raw_normalized(False).upper(), None)
 
         # For any left un-referenced at the end. Raise an issue about them.
         for name in remaining_ctes.values():

--- a/src/sqlfluff/utils/analysis/query.py
+++ b/src/sqlfluff/utils/analysis/query.py
@@ -326,7 +326,7 @@ class Query(Generic[T]):
 
         selectables = []
         subqueries = []
-        cte_defs = []
+        cte_defs: List[BaseSegment] = []
         query_type = QueryType.Simple
 
         if segment.is_type("select_statement", *SUBSELECT_TYPES):
@@ -387,7 +387,7 @@ class Query(Generic[T]):
             # is the name, but it's the same functionality we've run with for
             # a while.
             name_seg = cte.segments[0]
-            name = name_seg.raw_upper
+            name = name_seg.raw_normalized(False).upper()
             # Get the query out of it, just stop on the first one we find.
             try:
                 inner_qry = next(

--- a/test/fixtures/rules/std_rule_cases/ST03.yml
+++ b/test/fixtures/rules/std_rule_cases/ST03.yml
@@ -423,3 +423,39 @@ test_pass_nested_with_cte:
 
     SELECT *
     FROM container_cte
+
+test_pass_bigquery_quoted_cte_unquoted_ref:
+  pass_str: |
+    with `tabx` as (
+      select 1
+    )
+
+    select *
+    from tabx;
+  configs:
+    core:
+      dialect: bigquery
+
+test_pass_bigquery_quoted_cte_quoted_ref:
+  pass_str: |
+    with `tabx` as (
+      select 1
+    )
+
+    select *
+    from `tabx`;
+  configs:
+    core:
+      dialect: bigquery
+
+test_pass_bigquery_unquoted_cte_quoted_ref:
+  pass_str: |
+    with tabx as (
+      select 1
+    )
+
+    select *
+    from `tabx`;
+  configs:
+    core:
+      dialect: bigquery


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This allows for quotes to be in either the CTE name or the table_expression that references it (mix and match).
- fixes #6556

### Are there any other side effects of this change that we should be aware of?
This touches the `Query` class and removes quotes from the `ctes` dictionary keys. This may reveal other opportunities to apply the quote change to other rules, but a cursory glance determined minimal impact.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
