### PR TITLE
Housekeeping: snowflake use CommentEqualsClauseSegment everywhere

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -2612,9 +2612,7 @@ class AlterStorageIntegrationSegment(BaseSegment):
                 OneOf(
                     Ref("TagEqualsSegment", optional=True),
                     AnySetOf(
-                        Sequence(
-                            Ref("CommentEqualsClauseSegment"),
-                        ),
+                        Ref("CommentEqualsClauseSegment"),
                         Sequence(
                             "ENABLED",
                             Ref("EqualsSegment"),

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1081,11 +1081,7 @@ class CreateExternalVolumeStatementSegment(BaseSegment):
             Sequence(
                 "ALLOW_WRITES", Ref("EqualsSegment"), Ref("BooleanLiteralGrammar")
             ),
-            Sequence(
-                "COMMENT",
-                Ref("EqualsSegment"),
-                Ref("QuotedLiteralSegment"),
-            ),
+            Ref("CommentEqualsClauseSegment"),
             optional=True,
         ),
     )
@@ -1174,9 +1170,7 @@ class AlterExternalVolumeStatementSegment(BaseSegment):
             ),
             Sequence(
                 "SET",
-                "COMMENT",
-                Ref("EqualsSegment"),
-                Ref("QuotedLiteralSegment"),
+                Ref("CommentEqualsClauseSegment"),
             ),
         ),
     )
@@ -2619,7 +2613,7 @@ class AlterStorageIntegrationSegment(BaseSegment):
                     Ref("TagEqualsSegment", optional=True),
                     AnySetOf(
                         Sequence(
-                            "COMMENT", Ref("EqualsSegment"), Ref("QuotedLiteralSegment")
+                            Ref("CommentEqualsClauseSegment"),
                         ),
                         Sequence(
                             "ENABLED",
@@ -3455,11 +3449,7 @@ class AlterNetworkPolicyStatementSegment(BaseSegment):
                         Ref("EqualsSegment"),
                         Bracketed(Delimited(Ref("QuotedLiteralSegment"))),
                     ),
-                    Sequence(
-                        "COMMENT",
-                        Ref("EqualsSegment"),
-                        Ref("QuotedLiteralSegment"),
-                    ),
+                    Ref("CommentEqualsClauseSegment"),
                 ),
             ),
             Sequence(
@@ -4335,9 +4325,7 @@ class AlterRoleStatementSegment(BaseSegment):
                 OneOf(
                     Ref("RoleReferenceSegment"),
                     Ref("TagEqualsSegment"),
-                    Sequence(
-                        "COMMENT", Ref("EqualsSegment"), Ref("QuotedLiteralSegment")
-                    ),
+                    Ref("CommentEqualsClauseSegment"),
                 ),
             ),
             Sequence(
@@ -4637,12 +4625,7 @@ class DynamicTableOptionsSegment(BaseSegment):
                 Ref("NumericLiteralSegment"),
                 optional=True,
             ),
-            Sequence(
-                "COMMENT",
-                Ref("EqualsSegment"),
-                Ref("QuotedLiteralSegment"),
-                optional=True,
-            ),
+            Ref("CommentEqualsClauseSegment", optional=True),
             Sequence(
                 Ref.keyword("WITH", optional=True),
                 "ROW",
@@ -5001,11 +4984,7 @@ class CreateStatementSegment(BaseSegment):
                 "OUTBOUND",
                 optional=True,
             ),
-            Sequence(
-                "COMMENT",
-                Ref("EqualsSegment"),
-                Ref("QuotedLiteralSegment"),
-            ),
+            Ref("CommentEqualsClauseSegment"),
             # For tags
             Sequence(
                 "ALLOWED_VALUES",
@@ -5090,11 +5069,7 @@ class CreateStatementSegment(BaseSegment):
                     )
                 ),
             ),
