### PR TITLE
Refactor Bracketed

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -188,6 +188,7 @@ oracle_dialect.sets("unreserved_keywords").update(
         "BODY",
         "BULK_EXCEPTIONS",
         "BULK_ROWCOUNT",
+        "BYTE",
         "COMPILE",
         "COMPOUND",
         "CONSTANT",


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
This PR aims to remove recursion from the Bracketed grammar. It matches start bracket, contents, then end bracket, without recursing.

### Are there any other side effects of this change that we should be aware of?
Yes, it rooted out a missing keyword in Oracle. Other than that, every case in the test suite parses exactly the same.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
