### PR TITLE
Fix: column aliases should find the topmost alias

### DIFF
--- a/src/sqlfluff/core/parser/segments/base.py
+++ b/src/sqlfluff/core/parser/segments/base.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import logging
 import weakref
-from collections import deque
 from dataclasses import dataclass
 from functools import cached_property
 from io import StringIO
@@ -1054,44 +1053,6 @@ class BaseSegment(metaclass=SegmentMetaclass):
                         recurse_into=recurse_into,
                         no_recursive_seg_type=no_recursive_seg_type,
                     )
-
-    def bfs_crawl(
-        self,
-        *seg_type: str,
-        recurse_into: bool = True,
-        no_recursive_seg_type: Optional[Union[str, list[str]]] = None,
-    ) -> Iterator[BaseSegment]:
-        """Breadth-first crawl for segments of a given type.
-
-        Args:
-            seg_type: :obj:`str`: one or more type of segment
-                to look for.
-            recurse_into: :obj:`bool`: When an element of type "seg_type" is
-                found, whether to recurse into it.
-            no_recursive_seg_type: :obj:`Union[str, list[str]]`: a type of segment
-                not to recurse further into. It is highly recommended
-                to set this argument where possible, as it can significantly
-                narrow the search pattern.
-        """
-        if isinstance(no_recursive_seg_type, str):
-            no_recursive_seg_type = [no_recursive_seg_type]
-
-        queue = deque([self])
-
-        while queue:
-            current = queue.popleft()
-
-            if current.is_type(*seg_type):
-                yield current
-                if not recurse_into:
-                    continue
-
-            if not current.descendant_type_set.intersection(seg_type):
-                continue
-
-            for seg in current.segments:
-                if not no_recursive_seg_type or not seg.is_type(*no_recursive_seg_type):
-                    queue.append(seg)
 
     def path_to(self, other: "BaseSegment") -> list[PathStep]:
         """Given a segment which is assumed within self, get the intermediate segments.

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1819,10 +1819,8 @@ class SelectClauseElementSegment(BaseSegment):
     def get_alias(self) -> Optional[ColumnAliasInfo]:
         """Get info on alias within SELECT clause element."""
         alias_expression_segment = next(
-            self.bfs_crawl(
+            self.recursive_crawl(
                 "alias_expression",
-                # don't recurse into aliases
-                recurse_into=False,
                 # don't recurse into any subqueries
                 no_recursive_seg_type="select_statement",
             ),

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1818,7 +1818,16 @@ class SelectClauseElementSegment(BaseSegment):
 
     def get_alias(self) -> Optional[ColumnAliasInfo]:
         """Get info on alias within SELECT clause element."""
-        alias_expression_segment = next(self.bfs_crawl("alias_expression"), None)
+        alias_expression_segment = next(
+            self.bfs_crawl(
+                "alias_expression",
+                # don't recurse into aliases
+                recurse_into=False,
+                # don't recurse into any subqueries
+                no_recursive_seg_type="select_statement",
+            ),
+            None,
+        )
         if alias_expression_segment is None:
             # Return None if no alias expression is found.
             return None

--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1818,7 +1818,7 @@ class SelectClauseElementSegment(BaseSegment):
 
     def get_alias(self) -> Optional[ColumnAliasInfo]:
         """Get info on alias within SELECT clause element."""
-        alias_expression_segment = next(self.recursive_crawl("alias_expression"), None)
+        alias_expression_segment = next(self.bfs_crawl("alias_expression"), None)
         if alias_expression_segment is None:
             # Return None if no alias expression is found.
             return None

--- a/test/fixtures/rules/std_rule_cases/RF02.yml
+++ b/test/fixtures/rules/std_rule_cases/RF02.yml
@@ -521,3 +521,11 @@ test_fail_exists_subquery:
         SELECT 1 FROM foo2
         WHERE bar.id = id
     );
+
+test_pass_ignore_deeper_alias_6389:
+  pass_str: |
+    SELECT (SELECT MAX(x.col) AS m FROM x) AS _stats
+    FROM stats_today AS t
+    LEFT JOIN stats_this_month AS tm
+      ON tm.x = t.x
+    WHERE _stats IS NOT NULL;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
~~Previously, the `get_alias` function was getting the first alias found in a depth-first manner, which was not always the correct alias to include when a subquery may have had an internal `alias_expression`. This adds a breadth-first crawler and uses that to grab the topmost, first alias.~~
Prevent `get_alias` from recursively crawling through subqueries.
- fixes #6389


### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
