### PR TITLE
TSQL: fix `USER` (bare function) unparsable

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -131,7 +131,7 @@ tsql_dialect.sets("date_format").update(
 )
 
 tsql_dialect.sets("bare_functions").update(
-    ["system_user", "session_user", "current_user"]
+    ["CURRENT_USER", "SESSION_USER", "SYSTEM_USER", "USER"]
 )
 
 tsql_dialect.sets("sqlcmd_operators").clear()

--- a/test/fixtures/dialects/tsql/select.sql
+++ b/test/fixtures/dialects/tsql/select.sql
@@ -108,6 +108,8 @@ SELECT
     CURRENT_USER,
     SESSION_USER,
     SYSTEM_USER,
+	USER,
+
 	test(default, 2)
 
 

--- a/test/fixtures/dialects/tsql/select.sql
+++ b/test/fixtures/dialects/tsql/select.sql
@@ -108,9 +108,9 @@ SELECT
     CURRENT_USER,
     SESSION_USER,
     SYSTEM_USER,
-	USER,
+    USER,
 
-	test(default, 2)
+    test(default, 2)
 
 
 FROM dbo . all_pop;

--- a/test/fixtures/dialects/tsql/select.yml
+++ b/test/fixtures/dialects/tsql/select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3edcc09561d20cd0fb8d7b838b25f430c7d4cb4544cec22b035967ffa8daa0f2
+_hash: 753fa17f824e34805cf8b5bf8664984d8769fcd2c1f3e316ff534e58b12f71af
 file:
   batch:
   - statement:
@@ -902,6 +902,9 @@ file:
         - comma: ','
         - select_clause_element:
             bare_function: SYSTEM_USER
+        - comma: ','
+        - select_clause_element:
+            bare_function: USER
         - comma: ','
         - select_clause_element:
             function:


### PR DESCRIPTION

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
fixes #6933


### Are there any other side effects of this change that we should be aware of?
no

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
