### PR TITLE
Adds support for `RETURNING INTO` clause in `INSERT`, `UPDATE`, `DELETE` and `MERGE` statements in Oracle.

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -232,6 +232,7 @@ oracle_dialect.sets("unreserved_keywords").update(
         "RAISE",
         "RECORD",
         "RESULT_CACHE",
+        "RETURNING",
         "REUSE",
         "REVERSE",
         "ROWTYPE",
@@ -2427,6 +2428,7 @@ class MergeUpdateClauseSegment(BaseSegment):
         Ref("SetClauseListSegment"),
         Dedent,
         Ref("WhereClauseSegment", optional=True),
+        Ref("ReturningClauseSegment", optional=True),
     )
 
 
@@ -2457,6 +2459,7 @@ class InsertStatementSegment(BaseSegment):
                 optional=True,
             ),
         ),
+        Ref("ReturningClauseSegment", optional=True),
     )
 
 
@@ -2797,4 +2800,47 @@ class CreateUserStatementSegment(BaseSegment):
             Sequence("CONTAINER", Ref("EqualsSegment"), OneOf("CURRENT", "ALL")),
             Sequence("READ", OneOf("ONLY", "WRITE")),
         ),
+    )
+
+
+class ReturningClauseSegment(BaseSegment):
+    """A `RETURNING` clause.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/23/lnpls/RETURNING-INTO-clause.html
+    """
+
+    type = "returning_clause"
+
+    match_grammar: Matchable = Sequence(
+        OneOf("RETURNING", "RETURN"),
+        Delimited(
+            Sequence(
+                OneOf("OLD", "NEW", optional=True),
+                Ref("SingleIdentifierGrammar"),
+            ),
+            optional=True,
+        ),
+        OneOf(Ref("IntoClauseSegment"), Ref("BulkCollectIntoClauseSegment")),
+    )
+
+
+class UpdateStatementSegment(ansi.UpdateStatementSegment):
+    """An `Update` statement.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/UPDATE.html
+    """
+
+    match_grammar: Matchable = ansi.UpdateStatementSegment.match_grammar.copy(
+        insert=[Ref("ReturningClauseSegment", optional=True)]
+    )
+
+
+class DeleteStatementSegment(ansi.DeleteStatementSegment):
+    """A `DELETE` statement.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/DELETE.html
+    """
+
+    match_grammar: Matchable = ansi.DeleteStatementSegment.match_grammar.copy(
+        insert=[Ref("ReturningClauseSegment", optional=True)]
     )

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -2818,7 +2818,6 @@ class ReturningClauseSegment(BaseSegment):
                 OneOf("OLD", "NEW", optional=True),
                 Ref("SingleIdentifierGrammar"),
             ),
-            optional=True,
         ),
         OneOf(Ref("IntoClauseSegment"), Ref("BulkCollectIntoClauseSegment")),
     )

