### PR TITLE
RF02: do not trigger on snowflake lambda anonymous parameters

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -78,7 +78,7 @@ snowflake_dialect.insert_lexer_matchers(
     [
         # Keyword assigner needed for keyword functions.
         StringLexer("parameter_assigner", "=>", CodeSegment),
-        StringLexer("function_assigner", "->", CodeSegment),
+        StringLexer("right_arrow", "->", CodeSegment),
         RegexLexer("stage_path", r"(?:@[^\s;)]+|'@[^']+')", CodeSegment),
         # Column selector
         # https://docs.snowflake.com/en/sql-reference/sql/select.html#parameters
@@ -222,6 +222,7 @@ snowflake_dialect.add(
     ParameterAssignerSegment=StringParser(
         "=>", SymbolSegment, type="parameter_assigner"
     ),
+    LambdaArrowSegment=StringParser("->", SymbolSegment, type="lambda_arrow"),
     FunctionAssignerSegment=StringParser("->", SymbolSegment, type="function_assigner"),
     # Walrus operator for Snowflake scripting block statements
     WalrusOperatorSegment=StringParser(":=", SymbolSegment, type="assignment_operator"),
@@ -9043,23 +9044,23 @@ class LambdaExpressionSegment(BaseSegment):
     https://docs.snowflake.com/en/user-guide/querying-semistructured#lambda-expressions
     """
 
-    type = "lambda_expression"
+    type = "lambda_function"
     match_grammar = Sequence(
         OneOf(
             Sequence(
-                Ref("NakedIdentifierSegment"),
+                Ref("ParameterNameSegment"),
                 Ref("DatatypeSegment", optional=True),
             ),
             Bracketed(
                 Delimited(
                     Sequence(
-                        Ref("NakedIdentifierSegment"),
+                        Ref("ParameterNameSegment"),
                         Ref("DatatypeSegment", optional=True),
                     )
                 )
             ),
         ),
-        Ref("FunctionAssignerSegment"),
+        Ref("LambdaArrowSegment"),
         Ref("ExpressionSegment"),
     )
 

--- a/src/sqlfluff/utils/analysis/select.py
+++ b/src/sqlfluff/utils/analysis/select.py
@@ -218,6 +218,7 @@ def _get_lambda_argument_columns(
         "duckdb",
         "trino",
         "databricks",
+        "snowflake"
     ]:
         # Only athena and sparksql are known to have lambda expressions,
         # so all other dialects will have zero lambda columns

--- a/src/sqlfluff/utils/analysis/select.py
+++ b/src/sqlfluff/utils/analysis/select.py
@@ -218,7 +218,7 @@ def _get_lambda_argument_columns(
         "duckdb",
         "trino",
         "databricks",
-        "snowflake"
+        "snowflake",
     ]:
         # Only athena and sparksql are known to have lambda expressions,
         # so all other dialects will have zero lambda columns

--- a/test/fixtures/dialects/snowflake/select_higher_order_function.yml
+++ b/test/fixtures/dialects/snowflake/select_higher_order_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b010934e6f9b8805d2002e3c436aa7cde66fe9ca7a6c1c0a1a7ee2dfdd67c862
+_hash: 93b284a4e5cb4a7dac28c7a882c48befb7e0dda59543f42565720a1883dd319e
 file:
 - statement:
     select_statement:
@@ -20,9 +20,9 @@ file:
                   column_reference:
                     naked_identifier: ident
                 comma: ','
-                lambda_expression:
-                  naked_identifier: i
-                  function_assigner: ->
+                lambda_function:
+                  parameter: i
+                  lambda_arrow: ->
                   expression:
                     column_reference:
                       naked_identifier: i
@@ -48,9 +48,9 @@ file:
                   column_reference:
                     naked_identifier: ident
                 comma: ','
-                lambda_expression:
-                  naked_identifier: j
-                  function_assigner: ->
+                lambda_function:
+                  parameter: j
+                  lambda_arrow: ->
                   expression:
                     column_reference:
                       naked_identifier: j
@@ -73,11 +73,11 @@ file:
                   column_reference:
                     naked_identifier: ident
                 comma: ','
-                lambda_expression:
-                  naked_identifier: k
+                lambda_function:
+                  parameter: k
                   data_type:
                     data_type_identifier: variant
-                  function_assigner: ->
+                  lambda_arrow: ->
                   expression:
                     column_reference:
                       naked_identifier: k
@@ -111,18 +111,18 @@ file:
                   column_reference:
                     quoted_identifier: '"ident"'
                 comma: ','
-                lambda_expression:
+                lambda_function:
                   bracketed:
                   - start_bracket: (
-                  - naked_identifier: i
+                  - parameter: i
                   - data_type:
                       data_type_identifier: INT
                   - comma: ','
-                  - naked_identifier: j
+                  - parameter: j
                   - data_type:
                       data_type_identifier: VARIANT
                   - end_bracket: )
-                  function_assigner: ->
+                  lambda_arrow: ->
                   expression:
                     bracketed:
                       start_bracket: (
@@ -161,9 +161,9 @@ file:
                   column_reference:
                     quoted_identifier: '"ident"'
                 comma: ','
-                lambda_expression:
-                  naked_identifier: j
-                  function_assigner: ->
+                lambda_function:
+                  parameter: j
+                  lambda_arrow: ->
                   expression:
                     column_reference:
                       naked_identifier: j
@@ -182,9 +182,9 @@ file:
               - expression:
                   quoted_literal: "'unusual arguments'"
               - comma: ','
-              - lambda_expression:
-                  naked_identifier: x
-                  function_assigner: ->
+              - lambda_function:
+                  parameter: x
+                  lambda_arrow: ->
                   expression:
                     quoted_literal: "'still a lambda expression'"
               - comma: ','
@@ -226,14 +226,14 @@ file:
               - expression:
                   numeric_literal: '0'
               - comma: ','
-              - lambda_expression:
+              - lambda_function:
                   bracketed:
                   - start_bracket: (
-                  - naked_identifier: acc
+                  - parameter: acc
                   - comma: ','
-                  - naked_identifier: val
+                  - parameter: val
                   - end_bracket: )
-                  function_assigner: ->
+                  lambda_arrow: ->
                   expression:
                   - column_reference:
                       naked_identifier: acc

--- a/test/fixtures/rules/std_rule_cases/RF02.yml
+++ b/test/fixtures/rules/std_rule_cases/RF02.yml
@@ -115,6 +115,21 @@ test_pass_databricks_lambdas:
     core:
       dialect: databricks
 
+test_allow_unqualified_references_in_snowflake_lambdas:
+  pass_str: |
+    select
+        t.v,
+        o.v,
+        transform(t.arr1, x int -> x + 1) as f1,
+        filter(t.arr2, y -> y:value > 0) as f2,
+        reduce(o.arr, 0, (acc, val) -> acc + val) as f3
+    from some_table as t
+    inner join some_other_table as o
+        on t.id = o.id;
+  configs:
+    core:
+      dialect: snowflake
+
 test_allow_unqualified_references_in_athena_lambdas:
   pass_str: |
     select

--- a/test/fixtures/rules/std_rule_cases/RF03.yml
+++ b/test/fixtures/rules/std_rule_cases/RF03.yml
@@ -517,3 +517,13 @@ test_pass_trino_lambda_expression:
   configs:
     core:
       dialect: trino
+
+test_pass_snowflake_lambda_expression:
+  pass_str: |
+    select
+        a_column,
+        transform(array_col, x -> x + 1) as array_col_example
+    from example_table;
+  configs:
+    core:
+      dialect: snowflake


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #6683

Allows RF02 to ignore anonymous parameters for Snowflake lambda expressions used in functions `transform`, `filter`, `reduce`.
Dialect parsing implementation for lambdas in Snowflake was different than for trino and duckdb.
Made changes to snowflake tokens to match trino and duckdb implementation, this allows for minimal change in rule checking.
With the modified tokens, simply adding snowflake to the list of dialects that support lambda expressions in `analysis/select.py` fixes RF02 to no longer trigger incorrectly.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
