### PR TITLE
CI: Update to black 25.1 and pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: no-commit-to-branch
         args: [--branch, main]
@@ -32,11 +32,11 @@ repos:
             test/fixtures/linter/sqlfluffignore/
           )$
   - repo: https://github.com/psf/black
-    rev: 24.2.0
+    rev: 25.1.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.14.1
     hooks:
       - id: mypy
         additional_dependencies:
@@ -67,12 +67,12 @@ repos:
         # CI job.
         args: []
   - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
       - id: flake8
         additional_dependencies: [flake8-black>=0.3.6]
   - repo: https://github.com/pycqa/doc8
-    rev: v1.1.1
+    rev: v1.1.2
     hooks:
       - id: doc8
         args: [--file-encoding, utf8]
@@ -84,11 +84,11 @@ repos:
         args: [-c=.yamllint]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.3.2"
+    rev: "v0.9.3"
     hooks:
       - id: ruff
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.4.1
     hooks:
       - id: codespell
         exclude: (?x)^(test/fixtures/.*|pyproject.toml)$

--- a/src/sqlfluff/core/parser/helpers.py
+++ b/src/sqlfluff/core/parser/helpers.py
@@ -32,7 +32,7 @@ def check_still_complete(
 
 
 def trim_non_code_segments(
-    segments: Tuple["BaseSegment", ...]
+    segments: Tuple["BaseSegment", ...],
 ) -> Tuple[
     Tuple["BaseSegment", ...], Tuple["BaseSegment", ...], Tuple["BaseSegment", ...]
 ]:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This updates the pre-commit hooks and linting changes for black 25.1.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
