### PR TITLE
feat(snowflake): allow reference variables in create task 

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -4810,7 +4810,10 @@ class CreateTaskSegment(BaseSegment):
                 Sequence(
                     "WAREHOUSE",
                     Ref("EqualsSegment"),
-                    Ref("ObjectReferenceSegment"),
+                    OneOf(
+                        Ref("ObjectReferenceSegment"),
+                        Ref("ReferencedVariableNameSegment"),
+                    ),
                 ),
                 Sequence(
                     "USER_TASK_MANAGED_INITIAL_WAREHOUSE_SIZE",
@@ -4821,7 +4824,10 @@ class CreateTaskSegment(BaseSegment):
             Sequence(
                 "SCHEDULE",
                 Ref("EqualsSegment"),
-                Ref("QuotedLiteralSegment"),
+                OneOf(
+                    Ref("QuotedLiteralSegment"),
+                    Ref("ReferencedVariableNameSegment"),
+                ),
             ),
             Sequence(
                 "ALLOW_OVERLAPPING_EXECUTION",
@@ -4849,6 +4855,7 @@ class CreateTaskSegment(BaseSegment):
                 "GRANTS",
             ),
             Ref("CommentEqualsClauseSegment"),
+            Ref("LogLevelEqualsSegment"),
         ),
         Sequence(
             "AFTER",

--- a/test/fixtures/dialects/snowflake/create_task.sql
+++ b/test/fixtures/dialects/snowflake/create_task.sql
@@ -103,3 +103,12 @@ CREATE TASK task5
   AFTER task2, task3, task4
 AS
   INSERT INTO t1(ts) VALUES(CURRENT_TIMESTAMP);
+
+SET custom_warehouse = 'mywh';
+SET custom_schedule = 'USING CRON 15 7 2 * * UTC';
+CREATE OR ALTER TASK mytask
+    WAREHOUSE = $custom_warehouse
+    SCHEDULE = $custom_schedule
+    LOG_LEVEL = TRACE
+AS
+    CALL SCH.MY_SPROC();

--- a/test/fixtures/dialects/snowflake/create_task.yml
+++ b/test/fixtures/dialects/snowflake/create_task.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b51f809acffccdd7e1ec6605cef635ea166270c76ba1277811d16239ae47581b
+_hash: fe3c17758e2a6ae4e2e2aaec90347dbe4975d78d4d27064611e536210f7189ee
 file:
 - statement:
     create_task_statement:
@@ -582,4 +582,58 @@ file:
               expression:
                 bare_function: CURRENT_TIMESTAMP
               end_bracket: )
+- statement_terminator: ;
+- statement:
+    set_statement:
+      keyword: SET
+      variable: custom_warehouse
+      comparison_operator:
+        raw_comparison_operator: '='
+      expression:
+        quoted_literal: "'mywh'"
+- statement_terminator: ;
+- statement:
+    set_statement:
+      keyword: SET
+      variable: custom_schedule
+      comparison_operator:
+        raw_comparison_operator: '='
+      expression:
+        quoted_literal: "'USING CRON 15 7 2 * * UTC'"
+- statement_terminator: ;
+- statement:
+    create_task_statement:
+    - keyword: CREATE
+    - keyword: OR
+    - keyword: ALTER
+    - keyword: TASK
+    - object_reference:
+        naked_identifier: mytask
+    - keyword: WAREHOUSE
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        variable: $custom_warehouse
+    - keyword: SCHEDULE
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - variable: $custom_schedule
+    - log_level_equals:
+      - keyword: LOG_LEVEL
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - keyword: TRACE
+    - keyword: AS
+    - statement:
+        call_segment:
+          keyword: CALL
+          function:
+            function_name:
+              naked_identifier: SCH
+              dot: .
+              function_name_identifier: MY_SPROC
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Changes limited to `create task` in the snowflake dialect
* Enables the use of reference variables in the `warehouse` and `schedule` parameters.
* And adds LOG_LEVEL

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