-            Sequence(
-                "COMMENT",
-                Ref("EqualsSegment"),
-                Ref("QuotedLiteralSegment"),
-            ),
+            Ref("CommentEqualsClauseSegment"),
         ),
         # Next set are Pipe statements
         # https://docs.snowflake.com/en/sql-reference/sql/create-pipe.html
@@ -5150,10 +5125,8 @@ class CreateStatementSegment(BaseSegment):
                 Ref("DatatypeSegment"),
                 Ref("FunctionAssignerSegment"),
                 Ref("ExpressionSegment"),
-                Sequence(
-                    "COMMENT",
-                    Ref("EqualsSegment"),
-                    Ref("QuotedLiteralSegment"),
+                Ref(
+                    "CommentEqualsClauseSegment",
                     optional=True,
                 ),
                 optional=True,
@@ -5400,11 +5373,7 @@ class AlterViewStatementSegment(BaseSegment):
                 "TO",
                 Ref("TableReferenceSegment"),
             ),
-            Sequence(
-                "COMMENT",
-                Ref("EqualsSegment"),
-                Ref("QuotedLiteralSegment"),
-            ),
+            Ref("CommentEqualsClauseSegment"),
             Sequence(
                 "UNSET",
                 "COMMENT",
@@ -7494,10 +7463,8 @@ class CreateRoleStatementSegment(ansi.CreateRoleStatementSegment):
         "ROLE",
         Ref("IfNotExistsGrammar", optional=True),
         Ref("RoleReferenceSegment"),
-        Sequence(
-            "COMMENT",
-            Ref("EqualsSegment"),
-            Ref("QuotedLiteralSegment"),
+        Ref(
+            "CommentEqualsClauseSegment",
             optional=True,
         ),
     )
@@ -7523,10 +7490,8 @@ class CreateDatabaseRoleStatementSegment(BaseSegment):
             optional=True,
         ),
         Ref("DatabaseRoleReferenceSegment"),
-        Sequence(
-            "COMMENT",
-            Ref("EqualsSegment"),
-            Ref("QuotedLiteralSegment"),
+        Ref(
+            "CommentEqualsClauseSegment",
             optional=True,
         ),
     )
@@ -9122,7 +9087,7 @@ class PasswordPolicyOptionsSegment(BaseSegment):
         Sequence(
             "PASSWORD_HISTORY", Ref("EqualsSegment"), Ref("NumericLiteralSegment")
         ),
-        Sequence("COMMENT", Ref("EqualsSegment"), Ref("QuotedLiteralSegment")),
+        Ref("CommentEqualsClauseSegment"),
     )
 
 
@@ -9231,10 +9196,8 @@ class CreateRowAccessPolicyStatementSegment(BaseSegment):
         "BOOLEAN",
         Ref("FunctionAssignerSegment"),
         Ref("ExpressionSegment"),
-        Sequence(
-            "COMMENT",
-            Ref("EqualsSegment"),
-            Ref("QuotedLiteralSegment"),
+        Ref(
+            "CommentEqualsClauseSegment",
             optional=True,
         ),
     )
@@ -9306,9 +9269,7 @@ class AlterTagStatementSegment(BaseSegment):
             ),
             Sequence(
                 "SET",
-                "COMMENT",
-                Ref("EqualsSegment"),
-                Ref("QuotedLiteralSegment"),
+                Ref("CommentEqualsClauseSegment"),
             ),
             Sequence("UNSET", "COMMENT"),
             Sequence(
@@ -9460,10 +9421,8 @@ class CreateAuthenticationPolicySegment(BaseSegment):
             ),
             optional=True,
         ),
-        Sequence(
-            "COMMENT",
-            Ref("EqualsSegment"),
-            Ref("QuotedLiteralSegment"),
+        Ref(
+            "CommentEqualsClauseSegment",
             optional=True,
         ),
     )

