### PR TITLE
LT01: Brackets should touch datatypes

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -763,7 +763,7 @@ ansi_dialect.add(
     ListComprehensionGrammar=Nothing(),
     TimeWithTZGrammar=Sequence(
         OneOf("TIME", "TIMESTAMP"),
-        Bracketed(Ref("NumericLiteralSegment"), optional=True),
+        Ref("BracketedArguments", optional=True),
         Sequence(OneOf("WITH", "WITHOUT"), "TIME", "ZONE", optional=True),
     ),
     SequenceMinValueGrammar=OneOf(

--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -378,7 +378,7 @@ class ColumnDefinitionSegment(BaseSegment):
             ),
             Sequence(
                 OneOf("DATETIME", "TIMESTAMP"),
-                Bracketed(Ref("NumericLiteralSegment"), optional=True),  # Precision
+                Ref("BracketedArguments", optional=True),  # Precision
                 AnyNumberOf(
                     # Allow NULL/NOT NULL, DEFAULT, and ON UPDATE in any order
                     Sequence(Sequence("NOT", optional=True), "NULL", optional=True),

--- a/test/fixtures/dialects/athena/select_cast_withtimezone.yml
+++ b/test/fixtures/dialects/athena/select_cast_withtimezone.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e1f1add5999a73e226c754a91e2563fff6e68676f50c0e0ca4ecaf5430821f2d
+_hash: b65efbd8103026d276984396a02cd54ed0bace6db95b3f95e6bd50a0187d2302
 file:
   statement:
     select_statement:
@@ -57,10 +57,11 @@ file:
                 keyword: AS
                 data_type:
                 - keyword: TIMESTAMP
-                - bracketed:
-                    start_bracket: (
-                    numeric_literal: '6'
-                    end_bracket: )
+                - bracketed_arguments:
+                    bracketed:
+                      start_bracket: (
+                      numeric_literal: '6'
+                      end_bracket: )
                 - keyword: WITH
                 - keyword: TIME
                 - keyword: ZONE

--- a/test/fixtures/dialects/mariadb/create_table_datetime.yml
+++ b/test/fixtures/dialects/mariadb/create_table_datetime.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f7865d220a3f1403623e6653978bef7f4cde16b517b662ed9658bbf8d94bc0a9
+_hash: 04711fd76a3d8efbe053513b9a50ce0e2aaf4af87a96e105f521c58ca30810c6
 file:
   statement:
     create_table_statement:
@@ -115,10 +115,11 @@ file:
       - column_definition:
         - naked_identifier: ts7
         - keyword: TIMESTAMP
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '6'
-            end_bracket: )
+        - bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '6'
+              end_bracket: )
         - keyword: DEFAULT
         - keyword: CURRENT_TIMESTAMP
         - bracketed:

--- a/test/fixtures/dialects/mysql/create_table_datetime.yml
+++ b/test/fixtures/dialects/mysql/create_table_datetime.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: f7865d220a3f1403623e6653978bef7f4cde16b517b662ed9658bbf8d94bc0a9
+_hash: 04711fd76a3d8efbe053513b9a50ce0e2aaf4af87a96e105f521c58ca30810c6
 file:
   statement:
     create_table_statement:
@@ -115,10 +115,11 @@ file:
       - column_definition:
         - naked_identifier: ts7
         - keyword: TIMESTAMP
-        - bracketed:
-            start_bracket: (
-            numeric_literal: '6'
-            end_bracket: )
+        - bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '6'
+              end_bracket: )
         - keyword: DEFAULT
         - keyword: CURRENT_TIMESTAMP
         - bracketed:

--- a/test/fixtures/dialects/postgres/datatypes.yml
+++ b/test/fixtures/dialects/postgres/datatypes.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8ed9095e6968d0e0707fc92d9e3f21a4231398b4babcea898b95923bc2419705
+_hash: 7ece17f5ffc617f174ce2ca9d1a0dc541cbac65db272aba6f895573e6cb6586d
 file:
 - statement:
     create_table_statement:
@@ -320,20 +320,22 @@ file:
       - data_type:
           datetime_type_identifier:
             keyword: time
-            bracketed:
-              start_bracket: (
-              numeric_literal: '4'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '4'
+                end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: d
       - data_type:
           datetime_type_identifier:
           - keyword: time
-          - bracketed:
-              start_bracket: (
-              numeric_literal: '4'
-              end_bracket: )
+          - bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '4'
+                end_bracket: )
           - keyword: with
           - keyword: time
           - keyword: zone
