### PR TITLE
cli: Enable `--disregard-sqlfluffignores` for `fix` and `format`

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -366,6 +366,11 @@ def lint_options(f: Callable) -> Callable:
         default=False,
         help="Warn about unneeded '-- noqa:' comments.",
     )(f)
+    f = click.option(
+        "--disregard-sqlfluffignores",
+        is_flag=True,
+        help="Perform the operation regardless of .sqlfluffignore configurations",
+    )(f)
     return f
 
 
@@ -572,11 +577,6 @@ def dump_file_payload(filename: Optional[str], payload: str) -> None:
         "If set, the exit code will always be zero, regardless of violations "
         "found. This is potentially useful during rollout."
     ),
-)
-@click.option(
-    "--disregard-sqlfluffignores",
-    is_flag=True,
-    help="Perform the operation regardless of .sqlfluffignore configurations",
 )
 @click.argument("paths", nargs=-1, type=click.Path(allow_dash=True))
 def lint(
@@ -889,6 +889,7 @@ def _paths_fix(
     show_lint_violations,
     check: bool = False,
     persist_timing: Optional[str] = None,
+    ignore_files: bool = True,
 ) -> None:
     """Handle fixing from paths."""
     # Lint the paths (not with the fix argument at this stage), outputting as we go.
@@ -901,6 +902,7 @@ def _paths_fix(
             paths,
             fix=True,
             ignore_non_existent_files=False,
+            ignore_files=ignore_files,
             processes=processes,
             # If --check is set, then don't apply any fixes until the end.
             apply_fixes=not check,
@@ -1056,6 +1058,7 @@ def _paths_fix(
 def fix(
     force: bool,
     paths: tuple[str],
+    disregard_sqlfluffignores: bool,
     check: bool = False,
     bench: bool = False,
     quiet: bool = False,
@@ -1139,6 +1142,7 @@ def fix(
                 show_lint_violations,
                 check=check,
                 persist_timing=persist_timing,
+                ignore_files=not disregard_sqlfluffignores,
             )
 
 
@@ -1155,6 +1159,7 @@ def fix(
 @click.argument("paths", nargs=-1, type=click.Path(allow_dash=True))
 def cli_format(
     paths: tuple[str],
+    disregard_sqlfluffignores: bool,
     bench: bool = False,
     fixed_suffix: str = "",
     logger: Optional[logging.Logger] = None,
@@ -1240,6 +1245,7 @@ def cli_format(
                 bench=bench,
                 show_lint_violations=False,
                 persist_timing=persist_timing,
+                ignore_files=not disregard_sqlfluffignores,
             )
 
 

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -790,6 +790,29 @@ def test__cli__command_lint_skip_ignore_files():
     assert "LT12" in result.stdout.strip()
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        (fix),
+        (cli_format),
+    ],
+)
+def test__cli__command_fix_skip_ignore_files(command):
+    """Check "ignore file" is skipped when --disregard-sqlfluffignores flag is set."""
+    runner = CliRunner()
+    result = runner.invoke(
+        command,
+        [
+            "test/fixtures/linter/sqlfluffignore/path_b/query_c.sql",
+            "--disregard-sqlfluffignores",
+            "-x",
+            "_fix",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "LT12" in result.stdout.strip()
+
+
 def test__cli__command_lint_ignore_local_config():
     """Test that --ignore-local_config ignores .sqlfluff file as expected."""
     runner = CliRunner()


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This enables the usage of `--disregard-sqlfluffignores` when running the `format` or `fix` subcommands from the cli.
- fixes #6818

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
