### PR TITLE
Fix RawFileSlice idx and tags in lexer_test

### DIFF
--- a/test/core/parser/lexer_test.py
+++ b/test/core/parser/lexer_test.py
@@ -346,9 +346,9 @@ class _LexerSlicingTemplateFileCase(NamedTuple):
                     ),
                 ],
                 raw_sliced=[
-                    RawFileSlice("SELECT ", "literal", 0, None, 0),
-                    RawFileSlice("{# comment #}", "comment", 7, None, 0),
-                    RawFileSlice("1;", "literal", 20, None, 0),
+                    RawFileSlice("SELECT ", "literal", 0, 0, None),
+                    RawFileSlice("{# comment #}", "comment", 7, 0, None),
+                    RawFileSlice("1;", "literal", 20, 0, None),
                 ],
             ),
             expected_segments=[
@@ -376,7 +376,7 @@ class _LexerSlicingTemplateFileCase(NamedTuple):
                     TemplatedFileSlice("literal", slice(7, 9, None), slice(7, 9, None)),
                 ],
                 raw_sliced=[
-                    RawFileSlice("SELECT 1;", "literal", 0, None, 0),
+                    RawFileSlice("SELECT 1;", "literal", 0, 0, None),
                 ],
             ),
             expected_segments=[
@@ -404,10 +404,10 @@ class _LexerSlicingTemplateFileCase(NamedTuple):
                     ),
                 ],
                 raw_sliced=[
-                    RawFileSlice("SELECT '", "literal", 0, None, 0),
-                    RawFileSlice("{{", "escaped", 8, None, 0),
-                    RawFileSlice("}}", "escaped", 10, None, 0),
-                    RawFileSlice("' FROM TAB;", "literal", 12, None, 0),
+                    RawFileSlice("SELECT '", "literal", 0, 0, None),
+                    RawFileSlice("{{", "escaped", 8, 0, None),
+                    RawFileSlice("}}", "escaped", 10, 0, None),
+                    RawFileSlice("' FROM TAB;", "literal", 12, 0, None),
                 ],
             ),
             expected_segments=[


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
While running the lexer test in rust mode, these `RawFileSlice` tags came across with type errors. This fixes the order of the `block_idx` and `tag`.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
