### PR TITLE
Sqlite: Added `set_clause_list` to `UPDATE` statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -3770,12 +3770,7 @@ class SetClauseListSegment(BaseSegment):
     match_grammar: Matchable = Sequence(
         "SET",
         Indent,
-        Ref("SetClauseSegment"),
-        # set clause
-        AnyNumberOf(
-            Ref("CommaSegment"),
-            Ref("SetClauseSegment"),
-        ),
+        Delimited(Ref("SetClauseSegment")),
         Dedent,
     )
 

--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -1005,22 +1005,23 @@ class UpdateStatementSegment(ansi.UpdateStatementSegment):
         Ref("TableReferenceSegment"),
         Ref("AliasExpressionSegment", optional=True),
         Dedent,
-        "SET",
-        Indent,
-        Delimited(
-            Sequence(
-                OneOf(
-                    Ref("SingleIdentifierGrammar"),
-                    Ref("BracketedColumnReferenceListGrammar"),
-                ),
-                Ref("EqualsSegment"),
-                Ref("ExpressionSegment"),
-            ),
-        ),
-        Dedent,
+        Ref("SetClauseListSegment"),
         Ref("FromClauseSegment", optional=True),
         Ref("WhereClauseSegment", optional=True),
         Ref("ReturningClauseSegment", optional=True),
+    )
+
+
+class SetClauseSegment(ansi.SetClauseSegment):
+    """A set clause."""
+
+    match_grammar = Sequence(
+        OneOf(
+            Ref("SingleIdentifierGrammar"),
+            Ref("BracketedColumnReferenceListGrammar"),
+        ),
+        Ref("EqualsSegment"),
+        Ref("ExpressionSegment"),
     )
 
 

--- a/test/fixtures/dialects/sqlite/create_trigger.yml
+++ b/test/fixtures/dialects/sqlite/create_trigger.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 022908af92556f2d06a3fa24c4a426f7529f178e8bfbab8e7cfeb2df9b3609ae
+_hash: 0c409229b9910cd1161328f22a4c1415fe676d03094b4390924b452d75f4916a
 file:
 - statement:
     create_trigger:
@@ -20,19 +20,21 @@ file:
         naked_identifier: customers
     - keyword: BEGIN
     - update_statement:
-      - keyword: UPDATE
-      - table_reference:
+        keyword: UPDATE
+        table_reference:
           naked_identifier: orders
-      - keyword: SET
-      - naked_identifier: address
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - expression:
-          column_reference:
-          - naked_identifier: new
-          - dot: .
-          - naked_identifier: address
-      - where_clause:
+        set_clause_list:
+          keyword: SET
+          set_clause:
+            naked_identifier: address
+            comparison_operator:
+              raw_comparison_operator: '='
+            expression:
+              column_reference:
+              - naked_identifier: new
+              - dot: .
+              - naked_identifier: address
+        where_clause:
           keyword: WHERE
           expression:
           - column_reference:
@@ -63,19 +65,21 @@ file:
         naked_identifier: customer_address
     - keyword: BEGIN
     - update_statement:
-      - keyword: UPDATE
-      - table_reference:
+        keyword: UPDATE
+        table_reference:
           naked_identifier: customer
-      - keyword: SET
-      - naked_identifier: cust_addr
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - expression:
-          column_reference:
-          - naked_identifier: NEW
-          - dot: .
-          - naked_identifier: cust_addr
-      - where_clause:
+        set_clause_list:
+          keyword: SET
+          set_clause:
+            naked_identifier: cust_addr
+            comparison_operator:
+              raw_comparison_operator: '='
+            expression:
+              column_reference:
+              - naked_identifier: NEW
+              - dot: .
+              - naked_identifier: cust_addr
+        where_clause:
           keyword: WHERE
           expression:
           - column_reference:
@@ -269,16 +273,18 @@ file:
         null_literal: 'NULL'
     - keyword: BEGIN
     - update_statement:
-      - keyword: UPDATE
-      - table_reference:
+        keyword: UPDATE
+        table_reference:
           naked_identifier: y
-      - keyword: SET
-      - naked_identifier: z
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - expression:
-          boolean_literal: 'TRUE'
-      - where_clause:
+        set_clause_list:
+          keyword: SET
+          set_clause:
+            naked_identifier: z
+            comparison_operator:
+              raw_comparison_operator: '='
+            expression:
+              boolean_literal: 'TRUE'
+        where_clause:
           keyword: WHERE
           expression:
           - column_reference:

--- a/test/fixtures/dialects/sqlite/update.yml
+++ b/test/fixtures/dialects/sqlite/update.yml
@@ -3,28 +3,31 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3f382641c211d3e442174e8d53fadb4ed7ca713b0a59897392f15668a846bc2d
+_hash: 42292cae7083b7ade94847afb9f1e66782a0619019e4029e17bf554e9dee9565
 file:
 - statement:
     update_statement:
-    - keyword: UPDATE
-    - table_reference:
+      keyword: UPDATE
+      table_reference:
         naked_identifier: table_name
-    - keyword: SET
-    - naked_identifier: column1
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value1
-    - comma: ','
-    - naked_identifier: column2
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value2
-    - where_clause:
+      set_clause_list:
+      - keyword: SET
+      - set_clause:
+          naked_identifier: column1
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value1
+      - comma: ','
+      - set_clause:
+          naked_identifier: column2
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value2
+      where_clause:
         keyword: WHERE
         expression:
           column_reference:
@@ -35,24 +38,27 @@ file:
 - statement_terminator: ;
 - statement:
     update_statement:
