### PR TITLE
RF02: Add config for ignoring external references found in subqueries

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -398,6 +398,7 @@ force_enable = False
 # Comma separated list of words to ignore for this rule
 ignore_words = None
 ignore_words_regex = None
+subqueries_ignore_external_references = False
 
 [sqlfluff:rules:references.consistent]
 # References must be consistently used

--- a/src/sqlfluff/rules/references/RF02.py
+++ b/src/sqlfluff/rules/references/RF02.py
@@ -43,6 +43,14 @@ class Rule_RF02(Rule_AL04):
     aliases = ("L027",)
     groups = ("all", "references")
     # Crawl behaviour is defined in AL04
+    config_keywords = [
+        "subqueries_ignore_external_references",
+    ]
+
+    # Config type hints
+    ignore_words_regex: str
+    ignore_words_list: list[str]
+    subqueries_ignore_external_references: bool
 
     def _lint_references_and_aliases(
         self,
@@ -54,9 +62,6 @@ class Rule_RF02(Rule_AL04):
         parent_select: Optional[BaseSegment],
         rule_context: RuleContext,
     ) -> Optional[list[LintResult]]:
-        # Config type hints
-        self.ignore_words_regex: str
-
         if parent_select:
             parent_select_info = get_select_statement_info(
                 parent_select, rule_context.dialect
@@ -70,6 +75,7 @@ class Rule_RF02(Rule_AL04):
                             rule_context.segment
                         )
                         or is_from
+                        or self.subqueries_ignore_external_references
                     ):
                         # Skip the subquery alias itself or if the subquery is inside
                         # of a `from` or `join`` clause that isn't a nested where clause

--- a/src/sqlfluff/rules/references/__init__.py
+++ b/src/sqlfluff/rules/references/__init__.py
@@ -8,6 +8,11 @@ from sqlfluff.core.rules import BaseRule, ConfigInfo
 def get_configs_info() -> dict[str, ConfigInfo]:
     """Get additional rule config validations and descriptions."""
     return {
+        "subqueries_ignore_external_references": {
+            "validation": [True, False],
+            "definition": "If ``True``, parent query references are not included as "
+            "potentially ambiguous in subqueries. Defaults to ``False``.",
+        },
         "single_table_references": {
             "validation": ["consistent", "qualified", "unqualified"],
             "definition": "The expectation for references in single-table select.",

--- a/test/fixtures/rules/std_rule_cases/RF02.yml
+++ b/test/fixtures/rules/std_rule_cases/RF02.yml
@@ -381,12 +381,11 @@ test_pass_ignore_words_regex_column_name:
         ignore_words_regex: ^_
 
 test_pass_ignore_words_regex_bigquery_declare_example:
-  pass_str:
-    DECLARE _test INT64 DEFAULT 42;
+  pass_str: DECLARE _test INT64 DEFAULT 42;
     SELECT _test
     FROM t_table1
     LEFT JOIN t_table_2
-        ON TRUE
+    ON TRUE
   configs:
     core:
       dialect: bigquery
@@ -396,8 +395,7 @@ test_pass_ignore_words_regex_bigquery_declare_example:
 
 test_pass_redshift:
   # This was failing in issue 3380.
-  pass_str:
-    SELECT account.id
+  pass_str: SELECT account.id
     FROM salesforce_sd.account
     INNER JOIN salesforce_sd."user" ON salesforce_sd."user".id = account.ownerid
   configs:
@@ -406,23 +404,22 @@ test_pass_redshift:
 
 test_pass_tsql:
   # This was failing in issue 3342.
-  pass_str:
-    select
-        psc.col1
+  pass_str: select
+    psc.col1
     from
-        tbl1 as psc
+    tbl1 as psc
     where
-        exists
-        (
-            select 1 as data
-            from
-                tbl2 as pr
-            join tbl2 as c on c.cid = pr.cid
-            where
-                c.col1 = 'x'
-                and pr.col2 <= convert(date, getdate())
-                and pr.pid = psc.pid
-        )
+    exists
+    (
+    select 1 as data
+    from
+    tbl2 as pr
+    join tbl2 as c on c.cid = pr.cid
+    where
+    c.col1 = 'x'
+    and pr.col2 <= convert(date, getdate())
+    and pr.pid = psc.pid
+    )
   configs:
     core:
       dialect: tsql
@@ -544,3 +541,59 @@ test_pass_ignore_deeper_alias_6389:
     LEFT JOIN stats_this_month AS tm
       ON tm.x = t.x
     WHERE _stats IS NOT NULL;
+
+test_fail_unqual_refs_multi_table_statements_ignore_external_references:
+  fail_str: |
+    SELECT a, b
+    FROM foo
+    LEFT JOIN vee ON vee.a = foo.a
+  configs:
+    rules:
+      references.qualification:
+        subqueries_ignore_external_references: True
+
+test_fail_unqual_refs_multi_table_statements_subq_ignore_external_references:
+  fail_str: |
+    SELECT a
+    FROM (
+        SELECT a, b
+        FROM foo
+        LEFT JOIN vee ON vee.a = foo.a
+    )
+  configs:
+    rules:
+      references.qualification:
+        subqueries_ignore_external_references: True
+
+test_pass_unreferenced_subquery_column_subqueries_ignore_external_references:
+  pass_str: |
+    SELECT a
+    FROM foo
+    WHERE a IN (SELECT a FROM bar)
+  configs:
+    rules:
+      references.qualification:
+        subqueries_ignore_external_references: True
+
+test_pass_select_scalar_subquery_subqueries_ignore_external_references:
+  pass_str: |
+    SELECT
+        (SELECT max(id) FROM foo2) AS f1
+    FROM bar;
+  configs:
+    rules:
+      references.qualification:
+        subqueries_ignore_external_references: True
+
+test_pass_exists_subquery_subqueries_ignore_external_references:
+  pass_str: |
+    SELECT id
+    FROM bar
+    WHERE EXISTS (
+        SELECT 1 FROM foo2
+        WHERE bar.id = id
+    );
+  configs:
+    rules:
+      references.qualification:
+        subqueries_ignore_external_references: True


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds a configuration to RF02 which gives it a pre-#6091 option for subqueries.
- fixes #6326
- fixes #6557
- ref #6317

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
