### PR TITLE
CI: update coverage paths for C:\ directory

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -205,6 +205,9 @@ source =
     # These are the Github likely source paths
     D:\a\sqlfluff\sqlfluff\src\
     D:\a\sqlfluff\sqlfluff\.tox\winpy\Lib\site-packages\
+    # Github Actions are now using C:
+    C:\a\sqlfluff\sqlfluff\src\
+    C:\a\sqlfluff\sqlfluff\.tox\winpy\Lib\site-packages\
     /home/runner/work/sqlfluff/sqlfluff/src/
     /home/runner/work/sqlfluff/sqlfluff/.tox/*/lib/*/site-packages/
 dbt_templater =


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Github actions now appear to default `C:\` as the working directory for the Windows runner. I was unable to find any notes of this change.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
