### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -65,7 +65,7 @@ jobs:
     name: Python Tests
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
         include:
           # Default to test without coverage tracking on older python versions.
           # This saves time, as testing without coverage tracking is faster.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,8 +85,7 @@ changes.
 
 If you plan on working with a particular dbt plugin, you will need
 to ensure your python version is high enough to support it. For example,
-the instructions below use `python3.12`, and we support as low as `python3.8`
-but if you are working with `dbt-snowflake` 1.9.0 you will need python at least 3.9.
+the instructions below use `python3.13`, and we support as low as `python3.9`.
 
 The simplest way to set up a development environment is to use `tox`.
 
@@ -94,8 +93,8 @@ First ensure that you have tox installed:
 ```shell
 python3.12 -m pip install -U tox
 ```
-**IMPORTANT:** Python 3.8 is the minimum version we support. Feel free
-to test on anything between `python3.8` and `python3.13`.
+**IMPORTANT:** Python 3.9 is the minimum version we support. Feel free
+to test on anything between `python3.9` and `python3.13`.
 
 Note: Unfortunately tox does not currently support setting just a minimum
 Python version (though this may be be coming in tox 4!).
@@ -114,7 +113,7 @@ source .venv/bin/activate
 ```
 (The `dbt180` environment is a good default choice.
 However any version can be installed by replacing `dbt180` with
-`py`, `py38` through `py313`, `dbt140` through `dbt190`, etc.
+`py`, `py39` through `py313`, `dbt140` through `dbt190`, etc.
 `py` defaults to the python version that was used to install tox.
 To be able to run all tests including the dbt templater,
 choose one of the dbt environments.)
@@ -163,19 +162,19 @@ tox
 This will build and test for several Python versions, and also lint the project.
 Practically on a day-to-day basis, you might only want to lint and test for one
 Python version, so you can always specify a particular environment. For example,
-if you are developing in Python 3.8 you might call...
+if you are developing in Python 3.9 you might call...
 
 ```shell
-tox -e generate-fixture-yml,py38,linting,mypy
+tox -e generate-fixture-yml,py39,linting,mypy
 ```
 
 ...or if you also want to see the coverage reporting...
 
 ```shell
-tox -e generate-fixture-yml,cov-init,py38,cov-report,linting,mypy
+tox -e generate-fixture-yml,cov-init,py39,cov-report,linting,mypy
 ```
 
-> NB: The `cov-init` task clears the previous test results, the `py38` environment
+> NB: The `cov-init` task clears the previous test results, the `py39` environment
 > generates the results for tests in that Python version and the `cov-report`
 > environment reports those results out to you (excluding dbt).
 
@@ -184,13 +183,13 @@ faster while working on an issue, before running full tests at the end.
 For example, you can run specific tests by making use of the `-k` option in `pytest`:
 
 ```
-tox -e py38 -- -k AL02 test
+tox -e py39 -- -k AL02 test
 ```
 
 Alternatively, you can also run tests from a specific directory or file only:
 ```
-tox -e py38 -- test/cli
-tox -e py38 -- test/cli/commands_test.py
+tox -e py39 -- test/cli
+tox -e py39 -- test/cli/commands_test.py
 ```
 
 You can also manually test your updated code against a SQL file via:
@@ -264,7 +263,7 @@ We recommend using https://postgresapp.com/.
 To run the dbt-related tests you will have to explicitly include these tests:
 
 ```shell
