### PR TITLE
Fix rule failures for MySQL/MariaDB with backticked identifiers

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1672,7 +1672,12 @@ class FromExpressionElementSegment(BaseSegment):
             if segment:
                 segment = cast(IdentifierSegment, segment)
                 return AliasInfo(
-                    segment.raw, segment, True, self, alias_expression, ref
+                    segment.raw_normalized(casefold=False),
+                    segment,
+                    True,
+                    self,
+                    alias_expression,
+                    ref,
                 )
 
         # If not return the object name (or None if there isn't one)

--- a/src/sqlfluff/rules/structure/ST11.py
+++ b/src/sqlfluff/rules/structure/ST11.py
@@ -93,7 +93,7 @@ class Rule_ST11(BaseRule):
             alias_identifier = alias_expression.get_child("identifier")
             if alias_identifier:
                 # Append the raw representation and the from expression.
-                return alias_identifier.raw_upper
+                return alias_identifier.raw_normalized(casefold=False).upper()
         # Otherwise if no alias, we need the name of the object we're
         # referencing.
         for table_reference in segment.recursive_crawl(

--- a/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -435,3 +435,10 @@ test_sqlite_outside_of_trigger:
   configs:
     core:
       dialect: sqlite
+
+test_mysql_identifier_with_backticks_should_not_except:
+  pass_str: |
+    SELECT `f`.`bar` FROM `foo` AS `f`;
+  configs:
+    core:
+      dialect: mysql

--- a/test/fixtures/rules/std_rule_cases/ST11.yml
+++ b/test/fixtures/rules/std_rule_cases/ST11.yml
@@ -180,3 +180,10 @@ test_pass_table_expression_function_6558:
   configs:
     core:
       dialect: bigquery
+
+test_mysql_identifier_with_backticks_should_not_except:
+  pass_str: |
+    SELECT `f`.`bar`, `g`.`baz` FROM `foo` AS `f` LEFT JOIN `foobar` AS `g`;
+  configs:
+    core:
+      dialect: mysql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #5356

### Are there any other side effects of this change that we should be aware of?

Not that I can see.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
