### PR TITLE
CLI: Read inline configurations when using `--stdin-filename`

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -643,7 +643,9 @@ def lint(
         # add stdin if specified via lone '-'
         if ("-",) == paths:
             if stdin_filename:
-                lnt.config = lnt.config.make_child_from_path(stdin_filename)
+                lnt.config = lnt.config.make_child_from_path(
+                    stdin_filename, require_dialect=False
+                )
             result = lnt.lint_string_wrapped(sys.stdin.read(), fname="stdin")
         else:
             result = lnt.lint_paths(
@@ -1125,7 +1127,9 @@ def fix(
         # handle stdin case. should output formatted sql to stdout and nothing else.
         if fixing_stdin:
             if stdin_filename:
-                lnt.config = lnt.config.make_child_from_path(stdin_filename)
+                lnt.config = lnt.config.make_child_from_path(
+                    stdin_filename, require_dialect=False
+                )
             _stdin_fix(lnt, formatter, fix_even_unparsable)
         else:
             _paths_fix(
@@ -1227,7 +1231,9 @@ def cli_format(
         # handle stdin case. should output formatted sql to stdout and nothing else.
         if fixing_stdin:
             if stdin_filename:
-                lnt.config = lnt.config.make_child_from_path(stdin_filename)
+                lnt.config = lnt.config.make_child_from_path(
+                    stdin_filename, require_dialect=False
+                )
             _stdin_fix(lnt, formatter, fix_even_unparsable=False)
         else:
             _paths_fix(
@@ -1360,7 +1366,9 @@ def parse(
         if "-" == path:
             file_config = lnt.config
             if stdin_filename:
-                file_config = file_config.make_child_from_path(stdin_filename)
+                file_config = file_config.make_child_from_path(
+                    stdin_filename, require_dialect=False
+                )
             parsed_strings = [
                 lnt.parse_string(
                     sys.stdin.read(),

--- a/src/sqlfluff/core/config/fluffconfig.py
+++ b/src/sqlfluff/core/config/fluffconfig.py
@@ -343,6 +343,7 @@ class FluffConfig:
         ignore_local_config: bool = False,
         overrides: Optional[ConfigMappingType] = None,
         plugin_manager: Optional[pluggy.PluginManager] = None,
+        require_dialect: bool = True,
     ) -> FluffConfig:
         """Loads a config object given a particular path.
 
@@ -368,6 +369,8 @@ class FluffConfig:
                 this, as the class will fetch it's own if not provided.
                 This argument is used when creating new class instances to
                 avoid reloading the manager.
+            require_dialect (bool, optional, default is True): When True
+                an error will be raise if the dialect config value is unset.
 
         Returns:
             :obj:`FluffConfig`: The loaded config object.
@@ -383,6 +386,7 @@ class FluffConfig:
             ignore_local_config=ignore_local_config,
             overrides=overrides,
             plugin_manager=plugin_manager,
+            require_dialect=require_dialect,
         )
 
     @classmethod
@@ -467,12 +471,16 @@ class FluffConfig:
         """Instantiate the configured templater."""
         return self.get_templater_class()(**kwargs)
 
-    def make_child_from_path(self, path: str) -> FluffConfig:
+    def make_child_from_path(
+        self, path: str, require_dialect: bool = True
+    ) -> FluffConfig:
         """Make a child config at a path but pass on overrides and extra_config_path.
 
         Args:
             path (str): The path to load the new config object from, inheriting
                 the content of the calling `FluffConfig` as base values.
+            require_dialect (bool, optional, default is True): When True
+                an error will be raise if the dialect config value is unset.
 
         Returns:
             :obj:`FluffConfig`: A new config object which copies the current
@@ -485,6 +493,7 @@ class FluffConfig:
             ignore_local_config=self._ignore_local_config,
             overrides=self._overrides,
             plugin_manager=self._plugin_manager,
+            require_dialect=require_dialect,
         )
 
     def diff_to(self, other: FluffConfig) -> ConfigMappingType:

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -151,6 +151,32 @@ def test__cli__command_no_dialect(command):
     assert "Traceback (most recent call last)" not in result.stderr
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        parse,
+        lint,
+        cli_format,
+        fix,
+    ],
+)
+def test__cli__command_no_dialect_stdin_filename_inline_dialect(command):
+    """Check the script runs with no dialect but has an inline configuration."""
+    # The dialect is unknown should be a non-zero exit code
+    result = invoke_assert_code(
+        ret_code=0,
+        args=[
+            command,
+            ["--stdin-filename", "test.sql", "-"],
+        ],
+        cli_input="-- sqlfluff:dialect:ansi\nSELECT 1\n",
+    )
+    assert "User Error" not in result.stderr
+    assert "No dialect was specified" not in result.stderr
+    # No traceback should be in the output
+    assert "Traceback (most recent call last)" not in result.stderr
+
+
 def test__cli__command_parse_error_dialect_explicit_warning():
     """Check parsing error raises the right warning."""
     # For any parsing error there should be a non-zero exit code


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
When passing `--stdin-filename` sqlfluff will assume that a dialect is required to be specified. This changes allows for a dialect to be specified within stdin contents without one being specified inside a configuration file for that location.
- closes #6657 or at least the only way I knew how to reproduce it.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
