### PR TITLE
Trino Dialect - Parse UNNEST (...) WITH ORDINALITY

### DIFF
--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -180,6 +180,7 @@ trino_dialect.replace(
     PostFunctionGrammar=ansi_dialect.get_grammar("PostFunctionGrammar").copy(
         insert=[
             Ref("WithinGroupClauseSegment"),
+            Ref("WithOrdinalityClauseSegment"),
         ],
     ),
     FunctionContentsGrammar=AnyNumberOf(
@@ -493,6 +494,22 @@ class AnalyzeStatementSegment(BaseSegment):
             ),
             optional=True,
         ),
+    )
+
+
+class WithOrdinalityClauseSegment(BaseSegment):
+    """A WITH ORDINALITY AS t(name1, name2) clause for CROSS JOIN UNNEST(...).
+
+    https://trino.io/docs/current/sql/select.html#unnest
+
+    Trino supports an optional WITH ORDINALITY clause on UNNEST, which
+    adds a numerical ordinality column to the UNNEST result.
+    """
+
+    type = "withordinality_clause"
+    match_grammar = Sequence(
+        "WITH",
+        "ORDINALITY",
     )
 
 

--- a/test/fixtures/dialects/trino/unnest_with_ordinality.sql
+++ b/test/fixtures/dialects/trino/unnest_with_ordinality.sql
@@ -1,0 +1,55 @@
+-- Single UNNEST argument, 2-argument ordinality.
+WITH t AS (
+    SELECT ARRAY['a', 'b', 'c'] AS array_column
+)
+
+SELECT
+    u.element,
+    u.ordinality
+FROM t
+CROSS JOIN UNNEST(t.array_column) WITH ORDINALITY AS u(element, ordinality);
+
+-- Single UNNEST argument, 2-argument ordinality, no 'AS' after ORDINALITY
+WITH t AS (
+    SELECT ARRAY['a', 'b', 'c'] AS array_column
+)
+
+SELECT
+    u.element,
+    u.ordinality
+FROM t
+CROSS JOIN UNNEST(t.array_column) WITH ORDINALITY u(element, ordinality);
+
+-- Single UNNEST argument, 2-argument ordinality, space between "u" and ordinality spec.
+WITH t AS (
+    SELECT ARRAY['a', 'b', 'c'] AS array_column
+)
+
+SELECT
+    u.element,
+    u.ordinality
+FROM t
+CROSS JOIN UNNEST(t.array_column) WITH ORDINALITY u (element, ordinality);
+
+-- Multiple UNNEST arguments, 3-argument ordinality.
+WITH t AS (
+    SELECT
+        ARRAY['a', 'b', 'c'] AS array_column1,
+        ARRAY[1, 2] AS array_column2
+)
+
+SELECT
+    u.element1,
+    u.element2,
+    u.ordinality
+FROM t
+CROSS JOIN UNNEST(t.array_column1, t.array_column2) WITH ORDINALITY AS u(element1, element2, ordinality);
+
+-- A basic UNNEST, no ORDINALITY
+WITH t AS (
+    SELECT ARRAY[1, 2] AS array_column
+)
+
+SELECT u.number
+FROM t
+CROSS JOIN UNNEST(t.array_column) AS u (number);

