### PR TITLE
Clickhouse: support more complex types and functions in table definition

### DIFF
--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -518,12 +518,12 @@ class DatatypeSegment(BaseSegment):
         ),
         # LowCardinality(Type)
         Sequence(
-            StringParser("LowCardinality", CodeSegment, type="data_type_identifier"),
+            StringParser("LOWCARDINALITY", CodeSegment, type="data_type_identifier"),
             Bracketed(Ref("DatatypeSegment")),
         ),
         # DateTime64(precision, 'timezone')
         Sequence(
-            StringParser("DateTime64", CodeSegment, type="data_type_identifier"),
+            StringParser("DATETIME64", CodeSegment, type="data_type_identifier"),
             Bracketed(
                 Delimited(
                     OneOf(
@@ -537,7 +537,7 @@ class DatatypeSegment(BaseSegment):
         ),
         # DateTime('timezone')
         Sequence(
-            StringParser("DateTime", CodeSegment, type="data_type_identifier"),
+            StringParser("DATETIME", CodeSegment, type="data_type_identifier"),
             Bracketed(
                 Ref("QuotedLiteralSegment"),  # timezone
                 optional=True,
@@ -545,17 +545,17 @@ class DatatypeSegment(BaseSegment):
         ),
         # FixedString(length)
         Sequence(
-            StringParser("FixedString", CodeSegment, type="data_type_identifier"),
+            StringParser("FIXEDSTRING", CodeSegment, type="data_type_identifier"),
             Bracketed(Ref("NumericLiteralSegment")),  # length
         ),
         # Array(Type)
         Sequence(
-            StringParser("Array", CodeSegment, type="data_type_identifier"),
+            StringParser("ARRQY", CodeSegment, type="data_type_identifier"),
             Bracketed(Ref("DatatypeSegment")),
         ),
         # Map(KeyType, ValueType)
         Sequence(
-            StringParser("Map", CodeSegment, type="data_type_identifier"),
+            StringParser("MAP", CodeSegment, type="data_type_identifier"),
             Bracketed(
                 Delimited(
                     Ref("DatatypeSegment"),
@@ -565,7 +565,7 @@ class DatatypeSegment(BaseSegment):
         ),
         # Tuple(Type1, Type2) or Tuple(name1 Type1, name2 Type2)
         Sequence(
-            StringParser("Tuple", CodeSegment, type="data_type_identifier"),
+            StringParser("TUPLE", CodeSegment, type="data_type_identifier"),
             Bracketed(
                 Delimited(
                     OneOf(
@@ -586,7 +586,7 @@ class DatatypeSegment(BaseSegment):
         ),
         # Nested(name1 Type1, name2 Type2)
         Sequence(
-            StringParser("Nested", CodeSegment, type="data_type_identifier"),
+            StringParser("NESTED", CodeSegment, type="data_type_identifier"),
             Bracketed(
                 Delimited(
                     Sequence(
@@ -602,8 +602,8 @@ class DatatypeSegment(BaseSegment):
         # Enum8('val1' = 1, 'val2' = 2)
         Sequence(
             OneOf(
-                StringParser("Enum8", CodeSegment, type="data_type_identifier"),
-                StringParser("Enum16", CodeSegment, type="data_type_identifier"),
+                StringParser("ENUM8", CodeSegment, type="data_type_identifier"),
+                StringParser("ENUM16", CodeSegment, type="data_type_identifier"),
             ),
             Bracketed(
                 Delimited(

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -513,7 +513,7 @@ class DatatypeSegment(BaseSegment):
     match_grammar = OneOf(
         # Nullable(Type)
         Sequence(
-            StringParser("Nullable", CodeSegment, type="data_type_identifier"),
+            StringParser("NULLABLE", CodeSegment, type="data_type_identifier"),
             Bracketed(Ref("DatatypeSegment")),
         ),
         # LowCardinality(Type)

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -550,7 +550,7 @@ class DatatypeSegment(BaseSegment):
         ),
         # Array(Type)
         Sequence(
-            StringParser("ARRQY", CodeSegment, type="data_type_identifier"),
+            StringParser("ARRAY", CodeSegment, type="data_type_identifier"),
             Bracketed(Ref("DatatypeSegment")),
         ),
         # Map(KeyType, ValueType)

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -1313,10 +1313,30 @@ class CreateMaterializedViewStatementSegment(BaseSegment):
             Sequence(
                 "TO",
                 Ref("TableReferenceSegment"),
+                # Add support for column list in TO clause
+                Bracketed(
+                    Delimited(
+                        Ref("SingleIdentifierGrammar"),
+                    ),
+                    optional=True,
+                ),
                 Ref("TableEngineSegment", optional=True),
             ),
             Sequence(
                 Ref("TableEngineSegment", optional=True),
+                # Add support for PARTITION BY clause
+                Sequence(
+                    "PARTITION",
+                    "BY",
+                    Ref("ExpressionSegment"),
+                    optional=True,
+                ),
+                # Add support for ORDER BY clause
+                Ref("MergeTreesOrderByClauseSegment", optional=True),
+                # Add support for TTL clause
+                Ref("TableTTLSegment", optional=True),
+                # Add support for SETTINGS clause
+                Ref("SettingsClauseSegment", optional=True),
                 Sequence("POPULATE", optional=True),
             ),
         ),

--- a/src/sqlfluff/dialects/dialect_clickhouse.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse.py
@@ -511,9 +511,110 @@ class DatatypeSegment(BaseSegment):
 
     type = "data_type"
     match_grammar = OneOf(
+        # Nullable(Type)
         Sequence(
-            StringParser("NULLABLE", CodeSegment, type="data_type_identifier"),
+            StringParser("Nullable", CodeSegment, type="data_type_identifier"),
             Bracketed(Ref("DatatypeSegment")),
+        ),
+        # LowCardinality(Type)
+        Sequence(
+            StringParser("LowCardinality", CodeSegment, type="data_type_identifier"),
+            Bracketed(Ref("DatatypeSegment")),
+        ),
+        # DateTime64(precision, 'timezone')
+        Sequence(
+            StringParser("DateTime64", CodeSegment, type="data_type_identifier"),
+            Bracketed(
+                Delimited(
+                    OneOf(
+                        Ref("NumericLiteralSegment"),  # precision
+                        Ref("QuotedLiteralSegment"),  # timezone
+                    ),
+                    delimiter=Ref("CommaSegment"),
+                    optional=True,
+                )
+            ),
+        ),
+        # DateTime('timezone')
+        Sequence(
+            StringParser("DateTime", CodeSegment, type="data_type_identifier"),
+            Bracketed(
+                Ref("QuotedLiteralSegment"),  # timezone
+                optional=True,
+            ),
+        ),
+        # FixedString(length)
+        Sequence(
+            StringParser("FixedString", CodeSegment, type="data_type_identifier"),
+            Bracketed(Ref("NumericLiteralSegment")),  # length
+        ),
+        # Array(Type)
+        Sequence(
+            StringParser("Array", CodeSegment, type="data_type_identifier"),
+            Bracketed(Ref("DatatypeSegment")),
+        ),
+        # Map(KeyType, ValueType)
+        Sequence(
+            StringParser("Map", CodeSegment, type="data_type_identifier"),
+            Bracketed(
+                Delimited(
+                    Ref("DatatypeSegment"),
+                    delimiter=Ref("CommaSegment"),
+                )
+            ),
+        ),
+        # Tuple(Type1, Type2) or Tuple(name1 Type1, name2 Type2)
+        Sequence(
+            StringParser("Tuple", CodeSegment, type="data_type_identifier"),
+            Bracketed(
+                Delimited(
+                    OneOf(
+                        # Named tuple element: name Type
+                        Sequence(
+                            OneOf(
+                                Ref("SingleIdentifierGrammar"),
+                                Ref("QuotedIdentifierSegment"),
+                            ),
+                            Ref("DatatypeSegment"),
+                        ),
+                        # Regular tuple element: just Type
+                        Ref("DatatypeSegment"),
+                    ),
+                    delimiter=Ref("CommaSegment"),
+                )
+            ),
+        ),
+        # Nested(name1 Type1, name2 Type2)
+        Sequence(
+            StringParser("Nested", CodeSegment, type="data_type_identifier"),
+            Bracketed(
+                Delimited(
+                    Sequence(
+                        Ref("SingleIdentifierGrammar"),
+                        Ref("DatatypeSegment"),
+                    ),
+                    delimiter=Ref("CommaSegment"),
+                )
+            ),
+        ),
+        # JSON data type
+        StringParser("JSON", CodeSegment, type="data_type_identifier"),
+        # Enum8('val1' = 1, 'val2' = 2)
+        Sequence(
+            OneOf(
+                StringParser("Enum8", CodeSegment, type="data_type_identifier"),
+                StringParser("Enum16", CodeSegment, type="data_type_identifier"),
+            ),
+            Bracketed(
+                Delimited(
+                    Sequence(
+                        Ref("QuotedLiteralSegment"),
+                        Ref("EqualsSegment"),
+                        Ref("NumericLiteralSegment"),
+                    ),
+                    delimiter=Ref("CommaSegment"),
+                )
+            ),
         ),
         # double args
         Sequence(
@@ -1840,6 +1941,11 @@ class AlterTableStatementSegment(BaseSegment):
                             optional=True,
                         ),
                         Sequence(
+                            "ALIAS",
+                            Ref("ExpressionSegment"),
+                            optional=True,
+                        ),
+                        Sequence(
                             "CODEC",
                             Bracketed(
                                 Delimited(
@@ -1847,6 +1953,7 @@ class AlterTableStatementSegment(BaseSegment):
                                         Ref("FunctionSegment"),
                                         Ref("SingleIdentifierGrammar"),
                                     ),
+                                    delimiter=Ref("CommaSegment"),
                                 ),
                             ),
                             optional=True,
@@ -1866,6 +1973,11 @@ class AlterTableStatementSegment(BaseSegment):
                             optional=True,
                         ),
                         Sequence(
+                            "ALIAS",
+                            Ref("ExpressionSegment"),
+                            optional=True,
+                        ),
+                        Sequence(
                             "CODEC",
                             Bracketed(
                                 Delimited(
@@ -1873,6 +1985,7 @@ class AlterTableStatementSegment(BaseSegment):
                                         Ref("FunctionSegment"),
                                         Ref("SingleIdentifierGrammar"),
                                     ),
+                                    delimiter=Ref("CommaSegment"),
                                 ),
                             ),
                             optional=True,
@@ -1882,6 +1995,11 @@ class AlterTableStatementSegment(BaseSegment):
                     Sequence(
                         "ALIAS",
                         Ref("ExpressionSegment"),
+                    ),
+                    # Remove alias
+                    Sequence(
+                        "REMOVE",
+                        "ALIAS",
                     ),
                     # Remove property
                     Sequence(
@@ -1954,6 +2072,12 @@ class AlterTableStatementSegment(BaseSegment):
                 "MODIFY",
                 "TTL",
                 Ref("ExpressionSegment"),
+            ),
+            # ALTER TABLE ... MODIFY QUERY select_statement
+            Sequence(
+                "MODIFY",
+                "QUERY",
+                Ref("SelectStatementSegment"),
             ),
             # ALTER TABLE ... MATERIALIZE COLUMN col
             Sequence(
@@ -2076,5 +2200,65 @@ class IntervalExpressionSegment(BaseSegment):
                 Ref("ExpressionSegment"),
                 Ref("DatetimeUnitSegment"),
             ),
+        ),
+    )
+
+
+class ColumnDefinitionSegment(BaseSegment):
+    """A column definition, e.g. for CREATE TABLE or ALTER TABLE.
+
+    Supports ClickHouse specific options like CODEC, ALIAS, MATERIALIZED, etc.
+    """
+
+    type = "column_definition"
+    match_grammar = Sequence(
+        OneOf(
+            Ref("SingleIdentifierGrammar"),
+            Ref("QuotedIdentifierSegment"),
+        ),
+        Ref("DatatypeSegment"),
+        AnyNumberOf(
+            OneOf(
+                # DEFAULT expression
+                Sequence(
+                    "DEFAULT",
+                    OneOf(
+                        Ref("LiteralGrammar"),
+                        Ref("FunctionSegment"),
+                        Ref("ExpressionSegment"),
+                    ),
+                ),
+                # ALIAS expression
+                Sequence(
+                    "ALIAS",
+                    Ref("ExpressionSegment"),
+                ),
+                # MATERIALIZED expression
+                Sequence(
+                    "MATERIALIZED",
+                    Ref("ExpressionSegment"),
+                ),
+                # CODEC(...)
+                Sequence(
+                    "CODEC",
+                    Bracketed(
+                        Delimited(
+                            OneOf(
+                                Ref("FunctionSegment"),
+                                Ref("SingleIdentifierGrammar"),
+                            ),
+                            delimiter=Ref("CommaSegment"),
+                        ),
+                    ),
+                ),
+                # COMMENT 'text'
+                Sequence(
+                    "COMMENT",
+                    Ref("QuotedLiteralSegment"),
+                ),
+                # Column constraint
+                Ref("ColumnConstraintSegment"),
+            ),
+            optional=True,
         ),
     )

--- a/src/sqlfluff/dialects/dialect_clickhouse_keywords.py
+++ b/src/sqlfluff/dialects/dialect_clickhouse_keywords.py
@@ -227,6 +227,7 @@ UNRESERVED_KEYWORDS = [
     "PROFILE",
     "PROJECTION",
     "QUARTER",
+    "QUERY",
     "QUOTA",
     "QUEUES",
     "RANGE",

--- a/test/fixtures/dialects/clickhouse/alter_table.sql
+++ b/test/fixtures/dialects/clickhouse/alter_table.sql
@@ -80,3 +80,38 @@ ALTER TABLE table_with_ttl MODIFY COLUMN column_ttl REMOVE TTL;
 ALTER TABLE table_with_ttl REMOVE TTL;
 ALTER TABLE table_with_ttl ON CLUSTER '{cluster}' REMOVE TTL;
 ALTER TABLE table_name ON CLUSTER '{cluster}' MODIFY TTL event_time + INTERVAL 3 MONTH;
+
+-- ALIAS examples
+ALTER TABLE x ADD COLUMN y Int32 ALIAS z + 10;
+ALTER TABLE x ON CLUSTER '{cluster}' ADD COLUMN IF NOT EXISTS y Float32 ALIAS z * 100;
+ALTER TABLE x MODIFY COLUMN y ALIAS z/10;
+ALTER TABLE x ON CLUSTER '{cluster}' MODIFY COLUMN y REMOVE ALIAS;
+
+-- Basic ALTER TABLE MODIFY QUERY examples
+ALTER TABLE mv MODIFY QUERY SELECT * FROM source_table;
+ALTER TABLE mv MODIFY QUERY SELECT id, name, value FROM source_table WHERE value > 0;
+
+-- With ON CLUSTER clause
+ALTER TABLE mv ON CLUSTER cluster1 MODIFY QUERY SELECT * FROM source_table;
+ALTER TABLE mv ON CLUSTER '{cluster}' MODIFY QUERY SELECT id, name, value FROM source_table WHERE value > 0;
+
+-- With complex SELECT queries
+ALTER TABLE mv MODIFY QUERY
+  SELECT
+    id,
+    name,
+    sum(value) AS total_value
+  FROM source_table
+  GROUP BY id, name
+  HAVING total_value > 100
+  ORDER BY total_value DESC
+  LIMIT 10;
+
+ALTER TABLE mv MODIFY QUERY
+  SELECT
+    t1.id,
+    t1.name,
+    t2.value
+  FROM table1 AS t1
+  JOIN table2 AS t2 ON t1.id = t2.id
+  WHERE t1.active = 1;

--- a/test/fixtures/dialects/clickhouse/alter_table.yml
+++ b/test/fixtures/dialects/clickhouse/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d13e5dbd1716f833df92c8268c5452161c23cad664cd7deb617d3b1a510ab37e
+_hash: 6c74d5cb6edddf1b5bf34c872d6f03bf07f8f237ce3301fb2f15e84c520cedec
 file:
 - statement:
     alter_table_statement:
@@ -931,4 +931,347 @@ file:
           keyword: INTERVAL
           numeric_literal: '3'
           date_part: MONTH
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: x
+    - keyword: ADD
+    - keyword: COLUMN
+    - naked_identifier: y
+    - data_type:
+        data_type_identifier: Int32
+    - keyword: ALIAS
+    - expression:
+        column_reference:
+          naked_identifier: z
+        binary_operator: +
+        numeric_literal: '10'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: x
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - quoted_identifier: "'{cluster}'"
+    - keyword: ADD
+    - keyword: COLUMN
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - naked_identifier: y
+    - data_type:
+        data_type_identifier: Float32
+    - keyword: ALIAS
+    - expression:
+        column_reference:
+          naked_identifier: z
+        binary_operator: '*'
+        numeric_literal: '100'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: x
+    - keyword: MODIFY
+    - keyword: COLUMN
+    - naked_identifier: y
+    - keyword: ALIAS
+    - expression:
+        column_reference:
+          naked_identifier: z
+        binary_operator: /
+        numeric_literal: '10'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: x
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - quoted_identifier: "'{cluster}'"
+    - keyword: MODIFY
+    - keyword: COLUMN
+    - naked_identifier: y
+    - keyword: REMOVE
+    - keyword: ALIAS
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: mv
+    - keyword: MODIFY
+    - keyword: QUERY
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: mv
+    - keyword: MODIFY
+    - keyword: QUERY
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: value
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: value
+            comparison_operator:
+              raw_comparison_operator: '>'
+            numeric_literal: '0'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: mv
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: cluster1
+    - keyword: MODIFY
+    - keyword: QUERY
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: mv
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - quoted_identifier: "'{cluster}'"
+    - keyword: MODIFY
+    - keyword: QUERY
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: value
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+              naked_identifier: value
+            comparison_operator:
+              raw_comparison_operator: '>'
+            numeric_literal: '0'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: mv
+    - keyword: MODIFY
+    - keyword: QUERY
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: sum
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: value
+                  end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: total_value
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            naked_identifier: id
+        - comma: ','
+        - column_reference:
+            naked_identifier: name
+        having_clause:
+          keyword: HAVING
+          expression:
+            column_reference:
+              naked_identifier: total_value
+            comparison_operator:
+              raw_comparison_operator: '>'
+            numeric_literal: '100'
+        orderby_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: total_value
+        - keyword: DESC
+        limit_clause:
+          keyword: LIMIT
+          limit_clause_component:
+            numeric_literal: '10'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: mv
+    - keyword: MODIFY
+    - keyword: QUERY
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: t1
+            - dot: .
+            - naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: t1
+            - dot: .
+            - naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: t2
+            - dot: .
+            - naked_identifier: value
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: table1
+              alias_expression:
+                keyword: AS
+                naked_identifier: t1
+            join_clause:
+              keyword: JOIN
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: table2
+                alias_expression:
+                  keyword: AS
+                  naked_identifier: t2
+              join_on_condition:
+                keyword: 'ON'
+                expression:
+                - column_reference:
+                  - naked_identifier: t1
+                  - dot: .
+                  - naked_identifier: id
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                  - naked_identifier: t2
+                  - dot: .
+                  - naked_identifier: id
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+            - naked_identifier: t1
+            - dot: .
+            - naked_identifier: active
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '1'
 - statement_terminator: ;

--- a/test/fixtures/dialects/clickhouse/complex_table_definition.sql
+++ b/test/fixtures/dialects/clickhouse/complex_table_definition.sql
@@ -1,0 +1,76 @@
+
+CREATE TABLE db_name.table_name
+(
+    -- Basic types
+    `id` UInt64,
+    `timestamp` DateTime64(3, 'UTC') CODEC(Delta(8), LZ4),
+    `value_raw` Float32,
+
+    -- LowCardinality type
+    `category` LowCardinality(String),
+
+    -- Enum type
+    `status` Enum8('ACTIVE' = 1, 'INACTIVE' = 2, 'PENDING' = 3),
+
+    -- Nullable type
+    `description` Nullable(String),
+
+    -- Array type
+    `tags` Array(String),
+
+    -- ALIAS column
+    `value_calculated` Float32 ALIAS value_raw / (3600 / 30),
+    `flag_active` Int8 ALIAS if(status = 'ACTIVE', 1, 0),
+    `value_with_dict` Float32 ALIAS value_raw * dictGetOrDefault('dictionary.lookup', 'key', (category, 'CATEGORY'), toDateTime(timestamp), 0.),
+
+    -- MATERIALIZED column
+    `description_is_null` UInt8 MATERIALIZED description IS NULL,
+
+    -- Tuple types
+    `coordinates` Tuple(Float64, Float64),
+    `named_point` Tuple(x Float64, y Float64, z Float64),
+
+    -- Map type
+    `properties` Map(String, String),
+
+    -- JSON type
+    `json_data` JSON,
+
+    -- Nested type
+    `nested_data` Nested(
+        key String,
+        value Float64,
+        timestamp DateTime
+    )
+)
+ENGINE = MergeTree()
+ORDER BY id
+SETTINGS index_granularity = 8192;
+-- ALTER TABLE examples with various column types and options
+ALTER TABLE db_name.table_name ADD COLUMN `new_column` Float32 CODEC(Delta, LZ4);
+ALTER TABLE db_name.table_name ADD COLUMN `new_alias_column` Float32 ALIAS value_raw * 2;
+ALTER TABLE db_name.table_name ADD COLUMN `new_materialized_column` Float32 MATERIALIZED value_raw * 3;
+ALTER TABLE db_name.table_name ADD COLUMN `new_default_column` Float32 DEFAULT 100;
+ALTER TABLE db_name.table_name ADD COLUMN `new_enum_column` Enum8('VALUE1' = 1, 'VALUE2' = 2, 'VALUE3' = 3);
+ALTER TABLE db_name.table_name ADD COLUMN `new_lowcard_column` LowCardinality(String) DEFAULT 'DEFAULT_VALUE';
+ALTER TABLE db_name.table_name ADD COLUMN `new_datetime_column` DateTime64(3, 'UTC') CODEC(Delta(8), LZ4);
+ALTER TABLE db_name.table_name ADD COLUMN `new_nullable_column` Nullable(Float32);
+ALTER TABLE db_name.table_name ADD COLUMN `new_json_column` JSON;
+
+-- Modify column examples
+ALTER TABLE db_name.table_name MODIFY COLUMN `value_raw` Float64 CODEC(Delta, LZ4);
+ALTER TABLE db_name.table_name MODIFY COLUMN `value_calculated` Float64 ALIAS value_raw / (3600 / 30);
+ALTER TABLE db_name.table_name MODIFY COLUMN `flag_active` Int8 MATERIALIZED if(status = 'ACTIVE', 1, 0);
+ALTER TABLE db_name.table_name MODIFY COLUMN `category` LowCardinality(String) DEFAULT 'UNKNOWN_CATEGORY';
+
+-- Remove alias example
+ALTER TABLE db_name.table_name MODIFY COLUMN `value_with_dict` REMOVE ALIAS;
+
+-- Drop column example
+ALTER TABLE db_name.table_name DROP COLUMN `new_column`;
+
+-- Rename column example
+ALTER TABLE db_name.table_name RENAME COLUMN `new_column` TO `new_column_renamed`;
+
+-- Add alias from dictionary
+ALTER TABLE db_name.table_name ADD COLUMN `complex_alias` Float32 ALIAS value_raw * dictGetOrDefault('dictionary.lookup', 'price', (category, 'RESOURCE_TYPE'), toDateTime(timestamp), 0.);

--- a/test/fixtures/dialects/clickhouse/complex_table_definition.yml
+++ b/test/fixtures/dialects/clickhouse/complex_table_definition.yml
@@ -1,0 +1,695 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 5f17ac6287097aa73c1c8827b2104869d2f67d1a7ba0fb63abf4e61982bf3c68
+file:
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          quoted_identifier: '`id`'
+          data_type:
+            data_type_identifier: UInt64
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`timestamp`'
+          data_type:
+            data_type_identifier: DateTime64
+            bracketed:
+              start_bracket: (
+              numeric_literal: '3'
+              comma: ','
+              quoted_literal: "'UTC'"
+              end_bracket: )
+          keyword: CODEC
+          bracketed:
+            start_bracket: (
+            function:
+              function_name:
+                function_name_identifier: Delta
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '8'
+                  end_bracket: )
+            comma: ','
+            naked_identifier: LZ4
+            end_bracket: )
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`value_raw`'
+          data_type:
+            data_type_identifier: Float32
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`category`'
+          data_type:
+            data_type_identifier: LowCardinality
+            bracketed:
+              start_bracket: (
+              data_type:
+                data_type_identifier: String
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`status`'
+          data_type:
+            data_type_identifier: Enum8
+            bracketed:
+            - start_bracket: (
+            - quoted_literal: "'ACTIVE'"
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - numeric_literal: '1'
+            - comma: ','
+            - quoted_literal: "'INACTIVE'"
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - numeric_literal: '2'
+            - comma: ','
+            - quoted_literal: "'PENDING'"
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - numeric_literal: '3'
+            - end_bracket: )
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`description`'
+          data_type:
+            data_type_identifier: Nullable
+            bracketed:
+              start_bracket: (
+              data_type:
+                data_type_identifier: String
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`tags`'
+          data_type:
+            data_type_identifier: Array
+            bracketed:
+              start_bracket: (
+              data_type:
+                data_type_identifier: String
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`value_calculated`'
+          data_type:
+            data_type_identifier: Float32
+          keyword: ALIAS
+          expression:
+            column_reference:
+              naked_identifier: value_raw
+            binary_operator: /
+            bracketed:
+              start_bracket: (
+              expression:
+              - numeric_literal: '3600'
+              - binary_operator: /
+              - numeric_literal: '30'
+              end_bracket: )
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`flag_active`'
+          data_type:
+            data_type_identifier: Int8
+          keyword: ALIAS
+          expression:
+            function:
+              function_name:
+                function_name_identifier: if
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: status
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    quoted_literal: "'ACTIVE'"
+                - comma: ','
+                - expression:
+                    numeric_literal: '1'
+                - comma: ','
+                - expression:
+                    numeric_literal: '0'
+                - end_bracket: )
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`value_with_dict`'
+          data_type:
+            data_type_identifier: Float32
+          keyword: ALIAS
+          expression:
+            column_reference:
+              naked_identifier: value_raw
+            binary_operator: '*'
+            function:
+              function_name:
+                function_name_identifier: dictGetOrDefault
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    quoted_literal: "'dictionary.lookup'"
+                - comma: ','
+                - expression:
+                    quoted_literal: "'key'"
+                - comma: ','
+                - expression:
+                    bracketed:
+                      start_bracket: (
+                      column_reference:
+                        naked_identifier: category
+                      comma: ','
+                      quoted_literal: "'CATEGORY'"
+                      end_bracket: )
+                - comma: ','
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: toDateTime
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          expression:
+                            column_reference:
+                              naked_identifier: timestamp
+                          end_bracket: )
+                - comma: ','
+                - expression:
+                    numeric_literal: '0.'
+                - end_bracket: )
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`description_is_null`'
+          data_type:
+            data_type_identifier: UInt8
+          keyword: MATERIALIZED
+          expression:
+            column_reference:
+              naked_identifier: description
+            keyword: IS
+            null_literal: 'NULL'
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`coordinates`'
+          data_type:
+            data_type_identifier: Tuple
+            bracketed:
+            - start_bracket: (
+            - data_type:
+                data_type_identifier: Float64
+            - comma: ','
+            - data_type:
+                data_type_identifier: Float64
+            - end_bracket: )
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`named_point`'
+          data_type:
+            data_type_identifier: Tuple
+            bracketed:
+            - start_bracket: (
+            - naked_identifier: x
+            - data_type:
+                data_type_identifier: Float64
+            - comma: ','
+            - naked_identifier: y
+            - data_type:
+                data_type_identifier: Float64
+            - comma: ','
+            - naked_identifier: z
+            - data_type:
+                data_type_identifier: Float64
+            - end_bracket: )
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`properties`'
+          data_type:
+            data_type_identifier: Map
+            bracketed:
+            - start_bracket: (
+            - data_type:
+                data_type_identifier: String
+            - comma: ','
+            - data_type:
+                data_type_identifier: String
+            - end_bracket: )
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`json_data`'
+          data_type:
+            data_type_identifier: JSON
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '`nested_data`'
+          data_type:
+            data_type_identifier: Nested
+            bracketed:
+            - start_bracket: (
+            - naked_identifier: key
+            - data_type:
+                data_type_identifier: String
+            - comma: ','
+            - naked_identifier: value
+            - data_type:
+                data_type_identifier: Float64
+            - comma: ','
+            - naked_identifier: timestamp
+            - data_type:
+                data_type_identifier: DateTime
+            - end_bracket: )
+      - end_bracket: )
+    - engine:
+        keyword: ENGINE
+        comparison_operator:
+          raw_comparison_operator: '='
+        table_engine_function:
+          function_name:
+            function_name_identifier: MergeTree
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+        merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: id
+        settings_clause:
+          keyword: SETTINGS
+          naked_identifier: index_granularity
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '8192'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: ADD
+    - keyword: COLUMN
+    - quoted_identifier: '`new_column`'
+    - data_type:
+        data_type_identifier: Float32
+    - keyword: CODEC
+    - bracketed:
+      - start_bracket: (
+      - naked_identifier: Delta
+      - comma: ','
+      - naked_identifier: LZ4
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: ADD
+    - keyword: COLUMN
+    - quoted_identifier: '`new_alias_column`'
+    - data_type:
+        data_type_identifier: Float32
+    - keyword: ALIAS
+    - expression:
+        column_reference:
+          naked_identifier: value_raw
+        binary_operator: '*'
+        numeric_literal: '2'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: ADD
+    - keyword: COLUMN
+    - quoted_identifier: '`new_materialized_column`'
+    - data_type:
+        data_type_identifier: Float32
+    - keyword: MATERIALIZED
+    - expression:
+        column_reference:
+          naked_identifier: value_raw
+        binary_operator: '*'
+        numeric_literal: '3'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: ADD
+    - keyword: COLUMN
+    - quoted_identifier: '`new_default_column`'
+    - data_type:
+        data_type_identifier: Float32
+    - keyword: DEFAULT
+    - expression:
+        numeric_literal: '100'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: ADD
+    - keyword: COLUMN
+    - quoted_identifier: '`new_enum_column`'
+    - data_type:
+        data_type_identifier: Enum8
+        bracketed:
+        - start_bracket: (
+        - quoted_literal: "'VALUE1'"
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '1'
+        - comma: ','
+        - quoted_literal: "'VALUE2'"
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '2'
+        - comma: ','
+        - quoted_literal: "'VALUE3'"
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '3'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: ADD
+    - keyword: COLUMN
+    - quoted_identifier: '`new_lowcard_column`'
+    - data_type:
+        data_type_identifier: LowCardinality
+        bracketed:
+          start_bracket: (
+          data_type:
+            data_type_identifier: String
+          end_bracket: )
+    - keyword: DEFAULT
+    - expression:
+        quoted_literal: "'DEFAULT_VALUE'"
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: ADD
+    - keyword: COLUMN
+    - quoted_identifier: '`new_datetime_column`'
+    - data_type:
+        data_type_identifier: DateTime64
+        bracketed:
+          start_bracket: (
+          numeric_literal: '3'
+          comma: ','
+          quoted_literal: "'UTC'"
+          end_bracket: )
+    - keyword: CODEC
+    - bracketed:
+        start_bracket: (
+        function:
+          function_name:
+            function_name_identifier: Delta
+          function_contents:
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '8'
+              end_bracket: )
+        comma: ','
+        naked_identifier: LZ4
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: ADD
+    - keyword: COLUMN
+    - quoted_identifier: '`new_nullable_column`'
+    - data_type:
+        data_type_identifier: Nullable
+        bracketed:
+          start_bracket: (
+          data_type:
+            data_type_identifier: Float32
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: ADD
+    - keyword: COLUMN
+    - quoted_identifier: '`new_json_column`'
+    - data_type:
+        data_type_identifier: JSON
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: MODIFY
+    - keyword: COLUMN
+    - quoted_identifier: '`value_raw`'
+    - data_type:
+        data_type_identifier: Float64
+    - keyword: CODEC
+    - bracketed:
+      - start_bracket: (
+      - naked_identifier: Delta
+      - comma: ','
+      - naked_identifier: LZ4
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: MODIFY
+    - keyword: COLUMN
+    - quoted_identifier: '`value_calculated`'
+    - data_type:
+        data_type_identifier: Float64
+    - keyword: ALIAS
+    - expression:
+        column_reference:
+          naked_identifier: value_raw
+        binary_operator: /
+        bracketed:
+          start_bracket: (
+          expression:
+          - numeric_literal: '3600'
+          - binary_operator: /
+          - numeric_literal: '30'
+          end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: MODIFY
+    - keyword: COLUMN
+    - quoted_identifier: '`flag_active`'
+    - data_type:
+        data_type_identifier: Int8
+    - keyword: MATERIALIZED
+    - expression:
+        function:
+          function_name:
+            function_name_identifier: if
+          function_contents:
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  naked_identifier: status
+                comparison_operator:
+                  raw_comparison_operator: '='
+                quoted_literal: "'ACTIVE'"
+            - comma: ','
+            - expression:
+                numeric_literal: '1'
+            - comma: ','
+            - expression:
+                numeric_literal: '0'
+            - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: MODIFY
+    - keyword: COLUMN
+    - quoted_identifier: '`category`'
+    - data_type:
+        data_type_identifier: LowCardinality
+        bracketed:
+          start_bracket: (
+          data_type:
+            data_type_identifier: String
+          end_bracket: )
+    - keyword: DEFAULT
+    - expression:
+        quoted_literal: "'UNKNOWN_CATEGORY'"
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: MODIFY
+    - keyword: COLUMN
+    - quoted_identifier: '`value_with_dict`'
+    - keyword: REMOVE
+    - keyword: ALIAS
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: DROP
+    - keyword: COLUMN
+    - quoted_identifier: '`new_column`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: RENAME
+    - keyword: COLUMN
+    - quoted_identifier: '`new_column`'
+    - keyword: TO
+    - quoted_identifier: '`new_column_renamed`'
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: db_name
+      - dot: .
+      - naked_identifier: table_name
+    - keyword: ADD
+    - keyword: COLUMN
+    - quoted_identifier: '`complex_alias`'
+    - data_type:
+        data_type_identifier: Float32
+    - keyword: ALIAS
+    - expression:
+        column_reference:
+          naked_identifier: value_raw
+        binary_operator: '*'
+        function:
+          function_name:
+            function_name_identifier: dictGetOrDefault
+          function_contents:
+            bracketed:
+            - start_bracket: (
+            - expression:
+                quoted_literal: "'dictionary.lookup'"
+            - comma: ','
+            - expression:
+                quoted_literal: "'price'"
+            - comma: ','
+            - expression:
+                bracketed:
+                  start_bracket: (
+                  column_reference:
+                    naked_identifier: category
+                  comma: ','
+                  quoted_literal: "'RESOURCE_TYPE'"
+                  end_bracket: )
+            - comma: ','
+            - expression:
+                function:
+                  function_name:
+                    function_name_identifier: toDateTime
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: timestamp
+                      end_bracket: )
+            - comma: ','
+            - expression:
+                numeric_literal: '0.'
+            - end_bracket: )
+- statement_terminator: ;

--- a/test/fixtures/dialects/clickhouse/create_materialized_view.sql
+++ b/test/fixtures/dialects/clickhouse/create_materialized_view.sql
@@ -53,3 +53,168 @@ CREATE MATERIALIZED VIEW db.mv_table
 ENGINE MergeTree
 ORDER BY ()
 AS SELECT * FROM db.table;
+
+-- Basic materialized view
+CREATE MATERIALIZED VIEW my_view
+ENGINE = MergeTree()
+ORDER BY id
+AS SELECT id, name FROM source_table;
+
+-- Materialized view with IF NOT EXISTS
+CREATE MATERIALIZED VIEW IF NOT EXISTS my_view_2
+ENGINE = MergeTree()
+ORDER BY id
+AS SELECT id, value FROM source_table;
+
+-- Materialized view with ON CLUSTER (explicit cluster name)
+CREATE MATERIALIZED VIEW my_view_3
+ON CLUSTER my_cluster
+ENGINE = MergeTree()
+ORDER BY id
+AS SELECT id, timestamp FROM source_table;
+
+-- Materialized view with ON CLUSTER (using cluster macro)
+CREATE MATERIALIZED VIEW my_view_3_macro
+ON CLUSTER '{cluster}'
+ENGINE = MergeTree()
+ORDER BY id
+AS SELECT id, timestamp FROM source_table;
+
+-- Materialized view with TO clause
+CREATE MATERIALIZED VIEW my_view_4
+TO target_table
+AS SELECT id, category FROM source_table;
+
+-- Materialized view with IF NOT EXISTS, ON CLUSTER, and TO clause
+CREATE MATERIALIZED VIEW IF NOT EXISTS cdc_lay.table_mv
+ON CLUSTER default
+TO stg_lay.table
+AS SELECT * FROM source_table;
+
+-- Materialized view with IF NOT EXISTS, ON CLUSTER macro, and TO clause
+CREATE MATERIALIZED VIEW IF NOT EXISTS cdc_lay.table_mv_macro
+ON CLUSTER '{cluster}'
+TO stg_lay.table
+AS SELECT * FROM source_table;
+
+-- Materialized view with IF NOT EXISTS, ON CLUSTER macro, and TO clause
+CREATE MATERIALIZED VIEW IF NOT EXISTS cdc_lay.table_mv_macro
+ON CLUSTER default
+TO stg_lay.table
+AS SELECT * FROM source_table;
+
+-- Materialized view with POPULATE
+CREATE MATERIALIZED VIEW my_view_5
+ENGINE = MergeTree()
+ORDER BY id
+POPULATE
+AS SELECT id, status FROM source_table;
+
+-- Materialized view with complex engine settings
+CREATE MATERIALIZED VIEW my_view_6
+ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/my_view_6', '{replica}')
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (id, timestamp)
+TTL timestamp + INTERVAL 1 MONTH
+SETTINGS index_granularity = 8192
+AS SELECT id, timestamp, value FROM source_table;
+
+
+-- Materialized view with TO and database.table syntax
+CREATE MATERIALIZED VIEW my_view_7
+ON CLUSTER '{cluster}'
+TO db.target_table
+AS SELECT * FROM source_table;
+
+-- Materialized view with complex SELECT query
+CREATE MATERIALIZED VIEW my_view_8
+ENGINE = SummingMergeTree()
+ORDER BY (category, metric)
+AS
+SELECT
+    category,
+    metric,
+    sum(value) AS total_value,
+    count() AS count,
+    avg(value) AS avg_value
+FROM source_table
+GROUP BY category, metric;
+
+-- Materialized view with IF NOT EXISTS, ON CLUSTER, TO clause with column list
+CREATE MATERIALIZED VIEW IF NOT EXISTS cdc_lay.table_mv2
+ON CLUSTER default
+TO stg_lay.table2 (id, name, value)
+AS SELECT id, name, value FROM source_table;
+
+-- Materialized view from kafka table with column list
+CREATE MATERIALIZED VIEW IF NOT EXISTS db.consumer_kafka
+ON CLUSTER '{cluster}'
+TO db.local AS
+SELECT *, _timestamp_ms AS processedAt
+FROM db.kafka;
+
+-- Materialized view with ARRAY JOIN
+CREATE MATERIALIZED VIEW IF NOT EXISTS db.nested_data_mv
+ON CLUSTER '{cluster}'
+TO db.nested_data_local AS
+SELECT
+    identifier,
+    _timestamp_ms AS processedAt,
+    metrics.measuredAt AS measuredAt,
+    metrics.value AS value,
+    metrics.name AS name
+FROM db.kafka
+ARRAY JOIN metrics;
+
+-- Materialized view with subquery in FROM clause and GROUP BY
+CREATE MATERIALIZED VIEW IF NOT EXISTS db.aggeregating_mv
+ON CLUSTER '{cluster}'
+TO db.aggeregating_local AS
+SELECT
+    identifier,
+    _ingestedAt AS ingestedAt,
+    objectList
+FROM
+(
+    SELECT
+        toStartOfDay(ingestedAt) AS _ingestedAt,
+        identifier,
+        groupUniqArray(objectIdentfier) AS objectList
+    FROM db.raw_table
+    GROUP BY
+        identifier,
+        _ingestedAt
+);
+
+-- Materialized view with subquery in FROM clause and GROUP BY
+CREATE MATERIALIZED VIEW IF NOT EXISTS db.aggeregating_mv2
+ON CLUSTER '{cluster}'
+TO db.aggeregating_local2 AS
+SELECT
+    identifier,
+    _ingestedAt AS ingestedAt,
+    valueCount,
+    cumulativeLagSeconds
+FROM (
+    SELECT
+        identifier,
+        toStartOfMinute(ingestedAt) AS _ingestedAt,
+        count() AS valueCount,
+        sum((toUnixTimestamp64Milli(ingestedAt) - toUnixTimestamp64Milli(measuredAt)) / 1000) AS cumulativeLagSeconds
+    FROM db.raw_table
+    GROUP BY identifier, _ingestedAt
+);
+
+-- Materialized view with TO clause and complex SELECT
+CREATE MATERIALIZED VIEW IF NOT EXISTS db.kafka_errors
+ON CLUSTER '{cluster}'
+TO db.kafka_errors_local AS
+SELECT
+    _topic AS topic,
+    _partition AS kafka_partition,
+    _offset AS offset,
+    ifNull(_timestamp_ms, now()) AS processedAt,
+    _raw_message AS raw_message,
+    _error AS error
+FROM db.kafka
+WHERE length(_error) > 0;

--- a/test/fixtures/dialects/clickhouse/create_materialized_view.yml
+++ b/test/fixtures/dialects/clickhouse/create_materialized_view.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3f981faab492b7ca775ff380b8065518d427006901ffe9e4cddee3ff0a74a118
+_hash: 67da5fee840c85cbc40a5375461b76125f0a1a43e01d41f293de3acdf9e2220a
 file:
 - statement:
     create_materialized_view_statement:
@@ -266,4 +266,1110 @@ file:
                 - naked_identifier: db
                 - dot: .
                 - naked_identifier: table
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: my_view
+    - engine:
+        keyword: ENGINE
+        comparison_operator:
+          raw_comparison_operator: '='
+        table_engine_function:
+          function_name:
+            function_name_identifier: MergeTree
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+        merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: id
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: my_view_2
+    - engine:
+        keyword: ENGINE
+        comparison_operator:
+          raw_comparison_operator: '='
+        table_engine_function:
+          function_name:
+            function_name_identifier: MergeTree
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+        merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: id
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: value
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: my_view_3
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: my_cluster
+    - engine:
+        keyword: ENGINE
+        comparison_operator:
+          raw_comparison_operator: '='
+        table_engine_function:
+          function_name:
+            function_name_identifier: MergeTree
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+        merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: id
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: timestamp
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: my_view_3_macro
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - quoted_identifier: "'{cluster}'"
+    - engine:
+        keyword: ENGINE
+        comparison_operator:
+          raw_comparison_operator: '='
+        table_engine_function:
+          function_name:
+            function_name_identifier: MergeTree
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+        merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: id
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: timestamp
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: my_view_4
+    - keyword: TO
+    - table_reference:
+        naked_identifier: target_table
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: category
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: cdc_lay
+      - dot: .
+      - naked_identifier: table_mv
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: default
+    - keyword: TO
+    - table_reference:
+      - naked_identifier: stg_lay
+      - dot: .
+      - naked_identifier: table
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: cdc_lay
+      - dot: .
+      - naked_identifier: table_mv_macro
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - quoted_identifier: "'{cluster}'"
+    - keyword: TO
+    - table_reference:
+      - naked_identifier: stg_lay
+      - dot: .
+      - naked_identifier: table
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: cdc_lay
+      - dot: .
+      - naked_identifier: table_mv_macro
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: default
+    - keyword: TO
+    - table_reference:
+      - naked_identifier: stg_lay
+      - dot: .
+      - naked_identifier: table
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: my_view_5
+    - engine:
+        keyword: ENGINE
+        comparison_operator:
+          raw_comparison_operator: '='
+        table_engine_function:
+          function_name:
+            function_name_identifier: MergeTree
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+        merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - column_reference:
+            naked_identifier: id
+    - keyword: POPULATE
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: status
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: my_view_6
+    - engine:
+      - keyword: ENGINE
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - table_engine_function:
+          function_name:
+            function_name_identifier: ReplicatedReplacingMergeTree
+          function_contents:
+            bracketed:
+            - start_bracket: (
+            - expression:
+                quoted_literal: "'/clickhouse/tables/{shard}/my_view_6'"
+            - comma: ','
+            - expression:
+                quoted_literal: "'{replica}'"
+            - end_bracket: )
+      - keyword: PARTITION
+      - keyword: BY
+      - expression:
+          function:
+            function_name:
+              function_name_identifier: toYYYYMM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: timestamp
+                end_bracket: )
+      - merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: id
+          - comma: ','
+          - column_reference:
+              naked_identifier: timestamp
+          - end_bracket: )
+    - table_ttl_segment:
+        keyword: TTL
+        expression:
+          column_reference:
+            naked_identifier: timestamp
+          binary_operator: +
+          interval_expression:
+            keyword: INTERVAL
+            numeric_literal: '1'
+            date_part: MONTH
+    - settings_clause:
+        keyword: SETTINGS
+        naked_identifier: index_granularity
+        comparison_operator:
+          raw_comparison_operator: '='
+        numeric_literal: '8192'
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: timestamp
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: value
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: my_view_7
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - quoted_identifier: "'{cluster}'"
+    - keyword: TO
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: target_table
+    - keyword: AS
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - table_reference:
+        naked_identifier: my_view_8
+    - engine:
+        keyword: ENGINE
+        comparison_operator:
+          raw_comparison_operator: '='
+        table_engine_function:
+          function_name:
+            function_name_identifier: SummingMergeTree
+          function_contents:
+            bracketed:
+              start_bracket: (
+              end_bracket: )
+        merge_tree_order_by_clause:
+        - keyword: ORDER
+        - keyword: BY
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: category
+          - comma: ','
+          - column_reference:
+              naked_identifier: metric
+          - end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: category
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: metric
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: sum
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: value
+                  end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: total_value
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: count
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: count
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: avg
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: value
+                  end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: avg_value
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+        groupby_clause:
+        - keyword: GROUP
+        - keyword: BY
+        - column_reference:
+            naked_identifier: category
+        - comma: ','
+        - column_reference:
+            naked_identifier: metric
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: cdc_lay
+      - dot: .
+      - naked_identifier: table_mv2
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - naked_identifier: default
+    - keyword: TO
+    - table_reference:
+      - naked_identifier: stg_lay
+      - dot: .
+      - naked_identifier: table2
+    - bracketed:
+      - start_bracket: (
+      - naked_identifier: id
+      - comma: ','
+      - naked_identifier: name
+      - comma: ','
+      - naked_identifier: value
+      - end_bracket: )
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: name
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: value
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: source_table
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: consumer_kafka
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - quoted_identifier: "'{cluster}'"
+    - keyword: TO
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: local
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: _timestamp_ms
+            alias_expression:
+              keyword: AS
+              naked_identifier: processedAt
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: db
+                - dot: .
+                - naked_identifier: kafka
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: nested_data_mv
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - quoted_identifier: "'{cluster}'"
+    - keyword: TO
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: nested_data_local
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: identifier
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: _timestamp_ms
+            alias_expression:
+              keyword: AS
+              naked_identifier: processedAt
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: metrics
+            - dot: .
+            - naked_identifier: measuredAt
+            alias_expression:
+              keyword: AS
+              naked_identifier: measuredAt
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: metrics
+            - dot: .
+            - naked_identifier: value
+            alias_expression:
+              keyword: AS
+              naked_identifier: value
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: metrics
+            - dot: .
+            - naked_identifier: name
+            alias_expression:
+              keyword: AS
+              naked_identifier: name
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: db
+                - dot: .
+                - naked_identifier: kafka
+            array_join_clause:
+            - keyword: ARRAY
+            - keyword: JOIN
+            - select_clause_element:
+                column_reference:
+                  naked_identifier: metrics
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: aggeregating_mv
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - quoted_identifier: "'{cluster}'"
+    - keyword: TO
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: aggeregating_local
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: identifier
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: _ingestedAt
+            alias_expression:
+              keyword: AS
+              naked_identifier: ingestedAt
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: objectList
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                    - keyword: SELECT
+                    - select_clause_element:
+                        function:
+                          function_name:
+                            function_name_identifier: toStartOfDay
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: ingestedAt
+                              end_bracket: )
+                        alias_expression:
+                          keyword: AS
+                          naked_identifier: _ingestedAt
+                    - comma: ','
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: identifier
+                    - comma: ','
+                    - select_clause_element:
+                        function:
+                          function_name:
+                            function_name_identifier: groupUniqArray
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: objectIdentfier
+                              end_bracket: )
+                        alias_expression:
+                          keyword: AS
+                          naked_identifier: objectList
+                    from_clause:
+                      keyword: FROM
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                            - naked_identifier: db
+                            - dot: .
+                            - naked_identifier: raw_table
+                    groupby_clause:
+                    - keyword: GROUP
+                    - keyword: BY
+                    - column_reference:
+                        naked_identifier: identifier
+                    - comma: ','
+                    - column_reference:
+                        naked_identifier: _ingestedAt
+                  end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: aggeregating_mv2
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - quoted_identifier: "'{cluster}'"
+    - keyword: TO
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: aggeregating_local2
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: identifier
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: _ingestedAt
+            alias_expression:
+              keyword: AS
+              naked_identifier: ingestedAt
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: valueCount
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: cumulativeLagSeconds
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                bracketed:
+                  start_bracket: (
+                  select_statement:
+                    select_clause:
+                    - keyword: SELECT
+                    - select_clause_element:
+                        column_reference:
+                          naked_identifier: identifier
+                    - comma: ','
+                    - select_clause_element:
+                        function:
+                          function_name:
+                            function_name_identifier: toStartOfMinute
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                column_reference:
+                                  naked_identifier: ingestedAt
+                              end_bracket: )
+                        alias_expression:
+                          keyword: AS
+                          naked_identifier: _ingestedAt
+                    - comma: ','
+                    - select_clause_element:
+                        function:
+                          function_name:
+                            function_name_identifier: count
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              end_bracket: )
+                        alias_expression:
+                          keyword: AS
+                          naked_identifier: valueCount
+                    - comma: ','
+                    - select_clause_element:
+                        function:
+                          function_name:
+                            function_name_identifier: sum
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                  - function:
+                                      function_name:
+                                        function_name_identifier: toUnixTimestamp64Milli
+                                      function_contents:
+                                        bracketed:
+                                          start_bracket: (
+                                          expression:
+                                            column_reference:
+                                              naked_identifier: ingestedAt
+                                          end_bracket: )
+                                  - binary_operator: '-'
+                                  - function:
+                                      function_name:
+                                        function_name_identifier: toUnixTimestamp64Milli
+                                      function_contents:
+                                        bracketed:
+                                          start_bracket: (
+                                          expression:
+                                            column_reference:
+                                              naked_identifier: measuredAt
+                                          end_bracket: )
+                                  end_bracket: )
+                                binary_operator: /
+                                numeric_literal: '1000'
+                              end_bracket: )
+                        alias_expression:
+                          keyword: AS
+                          naked_identifier: cumulativeLagSeconds
+                    from_clause:
+                      keyword: FROM
+                      from_expression:
+                        from_expression_element:
+                          table_expression:
+                            table_reference:
+                            - naked_identifier: db
+                            - dot: .
+                            - naked_identifier: raw_table
+                    groupby_clause:
+                    - keyword: GROUP
+                    - keyword: BY
+                    - column_reference:
+                        naked_identifier: identifier
+                    - comma: ','
+                    - column_reference:
+                        naked_identifier: _ingestedAt
+                  end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_materialized_view_statement:
+    - keyword: CREATE
+    - keyword: MATERIALIZED
+    - keyword: VIEW
+    - keyword: IF
+    - keyword: NOT
+    - keyword: EXISTS
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: kafka_errors
+    - on_cluster_clause:
+      - keyword: 'ON'
+      - keyword: CLUSTER
+      - quoted_identifier: "'{cluster}'"
+    - keyword: TO
+    - table_reference:
+      - naked_identifier: db
+      - dot: .
+      - naked_identifier: kafka_errors_local
+    - keyword: AS
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: _topic
+            alias_expression:
+              keyword: AS
+              naked_identifier: topic
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: _partition
+            alias_expression:
+              keyword: AS
+              naked_identifier: kafka_partition
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: _offset
+            alias_expression:
+              keyword: AS
+              naked_identifier: offset
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: ifNull
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                      naked_identifier: _timestamp_ms
+                - comma: ','
+                - expression:
+                    function:
+                      function_name:
+                        function_name_identifier: now
+                      function_contents:
+                        bracketed:
+                          start_bracket: (
+                          end_bracket: )
+                - end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: processedAt
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: _raw_message
+            alias_expression:
+              keyword: AS
+              naked_identifier: raw_message
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: _error
+            alias_expression:
+              keyword: AS
+              naked_identifier: error
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: db
+                - dot: .
+                - naked_identifier: kafka
+        where_clause:
+          keyword: WHERE
+          expression:
+            function:
+              function_name:
+                function_name_identifier: length
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: _error
+                  end_bracket: )
+            comparison_operator:
+              raw_comparison_operator: '>'
+            numeric_literal: '0'
 - statement_terminator: ;

--- a/test/fixtures/dialects/clickhouse/create_table.yml
+++ b/test/fixtures/dialects/clickhouse/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7975daa1d4c35a27e534ac7a4b9ab060ecaf9435664a3a589c9fd4ae2ee39ad1
+_hash: 510ade774109376ca7c87f2cfdf72b7508b09d203f879ef8adbeab85d731451c
 file:
 - statement:
     create_table_statement:
@@ -391,29 +391,21 @@ file:
           naked_identifier: timestamp
           data_type:
             data_type_identifier: DateTime
-          column_constraint_segment:
-            keyword: CODEC
-            expression:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: DoubleDelta
-                end_bracket: )
+          keyword: CODEC
+          bracketed:
+            start_bracket: (
+            naked_identifier: DoubleDelta
+            end_bracket: )
       - comma: ','
       - column_definition:
           naked_identifier: slow_values
           data_type:
             data_type_identifier: Float32
-          column_constraint_segment:
-            keyword: CODEC
-            expression:
-              bracketed:
-                start_bracket: (
-                expression:
-                  column_reference:
-                    naked_identifier: Gorilla
-                end_bracket: )
+          keyword: CODEC
+          bracketed:
+            start_bracket: (
+            naked_identifier: Gorilla
+            end_bracket: )
       - end_bracket: )
     - engine:
         keyword: ENGINE
@@ -439,20 +431,15 @@ file:
           naked_identifier: x
           data_type:
             data_type_identifier: String
-          column_constraint_segment:
-            keyword: Codec
-            expression:
-              bracketed:
-              - start_bracket: (
-              - column_reference:
-                  naked_identifier: Delta
-              - comma: ','
-              - column_reference:
-                  naked_identifier: LZ4
-              - comma: ','
-              - column_reference:
-                  naked_identifier: AES_128_GCM_SIV
-              - end_bracket: )
+          keyword: Codec
+          bracketed:
+          - start_bracket: (
+          - naked_identifier: Delta
+          - comma: ','
+          - naked_identifier: LZ4
+          - comma: ','
+          - naked_identifier: AES_128_GCM_SIV
+          - end_bracket: )
         end_bracket: )
     - engine:
         keyword: ENGINE

--- a/test/fixtures/dialects/clickhouse/tuple_datatype.yml
+++ b/test/fixtures/dialects/clickhouse/tuple_datatype.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2e4a5aaa753e255388556599da5a2815dc96db426e4ef4ed480dcec274d396be
+_hash: bda5186334c61cbcf67de5e3087211edd7787957abf165d7a4ad1da80a483796
 file:
 - statement:
     select_statement:
@@ -22,23 +22,21 @@ file:
               - end_bracket: )
               casting_operator: '::'
               data_type:
-                struct_type:
-                  keyword: Tuple
-                  tuple_type_schema:
-                    bracketed:
-                    - start_bracket: (
-                    - naked_identifier: id
-                    - data_type:
-                        data_type_identifier: Int64
-                    - comma: ','
-                    - naked_identifier: name
-                    - data_type:
-                        data_type_identifier: String
-                    - comma: ','
-                    - naked_identifier: created_at
-                    - data_type:
-                        data_type_identifier: Date32
-                    - end_bracket: )
+                data_type_identifier: Tuple
+                bracketed:
+                - start_bracket: (
+                - naked_identifier: id
+                - data_type:
+                    data_type_identifier: Int64
+                - comma: ','
+                - naked_identifier: name
+                - data_type:
+                    data_type_identifier: String
+                - comma: ','
+                - naked_identifier: created_at
+                - data_type:
+                    data_type_identifier: Date32
+                - end_bracket: )
           alias_expression:
             keyword: as
             naked_identifier: struct
@@ -60,23 +58,21 @@ file:
               - end_bracket: )
               casting_operator: '::'
               data_type:
-                struct_type:
-                  keyword: Tuple
-                  tuple_type_schema:
-                    bracketed:
-                    - start_bracket: (
-                    - quoted_identifier: '`id`'
-                    - data_type:
-                        data_type_identifier: Int64
-                    - comma: ','
-                    - quoted_identifier: '`name`'
-                    - data_type:
-                        data_type_identifier: String
-                    - comma: ','
-                    - quoted_identifier: '`created_at`'
-                    - data_type:
-                        data_type_identifier: Date32
-                    - end_bracket: )
+                data_type_identifier: Tuple
+                bracketed:
+                - start_bracket: (
+                - quoted_identifier: '`id`'
+                - data_type:
+                    data_type_identifier: Int64
+                - comma: ','
+                - quoted_identifier: '`name`'
+                - data_type:
+                    data_type_identifier: String
+                - comma: ','
+                - quoted_identifier: '`created_at`'
+                - data_type:
+                    data_type_identifier: Date32
+                - end_bracket: )
           alias_expression:
             keyword: as
             naked_identifier: struct


### PR DESCRIPTION


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Adds support 

* for more complex data types in clickhouse (Enum, Tuple, Nested, Array, JSON) 
* ALIAS columns referencing dictionaries and using other functions.
* ALTER TABLE MODIFY QUERY statemetns

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
