### PR TITLE
Feat: Support explode in sparksql lateral clauses

### DIFF
--- a/src/sqlfluff/dialects/dialect_sparksql.py
+++ b/src/sqlfluff/dialects/dialect_sparksql.py
@@ -2254,9 +2254,10 @@ class LateralViewClauseSegment(BaseSegment):
     type = "lateral_view_clause"
 
     match_grammar = Sequence(
+        Ref("CommaSegment", optional=True),
         Indent,
         "LATERAL",
-        "VIEW",
+        OneOf("VIEW",optional=True),
         Ref.keyword("OUTER", optional=True),
         Ref("FunctionSegment"),
         OneOf(

--- a/test/fixtures/dialects/sparksql/select_lateral_view_supported_tvf.sql
+++ b/test/fixtures/dialects/sparksql/select_lateral_view_supported_tvf.sql
@@ -91,3 +91,10 @@ FROM test
     LATERAL VIEW parse_url(
         'http://spark.apache.org/path?query=1', 'HOST'
     ) AS c1;
+
+-- explode in a LATERAL CLAUSE
+SELECT 
+    a.id, 
+    b.col 
+FROM range(10) as test, 
+    LATERAL explode(array('a', 'b', 'c')) as b;

--- a/test/fixtures/dialects/sparksql/select_lateral_view_supported_tvf.yml
+++ b/test/fixtures/dialects/sparksql/select_lateral_view_supported_tvf.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bc08af1af13639e869d88b91f111684906ab36ac4e49da6166fb85674881091a
+_hash: 3f9d9d5bb6b91d1b33630ab87db8a12188e847e36118c6bd0cdc3492e51aad26
 file:
 - statement:
     select_statement:
@@ -736,4 +736,65 @@ file:
                 - end_bracket: )
           - keyword: AS
           - naked_identifier: c1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: a
+          - dot: .
+          - naked_identifier: id
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: b
+          - dot: .
+          - naked_identifier: col
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: range
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      numeric_literal: '10'
+                    end_bracket: )
+            alias_expression:
+              keyword: as
+              naked_identifier: test
+          lateral_view_clause:
+          - comma: ','
+          - keyword: LATERAL
+          - function:
+              function_name:
+                function_name_identifier: explode
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    function:
+                      function_name:
+                        function_name_identifier: array
+                      function_contents:
+                        bracketed:
+                        - start_bracket: (
+                        - expression:
+                            quoted_literal: "'a'"
+                        - comma: ','
+                        - expression:
+                            quoted_literal: "'b'"
+                        - comma: ','
+                        - expression:
+                            quoted_literal: "'c'"
+                        - end_bracket: )
+                  end_bracket: )
+          - keyword: as
+          - naked_identifier: b
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

Adding support for parts of the `LATERAL` syntax currently unparsable in Databricks SQL (originating in SparkSQL)


### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixed #6679 

### Are there any other side effects of this change that we should be aware of?

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
