### PR TITLE
BigQuery: Make select replace `AS` not optional

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -1266,9 +1266,11 @@ class ReplaceClauseSegment(BaseSegment):
         "REPLACE",
         Bracketed(
             Delimited(
-                # Not *really* a select target element. It behaves exactly
-                # the same way however.
-                Ref("SelectClauseElementSegment"),
+                Sequence(
+                    Ref("BaseExpressionElementGrammar"),
+                    "AS",
+                    Ref("SingleIdentifierGrammar"),
+                )
             )
         ),
     )

--- a/test/fixtures/dialects/bigquery/select_except.sql
+++ b/test/fixtures/dialects/bigquery/select_except.sql
@@ -1,5 +1,5 @@
 SELECT
-    * EXCEPT (seqnum) REPLACE (foo as bar, baz foobar)
+    * EXCEPT (seqnum) REPLACE (foo as bar, baz as foobar)
 FROM my_tbl;
 
 -- Catch potential bugs in unions

--- a/test/fixtures/dialects/bigquery/select_except.yml
+++ b/test/fixtures/dialects/bigquery/select_except.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 20669da1ec7b2ff521f943c541e2c9f914b4af17af1bc77738eef8c26fb40131
+_hash: 809df08535483e9970a92cfc5e7b1d3d673e476ba396a4982dd4cdd6b28c39f6
 file:
 - statement:
     select_statement:
@@ -23,18 +23,15 @@ file:
               keyword: REPLACE
               bracketed:
               - start_bracket: (
-              - select_clause_element:
-                  column_reference:
-                    naked_identifier: foo
-                  alias_expression:
-                    keyword: as
-                    naked_identifier: bar
+              - column_reference:
+                  naked_identifier: foo
+              - keyword: as
+              - naked_identifier: bar
               - comma: ','
-              - select_clause_element:
-                  column_reference:
-                    naked_identifier: baz
-                  alias_expression:
-                    naked_identifier: foobar
+              - column_reference:
+                  naked_identifier: baz
+              - keyword: as
+              - naked_identifier: foobar
               - end_bracket: )
       from_clause:
         keyword: FROM

--- a/test/fixtures/dialects/bigquery/select_except_replace.yml
+++ b/test/fixtures/dialects/bigquery/select_except_replace.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1029b94a6c6a3783450abc31dd1037028f4c16fdbd9de44f3db8d2c96860ea24
+_hash: f3f5e17ebc64910df81ab35a5f7772de922718281cc1fc1f5a2351cf9391ad9b
 file:
   statement:
     select_statement:
@@ -23,23 +23,21 @@ file:
               keyword: replace
               bracketed:
                 start_bracket: (
-                select_clause_element:
-                  function:
-                    function_name:
-                      function_name_identifier: concat
-                    function_contents:
-                      bracketed:
-                      - start_bracket: (
-                      - expression:
-                          column_reference:
-                            naked_identifier: fruit
-                      - comma: ','
-                      - expression:
-                          quoted_literal: "'berry'"
-                      - end_bracket: )
-                  alias_expression:
-                    keyword: as
-                    naked_identifier: fruit
+                function:
+                  function_name:
+                    function_name_identifier: concat
+                  function_contents:
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        column_reference:
+                          naked_identifier: fruit
+                    - comma: ','
+                    - expression:
+                        quoted_literal: "'berry'"
+                    - end_bracket: )
+                keyword: as
+                naked_identifier: fruit
                 end_bracket: )
       from_clause:
         keyword: from

--- a/test/fixtures/dialects/bigquery/select_replace.yml
+++ b/test/fixtures/dialects/bigquery/select_replace.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c2e5f397744adea51b0abb464fe2d12d5d807ec9b62dfadfaec91d8b49e0f9ad
+_hash: 8dde32d162f5fb4141f9a7861ff0470d6b8cd8198fbf1623a93c9161dc81e0a3
 file:
 - statement:
     select_statement:
@@ -17,22 +17,20 @@ file:
               keyword: REPLACE
               bracketed:
                 start_bracket: (
-                select_clause_element:
-                  function:
-                    function_name:
-                      function_name_identifier: CAST
-                    function_contents:
-                      bracketed:
-                        start_bracket: (
-                        expression:
-                          numeric_literal: '1'
-                        keyword: AS
-                        data_type:
-                          data_type_identifier: BOOLEAN
-                        end_bracket: )
-                  alias_expression:
-                    keyword: AS
-                    naked_identifier: foo
+                function:
+                  function_name:
+                    function_name_identifier: CAST
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        numeric_literal: '1'
+                      keyword: AS
+                      data_type:
+                        data_type_identifier: BOOLEAN
+                      end_bracket: )
+                keyword: AS
+                naked_identifier: foo
                 end_bracket: )
       from_clause:
         keyword: FROM
@@ -63,11 +61,9 @@ file:
               keyword: replace
               bracketed:
                 start_bracket: (
-                select_clause_element:
-                  quoted_literal: "'thing'"
-                  alias_expression:
-                    keyword: as
-                    naked_identifier: foo
+                quoted_literal: "'thing'"
+                keyword: as
+                naked_identifier: foo
                 end_bracket: )
       from_clause:
         keyword: from
@@ -89,21 +85,17 @@ file:
               keyword: REPLACE
               bracketed:
               - start_bracket: (
-              - select_clause_element:
-                  expression:
-                    column_reference:
-                      naked_identifier: quantity
-                    binary_operator: /
-                    numeric_literal: '2'
-                  alias_expression:
-                    keyword: AS
+              - expression:
+                  column_reference:
                     naked_identifier: quantity
+                  binary_operator: /
+                  numeric_literal: '2'
+              - keyword: AS
+              - naked_identifier: quantity
               - comma: ','
-              - select_clause_element:
-                  quoted_literal: "'thing'"
-                  alias_expression:
-                    keyword: as
-                    naked_identifier: foo
+              - quoted_literal: "'thing'"
+              - keyword: as
+              - naked_identifier: foo
               - end_bracket: )
       from_clause:
         keyword: from

--- a/test/fixtures/rules/std_rule_cases/AL02.yml
+++ b/test/fixtures/rules/std_rule_cases/AL02.yml
@@ -129,3 +129,14 @@ test_fail_alias_expression_oracle_columns:
   configs:
     core:
       dialect: oracle
+
+test_pass_bigquery_replace_clause_implicit:
+  pass_str: |
+    select * replace (concat(name, "_new") AS name_test)
+    FROM my_db.test;
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      aliasing.column:
+        aliasing: implicit


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This makes BigQuery's select replace syntax require the `AS` keyword and not remove it from AL02 when set to implicit.
- fixes #6775

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
