### PR TITLE
Fixes Oracle parsing tree with `/` operator.

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -602,6 +602,9 @@ oracle_dialect.add(
         Ref("NumericLiteralSegment"),
         RegexParser(r"[KMGTPE]?", LiteralSegment, type="size_prefix"),
     ),
+    SlashStatementTerminatorSegment=StringParser(
+        "/", SymbolSegment, type="statement_terminator"
+    ),
 )
 
 oracle_dialect.replace(
@@ -774,7 +777,7 @@ oracle_dialect.replace(
         ),
     ),
     DelimiterGrammar=Sequence(
-        Ref("SemicolonSegment"), Ref("DivideSegment", optional=True)
+        Ref("SemicolonSegment"), Ref("SlashStatementTerminatorSegment", optional=True)
     ),
     SelectClauseTerminatorGrammar=OneOf(
         "INTO",
@@ -786,7 +789,6 @@ oracle_dialect.replace(
         Ref("SetOperatorSegment"),
         "FETCH",
     ),
-    DivideSegment=StringParser("/", SymbolSegment, type="statement_terminator"),
 )
 
 
@@ -955,7 +957,7 @@ class ExecuteFileSegment(BaseSegment):
         AnyNumberOf(
             Ref("SingleIdentifierGrammar"),
             Ref("DotSegment"),
-            Ref("DivideSegment"),
+            Ref("SlashStatementTerminatorSegment"),
         ),
     )
 

--- a/test/fixtures/dialects/oracle/collections.yml
+++ b/test/fixtures/dialects/oracle/collections.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b18fb63c92776c45f4cf51d377232b6b47429d8d8ebdff274279689c92a1b733
+_hash: 83f3a149fbf3a452468d9d7a0835e12ba4cabb0b3fab78fbf4ca5cc5b9b9acca
 file:
 - statement:
     begin_end_block:
@@ -316,7 +316,7 @@ file:
                                     numeric_literal: '1'
                                   end_bracket: )
                               end_bracket: )
-                            statement_terminator: /
+                            binary_operator: /
                             numeric_literal: '2'
                           end_bracket: )
                 - statement_terminator: ;

--- a/test/fixtures/dialects/oracle/create_procedure.yml
+++ b/test/fixtures/dialects/oracle/create_procedure.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 12cf404d35d208e5cb468fe963917d4c458fc8a5942fa3a15c47fac6d1aee4c8
+_hash: 6fe577f21a538a984752889d5c57e135c42f82ea9954f5a82e1d7024932ee3a1
 file:
 - statement:
     create_procedure_statement:
@@ -232,7 +232,7 @@ file:
                     - column_reference:
                         naked_identifier: quota
                     end_bracket: )
-                  statement_terminator: /
+                  binary_operator: /
                   numeric_literal: '4'
           - statement_terminator: ;
           - statement:
@@ -383,7 +383,7 @@ file:
                     - column_reference:
                         naked_identifier: quota
                     end_bracket: )
-                  statement_terminator: /
+                  binary_operator: /
                   numeric_literal: '4'
           - statement_terminator: ;
           - keyword: ELSE

--- a/test/fixtures/dialects/oracle/forall.yml
+++ b/test/fixtures/dialects/oracle/forall.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c107aa4b51fd72e352ad3f8c99cfd4f325ba8b77c295f8d695ced5c0b288dc79
+_hash: c94c7ad0bc53b6dc0a0079fed3d8aca5d30676b2f370bce39cc1e2d87ae8d062
 file:
 - statement:
     begin_end_block:
@@ -423,7 +423,7 @@ file:
                           - column_reference:
                               naked_identifier: t1
                           end_bracket: )
-                        statement_terminator: /
+                        binary_operator: /
                         numeric_literal: '100'
                       end_bracket: )
               end_bracket: )
@@ -458,7 +458,7 @@ file:
                           - column_reference:
                               naked_identifier: t2
                           end_bracket: )
-                        statement_terminator: /
+                        binary_operator: /
                         numeric_literal: '100'
                       end_bracket: )
               end_bracket: )

--- a/test/fixtures/dialects/oracle/if.yml
+++ b/test/fixtures/dialects/oracle/if.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 06f9dd0270a41d8d2d1b831cb4fca2ddca12a1e50cab1115f2fd77036a602fd2
+_hash: e67ce96f8afb40f1f0d3294f475582134acf57bc2b9c31635c2c8095a9878978
 file:
 - statement:
     begin_end_block:
@@ -90,7 +90,7 @@ file:
                         - column_reference:
                             naked_identifier: quota
                         end_bracket: )
-                      statement_terminator: /
+                      binary_operator: /
                       numeric_literal: '4'
               - statement_terminator: ;
               - statement:
@@ -282,7 +282,7 @@ file:
                         - column_reference:
                             naked_identifier: quota
                         end_bracket: )
-                      statement_terminator: /
+                      binary_operator: /
                       numeric_literal: '4'
               - statement_terminator: ;
               - keyword: ELSE
@@ -458,7 +458,7 @@ file:
                         - column_reference:
                             naked_identifier: quota
                         end_bracket: )
-                      statement_terminator: /
+                      binary_operator: /
                       numeric_literal: '4'
               - statement_terminator: ;
               - keyword: ELSE

--- a/test/fixtures/dialects/oracle/select.sql
+++ b/test/fixtures/dialects/oracle/select.sql
@@ -3,3 +3,6 @@ select
     status,
     code
 from item_errors error;
+
+select quantity / 100
+from inventory;

--- a/test/fixtures/dialects/oracle/select.yml
+++ b/test/fixtures/dialects/oracle/select.yml
@@ -3,9 +3,9 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c3b973d4e1aa3c31a15cff622e0ba6a9594f7b1b5b2e7cab38350f4da817a957
+_hash: 7af02b3736ee5d5184d7f9a3145506f5ef95a3af84d202ff38f999784ea48d94
 file:
-  statement:
+- statement:
     select_statement:
       select_clause:
       - keyword: select
@@ -29,4 +29,22 @@ file:
                 naked_identifier: item_errors
             alias_expression:
               naked_identifier: error
-  statement_terminator: ;
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          expression:
+            column_reference:
+              naked_identifier: quantity
+            binary_operator: /
+            numeric_literal: '100'
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: inventory
+- statement_terminator: ;


### PR DESCRIPTION
Closes #6842 

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