--- a/test/fixtures/dialects/oracle/returning_into.sql
+++ b/test/fixtures/dialects/oracle/returning_into.sql
@@ -1,0 +1,152 @@
+DECLARE
+  TYPE EmpRec IS RECORD (
+    last_name  employees.last_name%TYPE,
+    salary     employees.salary%TYPE
+  );
+  emp_info    EmpRec;
+  old_salary  employees.salary%TYPE;
+BEGIN
+  SELECT salary INTO old_salary
+   FROM employees
+   WHERE employee_id = 100;
+
+  UPDATE employees
+    SET salary = salary * 1.1
+    WHERE employee_id = 100
+    RETURNING last_name, salary INTO emp_info;
+
+  DBMS_OUTPUT.PUT_LINE (
+    'Salary of ' || emp_info.last_name || ' raised from ' ||
+    old_salary || ' to ' || emp_info.salary
+  );
+END;
+/
+
+DECLARE
+  emp_id          employees_temp.employee_id%TYPE := 299;
+  emp_first_name  employees_temp.first_name%TYPE  := 'Bob';
+  emp_last_name   employees_temp.last_name%TYPE   := 'Henry';
+BEGIN
+  INSERT INTO employees_temp (employee_id, first_name, last_name)
+  VALUES (emp_id, emp_first_name, emp_last_name);
+
+  UPDATE employees_temp
+  SET first_name = 'Robert'
+  WHERE employee_id = emp_id;
+
+  DELETE FROM employees_temp
+  WHERE employee_id = emp_id
+  RETURNING first_name, last_name
+  INTO emp_first_name, emp_last_name;
+
+  COMMIT;
+  DBMS_OUTPUT.PUT_LINE (emp_first_name || ' ' || emp_last_name);
+END;
+/
+
+DECLARE
+  TYPE NumList IS TABLE OF employees.employee_id%TYPE;
+  enums  NumList;
+  TYPE NameList IS TABLE OF employees.last_name%TYPE;
+  names  NameList;
+BEGIN
+  DELETE FROM emp_temp
+  WHERE department_id = 30
+  RETURNING employee_id, last_name
+  BULK COLLECT INTO enums, names;
+
+  DBMS_OUTPUT.PUT_LINE ('Deleted ' || SQL%ROWCOUNT || ' rows:');
+  FOR i IN enums.FIRST .. enums.LAST
+  LOOP
+    DBMS_OUTPUT.PUT_LINE ('Employee #' || enums(i) || ': ' || names(i));
+  END LOOP;
+END;
+/
+
+DECLARE
+  TYPE SalList IS TABLE OF employees.salary%TYPE;
+  old_sals SalList;
+  new_sals SalList;
+  TYPE NameList IS TABLE OF employees.last_name%TYPE;
+  names NameList;
+BEGIN
+  UPDATE emp_temp SET salary = salary * 1.15
+  WHERE salary < 2500
+  RETURNING OLD salary, NEW salary, last_name
+  BULK COLLECT INTO old_sals, new_sals, names;
+
+  DBMS_OUTPUT.PUT_LINE('Updated ' || SQL%ROWCOUNT || ' rows: ');
+  FOR i IN old_sals.FIRST .. old_sals.LAST
+  LOOP
+    DBMS_OUTPUT.PUT_LINE(names(i) || ': Old Salary $' || old_sals(i) ||
+            ', New Salary $' || new_sals(i));
+  END LOOP;
+END;
+/
+
+DECLARE
+  TYPE NumList IS TABLE OF NUMBER;
+  depts  NumList := NumList(10,20,30);
+
+  TYPE enum_t IS TABLE OF employees.employee_id%TYPE;
+  e_ids  enum_t;
+
+  TYPE dept_t IS TABLE OF employees.department_id%TYPE;
+  d_ids  dept_t;
+
+BEGIN
+  FORALL j IN depts.FIRST..depts.LAST
+    DELETE FROM emp_temp
+    WHERE department_id = depts(j)
+    RETURNING employee_id, department_id
+    BULK COLLECT INTO e_ids, d_ids;
+
+  DBMS_OUTPUT.PUT_LINE ('Deleted ' || SQL%ROWCOUNT || ' rows:');
+
+  FOR i IN e_ids.FIRST .. e_ids.LAST
+  LOOP
+    DBMS_OUTPUT.PUT_LINE (
+      'Employee #' || e_ids(i) || ' from dept #' || d_ids(i)
+    );
+  END LOOP;
+END;
+/
+
+DECLARE
+  TYPE t_desc_tab IS TABLE OF t1.description%TYPE;
+  TYPE t_tab IS TABLE OF t1%ROWTYPE;
+  l_desc_tab t_desc_tab := t_desc_tab('FIVE', 'SIX', 'SEVEN');
+  l_tab   t_tab;
+BEGIN
+
+  FORALL i IN l_desc_tab.first .. l_desc_tab.last
+    INSERT INTO t1 VALUES (t1_seq.nextval, l_desc_tab(i))
+    RETURNING id, description BULK COLLECT INTO l_tab;
+
+  FOR i IN l_tab.first .. l_tab.last LOOP
+    DBMS_OUTPUT.put_line('INSERT ID=' || l_tab(i) ||
+                         ' DESC=' || l_tab(i));
+  END LOOP;
+
+  COMMIT;
+END;
+/
+
+DECLARE
+TYPE t_sal_tab IS TABLE OF emp.sal%TYPE;
+TYPE t_empno_tab IS TABLE OF emp.empno%TYPE;
+l_empno t_empno_tab;
+l_salo t_sal_tab;
+l_saln t_sal_tab;
+BEGIN
+    MERGE INTO emp t
+    USING  emp_sal_increase  q
+    ON    (t.deptno = q.deptno)
+    WHEN MATCHED THEN UPDATE SET t.sal=t.sal*(1+q.increase_pct/100)
+    RETURNING empno, OLD sal, NEW sal BULK COLLECT INTO l_empno, l_salo, l_saln;
+
+    FOR i IN l_salo.first .. l_salo.last LOOP
+      DBMS_OUTPUT.put_line('EMPNO=' || l_empno(i)|| ', SAL changed from '||l_salo(i) ||' to ' ||l_saln(i));
+    END LOOP;
+END;
+/

--- a/test/fixtures/dialects/oracle/returning_into.sql
+++ b/test/fixtures/dialects/oracle/returning_into.sql
@@ -114,18 +114,20 @@ END;
 
 DECLARE
   TYPE t_desc_tab IS TABLE OF t1.description%TYPE;
-  TYPE t_tab IS TABLE OF t1%ROWTYPE;
+  TYPE t_id_tab   IS TABLE OF t1.id%TYPE;
+  TYPE t_desc_out_tab IS TABLE OF t1.description%TYPE;
+
   l_desc_tab t_desc_tab := t_desc_tab('FIVE', 'SIX', 'SEVEN');
-  l_tab   t_tab;
+  l_id_tab   t_id_tab;
+  l_desc_out_tab t_desc_out_tab;
 BEGIN
+  FORALL i IN l_desc_tab.FIRST .. l_desc_tab.LAST
+    INSERT INTO t1 VALUES (t1_seq.NEXTVAL, l_desc_tab(i))
+    RETURNING id, description BULK COLLECT INTO l_id_tab, l_desc_out_tab;
 
