### PR TITLE
AL04: Check for duplicates in subquery aliases and table references

### DIFF
--- a/src/sqlfluff/rules/aliasing/AL04.py
+++ b/src/sqlfluff/rules/aliasing/AL04.py
@@ -80,6 +80,20 @@ class Rule_AL04(BaseRule):
         NB: Subclasses of this error should override this function.
 
         """
+        if parent_select:
+            parent_select_info = get_select_statement_info(
+                parent_select, rule_context.dialect
+            )
+            if parent_select_info:
+                # If we are looking at a subquery, include any table references
+                for table_alias in parent_select_info.table_aliases:
+                    if table_alias.from_expression_element.path_to(
+                        rule_context.segment
+                    ):
+                        # Skip the subquery alias itself
+                        continue
+                    table_aliases.append(table_alias)
+
         # Are any of the aliases the same?
         duplicate = set()
         for a1, a2 in itertools.combinations(table_aliases, 2):

--- a/test/fixtures/rules/std_rule_cases/AL04.yml
+++ b/test/fixtures/rules/std_rule_cases/AL04.yml
@@ -51,3 +51,27 @@ test_pass_tsql_table_variable:
   configs:
     core:
       dialect: tsql
+
+test_fail_subquery_same_alias:
+  fail_str: |
+    SELECT *
+    FROM tbl AS t
+    WHERE t.val IN (SELECT t.val FROM tbl2 AS t)
+
+test_fail_subquery_alias_matches_base_table:
+  fail_str: |
+    SELECT *
+    FROM tbl
+    WHERE val IN (SELECT tbl.val FROM tbl2 AS tbl)
+
+test_fail_subquery_table_matches_base_table:
+  fail_str: |
+    SELECT *
+    FROM tbl
+    WHERE val IN (SELECT tbl.val FROM tbl)
+
+test_fail_subquery_join_matches_base_table:
+  fail_str: |
+    SELECT tbl.val
+    FROM tbl
+    LEFT JOIN (SELECT tbl.val FROM tbl2 AS tbl);


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This now causes AL04 to check any reference or aliases that are within a subquery to not be a duplicated name with any elements in the parent query.
- makes progress on #6326

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
