### PR TITLE
SparkSQL/Databricks: Support dot sign operator

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -1176,7 +1176,13 @@ class SemiStructuredAccessorSegment(BaseSegment):
 
     type = "semi_structured_expression"
     match_grammar = Sequence(
-        Ref("ColonSegment"),
+        OneOf(
+            # If a field is already a VARIANT, this could
+            # be initiated by a colon or a dot. This is particularly
+            # useful when a field is an ARRAY of objects.
+            Ref("DotSegment"),
+            Ref("ColonSegment"),
+        ),
         OneOf(
             Ref("NakedSemiStructuredElementSegment"),
             Bracketed(Ref("QuotedSemiStructuredElementSegment"), bracket_type="square"),

--- a/test/fixtures/dialects/sparksql/structure_accessor.sql
+++ b/test/fixtures/dialects/sparksql/structure_accessor.sql
@@ -1,0 +1,4 @@
+select
+    struct_column.inner_array[0].foo as inner_array__foo,
+    try_element_at(struct_column.inner_array, 1).foo as inner_array__foo2
+from src;

--- a/test/fixtures/dialects/sparksql/structure_accessor.yml
+++ b/test/fixtures/dialects/sparksql/structure_accessor.yml
@@ -1,0 +1,59 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: cc01280e7aa88ab978133c09b32a61723f86239e3a2ac1dbb7d5050c8f6e8cde
+file:
+  statement:
+    select_statement:
+      select_clause:
+      - keyword: select
+      - select_clause_element:
+          expression:
+            column_reference:
+            - naked_identifier: struct_column
+            - dot: .
+            - naked_identifier: inner_array
+            array_accessor:
+              start_square_bracket: '['
+              numeric_literal: '0'
+              end_square_bracket: ']'
+            semi_structured_expression:
+              dot: .
+              semi_structured_element: foo
+          alias_expression:
+            keyword: as
+            naked_identifier: inner_array__foo
+      - comma: ','
+      - select_clause_element:
+          expression:
+            function:
+              function_name:
+                function_name_identifier: try_element_at
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                    - naked_identifier: struct_column
+                    - dot: .
+                    - naked_identifier: inner_array
+                - comma: ','
+                - expression:
+                    numeric_literal: '1'
+                - end_bracket: )
+            semi_structured_expression:
+              dot: .
+              semi_structured_element: foo
+          alias_expression:
+            keyword: as
+            naked_identifier: inner_array__foo2
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: src
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Support the dot operator for SparkSQL and Databricks.
- fixes #5593

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
