### PR TITLE
add ERROR_INTEGRATION to AlterPipeSegment

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -5937,6 +5937,11 @@ class AlterPipeSegment(BaseSegment):
                         Ref("EqualsSegment"),
                         Ref("BooleanLiteralGrammar"),
                     ),
+                    Sequence(
+                        "ERROR_INTEGRATION",
+                        Ref("EqualsSegment"),
+                        Ref("ObjectReferenceSegment"),
+                    ),
                     Ref("CommentEqualsClauseSegment"),
                 ),
             ),

--- a/test/fixtures/dialects/snowflake/alter_pipe.sql
+++ b/test/fixtures/dialects/snowflake/alter_pipe.sql
@@ -7,3 +7,4 @@ alter pipe mypipe set tag tag1 = 'value1', tag2 = 'value2';
 alter pipe mypipe unset pipe_execution_paused;
 alter pipe mypipe unset comment;
 alter pipe mypipe unset tag foo, bar;
+ALTER PIPE mypipe SET ERROR_INTEGRATION = my_notification_int;

--- a/test/fixtures/dialects/snowflake/alter_pipe.yml
+++ b/test/fixtures/dialects/snowflake/alter_pipe.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e420ce149b11c2ab44311a50476ee4c4f43a319f0b7b6a34155d1edc20d13011
+_hash: 9361058c94dc65161117f7795acc1bc937847abad8dd7e4aa24f35d559dbd493
 file:
 - statement:
     alter_pipe_segment:
@@ -125,4 +125,17 @@ file:
     - comma: ','
     - tag_reference:
         naked_identifier: bar
+- statement_terminator: ;
+- statement:
+    alter_pipe_segment:
+    - keyword: ALTER
+    - keyword: PIPE
+    - object_reference:
+        naked_identifier: mypipe
+    - keyword: SET
+    - keyword: ERROR_INTEGRATION
+    - comparison_operator:
+        raw_comparison_operator: '='
+    - object_reference:
+        naked_identifier: my_notification_int
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

closes #6770

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
