### PR TITLE
LT14: Add exclusion configuration option

### DIFF
--- a/docs/source/configuration/layout.rst
+++ b/docs/source/configuration/layout.rst
@@ -814,6 +814,78 @@ available:
          [sqlfluff:layout:type:having_clause]
          keyword_line_position = none
 
+* **Exclusions**: The :code:`keyword_line_position_exclusions` option allows you to
+     exclude specific types of segments from the :code:`keyword_line_position` rule.
+     This is useful when certain segments, such as window specifications or aggregate
+     functions, should not follow the same keyword line position rules as other segments
+     in the same clause.
+
+     For example, to exclude window specifications from the :code:`ORDER BY` clause's
+     keyword line position rule, you can configure it as follows:
+
+     .. code-block:: cfg
+
+        [sqlfluff:layout:type:orderby_clause]
+        keyword_line_position = leading
+        keyword_line_position_exclusions = window_specification
+
+     This configuration ensures that the `ORDER BY` clause follows the `leading` rule,
+     except for window specifications, which are allowed to remain inline.
+
+     You can also specify multiple exclusions by separating them with commas:
+
+     .. code-block:: cfg
+
+        [sqlfluff:layout:type:orderby_clause]
+        keyword_line_position = leading
+        keyword_line_position_exclusions = window_specification, aggregate_order_by
+
+     In this case, both window specifications and aggregate functions with `ORDER BY`
+     clauses are excluded from the `leading` rule.
+
+     **Example Usage**:
+
+     With the above configuration, the following SQL would pass:
+
+     .. code-block:: sql
+
+        SELECT
+        a,
+        b,
+        ROW_NUMBER() OVER (PARTITION BY c ORDER BY d) AS e,
+        STRING_AGG(a ORDER BY b, c)
+        FROM f
+        JOIN g
+        ON g.h = f.h
+
+     However, the following SQL would fail because the outer `ORDER BY` clause does not
+     follow the `leading` rule:
+
+     .. code-block:: sql
+
+        SELECT
+        a,
+        b,
+        ROW_NUMBER() OVER (PARTITION BY c ORDER BY d) AS e,
+        STRING_AGG(a ORDER BY b, c)
+        FROM f
+        JOIN g
+        ON g.h = f.h ORDER BY a
+
+     The corrected version would be:
+
+     .. code-block:: sql
+
+        SELECT
+        a,
+        b,
+        ROW_NUMBER() OVER (PARTITION BY c ORDER BY d) AS e,
+        STRING_AGG(a ORDER BY b, c)
+        FROM f
+        JOIN g
+        ON g.h = f.h
+        ORDER BY a
+
 .. _`C Preprocessor Directives`: https://www.cprogramming.com/reference/preprocessor/
 .. _`dbt Labs SQL style guide`: https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md
 .. _`Mozilla SQL style guide`: https://docs.telemetry.mozilla.org/concepts/sql_style.html#joins

--- a/src/sqlfluff/core/config/loader.py
+++ b/src/sqlfluff/core/config/loader.py
@@ -43,17 +43,6 @@ can still cache appropriately
 """
 
 
-ALLOWABLE_LAYOUT_CONFIG_KEYS = (
-    "spacing_before",
-    "spacing_after",
-    "spacing_within",
-    "line_position",
-    "align_within",
-    "align_scope",
-    "keyword_line_position",
-)
-
-
 def _get_user_config_dir_path(sys_platform: str) -> str:
     """Get the user config dir for this system.
 

--- a/src/sqlfluff/core/config/validate.py
+++ b/src/sqlfluff/core/config/validate.py
@@ -12,6 +12,7 @@ ALLOWABLE_LAYOUT_CONFIG_KEYS = (
     "align_within",
     "align_scope",
     "keyword_line_position",
+    "keyword_line_position_exclusions",
 )
 
 

--- a/src/sqlfluff/utils/reflow/config.py
+++ b/src/sqlfluff/utils/reflow/config.py
@@ -3,9 +3,10 @@
 # Until we have a proper structure this will work.
 # TODO: Migrate this to the config file.
 from dataclasses import dataclass
