### PR TITLE
cross-project aware `ref` macro

### DIFF
--- a/docs/source/configuration/templating/dbt.rst
+++ b/docs/source/configuration/templating/dbt.rst
@@ -123,6 +123,8 @@ configuration file.
     [sqlfluff:templater:jinja:macros]
     # Macros provided as builtins for dbt projects
     dbt_ref = {% macro ref(model_ref) %}{{model_ref}}{% endmacro %}
+    # Cross cross project or package aware ref
+    # dbt_ref = {% macro ref(package_or_model, model_ref=none) %}{% if model_ref %}{{model_ref}}{% else %}{{ package_or_model }}{% endif %}{% endmacro %}
     dbt_source = {% macro source(source_name, table) %}{{source_name}}_{{table}}{% endmacro %}
     dbt_config = {% macro config() %}{% for k in kwargs %}{% endfor %}{% endmacro %}
     dbt_var = {% macro var(variable, default='') %}item{% endmacro %}


### PR DESCRIPTION
Add cross project aware ref macro

### Brief summary of the change made

1. When using the `jinja` templater with the single argument `ref` macro provided in the docs 

```toml
[sqlfluff:templater:jinja:macros]
dbt_ref = {% macro ref(model_ref) %}{{model_ref}}{% endmacro %}
```

2. Then in a project using the project or package aware 2 argument form like:

```jinja
{{ ref('elementary', 'dbt_run_results') }}
```

3. generated the following error:

```sh
L:   1 | P:   1 |  TMP | Unrecoverable failure in Jinja templating: macro 'ref'                                                                                 
                       | takes not more than 1 argument(s). Have you correctly
                       | configured your variables?
                       | https://docs.sqlfluff.com/en/latest/perma/variables.html
```
4. Updating the macro to the following allows for an optional second argument.

```toml
[sqlfluff:templater:jinja:macros]
dbt_ref = {% macro ref(package_or_model, model_ref=none) %}{% if model_ref %}{{model_ref}}{% else %}{{ package_or_model }}{% endif %}{% endmacro %}
```

### Are there any other side effects of this change that we should be aware of?

- The updated macro preserves the behaviour of the original single argument by defaulting the second argument to `none`.
- When the second argument is provided it is preferred, otherwise the first argument is passed through as usual.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

I think this change is purely documentation and doesn't need the above? More than happy to be pointed in the right direction though.
