### PR TITLE
RF01: Fix quoted object references with dots

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -48,6 +48,7 @@ from sqlfluff.core.parser import (
     OneOf,
     OptionallyBracketed,
     ParseMode,
+    RawSegment,
     Ref,
     RegexLexer,
     RegexParser,
@@ -1060,17 +1061,18 @@ class ObjectReferenceSegment(BaseSegment):
         """Details about a table alias."""
 
         part: str  # Name of the part
-        # Segment(s) comprising the part. Usuaully just one segment, but could
+        # Segment(s) comprising the part. Usually just one segment, but could
         # be multiple in dialects (e.g. BigQuery) that support unusual
         # characters in names (e.g. "-")
-        segments: list[BaseSegment]
+        segments: list[RawSegment]
 
     @classmethod
-    def _iter_reference_parts(cls, elem) -> Generator[ObjectReferencePart, None, None]:
+    def _iter_reference_parts(
+        cls, elem: RawSegment
+    ) -> Generator[ObjectReferencePart, None, None]:
         """Extract the elements of a reference and yield."""
         # trim on quotes and split out any dots.
-        for part in elem.raw_trimmed().split("."):
-            yield cls.ObjectReferencePart(part, [elem])
+        yield cls.ObjectReferencePart(elem.raw_trimmed(), [elem])
 
     def iter_raw_references(self) -> Generator[ObjectReferencePart, None, None]:
         """Generate a list of reference strings and elements.
@@ -1080,7 +1082,7 @@ class ObjectReferenceSegment(BaseSegment):
         """
         # Extract the references from those identifiers (because some may be quoted)
         for elem in self.recursive_crawl("identifier"):
-            yield from self._iter_reference_parts(elem)
+            yield from self._iter_reference_parts(cast(IdentifierSegment, elem))
 
     def is_qualified(self) -> bool:
         """Return if there is more than one element to the reference."""
@@ -1781,7 +1783,7 @@ class WildcardIdentifierSegment(ObjectReferenceSegment):
         """
         # Extract the references from those identifiers (because some may be quoted)
         for elem in self.recursive_crawl("identifier", "star"):
-            yield from self._iter_reference_parts(elem)
+            yield from self._iter_reference_parts(cast(RawSegment, elem))
 
 
 class WildcardExpressionSegment(BaseSegment):

--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -6,6 +6,8 @@ and
 https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#string_and_bytes_literals
 """
 
+from collections.abc import Generator
+
 from sqlfluff.core.dialects import load_raw_dialect
 from sqlfluff.core.parser import (
     AnyNumberOf,
@@ -27,6 +29,7 @@ from sqlfluff.core.parser import (
     OneOf,
     OptionallyBracketed,
     ParseMode,
+    RawSegment,
     Ref,
     RegexLexer,
     RegexParser,
@@ -1457,7 +1460,27 @@ class SemiStructuredAccessorSegment(BaseSegment):
     )
 
 
-class ColumnReferenceSegment(ansi.ObjectReferenceSegment):
+class SplitableObjectReferenceGrammar(ansi.ObjectReferenceSegment):
+    """An extended object reference grammar for BigQuery.
+
+    This class customizes the splitting of object references (such as table or column
+    names) to handle BigQuery's syntax, where object names may be quoted and
+    can refer to columns, tables, datasets, or projects. In BigQuery, object references
+    can be multi-part (e.g., `project.dataset.table.column`) and may include quoted
+    identifiers that contain keywords or special characters.
+    """
+
+    @classmethod
+    def _iter_reference_parts(
+        cls, elem: RawSegment
+    ) -> Generator[ansi.ObjectReferenceSegment.ObjectReferencePart, None, None]:
+        """Extract the elements of a reference and yield."""
+        # trim on quotes and split out any dots.
+        for part in elem.raw_trimmed().split("."):
+            yield cls.ObjectReferencePart(part, [elem])
+
+
+class ColumnReferenceSegment(SplitableObjectReferenceGrammar):
     """A reference to column, field or alias.
 
     We override this for BigQuery to allow keywords in structures
@@ -1544,7 +1567,7 @@ class ColumnReferenceSegment(ansi.ObjectReferenceSegment):
         return super().extract_possible_multipart_references(levels)
 
 
-class TableReferenceSegment(ansi.ObjectReferenceSegment):
+class TableReferenceSegment(SplitableObjectReferenceGrammar):
     """A reference to an object that may contain embedded hyphens."""
 
     type = "table_reference"

--- a/test/fixtures/rules/std_rule_cases/RF01.yml
+++ b/test/fixtures/rules/std_rule_cases/RF01.yml
@@ -442,3 +442,28 @@ test_mysql_identifier_with_backticks_should_not_except:
   configs:
     core:
       dialect: mysql
+
+test_snowflake_pass_dot_inside_quotes:
+  pass_str: |
+    WITH CTE_DUMMY AS (
+        SELECT
+            1 AS "DUMMY.ALIAS"
+            , 2 AS "DUMMY_ALIAS"
+        FROM DUAL
+    )
+
+    SELECT
+        C1."DUMMY.ALIAS"
+        , C1."DUMMY_ALIAS"
+    FROM CTE_DUMMY AS C1
+  configs:
+    core:
+      dialect: snowflake
+
+test_postgres_pass_dot_inside_quotes:
+  pass_str: |
+    SELECT "a.b"
+    FROM table
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This prevents object references from splitting on dots when inside quotes. BigQuery retains the split for quoted object reference with dots. Also, added some type hinting.
- fixes #4929
- fixes #6352

### Are there any other side effects of this change that we should be aware of?
Should be none as BigQuery appears to be the only dialect that supports splitting in quotes.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
