### PR TITLE
TSQL: add support for `SECURITY POLICY` (`CREATE, ALTER, DROP`)

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -732,6 +732,9 @@ class StatementSegment(ansi.StatementSegment):
             Ref("OpenSymmetricKeySegment"),
             Ref("CreateLoginStatementSegment"),
             Ref("SetContextInfoSegment"),
+            Ref("CreateSecurityPolicySegment"),
+            Ref("AlterSecurityPolicySegment"),
+            Ref("DropSecurityPolicySegment"),
         ],
         remove=[
             Ref("CreateModelStatementSegment"),
@@ -6794,6 +6797,154 @@ class DropMasterKeySegment(BaseSegment):
         "DROP",
         "MASTER",
         "KEY",
+    )
+
+
+class CreateSecurityPolicySegment(BaseSegment):
+    """A `CREATE SECURITY POLICY` statement."""
+
+    # https://learn.microsoft.com/en-us/sql/t-sql/statements/create-security-policy-transact-sql
+
+    type = "create_security_policy_statement"
+
+    match_grammar: Matchable = Sequence(
+        "CREATE",
+        "SECURITY",
+        "POLICY",
+        Ref("ObjectReferenceSegment"),
+        Delimited(
+            Sequence(
+                "ADD",
+                OneOf("FILTER", "BLOCK", optional=True),
+                "PREDICATE",
+                Ref("ObjectReferenceSegment"),
+                Bracketed(
+                    Delimited(
+                        OneOf(
+                            Ref("ColumnReferenceSegment"),
+                            Ref("ExpressionSegment"),
+                        ),
+                    ),
+                ),
+                "ON",
+                Ref("ObjectReferenceSegment"),
+                OneOf(
+                    Sequence(
+                        "AFTER",
+                        OneOf("INSERT", "UPDATE"),
+                    ),
+                    Sequence(
+                        "BEFORE",
+                        OneOf("UPDATE", "DELETE"),
+                    ),
+                    optional=True,
+                ),
+            ),
+        ),
+        Sequence(
+            "WITH",
+            Bracketed(
+                Delimited(
+                    Sequence("STATE", Ref("EqualsSegment"), OneOf("ON", "OFF")),
+                    Sequence("SCHEMABINDING", Ref("EqualsSegment"), OneOf("ON", "OFF")),
+                    optional=True,
+                ),
+            ),
+            optional=True,
+        ),
+        Sequence(
+            "NOT",
+            "FOR",
+            "REPLICATION",
+            optional=True,
+        ),
+    )
+
+
+class AlterSecurityPolicySegment(BaseSegment):
+    """A `ALTER SECURITY POLICY` statement."""
+
+    # https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-security-policy-transact-sql
+
+    type = "alter_security_policy_statement"
+
+    match_grammar: Matchable = Sequence(
+        "ALTER",
+        "SECURITY",
+        "POLICY",
+        Ref("ObjectReferenceSegment"),
+        Delimited(
+            OneOf(
+                Sequence(
+                    OneOf("ADD", "ALTER"),
+                    OneOf("FILTER", "BLOCK", optional=True),
+                    "PREDICATE",
+                    Ref("ObjectReferenceSegment"),
+                    Bracketed(
+                        Delimited(
+                            OneOf(
+                                Ref("ColumnReferenceSegment"),
+                                Ref("ExpressionSegment"),
+                            ),
+                        ),
+                    ),
+                    "ON",
+                    Ref("ObjectReferenceSegment"),
+                    OneOf(
+                        Sequence(
+                            "AFTER",
+                            OneOf("INSERT", "UPDATE"),
+                        ),
+                        Sequence(
+                            "BEFORE",
+                            OneOf("UPDATE", "DELETE"),
+                        ),
+                        optional=True,
+                    ),
+                ),
+                Sequence(
+                    "DROP",
+                    OneOf("FILTER", "BLOCK", optional=True),
+                    "PREDICATE",
+                    "ON",
+                    Ref("ObjectReferenceSegment"),
+                ),
+            ),
+            optional=True,
+        ),
+        Sequence(
+            "WITH",
+            Bracketed(
+                Delimited(
+                    Sequence("STATE", Ref("EqualsSegment"), OneOf("ON", "OFF")),
+                    Sequence("SCHEMABINDING", Ref("EqualsSegment"), OneOf("ON", "OFF")),
+                    optional=True,
+                ),
+            ),
+            optional=True,
+        ),
+        Sequence(
+            "NOT",
+            "FOR",
+            "REPLICATION",
+            optional=True,
+        ),
+    )
+
+
+class DropSecurityPolicySegment(BaseSegment):
+    """A `DROP SECURITY POLICY` statement."""
+
+    # https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-security-policy-transact-sql
+
+    type = "drop_security_policy"
+
+    match_grammar: Matchable = Sequence(
+        "DROP",
+        "SECURITY",
+        "POLICY",
+        Sequence("IF", "EXISTS", optional=True),
+        Ref("ObjectReferenceSegment"),
     )
 
 

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -280,6 +280,7 @@ UNRESERVED_KEYWORDS = [
     "BEFORE",  # *future*
     "BERNOULLI",
     "BINARY",
+    "BLOCK",
     "BLOCKERS",
     "BREAK",
     "CACHE",
@@ -508,9 +509,11 @@ UNRESERVED_KEYWORDS = [
     "PERCENTILE_DISC",
     "PERIOD",
     "PERSISTED",
+    "POLICY",
     "POPULATION",
     "PRECEDING",
     "PRECISION",  # listed as reserved but functionally unreserved
+    "PREDICATE",
     "PRIOR",
     "PROFILE",
     "PROPERTY",
@@ -583,6 +586,7 @@ UNRESERVED_KEYWORDS = [
     "SCOPED",
     "SEARCH",
     "SECRET",
+    "SECURITY",
     "SECURITYAUDIT",  # listed as reserved but functionally unreserved
     "SELF",
     "SEQUENCE_NUMBER_COLUMN_NAME",
@@ -608,6 +612,7 @@ UNRESERVED_KEYWORDS = [
     "SPATIAL_WINDOW_MAX_CELLS",
     "SPLIT",
     "START",
+    "STATE",
     "STATISTICAL_SEMANTICS",
     "STATISTICS_INCREMENTAL",
     "STATISTICS_NORECOMPUTE",

--- a/test/fixtures/dialects/tsql/create_security_policy.sql
+++ b/test/fixtures/dialects/tsql/create_security_policy.sql
@@ -1,0 +1,53 @@
+-- https://learn.microsoft.com/en-us/sql/t-sql/statements/create-security-policy-transact-sql
+
+CREATE SECURITY POLICY [FederatedSecurityPolicy]
+ADD FILTER PREDICATE [rls].[fn_securitypredicate]([CustomerId])
+ON [dbo].[Customer];
+
+
+CREATE SECURITY POLICY [FederatedSecurityPolicy]
+ADD FILTER PREDICATE [rls].[fn_securitypredicate1]([CustomerId])
+    ON [dbo].[Customer],
+ADD FILTER PREDICATE [rls].[fn_securitypredicate1]([VendorId])
+    ON [dbo].[ Vendor],
+ADD FILTER PREDICATE [rls].[fn_securitypredicate2]([WingId])
+    ON [dbo].[Patient]
+WITH (STATE = ON);
+
+
+CREATE SECURITY POLICY rls.SecPol
+    ADD FILTER PREDICATE rls.tenantAccessPredicate(TenantId) ON dbo.Sales,
+    ADD BLOCK PREDICATE rls.tenantAccessPredicate(TenantId) ON dbo.Sales AFTER INSERT
+;
+
+
+
+-- https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-security-policy-transact-sql
+
+ALTER SECURITY POLICY pol1
+    ADD FILTER PREDICATE schema_preds.SecPredicate(column1)
+    ON myschema.mytable;
+
+ALTER SECURITY POLICY pol1 WITH ( STATE = ON );
+
+ALTER SECURITY POLICY pol1
+ADD FILTER PREDICATE schema_preds.SecPredicate1(column1)
+    ON myschema.mytable1,
+DROP FILTER PREDICATE
+    ON myschema.mytable2,
+ADD FILTER PREDICATE schema_preds.SecPredicate2(column2, 1)
+    ON myschema.mytable3;
+
+ALTER SECURITY POLICY pol1
+    ALTER FILTER PREDICATE schema_preds.SecPredicate2(column1)
+        ON myschema.mytable;
+
+ALTER SECURITY POLICY rls.SecPol
+    ALTER BLOCK PREDICATE rls.tenantAccessPredicate_v2(TenantId)
+    ON dbo.Sales AFTER INSERT;
+
+
+
+-- https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-security-policy-transact-sql
+
+DROP SECURITY POLICY secPolicy;

--- a/test/fixtures/dialects/tsql/create_security_policy.yml
+++ b/test/fixtures/dialects/tsql/create_security_policy.yml
@@ -1,0 +1,307 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: f6142e4b1801482cfb771453ba6d3ea6863cfa3231fa85db24b1b05c4544d360
+file:
+  batch:
+  - statement:
+      create_security_policy_statement:
+      - keyword: CREATE
+      - keyword: SECURITY
+      - keyword: POLICY
+      - object_reference:
+          quoted_identifier: '[FederatedSecurityPolicy]'
+      - keyword: ADD
+      - keyword: FILTER
+      - keyword: PREDICATE
+      - object_reference:
+        - quoted_identifier: '[rls]'
+        - dot: .
+        - quoted_identifier: '[fn_securitypredicate]'
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            quoted_identifier: '[CustomerId]'
+          end_bracket: )
+      - keyword: 'ON'
+      - object_reference:
+        - quoted_identifier: '[dbo]'
+        - dot: .
+        - quoted_identifier: '[Customer]'
+  - statement_terminator: ;
+  - statement:
+      create_security_policy_statement:
+      - keyword: CREATE
+      - keyword: SECURITY
+      - keyword: POLICY
+      - object_reference:
+          quoted_identifier: '[FederatedSecurityPolicy]'
+      - keyword: ADD
+      - keyword: FILTER
+      - keyword: PREDICATE
+      - object_reference:
+        - quoted_identifier: '[rls]'
+        - dot: .
+        - quoted_identifier: '[fn_securitypredicate1]'
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            quoted_identifier: '[CustomerId]'
+          end_bracket: )
+      - keyword: 'ON'
+      - object_reference:
+        - quoted_identifier: '[dbo]'
+        - dot: .
+        - quoted_identifier: '[Customer]'
+      - comma: ','
+      - keyword: ADD
+      - keyword: FILTER
+      - keyword: PREDICATE
+      - object_reference:
+        - quoted_identifier: '[rls]'
+        - dot: .
+        - quoted_identifier: '[fn_securitypredicate1]'
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            quoted_identifier: '[VendorId]'
+          end_bracket: )
+      - keyword: 'ON'
+      - object_reference:
+        - quoted_identifier: '[dbo]'
+        - dot: .
+        - quoted_identifier: '[ Vendor]'
+      - comma: ','
+      - keyword: ADD
+      - keyword: FILTER
+      - keyword: PREDICATE
+      - object_reference:
+        - quoted_identifier: '[rls]'
+        - dot: .
+        - quoted_identifier: '[fn_securitypredicate2]'
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            quoted_identifier: '[WingId]'
+          end_bracket: )
+      - keyword: 'ON'
+      - object_reference:
+        - quoted_identifier: '[dbo]'
+        - dot: .
+        - quoted_identifier: '[Patient]'
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - keyword: STATE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - keyword: 'ON'
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      create_security_policy_statement:
+      - keyword: CREATE
+      - keyword: SECURITY
+      - keyword: POLICY
+      - object_reference:
+        - naked_identifier: rls
+        - dot: .
+        - naked_identifier: SecPol
+      - keyword: ADD
+      - keyword: FILTER
+      - keyword: PREDICATE
+      - object_reference:
+        - naked_identifier: rls
+        - dot: .
+        - naked_identifier: tenantAccessPredicate
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            naked_identifier: TenantId
+          end_bracket: )
+      - keyword: 'ON'
+      - object_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: Sales
+      - comma: ','
+      - keyword: ADD
+      - keyword: BLOCK
+      - keyword: PREDICATE
+      - object_reference:
+        - naked_identifier: rls
+        - dot: .
+        - naked_identifier: tenantAccessPredicate
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            naked_identifier: TenantId
+          end_bracket: )
+      - keyword: 'ON'
+      - object_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: Sales
+      - keyword: AFTER
+      - keyword: INSERT
+  - statement_terminator: ;
+  - statement:
+      alter_security_policy_statement:
+      - keyword: ALTER
+      - keyword: SECURITY
+      - keyword: POLICY
+      - object_reference:
+          naked_identifier: pol1
+      - keyword: ADD
+      - keyword: FILTER
+      - keyword: PREDICATE
+      - object_reference:
+        - naked_identifier: schema_preds
+        - dot: .
+        - naked_identifier: SecPredicate
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            naked_identifier: column1
+          end_bracket: )
+      - keyword: 'ON'
+      - object_reference:
+        - naked_identifier: myschema
+        - dot: .
+        - naked_identifier: mytable
+  - statement_terminator: ;
+  - statement:
+      alter_security_policy_statement:
+      - keyword: ALTER
+      - keyword: SECURITY
+      - keyword: POLICY
+      - object_reference:
+          naked_identifier: pol1
+      - keyword: WITH
+      - bracketed:
+        - start_bracket: (
+        - keyword: STATE
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - keyword: 'ON'
+        - end_bracket: )
+  - statement_terminator: ;
+  - statement:
+      alter_security_policy_statement:
+      - keyword: ALTER
+      - keyword: SECURITY
+      - keyword: POLICY
+      - object_reference:
+          naked_identifier: pol1
+      - keyword: ADD
+      - keyword: FILTER
+      - keyword: PREDICATE
+      - object_reference:
+        - naked_identifier: schema_preds
+        - dot: .
+        - naked_identifier: SecPredicate1
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            naked_identifier: column1
+          end_bracket: )
+      - keyword: 'ON'
+      - object_reference:
+        - naked_identifier: myschema
+        - dot: .
+        - naked_identifier: mytable1
+      - comma: ','
+      - keyword: DROP
+      - keyword: FILTER
+      - keyword: PREDICATE
+      - keyword: 'ON'
+      - object_reference:
+        - naked_identifier: myschema
+        - dot: .
+        - naked_identifier: mytable2
+      - comma: ','
+      - keyword: ADD
+      - keyword: FILTER
+      - keyword: PREDICATE
+      - object_reference:
+        - naked_identifier: schema_preds
+        - dot: .
+        - naked_identifier: SecPredicate2
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            naked_identifier: column2
+          comma: ','
+          expression:
+            numeric_literal: '1'
+          end_bracket: )
+      - keyword: 'ON'
+      - object_reference:
+        - naked_identifier: myschema
+        - dot: .
+        - naked_identifier: mytable3
+  - statement_terminator: ;
+  - statement:
+      alter_security_policy_statement:
+      - keyword: ALTER
+      - keyword: SECURITY
+      - keyword: POLICY
+      - object_reference:
+          naked_identifier: pol1
+      - keyword: ALTER
+      - keyword: FILTER
+      - keyword: PREDICATE
+      - object_reference:
+        - naked_identifier: schema_preds
+        - dot: .
+        - naked_identifier: SecPredicate2
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            naked_identifier: column1
+          end_bracket: )
+      - keyword: 'ON'
+      - object_reference:
+        - naked_identifier: myschema
+        - dot: .
+        - naked_identifier: mytable
+  - statement_terminator: ;
+  - statement:
+      alter_security_policy_statement:
+      - keyword: ALTER
+      - keyword: SECURITY
+      - keyword: POLICY
+      - object_reference:
+        - naked_identifier: rls
+        - dot: .
+        - naked_identifier: SecPol
+      - keyword: ALTER
+      - keyword: BLOCK
+      - keyword: PREDICATE
+      - object_reference:
+        - naked_identifier: rls
+        - dot: .
+        - naked_identifier: tenantAccessPredicate_v2
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            naked_identifier: TenantId
+          end_bracket: )
+      - keyword: 'ON'
+      - object_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: Sales
+      - keyword: AFTER
+      - keyword: INSERT
+  - statement_terminator: ;
+  - statement:
+      drop_security_policy:
+      - keyword: DROP
+      - keyword: SECURITY
+      - keyword: POLICY
+      - object_reference:
+          naked_identifier: secPolicy
+  - statement_terminator: ;


### PR DESCRIPTION

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #6934


### Are there any other side effects of this change that we should be aware of?
no

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