-  FORALL i IN l_desc_tab.first .. l_desc_tab.last
-    INSERT INTO t1 VALUES (t1_seq.nextval, l_desc_tab(i))
-    RETURNING id, description BULK COLLECT INTO l_tab;
-
-  FOR i IN l_tab.first .. l_tab.last LOOP
-    DBMS_OUTPUT.put_line('INSERT ID=' || l_tab(i) ||
-                         ' DESC=' || l_tab(i));
+  FOR i IN l_id_tab.FIRST .. l_id_tab.LAST LOOP
+    DBMS_OUTPUT.put_line('INSERT ID=' || l_id_tab(i) ||
+                         ' DESC=' || l_desc_out_tab(i));
   END LOOP;
 
   COMMIT;

--- a/test/fixtures/dialects/oracle/returning_into.yml
+++ b/test/fixtures/dialects/oracle/returning_into.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d456124e88d00efb755e49694401cc30fb94a05e754e4b18d371ee6d371fd55e
+_hash: 7d0edcc692653b622543df1114b4d3ccdb6e9d087105fb91acaf6b933ddf32c8
 file:
 - statement:
     begin_end_block:
@@ -896,15 +896,31 @@ file:
       - statement_terminator: ;
       - collection_type:
         - keyword: TYPE
-        - naked_identifier: t_tab
+        - naked_identifier: t_id_tab
         - keyword: IS
         - keyword: TABLE
         - keyword: OF
-        - row_type_reference:
-            table_reference:
-              naked_identifier: t1
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: t1
+            - dot: .
+            - naked_identifier: id
             binary_operator: '%'
-            keyword: ROWTYPE
+            keyword: TYPE
+      - statement_terminator: ;
+      - collection_type:
+        - keyword: TYPE
+        - naked_identifier: t_desc_out_tab
+        - keyword: IS
+        - keyword: TABLE
+        - keyword: OF
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: t1
+            - dot: .
+            - naked_identifier: description
+            binary_operator: '%'
+            keyword: TYPE
       - statement_terminator: ;
       - naked_identifier: l_desc_tab
       - data_type:
@@ -929,9 +945,13 @@ file:
                   quoted_literal: "'SEVEN'"
               - end_bracket: )
       - statement_terminator: ;
-      - naked_identifier: l_tab
+      - naked_identifier: l_id_tab
       - data_type:
-          data_type_identifier: t_tab
+          data_type_identifier: t_id_tab
+      - statement_terminator: ;
+      - naked_identifier: l_desc_out_tab
+      - data_type:
+          data_type_identifier: t_desc_out_tab
       - statement_terminator: ;
     - keyword: BEGIN
     - statement:
@@ -941,12 +961,12 @@ file:
         - keyword: IN
         - naked_identifier: l_desc_tab
         - dot: .
-        - naked_identifier: first
+        - naked_identifier: FIRST
         - dot: .
         - dot: .
         - naked_identifier: l_desc_tab
         - dot: .
-        - naked_identifier: last
+        - naked_identifier: LAST
         - insert_statement:
           - keyword: INSERT
           - keyword: INTO
@@ -960,7 +980,7 @@ file:
                   column_reference:
                   - naked_identifier: t1_seq
                   - dot: .
-                  - naked_identifier: nextval
+                  - naked_identifier: NEXTVAL
               - comma: ','
               - expression:
                   function:
@@ -983,21 +1003,23 @@ file:
               - keyword: BULK
               - keyword: COLLECT
               - keyword: INTO
-              - naked_identifier: l_tab
+              - naked_identifier: l_id_tab
+              - comma: ','
+              - naked_identifier: l_desc_out_tab
     - statement_terminator: ;
     - statement:
         for_loop_statement:
         - keyword: FOR
         - naked_identifier: i
         - keyword: IN
-        - naked_identifier: l_tab
+        - naked_identifier: l_id_tab
         - dot: .
-        - naked_identifier: first
+        - naked_identifier: FIRST
         - dot: .
         - dot: .
-        - naked_identifier: l_tab
+        - naked_identifier: l_id_tab
         - dot: .
-        - naked_identifier: last
+        - naked_identifier: LAST
         - loop_statement:
           - keyword: LOOP
           - statement:
@@ -1016,7 +1038,7 @@ file:
                       - pipe: '|'
                     - function:
                         function_name:
