### PR TITLE
Add support for Postgres `ALTER FOREIGN TABLE` statement.

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -4790,6 +4790,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("CreateForeignDataWrapperStatementSegment"),
             Ref("DropForeignTableStatement"),
             Ref("CreateOperatorStatementSegment"),
+            Ref("AlterForeignTableStatementSegment"),
         ],
     )
 
@@ -6508,4 +6509,69 @@ class CreateOperatorStatementSegment(BaseSegment):
                 Ref.keyword("MERGES", optional=True),
             )
         ),
+    )
+
+
+class AlterForeignTableStatementSegment(BaseSegment):
+    """An `ALTER TABLE` statement.
+
+    https://www.postgresql.org/docs/17/sql-alterforeigntable.html
+    """
+
+    type = "alter_foreign_table_statement"
+
+    match_grammar = Sequence(
+        "ALTER",
+        "FOREIGN",
+        "TABLE",
+        OneOf(
+            Sequence(
+                Ref("IfExistsGrammar", optional=True),
+                Ref.keyword("ONLY", optional=True),
+                Ref("TableReferenceSegment"),
+                Ref("StarSegment", optional=True),
+                OneOf(
+                    Delimited(Ref("AlterForeignTableActionSegment")),
+                    Sequence(
+                        "RENAME",
+                        Ref.keyword("COLUMN", optional=True),
+                        Ref("ColumnReferenceSegment"),
+                        "TO",
+                        Ref("ColumnReferenceSegment"),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+class AlterForeignTableActionSegment(AlterTableActionSegment):
+    """Alter Foreign Table Action Segment.
+
+    https://www.postgresql.org/docs/17/sql-alterforeigntable.html
+    """
+
+    type = "alter_foreign_table_action_segment"
+
+    match_grammar = AlterTableActionSegment.match_grammar.copy(
+        insert=[
+            Sequence(
+                Sequence(
+                    "ALTER",
+                    Ref("COLUMN", optional=True),
+                    Ref("ColumnReferenceSegment"),
+                    optional=True,
+                ),
+                "OPTIONS",
+                Bracketed(
+                    Delimited(
+                        AnyNumberOf(
+                            OneOf("ADD", "SET", "DROP"),
+                            Ref("SingleIdentifierGrammar"),
+                            Ref("QuotedLiteralSegment"),
+                        )
+                    )
+                ),
+            )
+        ]
     )

--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -6524,21 +6524,19 @@ class AlterForeignTableStatementSegment(BaseSegment):
         "ALTER",
         "FOREIGN",
         "TABLE",
-        OneOf(
-            Sequence(
-                Ref("IfExistsGrammar", optional=True),
-                Ref.keyword("ONLY", optional=True),
-                Ref("TableReferenceSegment"),
-                Ref("StarSegment", optional=True),
-                OneOf(
-                    Delimited(Ref("AlterForeignTableActionSegment")),
-                    Sequence(
-                        "RENAME",
-                        Ref.keyword("COLUMN", optional=True),
-                        Ref("ColumnReferenceSegment"),
-                        "TO",
-                        Ref("ColumnReferenceSegment"),
-                    ),
+        Sequence(
+            Ref("IfExistsGrammar", optional=True),
+            Ref.keyword("ONLY", optional=True),
+            Ref("TableReferenceSegment"),
+            Ref("StarSegment", optional=True),
+            OneOf(
+                Delimited(Ref("AlterForeignTableActionSegment")),
+                Sequence(
+                    "RENAME",
+                    Ref.keyword("COLUMN", optional=True),
+                    Ref("ColumnReferenceSegment"),
+                    "TO",
+                    Ref("ColumnReferenceSegment"),
                 ),
             ),
         ),
@@ -6565,10 +6563,10 @@ class AlterForeignTableActionSegment(AlterTableActionSegment):
                 "OPTIONS",
                 Bracketed(
                     Delimited(
-                        AnyNumberOf(
-                            OneOf("ADD", "SET", "DROP"),
+                        Sequence(
+                            OneOf("ADD", "SET", "DROP", optional=True),
                             Ref("SingleIdentifierGrammar"),
-                            Ref("QuotedLiteralSegment"),
+                            Ref("QuotedLiteralSegment", optional=True),
                         )
                     )
                 ),

--- a/test/fixtures/dialects/postgres/alter_foreign_table.sql
+++ b/test/fixtures/dialects/postgres/alter_foreign_table.sql
@@ -1,0 +1,11 @@
+ALTER FOREIGN TABLE distributors ALTER COLUMN street SET NOT NULL;
+
+ALTER FOREIGN TABLE t_user ADD COLUMN my_column text;
+
+ALTER TABLE bar_fdw.foo ADD test varchar NULL;
+
+ALTER FOREIGN TABLE myschema.distributors OPTIONS (ADD opt1 'value', SET opt2 'value2', DROP opt3);
+
+ALTER FOREIGN TABLE test OPTIONS (SET table $$(select my_column from my_table)$$);
+
+ALTER FOREIGN TABLE test ADD COLUMN new_column int8, OPTIONS (SET table $$(select my_column from my_table)$$);

--- a/test/fixtures/dialects/postgres/alter_foreign_table.yml
+++ b/test/fixtures/dialects/postgres/alter_foreign_table.yml
@@ -1,0 +1,120 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: fb422bdb80c2368243abf4fbb79459993e69af838ddeb700d926c046c16da370
+file:
+- statement:
+    alter_foreign_table_statement:
+    - keyword: ALTER
+    - keyword: FOREIGN
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: distributors
+    - alter_foreign_table_action_segment:
+      - keyword: ALTER
+      - keyword: COLUMN
+      - column_reference:
+          naked_identifier: street
+      - keyword: SET
+      - keyword: NOT
+      - keyword: 'NULL'
+- statement_terminator: ;
+- statement:
+    alter_foreign_table_statement:
+    - keyword: ALTER
+    - keyword: FOREIGN
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t_user
+    - alter_foreign_table_action_segment:
+      - keyword: ADD
+      - keyword: COLUMN
+      - column_reference:
+          naked_identifier: my_column
+      - data_type:
+          keyword: text
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: bar_fdw
+      - dot: .
+      - naked_identifier: foo
+    - alter_table_action_segment:
+        keyword: ADD
+        column_reference:
+          naked_identifier: test
+        data_type:
+          keyword: varchar
+        column_constraint_segment:
+          keyword: 'NULL'
+- statement_terminator: ;
+- statement:
+    alter_foreign_table_statement:
+    - keyword: ALTER
+    - keyword: FOREIGN
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: myschema
+      - dot: .
+      - naked_identifier: distributors
+    - alter_foreign_table_action_segment:
+        keyword: OPTIONS
+        bracketed:
+        - start_bracket: (
+        - keyword: ADD
+        - naked_identifier: opt1
+        - quoted_literal: "'value'"
+        - comma: ','
+        - keyword: SET
+        - naked_identifier: opt2
+        - quoted_literal: "'value2'"
+        - comma: ','
+        - keyword: DROP
+        - naked_identifier: opt3
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_foreign_table_statement:
+    - keyword: ALTER
+    - keyword: FOREIGN
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: test
+    - alter_foreign_table_action_segment:
+        keyword: OPTIONS
+        bracketed:
+          start_bracket: (
+          keyword: SET
+          naked_identifier: table
+          quoted_literal: $$(select my_column from my_table)$$
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_foreign_table_statement:
+    - keyword: ALTER
+    - keyword: FOREIGN
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: test
+    - alter_foreign_table_action_segment:
+      - keyword: ADD
+      - keyword: COLUMN
+      - column_reference:
+          naked_identifier: new_column
+      - data_type:
+          keyword: int8
+    - comma: ','
+    - alter_foreign_table_action_segment:
+        keyword: OPTIONS
+        bracketed:
+          start_bracket: (
+          keyword: SET
+          naked_identifier: table
+          quoted_literal: $$(select my_column from my_table)$$
+          end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
Closes #6547.

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
