### PR TITLE
Fix tox config so that it supports spaces in the path name (#6726)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     # we force the right installation version up front in each environment.
     # NOTE: This is a bit of a hack around tox, but it does achieve reasonably
     # consistent results.
-    dbt{140,150,160,170,180,190}: -r {toxinidir}/constraints/{envname}.txt
+    dbt{140,150,160,170,180,190}: -r "{toxinidir}/constraints/{envname}.txt"
 # Include any other steps necessary for testing below.
 # {posargs} is there to allow us to specify specific tests, which
 # can then be invoked from tox by calling e.g.
@@ -32,17 +32,17 @@ commands =
     # number pinned to the same version number of the main sqlfluff library
     # so it _must_ be installed second in the context of a version which isn't
     # yet released (and so not available on pypi).
-    dbt{140,150,160,170,180,190}: python -m pip install {toxinidir}/plugins/sqlfluff-templater-dbt
+    dbt{140,150,160,170,180,190}: python -m pip install "{toxinidir}/plugins/sqlfluff-templater-dbt"
     # Add the example plugin.
     # NOTE: The trailing comma is important because in the github test suite
     # the python version is not specified and instead the "py" or "winpy"
     # environment is invoked. Leaving the trailing comma ensures that this
     # environment still installs the relevant plugins.
-    {py,winpy}{38,39,310,311,312,313,}: python -m pip install {toxinidir}/plugins/sqlfluff-plugin-example
+    {py,winpy}{38,39,310,311,312,313,}: python -m pip install "{toxinidir}/plugins/sqlfluff-plugin-example"
     # Clean up from previous tests
-    python {toxinidir}/util.py clean-tests
+    python "{toxinidir}/util.py" clean-tests
     # Run tests
-    pytest -vv -rsfE --cov-report=lcov {posargs: {toxinidir}/test}
+    pytest -vv -rsfE --cov-report=lcov {posargs: "{toxinidir}/test"}
     python test/patch_lcov.py
 
 [testenv:cov-init]
@@ -68,7 +68,7 @@ commands =
     coverage report --fail-under=100 --show-missing
 
 [testenv:generate-fixture-yml]
-commands = python {toxinidir}/test/generate_parse_fixture_yml.py {posargs}
+commands = python "{toxinidir}/test/generate_parse_fixture_yml.py" {posargs}
 
 [testenv:linting]
 # NOTE: We do install sqlfluff to run linting. This is
@@ -88,7 +88,7 @@ commands =
     lint-imports
 
 [testenv:doctests]
-commands = pytest -vv -rsfE --doctest-modules {posargs: {toxinidir}/src}
+commands = pytest -vv -rsfE --doctest-modules {posargs: "{toxinidir}/src"}
 
 [testenv:yamllint]
 skip_install = true
@@ -101,13 +101,13 @@ deps =
 commands =
     # Before linting, generate the rule & dialect docs.
     # If we don't we get import errors.
-    python {toxinidir}/docs/generate-auto-docs.py
-    doc8 {toxinidir}/docs/source --file-encoding utf8
+    python "{toxinidir}/docs/generate-auto-docs.py"
+    doc8 "{toxinidir}/docs/source" --file-encoding utf8
 
 [testenv:docbuild]
 deps =
     -rdocs/requirements.txt
-commands = make -C {toxinidir}/docs html
+commands = make -C "{toxinidir}/docs" html
 
 [testenv:mypy]
 # NOTE: We do install sqlfluff to run mypy, this
@@ -139,14 +139,14 @@ skip_install = true
 deps =
     build
 commands =
-    python -m build --sdist --wheel {posargs: {toxinidir}}
+    python -m build --sdist --wheel {posargs: "{toxinidir}"}
 
 [testenv:check-dist]
 skip_install = true
 deps =
     twine
 commands =
-    twine check {toxinidir}/dist/*
+    twine check "{toxinidir}/dist/*"
 
 [testenv:publish-dist]
 skip_install = true
@@ -155,7 +155,7 @@ deps =
     twine
 commands =
     {[testenv:build-dist]commands}
-    twine upload --skip-existing {toxinidir}/dist/*
+    twine upload --skip-existing "{toxinidir}/dist/*"
 
 [testenv:pre-commit]
 skip_install = true


### PR DESCRIPTION



<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #6726

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
