### PR TITLE
Adds support for `varchar(max)` in Redshift.

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -16,6 +16,7 @@ from sqlfluff.core.parser import (
     IdentifierSegment,
     ImplicitIndent,
     Indent,
+    LiteralKeywordSegment,
     Matchable,
     Nothing,
     OneOf,
@@ -25,6 +26,7 @@ from sqlfluff.core.parser import (
     RegexParser,
     SegmentGenerator,
     Sequence,
+    StringParser,
     WordSegment,
 )
 from sqlfluff.dialects import dialect_ansi as ansi
@@ -208,6 +210,11 @@ redshift_dialect.replace(
             casefold=str.lower,
         )
     ),
+    LiteralGrammar=ansi_dialect.get_grammar("LiteralGrammar").copy(
+        insert=[
+            Ref("MaxLiteralSegment"),
+        ]
+    ),
 )
 
 redshift_dialect.patch_lexer_matchers(
@@ -263,6 +270,7 @@ redshift_dialect.add(
             "UNLIMITED",
         ),
     ),
+    MaxLiteralSegment=StringParser("max", LiteralKeywordSegment, type="max_literal"),
 )
 
 

--- a/test/fixtures/dialects/redshift/create_table.sql
+++ b/test/fixtures/dialects/redshift/create_table.sql
@@ -160,3 +160,5 @@ create table public.t2
     c3 int,
     foreign key (c1, c2) references public.t1 (c1, c2)
 );
+
+create table test(col1 varchar(max));

--- a/test/fixtures/dialects/redshift/create_table.yml
+++ b/test/fixtures/dialects/redshift/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 81ea33a50c0e1ccc470746782f11abb036117142a236bba491e669a646e169ae
+_hash: adab8d47461f5a8bd21c56e7de3380e8825d5c7efa3a236f8a7c9f2700f8697b
 file:
 - statement:
     create_table_statement:
@@ -1014,4 +1014,23 @@ file:
               naked_identifier: c2
           - end_bracket: )
       - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: create
+    - keyword: table
+    - table_reference:
+        naked_identifier: test
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: col1
+        data_type:
+          keyword: varchar
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              max_literal: max
+              end_bracket: )
+        end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
Closes #5454 

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