--- a/test/fixtures/dialects/snowflake/alter_external_volume.yml
+++ b/test/fixtures/dialects/snowflake/alter_external_volume.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 05de2d1cd77835b8aa9645b33d09ec595f068c0b16fba8541a8268f21fb1814b
+_hash: bc44ab2007eafd2710d91e23551e649b97f73c181224c8d4eb43b90fc7e467e2
 file:
 - statement:
     alter_external_volume_statement:
@@ -128,8 +128,9 @@ file:
     - external_volume_reference:
         naked_identifier: exvol6
     - keyword: SET
-    - keyword: COMMENT
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'bar'"
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'bar'"
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/alter_role.yml
+++ b/test/fixtures/dialects/snowflake/alter_role.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 72a427cac4910bd00b0e70ccbc8fea04c0d16f25ddc293b83871cfb5d25b05d3
+_hash: 3e52792e1563a049414bc40d0ffbc5e02825ae4380e9f13f6de7ce3fddaec143
 file:
 - statement:
     alter_role_statement:
@@ -38,10 +38,11 @@ file:
     - role_reference:
         quoted_identifier: '"test_role"'
     - keyword: SET
-    - keyword: COMMENT
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'test_comment'"
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'test_comment'"
 - statement_terminator: ;
 - statement:
     alter_role_statement:
@@ -62,10 +63,11 @@ file:
     - role_reference:
         quoted_identifier: '"test_role"'
     - keyword: SET
-    - keyword: COMMENT
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'test_comment'"
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'test_comment'"
 - statement_terminator: ;
 - statement:
     alter_role_statement:

--- a/test/fixtures/dialects/snowflake/alter_storage_integration.yml
+++ b/test/fixtures/dialects/snowflake/alter_storage_integration.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9f3c2e27d2d0d69837f87b5cf9864a70a48856d013b05649a9170d67acfde55d
+_hash: 35e5da93d81b34c2fdcafb0dac843742e9c1d2cdef535e372b98f5792ac7f6a9
 file:
 - statement:
     alter_storage_integration_statement:
@@ -51,10 +51,11 @@ file:
     - object_reference:
         naked_identifier: test_integration
     - keyword: set
-    - keyword: comment
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'test comment'"
+    - comment_equals_clause:
+        keyword: comment
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'test comment'"
 - statement_terminator: ;
 - statement:
     alter_storage_integration_statement:
@@ -153,10 +154,11 @@ file:
     - comparison_operator:
         raw_comparison_operator: '='
     - boolean_literal: 'false'
-    - keyword: comment
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'test comment'"
+    - comment_equals_clause:
+        keyword: comment
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'test comment'"
 - statement_terminator: ;
 - statement:
     alter_storage_integration_statement:
@@ -166,10 +168,11 @@ file:
     - object_reference:
         naked_identifier: test_integration
     - keyword: set
-    - keyword: comment
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'test comment'"
+    - comment_equals_clause:
+        keyword: comment
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'test comment'"
     - keyword: enabled
     - comparison_operator:
         raw_comparison_operator: '='
@@ -395,10 +398,11 @@ file:
     - comparison_operator:
         raw_comparison_operator: '='
     - boolean_literal: 'true'
-    - keyword: comment
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'test_comment'"
+    - comment_equals_clause:
+        keyword: comment
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'test_comment'"
     - keyword: azure_tenant_id
     - comparison_operator:
         raw_comparison_operator: '='
@@ -434,10 +438,11 @@ file:
     - comparison_operator:
         raw_comparison_operator: '='
     - boolean_literal: 'true'
-    - keyword: comment
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'test_comment'"
+    - comment_equals_clause:
+        keyword: comment
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'test_comment'"
     - keyword: azure_tenant_id
     - comparison_operator:
         raw_comparison_operator: '='

--- a/test/fixtures/dialects/snowflake/alter_tag.yml
+++ b/test/fixtures/dialects/snowflake/alter_tag.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7b9e5f58760c35358fe11c2fb3a57d0d6bf04160c13d3a842964a094a0f02e26
+_hash: 7b7e09a56344fdadd7ff393c05e13cddb05a33287681857b0038fc55a9d08568
 file:
 - statement:
     alter_tag_statement:
