### PR TITLE
Add support for `key: value` syntax in functions in Postgres.

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -527,6 +527,13 @@ postgres_dialect.replace(
         Ref("IgnoreRespectNullsGrammar"),
         Ref("IndexColumnDefinitionSegment"),
         Ref("EmptyStructLiteralSegment"),
+        Delimited(
+            Sequence(
+                Ref("ExpressionSegment"),
+                OneOf("VALUE", Ref("ColonSegment")),
+                Ref("ExpressionSegment"),
+            )
+        ),
     ),
     QuotedLiteralSegment=OneOf(
         # Postgres allows newline-concatenated string literals (#1488).

--- a/test/fixtures/dialects/postgres/json_operators.sql
+++ b/test/fixtures/dialects/postgres/json_operators.sql
@@ -25,3 +25,14 @@ SELECT
     '["a", {"b":1}]'::jsonb #- '{1,b}',
     '{"a":[1,2,3,4,5]}'::jsonb @? '$.a[*] ? (@ > 2)',
     '{"a":[1,2,3,4,5]}'::jsonb @@ '$.a[*] > 2';
+
+SELECT json_object('code' VALUE 'P123', 'title': 'Jaws');
+
+SELECT json_object(
+        'word': CASE
+            WHEN str = '1' THEN 'One'
+            WHEN str = '2' THEN 'Two'
+            ELSE 'Unknown'
+        END
+    ) AS json_column
+FROM first_table;

--- a/test/fixtures/dialects/postgres/json_operators.yml
+++ b/test/fixtures/dialects/postgres/json_operators.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 947fce13543180fe3b7fce322f22c12f2f6a180eaa92f5e0ad5a6b6db113d2a6
+_hash: fe37b6045b1ed1f44a555be651b48e2f112a48960ecabd434e0ac655fc54772a
 file:
 - statement:
     select_statement:
@@ -237,4 +237,84 @@ file:
                 keyword: jsonb
             binary_operator: '@@'
             quoted_literal: "'$.a[*] > 2'"
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: json_object
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'code'"
+              - keyword: VALUE
+              - expression:
+                  quoted_literal: "'P123'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'title'"
+              - colon: ':'
+              - expression:
+                  quoted_literal: "'Jaws'"
+              - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: json_object
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'word'"
+              - colon: ':'
+              - expression:
+                  case_expression:
+                  - keyword: CASE
+                  - when_clause:
+                    - keyword: WHEN
+                    - expression:
+                        column_reference:
+                          naked_identifier: str
+                        comparison_operator:
+                          raw_comparison_operator: '='
+                        quoted_literal: "'1'"
+                    - keyword: THEN
+                    - expression:
+                        quoted_literal: "'One'"
+                  - when_clause:
+                    - keyword: WHEN
+                    - expression:
+                        column_reference:
+                          naked_identifier: str
+                        comparison_operator:
+                          raw_comparison_operator: '='
+                        quoted_literal: "'2'"
+                    - keyword: THEN
+                    - expression:
+                        quoted_literal: "'Two'"
+                  - else_clause:
+                      keyword: ELSE
+                      expression:
+                        quoted_literal: "'Unknown'"
+                  - keyword: END
+              - end_bracket: )
+          alias_expression:
+            keyword: AS
+            naked_identifier: json_column
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: first_table
 - statement_terminator: ;


### PR DESCRIPTION
Closes #6655 

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
