### PR TITLE
Allow double equals in hive dialect

### DIFF
--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -265,6 +265,22 @@ class ArrayTypeSegment(ansi.ArrayTypeSegment):
     )
 
 
+class EqualsSegment(ansi.EqualsSegment):
+    """Equals operator.
+
+    Hive allows double equals:
+    https://cwiki.apache.org/confluence/display/Hive/Hive+Operators
+    """
+
+    match_grammar: Matchable = OneOf(
+        Ref("RawEqualsSegment"),
+        Sequence(
+            Ref("RawEqualsSegment"),
+            Ref("RawEqualsSegment"),
+        ),
+    )
+
+
 class StructTypeSegment(ansi.StructTypeSegment):
     """Expression to construct a STRUCT datatype."""
 

--- a/src/sqlfluff/dialects/dialect_hive.py
+++ b/src/sqlfluff/dialects/dialect_hive.py
@@ -272,12 +272,9 @@ class EqualsSegment(ansi.EqualsSegment):
     https://cwiki.apache.org/confluence/display/Hive/Hive+Operators
     """
 
-    match_grammar: Matchable = OneOf(
+    match_grammar: Matchable = Sequence(
         Ref("RawEqualsSegment"),
-        Sequence(
-            Ref("RawEqualsSegment"),
-            Ref("RawEqualsSegment"),
-        ),
+        Ref("RawEqualsSegment", optional=True),
     )
 
 

--- a/test/fixtures/dialects/hive/double_equals.sql
+++ b/test/fixtures/dialects/hive/double_equals.sql
@@ -1,0 +1,6 @@
+SELECT
+    a
+FROM
+    t
+WHERE
+    t.a = = t.b

--- a/test/fixtures/dialects/hive/double_equals.sql
+++ b/test/fixtures/dialects/hive/double_equals.sql
@@ -3,4 +3,4 @@ SELECT
 FROM
     t
 WHERE
-    t.a = = t.b
+    t.a == t.b

--- a/test/fixtures/dialects/hive/double_equals.yml
+++ b/test/fixtures/dialects/hive/double_equals.yml
@@ -1,0 +1,35 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 0bc2fd65471cb9bbacd80e9410496fc3e63bb95cd2e5c52af735d6f87e1da34d
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: t
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: t
+          - dot: .
+          - naked_identifier: a
+        - comparison_operator:
+          - raw_comparison_operator: '='
+          - raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: t
+          - dot: .
+          - naked_identifier: b


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Allows the use of a `==` in the hive sql dialect as a synonym of `=` per [https://cwiki.apache.org/confluence/display/Hive/Hive+Operators]()

fixes #6622 
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?

None that I'm aware of

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
