### PR TITLE
Tsql add alter constraint if exists

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3516,10 +3516,17 @@ class AlterTableStatementSegment(BaseSegment):
                 ),
                 Sequence(
                     OneOf(
-                        "CHECK",
+                        "CHECK"
+                    ),
+                    "CONSTRAINT",
+                    Ref("ObjectReferenceSegment"),
+                ),
+                Sequence(
+                    OneOf(
                         "DROP",
                     ),
                     "CONSTRAINT",
+                    Ref("IfExistsGrammar", optional=True),
                     Ref("ObjectReferenceSegment"),
                 ),
                 # Rename

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3515,16 +3515,12 @@ class AlterTableStatementSegment(BaseSegment):
                     Ref("TableConstraintSegment"),
                 ),
                 Sequence(
-                    OneOf(
-                        "CHECK"
-                    ),
+                    "CHECK"
                     "CONSTRAINT",
                     Ref("ObjectReferenceSegment"),
                 ),
                 Sequence(
-                    OneOf(
-                        "DROP",
-                    ),
+                    "DROP"
                     "CONSTRAINT",
                     Ref("IfExistsGrammar", optional=True),
                     Ref("ObjectReferenceSegment"),

--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -3573,12 +3573,12 @@ class AlterTableStatementSegment(BaseSegment):
                     Ref("TableConstraintSegment"),
                 ),
                 Sequence(
-                    "CHECK"
+                    "CHECK",
                     "CONSTRAINT",
                     Ref("ObjectReferenceSegment"),
                 ),
                 Sequence(
-                    "DROP"
+                    "DROP",
                     "CONSTRAINT",
                     Ref("IfExistsGrammar", optional=True),
                     Ref("ObjectReferenceSegment"),

--- a/test/fixtures/dialects/tsql/alter_table.sql
+++ b/test/fixtures/dialects/tsql/alter_table.sql
@@ -41,6 +41,9 @@ GO
 ALTER TABLE Production.TransactionHistoryArchive
 DROP CONSTRAINT PK_TransactionHistoryArchive_TransactionID
 
+ALTER TABLE Production.TransactionHistoryArchive
+DROP CONSTRAINT IF EXISTS PK_TransactionHistoryArchive_TransactionID
+
 ALTER TABLE [Production].[ProductCostHistory]
 WITH CHECK ADD CONSTRAINT [FK_ProductCostHistory_Product_ProductID] FOREIGN KEY([ProductID])
 REFERENCES [Production].[Product] ([ProductID])

--- a/test/fixtures/dialects/tsql/alter_table.yml
+++ b/test/fixtures/dialects/tsql/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2a0d700bd5dc5418ed964e623a378ff5053d0abcadd537d2e9fb58905c6321c0
+_hash: 48376aa83f4f699ff9589a73506d9489f3d1d10da0ed466406965e333d5688a7
 file:
 - batch:
     statement:
@@ -316,6 +316,20 @@ file:
         - naked_identifier: TransactionHistoryArchive
       - keyword: DROP
       - keyword: CONSTRAINT
+      - object_reference:
+          naked_identifier: PK_TransactionHistoryArchive_TransactionID
+  - statement:
+      alter_table_statement:
+      - keyword: ALTER
+      - keyword: TABLE
+      - table_reference:
+        - naked_identifier: Production
+        - dot: .
+        - naked_identifier: TransactionHistoryArchive
+      - keyword: DROP
+      - keyword: CONSTRAINT
+      - keyword: IF
+      - keyword: EXISTS
       - object_reference:
           naked_identifier: PK_TransactionHistoryArchive_TransactionID
   - statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Allows for a DROP CONSTRAINT IF EXISTS sequence to te parsed correctly in tsql. 

fixes #6956

### Are there any other side effects of this change that we should be aware of?
Does not seem likely

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
