### PR TITLE
TSQL: Add support for CREATE TABLE GRAPH statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -681,6 +681,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("SetStatementSegment"),
             Ref("AlterTableSwitchStatementSegment"),
             Ref("PrintStatementSegment"),
+            Ref("CreateTableGraphStatementSegment"),
             Ref(
                 "CreateTableAsSelectStatementSegment"
             ),  # Azure Synapse Analytics specific
@@ -1895,6 +1896,33 @@ class CheckConstraintGrammar(BaseSegment):
         Sequence("NOT", "FOR", "REPLICATION", optional=True),
         Bracketed(
             Ref("ExpressionSegment"),
+        ),
+    )
+
+
+class ConnectionConstraintGrammar(BaseSegment):
+    """CONNECTION constraint option in `CREATE TABLE` statement.
+
+    https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-sql-graph
+    """
+
+    type = "connection_constraint_grammar"
+    match_grammar = Sequence(
+        "CONNECTION",
+        Bracketed(
+            Delimited(
+                Sequence(
+                    Ref("TableReferenceSegment"),
+                    "TO",
+                    Ref("TableReferenceSegment"),
+                    optional=True,
+                ),
+                allow_trailing=True,
+            )
+        ),
+        AnySetOf(
+            Sequence("ON", "DELETE", OneOf(Sequence("NO", "ACTION"), "CASCADE")),
+            Sequence("ON", "UPDATE", OneOf(Sequence("NO", "ACTION"), "CASCADE")),
         ),
     )
 
@@ -3459,6 +3487,46 @@ class CreateTableStatementSegment(BaseSegment):
     )
 
 
