### PR TITLE
Fill in gap in parsing `create user rsa_public_key=...` / snowflake

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -5201,12 +5201,18 @@ class CreateUserSegment(BaseSegment):
             Sequence(
                 "RSA_PUBLIC_KEY",
                 Ref("EqualsSegment"),
-                Ref("ObjectReferenceSegment"),
+                OneOf(
+                    Ref("ObjectReferenceSegment"),
+                    Ref("QuotedLiteralSegment"),
+                ),
             ),
             Sequence(
                 "RSA_PUBLIC_KEY_2",
                 Ref("EqualsSegment"),
-                Ref("ObjectReferenceSegment"),
+                OneOf(
+                    Ref("ObjectReferenceSegment"),
+                    Ref("QuotedLiteralSegment"),
+                ),
             ),
             Sequence(
                 "TYPE",

--- a/test/fixtures/dialects/snowflake/create_user.sql
+++ b/test/fixtures/dialects/snowflake/create_user.sql
@@ -24,3 +24,30 @@ create user user2
     default_warehouse = 'my_default_warehouse'
     default_namespace = 'my_default_namespace'
     must_change_password = false;
+
+create user user3
+    type = person
+    rsa_public_key = '<BASE 64 ENCODED PUBLIC KEY>'
+    default_role = myrole
+    display_name = user1
+    login_name = my_login_name
+    first_name = User1
+    middle_name = abc
+    last_name = Test1
+    default_warehouse = my_default_warehouse
+    default_namespace = my_default_namespace
+    default_secondary_roles = ('ALL');
+
+create user user4
+    type = person
+    rsa_public_key = '<BASE 64 ENCODED PUBLIC KEY>'
+    rsa_public_key_2 = '<SECOND BASE 64 ENCODED PUBLIC KEY>'
+    default_role = myrole
+    display_name = user1
+    login_name = my_login_name
+    first_name = User1
+    middle_name = abc
+    last_name = Test1
+    default_warehouse = my_default_warehouse
+    default_namespace = my_default_namespace
+    default_secondary_roles = ('ALL');

--- a/test/fixtures/dialects/snowflake/create_user.yml
+++ b/test/fixtures/dialects/snowflake/create_user.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c16501055dbb5932b274caf0eeebbe4e45641f82a95b58957d4a49b13139031e
+_hash: ec1c732b4ccf345c2e9ae7420589fdd632f5701217f932621d473c1b687049b3
 file:
 - statement:
     create_user_statement:
@@ -122,4 +122,134 @@ file:
     - comparison_operator:
         raw_comparison_operator: '='
     - boolean_literal: 'false'
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: create
+    - keyword: user
+    - object_reference:
+        naked_identifier: user3
+    - keyword: type
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: person
+    - keyword: rsa_public_key
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'<BASE 64 ENCODED PUBLIC KEY>'"
+    - keyword: default_role
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: myrole
+    - keyword: display_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: user1
+    - keyword: login_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: my_login_name
+    - keyword: first_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: User1
+    - keyword: middle_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: abc
+    - keyword: last_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: Test1
+    - keyword: default_warehouse
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: my_default_warehouse
+    - keyword: default_namespace
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: my_default_namespace
+    - keyword: default_secondary_roles
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+        start_bracket: (
+        quoted_literal: "'ALL'"
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_user_statement:
+    - keyword: create
+    - keyword: user
+    - object_reference:
+        naked_identifier: user4
+    - keyword: type
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: person
+    - keyword: rsa_public_key
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'<BASE 64 ENCODED PUBLIC KEY>'"
+    - keyword: rsa_public_key_2
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - quoted_literal: "'<SECOND BASE 64 ENCODED PUBLIC KEY>'"
+    - keyword: default_role
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: myrole
+    - keyword: display_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: user1
+    - keyword: login_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: my_login_name
+    - keyword: first_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: User1
+    - keyword: middle_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: abc
+    - keyword: last_name
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: Test1
+    - keyword: default_warehouse
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: my_default_warehouse
+    - keyword: default_namespace
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: my_default_namespace
+    - keyword: default_secondary_roles
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - bracketed:
+        start_bracket: (
+        quoted_literal: "'ALL'"
+        end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
fixes #6712 

Allow parsing of statements like:

```sql
CREATE USER user1
RSA_PUBLIC_KEY = '<PUBLIC RSA KEY IN BASE64>';
```

For the snowflake dialect: <https://docs.snowflake.com/en/sql-reference/sql/create-user>

Please review, I'll be happy to contribute to snowflake dialect.