--- a/test/fixtures/dialects/trino/unnest_with_ordinality.yml
+++ b/test/fixtures/dialects/trino/unnest_with_ordinality.yml
@@ -1,0 +1,415 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e374d620cc21a4b90578a4bcf72a3a68f9d3007682de699b6818812a756d6a56
+file:
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        naked_identifier: t
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - quoted_literal: "'a'"
+                  - comma: ','
+                  - quoted_literal: "'b'"
+                  - comma: ','
+                  - quoted_literal: "'c'"
+                  - end_square_bracket: ']'
+                alias_expression:
+                  keyword: AS
+                  naked_identifier: array_column
+          end_bracket: )
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: u
+            - dot: .
+            - naked_identifier: element
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: u
+            - dot: .
+            - naked_identifier: ordinality
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t
+            join_clause:
+            - keyword: CROSS
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  function:
+                    function_name:
+                      function_name_identifier: UNNEST
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                          - naked_identifier: t
+                          - dot: .
+                          - naked_identifier: array_column
+                        end_bracket: )
+                    withordinality_clause:
+                    - keyword: WITH
+                    - keyword: ORDINALITY
+                alias_expression:
+                  keyword: AS
+                  naked_identifier: u
+                  bracketed:
+                    start_bracket: (
+                    identifier_list:
+                    - naked_identifier: element
+                    - comma: ','
+                    - naked_identifier: ordinality
+                    end_bracket: )
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        naked_identifier: t
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - quoted_literal: "'a'"
+                  - comma: ','
+                  - quoted_literal: "'b'"
+                  - comma: ','
+                  - quoted_literal: "'c'"
+                  - end_square_bracket: ']'
+                alias_expression:
+                  keyword: AS
+                  naked_identifier: array_column
+          end_bracket: )
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: u
+            - dot: .
+            - naked_identifier: element
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: u
+            - dot: .
+            - naked_identifier: ordinality
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t
+            join_clause:
+            - keyword: CROSS
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  function:
+                    function_name:
+                      function_name_identifier: UNNEST
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                          - naked_identifier: t
+                          - dot: .
+                          - naked_identifier: array_column
+                        end_bracket: )
+                    withordinality_clause:
+                    - keyword: WITH
+                    - keyword: ORDINALITY
+                alias_expression:
+                  naked_identifier: u
+                  bracketed:
+                    start_bracket: (
+                    identifier_list:
+                    - naked_identifier: element
+                    - comma: ','
+                    - naked_identifier: ordinality
+                    end_bracket: )
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        naked_identifier: t
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - quoted_literal: "'a'"
+                  - comma: ','
+                  - quoted_literal: "'b'"
+                  - comma: ','
+                  - quoted_literal: "'c'"
+                  - end_square_bracket: ']'
+                alias_expression:
+                  keyword: AS
+                  naked_identifier: array_column
+          end_bracket: )
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: u
+            - dot: .
+            - naked_identifier: element
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: u
+            - dot: .
+            - naked_identifier: ordinality
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t
+            join_clause:
+            - keyword: CROSS
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  function:
+                    function_name:
+                      function_name_identifier: UNNEST
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                          - naked_identifier: t
+                          - dot: .
+                          - naked_identifier: array_column
+                        end_bracket: )
+                    withordinality_clause:
+                    - keyword: WITH
+                    - keyword: ORDINALITY
+                alias_expression:
+                  naked_identifier: u
+                  bracketed:
+                    start_bracket: (
+                    identifier_list:
+                    - naked_identifier: element
+                    - comma: ','
+                    - naked_identifier: ordinality
+                    end_bracket: )
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        naked_identifier: t
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - quoted_literal: "'a'"
+                  - comma: ','
+                  - quoted_literal: "'b'"
+                  - comma: ','
+                  - quoted_literal: "'c'"
+                  - end_square_bracket: ']'
+                alias_expression:
+                  keyword: AS
+                  naked_identifier: array_column1
+            - comma: ','
+            - select_clause_element:
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '1'
+                  - comma: ','
+                  - numeric_literal: '2'
+                  - end_square_bracket: ']'
+                alias_expression:
+                  keyword: AS
+                  naked_identifier: array_column2
+          end_bracket: )
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: u
+            - dot: .
+            - naked_identifier: element1
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: u
+            - dot: .
+            - naked_identifier: element2
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: u
+            - dot: .
+            - naked_identifier: ordinality
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t
+            join_clause:
+            - keyword: CROSS
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  function:
+                    function_name:
+                      function_name_identifier: UNNEST
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          column_reference:
+                          - naked_identifier: t
+                          - dot: .
+                          - naked_identifier: array_column1
+                      - comma: ','
+                      - expression:
+                          column_reference:
+                          - naked_identifier: t
+                          - dot: .
+                          - naked_identifier: array_column2
+                      - end_bracket: )
+                    withordinality_clause:
+                    - keyword: WITH
+                    - keyword: ORDINALITY
+                alias_expression:
+                  keyword: AS
+                  naked_identifier: u
+                  bracketed:
+                    start_bracket: (
+                    identifier_list:
+                    - naked_identifier: element1
+                    - comma: ','
+                    - naked_identifier: element2
+                    - comma: ','
+                    - naked_identifier: ordinality
+                    end_bracket: )
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        naked_identifier: t
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                typed_array_literal:
+                  array_type:
+                    keyword: ARRAY
+                  array_literal:
+                  - start_square_bracket: '['
+                  - numeric_literal: '1'
+                  - comma: ','
+                  - numeric_literal: '2'
+                  - end_square_bracket: ']'
+                alias_expression:
+                  keyword: AS
+                  naked_identifier: array_column
+          end_bracket: )
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+            - naked_identifier: u
+            - dot: .
+            - naked_identifier: number
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t
+            join_clause:
+            - keyword: CROSS
+            - keyword: JOIN
+            - from_expression_element:
+                table_expression:
+                  function:
+                    function_name:
+                      function_name_identifier: UNNEST
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                          - naked_identifier: t
+                          - dot: .
+                          - naked_identifier: array_column
+                        end_bracket: )
+                alias_expression:
+                  keyword: AS
+                  naked_identifier: u
+                  bracketed:
+                    start_bracket: (
+                    identifier_list:
+                      naked_identifier: number
+                    end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Fixes #5384
Trino Dialect - Parse UNNEST (...) WITH ORDINALITY

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

I added tests for parsing in Trino dialects directory to confirm the parsing error is resolved.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
