### PR TITLE
Fix tests with Click 8.2

### DIFF
--- a/src/sqlfluff/diff_quality_plugin.py
+++ b/src/sqlfluff/diff_quality_plugin.py
@@ -40,7 +40,7 @@ class SQLFluffDriver(QualityDriver):
 
     def installed(self) -> bool:
         """Check if SQLFluff is installed."""
-        return run_command_for_code("sqlfluff") == 0
+        return run_command_for_code(["sqlfluff", "--version"]) == 0
 
 
 class SQLFluffViolationReporter(QualityReporter):


### PR DESCRIPTION
### Brief summary of the change made
https://github.com/pallets/click/pull/2523 introduced changes to `click.testing` that broke some unit tests in SQLFluff: `mix_stderr=False` is now effectively the default and can no longer be specified explicitly.

In addition, https://github.com/pallets/click/pull/1489 caused the diff-quality plugin to incorrectly believe that SQLFluff is not installed.

Although this Click version hasn't been fully released yet, this adjusts SQLFluff to work with both old and new versions.

Fixes: #6676

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
