### PR TITLE
Snowflake: fix collate grammar with aliases

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -817,6 +817,7 @@ snowflake_dialect.replace(
             optional=True,
         ),
     ),
+    CollateGrammar=Sequence("COLLATE", Ref("CollationReferenceSegment")),
 )
 
 # Add all Snowflake keywords
@@ -4177,7 +4178,7 @@ class ColumnConstraintSegment(ansi.ColumnConstraintSegment):
     """
 
     match_grammar: Matchable = AnySetOf(
-        Sequence("COLLATE", Ref("CollationReferenceSegment")),
+        Ref("CollateGrammar"),
         Sequence(
             "DEFAULT",
             Ref("ExpressionSegment"),

--- a/test/fixtures/dialects/snowflake/create_table.sql
+++ b/test/fixtures/dialects/snowflake/create_table.sql
@@ -60,6 +60,7 @@ create table collation_demo (
   spanish_phrase varchar collate 'sp'
   );
 
+create table t2 as select col1 collate 'fr' as col1 from t1;
 
 create table mytable
   using template (

--- a/test/fixtures/dialects/snowflake/create_table.yml
+++ b/test/fixtures/dialects/snowflake/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7b6491692953ce94d2346c76f3a90039d863be132e68472aa4362ff4fadb8d0b
+_hash: c1eb743c09e4402f6934762732bc7cc287900199854ade2f833b0bd42c10db56
 file:
 - statement:
     create_table_statement:
@@ -585,6 +585,34 @@ file:
             collation_reference:
               quoted_literal: "'sp'"
       - end_bracket: )
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: create
+    - keyword: table
+    - table_reference:
+        naked_identifier: t2
+    - keyword: as
+    - select_statement:
+        select_clause:
+          keyword: select
+          select_clause_element:
+            expression:
+              column_reference:
+                naked_identifier: col1
+              keyword: collate
+              collation_reference:
+                quoted_literal: "'fr'"
+            alias_expression:
+              keyword: as
+              naked_identifier: col1
+        from_clause:
+          keyword: from
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: t1
 - statement_terminator: ;
 - statement:
     create_table_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This fixes `CREATE TABLE` statements that have `COLLATE` and aliases specified.
- fixes #6917 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
