### PR TITLE
Pin to Click < 8.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     "platformdirs",
     # To get the encoding of files.
     "chardet",
-    # Click can includle breaking changes in minor releases. Make sure to test
+    # Click can include breaking changes in minor releases. Make sure to test
     # well before updating upper bound.
     "click<=8.3.0",
     "colorama>=0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,9 @@ dependencies = [
     "platformdirs",
     # To get the encoding of files.
     "chardet",
-    "click",
+    # Click can includle breaking changes in minor releases. Make sure to test
+    # well before updating upper bound.
+    "click<=8.3.0",
     "colorama>=0.3",
     # Used for diffcover plugin
     "diff-cover>=2.5.0",


### PR DESCRIPTION
### Brief summary of the change made
While #6676 has a fix for Click 8.2.0, since Click can have breaking changes in minor releases, it is probably a good idea to explicitly pin the Click version in `pyproject.toml` to prevent issues like #6888 from affecting older releases in the future. Then the upper bound can be increased along with any changes needed.

https://github.com/pallets/click/issues/2909#issuecomment-2874389113

Part of #6888
(while this won't retroactively fix issues with older releases, it should help avoid similar problems in the future)

### Are there any other side effects of this change that we should be aware of?
When updating for newer Click versions, the upper bound will need to be updated along with any changes needed to code / tests.

IMO, the project might want to consider at least some basic version constraints in other dependent packages as well.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