-from typing import AbstractSet, Any, Optional
+from typing import AbstractSet, Any, Optional, Union
 
 from sqlfluff.core.config import FluffConfig
+from sqlfluff.core.helpers.string import split_comma_separated_string
 from sqlfluff.utils.reflow.depthmap import DepthInfo
 
 ConfigElementType = dict[str, str]
@@ -21,6 +22,7 @@ class BlockConfig:
     spacing_within: Optional[str] = None
     line_position: Optional[str] = None
     keyword_line_position: Optional[str] = None
+    keyword_line_position_exclusions: Union[str, list[str], None] = None
 
     def incorporate(
         self,
@@ -30,6 +32,7 @@ class BlockConfig:
         line_position: Optional[str] = None,
         config: Optional[ConfigElementType] = None,
         keyword_line_position: Optional[str] = None,
+        keyword_line_position_exclusions: Union[str, list[str], None] = None,
     ) -> None:
         """Mutate the config based on additional information."""
         config = config or {}
@@ -50,6 +53,14 @@ class BlockConfig:
             or config.get("keyword_line_position", None)
             or self.keyword_line_position
         )
+        klpe = (
+            keyword_line_position_exclusions
+            or config.get("keyword_line_position_exclusions", None)
+            or self.keyword_line_position_exclusions
+        )
+        if klpe is not None:
+            klpe = split_comma_separated_string(klpe)
+        self.keyword_line_position_exclusions = klpe
 
 
 @dataclass(frozen=True)

--- a/src/sqlfluff/utils/reflow/config.py
+++ b/src/sqlfluff/utils/reflow/config.py
@@ -53,14 +53,12 @@ class BlockConfig:
             or config.get("keyword_line_position", None)
             or self.keyword_line_position
         )
