### PR TITLE
SQLite: allow trailing unsigned

### DIFF
--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -537,6 +537,7 @@ class DatatypeSegment(ansi.DatatypeSegment):
                 Ref("DatatypeIdentifierSegment"),
             ),
             Ref("BracketedArguments", optional=True),
+            OneOf("UNSIGNED", optional=True),
         ),
     )
 

--- a/test/fixtures/dialects/sqlite/create_table_unsigned.sql
+++ b/test/fixtures/dialects/sqlite/create_table_unsigned.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "wellplated_format" (
+    "id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "bottom_row" varchar(1) NOT NULL,
+    "right_column" smallint unsigned NOT NULL CHECK ("right_column" >= 0)
+);

--- a/test/fixtures/dialects/sqlite/create_table_unsigned.yml
+++ b/test/fixtures/dialects/sqlite/create_table_unsigned.yml
@@ -1,0 +1,62 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 6072c4292a682a04c8bf5df58bfd0ede2d9faeb294c2e5f5eb8c877659c6c158
+file:
+  statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        quoted_identifier: '"wellplated_format"'
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+        - quoted_identifier: '"id"'
+        - data_type:
+            data_type_identifier: integer
+        - column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+        - column_constraint_segment:
+          - keyword: PRIMARY
+          - keyword: KEY
+          - keyword: AUTOINCREMENT
+      - comma: ','
+      - column_definition:
+          quoted_identifier: '"bottom_row"'
+          data_type:
+            data_type_identifier: varchar
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '1'
+                end_bracket: )
+          column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+      - comma: ','
+      - column_definition:
+        - quoted_identifier: '"right_column"'
+        - data_type:
+            data_type_identifier: smallint
+            keyword: unsigned
+        - column_constraint_segment:
+          - keyword: NOT
+          - keyword: 'NULL'
+        - column_constraint_segment:
+            keyword: CHECK
+            bracketed:
+              start_bracket: (
+              expression:
+                column_reference:
+                  quoted_identifier: '"right_column"'
+                comparison_operator:
+                - raw_comparison_operator: '>'
+                - raw_comparison_operator: '='
+                numeric_literal: '0'
+              end_bracket: )
+      - end_bracket: )
+  statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Like MySQL, allow the unsigned keyword to trail the data type identifier. Fixes #6844

### Are there any other side effects of this change that we should be aware of?
I don't anticipate side effects.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
