### PR TITLE
Adds support for `<=>` operator in MySQL.

### DIFF
--- a/src/sqlfluff/dialects/dialect_mysql.py
+++ b/src/sqlfluff/dialects/dialect_mysql.py
@@ -14,6 +14,7 @@ from sqlfluff.core.parser import (
     Bracketed,
     CodeSegment,
     CommentSegment,
+    CompositeComparisonOperatorSegment,
     Dedent,
     Delimited,
     IdentifierSegment,
@@ -306,6 +307,9 @@ mysql_dialect.replace(
     ),
     LikeGrammar=OneOf("LIKE", "RLIKE", "REGEXP"),
     CollateGrammar=Sequence("COLLATE", Ref("CollationReferenceSegment")),
+    ComparisonOperatorGrammar=ansi_dialect.get_grammar(
+        "ComparisonOperatorGrammar"
+    ).copy(insert=[Ref("NullSafeEqualsSegment")]),
 )
 
 mysql_dialect.add(
@@ -3241,4 +3245,18 @@ class DatatypeSegment(BaseSegment):
             ),
         ),
         Ref("ArrayTypeSegment"),
+    )
+
+
+class NullSafeEqualsSegment(CompositeComparisonOperatorSegment):
+    """NULL-safe equals operator.
+
+    https://dev.mysql.com/doc/refman/9.3/en/comparison-operators.html#operator_equal-to
+    """
+
+    match_grammar: Matchable = Sequence(
+        Ref("RawLessThanSegment"),
+        Ref("RawEqualsSegment"),
+        Ref("RawGreaterThanSegment"),
+        allow_gaps=False,
     )

--- a/test/fixtures/dialects/mysql/null_safe_equal.sql
+++ b/test/fixtures/dialects/mysql/null_safe_equal.sql
@@ -1,0 +1,3 @@
+SELECT 1 <=> 1, NULL <=> NULL, 1 <=> NULL;
+
+SELECT 1 WHERE NULL <=> 1;

--- a/test/fixtures/dialects/mysql/null_safe_equal.yml
+++ b/test/fixtures/dialects/mysql/null_safe_equal.yml
@@ -1,0 +1,54 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 0a7443feb698ba6dd2813824d70b0cdd3a879683434b1177f4047193b1b6084a
+file:
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+          - numeric_literal: '1'
+          - comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+            - raw_comparison_operator: '>'
+          - numeric_literal: '1'
+      - comma: ','
+      - select_clause_element:
+          expression:
+          - null_literal: 'NULL'
+          - comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+            - raw_comparison_operator: '>'
+          - null_literal: 'NULL'
+      - comma: ','
+      - select_clause_element:
+          expression:
+            numeric_literal: '1'
+            comparison_operator:
+            - raw_comparison_operator: <
+            - raw_comparison_operator: '='
+            - raw_comparison_operator: '>'
+            null_literal: 'NULL'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          numeric_literal: '1'
+      where_clause:
+        keyword: WHERE
+        expression:
+          null_literal: 'NULL'
+          comparison_operator:
+          - raw_comparison_operator: <
+          - raw_comparison_operator: '='
+          - raw_comparison_operator: '>'
+          numeric_literal: '1'
+- statement_terminator: ;


### PR DESCRIPTION
Closes #6907 

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
