### PR TITLE
Databricks: Prevent parsing error when reading from a streaming file

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -377,6 +377,7 @@ databricks_dialect.replace(
         TypedParser("word", WordSegment, type="function_name_identifier"),
         Ref("BackQuotedIdentifierSegment"),
     ),
+    PreTableFunctionKeywordsGrammar=OneOf("STREAM"),
 )
 
 

--- a/test/fixtures/dialects/databricks/select_from_read_file.sql
+++ b/test/fixtures/dialects/databricks/select_from_read_file.sql
@@ -1,0 +1,37 @@
+-- Taken from examples here: https://docs.databricks.com/aws/en/sql/language-manual/functions/read_files
+
+-- Reads the files available in the given path. Auto-detects the format and schema of the data.
+SELECT * FROM read_files('abfss://container@storageAccount.dfs.core.windows.net/base/path');
+
+SELECT * FROM read_files(
+    's3://bucket/path',
+    format => 'csv',
+    schema => 'id int, ts timestamp, event string');
+
+-- Infers the schema of CSV files with headers. Because the schema is not provided,
+-- the CSV files are assumed to have headers.
+SELECT * FROM read_files(
+    's3://bucket/path',
+    format => 'csv');
+
+-- Reads files that have a csv suffix.
+SELECT * FROM read_files('s3://bucket/path/*.csv');
+
+-- Reads a single JSON file
+SELECT * FROM read_files(
+    'abfss://container@storageAccount.dfs.core.windows.net/path/single.json');
+
+-- Reads JSON files and overrides the data type of the column `id` to integer.
+SELECT * FROM read_files(
+    's3://bucket/path',
+    format => 'json',
+    schemaHints => 'id int');
+
+-- Reads files that have been uploaded or modified yesterday.
+SELECT * FROM read_files(
+    'gs://my-bucket/avroData',
+    modifiedAfter => date_sub(current_date(), 1),
+    modifiedBefore => current_date());
+
+-- Reads a streaming table
+SELECT * FROM STREAM read_files('gs://my-bucket/avroData', includeExistingFiles => false);

--- a/test/fixtures/dialects/databricks/select_from_read_file.yml
+++ b/test/fixtures/dialects/databricks/select_from_read_file.yml
@@ -1,0 +1,263 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 174100b63d83fe671aa54d8162a534325ffad2cbbbcc12cbf31e20122e995016
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: read_files
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'abfss://container@storageAccount.dfs.core.windows.net/base/path'"
+                    end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: read_files
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'s3://bucket/path'"
+                  - comma: ','
+                  - named_argument:
+                      naked_identifier: format
+                      right_arrow: =>
+                      expression:
+                        quoted_literal: "'csv'"
+                  - comma: ','
+                  - named_argument:
+                      naked_identifier: schema
+                      right_arrow: =>
+                      expression:
+                        quoted_literal: "'id int, ts timestamp, event string'"
+                  - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: read_files
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'s3://bucket/path'"
+                    comma: ','
+                    named_argument:
+                      naked_identifier: format
+                      right_arrow: =>
+                      expression:
+                        quoted_literal: "'csv'"
+                    end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: read_files
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'s3://bucket/path/*.csv'"
+                    end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: read_files
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'abfss://container@storageAccount.dfs.core.windows.net/path/single.json'"
+                    end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: read_files
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'s3://bucket/path'"
+                  - comma: ','
+                  - named_argument:
+                      naked_identifier: format
+                      right_arrow: =>
+                      expression:
+                        quoted_literal: "'json'"
+                  - comma: ','
+                  - named_argument:
+                      naked_identifier: schemaHints
+                      right_arrow: =>
+                      expression:
+                        quoted_literal: "'id int'"
+                  - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: read_files
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'gs://my-bucket/avroData'"
+                  - comma: ','
+                  - named_argument:
+                      naked_identifier: modifiedAfter
+                      right_arrow: =>
+                      expression:
+                        function:
+                          function_name:
+                            function_name_identifier: date_sub
+                          function_contents:
+                            bracketed:
+                            - start_bracket: (
+                            - expression:
+                                function:
+                                  function_name:
+                                    function_name_identifier: current_date
+                                  function_contents:
+                                    bracketed:
+                                      start_bracket: (
+                                      end_bracket: )
+                            - comma: ','
+                            - expression:
+                                numeric_literal: '1'
+                            - end_bracket: )
+                  - comma: ','
+                  - named_argument:
+                      naked_identifier: modifiedBefore
+                      right_arrow: =>
+                      expression:
+                        function:
+                          function_name:
+                            function_name_identifier: current_date
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              end_bracket: )
+                  - end_bracket: )
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            keyword: STREAM
+            table_expression:
+              function:
+                function_name:
+                  function_name_identifier: read_files
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      quoted_literal: "'gs://my-bucket/avroData'"
+                    comma: ','
+                    named_argument:
+                      naked_identifier: includeExistingFiles
+                      right_arrow: =>
+                      expression:
+                        boolean_literal: 'false'
+                    end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Add `STREAM` as a pre table keyword for the databricks dialect as this is causing parsing issues due to the parser mistaking the keyword and function as a table name and alias:

Taking this example query: `SELECT * FROM STREAM read_files('gs://my-bucket/avroData', includeExistingFiles => false);`

The parser was producing the following:
```
[L:  1, P: 10]      |            from_clause:
// Removed
[L:  1, P: 15]      |                                naked_identifier:             'STREAM'
[L:  1, P: 21]      |                        whitespace:                           ' '
[L:  1, P: 22]      |                        alias_expression:
[L:  1, P: 22]      |                            naked_identifier:                 'read_files'
```

After this change the output is:
```
[L:  1, P: 10]      |            from_clause:
// Removed
[L:  1, P: 15]      |                    from_expression_element:
[L:  1, P: 15]      |                        keyword:                              'STREAM'
[L:  1, P: 21]      |                        whitespace:                           ' '
[L:  1, P: 22]      |                        table_expression:
[L:  1, P: 22]      |                            table_reference:
[L:  1, P: 22]      |                                naked_identifier:             'READ_FILES'
```

Fixes: #6414

### Are there any other side effects of this change that we should be aware of?

None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
