### PR TITLE
ST09: Handle `lt_eq_gt` operator

### DIFF
--- a/src/sqlfluff/rules/structure/ST09.py
+++ b/src/sqlfluff/rules/structure/ST09.py
@@ -234,7 +234,8 @@ class Rule_ST09(BaseRule):
                                 ],
                             )
                         ]
-                        if raw_comparison_operators[0].raw
+                        if raw_comparison_operators
+                        and raw_comparison_operators[0].raw
                         in raw_comparison_operator_opposites
                         and [r.raw for r in raw_comparison_operators] != ["<", ">"]
                         else []
@@ -242,7 +243,7 @@ class Rule_ST09(BaseRule):
                 )
 
         # STEP 5.a.
-        if fixes == []:
+        if not fixes:
             return None
 
         # STEP 5.b.

--- a/test/fixtures/rules/std_rule_cases/ST09.yml
+++ b/test/fixtures/rules/std_rule_cases/ST09.yml
@@ -406,3 +406,18 @@ test_fail_later_table_first_quoted_table_and_column:
     from "foo"
     left join "bar"
         on "foo"."a" = "bar"."a"
+
+test_fail_sparksql_lt_eq_gt_operator:
+  fail_str: |
+    SELECT bt.test
+    FROM base_table AS bt
+    INNER JOIN second_table AS st
+      ON st.test <=> bt.test
+  fix_str: |
+    SELECT bt.test
+    FROM base_table AS bt
+    INNER JOIN second_table AS st
+      ON bt.test <=> st.test
+  configs:
+    core:
+      dialect: sparksql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds support for the `<=>` operator in the ST09 rule. More generally it prevents some comparison operators from flipping that are not strictly the greater than or less than signs.
- fixes #6560

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
