### PR TITLE
Add support for `EVENT` statements in MySQL.

### DIFF
--- a/test/fixtures/dialects/mysql/alter_event.sql
+++ b/test/fixtures/dialects/mysql/alter_event.sql
@@ -1,0 +1,23 @@
+ALTER EVENT no_such_event
+    ON SCHEDULE
+        EVERY '2:3' DAY_HOUR;
+
+ALTER EVENT myevent
+    ON SCHEDULE
+      EVERY 12 HOUR
+    STARTS CURRENT_TIMESTAMP + INTERVAL 4 HOUR;
+
+ALTER EVENT myevent
+    ON SCHEDULE
+      AT CURRENT_TIMESTAMP + INTERVAL 1 DAY
+    DO
+      TRUNCATE TABLE myschema.mytable;
+
+ALTER EVENT myevent
+    DISABLE;
+
+ALTER EVENT myevent
+    RENAME TO yourevent;
+
+ALTER EVENT olddb.myevent
+    RENAME TO newdb.myevent;

--- a/test/fixtures/dialects/mysql/alter_event.yml
+++ b/test/fixtures/dialects/mysql/alter_event.yml
@@ -1,0 +1,103 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 152139666dcb2e7d6c30f4e3819eefa07ae3c2e3418b07d9f18f544c343a9716
+file:
+- statement:
+    alter_event_statement:
+    - keyword: ALTER
+    - keyword: EVENT
+    - object_reference:
+        naked_identifier: no_such_event
+    - keyword: 'ON'
+    - keyword: SCHEDULE
+    - keyword: EVERY
+    - expression:
+        quoted_literal: "'2:3'"
+    - date_part: DAY_HOUR
+- statement_terminator: ;
+- statement:
+    alter_event_statement:
+    - keyword: ALTER
+    - keyword: EVENT
+    - object_reference:
+        naked_identifier: myevent
+    - keyword: 'ON'
+    - keyword: SCHEDULE
+    - keyword: EVERY
+    - expression:
+        numeric_literal: '12'
+    - date_part: HOUR
+    - keyword: STARTS
+    - expression:
+        bare_function: CURRENT_TIMESTAMP
+        binary_operator: +
+        interval_expression:
+          keyword: INTERVAL
+          expression:
+            numeric_literal: '4'
+          date_part: HOUR
+- statement_terminator: ;
+- statement:
+    alter_event_statement:
+    - keyword: ALTER
+    - keyword: EVENT
+    - object_reference:
+        naked_identifier: myevent
+    - keyword: 'ON'
+    - keyword: SCHEDULE
+    - keyword: AT
+    - expression:
+        bare_function: CURRENT_TIMESTAMP
+        binary_operator: +
+        interval_expression:
+          keyword: INTERVAL
+          expression:
+            numeric_literal: '1'
+          date_part: DAY
+    - keyword: DO
+    - statement:
+        truncate_table:
+        - keyword: TRUNCATE
+        - keyword: TABLE
+        - table_reference:
+          - naked_identifier: myschema
+          - dot: .
+          - naked_identifier: mytable
+- statement_terminator: ;
+- statement:
+    alter_event_statement:
+    - keyword: ALTER
+    - keyword: EVENT
+    - object_reference:
+        naked_identifier: myevent
+    - keyword: DISABLE
+- statement_terminator: ;
+- statement:
+    alter_event_statement:
+    - keyword: ALTER
+    - keyword: EVENT
+    - object_reference:
+        naked_identifier: myevent
+    - keyword: RENAME
+    - keyword: TO
+    - object_reference:
+        naked_identifier: yourevent
+- statement_terminator: ;
+- statement:
+    alter_event_statement:
+    - keyword: ALTER
+    - keyword: EVENT
+    - object_reference:
+      - naked_identifier: olddb
+      - dot: .
+      - naked_identifier: myevent
+    - keyword: RENAME
+    - keyword: TO
+    - object_reference:
+      - naked_identifier: newdb
+      - dot: .
+      - naked_identifier: myevent
+- statement_terminator: ;

