### PR TITLE
Sqlfluff as DBEAVER's formater.

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -111,7 +111,10 @@ def set_logging_level(
     # that we don't break tests by changing the granularity
     # between tests.
     parser_logger = logging.getLogger("sqlfluff.parser")
-    if verbosity < 3:
+    if verbosity < 0:
+        fluff_logger.setLevel(logging.ERROR)
+        parser_logger.setLevel(logging.ERROR)
+    elif verbosity < 3 and verbosity >= 0:
         fluff_logger.setLevel(logging.WARNING)
         parser_logger.setLevel(logging.NOTSET)
     elif verbosity == 3:
@@ -855,7 +858,7 @@ def _stdin_fix(
     else:
         stdout = stdin
 
-    if templater_error:
+    if templater_error and formatter.verbosity >= 0:
         click.echo(
             formatter.colorize(
                 "Fix aborted due to unparsable template variables.",
@@ -871,7 +874,7 @@ def _stdin_fix(
             err=True,
         )
 
-    if unfixable_error:
+    if unfixable_error and formatter.verbosity >= 0:
         click.echo(
             formatter.colorize("Unfixable violations detected.", Color.red),
             err=True,

--- a/test/fixtures/cli/dbeaver/.sqlfluff
+++ b/test/fixtures/cli/dbeaver/.sqlfluff
@@ -1,0 +1,20 @@
+[sqlfluff]
+dialect = oracle
+templater = jinja
+exclude_rules = AL05,ST06,AL03
+max_line_length = 120
+
+[sqlfluff:layout:type:comma]
+line_position = leading
+
+[sqlfluff:indentation]
+tab_space_size = 4
+
+[sqlfluff:rules:capitalisation.keywords]  # Keywords
+capitalisation_policy = upper
+
+[sqlfluff:rules:capitalisation.identifiers]  # Unquoted identifiers
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.functions]  # Function names
+extended_capitalisation_policy = capitalise


### PR DESCRIPTION
I tried to close issue #5928.

I improved the --quiet arguments for the fix command.

### Brief summary of the change made
For users who would like to use Sqlfluff as a formatter for DBeaver, it is necessary to use the stdin method. However, I noticed that Sqlfluff always returns Warning Messages or messages like "Unfixable violations detected". For those who use DBeaver, messages of this type are undesirable.

### Are there any other side effects of this change that we should be aware of?
What I fixed was to eliminate the unwanted messages when the quiet option is active. I've avoid to change any other behavior.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.
- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - Other:
    - Included the test called "test__cli__command_stdin_verbose" to check sqlfluff fix queries with and without --quiet argument.
