### PR TITLE
API: prioritize configuration file's dialect

### DIFF
--- a/src/sqlfluff/api/simple.py
+++ b/src/sqlfluff/api/simple.py
@@ -38,11 +38,24 @@ def get_simple_config(
 
     # Instantiate a config object.
     try:
-        return FluffConfig.from_root(
+        config = FluffConfig.from_root(
             extra_config_path=config_path,
             ignore_local_config=True,
             overrides=overrides,
+            require_dialect=False,
         )
+
+        # If no dialect was specified, set it to ansi. This allows for the legacy
+        # behavior of the simple API to be maintained, where the dialect is not
+        # required to be specified, but defaults to ansi.
+        if not config.get("dialect"):
+            overrides["dialect"] = "ansi"
+            config = FluffConfig.from_root(
+                extra_config_path=config_path,
+                ignore_local_config=True,
+                overrides=overrides,
+            )
+        return config
     except SQLFluffUserError as err:  # pragma: no cover
         raise SQLFluffUserError(f"Error loading config: {str(err)}")
 
@@ -60,7 +73,7 @@ class APIParsingError(ValueError):
 
 def lint(
     sql: str,
-    dialect: str = "ansi",
+    dialect: Optional[str] = None,
     rules: Optional[list[str]] = None,
     exclude_rules: Optional[list[str]] = None,
     config: Optional[FluffConfig] = None,
@@ -70,7 +83,7 @@ def lint(
 
     Args:
         sql (:obj:`str`): The SQL to be linted.
-        dialect (:obj:`str`, optional): A reference to the dialect of the SQL
+        dialect (:obj:`Optional[str]`, optional): A reference to the dialect of the SQL
             to be linted. Defaults to `ansi`.
         rules (:obj:`Optional[list[str]`, optional): A list of rule
             references to lint for. Defaults to None.
@@ -101,7 +114,7 @@ def lint(
 
 def fix(
     sql: str,
-    dialect: str = "ansi",
+    dialect: Optional[str] = None,
     rules: Optional[list[str]] = None,
     exclude_rules: Optional[list[str]] = None,
     config: Optional[FluffConfig] = None,
@@ -112,7 +125,7 @@ def fix(
 
     Args:
         sql (:obj:`str`): The SQL to be fixed.
-        dialect (:obj:`str`, optional): A reference to the dialect of the SQL
+        dialect (:obj:`Optional[str]`, optional): A reference to the dialect of the SQL
             to be fixed. Defaults to `ansi`.
         rules (:obj:`Optional[list[str]`, optional): A subset of rule
             references to fix for. Defaults to None.
@@ -154,7 +167,7 @@ def fix(
 
 def parse(
     sql: str,
-    dialect: str = "ansi",
+    dialect: Optional[str] = None,
     config: Optional[FluffConfig] = None,
     config_path: Optional[str] = None,
 ) -> dict[str, Any]:
@@ -162,7 +175,7 @@ def parse(
 
     Args:
         sql (:obj:`str`): The SQL to be parsed.
-        dialect (:obj:`str`, optional): A reference to the dialect of the SQL
+        dialect (:obj:`Optional[str]`, optional): A reference to the dialect of the SQL
             to be parsed. Defaults to `ansi`.
         config (:obj:`Optional[FluffConfig]`, optional): A configuration object
             to use for the operation. Defaults to None.

--- a/test/api/simple_test.py
+++ b/test/api/simple_test.py
@@ -1,6 +1,7 @@
 """Tests for simple use cases of the public api."""
 
 import json
+from contextlib import nullcontext
 
 import pytest
 
@@ -521,6 +522,98 @@ def test__api__config_path():
 
     # Compare JSON from parse to expected result.
     assert parsed == expected_parsed
+
+
+@pytest.mark.parametrize(
+    "config_path,expectation",
+    [
+        ("test/fixtures/api/config_dialect/.sqlfluff", nullcontext()),
+        (None, pytest.raises(APIParsingError)),
+    ],
+)
+def test__api__parse_dialect_config_path(config_path, expectation):
+    """Test that we can load a dialect from a config file in the Simple API parse."""
+    # Load test SQL file.
+    with open("test/fixtures/api/config_dialect/config_dialect.sql", "r") as f:
+        sql = f.read()
+
+    # Load in expected result.
+    with open("test/fixtures/api/config_dialect/config_dialect_parse.json", "r") as f:
+        expected_parsed = json.load(f)
+
+    was_parsed = False
+    with expectation:
+        # Pass a config path to the Simple API.
+        parsed = sqlfluff.parse(
+            sql,
+            config_path=config_path,
+        )
+        was_parsed = True
+        # Compare JSON from parse to expected result.
+        assert parsed == expected_parsed
+
+    if isinstance(expectation, nullcontext):
+        assert was_parsed
+    else:
+        assert not was_parsed
+
+
+@pytest.mark.parametrize(
+    "config_path,fails",
+    [
+        ("test/fixtures/api/config_dialect/.sqlfluff", False),
+        (None, True),
+    ],
+)
+def test__api__lint_dialect_config_path(config_path, fails):
+    """Test that we can load a dialect from a config file in the Simple API lint."""
+    # Load test SQL file.
+    with open("test/fixtures/api/config_dialect/config_dialect.sql", "r") as f:
+        sql = f.read()
+
+    # Load in expected result.
+    issue_type = "prs" if fails else "lt01"
+    with open(
+        f"test/fixtures/api/config_dialect/config_dialect_lint_{issue_type}.json", "r"
+    ) as f:
+        expected_lint = json.load(f)
+
+    # Pass a config path to the Simple API.
+    linted = sqlfluff.lint(
+        sql,
+        config_path=config_path,
+    )
+    # Compare JSON from lint to expected result.
+    assert linted == expected_lint
+
+
+@pytest.mark.parametrize(
+    "config_path,fails",
+    [
+        ("test/fixtures/api/config_dialect/.sqlfluff", False),
+        (None, True),
+    ],
+)
+def test__api__fix_dialect_config_path(config_path, fails):
+    """Test that we can load a dialect from a config file in the Simple API fix."""
+    # Load test SQL file.
+    with open("test/fixtures/api/config_dialect/config_dialect.sql", "r") as f:
+        sql = f.read()
+
+    # Load in expected result.
+    if fails:
+        expected_fix = sql
+    else:
+        with open("test/fixtures/api/config_dialect/config_dialect_fix.sql", "r") as f:
+            expected_fix = f.read()
+
+    # Pass a config path to the Simple API.
+    fixed = sqlfluff.fix(
+        sql,
+        config_path=config_path,
+    )
+    # Compare to expected result.
+    assert fixed == expected_fix
 
 
 @pytest.mark.parametrize(

--- a/test/fixtures/api/config_dialect/.sqlfluff
+++ b/test/fixtures/api/config_dialect/.sqlfluff
@@ -1,0 +1,2 @@
+[sqlfluff]
+dialect = duckdb

--- a/test/fixtures/api/config_dialect/config_dialect.sql
+++ b/test/fixtures/api/config_dialect/config_dialect.sql
@@ -1,0 +1,2 @@
+FROM  tab
+WHERE a = 1;

--- a/test/fixtures/api/config_dialect/config_dialect_fix.sql
+++ b/test/fixtures/api/config_dialect/config_dialect_fix.sql
@@ -1,0 +1,2 @@
+FROM tab
+WHERE a = 1;

--- a/test/fixtures/api/config_dialect/config_dialect_lint_lt01.json
+++ b/test/fixtures/api/config_dialect/config_dialect_lint_lt01.json
@@ -1,0 +1,26 @@
+[
+    {
+        "code": "LT01",
+        "description": "Expected only single space before naked identifier. Found '  '.",
+        "end_file_pos": 6,
+        "end_line_no": 1,
+        "end_line_pos": 7,
+        "fixes": [
+            {
+                "edit": " ",
+                "end_file_pos": 6,
+                "end_line_no": 1,
+                "end_line_pos": 7,
+                "start_file_pos": 4,
+                "start_line_no": 1,
+                "start_line_pos": 5,
+                "type": "replace"
+            }
+        ],
+        "name": "layout.spacing",
+        "start_file_pos": 4,
+        "start_line_no": 1,
+        "start_line_pos": 5,
+        "warning": false
+    }
+]

--- a/test/fixtures/api/config_dialect/config_dialect_lint_prs.json
+++ b/test/fixtures/api/config_dialect/config_dialect_lint_prs.json
@@ -1,0 +1,14 @@
+[
+    {
+        "code": "PRS",
+        "description": "Line 1, Position 1: Found unparsable section: 'FROM  tab\\nWHERE a = 1;'",
+        "end_file_pos": 22,
+        "end_line_no": 2,
+        "end_line_pos": 13,
+        "name": "",
+        "start_file_pos": 0,
+        "start_line_no": 1,
+        "start_line_pos": 1,
+        "warning": false
+    }
+]

--- a/test/fixtures/api/config_dialect/config_dialect_parse.json
+++ b/test/fixtures/api/config_dialect/config_dialect_parse.json
@@ -1,0 +1,49 @@
+{
+    "file": {
+        "statement": {
+            "select_statement": {
+                "from_clause": {
+                    "keyword": "FROM",
+                    "whitespace": "  ",
+                    "from_expression": {
+                        "from_expression_element": {
+                            "table_expression": {
+                                "table_reference": {
+                                    "naked_identifier": "tab"
+                                }
+                            }
+                        }
+                    }
+                },
+                "newline": "\n",
+                "where_clause": {
+                    "keyword": "WHERE",
+                    "whitespace": " ",
+                    "expression": [
+                        {
+                            "column_reference": {
+                                "naked_identifier": "a"
+                            }
+                        },
+                        {
+                            "whitespace": " "
+                        },
+                        {
+                            "comparison_operator": {
+                                "raw_comparison_operator": "="
+                            }
+                        },
+                        {
+                            "whitespace": " "
+                        },
+                        {
+                            "numeric_literal": "1"
+                        }
+                    ]
+                }
+            }
+        },
+        "statement_terminator": ";",
+        "newline": "\n"
+    }
+}


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Currently, the API defaults the dialects to `ansi` if not specified. However, if a configuration file has a dialect, that is overwritten by the `ansi` default value. This fixes this overwrite.
- fixes #6949

### Are there any other side effects of this change that we should be aware of?
Currently this keeps the `ansi` default by reloading the configuration again with the dialect, but maybe this should be deprecated.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