-                          function_name_identifier: l_tab
+                          function_name_identifier: l_id_tab
                         function_contents:
                           bracketed:
                             start_bracket: (
@@ -1033,7 +1055,7 @@ file:
                       - pipe: '|'
                     - function:
                         function_name:
-                          function_name_identifier: l_tab
+                          function_name_identifier: l_desc_out_tab
                         function_contents:
                           bracketed:
                             start_bracket: (

--- a/test/fixtures/dialects/oracle/returning_into.yml
+++ b/test/fixtures/dialects/oracle/returning_into.yml
@@ -1,0 +1,1263 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: d456124e88d00efb755e49694401cc30fb94a05e754e4b18d371ee6d371fd55e
+file:
+- statement:
+    begin_end_block:
+    - declare_segment:
+      - keyword: DECLARE
+      - record_type:
+        - keyword: TYPE
+        - naked_identifier: EmpRec
+        - keyword: IS
+        - keyword: RECORD
+        - bracketed:
+          - start_bracket: (
+          - naked_identifier: last_name
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: employees
+              - dot: .
+              - naked_identifier: last_name
+              binary_operator: '%'
+              keyword: TYPE
+          - comma: ','
+          - naked_identifier: salary
+          - column_type_reference:
+              column_reference:
+              - naked_identifier: employees
+              - dot: .
+              - naked_identifier: salary
+              binary_operator: '%'
+              keyword: TYPE
+          - end_bracket: )
+      - statement_terminator: ;
+      - naked_identifier: emp_info
+      - data_type:
+          data_type_identifier: EmpRec
+      - statement_terminator: ;
+      - naked_identifier: old_salary
+      - column_type_reference:
+          column_reference:
+          - naked_identifier: employees
+          - dot: .
+          - naked_identifier: salary
+          binary_operator: '%'
+          keyword: TYPE
+      - statement_terminator: ;
+    - keyword: BEGIN
+    - statement:
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              column_reference:
+                naked_identifier: salary
+          into_clause:
+            keyword: INTO
+            naked_identifier: old_salary
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: employees
+          where_clause:
+            keyword: WHERE
+            expression:
+              column_reference:
+                naked_identifier: employee_id
+              comparison_operator:
+                raw_comparison_operator: '='
+              numeric_literal: '100'
+    - statement_terminator: ;
+    - statement:
+        update_statement:
+          keyword: UPDATE
+          table_reference:
+            naked_identifier: employees
+          set_clause_list:
+            keyword: SET
+            set_clause:
+              column_reference:
+                naked_identifier: salary
+              comparison_operator:
+                raw_comparison_operator: '='
+              expression:
+                column_reference:
+                  naked_identifier: salary
+                binary_operator: '*'
+                numeric_literal: '1.1'
+          where_clause:
+            keyword: WHERE
+            expression:
+              column_reference:
+                naked_identifier: employee_id
+              comparison_operator:
+                raw_comparison_operator: '='
+              numeric_literal: '100'
+          returning_clause:
+          - keyword: RETURNING
+          - naked_identifier: last_name
+          - comma: ','
+          - naked_identifier: salary
+          - into_clause:
+              keyword: INTO
+              naked_identifier: emp_info
+    - statement_terminator: ;
+    - statement:
+        function:
+          function_name:
+            naked_identifier: DBMS_OUTPUT
+            dot: .
+            function_name_identifier: PUT_LINE
+          function_contents:
+            bracketed:
+              start_bracket: (
+              expression:
+              - quoted_literal: "'Salary of '"
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - column_reference:
+                - naked_identifier: emp_info
+                - dot: .
+                - naked_identifier: last_name
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - quoted_literal: "' raised from '"
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - column_reference:
+                  naked_identifier: old_salary
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - quoted_literal: "' to '"
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - column_reference:
+                - naked_identifier: emp_info
+                - dot: .
+                - naked_identifier: salary
+              end_bracket: )
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;
+- statement_terminator: /
+- statement:
+    begin_end_block:
+    - declare_segment:
+      - keyword: DECLARE
+      - naked_identifier: emp_id
+      - column_type_reference:
+          column_reference:
+          - naked_identifier: employees_temp
+          - dot: .
+          - naked_identifier: employee_id
+          binary_operator: '%'
+          keyword: TYPE
+      - colon: ':'
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - expression:
+          numeric_literal: '299'
+      - statement_terminator: ;
+      - naked_identifier: emp_first_name
+      - column_type_reference:
+          column_reference:
+          - naked_identifier: employees_temp
+          - dot: .
+          - naked_identifier: first_name
+          binary_operator: '%'
+          keyword: TYPE
+      - colon: ':'
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - expression:
+          quoted_literal: "'Bob'"
+      - statement_terminator: ;
+      - naked_identifier: emp_last_name
+      - column_type_reference:
+          column_reference:
+          - naked_identifier: employees_temp
+          - dot: .
+          - naked_identifier: last_name
+          binary_operator: '%'
+          keyword: TYPE
+      - colon: ':'
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - expression:
+          quoted_literal: "'Henry'"
+      - statement_terminator: ;
+    - keyword: BEGIN
+    - statement:
+        insert_statement:
+        - keyword: INSERT
+        - keyword: INTO
+        - table_reference:
+            naked_identifier: employees_temp
+        - bracketed:
+          - start_bracket: (
+          - column_reference:
+              naked_identifier: employee_id
+          - comma: ','
+          - column_reference:
+              naked_identifier: first_name
+          - comma: ','
+          - column_reference:
+              naked_identifier: last_name
+          - end_bracket: )
+        - values_clause:
+            keyword: VALUES
+            bracketed:
+            - start_bracket: (
+            - expression:
+                column_reference:
+                  naked_identifier: emp_id
+            - comma: ','
+            - expression:
+                column_reference:
+                  naked_identifier: emp_first_name
+            - comma: ','
+            - expression:
+                column_reference:
+                  naked_identifier: emp_last_name
+            - end_bracket: )
+    - statement_terminator: ;
+    - statement:
+        update_statement:
+          keyword: UPDATE
+          table_reference:
+            naked_identifier: employees_temp
+          set_clause_list:
+            keyword: SET
+            set_clause:
+              column_reference:
+                naked_identifier: first_name
+              comparison_operator:
+                raw_comparison_operator: '='
+              quoted_literal: "'Robert'"
+          where_clause:
+            keyword: WHERE
+            expression:
+            - column_reference:
+                naked_identifier: employee_id
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - column_reference:
+                naked_identifier: emp_id
+    - statement_terminator: ;
+    - statement:
+        delete_statement:
+          keyword: DELETE
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: employees_temp
+          where_clause:
+            keyword: WHERE
+            expression:
+            - column_reference:
+                naked_identifier: employee_id
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - column_reference:
+                naked_identifier: emp_id
+          returning_clause:
+          - keyword: RETURNING
+          - naked_identifier: first_name
+          - comma: ','
+          - naked_identifier: last_name
+          - into_clause:
+            - keyword: INTO
+            - naked_identifier: emp_first_name
+            - comma: ','
+            - naked_identifier: emp_last_name
+    - statement_terminator: ;
+    - statement:
+        transaction_statement:
+          keyword: COMMIT
+    - statement_terminator: ;
+    - statement:
+        function:
+          function_name:
+            naked_identifier: DBMS_OUTPUT
+            dot: .
+            function_name_identifier: PUT_LINE
+          function_contents:
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                  naked_identifier: emp_first_name
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - quoted_literal: "' '"
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - column_reference:
+                  naked_identifier: emp_last_name
+              end_bracket: )
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;
+- statement_terminator: /
+- statement:
+    begin_end_block:
+    - declare_segment:
+      - keyword: DECLARE
+      - collection_type:
+        - keyword: TYPE
+        - naked_identifier: NumList
+        - keyword: IS
+        - keyword: TABLE
+        - keyword: OF
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: employee_id
+            binary_operator: '%'
+            keyword: TYPE
+      - statement_terminator: ;
+      - naked_identifier: enums
+      - data_type:
+          data_type_identifier: NumList
+      - statement_terminator: ;
+      - collection_type:
+        - keyword: TYPE
+        - naked_identifier: NameList
+        - keyword: IS
+        - keyword: TABLE
+        - keyword: OF
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: last_name
+            binary_operator: '%'
+            keyword: TYPE
+      - statement_terminator: ;
+      - naked_identifier: names
+      - data_type:
+          data_type_identifier: NameList
+      - statement_terminator: ;
+    - keyword: BEGIN
+    - statement:
+        delete_statement:
+          keyword: DELETE
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: emp_temp
+          where_clause:
+            keyword: WHERE
+            expression:
+              column_reference:
+                naked_identifier: department_id
+              comparison_operator:
+                raw_comparison_operator: '='
+              numeric_literal: '30'
+          returning_clause:
+          - keyword: RETURNING
+          - naked_identifier: employee_id
+          - comma: ','
+          - naked_identifier: last_name
+          - bulk_collect_into_clause:
+            - keyword: BULK
+            - keyword: COLLECT
+            - keyword: INTO
+            - naked_identifier: enums
+            - comma: ','
+            - naked_identifier: names
+    - statement_terminator: ;
+    - statement:
+        function:
+          function_name:
+            naked_identifier: DBMS_OUTPUT
+            dot: .
+            function_name_identifier: PUT_LINE
+          function_contents:
+            bracketed:
+              start_bracket: (
+              expression:
+              - quoted_literal: "'Deleted '"
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - naked_identifier: SQL
+              - binary_operator: '%'
+              - keyword: ROWCOUNT
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - quoted_literal: "' rows:'"
+              end_bracket: )
+    - statement_terminator: ;
+    - statement:
+        for_loop_statement:
+        - keyword: FOR
+        - naked_identifier: i
+        - keyword: IN
+        - naked_identifier: enums
+        - dot: .
+        - naked_identifier: FIRST
+        - dot: .
+        - dot: .
+        - naked_identifier: enums
+        - dot: .
+        - naked_identifier: LAST
+        - loop_statement:
+          - keyword: LOOP
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - quoted_literal: "'Employee #'"
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - function:
+                        function_name:
+                          function_name_identifier: enums
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: i
+                            end_bracket: )
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - quoted_literal: "': '"
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - function:
+                        function_name:
+                          function_name_identifier: names
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: i
+                            end_bracket: )
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;
+- statement_terminator: /
+- statement:
+    begin_end_block:
+    - declare_segment:
+      - keyword: DECLARE
+      - collection_type:
+        - keyword: TYPE
+        - naked_identifier: SalList
+        - keyword: IS
+        - keyword: TABLE
+        - keyword: OF
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: salary
+            binary_operator: '%'
+            keyword: TYPE
+      - statement_terminator: ;
+      - naked_identifier: old_sals
+      - data_type:
+          data_type_identifier: SalList
+      - statement_terminator: ;
+      - naked_identifier: new_sals
+      - data_type:
+          data_type_identifier: SalList
+      - statement_terminator: ;
+      - collection_type:
+        - keyword: TYPE
+        - naked_identifier: NameList
+        - keyword: IS
+        - keyword: TABLE
+        - keyword: OF
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: last_name
+            binary_operator: '%'
+            keyword: TYPE
+      - statement_terminator: ;
+      - naked_identifier: names
+      - data_type:
+          data_type_identifier: NameList
+      - statement_terminator: ;
+    - keyword: BEGIN
+    - statement:
+        update_statement:
+          keyword: UPDATE
+          table_reference:
+            naked_identifier: emp_temp
+          set_clause_list:
+            keyword: SET
+            set_clause:
+              column_reference:
+                naked_identifier: salary
+              comparison_operator:
+                raw_comparison_operator: '='
+              expression:
+                column_reference:
+                  naked_identifier: salary
+                binary_operator: '*'
+                numeric_literal: '1.15'
+          where_clause:
+            keyword: WHERE
+            expression:
+              column_reference:
+                naked_identifier: salary
+              comparison_operator:
+                raw_comparison_operator: <
+              numeric_literal: '2500'
+          returning_clause:
+          - keyword: RETURNING
+          - keyword: OLD
+          - naked_identifier: salary
+          - comma: ','
+          - keyword: NEW
+          - naked_identifier: salary
+          - comma: ','
+          - naked_identifier: last_name
+          - bulk_collect_into_clause:
+            - keyword: BULK
+            - keyword: COLLECT
+            - keyword: INTO
+            - naked_identifier: old_sals
+            - comma: ','
+            - naked_identifier: new_sals
+            - comma: ','
+            - naked_identifier: names
+    - statement_terminator: ;
+    - statement:
+        function:
+          function_name:
+            naked_identifier: DBMS_OUTPUT
+            dot: .
+            function_name_identifier: PUT_LINE
+          function_contents:
+            bracketed:
+              start_bracket: (
+              expression:
+              - quoted_literal: "'Updated '"
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - naked_identifier: SQL
+              - binary_operator: '%'
+              - keyword: ROWCOUNT
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - quoted_literal: "' rows: '"
+              end_bracket: )
+    - statement_terminator: ;
+    - statement:
+        for_loop_statement:
+        - keyword: FOR
+        - naked_identifier: i
+        - keyword: IN
+        - naked_identifier: old_sals
+        - dot: .
+        - naked_identifier: FIRST
+        - dot: .
+        - dot: .
+        - naked_identifier: old_sals
+        - dot: .
+        - naked_identifier: LAST
+        - loop_statement:
+          - keyword: LOOP
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - function:
+                        function_name:
+                          function_name_identifier: names
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: i
+                            end_bracket: )
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - quoted_literal: "': Old Salary $'"
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - function:
+                        function_name:
+                          function_name_identifier: old_sals
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: i
+                            end_bracket: )
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - quoted_literal: "', New Salary $'"
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - function:
+                        function_name:
+                          function_name_identifier: new_sals
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: i
+                            end_bracket: )
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;
+- statement_terminator: /
+- statement:
+    begin_end_block:
+    - declare_segment:
+      - keyword: DECLARE
+      - collection_type:
+        - keyword: TYPE
+        - naked_identifier: NumList
+        - keyword: IS
+        - keyword: TABLE
+        - keyword: OF
+        - data_type:
+            data_type_identifier: NUMBER
+      - statement_terminator: ;
+      - naked_identifier: depts
+      - data_type:
+          data_type_identifier: NumList
+      - colon: ':'
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - expression:
+          function:
+            function_name:
+              function_name_identifier: NumList
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  numeric_literal: '10'
+              - comma: ','
+              - expression:
+                  numeric_literal: '20'
+              - comma: ','
+              - expression:
+                  numeric_literal: '30'
+              - end_bracket: )
+      - statement_terminator: ;
+      - collection_type:
+        - keyword: TYPE
+        - naked_identifier: enum_t
+        - keyword: IS
+        - keyword: TABLE
+        - keyword: OF
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: employee_id
+            binary_operator: '%'
+            keyword: TYPE
+      - statement_terminator: ;
+      - naked_identifier: e_ids
+      - data_type:
+          data_type_identifier: enum_t
+      - statement_terminator: ;
+      - collection_type:
+        - keyword: TYPE
+        - naked_identifier: dept_t
+        - keyword: IS
+        - keyword: TABLE
+        - keyword: OF
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: employees
+            - dot: .
+            - naked_identifier: department_id
+            binary_operator: '%'
+            keyword: TYPE
+      - statement_terminator: ;
+      - naked_identifier: d_ids
+      - data_type:
+          data_type_identifier: dept_t
+      - statement_terminator: ;
+    - keyword: BEGIN
+    - statement:
+        forall_statement:
+        - keyword: FORALL
+        - naked_identifier: j
+        - keyword: IN
+        - naked_identifier: depts
+        - dot: .
+        - naked_identifier: FIRST
+        - dot: .
+        - dot: .
+        - naked_identifier: depts
+        - dot: .
+        - naked_identifier: LAST
+        - delete_statement:
+            keyword: DELETE
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: emp_temp
+            where_clause:
+              keyword: WHERE
+              expression:
+                column_reference:
+                  naked_identifier: department_id
+                comparison_operator:
+                  raw_comparison_operator: '='
+                function:
+                  function_name:
+                    function_name_identifier: depts
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                        column_reference:
+                          naked_identifier: j
+                      end_bracket: )
+            returning_clause:
+            - keyword: RETURNING
+            - naked_identifier: employee_id
+            - comma: ','
+            - naked_identifier: department_id
+            - bulk_collect_into_clause:
+              - keyword: BULK
+              - keyword: COLLECT
+              - keyword: INTO
+              - naked_identifier: e_ids
+              - comma: ','
+              - naked_identifier: d_ids
+    - statement_terminator: ;
+    - statement:
+        function:
+          function_name:
+            naked_identifier: DBMS_OUTPUT
+            dot: .
+            function_name_identifier: PUT_LINE
+          function_contents:
+            bracketed:
+              start_bracket: (
+              expression:
+              - quoted_literal: "'Deleted '"
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - naked_identifier: SQL
+              - binary_operator: '%'
+              - keyword: ROWCOUNT
+              - binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+              - quoted_literal: "' rows:'"
+              end_bracket: )
+    - statement_terminator: ;
+    - statement:
+        for_loop_statement:
+        - keyword: FOR
+        - naked_identifier: i
+        - keyword: IN
+        - naked_identifier: e_ids
+        - dot: .
+        - naked_identifier: FIRST
+        - dot: .
+        - dot: .
+        - naked_identifier: e_ids
+        - dot: .
+        - naked_identifier: LAST
+        - loop_statement:
+          - keyword: LOOP
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: PUT_LINE
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - quoted_literal: "'Employee #'"
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - function:
+                        function_name:
+                          function_name_identifier: e_ids
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: i
+                            end_bracket: )
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - quoted_literal: "' from dept #'"
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - function:
+                        function_name:
+                          function_name_identifier: d_ids
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: i
+                            end_bracket: )
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;
+- statement_terminator: /
+- statement:
+    begin_end_block:
+    - declare_segment:
+      - keyword: DECLARE
+      - collection_type:
+        - keyword: TYPE
+        - naked_identifier: t_desc_tab
+        - keyword: IS
+        - keyword: TABLE
+        - keyword: OF
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: t1
+            - dot: .
+            - naked_identifier: description
+            binary_operator: '%'
+            keyword: TYPE
+      - statement_terminator: ;
+      - collection_type:
+        - keyword: TYPE
+        - naked_identifier: t_tab
+        - keyword: IS
+        - keyword: TABLE
+        - keyword: OF
+        - row_type_reference:
+            table_reference:
+              naked_identifier: t1
+            binary_operator: '%'
+            keyword: ROWTYPE
+      - statement_terminator: ;
+      - naked_identifier: l_desc_tab
+      - data_type:
+          data_type_identifier: t_desc_tab
+      - colon: ':'
+      - comparison_operator:
+          raw_comparison_operator: '='
+      - expression:
+          function:
+            function_name:
+              function_name_identifier: t_desc_tab
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'FIVE'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'SIX'"
+              - comma: ','
+              - expression:
+                  quoted_literal: "'SEVEN'"
+              - end_bracket: )
+      - statement_terminator: ;
+      - naked_identifier: l_tab
+      - data_type:
+          data_type_identifier: t_tab
+      - statement_terminator: ;
+    - keyword: BEGIN
+    - statement:
+        forall_statement:
+        - keyword: FORALL
+        - naked_identifier: i
+        - keyword: IN
+        - naked_identifier: l_desc_tab
+        - dot: .
+        - naked_identifier: first
+        - dot: .
+        - dot: .
+        - naked_identifier: l_desc_tab
+        - dot: .
+        - naked_identifier: last
+        - insert_statement:
+          - keyword: INSERT
+          - keyword: INTO
+          - table_reference:
+              naked_identifier: t1
+          - values_clause:
+              keyword: VALUES
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                  - naked_identifier: t1_seq
+                  - dot: .
+                  - naked_identifier: nextval
+              - comma: ','
+              - expression:
+                  function:
+                    function_name:
+                      function_name_identifier: l_desc_tab
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: i
+                        end_bracket: )
+              - end_bracket: )
+          - returning_clause:
+            - keyword: RETURNING
+            - naked_identifier: id
+            - comma: ','
+            - naked_identifier: description
+            - bulk_collect_into_clause:
+              - keyword: BULK
+              - keyword: COLLECT
+              - keyword: INTO
+              - naked_identifier: l_tab
+    - statement_terminator: ;
+    - statement:
+        for_loop_statement:
+        - keyword: FOR
+        - naked_identifier: i
+        - keyword: IN
+        - naked_identifier: l_tab
+        - dot: .
+        - naked_identifier: first
+        - dot: .
+        - dot: .
+        - naked_identifier: l_tab
+        - dot: .
+        - naked_identifier: last
+        - loop_statement:
+          - keyword: LOOP
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: put_line
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - quoted_literal: "'INSERT ID='"
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - function:
+                        function_name:
+                          function_name_identifier: l_tab
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: i
+                            end_bracket: )
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - quoted_literal: "' DESC='"
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - function:
+                        function_name:
+                          function_name_identifier: l_tab
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: i
+                            end_bracket: )
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+    - statement_terminator: ;
+    - statement:
+        transaction_statement:
+          keyword: COMMIT
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;
+- statement_terminator: /
+- statement:
+    begin_end_block:
+    - declare_segment:
+      - keyword: DECLARE
+      - collection_type:
+        - keyword: TYPE
+        - naked_identifier: t_sal_tab
+        - keyword: IS
+        - keyword: TABLE
+        - keyword: OF
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: emp
+            - dot: .
+            - naked_identifier: sal
+            binary_operator: '%'
+            keyword: TYPE
+      - statement_terminator: ;
+      - collection_type:
+        - keyword: TYPE
+        - naked_identifier: t_empno_tab
+        - keyword: IS
+        - keyword: TABLE
+        - keyword: OF
+        - column_type_reference:
+            column_reference:
+            - naked_identifier: emp
+            - dot: .
+            - naked_identifier: empno
+            binary_operator: '%'
+            keyword: TYPE
+      - statement_terminator: ;
+      - naked_identifier: l_empno
+      - data_type:
+          data_type_identifier: t_empno_tab
+      - statement_terminator: ;
+      - naked_identifier: l_salo
+      - data_type:
+          data_type_identifier: t_sal_tab
+      - statement_terminator: ;
+      - naked_identifier: l_saln
+      - data_type:
+          data_type_identifier: t_sal_tab
+      - statement_terminator: ;
+    - keyword: BEGIN
+    - statement:
+        merge_statement:
+        - keyword: MERGE
+        - keyword: INTO
+        - table_reference:
+            naked_identifier: emp
+        - alias_expression:
+            naked_identifier: t
+        - keyword: USING
+        - table_reference:
+            naked_identifier: emp_sal_increase
+        - alias_expression:
+            naked_identifier: q
+        - join_on_condition:
+            keyword: 'ON'
+            bracketed:
+              start_bracket: (
+              expression:
+              - column_reference:
+                - naked_identifier: t
+                - dot: .
+                - naked_identifier: deptno
+              - comparison_operator:
+                  raw_comparison_operator: '='
+              - column_reference:
+                - naked_identifier: q
+                - dot: .
+                - naked_identifier: deptno
+              end_bracket: )
+        - merge_match:
+            merge_when_matched_clause:
+            - keyword: WHEN
+            - keyword: MATCHED
+            - keyword: THEN
+            - merge_update_clause:
+                keyword: UPDATE
+                set_clause_list:
+                  keyword: SET
+                  set_clause:
+                    column_reference:
+                    - naked_identifier: t
+                    - dot: .
+                    - naked_identifier: sal
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    expression:
+                      column_reference:
+                      - naked_identifier: t
+                      - dot: .
+                      - naked_identifier: sal
+                      binary_operator: '*'
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                        - numeric_literal: '1'
+                        - binary_operator: +
+                        - column_reference:
+                          - naked_identifier: q
+                          - dot: .
+                          - naked_identifier: increase_pct
+                        - binary_operator: /
+                        - numeric_literal: '100'
+                        end_bracket: )
+                returning_clause:
+                - keyword: RETURNING
+                - naked_identifier: empno
+                - comma: ','
+                - keyword: OLD
+                - naked_identifier: sal
+                - comma: ','
+                - keyword: NEW
+                - naked_identifier: sal
+                - bulk_collect_into_clause:
+                  - keyword: BULK
+                  - keyword: COLLECT
+                  - keyword: INTO
+                  - naked_identifier: l_empno
+                  - comma: ','
+                  - naked_identifier: l_salo
+                  - comma: ','
+                  - naked_identifier: l_saln
+    - statement_terminator: ;
+    - statement:
+        for_loop_statement:
+        - keyword: FOR
+        - naked_identifier: i
+        - keyword: IN
+        - naked_identifier: l_salo
+        - dot: .
+        - naked_identifier: first
+        - dot: .
+        - dot: .
+        - naked_identifier: l_salo
+        - dot: .
+        - naked_identifier: last
+        - loop_statement:
+          - keyword: LOOP
+          - statement:
+              function:
+                function_name:
+                  naked_identifier: DBMS_OUTPUT
+                  dot: .
+                  function_name_identifier: put_line
+                function_contents:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - quoted_literal: "'EMPNO='"
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - function:
+                        function_name:
+                          function_name_identifier: l_empno
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: i
+                            end_bracket: )
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - quoted_literal: "', SAL changed from '"
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - function:
+                        function_name:
+                          function_name_identifier: l_salo
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: i
+                            end_bracket: )
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - quoted_literal: "' to '"
+                    - binary_operator:
+                      - pipe: '|'
+                      - pipe: '|'
+                    - function:
+                        function_name:
+                          function_name_identifier: l_saln
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: i
+                            end_bracket: )
+                    end_bracket: )
+          - statement_terminator: ;
+          - keyword: END
+          - keyword: LOOP
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;
+- statement_terminator: /


### PR DESCRIPTION
Closes #6932 

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
