### PR TITLE
CI: Ignore mypy call-arg for CliRunner mix_stderr

### DIFF
--- a/src/sqlfluff/utils/testing/cli.py
+++ b/src/sqlfluff/utils/testing/cli.py
@@ -21,7 +21,7 @@ def invoke_assert_code(
     if cli_input:
         kwargs["input"] = cli_input
     if "mix_stderr" in inspect.signature(CliRunner).parameters:  # pragma: no cover
-        runner = CliRunner(mix_stderr=False)  # type: ignore[call-arg]
+        runner = CliRunner(mix_stderr=False)  # type: ignore[call-arg,unused-ignore]
     else:  # pragma: no cover
         runner = CliRunner()
     result = runner.invoke(*args, **kwargs)

--- a/src/sqlfluff/utils/testing/cli.py
+++ b/src/sqlfluff/utils/testing/cli.py
@@ -21,7 +21,7 @@ def invoke_assert_code(
     if cli_input:
         kwargs["input"] = cli_input
     if "mix_stderr" in inspect.signature(CliRunner).parameters:  # pragma: no cover
-        runner = CliRunner(mix_stderr=False) # type: ignore[call-arg]
+        runner = CliRunner(mix_stderr=False)  # type: ignore[call-arg]
     else:  # pragma: no cover
         runner = CliRunner()
     result = runner.invoke(*args, **kwargs)

--- a/src/sqlfluff/utils/testing/cli.py
+++ b/src/sqlfluff/utils/testing/cli.py
@@ -21,7 +21,7 @@ def invoke_assert_code(
     if cli_input:
         kwargs["input"] = cli_input
     if "mix_stderr" in inspect.signature(CliRunner).parameters:  # pragma: no cover
-        runner = CliRunner(mix_stderr=False)
+        runner = CliRunner(mix_stderr=False) # type: ignore[call-arg]
     else:  # pragma: no cover
         runner = CliRunner()
     result = runner.invoke(*args, **kwargs)


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
With the release of click 8.2.0, mix_stderr has been removed. However to continue supporting older version (namely for python 3.9) we need to ignore the missing argument where the signature is already checked in the prior line.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