@@ -343,10 +345,11 @@ file:
       - data_type:
           datetime_type_identifier:
           - keyword: time
-          - bracketed:
-              start_bracket: (
-              numeric_literal: '4'
-              end_bracket: )
+          - bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '4'
+                end_bracket: )
           - keyword: without
           - keyword: time
           - keyword: zone
@@ -356,20 +359,22 @@ file:
       - data_type:
           datetime_type_identifier:
             keyword: timestamp
-            bracketed:
-              start_bracket: (
-              numeric_literal: '4'
-              end_bracket: )
+            bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '4'
+                end_bracket: )
       - comma: ','
       - column_reference:
           naked_identifier: g
       - data_type:
           datetime_type_identifier:
           - keyword: timestamp
-          - bracketed:
-              start_bracket: (
-              numeric_literal: '4'
-              end_bracket: )
+          - bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '4'
+                end_bracket: )
           - keyword: with
           - keyword: time
           - keyword: zone
@@ -379,10 +384,11 @@ file:
       - data_type:
           datetime_type_identifier:
           - keyword: timestamp
-          - bracketed:
-              start_bracket: (
-              numeric_literal: '4'
-              end_bracket: )
+          - bracketed_arguments:
+              bracketed:
+                start_bracket: (
+                numeric_literal: '4'
+                end_bracket: )
           - keyword: without
           - keyword: time
           - keyword: zone

--- a/test/fixtures/dialects/trino/timestamp_resolutions.yml
+++ b/test/fixtures/dialects/trino/timestamp_resolutions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 03286c72e8154da3f1893661080540aa6cef0967cc871ae0ef42947372bbd5be
+_hash: 351e0f55b3561e752332d82fa7478e3c75b97e39a1f457890aceb9c14db716e0
 file:
 - statement:
     select_statement:
@@ -49,10 +49,11 @@ file:
                 keyword: AS
                 data_type:
                   keyword: TIMESTAMP
-                  bracketed:
-                    start_bracket: (
-                    numeric_literal: '0'
-                    end_bracket: )
+                  bracketed_arguments:
+                    bracketed:
+                      start_bracket: (
+                      numeric_literal: '0'
+                      end_bracket: )
                 end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -76,10 +77,11 @@ file:
                 keyword: AS
                 data_type:
                   keyword: TIMESTAMP
-                  bracketed:
-                    start_bracket: (
-                    numeric_literal: '12'
-                    end_bracket: )
+                  bracketed_arguments:
+                    bracketed:
+                      start_bracket: (
+                      numeric_literal: '12'
+                      end_bracket: )
                 end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -155,10 +157,11 @@ file:
                 keyword: AS
                 data_type:
                 - keyword: TIMESTAMP
-                - bracketed:
-                    start_bracket: (
-                    numeric_literal: '6'
-                    end_bracket: )
+                - bracketed_arguments:
+                    bracketed:
+                      start_bracket: (
+                      numeric_literal: '6'
+                      end_bracket: )
                 - keyword: WITH
                 - keyword: TIME
                 - keyword: ZONE
@@ -185,10 +188,11 @@ file:
                 keyword: AS
                 data_type:
                 - keyword: TIMESTAMP
-                - bracketed:
-                    start_bracket: (
-                    numeric_literal: '6'
-                    end_bracket: )
+                - bracketed_arguments:
+                    bracketed:
+                      start_bracket: (
+                      numeric_literal: '6'
+                      end_bracket: )
                 - keyword: WITHOUT
                 - keyword: TIME
                 - keyword: ZONE

--- a/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-brackets.yml
@@ -60,3 +60,14 @@ test_fail_snowflake_match_condition:
   configs:
     core:
       dialect: snowflake
+
+test_pass_ansi_bracketed_data_types:
+  pass_str: |
+    CREATE TABLE fractest (c1 TIME(2), c2 DATETIME(2), c3 TIMESTAMP(2));
+
+test_pass_mysql_bracketed_data_types:
+  pass_str: |
+    CREATE TABLE fractest (c1 TIME(2), c2 DATETIME(2), c3 TIMESTAMP(2));
+  configs:
+    core:
+      dialect: mysql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This corrects where some datatypes that had bracketed parts to be disjointed when LT01 was ran.
- fixes #6846

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