-    - keyword: UPDATE
-    - table_reference:
+      keyword: UPDATE
+      table_reference:
         naked_identifier: table_name
-    - keyword: SET
-    - naked_identifier: column1
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value1
-    - comma: ','
-    - naked_identifier: column2
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value2
-    - where_clause:
+      set_clause_list:
+      - keyword: SET
+      - set_clause:
+          naked_identifier: column1
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value1
+      - comma: ','
+      - set_clause:
+          naked_identifier: column2
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value2
+      where_clause:
         keyword: WHERE
         expression:
           column_reference:
@@ -60,7 +66,7 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           numeric_literal: '1'
-    - returning_clause:
+      returning_clause:
         keyword: RETURNING
         wildcard_expression:
           wildcard_identifier:
@@ -68,24 +74,27 @@ file:
 - statement_terminator: ;
 - statement:
     update_statement:
-    - keyword: UPDATE
-    - table_reference:
+      keyword: UPDATE
+      table_reference:
         naked_identifier: table_name
-    - keyword: SET
-    - naked_identifier: column1
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value1
-    - comma: ','
-    - naked_identifier: column2
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value2
-    - where_clause:
+      set_clause_list:
+      - keyword: SET
+      - set_clause:
+          naked_identifier: column1
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value1
+      - comma: ','
+      - set_clause:
+          naked_identifier: column2
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value2
+      where_clause:
         keyword: WHERE
         expression:
           column_reference:
@@ -93,7 +102,7 @@ file:
           comparison_operator:
             raw_comparison_operator: '='
           numeric_literal: '1'
-    - returning_clause:
+      returning_clause:
       - keyword: RETURNING
       - expression:
           column_reference:
@@ -115,20 +124,23 @@ file:
     - keyword: IGNORE
     - table_reference:
         naked_identifier: table_name
-    - keyword: SET
-    - naked_identifier: column1
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value1
-    - comma: ','
-    - naked_identifier: column2
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value2
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+          naked_identifier: column1
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value1
+      - comma: ','
+      - set_clause:
+          naked_identifier: column2
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value2
     - where_clause:
         keyword: WHERE
         expression:
@@ -145,20 +157,23 @@ file:
     - keyword: ABORT
     - table_reference:
         naked_identifier: table_name
-    - keyword: SET
-    - naked_identifier: column1
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value1
-    - comma: ','
-    - naked_identifier: column2
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value2
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+          naked_identifier: column1
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value1
+      - comma: ','
+      - set_clause:
+          naked_identifier: column2
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value2
     - where_clause:
         keyword: WHERE
         expression:
@@ -175,20 +190,23 @@ file:
     - keyword: FAIL
     - table_reference:
         naked_identifier: table_name
-    - keyword: SET
-    - naked_identifier: column1
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value1
-    - comma: ','
-    - naked_identifier: column2
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value2
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+          naked_identifier: column1
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value1
+      - comma: ','
+      - set_clause:
+          naked_identifier: column2
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value2
     - where_clause:
         keyword: WHERE
         expression:
@@ -205,20 +223,23 @@ file:
     - keyword: REPLACE
     - table_reference:
         naked_identifier: table_name
-    - keyword: SET
-    - naked_identifier: column1
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value1
-    - comma: ','
-    - naked_identifier: column2
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value2
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+          naked_identifier: column1
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value1
+      - comma: ','
+      - set_clause:
+          naked_identifier: column2
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value2
     - where_clause:
         keyword: WHERE
         expression:
@@ -235,20 +256,23 @@ file:
     - keyword: ROLLBACK
     - table_reference:
         naked_identifier: table_name
-    - keyword: SET
-    - naked_identifier: column1
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value1
-    - comma: ','
-    - naked_identifier: column2
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        column_reference:
-          naked_identifier: value2
+    - set_clause_list:
+      - keyword: SET
+      - set_clause:
+          naked_identifier: column1
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value1
+      - comma: ','
+      - set_clause:
+          naked_identifier: column2
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              naked_identifier: value2
     - where_clause:
         keyword: WHERE
         expression:
@@ -260,39 +284,41 @@ file:
 - statement_terminator: ;
 - statement:
     update_statement:
-    - keyword: UPDATE
-    - table_reference:
+      keyword: UPDATE
+      table_reference:
         naked_identifier: table_name
-    - keyword: SET
-    - bracketed:
-      - start_bracket: (
-      - column_reference:
-          naked_identifier: context
-      - comma: ','
-      - column_reference:
-          naked_identifier: country
-      - end_bracket: )
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - expression:
-        bracketed:
-          start_bracket: (
-          select_statement:
-            select_clause:
-            - keyword: SELECT
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: context
-            - comma: ','
-            - select_clause_element:
-                column_reference:
-                  naked_identifier: country
-            from_clause:
-              keyword: FROM
-              from_expression:
-                from_expression_element:
-                  table_expression:
-                    table_reference:
-                      naked_identifier: Nations
-          end_bracket: )
+      set_clause_list:
+        keyword: SET
+        set_clause:
+          bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: context
+          - comma: ','
+          - column_reference:
+              naked_identifier: country
+          - end_bracket: )
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            bracketed:
+              start_bracket: (
+              select_statement:
+                select_clause:
+                - keyword: SELECT
+                - select_clause_element:
+                    column_reference:
+                      naked_identifier: context
+                - comma: ','
+                - select_clause_element:
+                    column_reference:
+                      naked_identifier: country
+                from_clause:
+                  keyword: FROM
+                  from_expression:
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                          naked_identifier: Nations
+              end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds the `set_clause_list` parsing grammar to sqlite's UPDATE statement.
- fixes #6602

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
