### PR TITLE
Fix reserved keywords in Postgres.

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -275,6 +275,7 @@ postgres_dialect.patch_lexer_matchers(
     ]
 )
 
+postgres_dialect.sets("reserved_keywords").clear()
 postgres_dialect.sets("reserved_keywords").update(
     get_keywords(postgres_keywords, "reserved")
 )

--- a/test/fixtures/dialects/postgres/create_table.sql
+++ b/test/fixtures/dialects/postgres/create_table.sql
@@ -366,3 +366,7 @@ CREATE TABLE myschema.user (
     user_id bigint PRIMARY KEY,
     name    varchar(40)
 );
+
+CREATE TABLE my_table (
+  interval  bigint
+);

--- a/test/fixtures/dialects/postgres/create_table.yml
+++ b/test/fixtures/dialects/postgres/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 557b9722dcb9510ef6be202c8d12b4c3a1f21983ecc5faaabaae8761d0917564
+_hash: b29349b7774cc915b3f0c6468b540983be17bb3f4ad438eda3fec36b245bb9e9
 file:
 - statement:
     create_table_statement:
@@ -2462,4 +2462,18 @@ file:
               numeric_literal: '40'
               end_bracket: )
       - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: my_table
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: interval
+        data_type:
+          keyword: bigint
+        end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
Postgres reserved keywords were being set with ansi reserved keywords and updated with dialect reserved keywords. So `INTERVAL`, for example, were considered reserved despite it's `non-reserved-(cannot-be-function-or-type)`.

Closes #4893

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
