### PR TITLE
feat(redshift): add support for ALTER TABLE SET LOCATION syntax

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -722,6 +722,11 @@ class AlterTableActionSegment(BaseSegment):
             Ref.keyword("IGNOREEXTRA", optional=True),
             Ref.keyword("FILLTARGET", optional=True),
         ),
+        Sequence(
+            "SET",
+            "LOCATION",
+            Ref("QuotedLiteralSegment"),
+        ),
     )
 
 

--- a/test/fixtures/dialects/redshift/alter_table.sql
+++ b/test/fixtures/dialects/redshift/alter_table.sql
@@ -59,3 +59,5 @@ drop column feedback_score cascade;
 ALTER TABLE the_schema.the_table APPEND FROM the_schema.the_temp_table IGNOREEXTRA FILLTARGET;
 
 ALTER TABLE the_schema.the_table APPEND FROM the_schema.the_temp_table;
+
+ALTER TABLE the_schema.the_table SET LOCATION 's3://bucket/folder/';

--- a/test/fixtures/dialects/redshift/alter_table.yml
+++ b/test/fixtures/dialects/redshift/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8625286eacd50d6ec538e32d6cb127a141aeef835c85f95c2a86727d38455321
+_hash: de2269d68c7f114d0429b086bb24aaa20fa9bacbf4497d5291eb34615dc88365
 file:
 - statement:
     alter_table_statement:
@@ -430,4 +430,17 @@ file:
         - naked_identifier: the_schema
         - dot: .
         - naked_identifier: the_temp_table
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: the_schema
+      - dot: .
+      - naked_identifier: the_table
+    - alter_table_action_segment:
+      - keyword: SET
+      - keyword: LOCATION
+      - quoted_literal: "'s3://bucket/folder/'"
 - statement_terminator: ;


### PR DESCRIPTION
* Add SET LOCATION action to AlterTableActionSegment in Redshift dialect
* Add test case for ALTER TABLE ... SET LOCATION 's3://bucket/folder/'
* Supports external table location changes in Redshift
* Updated corresponding YAML test fixture

This enables parsing of ALTER TABLE table_name SET LOCATION 'location_string' syntax which is used for modifying external table locations in Amazon Redshift.

AWS documentation:

https://docs.aws.amazon.com/redshift/latest/dg/r_ALTER_TABLE.html


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Summary in commit message.

### Are there any other side effects of this change that we should be aware of?

No


### Pull Request checklist
- [✅] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