-        klpe = (
+        self.keyword_line_position_exclusions = split_comma_separated_string(
             keyword_line_position_exclusions
             or config.get("keyword_line_position_exclusions", None)
             or self.keyword_line_position_exclusions
+            or []
         )
-        if klpe is not None:
-            klpe = split_comma_separated_string(klpe)
-        self.keyword_line_position_exclusions = klpe
 
 
 @dataclass(frozen=True)

--- a/src/sqlfluff/utils/reflow/elements.py
+++ b/src/sqlfluff/utils/reflow/elements.py
@@ -165,6 +165,14 @@ class ReflowBlock(ReflowElement):
     #: of the segment in this block.
     #: See :ref:`layoutspacingconfig`
     keyword_line_position_configs: dict[int, str]
+    #: Parent segments which this block's keyword line positioning
+    #: should not apply.
+    #: See :ref:`layoutspacingconfig`
+    keyword_line_position_exclusions: Union[str, list[str], None]
+    #: Configurations for parent segments which this block's keyword
+    #: line positioning should not apply.
+    #: See :ref:`layoutspacingconfig`
+    keyword_line_position_exclusions_configs: dict[int, Union[str, list[str]]]
 
     @classmethod
     def from_config(
@@ -184,6 +192,7 @@ class ReflowBlock(ReflowElement):
         stack_spacing_configs = {}
         line_position_configs = {}
         keyword_line_position_configs = {}
+        keyword_line_position_exclusions_configs = {}
         for hash, class_types in zip(
             depth_info.stack_hashes, depth_info.stack_class_types
         ):
@@ -194,6 +203,10 @@ class ReflowBlock(ReflowElement):
                 line_position_configs[hash] = cfg.line_position
             if cfg.keyword_line_position:
                 keyword_line_position_configs[hash] = cfg.keyword_line_position
+            if cfg.keyword_line_position_exclusions:
+                keyword_line_position_exclusions_configs[hash] = (
+                    cfg.keyword_line_position_exclusions
+                )
         return cls(
             segments=segments,
             spacing_before=block_config.spacing_before,
@@ -204,6 +217,12 @@ class ReflowBlock(ReflowElement):
             line_position_configs=line_position_configs,
             keyword_line_position=block_config.keyword_line_position,
             keyword_line_position_configs=keyword_line_position_configs,
+            keyword_line_position_exclusions=(
+                block_config.keyword_line_position_exclusions
+            ),
+            keyword_line_position_exclusions_configs=(
+                keyword_line_position_exclusions_configs
+            ),
         )
 
 

--- a/src/sqlfluff/utils/reflow/rebreak.py
+++ b/src/sqlfluff/utils/reflow/rebreak.py
@@ -327,6 +327,20 @@ def identify_keyword_rebreak_spans(
                     # Found the end. Add it to the stack.
                     # We reference the appropriate element from the parent stack.
                     target = element_buffer[idx].segments[0]
+                    parent_exclusion = (
+                        elem.keyword_line_position_exclusions_configs.get(key, [])
+                    )
+                    if any(
+                        t.intersection(parent_exclusion)
+                        for t in elem.depth_info.stack_class_types
+                    ):
+                        # If the keyword is excluded, skip it.
+                        reflow_logger.debug(
+                            "# Skipping rebreak span on %s because "
+                            "excluded by keyword_line_position_exclusions.",
+                            elem.segments[0],
+                        )
+                        break
                     spans.append(
                         _RebreakSpan(
                             target,

--- a/test/fixtures/rules/std_rule_cases/LT14.yml
+++ b/test/fixtures/rules/std_rule_cases/LT14.yml
@@ -516,3 +516,88 @@ test_pass_single_line_set:
   configs:
     core:
       dialect: snowflake
+
+test_pass_leading_orderby_except_window_function:
+  pass_str: |
+    SELECT
+    a,
+    b,
+    ROW_NUMBER() OVER (PARTITION BY c ORDER BY d) AS e
+    FROM f
+    JOIN g
+    ON g.h = f.h
+  configs:
+    layout:
+      type:
+        orderby_clause:
+          keyword_line_position: leading
+          keyword_line_position_exclusions: window_specification
+
+test_pass_leading_orderby_except_list_function:
+  pass_str: |
+    SELECT
+    a,
+    b,
+    ROW_NUMBER() OVER (PARTITION BY c ORDER BY d) AS e,
+    STRING_AGG(a ORDER BY b, c)
+    FROM f
+    JOIN g
+    ON g.h = f.h
+  configs:
+    layout:
+      type:
+        orderby_clause:
+          keyword_line_position: leading
+          keyword_line_position_exclusions: window_specification, aggregate_order_by
+
+test_fail_leading_orderby_except_window_function_outer_orderby:
+  fail_str: |
+    SELECT
+    a,
+    b,
+    ROW_NUMBER() OVER (PARTITION BY c ORDER BY d) AS e
+    FROM f
+    JOIN g
+    ON g.h = f.h ORDER BY a
+  fix_str: |
+    SELECT
+    a,
+    b,
+    ROW_NUMBER() OVER (PARTITION BY c ORDER BY d) AS e
+    FROM f
+    JOIN g
+    ON g.h = f.h
+    ORDER BY a
+  configs:
+    layout:
+      type:
+        orderby_clause:
+          keyword_line_position: leading
+          keyword_line_position_exclusions: window_specification
+
+test_fail_leading_orderby_except_list_outer_orderby:
+  fail_str: |
+    SELECT
+    a,
+    b,
+    ROW_NUMBER() OVER (PARTITION BY c ORDER BY d) AS e,
+    STRING_AGG(a ORDER BY b, c)
+    FROM f
+    JOIN g
+    ON g.h = f.h ORDER BY a
+  fix_str: |
+    SELECT
+    a,
+    b,
+    ROW_NUMBER() OVER (PARTITION BY c ORDER BY d) AS e,
+    STRING_AGG(a ORDER BY b, c)
+    FROM f
+    JOIN g
+    ON g.h = f.h
+    ORDER BY a
+  configs:
+    layout:
+      type:
+        orderby_clause:
+          keyword_line_position: leading
+          keyword_line_position_exclusions: window_specification, aggregate_order_by


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This allows LT14 to exclude changing the keyword line layout of a type of keyword when they exist as a descendent of another type.
- closes #6752
- fixes #6495

This also removes `ALLOWABLE_LAYOUT_CONFIG_KEYS` which was unused in `config/loader.py`

### Are there any other side effects of this change that we should be aware of?
None, but it might be worth adding some defaults to this.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
