### PR TITLE
Adds support for `JoinClauseSegment` in `DeleteStatementSegment` in Postgres

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -5772,6 +5772,7 @@ class DeleteStatementSegment(ansi.DeleteStatementSegment):
             Dedent,
             optional=True,
         ),
+        Ref("JoinClauseSegment", optional=True),
         OneOf(
             Sequence("WHERE", "CURRENT", "OF", Ref("ObjectReferenceSegment")),
             Ref("WhereClauseSegment"),

--- a/test/fixtures/dialects/postgres/delete.sql
+++ b/test/fixtures/dialects/postgres/delete.sql
@@ -52,3 +52,8 @@ WITH RECURSIVE t(n) AS (
     SELECT n+1 FROM t WHERE n < 100
 )
 DELETE FROM films;
+
+DELETE FROM foo USING baz
+  LEFT JOIN bar ON baz.bar_id = bar.id
+  WHERE foo.id = bar.foo_id
+    AND baz.id = 'c';

--- a/test/fixtures/dialects/postgres/delete.yml
+++ b/test/fixtures/dialects/postgres/delete.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 807bc630f751ca3385876e9134d7b8d6e4a64f4898fca5dcfe14f3cf656b92b2
+_hash: 9490e035393d40c490bdb4928e5e43d4def7c95e792dfa39e772729a6ad7ac6b
 file:
 - statement:
     delete_statement:
@@ -546,4 +546,56 @@ file:
       - keyword: FROM
       - table_reference:
           naked_identifier: films
+- statement_terminator: ;
+- statement:
+    delete_statement:
+    - keyword: DELETE
+    - keyword: FROM
+    - table_reference:
+        naked_identifier: foo
+    - keyword: USING
+    - table_expression:
+        table_reference:
+          naked_identifier: baz
+    - join_clause:
+      - keyword: LEFT
+      - keyword: JOIN
+      - from_expression_element:
+          table_expression:
+            table_reference:
+              naked_identifier: bar
+      - join_on_condition:
+          keyword: 'ON'
+          expression:
+          - column_reference:
+            - naked_identifier: baz
+            - dot: .
+            - naked_identifier: bar_id
+          - comparison_operator:
+              raw_comparison_operator: '='
+          - column_reference:
+            - naked_identifier: bar
+            - dot: .
+            - naked_identifier: id
+    - where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: foo
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: bar
+          - dot: .
+          - naked_identifier: foo_id
+        - binary_operator: AND
+        - column_reference:
+          - naked_identifier: baz
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - quoted_literal: "'c'"
 - statement_terminator: ;


### PR DESCRIPTION
Closes #6409 

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
