### PR TITLE
New Rule: LT15

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -434,6 +434,10 @@ case_sensitive = True
 ignore_comment_lines = False
 ignore_comment_clauses = False
 
+[sqlfluff:rules:layout.newlines]
+maximum_empty_lines_between_statements = 2
+maximum_empty_lines_inside_statements = 1
+
 [sqlfluff:rules:layout.select_targets]
 wildcard_policy = single
 

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -1,8 +1,9 @@
 """Implementation of Rule LT15."""
 
+from typing import List, Optional
+
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
-from typing import List, Optional
 
 
 class Rule_LT15(BaseRule):
@@ -48,8 +49,7 @@ class Rule_LT15(BaseRule):
     is_fix_compatible = True
 
     def _eval(self, context: RuleContext) -> Optional[List[LintResult]]:
-        """Keyword clauses should begin on a newline."""
-
+        """There should be a maximum number of empty lines."""
         self.maximum_empty_lines_between_statements: int
         self.maximum_empty_lines_inside_statements: int
         context_seg = context.segment

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -54,8 +54,6 @@ class Rule_LT15(BaseRule):
         self.maximum_empty_lines_inside_statements: int
         context_seg = context.segment
 
-        print(context.parent_stack)
-
         maximum_empty_lines = (
             self.maximum_empty_lines_inside_statements
             if any(seg.is_type("statement") for seg in context.parent_stack)

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -67,7 +67,7 @@ class Rule_LT15(BaseRule):
 
         if all(
             raw_seg.is_type("newline")
-            for raw_seg in context.raw_stack[-maximum_empty_lines - 1:]
+            for raw_seg in context.raw_stack[-maximum_empty_lines - 1 :]
         ):
 
             return [

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -2,8 +2,8 @@
 
 from typing import List, Optional
 
-from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
 
 
 class Rule_LT15(BaseRule):
@@ -37,7 +37,7 @@ class Rule_LT15(BaseRule):
         LIMIT 5
         ;
 
-"""
+    """
 
     name = "layout.newlines"
     groups = ("all", "layout")

--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -1,0 +1,80 @@
+"""Implementation of Rule LT15."""
+
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
+from typing import List, Optional
+
+
+class Rule_LT15(BaseRule):
+    """Too many consecutive blank lines.
+
+    **Anti-pattern**
+
+    In this example, the maximum number of empty lines inside a statement is set to 0.
+
+    .. code-block:: sql
+
+        SELECT 'a' AS col
+        FROM tab
+
+
+        WHERE x = 4
+        ORDER BY y
+
+
+        LIMIT 5
+        ;
+
+    **Best practice**
+
+    .. code-block:: sql
+
+        SELECT 'a' AS col
+        FROM tab
+        WHERE x = 4
+        ORDER BY y
+        LIMIT 5
+        ;
+
+"""
+
+    name = "layout.newlines"
+    groups = ("all", "layout")
+    config_keywords = [
+        "maximum_empty_lines_between_statements",
+        "maximum_empty_lines_inside_statements",
+    ]
+    crawl_behaviour = SegmentSeekerCrawler(types={"newline"}, provide_raw_stack=True)
+    is_fix_compatible = True
+
+    def _eval(self, context: RuleContext) -> Optional[List[LintResult]]:
+        """Keyword clauses should begin on a newline."""
+
+        self.maximum_empty_lines_between_statements: int
+        self.maximum_empty_lines_inside_statements: int
+        context_seg = context.segment
+
+        print(context.parent_stack)
+
+        maximum_empty_lines = (
+            self.maximum_empty_lines_inside_statements
+            if any(seg.is_type("statement") for seg in context.parent_stack)
+            else self.maximum_empty_lines_between_statements
+        )
+
+        if len(context.raw_stack) < maximum_empty_lines:
+            return None
+
+        if all(
+            raw_seg.is_type("newline")
+            for raw_seg in context.raw_stack[-maximum_empty_lines - 1:]
+        ):
+
+            return [
+                LintResult(
+                    anchor=context_seg,
+                    fixes=[LintFix.delete(context_seg)],
+                )
+            ]
+
+        return None

--- a/src/sqlfluff/rules/layout/__init__.py
+++ b/src/sqlfluff/rules/layout/__init__.py
@@ -27,7 +27,9 @@ def get_configs_info() -> Dict[str, Any]:
         "maximum_empty_lines_between_statements": {
             "validation": range(1000),
             "definition": (
-                "The maximum number of empty lines allowed between statements."
+                "The maximum number of empty lines allowed between statements. "
+                "Note that currently, the gap _before_ and _after_ the semicolon "
+                "is considered 'between' statements."
             ),
         },
         "maximum_empty_lines_inside_statements": {

--- a/src/sqlfluff/rules/layout/__init__.py
+++ b/src/sqlfluff/rules/layout/__init__.py
@@ -24,6 +24,18 @@ def get_configs_info() -> Dict[str, Any]:
                 " when linting line lengths?"
             ),
         },
+        "maximum_empty_lines_between_statements": {
+            "validation": range(1000),
+            "definition": (
+                "The maximum number of empty lines allowed between statements."
+            ),
+        },
+        "maximum_empty_lines_inside_statements": {
+            "validation": range(1000),
+            "definition": (
+                "The maximum number of empty lines allowed inside statements."
+            ),
+        },
         "wildcard_policy": {
             "validation": ["single", "multiple"],
             "definition": "Treatment of wildcards. Defaults to ``single``.",
@@ -52,6 +64,7 @@ def get_rules() -> List[Type[BaseRule]]:
     from sqlfluff.rules.layout.LT12 import Rule_LT12
     from sqlfluff.rules.layout.LT13 import Rule_LT13
     from sqlfluff.rules.layout.LT14 import Rule_LT14
+    from sqlfluff.rules.layout.LT15 import Rule_LT15
 
     return [
         Rule_LT01,
@@ -68,4 +81,5 @@ def get_rules() -> List[Type[BaseRule]]:
         Rule_LT12,
         Rule_LT13,
         Rule_LT14,
+        Rule_LT15,
     ]

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -53,3 +53,30 @@ test_fail_one_empty_line_between_statements:
     rules:
       layout.newlines:
         maximum_empty_lines_between_statements: 1
+
+test_fail_bad_edge_case:
+  fail_str: |
+    SELECT foo
+    FROM
+      bar
+
+
+    ;
+
+
+    SELECT foo
+    ;
+  fix_str: |
+    SELECT foo
+    FROM
+      bar
+
+    ;
+
+    SELECT foo
+    ;
+  configs:
+    rules:
+      layout.newlines:
+        maximum_empty_lines_between_statements: 1
+        maximum_empty_lines_within_statements: 0

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -14,7 +14,7 @@ test_pass_one_empty_line:
   configs:
     rules:
       layout.newlines:
-          maximum_empty_lines_inside_statements: 1
+        maximum_empty_lines_inside_statements: 1
 
 test_fail_no_empty_lines:
   fail_str: |
@@ -29,7 +29,7 @@ test_fail_no_empty_lines:
   configs:
     rules:
       layout.newlines:
-          maximum_empty_lines_inside_statements: 0
+        maximum_empty_lines_inside_statements: 0
 
 test_fail_one_empty_line_between_statements:
   fail_str: |
@@ -52,4 +52,4 @@ test_fail_one_empty_line_between_statements:
   configs:
     rules:
       layout.newlines:
-          maximum_empty_lines_between_statements: 1
+        maximum_empty_lines_between_statements: 1

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -1,0 +1,55 @@
+rule: LT15
+
+test_pass_no_empty_lines:
+  pass_str: |
+    SELECT foo
+    FROM bar
+
+test_pass_one_empty_line:
+  pass_str: |
+    SELECT foo
+
+    FROM
+      bar
+  configs:
+    rules:
+      layout.newlines:
+          maximum_empty_lines_inside_statements: 1
+
+test_fail_no_empty_lines:
+  fail_str: |
+    SELECT foo
+
+    FROM
+      bar
+  fix_str: |
+    SELECT foo
+    FROM
+      bar
+  configs:
+    rules:
+      layout.newlines:
+          maximum_empty_lines_inside_statements: 0
+
+test_fail_one_empty_line_between_statements:
+  fail_str: |
+    SELECT foo
+    FROM
+      bar
+    ;
+
+
+    SELECT foo
+    ;
+  fix_str: |
+    SELECT foo
+    FROM
+      bar
+    ;
+
+    SELECT foo
+    ;
+  configs:
+    rules:
+      layout.newlines:
+          maximum_empty_lines_between_statements: 1

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -55,6 +55,13 @@ test_fail_one_empty_line_between_statements:
         maximum_empty_lines_between_statements: 1
 
 test_fail_bad_edge_case:
+  # This test case is a little controversial. Currently the gap before and
+  # after the semicolon is considered *between* statements. While this is
+  # on the lenient side, and also allows people to operate with "leading semicolons"
+  # if they want - it's very possible that some users will want this to be
+  # further tightened. Recommendation for the future is to add an additional
+  # config to control restrict whether the gap a) before b) after or c) both
+  # before and after should be considered "between" statements.
   fail_str: |
     SELECT foo
     FROM


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
This PR adds a long-requested rule. It allows the control of how many blank lines there can be in a row. It is configurable to different values inside and outside of a statement.

This changes the default rule set - and so should trigger a minor release.

Fixes #2634 

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
