### PR TITLE
Duckdb: Adding InsertStatementSegment for Duckdb specifics

### DIFF
--- a/src/sqlfluff/dialects/dialect_duckdb.py
+++ b/src/sqlfluff/dialects/dialect_duckdb.py
@@ -509,7 +509,7 @@ class SelectStatementSegment(ansi.SelectStatementSegment):
             Ref("WithNoSchemaBindingClauseSegment"),
             Ref("WithDataClauseSegment"),
             Sequence("ON", "CONFLICT"),
-            Ref.keyword("RETURNING"),
+            "RETURNING",
             Ref("WithCheckOptionSegment"),
             Ref("MetaCommandQueryBufferSegment"),
         ],
@@ -549,7 +549,7 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
             Ref("OrderByClauseSegment"),
             Ref("LimitClauseSegment"),
             Sequence("ON", "CONFLICT"),
-            Ref.keyword("RETURNING"),
+            "RETURNING",
         ],
     )
 

--- a/test/fixtures/dialects/duckdb/insert.sql
+++ b/test/fixtures/dialects/duckdb/insert.sql
@@ -1,0 +1,50 @@
+INSERT INTO tbl
+    VALUES (1), (2), (3);
+
+INSERT INTO tbl
+    SELECT
+        col1,
+        col2,
+        col3
+    FROM other_tbl;
+
+INSERT OR REPLACE INTO tbl (i)
+    VALUES (1);
+
+INSERT OR IGNORE INTO tbl (i)
+    VALUES (1);
+
+INSERT INTO tbl
+BY POSITION
+    VALUES (5, 42);
+
+INSERT INTO tbl BY NAME (SELECT 22 AS b);
+
+INSERT INTO tbl
+    VALUES (1, 84)
+    ON CONFLICT DO NOTHING;
+
+INSERT INTO tbl VALUES (1, 52), (1, 62) ON CONFLICT DO UPDATE SET j = EXCLUDED.j;
+
+INSERT INTO tbl
+BY NAME (
+    SELECT
+        1 AS i,
+        336 AS j
+)
+ON CONFLICT DO UPDATE SET j = EXCLUDED.j;
+
+INSERT INTO t1
+    VALUES (1), (2), (3)
+    RETURNING *;
+
+CREATE TABLE t1 (i INTEGER);
+INSERT INTO t1
+    VALUES (1), (2), (3);
+
+CREATE TABLE t2 (i INTEGER);
+INSERT INTO t2
+    SELECT i FROM t1
+    WHERE i IN (1, 3)
+    ON CONFLICT DO UPDATE SET j = EXCLUDED.j
+    RETURNING *;

--- a/test/fixtures/dialects/duckdb/insert.yml
+++ b/test/fixtures/dialects/duckdb/insert.yml
@@ -1,0 +1,377 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 64ae9955f1b91c4c43d6d047d98af8f814ebe3c81cdc19d059b8e1fa5c707bfc
+file:
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: tbl
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+          start_bracket: (
+          expression:
+            numeric_literal: '1'
+          end_bracket: )
+      - comma: ','
+      - bracketed:
+          start_bracket: (
+          expression:
+            numeric_literal: '2'
+          end_bracket: )
+      - comma: ','
+      - bracketed:
+          start_bracket: (
+          expression:
+            numeric_literal: '3'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: tbl
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: col1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: col2
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: col3
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: other_tbl
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OR
+    - keyword: REPLACE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: tbl
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: i
+        end_bracket: )
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+          start_bracket: (
+          expression:
+            numeric_literal: '1'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: OR
+    - keyword: IGNORE
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: tbl
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: i
+        end_bracket: )
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+          start_bracket: (
+          expression:
+            numeric_literal: '1'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: tbl
+    - keyword: BY
+    - keyword: POSITION
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '5'
+        - comma: ','
+        - expression:
+            numeric_literal: '42'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: tbl
+    - keyword: BY
+    - keyword: NAME
+    - bracketed:
+        start_bracket: (
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              numeric_literal: '22'
+              alias_expression:
+                keyword: AS
+                naked_identifier: b
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: tbl
+    - values_clause:
+        keyword: VALUES
+        bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '84'
+        - end_bracket: )
+    - keyword: 'ON'
+    - keyword: CONFLICT
+    - conflict_action:
+      - keyword: DO
+      - keyword: NOTHING
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: tbl
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '52'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            numeric_literal: '1'
+        - comma: ','
+        - expression:
+            numeric_literal: '62'
+        - end_bracket: )
+    - keyword: 'ON'
+    - keyword: CONFLICT
+    - conflict_action:
+      - keyword: DO
+      - keyword: UPDATE
+      - keyword: SET
+      - column_reference:
+          naked_identifier: j
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - expression:
+          column_reference:
+          - naked_identifier: EXCLUDED
+          - dot: .
+          - naked_identifier: j
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: tbl
+    - keyword: BY
+    - keyword: NAME
+    - bracketed:
+        start_bracket: (
+        select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              numeric_literal: '1'
+              alias_expression:
+                keyword: AS
+                naked_identifier: i
+          - comma: ','
+          - select_clause_element:
+              numeric_literal: '336'
+              alias_expression:
+                keyword: AS
+                naked_identifier: j
+        end_bracket: )
+    - keyword: 'ON'
+    - keyword: CONFLICT
+    - conflict_action:
+      - keyword: DO
+      - keyword: UPDATE
+      - keyword: SET
+      - column_reference:
+          naked_identifier: j
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - expression:
+          column_reference:
+          - naked_identifier: EXCLUDED
+          - dot: .
+          - naked_identifier: j
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+          start_bracket: (
+          expression:
+            numeric_literal: '1'
+          end_bracket: )
+      - comma: ','
+      - bracketed:
+          start_bracket: (
+          expression:
+            numeric_literal: '2'
+          end_bracket: )
+      - comma: ','
+      - bracketed:
+          start_bracket: (
+          expression:
+            numeric_literal: '3'
+          end_bracket: )
+    - keyword: RETURNING
+    - star: '*'
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t1
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: i
+        data_type:
+          keyword: INTEGER
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t1
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+          start_bracket: (
+          expression:
+            numeric_literal: '1'
+          end_bracket: )
+      - comma: ','
+      - bracketed:
+          start_bracket: (
+          expression:
+            numeric_literal: '2'
+          end_bracket: )
+      - comma: ','
+      - bracketed:
+          start_bracket: (
+          expression:
+            numeric_literal: '3'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: t2
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: i
+        data_type:
+          keyword: INTEGER
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: t2
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: i
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t1
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: i
+            keyword: IN
+            bracketed:
+            - start_bracket: (
+            - numeric_literal: '1'
+            - comma: ','
+            - numeric_literal: '3'
+            - end_bracket: )
+    - keyword: 'ON'
+    - keyword: CONFLICT
+    - conflict_action:
+      - keyword: DO
+      - keyword: UPDATE
+      - keyword: SET
+      - column_reference:
+          naked_identifier: j
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - expression:
+          column_reference:
+          - naked_identifier: EXCLUDED
+          - dot: .
+          - naked_identifier: j
+    - keyword: RETURNING
+    - star: '*'
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes #6649 

Adding the InsertStatementSegment for Duckdb specific syntax following documentation:
https://duckdb.org/docs/stable/sql/statements/insert.html

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
