### PR TITLE
SparkSQL: Make colon optional in `STRUCT` datatype

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -1149,10 +1149,23 @@ class StructTypeSegment(hive.StructTypeSegment):
     pass
 
 
-class StructTypeSchemaSegment(hive.StructTypeSchemaSegment):
-    """STRUCT type schema as per hive."""
+class StructTypeSchemaSegment(BaseSegment):
+    """Expression to construct the schema of a STRUCT datatype."""
 
-    pass
+    type = "struct_type_schema"
+    match_grammar = Bracketed(
+        Delimited(
+            Sequence(
+                Ref("SingleIdentifierGrammar"),
+                Ref("ColonSegment", optional=True),
+                Ref("DatatypeSegment"),
+                Ref("CommentGrammar", optional=True),
+            ),
+            bracket_pairs_set="angle_bracket_pairs",
+        ),
+        bracket_pairs_set="angle_bracket_pairs",
+        bracket_type="angle",
+    )
 
 
 class SemiStructuredAccessorSegment(BaseSegment):

--- a/test/fixtures/dialects/sparksql/create_table_complex_datatypes.sql
+++ b/test/fixtures/dialects/sparksql/create_table_complex_datatypes.sql
@@ -2,6 +2,10 @@
 CREATE TABLE table_identifier
 ( a STRUCT<b: STRING, c: BOOLEAN>, d MAP<STRING, BOOLEAN>, e ARRAY<STRING>);
 
+--Create Table with complex datatypes without : in struct
+CREATE TABLE table_identifier
+( a STRUCT<b STRING, c BOOLEAN>, d MAP<STRING, BOOLEAN>, e ARRAY<STRING>);
+
 --Create Table with complex datatypes and comments
 CREATE TABLE table_identifier
 ( a STRUCT<b: STRING COMMENT 'struct_comment', c: BOOLEAN> COMMENT 'col_comment', d MAP<STRING, BOOLEAN> COMMENT 'col_comment', e ARRAY<STRING> COMMENT 'col_comment');
@@ -9,6 +13,11 @@ CREATE TABLE table_identifier
 --Create Table with nested complex datatypes
 CREATE TABLE table_identifier
 ( a STRUCT<b: STRING, c: MAP<STRING, BOOLEAN>>, d MAP<STRING, STRUCT<e: STRING, f: MAP<STRING, BOOLEAN>>>, g ARRAY<STRUCT<h: STRING, i: MAP<STRING, BOOLEAN>>>);
+
+--Create Table with nested complex datatypes without : in struct
+CREATE TABLE table_identifier
+( a STRUCT<b STRING, c MAP<STRING, BOOLEAN>>, d MAP<STRING, STRUCT<e STRING, f MAP<STRING, BOOLEAN>>>, g ARRAY<STRUCT<h STRING, i MAP<STRING, BOOLEAN>>>);
+
 
 --Create Table with complex datatypes and quoted identifiers
 CREATE TABLE table_identifier

--- a/test/fixtures/dialects/sparksql/create_table_complex_datatypes.yml
+++ b/test/fixtures/dialects/sparksql/create_table_complex_datatypes.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 194112eabf0998f956d77665f1688527afee60d3ae477c84afbc42796bd581d3
+_hash: ff37c473a3e2360d1b7b3a48c34177fcfef7873a068bfdcf2cb99abeae846467
 file:
 - statement:
     create_table_statement:
@@ -29,6 +29,61 @@ file:
               - comma: ','
               - naked_identifier: c
               - colon: ':'
