### PR TITLE
Tighter typing of Rule configs

### DIFF
--- a/plugins/sqlfluff-plugin-example/src/sqlfluff_plugin_example/__init__.py
+++ b/plugins/sqlfluff-plugin-example/src/sqlfluff_plugin_example/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Type
 
 from sqlfluff.core.config import load_config_resource
 from sqlfluff.core.plugin import hookimpl
-from sqlfluff.core.rules import BaseRule
+from sqlfluff.core.rules import BaseRule, ConfigInfo
 
 # For backward compatibility we still support importing
 # rules within the body of the root plugin module. This is included
@@ -48,7 +48,7 @@ def load_default_config() -> Dict[str, Any]:
 
 
 @hookimpl
-def get_configs_info() -> Dict[str, Dict[str, Any]]:
+def get_configs_info() -> Dict[str, ConfigInfo]:
     """Get rule config validations and descriptions."""
     return {
         "forbidden_columns": {"definition": "A list of column to forbid"},

--- a/src/sqlfluff/core/plugin/lib.py
+++ b/src/sqlfluff/core/plugin/lib.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Type
 
 from sqlfluff.core.config import load_config_resource
 from sqlfluff.core.plugin import hookimpl
-from sqlfluff.core.rules import BaseRule
+from sqlfluff.core.rules import BaseRule, ConfigInfo
 from sqlfluff.core.rules.config_info import STANDARD_CONFIG_INFO_DICT
 from sqlfluff.core.rules.loader import get_rules_from_path
 from sqlfluff.core.templaters import RawTemplater, core_templaters
@@ -38,6 +38,6 @@ def load_default_config() -> Dict[str, Any]:
 
 
 @hookimpl
-def get_configs_info() -> Dict[str, Any]:
+def get_configs_info() -> Dict[str, ConfigInfo]:
     """Get rule config validations and descriptions."""
     return STANDARD_CONFIG_INFO_DICT

--- a/src/sqlfluff/core/rules/__init__.py
+++ b/src/sqlfluff/core/rules/__init__.py
@@ -9,7 +9,7 @@ from sqlfluff.core.rules.base import (
     RulePack,
     RuleSet,
 )
-from sqlfluff.core.rules.config_info import get_config_info
+from sqlfluff.core.rules.config_info import ConfigInfo, get_config_info
 from sqlfluff.core.rules.context import RuleContext
 from sqlfluff.core.rules.fix import LintFix
 
@@ -48,4 +48,5 @@ __all__ = (
     "RuleContext",
     "RuleGhost",
     "EvalResultType",
+    "ConfigInfo",
 )

--- a/src/sqlfluff/core/rules/base.py
+++ b/src/sqlfluff/core/rules/base.py
@@ -44,7 +44,7 @@ from sqlfluff.core.errors import SQLFluffUserError, SQLLintError
 from sqlfluff.core.helpers.string import split_comma_separated_string
 from sqlfluff.core.parser import BaseSegment, RawSegment
 from sqlfluff.core.plugin.host import is_main_process, plugins_loaded
-from sqlfluff.core.rules.config_info import get_config_info
+from sqlfluff.core.rules.config_info import ConfigInfo, get_config_info
 from sqlfluff.core.rules.context import RuleContext
 from sqlfluff.core.rules.crawlers import BaseCrawler
 from sqlfluff.core.rules.fix import LintFix
@@ -224,9 +224,9 @@ class RuleMetaclass(type):
         docstring so that it can be displayed in the sphinx docs.
         """
         # Ensure that there _is_ a docstring.
-        assert (
-            "__doc__" in class_dict
-        ), f"Tried to define rule {name!r} without docstring."
+        assert "__doc__" in class_dict, (
+            f"Tried to define rule {name!r} without docstring."
+        )
 
         # Build up a buffer of entries to add to the docstring.
         fix_docs = (
@@ -907,7 +907,7 @@ class RuleSet:
 
     """
 
-    def __init__(self, name: str, config_info: Dict[str, Dict[str, Any]]) -> None:
+    def __init__(self, name: str, config_info: Dict[str, ConfigInfo]) -> None:
         self.name = name
         self.config_info = config_info
         self._register: Dict[str, RuleManifest] = {}

--- a/src/sqlfluff/core/rules/config_info.py
+++ b/src/sqlfluff/core/rules/config_info.py
@@ -13,11 +13,32 @@ of more general wider use - please define it in the specific plugin
 rather than here.
 """
 
-from typing import Any, Dict
+from typing import Dict, List, NotRequired, TypedDict
 
 from sqlfluff.core.plugin.host import get_plugin_manager
 
-STANDARD_CONFIG_INFO_DICT: Dict[str, Dict[str, Any]] = {
+
+class ConfigInfo(TypedDict):
+    """Type definition for a single config info value.
+
+    This TypedDict defines the structure for configuration information used across
+    SQLFluff rules. Each config value must have a definition, and may optionally
+    include validation criteria.
+
+    Args:
+        definition: Required string containing a detailed description of the config
+            option and its purpose. This should be clear enough for users to
+            understand when and how to use the config.
+        validation: Optional list or range of valid values for the config option.
+            Can contain boolean, string, or integer values. If not provided,
+            the config option accepts any value of its expected type.
+    """
+
+    definition: str
+    validation: NotRequired[List[bool | str | int] | range]
+
+
+STANDARD_CONFIG_INFO_DICT: Dict[str, ConfigInfo] = {
     "force_enable": {
         "validation": [True, False],
         "definition": (
@@ -62,7 +83,7 @@ STANDARD_CONFIG_INFO_DICT: Dict[str, Dict[str, Any]] = {
 }
 
 
-def get_config_info() -> Dict[str, Any]:
+def get_config_info() -> Dict[str, ConfigInfo]:
     """Get the config from core sqlfluff and sqlfluff plugins and merges them.
 
     NOTE: This should be the entry point into getting config info rather than

--- a/src/sqlfluff/rules/aliasing/__init__.py
+++ b/src/sqlfluff/rules/aliasing/__init__.py
@@ -1,13 +1,13 @@
 """The aliasing plugin bundle."""
 
-from typing import Any, Dict, List, Type
+from typing import Dict, List, Type
 
 from sqlfluff.core.plugin import hookimpl
-from sqlfluff.core.rules import BaseRule
+from sqlfluff.core.rules import BaseRule, ConfigInfo
 
 
 @hookimpl
-def get_configs_info() -> Dict[str, Any]:
+def get_configs_info() -> Dict[str, ConfigInfo]:
     """Get additional rule config validations and descriptions."""
     return {
         "aliasing": {

--- a/src/sqlfluff/rules/ambiguous/__init__.py
+++ b/src/sqlfluff/rules/ambiguous/__init__.py
@@ -3,14 +3,14 @@
 NOTE: Yes the title of this bundle is ...ambiguous. 😁
 """
 
-from typing import Any, Dict, List, Type
+from typing import Dict, List, Type
 
 from sqlfluff.core.plugin import hookimpl
-from sqlfluff.core.rules import BaseRule
+from sqlfluff.core.rules import BaseRule, ConfigInfo
 
 
 @hookimpl
-def get_configs_info() -> Dict[str, Any]:
+def get_configs_info() -> Dict[str, ConfigInfo]:
     """Get additional rule config validations and descriptions."""
     return {
         "fully_qualify_join_types": {

--- a/src/sqlfluff/rules/capitalisation/__init__.py
+++ b/src/sqlfluff/rules/capitalisation/__init__.py
@@ -1,13 +1,13 @@
 """The capitalisation plugin bundle."""
 
-from typing import Any, Dict, List, Type
+from typing import Dict, List, Type
 
 from sqlfluff.core.plugin import hookimpl
-from sqlfluff.core.rules import BaseRule
+from sqlfluff.core.rules import BaseRule, ConfigInfo
 
 
 @hookimpl
-def get_configs_info() -> Dict[str, Any]:
+def get_configs_info() -> Dict[str, ConfigInfo]:
     """Get additional rule config validations and descriptions."""
     return {
         "capitalisation_policy": {

--- a/src/sqlfluff/rules/convention/__init__.py
+++ b/src/sqlfluff/rules/convention/__init__.py
@@ -1,13 +1,13 @@
 """The convention plugin bundle."""
 
-from typing import Any, Dict, List, Type
+from typing import Dict, List, Type
 
 from sqlfluff.core.plugin import hookimpl
-from sqlfluff.core.rules import BaseRule
+from sqlfluff.core.rules import BaseRule, ConfigInfo
 
 
 @hookimpl
-def get_configs_info() -> Dict[str, Any]:
+def get_configs_info() -> Dict[str, ConfigInfo]:
     """Get additional rule config validations and descriptions."""
     return {
         "preferred_not_equal_style": {

--- a/src/sqlfluff/rules/layout/__init__.py
+++ b/src/sqlfluff/rules/layout/__init__.py
@@ -1,13 +1,13 @@
 """The aliasing plugin bundle."""
 
-from typing import Any, Dict, List, Type
+from typing import Dict, List, Type
 
 from sqlfluff.core.plugin import hookimpl
-from sqlfluff.core.rules import BaseRule
+from sqlfluff.core.rules import BaseRule, ConfigInfo
 
 
 @hookimpl
-def get_configs_info() -> Dict[str, Any]:
+def get_configs_info() -> Dict[str, ConfigInfo]:
     """Get additional rule config validations and descriptions."""
     return {
         "ignore_comment_lines": {

--- a/src/sqlfluff/rules/references/__init__.py
+++ b/src/sqlfluff/rules/references/__init__.py
@@ -1,13 +1,13 @@
 """The references plugin bundle."""
 
-from typing import Any, Dict, List, Type
+from typing import Dict, List, Type
 
 from sqlfluff.core.plugin import hookimpl
-from sqlfluff.core.rules import BaseRule
+from sqlfluff.core.rules import BaseRule, ConfigInfo
 
 
 @hookimpl
-def get_configs_info() -> Dict[str, Any]:
+def get_configs_info() -> Dict[str, ConfigInfo]:
     """Get additional rule config validations and descriptions."""
     return {
         "single_table_references": {

--- a/src/sqlfluff/rules/structure/__init__.py
+++ b/src/sqlfluff/rules/structure/__init__.py
@@ -1,13 +1,13 @@
 """The structure plugin bundle."""
 
-from typing import Any, Dict, List, Type
+from typing import Dict, List, Type
 
 from sqlfluff.core.plugin import hookimpl
-from sqlfluff.core.rules import BaseRule
+from sqlfluff.core.rules import BaseRule, ConfigInfo
 
 
 @hookimpl
-def get_configs_info() -> Dict[str, Any]:
+def get_configs_info() -> Dict[str, ConfigInfo]:
     """Get additional rule config validations and descriptions."""
     return {
         "forbid_subquery_in": {


### PR DESCRIPTION
We've had some `Any` types in the Rule configs for a while which I've been wanting to get rid of. This introduces more explicit typing for them and banishes some of some of the remaining `Any` types.