### PR TITLE
Leading comma alignment

### DIFF
--- a/docs/source/configuration/layout.rst
+++ b/docs/source/configuration/layout.rst
@@ -734,6 +734,25 @@ available:
          [sqlfluff:layout:type:comma]
          line_position = leading
 
+   *  :code:`leading` can be qualified with the :code:`:align-following` modifier
+      - which allows the line position to be aligned with the following element,
+      instead of the configured element itself. For example, when the modifier is
+      added to comma line position:
+
+      .. code-block:: cfg
+
+         [sqlfluff:layout:type:comma]
+         line_position = leading:align-following
+
+      then the following query would be allowed:
+
+      .. code-block:: sql
+
+         SELECT
+            col_a AS a
+          , col_b AS b
+         FROM foo;
+
    *  :code:`alone`, which means if there is a line break on either side,
       then there must be a line break on *both sides* (i.e. that it should
       be the only thing on that line.

--- a/src/sqlfluff/utils/reflow/config.py
+++ b/src/sqlfluff/utils/reflow/config.py
@@ -74,6 +74,7 @@ class ReflowConfig:
     allow_implicit_indents: bool = False
     trailing_comments: str = "before"
     ignore_comment_lines: bool = False
+    leading_comma_align_elements: bool = False
 
     @classmethod
     def from_dict(cls, config_dict: ConfigDictType, **kwargs: Any) -> "ReflowConfig":
@@ -110,6 +111,9 @@ class ReflowConfig:
             ),
             trailing_comments=config.get("trailing_comments", ["indentation"]),
             ignore_comment_lines=config.get("ignore_comment_lines", ["indentation"]),
+            leading_comma_align_elements=config.get(
+                "leading_comma_align_elements", ["indentation"]
+            ),
         )
 
     def get_block_config(

--- a/src/sqlfluff/utils/reflow/config.py
+++ b/src/sqlfluff/utils/reflow/config.py
@@ -74,7 +74,6 @@ class ReflowConfig:
     allow_implicit_indents: bool = False
     trailing_comments: str = "before"
     ignore_comment_lines: bool = False
-    leading_comma_align_elements: bool = False
 
     @classmethod
     def from_dict(cls, config_dict: ConfigDictType, **kwargs: Any) -> "ReflowConfig":
@@ -111,9 +110,6 @@ class ReflowConfig:
             ),
             trailing_comments=config.get("trailing_comments", ["indentation"]),
             ignore_comment_lines=config.get("ignore_comment_lines", ["indentation"]),
