### PR TITLE
Remove AliasedObjectReferenceSegment

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1253,15 +1253,6 @@ class ArrayAccessorSegment(BaseSegment):
     )
 
 
-class AliasedObjectReferenceSegment(BaseSegment):
-    """A reference to an object with an `AS` clause."""
-
-    type = "object_reference"
-    match_grammar: Matchable = Sequence(
-        Ref("ObjectReferenceSegment"), Ref("AliasExpressionSegment")
-    )
-
-
 ansi_dialect.add(
     # This is a hook point to allow subclassing for other dialects
     AliasedTableReferenceGrammar=Sequence(


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
As the issue points out, this is an unused class, so removing it.
Fixes #6658

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
