### PR TITLE
IN TABLE/CTE and implicit Array, Tuple support for ClickHouse

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -818,6 +818,16 @@ class IntervalExpressionSegment(BaseSegment):
     )
 
 
+class TupleSegment(BaseSegment):
+    """Expression to construct a TUPLE.
+
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#tuple_syntax
+    """
+
+    type = "tuple"
+    match_grammar = Bracketed(Delimited(Ref("BaseExpressionElementGrammar")))
+
+
 class ArrayTypeSegment(BaseSegment):
     """Prefix for array literals specifying the type.
 

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1314,16 +1314,6 @@ class ArrayExpressionSegment(ansi.ArrayExpressionSegment):
     )
 
 
-class TupleSegment(BaseSegment):
-    """Expression to construct a TUPLE.
-
-    https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#tuple_syntax
-    """
-
-    type = "tuple"
-    match_grammar = Bracketed(Delimited(Ref("BaseExpressionElementGrammar")))
-
-
 class NamedArgumentSegment(BaseSegment):
     """Named argument to a function.
 

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -240,6 +240,10 @@ clickhouse_dialect.replace(
         Ref.keyword("NOT", optional=True),
         "IN",
         OneOf(
+            Ref("FunctionSegment"),  # E.g. IN tuple(1, 2)
+            Ref("ArrayLiteralSegment"),  # E.g. IN [1, 2]
+            Ref("TupleSegment"),  # E.g. IN (1, 2)
+            Ref("SingleIdentifierGrammar"),  # E.g. IN TABLE, IN CTE
             Bracketed(
                 OneOf(
                     Delimited(
@@ -249,9 +253,6 @@ clickhouse_dialect.replace(
                 ),
                 parse_mode=ParseMode.GREEDY,
             ),
-            Ref("FunctionSegment"),  # E.g. IN tuple(1, 2)
-            Ref("ArrayLiteralSegment"),  # E.g. IN [1, 2]
-            Ref("SingleIdentifierGrammar"),  # E.g. IN TABLE, IN CTE
         ),
     ),
     SelectClauseTerminatorGrammar=ansi_dialect.get_grammar(

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -235,9 +235,24 @@ clickhouse_dialect.replace(
         Ref("SingleQuotedIdentifierSegment"),
         Ref("BackQuotedIdentifierSegment"),
     ),
-    InOperatorGrammar=ansi_dialect.get_grammar("InOperatorGrammar").copy(
-        insert=[Ref.keyword("GLOBAL", optional=True)],
-        before=Ref.keyword("NOT", optional=True),
+    InOperatorGrammar=Sequence(
+        Ref.keyword("GLOBAL", optional=True),
+        Ref.keyword("NOT", optional=True),
+        "IN",
+        OneOf(
+            Bracketed(
+                OneOf(
+                    Delimited(
+                        Ref("Expression_A_Grammar"),
+                    ),
+                    Ref("SelectableGrammar"),
+                ),
+                parse_mode=ParseMode.GREEDY,
+            ),
+            Ref("FunctionSegment"),  # E.g. IN tuple(1, 2)
+            Ref("ArrayLiteralSegment"),  # E.g. IN [1, 2]
+            Ref("SingleIdentifierGrammar"),  # E.g. IN TABLE, IN CTE
+        ),
     ),
     SelectClauseTerminatorGrammar=ansi_dialect.get_grammar(
         "SelectClauseTerminatorGrammar"

--- a/test/fixtures/cli/passing_timing.sql
+++ b/test/fixtures/cli/passing_timing.sql
@@ -2,17 +2,17 @@
 -- takes longer and can effectively measure timing routines.
 
 {% for i in range(10) %}
-    SELECT
-        tbl.name,
-        b.value,
-        /*
+  SELECT
+    tbl.name,
+    b.value,
+    /*
         This is a block comment
         */
-        d.something,    -- Which a comment after it
-        tbl.foo,
-        d.val + b.val / -2 AS a_calculation
-    FROM tbl
-    INNER JOIN b ON (tbl.common_id = b.common_id)
-    LEFT JOIN d ON (tbl.id = d.other_id)
-    ORDER BY tbl.name ASC;
+    d.something,    -- Which a comment after it
+    tbl.foo,
+    d.val + b.val / -2 AS a_calculation
+  FROM tbl
+  INNER JOIN b ON (tbl.common_id = b.common_id)
+  LEFT JOIN d ON (tbl.id = d.other_id)
+  ORDER BY tbl.name ASC;
 {% endfor %}

--- a/test/fixtures/cli/passing_timing.sql
+++ b/test/fixtures/cli/passing_timing.sql
@@ -2,17 +2,17 @@
 -- takes longer and can effectively measure timing routines.
 
 {% for i in range(10) %}
-  SELECT
-    tbl.name,
-    b.value,
-    /*
+    SELECT
+        tbl.name,
+        b.value,
+        /*
         This is a block comment
         */
-    d.something,    -- Which a comment after it
-    tbl.foo,
-    d.val + b.val / -2 AS a_calculation
-  FROM tbl
-  INNER JOIN b ON (tbl.common_id = b.common_id)
-  LEFT JOIN d ON (tbl.id = d.other_id)
-  ORDER BY tbl.name ASC;
+        d.something,    -- Which a comment after it
+        tbl.foo,
+        d.val + b.val / -2 AS a_calculation
+    FROM tbl
+    INNER JOIN b ON (tbl.common_id = b.common_id)
+    LEFT JOIN d ON (tbl.id = d.other_id)
+    ORDER BY tbl.name ASC;
 {% endfor %}

--- a/test/fixtures/dialects/clickhouse/in_implicit_array_tuple.sql
+++ b/test/fixtures/dialects/clickhouse/in_implicit_array_tuple.sql
@@ -1,0 +1,15 @@
+select *
+from tbl
+where int_col in (1, 2);
+
+select *
+from tbl
+where int_col in [1, 2];
+
+select *
+from tbl
+where int_col global in (1, 2);
+
+select *
+from tbl
+where int_col not in [toUUID('a'), toUUID('b')];

--- a/test/fixtures/dialects/clickhouse/in_implicit_array_tuple.yml
+++ b/test/fixtures/dialects/clickhouse/in_implicit_array_tuple.yml
@@ -1,0 +1,137 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 78f48a4f5b7c915e5b6a6874ea999d6562b0f96b7234100eb7b65935b91de567
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl
+      where_clause:
+        keyword: where
+        expression:
+          column_reference:
+            naked_identifier: int_col
+          keyword: in
+          bracketed:
+          - start_bracket: (
+          - numeric_literal: '1'
+          - comma: ','
+          - numeric_literal: '2'
+          - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl
+      where_clause:
+        keyword: where
+        expression:
+          column_reference:
+            naked_identifier: int_col
+          keyword: in
+          array_literal:
+          - start_square_bracket: '['
+          - numeric_literal: '1'
+          - comma: ','
+          - numeric_literal: '2'
+          - end_square_bracket: ']'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl
+      where_clause:
+        keyword: where
+        expression:
+        - column_reference:
+            naked_identifier: int_col
+        - keyword: global
+        - keyword: in
+        - bracketed:
+          - start_bracket: (
+          - numeric_literal: '1'
+          - comma: ','
+          - numeric_literal: '2'
+          - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: tbl
+      where_clause:
+        keyword: where
+        expression:
+        - column_reference:
+            naked_identifier: int_col
+        - keyword: not
+        - keyword: in
+        - array_literal:
+          - start_square_bracket: '['
+          - function:
+              function_name:
+                function_name_identifier: toUUID
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    quoted_literal: "'a'"
+                  end_bracket: )
+          - comma: ','
+          - function:
+              function_name:
+                function_name_identifier: toUUID
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    quoted_literal: "'b'"
+                  end_bracket: )
+          - end_square_bracket: ']'
+- statement_terminator: ;

--- a/test/fixtures/dialects/clickhouse/in_implicit_array_tuple.yml
+++ b/test/fixtures/dialects/clickhouse/in_implicit_array_tuple.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 78f48a4f5b7c915e5b6a6874ea999d6562b0f96b7234100eb7b65935b91de567
+_hash: 6db308c535fac1aa62523f99f47be40d718e1c368e4340b76e22f53ec18d6ca3
 file:
 - statement:
     select_statement:
@@ -26,12 +26,13 @@ file:
           column_reference:
             naked_identifier: int_col
           keyword: in
-          bracketed:
-          - start_bracket: (
-          - numeric_literal: '1'
-          - comma: ','
-          - numeric_literal: '2'
-          - end_bracket: )
+          tuple:
+            bracketed:
+            - start_bracket: (
+            - numeric_literal: '1'
+            - comma: ','
+            - numeric_literal: '2'
+            - end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -83,12 +84,13 @@ file:
             naked_identifier: int_col
         - keyword: global
         - keyword: in
-        - bracketed:
-          - start_bracket: (
-          - numeric_literal: '1'
-          - comma: ','
-          - numeric_literal: '2'
-          - end_bracket: )
+        - tuple:
+            bracketed:
+            - start_bracket: (
+            - numeric_literal: '1'
+            - comma: ','
+            - numeric_literal: '2'
+            - end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:

--- a/test/fixtures/dialects/clickhouse/in_operator.yml
+++ b/test/fixtures/dialects/clickhouse/in_operator.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 846662c040f27c95a6da4d17ae6a4c57d7eab1f9757b1e66608e955d9e199cb7
+_hash: 15c6a5e3466927fe29c0ab9f7f85b50f459ded3952818f223e1b3e09df5577a0
 file:
 - statement:
     select_statement:
@@ -33,30 +33,32 @@ file:
           column_reference:
             naked_identifier: col1
           keyword: IN
-          bracketed:
-            start_bracket: (
-            select_statement:
-              select_clause:
-                keyword: SELECT
-                select_clause_element:
-                  column_reference:
-                    naked_identifier: col1
-              from_clause:
-                keyword: FROM
-                from_expression:
-                  from_expression_element:
-                    table_expression:
-                      table_reference:
-                        naked_identifier: table1
-              where_clause:
-                keyword: WHERE
-                expression:
-                  column_reference:
-                    naked_identifier: col2
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '34'
-            end_bracket: )
+          tuple:
+            bracketed:
+              start_bracket: (
+              expression:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      column_reference:
+                        naked_identifier: col1
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: table1
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                      column_reference:
+                        naked_identifier: col2
+                      comparison_operator:
+                        raw_comparison_operator: '='
+                      numeric_literal: '34'
+              end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -87,30 +89,32 @@ file:
             naked_identifier: col1
         - keyword: NOT
         - keyword: IN
-        - bracketed:
-            start_bracket: (
-            select_statement:
-              select_clause:
-                keyword: SELECT
-                select_clause_element:
-                  column_reference:
-                    naked_identifier: col1
-              from_clause:
-                keyword: FROM
-                from_expression:
-                  from_expression_element:
-                    table_expression:
-                      table_reference:
-                        naked_identifier: table1
-              where_clause:
-                keyword: WHERE
-                expression:
-                  column_reference:
-                    naked_identifier: col2
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '34'
-            end_bracket: )
+        - tuple:
+            bracketed:
+              start_bracket: (
+              expression:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      column_reference:
+                        naked_identifier: col1
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: table1
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                      column_reference:
+                        naked_identifier: col2
+                      comparison_operator:
+                        raw_comparison_operator: '='
+                      numeric_literal: '34'
+              end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -141,30 +145,32 @@ file:
             naked_identifier: col1
         - keyword: GLOBAL
         - keyword: IN
-        - bracketed:
-            start_bracket: (
-            select_statement:
-              select_clause:
-                keyword: SELECT
-                select_clause_element:
-                  column_reference:
-                    naked_identifier: col1
-              from_clause:
-                keyword: FROM
-                from_expression:
-                  from_expression_element:
-                    table_expression:
-                      table_reference:
-                        naked_identifier: table1
-              where_clause:
-                keyword: WHERE
-                expression:
-                  column_reference:
-                    naked_identifier: col2
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '34'
-            end_bracket: )
+        - tuple:
+            bracketed:
+              start_bracket: (
+              expression:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      column_reference:
+                        naked_identifier: col1
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: table1
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                      column_reference:
+                        naked_identifier: col2
+                      comparison_operator:
+                        raw_comparison_operator: '='
+                      numeric_literal: '34'
+              end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:
@@ -196,30 +202,32 @@ file:
         - keyword: GLOBAL
         - keyword: NOT
         - keyword: IN
-        - bracketed:
-            start_bracket: (
-            select_statement:
-              select_clause:
-                keyword: SELECT
-                select_clause_element:
-                  column_reference:
-                    naked_identifier: col1
-              from_clause:
-                keyword: FROM
-                from_expression:
-                  from_expression_element:
-                    table_expression:
-                      table_reference:
-                        naked_identifier: table1
-              where_clause:
-                keyword: WHERE
-                expression:
-                  column_reference:
-                    naked_identifier: col2
-                  comparison_operator:
-                    raw_comparison_operator: '='
-                  numeric_literal: '34'
-            end_bracket: )
+        - tuple:
+            bracketed:
+              start_bracket: (
+              expression:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      column_reference:
+                        naked_identifier: col1
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: table1
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                      column_reference:
+                        naked_identifier: col2
+                      comparison_operator:
+                        raw_comparison_operator: '='
+                      numeric_literal: '34'
+              end_bracket: )
 - statement_terminator: ;
 - statement:
     select_statement:

--- a/test/fixtures/dialects/clickhouse/in_table_cte.sql
+++ b/test/fixtures/dialects/clickhouse/in_table_cte.sql
@@ -1,0 +1,19 @@
+with (select (1, 2, 3)) as in_arr_cte
+select *
+from tbl
+where int_col in in_arr_cte;
+
+with (1, 2, 3) as int_arr
+select *
+from tbl
+where int_col in int_arr;
+
+with [1, 2, 3] as int_arr
+select *
+from tbl
+where int_col in int_arr;
+
+with [1, 2, 3] as int_arr
+select *,
+       if(int_col in int_arr, 1, 0) as in_array_flag
+from tbl;

--- a/test/fixtures/dialects/clickhouse/in_table_cte.yml
+++ b/test/fixtures/dialects/clickhouse/in_table_cte.yml
@@ -1,0 +1,182 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 6b844f1cfa918894591b7d23b0c89bbd947961fcc52647e563e928a790410151
+file:
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        expression:
+          bracketed:
+            start_bracket: (
+            expression:
+              function:
+                function_name:
+                  function_name_identifier: select
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      numeric_literal: '1'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '2'
+                  - comma: ','
+                  - expression:
+                      numeric_literal: '3'
+                  - end_bracket: )
+            end_bracket: )
+        keyword: as
+        naked_identifier: in_arr_cte
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tbl
+        where_clause:
+          keyword: where
+          expression:
+            column_reference:
+              naked_identifier: int_col
+            keyword: in
+            naked_identifier: in_arr_cte
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        expression:
+          bracketed:
+          - start_bracket: (
+          - numeric_literal: '1'
+          - comma: ','
+          - numeric_literal: '2'
+          - comma: ','
+          - numeric_literal: '3'
+          - end_bracket: )
+        keyword: as
+        naked_identifier: int_arr
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tbl
+        where_clause:
+          keyword: where
+          expression:
+            column_reference:
+              naked_identifier: int_col
+            keyword: in
+            naked_identifier: int_arr
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        expression:
+          array_literal:
+          - start_square_bracket: '['
+          - numeric_literal: '1'
+          - comma: ','
+          - numeric_literal: '2'
+          - comma: ','
+          - numeric_literal: '3'
+          - end_square_bracket: ']'
+        keyword: as
+        naked_identifier: int_arr
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tbl
+        where_clause:
+          keyword: where
+          expression:
+            column_reference:
+              naked_identifier: int_col
+            keyword: in
+            naked_identifier: int_arr
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: with
+      common_table_expression:
+        expression:
+          array_literal:
+          - start_square_bracket: '['
+          - numeric_literal: '1'
+          - comma: ','
+          - numeric_literal: '2'
+          - comma: ','
+          - numeric_literal: '3'
+          - end_square_bracket: ']'
+        keyword: as
+        naked_identifier: int_arr
+      select_statement:
+        select_clause:
+        - keyword: select
+        - select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: if
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: int_col
+                    keyword: in
+                    naked_identifier: int_arr
+                - comma: ','
+                - expression:
+                    numeric_literal: '1'
+                - comma: ','
+                - expression:
+                    numeric_literal: '0'
+                - end_bracket: )
+            alias_expression:
+              keyword: as
+              naked_identifier: in_array_flag
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tbl
+- statement_terminator: ;


### PR DESCRIPTION
### Summary of Changes  
- Added support for queries like `WHERE id IN (1,2)`, `WHERE id IN [1,2]`, `WHERE id IN table_name`, and `WHERE id IN cte`, where `table_name` and `cte` contain only a single column.  
- Exported `TupleSegment` to the ANSI dialect to enable passing it to the ClickHouse dialect, as tuples are supported in ANSI.

### Potential Side Effects  
- ANSI supports `IN tuple`, but its implementation differs from ClickHouse.  
- This leads to inconsistent parsing of expressions like `IN (1,2)`:  
  - **ANSI Parsing:**
    ```
    bracketed:
    - start_bracket: (
    - numeric_literal: '1'
    - comma: ','
    - numeric_literal: '2'
    - end_bracket: )
    ```
  - **ClickHouse Parsing:**
    ```
    tuple:
      bracketed:
      - start_bracket: (
      - numeric_literal: '1'
      - comma: ','
      - numeric_literal: '2'
      - end_bracket: )
    ```
- Explicitly adding `tuple` to [dialect_ansi.py#L478](https://github.com/sqlfluff/sqlfluff/blob/main/src/sqlfluff/dialects/dialect_ansi.py#L478) would cause changes in multiple test results. 

### Checklist  
- [x] Included test cases demonstrating the changes (`.sql`/`.yml` in `test/fixtures/dialects`).  
  - (YML files can be auto-generated with `tox -e generate-fixture-yml`).  
- [x] Added appropriate documentation for the change.