### PR TITLE
feat(snowflake): add support for 'DROP ICEBERG TABLE' statement

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -9668,7 +9668,7 @@ class DropIcebergTableStatementSegment(BaseSegment):
         Ref("IfExistsGrammar", optional=True),
         Ref("TableReferenceSegment"),
     )
-    
+
 
 class DropDynamicTableSegment(BaseSegment):
     """Drop dynamic table segment."""

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -9652,6 +9652,7 @@ class ExceptionBlockStatementSegment(BaseSegment):
         ),
     )
 
+
 class DropIcebergTableStatementSegment(BaseSegment):
     """`DROP ICEBERG TABLE` statement.
 
@@ -9667,6 +9668,7 @@ class DropIcebergTableStatementSegment(BaseSegment):
         Ref("IfExistsGrammar", optional=True),
         Ref("TableReferenceSegment"),
     )
+    
 
 class DropDynamicTableSegment(BaseSegment):
     """Drop dynamic table segment."""

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1436,6 +1436,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("AlterTagStatementSegment"),
             Ref("ExceptionBlockStatementSegment"),
             Ref("DropDynamicTableSegment"),
+            Ref("DropIcebergTableStatementSegment"),
             Ref("CreateAuthenticationPolicySegment"),
             Ref("DropResourceMonitorStatementSegment"),
         ],
@@ -9651,6 +9652,21 @@ class ExceptionBlockStatementSegment(BaseSegment):
         ),
     )
 
+class DropIcebergTableStatementSegment(BaseSegment):
+    """`DROP ICEBERG TABLE` statement.
+
+    Snowflake syntax reference:
+    https://docs.snowflake.com/en/sql-reference/sql/drop-table.html
+    """
+
+    type = "drop_iceberg_table_statement"
+    match_grammar = Sequence(
+        "DROP",
+        "ICEBERG",
+        "TABLE",
+        Ref("IfExistsGrammar", optional=True),
+        Ref("TableReferenceSegment"),
+    )
 
 class DropDynamicTableSegment(BaseSegment):
     """Drop dynamic table segment."""

--- a/test/fixtures/dialects/snowflake/drop_iceberg_table.sql
+++ b/test/fixtures/dialects/snowflake/drop_iceberg_table.sql
@@ -1,0 +1,3 @@
+DROP ICEBERG TABLE my_table;
+
+DROP ICEBERG TABLE IF EXISTS my_table;

--- a/test/fixtures/dialects/snowflake/drop_iceberg_table.yml
+++ b/test/fixtures/dialects/snowflake/drop_iceberg_table.yml
@@ -1,0 +1,25 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9f5643694cd0e3139eb9f6daec5452d1916d4a5b947aa93fcf5520299640ae22
+file:
+- statement:
+    drop_iceberg_table_statement:
+    - keyword: DROP
+    - keyword: ICEBERG
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: my_table
+- statement_terminator: ;
+- statement:
+    drop_iceberg_table_statement:
+    - keyword: DROP
+    - keyword: ICEBERG
+    - keyword: TABLE
+    - keyword: IF
+    - keyword: EXISTS
+    - table_reference:
+        naked_identifier: my_table
+- statement_terminator: ;


### PR DESCRIPTION
Added a new segment `DropIcebergTableStatementSegment` in the Snowflake dialect to support parsing of `DROP ICEBERG TABLE [IF EXISTS] <table_name>` syntax.

Changes made:
- Defined `DropIcebergTableStatementSegment` with appropriate `match_grammar` using `Sequence`, `Ref`, and `IfExistsGrammar`.
- Registered the new segment via `snowflake_dialect.add(...)`.

This change resolves issues with SQLFluff failing to parse valid Snowflake statements involving Iceberg tables, such as:

    DROP ICEBERG TABLE IF EXISTS SAMPLE_DEV.SAMPLE.CASH;

Helps avoid parse errors like:
    PRS | Found unparsable section: 'DROP ICEBERG TABLE IF EXISTS ...'


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
