### PR TITLE
Always use utf-8 encoding for toml files

### DIFF
--- a/src/sqlfluff/core/config/toml.py
+++ b/src/sqlfluff/core/config/toml.py
@@ -54,7 +54,7 @@ def load_toml_file_config(filepath: str) -> ConfigMappingType:
     We don't need to change any key names here, because the root
     section of the toml file format is `tool.sqlfluff.core`.
     """
-    with open(filepath, mode="r") as file:
+    with open(filepath, mode="r", encoding="utf-8") as file:
         toml_dict = tomllib.loads(file.read())
     config_dict = _validate_structure(toml_dict.get("tool", {}).get("sqlfluff", {}))
 

--- a/src/sqlfluff/core/config/toml.py
+++ b/src/sqlfluff/core/config/toml.py
@@ -53,6 +53,9 @@ def load_toml_file_config(filepath: str) -> ConfigMappingType:
 
     We don't need to change any key names here, because the root
     section of the toml file format is `tool.sqlfluff.core`.
+
+    NOTE: Toml files are always encoded in UTF-8. That is a necessary
+    part of the toml spec: https://toml.io/en/v1.0.0
     """
     with open(filepath, mode="r", encoding="utf-8") as file:
         toml_dict = tomllib.loads(file.read())

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -235,7 +235,7 @@ def test__cli__command_extra_config_fail():
 
 
 stdin_cli_input = (
-    "SELECT\n    A.COL1,\n    B.COL2\nFROM TABA AS A\n" "POSITIONAL JOIN TABB AS B;\n"
+    "SELECT\n    A.COL1,\n    B.COL2\nFROM TABA AS A\nPOSITIONAL JOIN TABB AS B;\n"
 )
 
 
@@ -875,7 +875,8 @@ def test__cli__command_versioning():
     """Check version command."""
     # Get the package version info
     pkg_version = sqlfluff.__version__
-    # Get the version info from the config file
+    # Get the version info from the config file.
+    # NOTE: Toml files are always encoded in UTF-8.
     with open("pyproject.toml", "r", encoding="utf-8") as config_file:
         config = tomllib.loads(config_file.read())
     config_version = config["project"]["version"]
@@ -2399,7 +2400,7 @@ def test__cli__render_fail():
             ],
         ],
         assert_stdout_contains=(
-            "L:   3 | P:   8 |  TMP | Undefined jinja template " "variable: 'something'"
+            "L:   3 | P:   8 |  TMP | Undefined jinja template variable: 'something'"
         ),
     )
 

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -876,7 +876,7 @@ def test__cli__command_versioning():
     # Get the package version info
     pkg_version = sqlfluff.__version__
     # Get the version info from the config file
-    with open("pyproject.toml", "r") as config_file:
+    with open("pyproject.toml", "r", encoding="utf-8") as config_file:
         config = tomllib.loads(config_file.read())
     config_version = config["project"]["version"]
     assert pkg_version == config_version

--- a/util.py
+++ b/util.py
@@ -204,6 +204,7 @@ def release(new_version_num):
 
     click.echo("Updating plugins/sqlfluff-templater-dbt/pyproject.toml")
     for filename in ["plugins/sqlfluff-templater-dbt/pyproject.toml"]:
+        # NOTE: Toml files are always encoded in UTF-8.
         input_file = open(filename, "r", encoding="utf-8").readlines()
         # Regardless of platform, write newlines as \n
         write_file = open(filename, "w", encoding="utf-8", newline="\n")

--- a/util.py
+++ b/util.py
@@ -204,9 +204,9 @@ def release(new_version_num):
 
     click.echo("Updating plugins/sqlfluff-templater-dbt/pyproject.toml")
     for filename in ["plugins/sqlfluff-templater-dbt/pyproject.toml"]:
-        input_file = open(filename, "r").readlines()
+        input_file = open(filename, "r", encoding="utf-8").readlines()
         # Regardless of platform, write newlines as \n
-        write_file = open(filename, "w", newline="\n")
+        write_file = open(filename, "w", encoding="utf-8", newline="\n")
         for line in input_file:
             if line.startswith("version"):
                 line = f'version = "{new_version_num}"\n'
@@ -222,9 +222,9 @@ def release(new_version_num):
 
     click.echo("Updating pyproject.toml")
     for filename in ["pyproject.toml"]:
-        input_file = open(filename, "r").readlines()
+        input_file = open(filename, "r", encoding="utf-8").readlines()
         # Regardless of platform, write newlines as \n
-        write_file = open(filename, "w", newline="\n")
+        write_file = open(filename, "w", encoding="utf-8", newline="\n")
         for line in input_file:
             for key in keys:
                 if line.startswith(key):


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
As part of the TOML spec, they should always be utf-8 encoded.
- fixes #6208

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
