### PR TITLE
CV12 rule to exclude APPLY clause from the rule

### DIFF
--- a/src/sqlfluff/rules/convention/CV12.py
+++ b/src/sqlfluff/rules/convention/CV12.py
@@ -113,12 +113,13 @@ class Rule_CV12(BaseRule):
             ]
 
             if any(
-                kw.raw_upper in ("CROSS", "POSITIONAL", "USING")
+                kw.raw_upper in ("CROSS", "POSITIONAL", "USING", "APPLY")
                 for kw in join_clause_keywords
             ):
                 # If explicit CROSS JOIN is used, disregard lack of condition
                 # If explicit POSITIONAL JOIN is used, disregard lack of condition
                 # If explicit JOIN USING is used, disregard lack of condition
+                # If explicit CROSS/OUTER APPLY is used, disregard lack of condition
                 continue
 
             this_join_condition = join_clause.get_child("join_on_condition")

--- a/test/fixtures/dialects/tsql/outer_apply.sql
+++ b/test/fixtures/dialects/tsql/outer_apply.sql
@@ -3,4 +3,5 @@ SELECT table1.*
 FROM table1
 OUTER APPLY table2
 INNER JOIN table3
-    ON table1.col = table3.col;
+    ON table1.col = table3.col
+WHERE table1.Column1 ='blah';

--- a/test/fixtures/dialects/tsql/outer_apply.yml
+++ b/test/fixtures/dialects/tsql/outer_apply.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2c00e0d4150da03673fd39303dddebf447f51e071d6c0843ed313d8e708b8a37
+_hash: 5f5977e5f945725793ca079e43432a553ea46e18e73ce69b565ea377b346c68f
 file:
   batch:
     statement:
@@ -50,4 +50,14 @@ file:
                   - naked_identifier: table3
                   - dot: .
                   - naked_identifier: col
-          statement_terminator: ;
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+            - naked_identifier: table1
+            - dot: .
+            - naked_identifier: Column1
+            comparison_operator:
+              raw_comparison_operator: '='
+            quoted_literal: "'blah'"
+        statement_terminator: ;

--- a/test/fixtures/dialects/tsql/select_cross_apply.sql
+++ b/test/fixtures/dialects/tsql/select_cross_apply.sql
@@ -2,8 +2,19 @@ SELECT DeptID, DeptName, DeptMgrID, EmpID, EmpLastName, EmpSalary
 FROM Departments d
 CROSS APPLY dbo.GetReports(d.DeptMgrID) ;
 
+SELECT d.DeptID, d.DeptName, DeptMgrID, reps.EmpID, reps.EmpLastName, reps.EmpSalary
+FROM Departments AS d
+CROSS APPLY dbo.GetReports(d.DeptMgrID) AS reps
+WHERE d.DeptMgrID = 10;
+
 SELECT * FROM Department D
 OUTER APPLY dbo.fn_GetAllEmployeeOfADepartment(D.DepartmentID);
+
+
+SELECT * FROM Department D
+OUTER APPLY dbo.fn_GetAllEmployeeOfADepartment(D.DepartmentID) AS AllEmp
+WHERE D.DepartmentId = 10;
+
 
 select
 	s.column_id

--- a/test/fixtures/dialects/tsql/select_cross_apply.yml
+++ b/test/fixtures/dialects/tsql/select_cross_apply.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2f58b6cbab8fec025a7fc6a1f1072a36c146a38e23d5c96e4e6ea79650e53dbc
+_hash: 2e2c7637899f7476f622812d11b3143df72b03cec6987cf9a113dfdcd0e28ad4
 file:
   batch:
   - statement:
@@ -65,6 +65,86 @@ file:
   - statement:
       select_statement:
         select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: d
+            - dot: .
+            - naked_identifier: DeptID
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: d
+            - dot: .
+            - naked_identifier: DeptName
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+              naked_identifier: DeptMgrID
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: reps
+            - dot: .
+            - naked_identifier: EmpID
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: reps
+            - dot: .
+            - naked_identifier: EmpLastName
+        - comma: ','
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: reps
+            - dot: .
+            - naked_identifier: EmpSalary
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: Departments
+              alias_expression:
+                keyword: AS
+                naked_identifier: d
+            join_clause:
+            - keyword: CROSS
+            - keyword: APPLY
+            - from_expression_element:
+                table_expression:
+                  function:
+                    function_name:
+                      naked_identifier: dbo
+                      dot: .
+                      function_name_identifier: GetReports
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                          - naked_identifier: d
+                          - dot: .
+                          - naked_identifier: DeptMgrID
+                        end_bracket: )
+                alias_expression:
+                  keyword: AS
+                  naked_identifier: reps
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+            - naked_identifier: d
+            - dot: .
+            - naked_identifier: DeptMgrID
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '10'
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
           keyword: SELECT
           select_clause_element:
             wildcard_expression:
@@ -99,6 +179,56 @@ file:
                           - naked_identifier: DepartmentID
                         end_bracket: )
           statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: Department
+              alias_expression:
+                naked_identifier: D
+            join_clause:
+            - keyword: OUTER
+            - keyword: APPLY
+            - from_expression_element:
+                table_expression:
+                  function:
+                    function_name:
+                      naked_identifier: dbo
+                      dot: .
+                      function_name_identifier: fn_GetAllEmployeeOfADepartment
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                          - naked_identifier: D
+                          - dot: .
+                          - naked_identifier: DepartmentID
+                        end_bracket: )
+                alias_expression:
+                  keyword: AS
+                  naked_identifier: AllEmp
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+            - naked_identifier: D
+            - dot: .
+            - naked_identifier: DepartmentId
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '10'
+        statement_terminator: ;
   - statement:
       select_statement:
         select_clause:

--- a/test/fixtures/rules/std_rule_cases/CV12.yml
+++ b/test/fixtures/rules/std_rule_cases/CV12.yml
@@ -46,6 +46,13 @@ test_noop_positional_join_duckdb:
     core:
       dialect: duckdb
 
+test_noop_outer_apply_tsql:
+  pass_str: |
+    SELECT foo.a, bar.b FROM foo OUTER APPLY bar(foo.a) AS bar WHERE bar.x > 3;
+  configs:
+    core:
+      dialect: tsql
+
 test_fail_unqualified:
   # ambiguous, fail without fix
   fail_str: |


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
In TSQL there is the CROSS APPLY and OUTER APPLY joins that don't have an ON clause. CV12 was throwing error for OUTER APPLY joins.
Fixes [#6825](https://github.com/sqlfluff/sqlfluff/issues/6825)


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
