### PR TITLE
MySQL: Add collate expressions

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -305,6 +305,7 @@ mysql_dialect.replace(
         )
     ),
     LikeGrammar=OneOf("LIKE", "RLIKE", "REGEXP"),
+    CollateGrammar=Sequence("COLLATE", Ref("CollationReferenceSegment")),
 )
 
 mysql_dialect.add(
@@ -984,7 +985,7 @@ class ColumnConstraintSegment(ansi.ColumnConstraintSegment):
                 Ref("DoubleQuotedIdentifierSegment"),
             ),
         ),
-        Sequence("COLLATE", Ref("CollationReferenceSegment")),
+        Ref("CollateGrammar"),
         Sequence(
             Sequence("GENERATED", "ALWAYS", optional=True),
             "AS",

--- a/test/fixtures/dialects/mysql/collate.sql
+++ b/test/fixtures/dialects/mysql/collate.sql
@@ -1,0 +1,1 @@
+SELECT "a string" COLLATE "utf8mb4_general_ci";

--- a/test/fixtures/dialects/mysql/collate.yml
+++ b/test/fixtures/dialects/mysql/collate.yml
@@ -1,0 +1,18 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: a45811c5f37876180a216a61d4fd2c31baf906e06f25659393e277ee50442028
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            quoted_literal: '"a string"'
+            keyword: COLLATE
+            collation_reference:
+              quoted_literal: '"utf8mb4_general_ci"'
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Supports `COLLATE` expressions in MySQL.
- fixes a separate issue noted in #5754

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
