### PR TITLE
CI: mirror image deployment to ghcr.io

### DIFF
--- a/.github/workflows/publish-sqlfluff-docker-image-to-dockerhub.yaml
+++ b/.github/workflows/publish-sqlfluff-docker-image-to-dockerhub.yaml
@@ -13,6 +13,11 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     steps:
       # Get the version of latest release in
       # order to tag published Docker image.
@@ -38,6 +43,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # Authenticate with Container registry
+      - name: Login to Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Build amd64 image to use in the integration test.
       - name: Build and export to Docker
         id: docker_build
@@ -55,7 +68,7 @@ jobs:
           echo "SELECT 1" > test.sql
           docker run --rm -i -v $PWD:/sql ${{ env.TEST_TAG }} lint --dialect ansi /sql/test.sql
 
-      # Build arm64 image (amd64 is cached from docker_build step) and export to DockerHub.
+      # Build arm64 image (amd64 is cached from docker_build step) and export to DockerHub and GHCR.
       # N.B. We tag this image as both latest and with its version number.
       - name: Build and push
         id: docker_build_push
@@ -66,5 +79,15 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/sqlfluff:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/sqlfluff:${{ steps.latest_release.outputs.release }}
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.latest_release.outputs.release }}
           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/sqlfluff:latest
           cache-to: type=inline
+
+      # Add artifact attestation for GHCR
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.docker_build_push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This is a best effort on deploying the release docker images to ghcr.io in addition to docker hub.
The instructions have been replicated from [here](https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-docker-hub-and-github-packages) but still include the cached testing step.
- resolves #6677

### Are there any other side effects of this change that we should be aware of?
This change can't be tested without an actual release (maybe 3.4.0 can be that?) so it may need a revisit if something has been incorrectly configured.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
