### PR TITLE
T-SQL: modify parsing variable assignment

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -774,6 +774,7 @@ class SelectClauseElementSegment(ansi.SelectClauseElementSegment):
     match_grammar = OneOf(
         # *, blah.*, blah.blah.*, etc.
         Ref("WildcardExpressionSegment"),
+        Ref("ParameterAssignmentSegment"),
         Sequence(
             Ref("AltAliasExpressionSegment"),
             Ref("BaseExpressionElementGrammar"),
@@ -2820,20 +2821,28 @@ class SetStatementSegment(BaseSegment):
                         Ref("QualifiedNumericLiteralSegment"),
                     ),
                 ),
-                Sequence(
-                    Ref("ParameterNameSegment"),
-                    Ref("AssignmentOperatorSegment"),
-                    OneOf(
-                        Ref("ExpressionSegment"),
-                        Ref("SelectableGrammar"),
-                    ),
-                ),
+                Ref("ParameterAssignmentSegment")
             ),
         ),
         Dedent,
         Ref("DelimiterGrammar", optional=True),
     )
 
+class ParameterAssignmentSegment(BaseSegment):
+    """ Assigning a value to a parameter.
+
+        Used in both SET and the now-deprecated SELECT statements (with the latter fixable under linting)
+    """
+
+    type = "parameter_assignment"
+    match_grammar = Sequence(
+        Ref("ParameterNameSegment"),
+        Ref("AssignmentOperatorSegment"),
+        OneOf(
+            Ref("ExpressionSegment"),
+            Ref("SelectableGrammar"),
+        ),
+    )
 
 class AssignmentOperatorSegment(BaseSegment):
     """One of the assignment operators.

--- a/src/sqlfluff/rules/references/RF01.py
+++ b/src/sqlfluff/rules/references/RF01.py
@@ -157,8 +157,9 @@ class Rule_RF01(BaseRule):
         # - They are the target table, similar to an INSERT or UPDATE
         #   statement, thus not expected to match a table in the FROM
         #   clause.
+        # Likewise in T-SQL SELECT @parameter = NEXT VALUE FOR table
         if ref_path:
-            return any(ps.segment.is_type("into_table_clause") for ps in ref_path)
+            return any(ps.segment.is_type("into_table_clause") or ps.segment.is_type("sequence_next_value") for ps in ref_path)
         else:
             return False  # pragma: no cover
 

--- a/src/sqlfluff/rules/tsql/TQ02.py
+++ b/src/sqlfluff/rules/tsql/TQ02.py
@@ -1,0 +1,61 @@
+"""Implementation of Rule TQ02."""
+
+from typing import Optional
+
+from sqlfluff.core.parser.segments.base import BaseSegment
+from sqlfluff.core.rules import BaseRule, LintResult, RuleContext
+from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
+
+
+class Rule_TQ02(BaseRule):
+    r"""Use ``SET` rather than ``SELECT`` to assign variables in T-SQL.
+
+    **Anti-pattern**
+
+    .. code-block:: sql
+
+        SELECT @VARIABLE = X.ID FROM X WHERE X.EMAIL = 'foo@bar.com';
+
+    **Best practice**
+
+    Variable value is ambiguous after the above query if it returns >1 row.
+    Avoid this by re-writing as SET statement; this will error if >1 row is returned.
+    TODO: automate ability to fix; the following re-writing only applies in the simplest cases with no other projections or joins
+
+    .. code-block:: sql
+
+        SET @VARIABLE = ( SELECT X.ID FROM X WHERE X.EMAIL = 'foo@bar.com' );
+
+    """
+
+    name = "tsql.select_into_variable"
+    aliases = ()
+    groups = ("all", "tsql")
+    # NB T-SQL dialect code uses the term 'parameter' whenever lexing '@identifier'
+    # This case is 'local variable' in MS docs so we use 'variable' in user-facing docs here
+    crawl_behaviour = SegmentSeekerCrawler({"parameter_assignment"})
+    is_fix_compatible = False
+
+    def _eval(self, context: RuleContext) -> Optional[LintResult]:
+        """Enforce SET over SELECT for assigning local variables."""
+
+        # Rule only applies to T-SQL syntax.
+        if context.dialect.name != "tsql":
+            return None  # pragma: no cover
+
+        # We are only interested in CREATE PROCEDURE statements.
+        assert context.segment.is_type("parameter_assignment")
+
+        # Warning depends on parent element
+        _parent: BaseSegment = context.parent_stack[-1]
+        if _parent.is_type("set_segment"):
+            return None
+        elif _parent.is_type("select_clause_element"):
+            return LintResult(
+                _parent,
+                description="Prefer 'SET' for variable assignment over 'SELECT'.",
+            )
+        else:  # pragma: no cover
+            raise NotImplementedError(
+                "T-SQL parameter assignment not within SET or SELECT clause?  Raise this as a bug on GitHub."
+            )

--- a/src/sqlfluff/rules/tsql/__init__.py
+++ b/src/sqlfluff/rules/tsql/__init__.py
@@ -20,5 +20,9 @@ def get_rules() -> List[Type[BaseRule]]:
     when rules aren't used.
     """
     from sqlfluff.rules.tsql.TQ01 import Rule_TQ01
+    from sqlfluff.rules.tsql.TQ02 import Rule_TQ02
 
-    return [Rule_TQ01]
+    return [
+        Rule_TQ01,
+        Rule_TQ02,
+    ]

--- a/test/fixtures/dialects/tsql/create_function.yml
+++ b/test/fixtures/dialects/tsql/create_function.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cadc8d465e943aa03d7c43c7298aceb14643874dab788e3366f89aec410c6492
+_hash: a377d2f471e3f5f5c755584c48a4b855cb14da285361738b29c5c1385d72e316
 file:
 - batch:
     statement:
@@ -45,64 +45,65 @@ file:
             - statement:
                 set_segment:
                   keyword: SET
-                  parameter: '@ISOweek'
-                  assignment_operator:
-                    raw_comparison_operator: '='
-                  expression:
-                  - function:
-                      function_name:
-                        function_name_identifier: DATEPART
-                      function_contents:
-                        bracketed:
-                          start_bracket: (
-                          date_part: wk
-                          comma: ','
-                          expression:
-                            parameter: '@DATE'
-                          end_bracket: )
-                  - binary_operator: +
-                  - numeric_literal: '1'
-                  - binary_operator: '-'
-                  - function:
-                      function_name:
-                        function_name_identifier: DATEPART
-                      function_contents:
-                        bracketed:
-                          start_bracket: (
-                          date_part: wk
-                          comma: ','
-                          expression:
-                            function:
-                              function_name:
-                                keyword: CAST
-                              function_contents:
-                                bracketed:
-                                  start_bracket: (
-                                  expression:
-                                    function:
-                                      function_name:
-                                        function_name_identifier: DATEPART
-                                      function_contents:
+                  parameter_assignment:
+                    parameter: '@ISOweek'
+                    assignment_operator:
+                      raw_comparison_operator: '='
+                    expression:
+                    - function:
+                        function_name:
+                          function_name_identifier: DATEPART
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            date_part: wk
+                            comma: ','
+                            expression:
+                              parameter: '@DATE'
+                            end_bracket: )
+                    - binary_operator: +
+                    - numeric_literal: '1'
+                    - binary_operator: '-'
+                    - function:
+                        function_name:
+                          function_name_identifier: DATEPART
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            date_part: wk
+                            comma: ','
+                            expression:
+                              function:
+                                function_name:
+                                  keyword: CAST
+                                function_contents:
+                                  bracketed:
+                                    start_bracket: (
+                                    expression:
+                                      function:
+                                        function_name:
+                                          function_name_identifier: DATEPART
+                                        function_contents:
+                                          bracketed:
+                                            start_bracket: (
+                                            date_part: yy
+                                            comma: ','
+                                            expression:
+                                              parameter: '@DATE'
+                                            end_bracket: )
+                                    keyword: as
+                                    data_type:
+                                      data_type_identifier: CHAR
+                                      bracketed_arguments:
                                         bracketed:
                                           start_bracket: (
-                                          date_part: yy
-                                          comma: ','
                                           expression:
-                                            parameter: '@DATE'
+                                            numeric_literal: '4'
                                           end_bracket: )
-                                  keyword: as
-                                  data_type:
-                                    data_type_identifier: CHAR
-                                    bracketed_arguments:
-                                      bracketed:
-                                        start_bracket: (
-                                        expression:
-                                          numeric_literal: '4'
-                                        end_bracket: )
-                                  end_bracket: )
-                            binary_operator: +
-                            quoted_literal: "'0104'"
-                          end_bracket: )
+                                    end_bracket: )
+                              binary_operator: +
+                              quoted_literal: "'0104'"
+                            end_bracket: )
                   statement_terminator: ;
             - statement:
                 if_then_statement:
@@ -120,85 +121,86 @@ file:
                   statement:
                     set_segment:
                       keyword: SET
-                      parameter: '@ISOweek'
-                      assignment_operator:
-                        raw_comparison_operator: '='
-                      expression:
-                        function:
-                          function_name:
-                            naked_identifier: dbo
-                            dot: .
-                            function_name_identifier: ISOweek
-                          function_contents:
-                            bracketed:
-                              start_bracket: (
-                              expression:
-                              - function:
-                                  function_name:
-                                    keyword: CAST
-                                  function_contents:
-                                    bracketed:
-                                      start_bracket: (
-                                      expression:
-                                        function:
-                                          function_name:
-                                            function_name_identifier: DATEPART
-                                          function_contents:
+                      parameter_assignment:
+                        parameter: '@ISOweek'
+                        assignment_operator:
+                          raw_comparison_operator: '='
+                        expression:
+                          function:
+                            function_name:
+                              naked_identifier: dbo
+                              dot: .
+                              function_name_identifier: ISOweek
+                            function_contents:
+                              bracketed:
+                                start_bracket: (
+                                expression:
+                                - function:
+                                    function_name:
+                                      keyword: CAST
+                                    function_contents:
+                                      bracketed:
+                                        start_bracket: (
+                                        expression:
+                                          function:
+                                            function_name:
+                                              function_name_identifier: DATEPART
+                                            function_contents:
+                                              bracketed:
+                                                start_bracket: (
+                                                date_part: yy
+                                                comma: ','
+                                                expression:
+                                                  parameter: '@DATE'
+                                                end_bracket: )
+                                          binary_operator: '-'
+                                          numeric_literal: '1'
+                                        keyword: AS
+                                        data_type:
+                                          data_type_identifier: CHAR
+                                          bracketed_arguments:
                                             bracketed:
                                               start_bracket: (
-                                              date_part: yy
-                                              comma: ','
                                               expression:
-                                                parameter: '@DATE'
+                                                numeric_literal: '4'
                                               end_bracket: )
-                                        binary_operator: '-'
-                                        numeric_literal: '1'
-                                      keyword: AS
-                                      data_type:
-                                        data_type_identifier: CHAR
-                                        bracketed_arguments:
-                                          bracketed:
-                                            start_bracket: (
-                                            expression:
-                                              numeric_literal: '4'
-                                            end_bracket: )
-                                      end_bracket: )
-                              - binary_operator: +
-                              - quoted_literal: "'12'"
-                              - binary_operator: +
-                              - function:
-                                  function_name:
-                                    keyword: CAST
-                                  function_contents:
-                                    bracketed:
-                                      start_bracket: (
-                                      expression:
-                                        numeric_literal: '24'
-                                        binary_operator: +
-                                        function:
-                                          function_name:
-                                            function_name_identifier: DATEPART
-                                          function_contents:
+                                        end_bracket: )
+                                - binary_operator: +
+                                - quoted_literal: "'12'"
+                                - binary_operator: +
+                                - function:
+                                    function_name:
+                                      keyword: CAST
+                                    function_contents:
+                                      bracketed:
+                                        start_bracket: (
+                                        expression:
+                                          numeric_literal: '24'
+                                          binary_operator: +
+                                          function:
+                                            function_name:
+                                              function_name_identifier: DATEPART
+                                            function_contents:
+                                              bracketed:
+                                                start_bracket: (
+                                                date_part: DAY
+                                                comma: ','
+                                                expression:
+                                                  parameter: '@DATE'
+                                                end_bracket: )
+                                        keyword: AS
+                                        data_type:
+                                          data_type_identifier: CHAR
+                                          bracketed_arguments:
                                             bracketed:
                                               start_bracket: (
-                                              date_part: DAY
-                                              comma: ','
                                               expression:
-                                                parameter: '@DATE'
+                                                numeric_literal: '2'
                                               end_bracket: )
-                                      keyword: AS
-                                      data_type:
-                                        data_type_identifier: CHAR
-                                        bracketed_arguments:
-                                          bracketed:
-                                            start_bracket: (
-                                            expression:
-                                              numeric_literal: '2'
-                                            end_bracket: )
-                                      end_bracket: )
-                              end_bracket: )
-                        binary_operator: +
-                        numeric_literal: '1'
+                                        end_bracket: )
+                                end_bracket: )
+                          binary_operator: +
+                          numeric_literal: '1'
                       statement_terminator: ;
             - statement:
                 if_then_statement:
@@ -266,11 +268,12 @@ file:
                   statement:
                     set_segment:
                       keyword: SET
-                      parameter: '@ISOweek'
-                      assignment_operator:
-                        raw_comparison_operator: '='
-                      expression:
-                        numeric_literal: '1'
+                      parameter_assignment:
+                        parameter: '@ISOweek'
+                        assignment_operator:
+                          raw_comparison_operator: '='
+                        expression:
+                          numeric_literal: '1'
                       statement_terminator: ;
             - statement:
                 return_segment:
@@ -448,14 +451,15 @@ file:
                   select_clause:
                     keyword: SELECT
                     select_clause_element:
-                      expression:
-                      - parameter: '@str'
-                      - comparison_operator:
+                      parameter_assignment:
+                        parameter: '@str'
+                        assignment_operator:
                           raw_comparison_operator: '='
-                      - parameter: '@str'
-                      - binary_operator: +
-                      - column_reference:
-                          quoted_identifier: '[item]'
+                        expression:
+                          parameter: '@str'
+                          binary_operator: +
+                          column_reference:
+                            quoted_identifier: '[item]'
                   from_clause:
                     keyword: FROM
                     from_expression:

--- a/test/fixtures/dialects/tsql/create_procedure.yml
+++ b/test/fixtures/dialects/tsql/create_procedure.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1e3dbbb369e77aad853148e94e4f042e480957913603cebc2117f389ec4d52d3
+_hash: 1cb33494c6391c9f57c5c092b68812d6a76045b23ee09f6b48f765592a26c2b1
 file:
 - batch:
     create_procedure_statement:
@@ -228,29 +228,30 @@ file:
           - statement:
               set_segment:
                 keyword: SET
-                parameter: '@output'
-                assignment_operator:
-                  raw_comparison_operator: '='
-                expression:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      select_statement:
-                        select_clause:
-                          keyword: SELECT
-                          select_clause_element:
-                            column_reference:
-                              naked_identifier: tinyint_value
-                        from_clause:
-                          keyword: FROM
-                          from_expression:
-                            from_expression_element:
-                              table_expression:
-                                table_reference:
-                                - naked_identifier: dbo
-                                - dot: .
-                                - naked_identifier: TEST
-                    end_bracket: )
+                parameter_assignment:
+                  parameter: '@output'
+                  assignment_operator:
+                    raw_comparison_operator: '='
+                  expression:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        select_statement:
+                          select_clause:
+                            keyword: SELECT
+                            select_clause_element:
+                              column_reference:
+                                naked_identifier: tinyint_value
+                          from_clause:
+                            keyword: FROM
+                            from_expression:
+                              from_expression_element:
+                                table_expression:
+                                  table_reference:
+                                  - naked_identifier: dbo
+                                  - dot: .
+                                  - naked_identifier: TEST
+                      end_bracket: )
                 statement_terminator: ;
           - statement:
               if_then_statement:

--- a/test/fixtures/dialects/tsql/declare_with_following_statements.yml
+++ b/test/fixtures/dialects/tsql/declare_with_following_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cd0403da69096df18ca1ae2d66b26cf180b6d555dbb7e2cca8f9eec07064a3d2
+_hash: 4b1340db6f38609718ebaaf016f2e355a2889a9576cbc99a811c1ee00c8dc571
 file:
   batch:
     create_procedure_statement:
@@ -112,27 +112,29 @@ file:
           - statement:
               set_segment:
                 keyword: SET
-                parameter: '@EOMONTH'
-                assignment_operator:
-                  raw_comparison_operator: '='
-                expression:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      quoted_literal: "'2000-01-01'"
-                    end_bracket: )
+                parameter_assignment:
+                  parameter: '@EOMONTH'
+                  assignment_operator:
+                    raw_comparison_operator: '='
+                  expression:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        quoted_literal: "'2000-01-01'"
+                      end_bracket: )
           - statement:
               set_segment:
                 keyword: SET
-                parameter: '@EOMONTH'
-                assignment_operator:
-                  raw_comparison_operator: '='
-                expression:
-                  bracketed:
-                    start_bracket: (
-                    expression:
-                      quoted_literal: "'2001-01-01'"
-                    end_bracket: )
+                parameter_assignment:
+                  parameter: '@EOMONTH'
+                  assignment_operator:
+                    raw_comparison_operator: '='
+                  expression:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        quoted_literal: "'2001-01-01'"
+                      end_bracket: )
                 statement_terminator: ;
           - statement:
               if_then_statement:

--- a/test/fixtures/dialects/tsql/function_with_variable.yml
+++ b/test/fixtures/dialects/tsql/function_with_variable.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a4f778729ae8ba6dcd284c585c2f3167abdc3a32fadc7682c3c620a00161f1db
+_hash: c3cccf15fc621ccb749c6912ecd1589a125fd37604734ca667de444362123415
 file:
   batch:
     statement:
@@ -44,11 +44,12 @@ file:
             - statement:
                 set_segment:
                   keyword: SET
-                  parameter: '@result'
-                  assignment_operator:
-                    raw_comparison_operator: '='
-                  expression:
-                    numeric_literal: '4'
+                  parameter_assignment:
+                    parameter: '@result'
+                    assignment_operator:
+                      raw_comparison_operator: '='
+                    expression:
+                      numeric_literal: '4'
             - statement:
                 return_segment:
                   keyword: RETURN

--- a/test/fixtures/dialects/tsql/if_else.yml
+++ b/test/fixtures/dialects/tsql/if_else.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a434408ffdec3fdb7fdd83fea832c56515bd7d363716de0a1723a87358567d20
+_hash: 6296d2356b315dd33c6171448e25f318fe9decd335c068ea0d99584d76168a86
 file:
   batch:
   - statement:
@@ -158,9 +158,10 @@ file:
         statement:
           set_segment:
             keyword: set
-            parameter: '@var'
-            assignment_operator:
-              raw_comparison_operator: '='
-            expression:
-              numeric_literal: '1'
+            parameter_assignment:
+              parameter: '@var'
+              assignment_operator:
+                raw_comparison_operator: '='
+              expression:
+                numeric_literal: '1'
             statement_terminator: ;

--- a/test/fixtures/dialects/tsql/replicate.yml
+++ b/test/fixtures/dialects/tsql/replicate.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: cbf4289dcc8331d80476fd346acaace6b8aa7810cfdca1c0315541c0f973b104
+_hash: cbc69eadb99fcb9dae7997d1a4b8b43ccba1148eb34030e813a05884bc7a00cc
 file:
   batch:
   - statement:
@@ -97,36 +97,37 @@ file:
   - statement:
       set_segment:
         keyword: SET
-        parameter: '@BinVar'
-        assignment_operator:
-          raw_comparison_operator: '='
-        expression:
-          function:
-            function_name:
-              keyword: CAST
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  function:
-                    function_name:
-                      keyword: REPLICATE
-                    function_contents:
+        parameter_assignment:
+          parameter: '@BinVar'
+          assignment_operator:
+            raw_comparison_operator: '='
+          expression:
+            function:
+              function_name:
+                keyword: CAST
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    function:
+                      function_name:
+                        keyword: REPLICATE
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          numeric_literal: '0x20'
+                          comma: ','
+                          expression:
+                            numeric_literal: '128'
+                          end_bracket: )
+                  keyword: AS
+                  data_type:
+                    data_type_identifier: varbinary
+                    bracketed_arguments:
                       bracketed:
                         start_bracket: (
-                        numeric_literal: '0x20'
-                        comma: ','
                         expression:
                           numeric_literal: '128'
                         end_bracket: )
-                keyword: AS
-                data_type:
-                  data_type_identifier: varbinary
-                  bracketed_arguments:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        numeric_literal: '128'
-                      end_bracket: )
-                end_bracket: )
+                  end_bracket: )
         statement_terminator: ;

--- a/test/fixtures/dialects/tsql/select_assign_parameter.sql
+++ b/test/fixtures/dialects/tsql/select_assign_parameter.sql
@@ -1,11 +1,23 @@
+-- T-SQL alternative alias syntax (AltAliasExpression)
+
 select userid = c.id
 from
 	mydb.myschema.customer c
 where
 	c.name = 'drjwelch';
 
+-- T-SQL parameter assignment, previously (<3.1.0) parsed as AltAliasExpression
+
 select @userid_parameter = c.id
 from
 	mydb.myschema.customer c
 where
 	c.name = 'drjwelch';
+
+-- T-SQL parameter assignment from sequence
+
+select @userid_parameter = NEXT VALUE FOR myschema.customer_ids;
+
+-- NULL assignment to parameter using SELECT is not linted as a comparison (issue #6000)
+
+select @userid_parameter = NULL;

--- a/test/fixtures/dialects/tsql/select_assign_parameter.yml
+++ b/test/fixtures/dialects/tsql/select_assign_parameter.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f68e7dca9031c7e4c03e06b79a621336421c3716702697fa092af9aef5f274b5
+_hash: 691c9c75343efc1bec9dbaec970b3e8fa8753051445953b7f3d3eeaea03e90ad
 file:
   batch:
   - statement:
@@ -47,14 +47,15 @@ file:
         select_clause:
           keyword: select
           select_clause_element:
-            expression:
+            parameter_assignment:
               parameter: '@userid_parameter'
-              comparison_operator:
+              assignment_operator:
                 raw_comparison_operator: '='
-              column_reference:
-              - naked_identifier: c
-              - dot: .
-              - naked_identifier: id
+              expression:
+                column_reference:
+                - naked_identifier: c
+                - dot: .
+                - naked_identifier: id
         from_clause:
           keyword: from
           from_expression:
@@ -78,4 +79,35 @@ file:
             comparison_operator:
               raw_comparison_operator: '='
             quoted_literal: "'drjwelch'"
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            parameter_assignment:
+              parameter: '@userid_parameter'
+              assignment_operator:
+                raw_comparison_operator: '='
+              expression:
+                sequence_next_value:
+                - keyword: NEXT
+                - keyword: VALUE
+                - keyword: FOR
+                - object_reference:
+                  - naked_identifier: myschema
+                  - dot: .
+                  - naked_identifier: customer_ids
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            parameter_assignment:
+              parameter: '@userid_parameter'
+              assignment_operator:
+                raw_comparison_operator: '='
+              expression:
+                null_literal: 'NULL'
         statement_terminator: ;

--- a/test/fixtures/dialects/tsql/set_context_info.yml
+++ b/test/fixtures/dialects/tsql/set_context_info.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 0ceaf083acfcd10c06e99d6627bc416a777a0a2ef84999efd8816105e1f68ce9
+_hash: ccaff02b06f3c9c68a26ed5aee72e349412a629c2c29956f7d1a9811ac5a53b2
 file:
   batch:
   - statement:
@@ -28,38 +28,39 @@ file:
   - statement:
       set_segment:
         keyword: SET
-        parameter: '@BinVar'
-        assignment_operator:
-          raw_comparison_operator: '='
-        expression:
-          function:
-            function_name:
-              keyword: CAST
-            function_contents:
-              bracketed:
-                start_bracket: (
-                expression:
-                  function:
-                    function_name:
-                      keyword: REPLICATE
-                    function_contents:
+        parameter_assignment:
+          parameter: '@BinVar'
+          assignment_operator:
+            raw_comparison_operator: '='
+          expression:
+            function:
+              function_name:
+                keyword: CAST
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    function:
+                      function_name:
+                        keyword: REPLICATE
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          numeric_literal: '0x20'
+                          comma: ','
+                          expression:
+                            numeric_literal: '128'
+                          end_bracket: )
+                  keyword: AS
+                  data_type:
+                    data_type_identifier: varbinary
+                    bracketed_arguments:
                       bracketed:
                         start_bracket: (
-                        numeric_literal: '0x20'
-                        comma: ','
                         expression:
                           numeric_literal: '128'
                         end_bracket: )
-                keyword: AS
-                data_type:
-                  data_type_identifier: varbinary
-                  bracketed_arguments:
-                    bracketed:
-                      start_bracket: (
-                      expression:
-                        numeric_literal: '128'
-                      end_bracket: )
-                end_bracket: )
+                  end_bracket: )
         statement_terminator: ;
   - statement:
       set_context_info_statement:

--- a/test/fixtures/dialects/tsql/set_statements.sql
+++ b/test/fixtures/dialects/tsql/set_statements.sql
@@ -33,3 +33,7 @@ SET @param1 += 1,
 -- Param with sequence in expression
 SET @param1 = (NEXT VALUE FOR [dbo].[SEQUENCE_NAME])
 ;
+
+-- Param set to NULL value is treated as assignment not comparison (issue #6000)
+SET @param1 = NULL
+;

--- a/test/fixtures/dialects/tsql/set_statements.yml
+++ b/test/fixtures/dialects/tsql/set_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: ad529eb73bf8da610ceddcbb5d0a7f5cbfa86bc470a92596bf7c4c82704278c1
+_hash: 4bb34cc0fae734fe9df543795d67f932d654a12611aac7d862db174f9e2edfbc
 file:
   batch:
   - statement:
@@ -18,143 +18,169 @@ file:
   - statement:
       set_segment:
         keyword: SET
-        parameter: '@param1'
-        assignment_operator:
-          raw_comparison_operator: '='
-        expression:
-          numeric_literal: '1'
+        parameter_assignment:
+          parameter: '@param1'
+          assignment_operator:
+            raw_comparison_operator: '='
+          expression:
+            numeric_literal: '1'
         statement_terminator: ;
   - statement:
       set_segment:
       - keyword: SET
-      - parameter: '@param1'
-      - assignment_operator:
-          raw_comparison_operator: '='
-      - expression:
-          numeric_literal: '1'
+      - parameter_assignment:
+          parameter: '@param1'
+          assignment_operator:
+            raw_comparison_operator: '='
+          expression:
+            numeric_literal: '1'
       - comma: ','
-      - parameter: '@param2'
-      - assignment_operator:
-          raw_comparison_operator: '='
-      - expression:
-          numeric_literal: '2'
+      - parameter_assignment:
+          parameter: '@param2'
+          assignment_operator:
+            raw_comparison_operator: '='
+          expression:
+            numeric_literal: '2'
       - statement_terminator: ;
   - statement:
       set_segment:
       - keyword: SET
-      - parameter: '@param1'
-      - assignment_operator:
-          raw_comparison_operator: '='
-      - expression:
-          column_reference:
-            quoted_identifier: '"test, test"'
+      - parameter_assignment:
+          parameter: '@param1'
+          assignment_operator:
+            raw_comparison_operator: '='
+          expression:
+            column_reference:
+              quoted_identifier: '"test, test"'
       - comma: ','
-      - parameter: '@param2'
-      - assignment_operator:
-          raw_comparison_operator: '='
-      - expression:
-          numeric_literal: '2'
+      - parameter_assignment:
+          parameter: '@param2'
+          assignment_operator:
+            raw_comparison_operator: '='
+          expression:
+            numeric_literal: '2'
       - statement_terminator: ;
   - statement:
       set_segment:
       - keyword: SET
-      - parameter: '@param1'
-      - assignment_operator:
-          raw_comparison_operator: '='
-      - expression:
-          bracketed:
-          - start_bracket: (
-          - column_reference:
-              quoted_identifier: '"test"'
-          - comma: ','
-          - column_reference:
-              quoted_identifier: '"test"'
-          - end_bracket: )
+      - parameter_assignment:
+          parameter: '@param1'
+          assignment_operator:
+            raw_comparison_operator: '='
+          expression:
+            bracketed:
+            - start_bracket: (
+            - column_reference:
+                quoted_identifier: '"test"'
+            - comma: ','
+            - column_reference:
+                quoted_identifier: '"test"'
+            - end_bracket: )
       - comma: ','
-      - parameter: '@param2'
-      - assignment_operator:
-          raw_comparison_operator: '='
-      - expression:
-          numeric_literal: '2'
+      - parameter_assignment:
+          parameter: '@param2'
+          assignment_operator:
+            raw_comparison_operator: '='
+          expression:
+            numeric_literal: '2'
       - statement_terminator: ;
   - statement:
       set_segment:
       - keyword: SET
-      - parameter: '@param1'
-      - assignment_operator:
-          binary_operator: +
-          raw_comparison_operator: '='
-      - expression:
-          numeric_literal: '1'
+      - parameter_assignment:
+          parameter: '@param1'
+          assignment_operator:
+            binary_operator: +
+            raw_comparison_operator: '='
+          expression:
+            numeric_literal: '1'
       - comma: ','
-      - parameter: '@param2'
-      - assignment_operator:
-          binary_operator: '-'
-          raw_comparison_operator: '='
-      - expression:
-          numeric_literal: '2'
+      - parameter_assignment:
+          parameter: '@param2'
+          assignment_operator:
+            binary_operator: '-'
+            raw_comparison_operator: '='
+          expression:
+            numeric_literal: '2'
       - comma: ','
-      - parameter: '@param3'
-      - assignment_operator:
-          binary_operator: '*'
-          raw_comparison_operator: '='
-      - expression:
-          numeric_literal: '3'
+      - parameter_assignment:
+          parameter: '@param3'
+          assignment_operator:
+            binary_operator: '*'
+            raw_comparison_operator: '='
+          expression:
+            numeric_literal: '3'
       - comma: ','
-      - parameter: '@param4'
-      - assignment_operator:
-          binary_operator: /
-          raw_comparison_operator: '='
-      - expression:
-          numeric_literal: '4'
+      - parameter_assignment:
+          parameter: '@param4'
+          assignment_operator:
+            binary_operator: /
+            raw_comparison_operator: '='
+          expression:
+            numeric_literal: '4'
       - comma: ','
-      - parameter: '@param5'
-      - assignment_operator:
-          binary_operator: '%'
-          raw_comparison_operator: '='
-      - expression:
-          numeric_literal: '5'
+      - parameter_assignment:
+          parameter: '@param5'
+          assignment_operator:
+            binary_operator: '%'
+            raw_comparison_operator: '='
+          expression:
+            numeric_literal: '5'
       - comma: ','
-      - parameter: '@param5'
-      - assignment_operator:
-          binary_operator: ^
-          raw_comparison_operator: '='
-      - expression:
-          numeric_literal: '6'
+      - parameter_assignment:
+          parameter: '@param5'
+          assignment_operator:
+            binary_operator: ^
+            raw_comparison_operator: '='
+          expression:
+            numeric_literal: '6'
       - comma: ','
-      - parameter: '@param5'
-      - assignment_operator:
-          binary_operator:
-            ampersand: '&'
-          raw_comparison_operator: '='
-      - expression:
-          numeric_literal: '7'
+      - parameter_assignment:
+          parameter: '@param5'
+          assignment_operator:
+            binary_operator:
+              ampersand: '&'
+            raw_comparison_operator: '='
+          expression:
+            numeric_literal: '7'
       - comma: ','
-      - parameter: '@param5'
-      - assignment_operator:
-          binary_operator:
-            pipe: '|'
-          raw_comparison_operator: '='
-      - expression:
-          numeric_literal: '8'
+      - parameter_assignment:
+          parameter: '@param5'
+          assignment_operator:
+            binary_operator:
+              pipe: '|'
+            raw_comparison_operator: '='
+          expression:
+            numeric_literal: '8'
       - statement_terminator: ;
   - statement:
       set_segment:
         keyword: SET
-        parameter: '@param1'
-        assignment_operator:
-          raw_comparison_operator: '='
-        expression:
-          bracketed:
-            start_bracket: (
-            expression:
-              sequence_next_value:
-              - keyword: NEXT
-              - keyword: VALUE
-              - keyword: FOR
-              - object_reference:
-                - quoted_identifier: '[dbo]'
-                - dot: .
-                - quoted_identifier: '[SEQUENCE_NAME]'
-            end_bracket: )
+        parameter_assignment:
+          parameter: '@param1'
+          assignment_operator:
+            raw_comparison_operator: '='
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+                sequence_next_value:
+                - keyword: NEXT
+                - keyword: VALUE
+                - keyword: FOR
+                - object_reference:
+                  - quoted_identifier: '[dbo]'
+                  - dot: .
+                  - quoted_identifier: '[SEQUENCE_NAME]'
+              end_bracket: )
+        statement_terminator: ;
+  - statement:
+      set_segment:
+        keyword: SET
+        parameter_assignment:
+          parameter: '@param1'
+          assignment_operator:
+            raw_comparison_operator: '='
+          expression:
+            null_literal: 'NULL'
         statement_terminator: ;

--- a/test/fixtures/dialects/tsql/stored_procedure_begin_end.yml
+++ b/test/fixtures/dialects/tsql/stored_procedure_begin_end.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7f71fc8304b1b2f26f7e6755ba3326e8051a2d846e70c1f6b8e78fdfe899e279
+_hash: 7f4effa2c6f2a0a8c69ee2c2082deda6018dd70534ccbaada2264b70b6c9ccc4
 file:
 - batch:
     create_procedure_statement:
@@ -211,60 +211,64 @@ file:
               - statement:
                   set_segment:
                     keyword: SET
-                    parameter: '@v_nSysErrorNum'
-                    assignment_operator:
-                      raw_comparison_operator: '='
-                    expression:
-                      function:
-                        function_name:
-                          function_name_identifier: ERROR_NUMBER
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            end_bracket: )
+                    parameter_assignment:
+                      parameter: '@v_nSysErrorNum'
+                      assignment_operator:
+                        raw_comparison_operator: '='
+                      expression:
+                        function:
+                          function_name:
+                            function_name_identifier: ERROR_NUMBER
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              end_bracket: )
                     statement_terminator: ;
               - statement:
                   set_segment:
                     keyword: SET
-                    parameter: '@v_vchCode'
-                    assignment_operator:
-                      raw_comparison_operator: '='
-                    expression:
-                      function:
-                        function_name:
-                          function_name_identifier: ERROR_LINE
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            end_bracket: )
+                    parameter_assignment:
+                      parameter: '@v_vchCode'
+                      assignment_operator:
+                        raw_comparison_operator: '='
+                      expression:
+                        function:
+                          function_name:
+                            function_name_identifier: ERROR_LINE
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              end_bracket: )
                     statement_terminator: ;
               - statement:
                   set_segment:
                     keyword: SET
-                    parameter: '@v_vchMsg'
-                    assignment_operator:
-                      raw_comparison_operator: '='
-                    expression:
-                      quoted_literal: "N'Missing control type.'"
+                    parameter_assignment:
+                      parameter: '@v_vchMsg'
+                      assignment_operator:
+                        raw_comparison_operator: '='
+                      expression:
+                        quoted_literal: "N'Missing control type.'"
                     statement_terminator: ;
               - statement:
                   set_segment:
                     keyword: SET
-                    parameter: '@v_vchMsg'
-                    assignment_operator:
-                      raw_comparison_operator: '='
-                    expression:
-                    - parameter: '@v_vchMsg'
-                    - binary_operator: +
-                    - quoted_literal: "N' SQL Error = '"
-                    - binary_operator: +
-                    - function:
-                        function_name:
-                          function_name_identifier: ERROR_MESSAGE
-                        function_contents:
-                          bracketed:
-                            start_bracket: (
-                            end_bracket: )
+                    parameter_assignment:
+                      parameter: '@v_vchMsg'
+                      assignment_operator:
+                        raw_comparison_operator: '='
+                      expression:
+                      - parameter: '@v_vchMsg'
+                      - binary_operator: +
+                      - quoted_literal: "N' SQL Error = '"
+                      - binary_operator: +
+                      - function:
+                          function_name:
+                            function_name_identifier: ERROR_MESSAGE
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              end_bracket: )
                     statement_terminator: ;
               - statement:
                   goto_statement:

--- a/test/fixtures/dialects/tsql/stored_procedured_mixed_statements.yml
+++ b/test/fixtures/dialects/tsql/stored_procedured_mixed_statements.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2d2452b5af1e64d4115fbc459772a84fad16b23caf8252614e8dddbdcc17ce94
+_hash: 5c760aec0eae0f92044c29e75e01845d308271c1bd685290e3c093015a19a241
 file:
   batch:
     create_procedure_statement:
@@ -56,11 +56,12 @@ file:
       - statement:
           set_segment:
             keyword: SET
-            parameter: '@deadlock_var'
-            assignment_operator:
-              raw_comparison_operator: '='
-            expression:
-              quoted_literal: "N'LOW'"
+            parameter_assignment:
+              parameter: '@deadlock_var'
+              assignment_operator:
+                raw_comparison_operator: '='
+              expression:
+                quoted_literal: "N'LOW'"
             statement_terminator: ;
       - statement:
           begin_end_block:

--- a/test/fixtures/rules/std_rule_cases/CV05.yml
+++ b/test/fixtures/rules/std_rule_cases/CV05.yml
@@ -106,6 +106,14 @@ test_tsql_alternate_alias_syntax:
     core:
       dialect: tsql
 
+test_tsql_declare_set_null:
+  pass_str: |
+    declare
+      @variable INT = null
+  configs:
+    core:
+      dialect: tsql
+
 test_exclude_constraint:
   pass_str: |
     alter table abc add constraint xyz exclude (field WITH =);

--- a/test/fixtures/rules/std_rule_cases/TQ02.yml
+++ b/test/fixtures/rules/std_rule_cases/TQ02.yml
@@ -1,0 +1,43 @@
+rule: TQ02
+
+test_fail_select_assignment:
+  fail_str: |
+    SELECT @CUSTOMERID = X.ID FROM X WHERE X.EMAIL = 'foo@bar.com';
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_set_assignment:
+  pass_str: |
+    SET @CUSTOMERID = (SELECT X.ID FROM X WHERE X.EMAIL = 'foo@bar.com');
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_select_alt_alias:
+  pass_str: |
+    SELECT CUSTOMERID = X.ID FROM X WHERE X.EMAIL = 'foo@bar.com';
+  configs:
+    core:
+      dialect: tsql
+
+test_fail_select_literal:
+  fail_str: |
+    SELECT @EMAIL = 'foo@bar.com';
+  configs:
+    core:
+      dialect: tsql
+
+test_fail_select_null_literal:
+  fail_str: |
+    SELECT @EMAIL = NULL;
+  configs:
+    core:
+      dialect: tsql
+
+test_pass_declare:
+  pass_str: |
+    DECLARE @MYAGE INT = 12;
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fixes #6000 

T-SQL allows a widely-used "legacy" variable assignment syntax thus: `SELECT @variable = <expression>`

Microsoft recommend replacing this syntax with `SET @variable = <expression>` (see [MS docs](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/select-local-variable-transact-sql?view=sql-server-ver16))

Prior to sqlfluff 3.1.0 rule AL09 threw assertion error because this legacy parameter assignment in SELECT was parsed incorrectly as AltAliasSegment.  This was issue #5678.

PR #5934 resolved this by restricting what segment types could be classified as type 'alias_expression'.

This resolution inadvertently caused issue #6000 : in this issue, rule ST05 makes the following **invalid** fix:
- from: `SELECT @variable = NULL`
- to: `SELECT @variable IS NULL`

This did not occur previously because the projection was incorrectly parsed as an alias expression and rule ST05 did not run on the segment; the above fix corrected this but did not correct the behaviour of ST05.  This new incorrect behaviour was a result of the '=' still being parsed as a comparison operator, rather than assignment.

The current change:
- abstracts a new ParameterAssignmentSegment (matching `@myVariable = <expression>`) out of SetStatementSegment and re-uses it in SelectClauseElementSegment;
- adds a new test TQ02 to lint this syntax as an error;
- adds several more test cases;
- adds a new exception to rule RF01 (for assignment to sequences).

### Are there any other side effects of this change that we should be aware of?

TODO: be able to lint **fix** for TQ02 - until this is done many users with legacy codebases (most of us!) might want to disable this rule.  Should we disable it as default?

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
