### PR TITLE
Add support for `WithCompoundStatementSegment` in procedures in Postgres

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -1645,7 +1645,10 @@ class FunctionDefinitionGrammar(ansi.FunctionDefinitionGrammar):
                         Ref("SemicolonSegment"),
                     ),
                     Sequence(
-                        Ref("SelectStatementSegment"),
+                        OneOf(
+                            Ref("WithCompoundStatementSegment"),
+                            Ref("SelectStatementSegment"),
+                        ),
                         Ref("SemicolonSegment"),
                     ),
                     Sequence(

--- a/test/fixtures/dialects/postgres/create_procedure.sql
+++ b/test/fixtures/dialects/postgres/create_procedure.sql
@@ -15,3 +15,16 @@ AS $$
 INSERT INTO tbl VALUES (a);
 INSERT INTO tbl VALUES (b);
 $$;
+
+CREATE PROCEDURE abc.cdf()
+LANGUAGE sql
+BEGIN ATOMIC
+WITH tbl2 AS (
+SELECT a.apple
+FROM tbl1 a
+)
+
+SELECT t.apple
+FROM tbl2 t
+;
+END;

--- a/test/fixtures/dialects/postgres/create_procedure.yml
+++ b/test/fixtures/dialects/postgres/create_procedure.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b038c0c2ee3d0f7a1afe80e9651148bcf3952190b0f8ab3f94250e4166e03bee
+_hash: b95429c2a11a114bca6dae1a3936a2468fe95f2637321f7ffb1c521509a4b838
 file:
 - statement:
     create_procedure_statement:
@@ -51,4 +51,67 @@ file:
         keyword: AS
         quoted_literal: "$$\nINSERT INTO tbl VALUES (a);\nINSERT INTO tbl VALUES (b);\n\
           $$"
+- statement_terminator: ;
+- statement:
+    create_procedure_statement:
+    - keyword: CREATE
+    - keyword: PROCEDURE
+    - function_name:
+        naked_identifier: abc
+        dot: .
+        function_name_identifier: cdf
+    - function_parameter_list:
+        bracketed:
+          start_bracket: (
+          end_bracket: )
+    - function_definition:
+      - language_clause:
+          keyword: LANGUAGE
+          naked_identifier: sql
+      - keyword: BEGIN
+      - keyword: ATOMIC
+      - with_compound_statement:
+          keyword: WITH
+          common_table_expression:
+            naked_identifier: tbl2
+            keyword: AS
+            bracketed:
+              start_bracket: (
+              select_statement:
+                select_clause:
+                  keyword: SELECT
+                  select_clause_element:
+                    column_reference:
+                    - naked_identifier: a
+                    - dot: .
+                    - naked_identifier: apple
+                from_clause:
+                  keyword: FROM
+                  from_expression:
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                          naked_identifier: tbl1
+                      alias_expression:
+                        naked_identifier: a
+              end_bracket: )
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: apple
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: tbl2
+                  alias_expression:
+                    naked_identifier: t
+      - statement_terminator: ;
+      - keyword: END
 - statement_terminator: ;


### PR DESCRIPTION
Closes #6481.

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
