### PR TITLE
ST05: Ignore table_expressions that aren't bracketed

### DIFF
--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -274,9 +274,9 @@ class Rule_ST05(BaseRule):
             # if the subquery is table_expression, get the bracketed child instead.
             if anchor.is_type("table_expression"):
                 bracket_anchor = anchor.get_child("bracketed")
-                assert (
-                    bracket_anchor
-                ), "table_expression should have a bracketed segment"
+                # if the table_expression isn't bracketed, assume it isn't a subquery.
+                if not bracket_anchor:
+                    continue
             else:
                 bracket_anchor = anchor
 

--- a/test/fixtures/rules/std_rule_cases/ST05.yml
+++ b/test/fixtures/rules/std_rule_cases/ST05.yml
@@ -1051,3 +1051,35 @@ test_fail_no_fix_nested_subquery_join:
             ON w2.a = y.a
     )
         ON x.a = w2.a;
+
+test_pass_nested_table_function:
+  pass_str: |
+    SELECT *
+    FROM `func`((
+      SELECT 1
+    ));
+  configs:
+    core:
+      dialect: bigquery
+    rules:
+      structure.subquery:
+        forbid_subquery_in: both
+
+test_pass_nested_table_function_with_subquery:
+  pass_str: |
+    SELECT
+      t.col1,
+      res.result
+    FROM t,
+      TABLE(
+        utils.udfs.udtf(
+          t.col1,
+          (SELECT dist.stats FROM dist)
+        ) OVER (
+          PARTITION BY t.col1
+          ORDER BY t.col2 DESC
+        )
+      ) AS res;
+  configs:
+    core:
+      dialect: snowflake


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This corrects where it was assumed that a `table_expression` would always have a `bracketed` section. Now, we skip over non-bracketed table expressions such as functions.
- fixes #6777

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