+              - data_type:
+                  primitive_type:
+                    keyword: BOOLEAN
+              - end_angle_bracket: '>'
+      - comma: ','
+      - column_definition:
+          column_reference:
+            naked_identifier: d
+          data_type:
+          - keyword: MAP
+          - start_angle_bracket: <
+          - data_type:
+              primitive_type:
+                keyword: STRING
+          - comma: ','
+          - data_type:
+              primitive_type:
+                keyword: BOOLEAN
+          - end_angle_bracket: '>'
+      - comma: ','
+      - column_definition:
+          column_reference:
+            naked_identifier: e
+          data_type:
+            array_type:
+              keyword: ARRAY
+              start_angle_bracket: <
+              data_type:
+                primitive_type:
+                  keyword: STRING
+              end_angle_bracket: '>'
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table_identifier
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          column_reference:
+            naked_identifier: a
+          data_type:
+            struct_type:
+              keyword: STRUCT
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: b
+              - data_type:
+                  primitive_type:
+                    keyword: STRING
+              - comma: ','
+              - naked_identifier: c
               - data_type:
                   primitive_type:
                     keyword: BOOLEAN
@@ -227,6 +282,109 @@ file:
                   - comma: ','
                   - naked_identifier: i
                   - colon: ':'
+                  - data_type:
+                    - keyword: MAP
+                    - start_angle_bracket: <
+                    - data_type:
+                        primitive_type:
+                          keyword: STRING
+                    - comma: ','
+                    - data_type:
+                        primitive_type:
+                          keyword: BOOLEAN
+                    - end_angle_bracket: '>'
+                  - end_angle_bracket: '>'
+              end_angle_bracket: '>'
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table_identifier
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          column_reference:
+            naked_identifier: a
+          data_type:
+            struct_type:
+              keyword: STRUCT
+              struct_type_schema:
+              - start_angle_bracket: <
+              - naked_identifier: b
+              - data_type:
+                  primitive_type:
+                    keyword: STRING
+              - comma: ','
+              - naked_identifier: c
+              - data_type:
+                - keyword: MAP
+                - start_angle_bracket: <
+                - data_type:
+                    primitive_type:
+                      keyword: STRING
+                - comma: ','
+                - data_type:
+                    primitive_type:
+                      keyword: BOOLEAN
+                - end_angle_bracket: '>'
+              - end_angle_bracket: '>'
+      - comma: ','
+      - column_definition:
+          column_reference:
+            naked_identifier: d
+          data_type:
+          - keyword: MAP
+          - start_angle_bracket: <
+          - data_type:
+              primitive_type:
+                keyword: STRING
+          - comma: ','
+          - data_type:
+              struct_type:
+                keyword: STRUCT
+                struct_type_schema:
+                - start_angle_bracket: <
+                - naked_identifier: e
+                - data_type:
+                    primitive_type:
+                      keyword: STRING
+                - comma: ','
+                - naked_identifier: f
+                - data_type:
+                  - keyword: MAP
+                  - start_angle_bracket: <
+                  - data_type:
+                      primitive_type:
+                        keyword: STRING
+                  - comma: ','
+                  - data_type:
+                      primitive_type:
+                        keyword: BOOLEAN
+                  - end_angle_bracket: '>'
+                - end_angle_bracket: '>'
+          - end_angle_bracket: '>'
+      - comma: ','
+      - column_definition:
+          column_reference:
+            naked_identifier: g
+          data_type:
+            array_type:
+              keyword: ARRAY
+              start_angle_bracket: <
+              data_type:
+                struct_type:
+                  keyword: STRUCT
+                  struct_type_schema:
+                  - start_angle_bracket: <
+                  - naked_identifier: h
+                  - data_type:
+                      primitive_type:
+                        keyword: STRING
+                  - comma: ','
+                  - naked_identifier: i
                   - data_type:
                     - keyword: MAP
                     - start_angle_bracket: <


### PR DESCRIPTION
### Brief summary of the change made
Fixes #6699. The colon is optional in Spark SQL. See https://docs.databricks.com/aws/en/sql/language-manual/data-types/struct-type.

In addition to the Databricks documentation, I've also confirmed in vanilla Spark SQL that these create table statements are valid.

I wasn't able to confirm whether this is true for Hive, so I've copied over the Hive implementation and changed the colon to optional.

### Are there any other side effects of this change that we should be aware of?
N/A

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
