### PR TITLE
TSQL: Add support for JSON_ARRAY and JSON_OBJECT

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3065,6 +3065,19 @@ class ReplicateFunctionNameSegment(BaseSegment):
     match_grammar = Sequence("REPLICATE")
 
 
+class JsonFunctionNameSegment(BaseSegment):
+    """JSON functions name segment.
+
+    https://learn.microsoft.com/en-us/sql/t-sql/functions/json-object-transact-sql
+
+    Need to be able to specify this as type function_name
+    so that linting rules identify it properly
+    """
+
+    type = "function_name"
+    match_grammar = OneOf("JSON_ARRAY", "JSON_OBJECT")
+
+
 class RankFunctionNameSegment(BaseSegment):
     """Rank function name segment.
 
@@ -3263,6 +3276,58 @@ class ReplicateFunctionContentsSegment(BaseSegment):
     )
 
 
+class JsonFunctionContentsSegment(BaseSegment):
+    """JSON function contents."""
+
+    type = "function_contents"
+
+    _json_null_clause = OneOf(
+        Sequence("NULL", "ON", "NULL"),
+        Sequence("ABSENT", "ON", "NULL"),
+        optional=True,
+    )
+
+    _json_key_value = Sequence(
+        OneOf(
+            Ref("QuotedLiteralSegment"),
+            Ref("ParameterNameSegment"),
+        ),
+        Ref("ColonSegment"),
+        Sequence(
+            OneOf(
+                Ref("QuotedLiteralSegment"),
+                Ref("LiteralGrammar"),
+                Ref("NumericLiteralSegment"),
+                Ref("ColumnReferenceSegment"),
+                Ref("ParameterNameSegment"),
+                Ref("FunctionSegment"),
+                Bracketed(Ref("SelectStatementSegment")),
+                "NULL",
+            ),
+            _json_null_clause,
+        ),
+        allow_gaps=True,
+    )
+
+    match_grammar = OneOf(
+        Bracketed(
+            Delimited(
+                AnyNumberOf(
+                    Ref("QuotedLiteralSegment"),
+                    Ref("NumericLiteralSegment"),
+                    Ref("ColumnReferenceSegment"),
+                    Ref("ParameterNameSegment"),
+                    "NULL",
+                    _json_null_clause,
+                )
+            )
+        ),
+        Bracketed(
+            Delimited(_json_key_value, _json_null_clause),
+        ),
+    )
+
+
 class RankFunctionContentsSegment(BaseSegment):
     """Rank Function contents."""
 
@@ -3340,6 +3405,10 @@ class FunctionSegment(BaseSegment):
             ),
             Ref("FunctionContentsSegment"),
             Ref("PostFunctionGrammar", optional=True),
+        ),
+        Sequence(
+            Ref("JsonFunctionNameSegment"),
+            Ref("JsonFunctionContentsSegment"),
         ),
     )
 

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -413,6 +413,8 @@ UNRESERVED_KEYWORDS = [
     "IO",
     "ISOLATION",
     "JSON",
+    "JSON_ARRAY",
+    "JSON_OBJECT",
     "KEEP",
     "KEEPDEFAULTS",
     "KEEPFIXED",

--- a/test/fixtures/dialects/tsql/json_functions.sql
+++ b/test/fixtures/dialects/tsql/json_functions.sql
@@ -1,0 +1,31 @@
+SELECT JSON_OBJECT(ABSENT ON NULL);
+
+SELECT JSON_ARRAY('a', 1, 'b', 2);
+
+SELECT JSON_ARRAY('a', 1, NULL, 2, NULL ON NULL);
+
+SELECT JSON_OBJECT('name': 'value', 'new': 1);
+
+SELECT JSON_OBJECT('name': 'value', 'type': NULL ABSENT ON NULL)
+
+SELECT JSON_OBJECT('name': 'value', 'type': JSON_ARRAY(1, 2))
+
+SELECT JSON_OBJECT('name': 'value', 'type': JSON_OBJECT('type_id': 1, 'name': 'a'))
+
+DECLARE @id_key nvarchar(10) = N'id', @id_value nvarchar(64) = NEWID();
+SELECT JSON_OBJECT('user_name': USER_NAME(), @id_key: @id_value, 'sid': (SELECT @@SPID));
+
+SELECT s.session_id, JSON_OBJECT('security_id': s.security_id, 'login': s.login_name, 'status': s.status) AS info
+FROM sys.dm_exec_sessions AS s
+WHERE s.is_user_process = 1;
+
+SELECT JSON_ARRAY('a', JSON_OBJECT('name': 'value', 'type': 1));
+
+SELECT JSON_ARRAY('a', JSON_OBJECT('name': 'value', 'type': 1), JSON_ARRAY(1, NULL, 2 NULL ON NULL));
+
+DECLARE @id_value nvarchar(64) = NEWID();
+SELECT JSON_ARRAY(1, @id_value, (SELECT @@SPID));
+
+SELECT s.session_id, JSON_ARRAY(s.host_name, s.program_name, s.client_interface_name)
+FROM sys.dm_exec_sessions AS s
+WHERE s.is_user_process = 1;

--- a/test/fixtures/dialects/tsql/json_functions.yml
+++ b/test/fixtures/dialects/tsql/json_functions.yml
@@ -1,0 +1,503 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 239013b521b0192fd7c63b5eac97cbf964128a89fc638c20d9476df945dbed14
+file:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                keyword: JSON_OBJECT
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - keyword: ABSENT
+                - keyword: 'ON'
+                - keyword: 'NULL'
+                - end_bracket: )
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_ARRAY
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    quoted_literal: "'a'"
+                - comma: ','
+                - expression:
+                    numeric_literal: '1'
+                - comma: ','
+                - expression:
+                    quoted_literal: "'b'"
+                - comma: ','
+                - expression:
+                    numeric_literal: '2'
+                - end_bracket: )
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                keyword: JSON_ARRAY
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - quoted_literal: "'a'"
+                - comma: ','
+                - numeric_literal: '1'
+                - comma: ','
+                - keyword: 'NULL'
+                - comma: ','
+                - numeric_literal: '2'
+                - comma: ','
+                - keyword: 'NULL'
+                - keyword: 'ON'
+                - keyword: 'NULL'
+                - end_bracket: )
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                keyword: JSON_OBJECT
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - quoted_literal: "'name'"
+                - colon: ':'
+                - quoted_literal: "'value'"
+                - comma: ','
+                - quoted_literal: "'new'"
+                - colon: ':'
+                - numeric_literal: '1'
+                - end_bracket: )
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                keyword: JSON_OBJECT
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - quoted_literal: "'name'"
+                - colon: ':'
+                - quoted_literal: "'value'"
+                - comma: ','
+                - quoted_literal: "'type'"
+                - colon: ':'
+                - null_literal: 'NULL'
+                - keyword: ABSENT
+                - keyword: 'ON'
+                - keyword: 'NULL'
+                - end_bracket: )
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                keyword: JSON_OBJECT
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - quoted_literal: "'name'"
+                - colon: ':'
+                - quoted_literal: "'value'"
+                - comma: ','
+                - quoted_literal: "'type'"
+                - colon: ':'
+                - function:
+                    function_name:
+                      function_name_identifier: JSON_ARRAY
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          numeric_literal: '1'
+                      - comma: ','
+                      - expression:
+                          numeric_literal: '2'
+                      - end_bracket: )
+                - end_bracket: )
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                keyword: JSON_OBJECT
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - quoted_literal: "'name'"
+                - colon: ':'
+                - quoted_literal: "'value'"
+                - comma: ','
+                - quoted_literal: "'type'"
+                - colon: ':'
+                - function:
+                    function_name:
+                      keyword: JSON_OBJECT
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - quoted_literal: "'type_id'"
+                      - colon: ':'
+                      - numeric_literal: '1'
+                      - comma: ','
+                      - quoted_literal: "'name'"
+                      - colon: ':'
+                      - quoted_literal: "'a'"
+                      - end_bracket: )
+                - end_bracket: )
+  - statement:
+      declare_segment:
+      - keyword: DECLARE
+      - parameter: '@id_key'
+      - data_type:
+          data_type_identifier: nvarchar
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '10'
+              end_bracket: )
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - expression:
+          quoted_literal: "N'id'"
+      - comma: ','
+      - parameter: '@id_value'
+      - data_type:
+          data_type_identifier: nvarchar
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '64'
+              end_bracket: )
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - expression:
+          function:
+            function_name:
+              function_name_identifier: NEWID
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+      - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                keyword: JSON_OBJECT
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - quoted_literal: "'user_name'"
+                - colon: ':'
+                - function:
+                    function_name:
+                      function_name_identifier: USER_NAME
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        end_bracket: )
+                - comma: ','
+                - parameter: '@id_key'
+                - colon: ':'
+                - parameter: '@id_value'
+                - comma: ','
+                - quoted_literal: "'sid'"
+                - colon: ':'
+                - bracketed:
+                    start_bracket: (
+                    select_statement:
+                      select_clause:
+                        keyword: SELECT
+                        select_clause_element:
+                          system_variable: '@@SPID'
+                    end_bracket: )
+                - end_bracket: )
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: s
+            - dot: .
+            - naked_identifier: session_id
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                keyword: JSON_OBJECT
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - quoted_literal: "'security_id'"
+                - colon: ':'
+                - column_reference:
+                  - naked_identifier: s
+                  - dot: .
+                  - naked_identifier: security_id
+                - comma: ','
+                - quoted_literal: "'login'"
+                - colon: ':'
+                - column_reference:
+                  - naked_identifier: s
+                  - dot: .
+                  - naked_identifier: login_name
+                - comma: ','
+                - quoted_literal: "'status'"
+                - colon: ':'
+                - column_reference:
+                  - naked_identifier: s
+                  - dot: .
+                  - naked_identifier: status
+                - end_bracket: )
+            alias_expression:
+              keyword: AS
+              naked_identifier: info
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: sys
+                - dot: .
+                - naked_identifier: dm_exec_sessions
+              alias_expression:
+                keyword: AS
+                naked_identifier: s
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+            - naked_identifier: s
+            - dot: .
+            - naked_identifier: is_user_process
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '1'
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_ARRAY
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    quoted_literal: "'a'"
+                - comma: ','
+                - expression:
+                    function:
+                      function_name:
+                        keyword: JSON_OBJECT
+                      function_contents:
+                        bracketed:
+                        - start_bracket: (
+                        - quoted_literal: "'name'"
+                        - colon: ':'
+                        - quoted_literal: "'value'"
+                        - comma: ','
+                        - quoted_literal: "'type'"
+                        - colon: ':'
+                        - numeric_literal: '1'
+                        - end_bracket: )
+                - end_bracket: )
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_ARRAY
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    quoted_literal: "'a'"
+                - comma: ','
+                - expression:
+                    function:
+                      function_name:
+                        keyword: JSON_OBJECT
+                      function_contents:
+                        bracketed:
+                        - start_bracket: (
+                        - quoted_literal: "'name'"
+                        - colon: ':'
+                        - quoted_literal: "'value'"
+                        - comma: ','
+                        - quoted_literal: "'type'"
+                        - colon: ':'
+                        - numeric_literal: '1'
+                        - end_bracket: )
+                - comma: ','
+                - expression:
+                    function:
+                      function_name:
+                        keyword: JSON_ARRAY
+                      function_contents:
+                        bracketed:
+                        - start_bracket: (
+                        - numeric_literal: '1'
+                        - comma: ','
+                        - keyword: 'NULL'
+                        - comma: ','
+                        - numeric_literal: '2'
+                        - keyword: 'NULL'
+                        - keyword: 'ON'
+                        - keyword: 'NULL'
+                        - end_bracket: )
+                - end_bracket: )
+        statement_terminator: ;
+  - statement:
+      declare_segment:
+        keyword: DECLARE
+        parameter: '@id_value'
+        data_type:
+          data_type_identifier: nvarchar
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '64'
+              end_bracket: )
+        comparison_operator:
+          raw_comparison_operator: '='
+        expression:
+          function:
+            function_name:
+              function_name_identifier: NEWID
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_ARRAY
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    numeric_literal: '1'
+                - comma: ','
+                - expression:
+                    parameter: '@id_value'
+                - comma: ','
+                - expression:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        select_statement:
+                          select_clause:
+                            keyword: SELECT
+                            select_clause_element:
+                              system_variable: '@@SPID'
+                      end_bracket: )
+                - end_bracket: )
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+            - naked_identifier: s
+            - dot: .
+            - naked_identifier: session_id
+        - comma: ','
+        - select_clause_element:
+            function:
+              function_name:
+                function_name_identifier: JSON_ARRAY
+              function_contents:
+                bracketed:
+                - start_bracket: (
+                - expression:
+                    column_reference:
+                    - naked_identifier: s
+                    - dot: .
+                    - naked_identifier: host_name
+                - comma: ','
+                - expression:
+                    column_reference:
+                    - naked_identifier: s
+                    - dot: .
+                    - naked_identifier: program_name
+                - comma: ','
+                - expression:
+                    column_reference:
+                    - naked_identifier: s
+                    - dot: .
+                    - naked_identifier: client_interface_name
+                - end_bracket: )
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                - naked_identifier: sys
+                - dot: .
+                - naked_identifier: dm_exec_sessions
+              alias_expression:
+                keyword: AS
+                naked_identifier: s
+        where_clause:
+          keyword: WHERE
+          expression:
+            column_reference:
+            - naked_identifier: s
+            - dot: .
+            - naked_identifier: is_user_process
+            comparison_operator:
+              raw_comparison_operator: '='
+            numeric_literal: '1'
+        statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #6843

Adds support to tsql for JSON_ARRAY and JSON_OBJECT functions following syntax from documentation:
https://learn.microsoft.com/en-us/sql/t-sql/functions/json-array-transact-sql
https://learn.microsoft.com/en-us/sql/t-sql/functions/json-object-transact-sql

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
