### PR TITLE
converted large_file_skip_byte_limit value to integer before comparison, fixes Issue #6847

### DIFF
--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -126,7 +126,7 @@ class Linter:
         config_encoding: str = file_config.get("encoding", default="autodetect")
         encoding = get_encoding(fname=fname, config_encoding=config_encoding)
         # Check file size before loading.
-        limit = file_config.get("large_file_skip_byte_limit")
+        limit = int(file_config.get("large_file_skip_byte_limit"))
         if limit:
             # Get the file size
             file_size = os.path.getsize(fname)


### PR DESCRIPTION
### In the linter, converted the value for large_file_skip_byte_limit to an integer to prevent the error in the comparison
This should fix Issue #6847 with no side effects.



### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