@@ -66,10 +66,11 @@ file:
     - object_reference:
         naked_identifier: my_tag
     - keyword: SET
-    - keyword: COMMENT
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'this is a comment'"
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'this is a comment'"
 - statement_terminator: ;
 - statement:
     alter_tag_statement:

--- a/test/fixtures/dialects/snowflake/create_authentication_policy.yml
+++ b/test/fixtures/dialects/snowflake/create_authentication_policy.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: a37eed13c4e996a62daade20220a7dbd0965899a21e34ba0dbc91afaf31accd7
+_hash: b73622a91d7a9173dec58202c397d9f7d4f6398452635a47083b14e0a9734ece
 file:
 - statement:
     create_authentication_policy_segment:
@@ -37,10 +37,11 @@ file:
         start_bracket: (
         quoted_literal: "'MY CLIENT'"
         end_bracket: )
-    - keyword: COMMENT
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'My Comment'"
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'My Comment'"
 - statement_terminator: ;
 - statement:
     create_authentication_policy_segment:
@@ -74,10 +75,11 @@ file:
       - comma: ','
       - quoted_literal: "'CLIENT3'"
       - end_bracket: )
-    - keyword: COMMENT
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'My Comment'"
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'My Comment'"
 - statement_terminator: ;
 - statement:
     create_authentication_policy_segment:

--- a/test/fixtures/dialects/snowflake/create_database_role.yml
+++ b/test/fixtures/dialects/snowflake/create_database_role.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8a192cf4ddea53c091d92c24c2029bf1f3807a87327ab497edf6edaf66c2416f
+_hash: 2dac87062d52be47a7568a5591a3369107ef10111e5e26163cdaa3ef442a3bcf
 file:
   statement:
     create_database_role_statement:
@@ -14,8 +14,9 @@ file:
       - naked_identifier: dbname
       - dot: .
       - naked_identifier: rolename
-    - keyword: comment
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'TEST'"
+    - comment_equals_clause:
+        keyword: comment
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'TEST'"
   statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/create_external_volume.yml
+++ b/test/fixtures/dialects/snowflake/create_external_volume.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 861917033a0396ca619e966ac8613948f40da6abd4e20da929922ecb70c31bb9
+_hash: 572872fae9805707446ef60b04cef039d009100f4fab83822c2cb737db89cda5
 file:
 - statement:
     create_external_volume_statement:
@@ -217,8 +217,9 @@ file:
     - comparison_operator:
         raw_comparison_operator: '='
     - boolean_literal: 'FALSE'
-    - keyword: COMMENT
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'foo'"
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'foo'"
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/create_masking_policy.yml
+++ b/test/fixtures/dialects/snowflake/create_masking_policy.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 80f1ee6bb943bc6446afcaa2e00ae561c4e53cc8dee22b077b6b7a38361a178c
+_hash: 60f2b250052508638be20535891e603154d98f2225929da658b052f847e92d98
 file:
 - statement:
     create_statement:
@@ -57,10 +57,11 @@ file:
             expression:
               quoted_literal: "'*** masked ***'"
         - keyword: END
-    - keyword: COMMENT
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'Applied 2021-07-13T03:12:16+0000'"
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'Applied 2021-07-13T03:12:16+0000'"
 - statement_terminator: ;
 - statement:
     create_statement:

--- a/test/fixtures/dialects/snowflake/create_network_policy.yml
+++ b/test/fixtures/dialects/snowflake/create_network_policy.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9315b4c172e0bf1ae67125034ad97c68730a35c856061ebdd6fe8a0fe9aaaaf7
+_hash: 92c0ae839885d5230a2f065196d23739a40abd13903e5cc388c05b5e088332ac
 file:
 - statement:
     create_statement:
