### PR TITLE
Redshift: Add support for `select exclude` syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2715,6 +2715,33 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
     )
 
 
+class WildcardExpressionSegment(ansi.WildcardExpressionSegment):
+    """An extension of the star expression for Redshift."""
+
+    match_grammar = ansi.WildcardExpressionSegment.match_grammar.copy(
+        insert=[
+            # Optional Exclude
+            Ref("ExcludeClauseSegment", optional=True),
+        ]
+    )
+
+
+class ExcludeClauseSegment(BaseSegment):
+    """A Redshift SELECT EXCLUDE clause.
+
+    https://docs.aws.amazon.com/redshift/latest/dg/r_EXCLUDE_list.html
+    """
+
+    type = "select_exclude_clause"
+    match_grammar = Sequence(
+        "EXCLUDE",
+        OneOf(
+            Bracketed(Delimited(Ref("SingleIdentifierGrammar"))),
+            Ref("SingleIdentifierGrammar"),
+        ),
+    )
+
+
 class GroupByClauseSegment(postgres.GroupByClauseSegment):
     """A `GROUP BY` clause like in `SELECT`."""
 

--- a/test/fixtures/dialects/redshift/select_exclude.sql
+++ b/test/fixtures/dialects/redshift/select_exclude.sql
@@ -1,0 +1,7 @@
+SELECT * EXCLUDE col1 FROM table1;
+
+SELECT * EXCLUDE col1, col2 FROM table1;
+
+SELECT * EXCLUDE (col1) FROM table1;
+
+SELECT * EXCLUDE (col1, col2) FROM table1;

--- a/test/fixtures/dialects/redshift/select_exclude.yml
+++ b/test/fixtures/dialects/redshift/select_exclude.yml
@@ -1,0 +1,95 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: ccfe5628326043e2977dbfdf0721ccb5be8f8449f571dcb4fbb46d8e92aa9eb8
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_exclude_clause:
+              keyword: EXCLUDE
+              naked_identifier: col1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_exclude_clause:
+              keyword: EXCLUDE
+              naked_identifier: col1
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: col2
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_exclude_clause:
+              keyword: EXCLUDE
+              bracketed:
+                start_bracket: (
+                naked_identifier: col1
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+            select_exclude_clause:
+              keyword: EXCLUDE
+              bracketed:
+              - start_bracket: (
+              - naked_identifier: col1
+              - comma: ','
+              - naked_identifier: col2
+              - end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table1
+- statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Add support for the [`SELECT * EXCLUDE` syntax](https://docs.aws.amazon.com/redshift/latest/dg/r_EXCLUDE_list.html) introduced in [Amazon Redshift patch 188](https://docs.aws.amazon.com/redshift/latest/mgmt/cluster-versions.html#cluster-version-188):

```sql
-- EXCLUDE column-name, ... | ( column-name, ... )
-- For example:
SELECT * EXCLUDE col1 FROM table1;
SELECT * EXCLUDE col1, col2 FROM table1;
SELECT * EXCLUDE (col1) FROM table1;
SELECT * EXCLUDE (col1, col2) FROM table1;
```

See https://docs.aws.amazon.com/redshift/latest/dg/r_EXCLUDE_list.html


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