--- a/test/fixtures/dialects/mysql/create_event.sql
+++ b/test/fixtures/dialects/mysql/create_event.sql
@@ -1,0 +1,40 @@
+CREATE EVENT myevent
+    ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 HOUR
+    DO
+      UPDATE myschema.mytable SET mycol = mycol + 1;
+
+CREATE EVENT e_totals
+    ON SCHEDULE AT '2006-02-10 23:59:00'
+    DO INSERT INTO test.totals VALUES (NOW());
+
+CREATE EVENT e_hourly
+    ON SCHEDULE
+      EVERY 1 HOUR
+    COMMENT 'Clears out sessions table each hour.'
+    DO
+      DELETE FROM site_activity.sessions;
+
+CREATE EVENT e_daily
+    ON SCHEDULE
+      EVERY 1 DAY
+    COMMENT 'Saves total number of sessions then clears the table each day'
+    DO
+      BEGIN
+        INSERT INTO site_activity.totals (time, total)
+          SELECT CURRENT_TIMESTAMP, COUNT(*)
+            FROM site_activity.sessions;
+        DELETE FROM site_activity.sessions;
+      END;
+
+CREATE EVENT e_call_myproc
+    ON SCHEDULE
+      AT CURRENT_TIMESTAMP + INTERVAL 1 DAY
+    DO CALL myproc(5, 27);
+
+CREATE EVENT e
+  ON SCHEDULE EVERY interval SECOND
+  STARTS CURRENT_TIMESTAMP + INTERVAL 10 SECOND
+  ENDS CURRENT_TIMESTAMP + INTERVAL 2 MINUTE
+  ON COMPLETION PRESERVE
+  DO
+    INSERT INTO d.t1 VALUES ROW(NULL, NOW(), FLOOR(RAND()*100));