-tox -e cov-init,dbt018-py38,cov-report-dbt -- plugins/sqlfluff-templater-dbt
+tox -e cov-init,dbt019-py39,cov-report-dbt -- plugins/sqlfluff-templater-dbt
 ```
 
 For more information on adding and running test cases see the [Parser Test README](test/fixtures/dialects/README.md) and the [Rules Test README](test/fixtures/rules/std_rule_cases/README.md).

--- a/docs/source/guides/contributing/dialect.rst
+++ b/docs/source/guides/contributing/dialect.rst
@@ -1025,7 +1025,7 @@ For example if you're adding or modifying
 
 .. code-block:: bash
 
-   tox -e py38 -- -s test/dialects/dialects_test.py -k hive-select_interval.sql
+   tox -e py39 -- -s test/dialects/dialects_test.py -k hive-select_interval.sql
 
 The :code:`-s` flag for pytest enables printing of post-parse structure,
 which allows you to quickly check that each query element is typed
@@ -1045,13 +1045,13 @@ The following command runs just the dialect tests, for **all** dialects:
 
 .. code-block:: bash
 
-   tox -e py38 -- test/dialects/dialects_test.py
+   tox -e py39 -- test/dialects/dialects_test.py
 
 The following command runs just the dialect tests, for **a specific** dialect:
 
 .. code-block:: bash
 
-   tox -e py38 -- test/dialects/dialects_test.py -k ansi
+   tox -e py39 -- test/dialects/dialects_test.py -k ansi
 
 Or, if making a dialect change to fix a rule that is incorrectly flagging,
 you can just run the tests for that one rule, for example to run the
@@ -1059,7 +1059,7 @@ you can just run the tests for that one rule, for example to run the
 
 .. code-block:: bash
 
-   tox -e py38 -- -k LT01 test
+   tox -e py39 -- -k LT01 test
 
 Final checks before committing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/guides/contributing/git.rst
+++ b/docs/source/guides/contributing/git.rst
@@ -476,7 +476,7 @@ So, when you're ready to make your first changes, do the following:
 
 5. If making code changes to the website then test them - follow instructions
    in `CONTRIBUTING.md`_ to set up the environment and then use
-   :code:`tox -e generate-fixture-yml,cov-init,py38,cov-report,linting` to
+   :code:`tox -e generate-fixture-yml,cov-init,py39,cov-report,linting` to
    run most of the tests.
 
 6. Add any new files you added in this change that you want tracked in
@@ -678,7 +678,7 @@ to open a pull request back to the original repo to accept your code into
 SQLFluff:
 
 1. Merge in any changes that happened to SQLFluff code since you branches (see above).
-2. Run all the automated tests :code:`tox -e generate-fixture-yml,cov-init,py38,cov-report,linting`.
+2. Run all the automated tests :code:`tox -e generate-fixture-yml,cov-init,py39,cov-report,linting`.
 3. Make sure all your changes are pushed to GitHub.
 4. Open a pull request in GitHub.
 5. If the pull request closes an issue then you can add "Closes #123" or

--- a/plugins/sqlfluff-plugin-example/pyproject.toml
+++ b/plugins/sqlfluff-plugin-example/pyproject.toml
@@ -6,9 +6,9 @@ build-backend = "setuptools.build_meta"
 # Change this name in your plugin, e.g. company name or plugin purpose.
 name = "sqlfluff-plugin-example"
 version = "1.0.0"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-    "sqlfluff>=0.4.0"
+    "sqlfluff>=3.1.0"
 ]
 
 [project.entry-points.sqlfluff]

--- a/plugins/sqlfluff-templater-dbt/pyproject.toml
+++ b/plugins/sqlfluff-templater-dbt/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "sqlfluff"
 version = "3.3.1"
 description = "The SQL Linter for Humans"
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
   {name = "Alan Cruickshank", email = "alan@designingoverload.com"},
 ]
@@ -24,7 +24,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -75,7 +74,6 @@ dependencies = [
     "colorama>=0.3",
     # Used for diffcover plugin
     "diff-cover>=2.5.0",
-    "importlib_resources; python_version < '3.9'",
     "Jinja2",
     # Used for .sqlfluffignore
     "pathspec",

--- a/src/sqlfluff/__init__.py
+++ b/src/sqlfluff/__init__.py
@@ -25,7 +25,7 @@ if sys.version_info[0] < 3:
 # Check minor python version
 elif sys.version_info[1] < 8:
     raise Exception(
-        "Sqlfluff %s only supports Python 3.8 and beyond. "
+        "Sqlfluff %s only supports Python 3.9 and beyond. "
         "Use an earlier version of sqlfluff or a later version of Python" % __version__
     )
 

--- a/src/sqlfluff/core/config/loader.py
+++ b/src/sqlfluff/core/config/loader.py
@@ -7,12 +7,12 @@ rather than the individual file caching in the `file` module.
 """
 
 from __future__ import annotations
-from importlib.resources import files
 
 import logging
 import os
 import os.path
 import sys
+from importlib.resources import files
 from pathlib import Path
 from typing import (
     Optional,

--- a/src/sqlfluff/core/config/loader.py
+++ b/src/sqlfluff/core/config/loader.py
@@ -7,12 +7,7 @@ rather than the individual file caching in the `file` module.
 """
 
 from __future__ import annotations
-
-try:
-    from importlib.resources import files
-except ImportError:  # pragma: no cover
-    # fallback for python <=3.8
-    from importlib_resources import files  # type: ignore
+from importlib.resources import files
 
 import logging
 import os

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = generate-fixture-yml, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{38,39,310,311,312,313}, dbt{140,150,160,170,180,190}, cov-report, mypy, mypyc, winpy, dbt{150,180,190}-winpy, yamllint
+envlist = generate-fixture-yml, linting, doclinting, ruleslinting, docbuild, cov-init, doctests, py{39,310,311,312,313}, dbt{140,150,160,170,180,190}, cov-report, mypy, mypyc, winpy, dbt{150,180,190}-winpy, yamllint
 min_version = 4.0  # Require 4.0+ for proper pyproject.toml support
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     # we force the right installation version up front in each environment.
     # NOTE: This is a bit of a hack around tox, but it does achieve reasonably
     # consistent results.
-    dbt{140,150,160,170,180,190}: -r "{toxinidir}/constraints/{envname}.txt"
+    dbt{140,150,160,170,180,190}: -r "constraints/{envname}.txt"
 # Include any other steps necessary for testing below.
 # {posargs} is there to allow us to specify specific tests, which
 # can then be invoked from tox by calling e.g.

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands =
     # the python version is not specified and instead the "py" or "winpy"
     # environment is invoked. Leaving the trailing comma ensures that this
     # environment still installs the relevant plugins.
-    {py,winpy}{38,39,310,311,312,313,}: python -m pip install "{toxinidir}/plugins/sqlfluff-plugin-example"
+    {py,winpy}{39,310,311,312,313,}: python -m pip install "{toxinidir}/plugins/sqlfluff-plugin-example"
     # Clean up from previous tests
     python "{toxinidir}/util.py" clean-tests
     # Run tests

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     # we force the right installation version up front in each environment.
     # NOTE: This is a bit of a hack around tox, but it does achieve reasonably
     # consistent results.
-    dbt{140,150,160,170,180,190}: -r "constraints/{envname}.txt"
+    dbt{140,150,160,170,180,190}: -r constraints/{envname}.txt
 # Include any other steps necessary for testing below.
 # {posargs} is there to allow us to specify specific tests, which
 # can then be invoked from tox by calling e.g.


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Python 3.8 hit EOL in October 2024. 5 months on is probably a good time to drop support for it. It allows us to drop a dependency, there's probably some other code clean up we can do without it. This'll trigger a minor release.

### Are there any other side effects of this change that we should be aware of?
About 2% of our downloads are still on Python 3.8. But this still seems like a reasonable time to stop developing new features for it.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
