### PR TITLE
ST11: Fix quoted table name comparisons

### DIFF
--- a/src/sqlfluff/rules/structure/ST11.py
+++ b/src/sqlfluff/rules/structure/ST11.py
@@ -100,7 +100,7 @@ class Rule_ST11(BaseRule):
         for table_reference in segment.recursive_crawl(
             "table_reference", no_recursive_seg_type="select_statement"
         ):
-            return table_reference.segments[-1].raw_upper
+            return table_reference.segments[-1].raw_normalized(casefold=False).upper()
         # If we can't find a reference, just return an empty string
         # to signal that there isn't one. This could be a case of a
         # VALUES clause, or anything else selectable which hasn't

--- a/test/fixtures/rules/std_rule_cases/ST11.yml
+++ b/test/fixtures/rules/std_rule_cases/ST11.yml
@@ -187,3 +187,24 @@ test_mysql_identifier_with_backticks_should_not_except:
   configs:
     core:
       dialect: mysql
+
+test_pass_quoted_table_name:
+  pass_str: |
+    SELECT
+        test.one,
+        "test-2".two
+    FROM test
+    LEFT JOIN "test-2"
+        ON test.id = "test-2".id
+
+test_pass_quoted_brackets_table_name:
+  pass_str: |
+    SELECT
+        test.one,
+        [test-2].two
+    FROM test
+    LEFT JOIN [test-2]
+        ON test.id = [test-2].id
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Builds on #6702 to also check quoted table names.
- fixes #6741

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