@@ -45,8 +45,9 @@ file:
       - comma: ','
       - quoted_literal: "'xx.xxx.xxx.xx/xx'"
       - end_bracket: )
-    - keyword: COMMENT
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'NW Policy'"
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'NW Policy'"
 - statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/create_password_policy.yml
+++ b/test/fixtures/dialects/snowflake/create_password_policy.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1711ef9e400577a3a50786f2de939de3cfa8ee35d2a5bc1d747d1d023a339994
+_hash: eda717b7d78108ee06856e29dd606bcb35973bc9fa331ef0abd59a25c36de756
 file:
   statement:
     create_password_policy_statement:
@@ -57,8 +57,9 @@ file:
       - comparison_operator:
           raw_comparison_operator: '='
       - numeric_literal: '5'
-      - keyword: COMMENT
-      - comparison_operator:
-          raw_comparison_operator: '='
-      - quoted_literal: "'production account password policy'"
+      - comment_equals_clause:
+          keyword: COMMENT
+          comparison_operator:
+            raw_comparison_operator: '='
+          quoted_literal: "'production account password policy'"
   statement_terminator: ;

--- a/test/fixtures/dialects/snowflake/create_role.yml
+++ b/test/fixtures/dialects/snowflake/create_role.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3eab60ef429df6fbba1b03306b4474806b4e1cfd54dc11d73c2b4ef8b8265145
+_hash: cdb3e0a8052a94e2279df9bd1077936dbe71d6aecc59ef44399dea2a84dbe275
 file:
 - statement:
     create_role_statement:
@@ -30,10 +30,11 @@ file:
     - keyword: EXISTS
     - role_reference:
         naked_identifier: foo_role
-    - keyword: COMMENT
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'this is a fake role'"
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'this is a fake role'"
 - statement_terminator: ;
 - statement:
     create_role_statement:

--- a/test/fixtures/dialects/snowflake/create_row_access_policy.yml
+++ b/test/fixtures/dialects/snowflake/create_row_access_policy.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 1a0a2037d2d40af831eadf08d1c019c8b05d457e56b4559ead0c4fbe00a339a2
+_hash: f5a47e570e363960aee0787bdb9dcebb1e1cf7fd52ef4594ad7d1e2ba226b51c
 file:
 - statement:
     create_row_access_policy_statement:
@@ -103,10 +103,11 @@ file:
     - function_assigner: ->
     - expression:
         boolean_literal: 'TRUE'
-    - keyword: COMMENT
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'My Comment'"
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'My Comment'"
 - statement_terminator: ;
 - statement:
     create_row_access_policy_statement:
@@ -149,10 +150,11 @@ file:
     - function_assigner: ->
     - expression:
         boolean_literal: 'TRUE'
-    - keyword: COMMENT
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'My Comment'"
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'My Comment'"
 - statement_terminator: ;
 - statement:
     create_row_access_policy_statement:

--- a/test/fixtures/dialects/snowflake/create_tag.yml
+++ b/test/fixtures/dialects/snowflake/create_tag.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 88d5bd2ded5ad8524417efc8f9ec4266186eae436ee5498dabf35c9b969f4813
+_hash: b39b68de1c5c556619b129e5d9b0b2fe7d062a37c4c514a4a85796d8b097dbf6
 file:
 - statement:
     create_statement:
@@ -23,10 +23,11 @@ file:
     - keyword: TAG
     - object_reference:
         naked_identifier: cost_center
-    - keyword: COMMENT
-    - comparison_operator:
-        raw_comparison_operator: '='
-    - quoted_literal: "'cost_center tag'"
+    - comment_equals_clause:
+        keyword: COMMENT
+        comparison_operator:
+          raw_comparison_operator: '='
+        quoted_literal: "'cost_center tag'"
 - statement_terminator: ;
 - statement:
     create_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Use the CommentEqualsClauseSegment everywhere where it should be used 

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