-            leading_comma_align_elements=config.get(
-                "leading_comma_align_elements", ["indentation"]
-            ),
         )
 
     def get_block_config(

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -1225,6 +1225,7 @@ def _lint_line_starting_indent(
     indent_line: _IndentLine,
     single_indent: str,
     forced_indents: List[int],
+    leading_comma_align_elements: bool,
 ) -> List[LintResult]:
     """Lint the indent at the start of a line.
 
@@ -1239,7 +1240,13 @@ def _lint_line_starting_indent(
         elements, indent_points[-1].last_line_break_idx
     )
     desired_indent_units = indent_line.desired_indent_units(forced_indents)
-    desired_starting_indent = desired_indent_units * single_indent
+    desired_starting_indent = _calculate_desired_starting_indent(
+        elements=elements,
+        initial_point_idx=initial_point_idx,
+        desired_indent_units=desired_indent_units,
+        single_indent=single_indent,
+        leading_comma_align_elements=leading_comma_align_elements,
+    )
     initial_point = cast(ReflowPoint, elements[initial_point_idx])
 
     if current_indent == desired_starting_indent:
@@ -1322,6 +1329,47 @@ def _lint_line_starting_indent(
 
     elements[initial_point_idx] = new_point
     return new_results
+
+
+def _calculate_desired_starting_indent(
+    elements: ReflowSequenceType,
+    initial_point_idx: int,
+    desired_indent_units: int,
+    single_indent: str,
+    leading_comma_align_elements: bool,
+) -> str:
+    """Calculate the desired starting indent, accounting for leading comma alignment."""
+    unaligned_starting_indent = desired_indent_units * single_indent
+
+    # If leading comma alignment is not enabled, simply return the desired indent.
+    if not leading_comma_align_elements:
+        return unaligned_starting_indent
+
+    # We don't have a good way to enable leading comma alignment for tabs or spaces with
+    # size less than 4, so we'll warn and return the desired indent.
+    if len(single_indent) < 4 or set(single_indent) != {" "}:
+        reflow_logger.warning(
+            "`leading_comma_align_elements` is only supported for `indent_unit` set to "
+            "`space` and `tab_space_size` set to 4."
+        )
+        return unaligned_starting_indent
+
+    # Leading comma alignment is enabled, so we need to check if the current
+    # working line is not the first column reference.
+    if len(elements[initial_point_idx + 1].segments) > 1:
+        initial_seg = elements[initial_point_idx + 1].segments[0]
+        parent_result = initial_seg.get_parent()
+        if not parent_result:
+            return unaligned_starting_indent
+
+        initial_seg_parent, initial_seg_parent_idx = parent_result
+        if initial_seg_parent_idx > 0 and initial_seg.is_type("comma"):
+            reflow_logger.debug("    Not the first column reference. Dedent by 2.")
+            # TODO: should not be a fix number 2
+            # but depends on if there is whitespace following
+            return unaligned_starting_indent[:-2]
+
+    return unaligned_starting_indent
 
 
 def _lint_line_untaken_positive_indents(
@@ -1539,6 +1587,7 @@ def _lint_line_buffer_indents(
     single_indent: str,
     forced_indents: List[int],
     imbalanced_indent_locs: List[int],
+    leading_comma_align_elements: bool,
 ) -> List[LintResult]:
     """Evaluate a single set of indent points on one line.
 
@@ -1592,7 +1641,11 @@ def _lint_line_buffer_indents(
 
     # First, handle starting indent.
     results += _lint_line_starting_indent(
-        elements, indent_line, single_indent, forced_indents
+        elements=elements,
+        indent_line=indent_line,
+        single_indent=single_indent,
+        forced_indents=forced_indents,
+        leading_comma_align_elements=leading_comma_align_elements,
     )
 
     # Second, handle potential missing positive indents.
@@ -1628,6 +1681,7 @@ def lint_indent_points(
     skip_indentation_in: FrozenSet[str] = frozenset(),
     allow_implicit_indents: bool = False,
     ignore_comment_lines: bool = False,
+    leading_comma_align_elements: bool = False,
 ) -> Tuple[ReflowSequenceType, List[LintResult]]:
     """Lint the indent points to check we have line breaks where we should.
 
@@ -1690,7 +1744,12 @@ def lint_indent_points(
     elem_buffer = elements.copy()  # Make a working copy to mutate.
     for line in lines:
         line_results = _lint_line_buffer_indents(
-            elem_buffer, line, single_indent, forced_indents, imbalanced_indent_locs
+            elements=elem_buffer,
+            indent_line=line,
+            single_indent=single_indent,
+            forced_indents=forced_indents,
+            imbalanced_indent_locs=imbalanced_indent_locs,
+            leading_comma_align_elements=leading_comma_align_elements,
         )
         if line_results:
             reflow_logger.info("      PROBLEMS:")

--- a/src/sqlfluff/utils/reflow/reindent.py
+++ b/src/sqlfluff/utils/reflow/reindent.py
@@ -1225,7 +1225,7 @@ def _lint_line_starting_indent(
     indent_line: _IndentLine,
     single_indent: str,
     forced_indents: List[int],
-    leading_comma_align_elements: bool,
+    starting_indent_compensation_spaces: int,
 ) -> List[LintResult]:
     """Lint the indent at the start of a line.
 
@@ -1241,11 +1241,9 @@ def _lint_line_starting_indent(
     )
     desired_indent_units = indent_line.desired_indent_units(forced_indents)
     desired_starting_indent = _calculate_desired_starting_indent(
-        elements=elements,
-        initial_point_idx=initial_point_idx,
         desired_indent_units=desired_indent_units,
         single_indent=single_indent,
-        leading_comma_align_elements=leading_comma_align_elements,
+        starting_indent_compensation_spaces=starting_indent_compensation_spaces,
     )
     initial_point = cast(ReflowPoint, elements[initial_point_idx])
 
@@ -1332,44 +1330,32 @@ def _lint_line_starting_indent(
 
 
 def _calculate_desired_starting_indent(
-    elements: ReflowSequenceType,
-    initial_point_idx: int,
     desired_indent_units: int,
     single_indent: str,
-    leading_comma_align_elements: bool,
+    starting_indent_compensation_spaces: int,
 ) -> str:
     """Calculate the desired starting indent, accounting for leading comma alignment."""
     unaligned_starting_indent = desired_indent_units * single_indent
 
-    # If leading comma alignment is not enabled, simply return the desired indent.
-    if not leading_comma_align_elements:
+    # If indent compensation is not needed, simply return the desired indent.
+    if not starting_indent_compensation_spaces:
         return unaligned_starting_indent
 
     # We don't have a good way to enable leading comma alignment for tabs or spaces with
     # size less than 4, so we'll warn and return the desired indent.
-    if len(single_indent) < 4 or set(single_indent) != {" "}:
+    if len(unaligned_starting_indent) < abs(starting_indent_compensation_spaces):
         reflow_logger.warning(
-            "`leading_comma_align_elements` is only supported for `indent_unit` set to "
-            "`space` and `tab_space_size` set to 4."
+            "Not enough space to compensate indentation. "
+            "Ignoring indentation compensation."
         )
         return unaligned_starting_indent
 
-    # Leading comma alignment is enabled, so we need to check if the current
-    # working line is not the first column reference.
-    if len(elements[initial_point_idx + 1].segments) > 1:
-        initial_seg = elements[initial_point_idx + 1].segments[0]
-        parent_result = initial_seg.get_parent()
-        if not parent_result:
-            return unaligned_starting_indent
-
-        initial_seg_parent, initial_seg_parent_idx = parent_result
-        if initial_seg_parent_idx > 0 and initial_seg.is_type("comma"):
-            reflow_logger.debug("    Not the first column reference. Dedent by 2.")
-            # TODO: should not be a fix number 2
-            # but depends on if there is whitespace following
-            return unaligned_starting_indent[:-2]
-
-    return unaligned_starting_indent
+    # remove the tailing spaces from the starting indentation
+    reflow_logger.debug(
+        "Compensating the starting indent by %s spaces.",
+        starting_indent_compensation_spaces,
+    )
+    return unaligned_starting_indent[:starting_indent_compensation_spaces]
 
 
 def _lint_line_untaken_positive_indents(
@@ -1587,7 +1573,7 @@ def _lint_line_buffer_indents(
     single_indent: str,
     forced_indents: List[int],
     imbalanced_indent_locs: List[int],
-    leading_comma_align_elements: bool,
+    starting_indent_compensation_spaces: int,
 ) -> List[LintResult]:
     """Evaluate a single set of indent points on one line.
 
@@ -1645,7 +1631,7 @@ def _lint_line_buffer_indents(
         indent_line=indent_line,
         single_indent=single_indent,
         forced_indents=forced_indents,
-        leading_comma_align_elements=leading_comma_align_elements,
+        starting_indent_compensation_spaces=starting_indent_compensation_spaces,
     )
 
     # Second, handle potential missing positive indents.
@@ -1681,7 +1667,7 @@ def lint_indent_points(
     skip_indentation_in: FrozenSet[str] = frozenset(),
     allow_implicit_indents: bool = False,
     ignore_comment_lines: bool = False,
-    leading_comma_align_elements: bool = False,
+    indentation_align_following: dict[str, int] | None = None,
 ) -> Tuple[ReflowSequenceType, List[LintResult]]:
     """Lint the indent points to check we have line breaks where we should.
 
@@ -1703,6 +1689,9 @@ def lint_indent_points(
     having line breaks in the right place, but if we're inserting a line
     break, we need to also know how much to indent by.
     """
+    if indentation_align_following is None:
+        indentation_align_following = {}
+
     # First map the line buffers.
     lines: List[_IndentLine]
     imbalanced_indent_locs: List[int]
@@ -1743,13 +1732,23 @@ def lint_indent_points(
     forced_indents: List[int] = []
     elem_buffer = elements.copy()  # Make a working copy to mutate.
     for line in lines:
+        if indentation_align_following:
+            # detect if we need to compensate indentation for the leading element
+            compensate_spaces = _calculate_indent_compensation(
+                elements=elements,
+                line=line,
+                indentation_align_following=indentation_align_following,
+            )
+        else:
+            compensate_spaces = 0
+
         line_results = _lint_line_buffer_indents(
             elements=elem_buffer,
             indent_line=line,
             single_indent=single_indent,
             forced_indents=forced_indents,
             imbalanced_indent_locs=imbalanced_indent_locs,
-            leading_comma_align_elements=leading_comma_align_elements,
+            starting_indent_compensation_spaces=compensate_spaces,
         )
         if line_results:
             reflow_logger.info("      PROBLEMS:")
@@ -1759,6 +1758,38 @@ def lint_indent_points(
         results += line_results
 
     return elem_buffer, results
+
+
+def _calculate_indent_compensation(
+    elements: ReflowSequenceType,
+    line: _IndentLine,
+    indentation_align_following: dict[str, int],
+) -> int:
+    """Calculate the number of spaces to compensate for the leading element.
+
+    This is the number of spaces to remove from the indent of the first element
+    in the line.
+    """
+    # detect if we need to compensate indentation for the leading element
+    for block in line.iter_blocks(elements):
+        # ignore blocks until we reach the first non-whitespace block
+        segment = block.segments[0]
+        if not segment.is_type("whitespace"):
+            if (
+                space_after := indentation_align_following.get(segment.get_type(), None)
+            ) is not None:
+                reflow_logger.debug(
+                    "Compensating line as it starts with %s", segment.type
+                )
+                compensation = len(segment.raw) + space_after
+                reflow_logger.debug(
+                    "Length of segment: %s, space following token: %s",
+                    compensation,
+                    space_after,
+                )
+                return -compensation
+        break
+    return 0
 
 
 def _source_char_len(elements: ReflowSequenceType) -> int:

--- a/src/sqlfluff/utils/reflow/sequence.py
+++ b/src/sqlfluff/utils/reflow/sequence.py
@@ -592,6 +592,7 @@ class ReflowSequence:
             skip_indentation_in=self.reflow_config.skip_indentation_in,
             allow_implicit_indents=self.reflow_config.allow_implicit_indents,
             ignore_comment_lines=self.reflow_config.ignore_comment_lines,
+            leading_comma_align_elements=self.reflow_config.leading_comma_align_elements,  # noqa: E501
         )
 
         return ReflowSequence(

--- a/src/sqlfluff/utils/reflow/sequence.py
+++ b/src/sqlfluff/utils/reflow/sequence.py
@@ -585,6 +585,27 @@ class ReflowSequence:
             tab_space_size=self.reflow_config.tab_space_size,
         )
 
+        # For comma and binary operator, allow indentation to be anchored to
+        # the first non-whitespace element following the comma or binary operator
+        indentation_align_following: dict[str, int] = {}
+        for t in {"comma", "binary_operator"}:
+            block_config = self.reflow_config.get_block_config({t})
+            if block_config.line_position == "leading:align-following":
+                # For future proofing, in case `spacing_after` can be set to `touch`
+                match block_config.spacing_after:
+                    case "single":
+                        spaces_after = 1
+                    case "touch":
+                        spaces_after = 0
+                    case _:
+                        reflow_logger.warning(
+                            "Unexpected `spacing_after` value for calculating "
+                            "indentation compensation: %s",
+                            block_config.spacing_after,
+                        )
+                        spaces_after = 1
+                indentation_align_following[t] = spaces_after
+
         reflow_logger.info("# Evaluating indents.")
         elements, indent_results = lint_indent_points(
             self.elements,
@@ -592,7 +613,7 @@ class ReflowSequence:
             skip_indentation_in=self.reflow_config.skip_indentation_in,
             allow_implicit_indents=self.reflow_config.allow_implicit_indents,
             ignore_comment_lines=self.reflow_config.ignore_comment_lines,
-            leading_comma_align_elements=self.reflow_config.leading_comma_align_elements,  # noqa: E501
+            indentation_align_following=indentation_align_following,
         )
 
         return ReflowSequence(
@@ -610,8 +631,7 @@ class ReflowSequence:
         """
         if self.lint_results:
             raise NotImplementedError(  # pragma: no cover
-                "break_long_lines cannot currently handle pre-existing "
-                "embodied fixes."
+                "break_long_lines cannot currently handle pre-existing embodied fixes."
             )
 
         single_indent = construct_single_indent(

--- a/test/fixtures/rules/std_rule_cases/LT02-indent.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent.yml
@@ -2508,3 +2508,63 @@ test_jinja_value_error_6378:
           tables: ["tbl_a", "tbl_b", "tbl_c"]
           each_table_cols:
             [["aa", "ab", "ac"], ["ba", "bb", "bc"], ["ca", "cb", "cc"]]
+
+test_indent_leading_comma_align_following:
+  fail_str: |
+    SELECT
+        a
+        , b
+    FROM foo;
+  fix_str: |
+    SELECT
+        a
+      , b
+    FROM foo;
+  configs:
+    layout:
+      type:
+        comma:
+          line_position: "leading:align-following"
+
+test_indent_leading_segment_align_following_window_function:
+  fail_str: |
+    SELECT
+        table_1.a AS col_1
+        , table_1.b
+        , ROW_NUMBER() OVER (
+            PARTITION BY table_1.a
+            ORDER BY table_1.d
+        )         AS col_2
+    FROM
+        table_1
+        INNER JOIN table_2
+            ON
+                table_1.a = table_2.a
+                AND table_1.b = table_2.b
+                OR table_1.c = table_2.c;
+  fix_str: |
+    SELECT
+        table_1.a AS col_1
+      , table_1.b
+      , ROW_NUMBER() OVER (
+            PARTITION BY table_1.a
+            ORDER BY table_1.d
+        )         AS col_2
+    FROM
+        table_1
+        INNER JOIN table_2
+            ON
+                table_1.a = table_2.a
+            AND table_1.b = table_2.b
+             OR table_1.c = table_2.c;
+  configs:
+    layout:
+      type:
+        comma:
+          line_position: "leading:align-following"
+        binary_operator:
+          line_position: "leading:align-following"
+    indentation:
+      indented_joins: True
+      allow_implicit_indents: False
+      indented_on_contents: True


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Closes #4901. 

Add a modifier `:align-following` to `line_position = leading`. When enable, the indentation would be calculated based on the first non-whitespace following
- When leading comma is enabled, allow the indentation to be aligned the select target instead of the leading comma
- When leading binary operator is enabled, allow the indentation to be aligned on the join on conditions instead of the leading binary operator

Example:
```sql
/* 
  ...
  [sqlfluff:layout:type:comma]
  line_position = trailing

  [sqlfluff:layout:type:binary_operator]
  line_position = trailing
*/
SELECT 
    foo.a
    , foo.b
FROM
    foo
    INNER JOIN bar
        ON 
            foo.a = bar.a
            AND foo.a = bar.a;

/* 
  assuming all other configs are the same except the following:

  [sqlfluff:layout:type:comma]
  line_position = trailing:align-following

  [sqlfluff:layout:type:binary_operator]
  line_position = trailing:align-following
*/
SELECT 
    foo.a
  , foo.b
FROM
    foo
    INNER JOIN bar
        ON 
            foo.a = bar.a
        AND foo.a = bar.a;
```

### Are there any other side effects of this change that we should be aware of?
Not that I am aware of.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