+class CreateTableGraphStatementSegment(BaseSegment):
+    """A `CREATE TABLE` GRAPH statement."""
+
+    type = "create_table_graph_statement"
+    # https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-sql-graph
+    match_grammar = Sequence(
+        "CREATE",
+        "TABLE",
+        Ref("TableReferenceSegment"),
+        OneOf(
+            # Columns and comment syntax:
+            Sequence(
+                Bracketed(
+                    Delimited(
+                        OneOf(
+                            Ref("GraphTableConstraintSegment"),
+                            Ref("ComputedColumnDefinitionSegment"),
+                            Ref("ColumnDefinitionSegment"),
+                            Ref("TableIndexSegment"),
+                            Ref("PeriodSegment"),
+                        ),
+                        allow_trailing=True,
+                    )
+                ),
+            ),
+            optional=True,
+        ),
+        # GRAPH
+        Sequence(
+            "AS",
+            OneOf(
+                "NODE",
+                "EDGE",
+            ),
+        ),
+        Ref("OnPartitionOrFilegroupOptionSegment", optional=True),
+        Ref("DelimiterGrammar", optional=True),
+    )
+
+
 class AlterTableStatementSegment(BaseSegment):
     """An `ALTER TABLE` statement.
 
@@ -3630,6 +3698,35 @@ class TableConstraintSegment(BaseSegment):
                 # REFERENCES reftable [ ( refcolumn) ] + ON DELETE/ON UPDATE
                 Ref("ReferencesConstraintGrammar"),
             ),
+            Ref("CheckConstraintGrammar", optional=True),
+        ),
+    )
+
+
+class GraphTableConstraintSegment(BaseSegment):
+    """A table constraint segment for graph tables, including connection constraints."""
+
+    type = "graph_table_constraint"
+    match_grammar = Sequence(
+        Sequence(  # [ CONSTRAINT <Constraint name> ]
+            "CONSTRAINT", Ref("ObjectReferenceSegment"), optional=True
+        ),
+        OneOf(
+            Sequence(
+                Ref("PrimaryKeyGrammar"),
+                Ref("BracketedIndexColumnListGrammar"),
+                Ref("RelationalIndexOptionsSegment", optional=True),
+                Ref("OnPartitionOrFilegroupOptionSegment", optional=True),
+            ),
+            Sequence(  # FOREIGN KEY ( column_name [, ... ] )
+                # REFERENCES reftable [ ( refcolumn [, ... ] ) ]
+                Ref("ForeignKeyGrammar"),
+                # Local columns making up FOREIGN KEY constraint
+                Ref("BracketedColumnReferenceListGrammar"),
+                # REFERENCES reftable [ ( refcolumn) ] + ON DELETE/ON UPDATE
+                Ref("ReferencesConstraintGrammar"),
+            ),
+            Ref("ConnectionConstraintGrammar", optional=True),
             Ref("CheckConstraintGrammar", optional=True),
         ),
     )

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3454,19 +3454,16 @@ class CreateTableStatementSegment(BaseSegment):
         Ref("TableReferenceSegment"),
         OneOf(
             # Columns and comment syntax:
-            Sequence(
-                Bracketed(
-                    Delimited(
-                        OneOf(
-                            Ref("TableConstraintSegment"),
-                            Ref("ComputedColumnDefinitionSegment"),
-                            Ref("ColumnDefinitionSegment"),
-                            Ref("TableIndexSegment"),
-                            Ref("PeriodSegment"),
-                        ),
-                        allow_trailing=True,
-                    )
+            Bracketed(
+                Delimited(
+                    Ref("TableConstraintSegment"),
+                    Ref("ComputedColumnDefinitionSegment"),
+                    Ref("ColumnDefinitionSegment"),
+                    Ref("TableIndexSegment"),
+                    Ref("PeriodSegment"),
+                    allow_trailing=True,
                 ),
+                optional=True,
             ),
             # Create AS syntax:
             Sequence(
@@ -3496,21 +3493,14 @@ class CreateTableGraphStatementSegment(BaseSegment):
         "CREATE",
         "TABLE",
         Ref("TableReferenceSegment"),
-        OneOf(
-            # Columns and comment syntax:
-            Sequence(
-                Bracketed(
-                    Delimited(
-                        OneOf(
-                            Ref("GraphTableConstraintSegment"),
-                            Ref("ComputedColumnDefinitionSegment"),
-                            Ref("ColumnDefinitionSegment"),
-                            Ref("TableIndexSegment"),
-                            Ref("PeriodSegment"),
-                        ),
-                        allow_trailing=True,
-                    )
-                ),
+        Bracketed(
+            Delimited(
+                Ref("GraphTableConstraintSegment"),
+                Ref("ComputedColumnDefinitionSegment"),
+                Ref("ColumnDefinitionSegment"),
+                Ref("TableIndexSegment"),
+                Ref("PeriodSegment"),
+                allow_trailing=True,
             ),
             optional=True,
         ),

--- a/src/sqlfluff/dialects/dialect_tsql_keywords.py
+++ b/src/sqlfluff/dialects/dialect_tsql_keywords.py
@@ -302,6 +302,7 @@ UNRESERVED_KEYWORDS = [
     "COMPRESSION",
     "CONCAT_NULL_YIELDS_NULL",
     "CONCAT",
+    "CONNECTION",
     "CONNECTION_OPTIONS",
     "CONTAINED",
     "CONTEXT_INFO",
@@ -340,6 +341,7 @@ UNRESERVED_KEYWORDS = [
     "DROP_EXISTING",
     "DUMP",  # listed as reserved but functionally unreserved
     "DURABILITY",
+    "EDGE",
     "ELEMENT",  # *future*
     "ELEMENTS",
     "ENCODING",
@@ -463,6 +465,7 @@ UNRESERVED_KEYWORDS = [
     "NO_PERFORMANCE_SPOOL",
     "NO",
     "NOCOUNT",
+    "NODE",
     "NOEXEC",
     "NOEXPAND",
     "NOLOCK",

--- a/test/fixtures/dialects/tsql/create_table_graph.sql
+++ b/test/fixtures/dialects/tsql/create_table_graph.sql
@@ -13,7 +13,7 @@ CREATE TABLE friends (
 -- Create a likes edge table, this table does not have any user defined attributes
 CREATE TABLE likes AS EDGE;
 
--- Create friend edge table with CONSTRAINT, restricts for nodes and it direction
+-- Create friend edge table with CONSTRAINT, restricts for nodes and its direction
 CREATE TABLE dbo.FriendOf(
   CONSTRAINT cnt_Person_FriendOf_Person
     CONNECTION (dbo.Person TO dbo.Person)

--- a/test/fixtures/dialects/tsql/create_table_graph.sql
+++ b/test/fixtures/dialects/tsql/create_table_graph.sql
@@ -1,0 +1,27 @@
+-- Simple node table with a user defined attributes
+CREATE TABLE [dbo].[Person] (
+   ID INTEGER PRIMARY KEY,
+   [name] VARCHAR(100)
+) AS NODE;
+
+-- A simple edge table with a user defined attribute
+CREATE TABLE friends (
+   id INTEGER PRIMARY KEY,
+   start_date DATE
+) AS EDGE;
+
+-- Create a likes edge table, this table does not have any user defined attributes
+CREATE TABLE likes AS EDGE;
+
+-- Create friend edge table with CONSTRAINT, restricts for nodes and it direction
+CREATE TABLE dbo.FriendOf(
+  CONSTRAINT cnt_Person_FriendOf_Person
+    CONNECTION (dbo.Person TO dbo.Person)
+) AS EDGE;
+
+-- Create friend edge table with CONSTRAINT,
+-- with ON DELETE CASCADE option
+CREATE TABLE dbo.FriendOf(
+  CONSTRAINT cnt_Person_FriendOf_Person
+    CONNECTION (dbo.Person TO dbo.Person) ON DELETE CASCADE
+) AS EDGE;

--- a/test/fixtures/dialects/tsql/create_table_graph.yml
+++ b/test/fixtures/dialects/tsql/create_table_graph.yml
@@ -1,0 +1,140 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: eec36e50396bb61abe0713b0338d60f4c17688597f014d5ea215db882d52c97d
+file:
+  batch:
+  - statement:
+      create_table_graph_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - quoted_identifier: '[dbo]'
+        - dot: .
+        - quoted_identifier: '[Person]'
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: ID
+            data_type:
+              data_type_identifier: INTEGER
+            column_constraint_segment:
+            - keyword: PRIMARY
+            - keyword: KEY
+        - comma: ','
+        - column_definition:
+            quoted_identifier: '[name]'
+            data_type:
+              data_type_identifier: VARCHAR
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    numeric_literal: '100'
+                  end_bracket: )
+        - end_bracket: )
+      - keyword: AS
+      - keyword: NODE
+      - statement_terminator: ;
+  - statement:
+      create_table_graph_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: friends
+      - bracketed:
+        - start_bracket: (
+        - column_definition:
+            naked_identifier: id
+            data_type:
+              data_type_identifier: INTEGER
+            column_constraint_segment:
+            - keyword: PRIMARY
+            - keyword: KEY
+        - comma: ','
+        - column_definition:
+            naked_identifier: start_date
+            data_type:
+              data_type_identifier: DATE
+        - end_bracket: )
+      - keyword: AS
+      - keyword: EDGE
+      - statement_terminator: ;
+  - statement:
+      create_table_graph_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+          naked_identifier: likes
+      - keyword: AS
+      - keyword: EDGE
+      - statement_terminator: ;
+  - statement:
+      create_table_graph_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: FriendOf
+      - bracketed:
+          start_bracket: (
+          graph_table_constraint:
+            keyword: CONSTRAINT
+            object_reference:
+              naked_identifier: cnt_Person_FriendOf_Person
+            connection_constraint_grammar:
+              keyword: CONNECTION
+              bracketed:
+              - start_bracket: (
+              - table_reference:
+                - naked_identifier: dbo
+                - dot: .
+                - naked_identifier: Person
+              - keyword: TO
+              - table_reference:
+                - naked_identifier: dbo
+                - dot: .
+                - naked_identifier: Person
+              - end_bracket: )
+          end_bracket: )
+      - keyword: AS
+      - keyword: EDGE
+      - statement_terminator: ;
+  - statement:
+      create_table_graph_statement:
+      - keyword: CREATE
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: dbo
+        - dot: .
+        - naked_identifier: FriendOf
+      - bracketed:
+          start_bracket: (
+          graph_table_constraint:
+            keyword: CONSTRAINT
+            object_reference:
+              naked_identifier: cnt_Person_FriendOf_Person
+            connection_constraint_grammar:
+            - keyword: CONNECTION
+            - bracketed:
+              - start_bracket: (
+              - table_reference:
+                - naked_identifier: dbo
+                - dot: .
+                - naked_identifier: Person
+              - keyword: TO
+              - table_reference:
+                - naked_identifier: dbo
+                - dot: .
+                - naked_identifier: Person
+              - end_bracket: )
+            - keyword: 'ON'
+            - keyword: DELETE
+            - keyword: CASCADE
+          end_bracket: )
+      - keyword: AS
+      - keyword: EDGE
+      - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

This PR is adding support for graph tables in TSQL. These use special syntax at table creation and a specific constraint for such tables.

* Add required keywords
* Add graph table syntax variation with AS NODE and AS EDGE reusing as much as possible
* Add related constraints

PS: My first contribution to this repo, happy to take advice on further improvements in this PR.

### Are there any other side effects of this change that we should be aware of?
No

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
