### PR TITLE
CP02, LT01: Fix duplicated elements generated from a `FixPatch` ordering conflict

### DIFF
--- a/src/sqlfluff/core/linter/patch.py
+++ b/src/sqlfluff/core/linter/patch.py
@@ -158,13 +158,15 @@ def _iter_templated_patches(
                     # a consumed element of the source. We can use the tracking
                     # markers from the last segment to recreate where this element
                     # should be inserted in both source and template.
+                    # The slices must never go backwards so the end of the slice must
+                    # be greater than or equal to the start.
                     source_slice=slice(
                         source_idx,
-                        first_segment_pos.source_slice.start,
+                        max(first_segment_pos.source_slice.start, source_idx),
                     ),
                     templated_slice=slice(
                         templated_idx,
-                        first_segment_pos.templated_slice.start,
+                        max(first_segment_pos.templated_slice.start, templated_idx),
                     ),
                     patch_category="mid_point",
                     fixed_raw=insert_buff,

--- a/test/fixtures/rules/std_rule_cases/CP02_LT01.yml
+++ b/test/fixtures/rules/std_rule_cases/CP02_LT01.yml
@@ -1,0 +1,66 @@
+rule: CP02,LT01
+
+# Sanity tests
+test_fail_cp02_fail_lt01:
+  fail_str: SELECT a,B
+  fix_str: SELECT a, b
+
+test_fail_cp02_pass_lt01:
+  fail_str: SELECT a, B
+  fix_str: SELECT a, b
+
+test_pass_cp02_fail_lt01:
+  fail_str: SELECT a,b
+  fix_str: SELECT a, b
+
+test_pass_cp02_pass_lt01:
+  pass_str: SELECT a, b
+
+# `ProblemHere` has two errors in the same location, but templating
+# previously caused issues with fixes. The two fixes should be
+#    1) Uppercase `PROBLEMHERE`
+#    2) Add a space after `PROBLEMHERE` and `(`
+test_fail_fix_cp02_lt01_with_templating_6678:
+  fail_str: |
+    create task ${env}_ENT_LANDING.SCHEMA_NAME.TASK_NAME
+        warehouse=${lnd_hist_wkl_default}
+        schedule='${repl_cdc_schedule}'
+    as
+        COPY INTO ${env}_ENT_LANDING.SCHEMA_NAME.ProblemHere(
+            ONE_OR_MORE_COLUMN_NAMES_HERE
+        )
+        FROM (
+            SELECT
+                *
+            FROM @${env}_ENT_COMMON.GLOBAL.FILEINGESTION_STAGE/file
+        )
+        FILE_FORMAT = (
+            TYPE = JSON
+        )
+        ON_ERROR = 'SKIP_FILE'
+    ;
+  fix_str: |
+    create task ${env}_ENT_LANDING.SCHEMA_NAME.TASK_NAME
+        warehouse = ${lnd_hist_wkl_default}
+        schedule = '${repl_cdc_schedule}'
+    as
+        COPY INTO ${env}_ENT_LANDING.SCHEMA_NAME.PROBLEMHERE (
+            ONE_OR_MORE_COLUMN_NAMES_HERE
+        )
+        FROM (
+            SELECT
+                *
+            FROM @${env}_ENT_COMMON.GLOBAL.FILEINGESTION_STAGE/file
+        )
+        FILE_FORMAT = (
+            TYPE = JSON
+        )
+        ON_ERROR = 'SKIP_FILE'
+    ;
+  configs:
+    core:
+      dialect: snowflake
+      templater: placeholder
+    templater:
+      placeholder:
+        param_style: flyway_var


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This introduces two changes:
1) This corrects when two fixes are applied to the same templated location where `PatchFix` slices were going backwards.
2) Enhances the rules yaml test framework to work with a combination of rules to check namely conflicts between applying multiple rules. This was a bit easier to work with for the placeholder templater than autofix tests.
- fixes #6678

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
