### PR TITLE
AL03: Lint for missing aliases on subqueries

### DIFF
--- a/src/sqlfluff/rules/aliasing/AL03.py
+++ b/src/sqlfluff/rules/aliasing/AL03.py
@@ -130,6 +130,11 @@ def _recursively_check_is_complex(select_clause_or_exp_children: Segments) -> bo
         return False
 
     first_el = filtered.first()
+
+    # If the element has a select statement inside, this is likely a subquery
+    if first_el.recursive_crawl("select_statement").any():
+        return True
+
     # Anything except a single expression seg remains
     # Then it was complex
     if remaining_count > 1 or not first_el.all(sp.is_type("expression")):

--- a/test/fixtures/rules/std_rule_cases/AL03.yml
+++ b/test/fixtures/rules/std_rule_cases/AL03.yml
@@ -105,3 +105,17 @@ test_pass_duckdb_replace_expression:
   configs:
     core:
       dialect: duckdb
+
+test_fail_subquery_without_alias:
+  fail_str: |
+    SELECT
+        (SELECT MAX(t.col) AS m FROM t),
+        (SELECT MAX(t.col2) AS m FROM t)
+    FROM tbl;
+
+test_pass_subquery_with_alias:
+  pass_str: |
+    SELECT
+        (SELECT MAX(t.col) AS m FROM t) AS a,
+        (SELECT MAX(t.col2) AS m FROM t) AS b
+    FROM tbl;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This now correctly lints missing aliases for AL03 when the `select_clause_element` is a subquery.
- fixes #6650

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
