### PR TITLE
Fix check constraints in `ALTER TABLE` statements in Oracle.

### DIFF
--- a/test/fixtures/dialects/oracle/alter_table.sql
+++ b/test/fixtures/dialects/oracle/alter_table.sql
@@ -32,3 +32,5 @@ ALTER TABLE table_name MODIFY
 
 ALTER TABLE table_name
 MODIFY (column_name DEFAULT 10 NOT NULL ENABLE);
+
+ALTER TABLE employees ADD CONSTRAINT salary_check CHECK (salary > 0);

--- a/test/fixtures/dialects/oracle/alter_table.yml
+++ b/test/fixtures/dialects/oracle/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 12d7e9e7e03ef1a35e91fa4258be722ef43fb9dd4d7c1e251e1909a0fb24b499
+_hash: 9eec6cfe5e73ecdcee8624fae8b6172f082deb550dcb83cab053fe1e6500bf6e
 file:
 - statement:
     alter_table_statement:
@@ -183,4 +183,27 @@ file:
             - keyword: 'NULL'
           - keyword: ENABLE
           end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: employees
+    - alter_table_constraint_clauses:
+        keyword: ADD
+        table_constraint:
+        - keyword: CONSTRAINT
+        - object_reference:
+            naked_identifier: salary_check
+        - keyword: CHECK
+        - bracketed:
+            start_bracket: (
+            expression:
+              column_reference:
+                naked_identifier: salary
+              comparison_operator:
+                raw_comparison_operator: '>'
+              numeric_literal: '0'
+            end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
Fix #6628

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
