### PR TITLE
Add support for the WITH clause for an OPENROWSET in T-SQL

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -4159,6 +4159,33 @@ class OpenRowSetSegment(BaseSegment):
                 ),
             ),
         ),
+        Ref("OpenRowSetWithClauseSegment", optional=True),
+    )
+
+
+class OpenRowSetWithClauseSegment(BaseSegment):
+    """A `WITH` clause of an `OPENROWSET()` table-valued function.
+
+    https://learn.microsoft.com/en-us/azure/synapse-analytics/sql/develop-openrowset#syntax
+    """
+
+    type = "openrowset_with_clause"
+
+    match_grammar = Sequence(
+        "WITH",
+        Bracketed(
+            Delimited(
+                Sequence(
+                    Ref("ColumnDefinitionSegment"),
+                    Ref("CollateGrammar", optional=True),
+                    OneOf(
+                        RegexParser(r"[0-9]+", CodeSegment, type="column_ordinal"),
+                        Ref("QuotedIdentifierSegment"),  # json path
+                        optional=True,
+                    ),
+                )
+            )
+        ),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -4164,7 +4164,7 @@ class OpenRowSetSegment(BaseSegment):
 
 
 class OpenRowSetWithClauseSegment(BaseSegment):
-    """A `WITH` clause of an `OPENROWSET()` table-valued function.
+    """A `WITH` clause of an `OPENROWSET()` segment.
 
     https://learn.microsoft.com/en-us/azure/synapse-analytics/sql/develop-openrowset#syntax
     """
@@ -4176,11 +4176,13 @@ class OpenRowSetWithClauseSegment(BaseSegment):
         Bracketed(
             Delimited(
                 Sequence(
-                    Ref("ColumnDefinitionSegment"),
+                    Ref("SingleIdentifierGrammar"),  # Column name
+                    Ref("DatatypeSegment"),  # Column type
+                    Bracketed(Ref("NumericLiteralSegment"), optional=True),
                     Ref("CollateGrammar", optional=True),
                     OneOf(
-                        RegexParser(r"[0-9]+", CodeSegment, type="column_ordinal"),
-                        Ref("QuotedIdentifierSegment"),  # json path
+                        Ref("NumericLiteralSegment"),  # Column ordinal
+                        Ref("QuotedLiteralSegment"),  # JSON path
                         optional=True,
                     ),
                 )

--- a/test/fixtures/dialects/tsql/openrowset.sql
+++ b/test/fixtures/dialects/tsql/openrowset.sql
@@ -42,3 +42,32 @@ SELECT TOP 10 *
 from OPENROWSET(BULK 'https://pandemicdatalake.blob.core.windows.net/public/curated/covid-19/ecdc_cases/latest/ecdc_cases.parquet',
     FORMAT = 'PARQUET') as rows
 GO
+
+SELECT TOP 10 *
+FROM OPENROWSET(
+      BULK 'https://pandemicdatalake.blob.core.windows.net/public/curated/covid-19/ecdc_cases/latest/ecdc_cases.parquet',
+      FORMAT = 'PARQUET'
+   )
+WITH (
+    [country_code] VARCHAR(5) COLLATE Latin1_General_BIN2,
+    [country_name] VARCHAR(100) COLLATE Latin1_General_BIN2 2,
+    [year] smallint,
+    [population] bigint
+) as rows
+GO
+
+SELECT
+    TOP 1 *
+FROM OPENROWSET(
+        BULK 'https://azureopendatastorage.blob.core.windows.net/censusdatacontainer/release/us_population_county/year=20*/*.parquet',
+        FORMAT='PARQUET'
+    )
+WITH (
+    [stateName] VARCHAR(50),
+    [stateName_explicit_path] VARCHAR(50) '$.stateName',
+    [COUNTYNAME] VARCHAR(50),
+    [countyName_explicit_path] VARCHAR(50) '$.COUNTYNAME',
+    [population] bigint 'strict $.population'
+)
+AS [r]
+GO

--- a/test/fixtures/dialects/tsql/openrowset.yml
+++ b/test/fixtures/dialects/tsql/openrowset.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 85e6ba7c26e6d76db153fcfdb0de246904129a19d56a6b82546e61d46e67c348
+_hash: 705d4b95efafed60cf7ce05e9a5968eb96d683e0d772e32d9ecd633cfc19d2e7
 file:
 - batch:
     statement:
@@ -313,48 +313,40 @@ file:
                     keyword: WITH
                     bracketed:
                     - start_bracket: (
-                    - column_definition:
-                        quoted_identifier: '[country_code]'
-                        data_type:
-                          data_type_identifier: VARCHAR
-                          bracketed_arguments:
-                            bracketed:
-                              start_bracket: (
-                              expression:
-                                numeric_literal: '5'
-                              end_bracket: )
-                        column_constraint_segment:
-                          keyword: COLLATE
-                          collation_reference:
-                            naked_identifier: Latin1_General_BIN2
+                    - quoted_identifier: '[country_code]'
+                    - data_type:
+                        data_type_identifier: VARCHAR
+                        bracketed_arguments:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              numeric_literal: '5'
+                            end_bracket: )
+                    - keyword: COLLATE
+                    - collation_reference:
+                        naked_identifier: Latin1_General_BIN2
                     - comma: ','
-                    - column_definition:
-                      - quoted_identifier: '[country_name]'
-                      - data_type:
-                          data_type_identifier: VARCHAR
-                          bracketed_arguments:
-                            bracketed:
-                              start_bracket: (
-                              expression:
-                                numeric_literal: '100'
-                              end_bracket: )
-                      - column_constraint_segment:
-                          keyword: COLLATE
-                          collation_reference:
-                            naked_identifier: Latin1_General_BIN2
-                      - column_constraint_segment:
-                          on_partition_or_filegroup_statement:
-                            numeric_literal: '2'
+                    - quoted_identifier: '[country_name]'
+                    - data_type:
+                        data_type_identifier: VARCHAR
+                        bracketed_arguments:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              numeric_literal: '100'
+                            end_bracket: )
+                    - keyword: COLLATE
+                    - collation_reference:
+                        naked_identifier: Latin1_General_BIN2
+                    - numeric_literal: '2'
                     - comma: ','
-                    - column_definition:
-                        quoted_identifier: '[year]'
-                        data_type:
-                          data_type_identifier: smallint
+                    - quoted_identifier: '[year]'
+                    - data_type:
+                        data_type_identifier: smallint
                     - comma: ','
-                    - column_definition:
-                        quoted_identifier: '[population]'
-                        data_type:
-                          data_type_identifier: bigint
+                    - quoted_identifier: '[population]'
+                    - data_type:
+                        data_type_identifier: bigint
                     - end_bracket: )
               alias_expression:
                 keyword: as
@@ -395,63 +387,52 @@ file:
                     keyword: WITH
                     bracketed:
                     - start_bracket: (
-                    - column_definition:
-                        quoted_identifier: '[stateName]'
-                        data_type:
-                          data_type_identifier: VARCHAR
-                          bracketed_arguments:
-                            bracketed:
-                              start_bracket: (
-                              expression:
-                                numeric_literal: '50'
-                              end_bracket: )
+                    - quoted_identifier: '[stateName]'
+                    - data_type:
+                        data_type_identifier: VARCHAR
+                        bracketed_arguments:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              numeric_literal: '50'
+                            end_bracket: )
                     - comma: ','
-                    - column_definition:
-                        quoted_identifier: '[stateName_explicit_path]'
-                        data_type:
-                          data_type_identifier: VARCHAR
-                          bracketed_arguments:
-                            bracketed:
-                              start_bracket: (
-                              expression:
-                                numeric_literal: '50'
-                              end_bracket: )
-                        column_constraint_segment:
-                          on_partition_or_filegroup_statement:
-                            quoted_literal: "'$.stateName'"
+                    - quoted_identifier: '[stateName_explicit_path]'
+                    - data_type:
+                        data_type_identifier: VARCHAR
+                        bracketed_arguments:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              numeric_literal: '50'
+                            end_bracket: )
+                    - quoted_literal: "'$.stateName'"
                     - comma: ','
-                    - column_definition:
-                        quoted_identifier: '[COUNTYNAME]'
-                        data_type:
-                          data_type_identifier: VARCHAR
-                          bracketed_arguments:
-                            bracketed:
-                              start_bracket: (
-                              expression:
-                                numeric_literal: '50'
-                              end_bracket: )
+                    - quoted_identifier: '[COUNTYNAME]'
+                    - data_type:
+                        data_type_identifier: VARCHAR
+                        bracketed_arguments:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              numeric_literal: '50'
+                            end_bracket: )
                     - comma: ','
-                    - column_definition:
-                        quoted_identifier: '[countyName_explicit_path]'
-                        data_type:
-                          data_type_identifier: VARCHAR
-                          bracketed_arguments:
-                            bracketed:
-                              start_bracket: (
-                              expression:
-                                numeric_literal: '50'
-                              end_bracket: )
-                        column_constraint_segment:
-                          on_partition_or_filegroup_statement:
-                            quoted_literal: "'$.COUNTYNAME'"
+                    - quoted_identifier: '[countyName_explicit_path]'
+                    - data_type:
+                        data_type_identifier: VARCHAR
+                        bracketed_arguments:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              numeric_literal: '50'
+                            end_bracket: )
+                    - quoted_literal: "'$.COUNTYNAME'"
                     - comma: ','
-                    - column_definition:
-                        quoted_identifier: '[population]'
-                        data_type:
-                          data_type_identifier: bigint
-                        column_constraint_segment:
-                          on_partition_or_filegroup_statement:
-                            quoted_literal: "'strict $.population'"
+                    - quoted_identifier: '[population]'
+                    - data_type:
+                        data_type_identifier: bigint
+                    - quoted_literal: "'strict $.population'"
                     - end_bracket: )
               alias_expression:
                 keyword: AS

--- a/test/fixtures/dialects/tsql/openrowset.yml
+++ b/test/fixtures/dialects/tsql/openrowset.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c4e80150f24711897ab28de979a8fbef9f20561f721e2158a8d6a30a6af1a49e
+_hash: 85e6ba7c26e6d76db153fcfdb0de246904129a19d56a6b82546e61d46e67c348
 file:
 - batch:
     statement:
@@ -277,5 +277,184 @@ file:
               alias_expression:
                 keyword: as
                 naked_identifier: rows
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_modifier:
+            keyword: TOP
+            expression:
+              numeric_literal: '10'
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                openrowset_segment:
+                  keyword: OPENROWSET
+                  bracketed:
+                  - start_bracket: (
+                  - keyword: BULK
+                  - quoted_literal: "'https://pandemicdatalake.blob.core.windows.net/public/curated/covid-19/ecdc_cases/latest/ecdc_cases.parquet'"
+                  - comma: ','
+                  - keyword: FORMAT
+                  - comparison_operator:
+                      raw_comparison_operator: '='
+                  - quoted_literal: "'PARQUET'"
+                  - end_bracket: )
+                  openrowset_with_clause:
+                    keyword: WITH
+                    bracketed:
+                    - start_bracket: (
+                    - column_definition:
+                        quoted_identifier: '[country_code]'
+                        data_type:
+                          data_type_identifier: VARCHAR
+                          bracketed_arguments:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                numeric_literal: '5'
+                              end_bracket: )
+                        column_constraint_segment:
+                          keyword: COLLATE
+                          collation_reference:
+                            naked_identifier: Latin1_General_BIN2
+                    - comma: ','
+                    - column_definition:
+                      - quoted_identifier: '[country_name]'
+                      - data_type:
+                          data_type_identifier: VARCHAR
+                          bracketed_arguments:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                numeric_literal: '100'
+                              end_bracket: )
+                      - column_constraint_segment:
+                          keyword: COLLATE
+                          collation_reference:
+                            naked_identifier: Latin1_General_BIN2
+                      - column_constraint_segment:
+                          on_partition_or_filegroup_statement:
+                            numeric_literal: '2'
+                    - comma: ','
+                    - column_definition:
+                        quoted_identifier: '[year]'
+                        data_type:
+                          data_type_identifier: smallint
+                    - comma: ','
+                    - column_definition:
+                        quoted_identifier: '[population]'
+                        data_type:
+                          data_type_identifier: bigint
+                    - end_bracket: )
+              alias_expression:
+                keyword: as
+                naked_identifier: rows
+- go_statement:
+    keyword: GO
+- batch:
+    statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_modifier:
+            keyword: TOP
+            expression:
+              numeric_literal: '1'
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                openrowset_segment:
+                  keyword: OPENROWSET
+                  bracketed:
+                  - start_bracket: (
+                  - keyword: BULK
+                  - quoted_literal: "'https://azureopendatastorage.blob.core.windows.net/censusdatacontainer/release/us_population_county/year=20*/*.parquet'"
+                  - comma: ','
+                  - keyword: FORMAT
+                  - comparison_operator:
+                      raw_comparison_operator: '='
+                  - quoted_literal: "'PARQUET'"
+                  - end_bracket: )
+                  openrowset_with_clause:
+                    keyword: WITH
+                    bracketed:
+                    - start_bracket: (
+                    - column_definition:
+                        quoted_identifier: '[stateName]'
+                        data_type:
+                          data_type_identifier: VARCHAR
+                          bracketed_arguments:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                numeric_literal: '50'
+                              end_bracket: )
+                    - comma: ','
+                    - column_definition:
+                        quoted_identifier: '[stateName_explicit_path]'
+                        data_type:
+                          data_type_identifier: VARCHAR
+                          bracketed_arguments:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                numeric_literal: '50'
+                              end_bracket: )
+                        column_constraint_segment:
+                          on_partition_or_filegroup_statement:
+                            quoted_literal: "'$.stateName'"
+                    - comma: ','
+                    - column_definition:
+                        quoted_identifier: '[COUNTYNAME]'
+                        data_type:
+                          data_type_identifier: VARCHAR
+                          bracketed_arguments:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                numeric_literal: '50'
+                              end_bracket: )
+                    - comma: ','
+                    - column_definition:
+                        quoted_identifier: '[countyName_explicit_path]'
+                        data_type:
+                          data_type_identifier: VARCHAR
+                          bracketed_arguments:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                numeric_literal: '50'
+                              end_bracket: )
+                        column_constraint_segment:
+                          on_partition_or_filegroup_statement:
+                            quoted_literal: "'$.COUNTYNAME'"
+                    - comma: ','
+                    - column_definition:
+                        quoted_identifier: '[population]'
+                        data_type:
+                          data_type_identifier: bigint
+                        column_constraint_segment:
+                          on_partition_or_filegroup_statement:
+                            quoted_literal: "'strict $.population'"
+                    - end_bracket: )
+              alias_expression:
+                keyword: AS
+                quoted_identifier: '[r]'
 - go_statement:
     keyword: GO


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Add support for the WITH clause for an OPENROWSET in T-SQL as used in Azure Synapse Analytics. The syntax documentation can be found [here](https://learn.microsoft.com/en-us/azure/synapse-analytics/sql/develop-openrowset#syntax) 


### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