--- a/test/fixtures/dialects/mysql/create_event.yml
+++ b/test/fixtures/dialects/mysql/create_event.yml
@@ -1,0 +1,299 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: b5b199559d90736fe98b7d2ddb5e05b77be6fcc1b5685a2e4123147996df0920
+file:
+- statement:
+    create_event_statement:
+    - keyword: CREATE
+    - keyword: EVENT
+    - object_reference:
+        naked_identifier: myevent
+    - keyword: 'ON'
+    - keyword: SCHEDULE
+    - keyword: AT
+    - expression:
+        bare_function: CURRENT_TIMESTAMP
+        binary_operator: +
+        interval_expression:
+          keyword: INTERVAL
+          expression:
+            numeric_literal: '1'
+          date_part: HOUR
+    - keyword: DO
+    - statement:
+        update_statement:
+          keyword: UPDATE
+          table_reference:
+          - naked_identifier: myschema
+          - dot: .
+          - naked_identifier: mytable
+          set_clause_list:
+            keyword: SET
+            set_clause:
+              column_reference:
+                naked_identifier: mycol
+              comparison_operator:
+                raw_comparison_operator: '='
+              expression:
+                column_reference:
+                  naked_identifier: mycol
+                binary_operator: +
+                numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    create_event_statement:
+    - keyword: CREATE
+    - keyword: EVENT
+    - object_reference:
+        naked_identifier: e_totals
+    - keyword: 'ON'
+    - keyword: SCHEDULE
+    - keyword: AT
+    - expression:
+        quoted_literal: "'2006-02-10 23:59:00'"
+    - keyword: DO
+    - statement:
+        insert_statement:
+        - keyword: INSERT
+        - keyword: INTO
+        - table_reference:
+          - naked_identifier: test
+          - dot: .
+          - naked_identifier: totals
+        - values_clause:
+            keyword: VALUES
+            bracketed:
+              start_bracket: (
+              expression:
+                function:
+                  function_name:
+                    function_name_identifier: NOW
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      end_bracket: )
+              end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_event_statement:
+    - keyword: CREATE
+    - keyword: EVENT
+    - object_reference:
+        naked_identifier: e_hourly
+    - keyword: 'ON'
+    - keyword: SCHEDULE
+    - keyword: EVERY
+    - expression:
+        numeric_literal: '1'
+    - date_part: HOUR
+    - comment_clause:
+        keyword: COMMENT
+        quoted_literal: "'Clears out sessions table each hour.'"
+    - keyword: DO
+    - statement:
+        delete_statement:
+          keyword: DELETE
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                  - naked_identifier: site_activity
+                  - dot: .
+                  - naked_identifier: sessions
+- statement_terminator: ;
+- statement:
+    create_event_statement:
+    - keyword: CREATE
+    - keyword: EVENT
+    - object_reference:
+        naked_identifier: e_daily
+    - keyword: 'ON'
+    - keyword: SCHEDULE
+    - keyword: EVERY
+    - expression:
+        numeric_literal: '1'
+    - date_part: DAY
+    - comment_clause:
+        keyword: COMMENT
+        quoted_literal: "'Saves total number of sessions then clears the table each\
+          \ day'"
+    - keyword: DO
+    - statement:
+        transaction_statement:
+          keyword: BEGIN
+          statement:
+            insert_statement:
+            - keyword: INSERT
+            - keyword: INTO
+            - table_reference:
+              - naked_identifier: site_activity
+              - dot: .
+              - naked_identifier: totals
+            - bracketed:
+              - start_bracket: (
+              - column_reference:
+                  naked_identifier: time
+              - comma: ','
+              - column_reference:
+                  naked_identifier: total
+              - end_bracket: )
+            - select_statement:
+                select_clause:
+                - keyword: SELECT
+                - select_clause_element:
+                    bare_function: CURRENT_TIMESTAMP
+                - comma: ','
+                - select_clause_element:
+                    function:
+                      function_name:
+                        function_name_identifier: COUNT
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          star: '*'
+                          end_bracket: )
+                from_clause:
+                  keyword: FROM
+                  from_expression:
+                    from_expression_element:
+                      table_expression:
+                        table_reference:
+                        - naked_identifier: site_activity
+                        - dot: .
+                        - naked_identifier: sessions
+- statement_terminator: ;
+- statement:
+    delete_statement:
+      keyword: DELETE
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+              - naked_identifier: site_activity
+              - dot: .
+              - naked_identifier: sessions
+- statement_terminator: ;
+- statement:
+    transaction_statement:
+      keyword: END
+- statement_terminator: ;
+- statement:
+    create_event_statement:
+    - keyword: CREATE
+    - keyword: EVENT
+    - object_reference:
+        naked_identifier: e_call_myproc
+    - keyword: 'ON'
+    - keyword: SCHEDULE
+    - keyword: AT
+    - expression:
+        bare_function: CURRENT_TIMESTAMP
+        binary_operator: +
+        interval_expression:
+          keyword: INTERVAL
+          expression:
+            numeric_literal: '1'
+          date_part: DAY
+    - keyword: DO
+    - statement:
+        call_statement:
+          keyword: CALL
+          function:
+            function_name:
+              function_name_identifier: myproc
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  numeric_literal: '5'
+              - comma: ','
+              - expression:
+                  numeric_literal: '27'
+              - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_event_statement:
+    - keyword: CREATE
+    - keyword: EVENT
+    - object_reference:
+        naked_identifier: e
+    - keyword: 'ON'
+    - keyword: SCHEDULE
+    - keyword: EVERY
+    - expression:
+        interval_expression:
+          keyword: interval
+          date_part: SECOND
+    - keyword: STARTS
+    - expression:
+        bare_function: CURRENT_TIMESTAMP
+        binary_operator: +
+        interval_expression:
+          keyword: INTERVAL
+          expression:
+            numeric_literal: '10'
+          date_part: SECOND
+    - keyword: ENDS
+    - expression:
+        bare_function: CURRENT_TIMESTAMP
+        binary_operator: +
+        interval_expression:
+          keyword: INTERVAL
+          expression:
+            numeric_literal: '2'
+          date_part: MINUTE
+    - keyword: 'ON'
+    - keyword: COMPLETION
+    - keyword: PRESERVE
+    - keyword: DO
+    - statement:
+        insert_statement:
+        - keyword: INSERT
+        - keyword: INTO
+        - table_reference:
+          - naked_identifier: d
+          - dot: .
+          - naked_identifier: t1
+        - values_clause:
+          - keyword: VALUES
+          - keyword: ROW
+          - bracketed:
+            - start_bracket: (
+            - null_literal: 'NULL'
+            - comma: ','
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: NOW
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      end_bracket: )
+            - comma: ','
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: FLOOR
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        function:
+                          function_name:
+                            function_name_identifier: RAND
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              end_bracket: )
+                        binary_operator: '*'
+                        numeric_literal: '100'
+                      end_bracket: )
+            - end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/mysql/drop_event.sql
+++ b/test/fixtures/dialects/mysql/drop_event.sql
@@ -1,0 +1,3 @@
+DROP EVENT test;
+
+DROP EVENT IF EXISTS test;

--- a/test/fixtures/dialects/mysql/drop_event.yml
+++ b/test/fixtures/dialects/mysql/drop_event.yml
@@ -1,0 +1,23 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: c51ea105f48aeac608b37754da7a991b2353072011554a12d4dcc01e2b4a04c4
+file:
+- statement:
+    drop_event_statement:
+    - keyword: DROP
+    - keyword: EVENT
+    - object_reference:
+        naked_identifier: test
+- statement_terminator: ;
+- statement:
+    drop_event_statement:
+    - keyword: DROP
+    - keyword: EVENT
+    - keyword: IF
+    - keyword: EXISTS
+    - object_reference:
+        naked_identifier: test
+- statement_terminator: ;


### PR DESCRIPTION
Closes #5591.

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
