### PR TITLE
SQLite: Make `ACTION` a non-reserved keyword

### DIFF
--- a/src/sqlfluff/dialects/dialect_sqlite_keywords.py
+++ b/src/sqlfluff/dialects/dialect_sqlite_keywords.py
@@ -7,7 +7,6 @@ Augmented with data types, and a couple of omitted keywords.
 
 RESERVED_KEYWORDS = [
     "ABORT",
-    "ACTION",
     "ADD",
     "AFTER",
     "ALL",
@@ -205,4 +204,5 @@ UNRESERVED_KEYWORDS = [
     "NOCASE",
     "RTRIM",
     "STORED",  # https://sqlite.org/forum/forumpost/91127ba3db
+    "ACTION",
 ]

--- a/test/fixtures/dialects/sqlite/create_trigger.sql
+++ b/test/fixtures/dialects/sqlite/create_trigger.sql
@@ -53,3 +53,9 @@ WHEN new.z IS NULL   -- putting this expression in parens allows parsing
 BEGIN
 UPDATE y SET z = TRUE WHERE rowid = new.rowid;
 END;
+
+CREATE TRIGGER trigger_name
+AFTER UPDATE ON table_name
+BEGIN
+    INSERT INTO table_name_history (action) VALUES ('UPDATE');
+END;

--- a/test/fixtures/dialects/sqlite/create_trigger.yml
+++ b/test/fixtures/dialects/sqlite/create_trigger.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 2f921f4c3a819a43013daaffbe9cc90ce983411531c2ead3376633ac6557dd26
+_hash: 13aaf97dae29df6299a0e6162bba68dda476463abf453b36aedc777abb092c5d
 file:
 - statement:
     create_trigger:
@@ -295,6 +295,38 @@ file:
             - naked_identifier: new
             - dot: .
             - naked_identifier: rowid
+    - statement_terminator: ;
+    - keyword: END
+- statement_terminator: ;
+- statement:
+    create_trigger:
+    - keyword: CREATE
+    - keyword: TRIGGER
+    - trigger_reference:
+        naked_identifier: trigger_name
+    - keyword: AFTER
+    - keyword: UPDATE
+    - keyword: 'ON'
+    - table_reference:
+        naked_identifier: table_name
+    - keyword: BEGIN
+    - insert_statement:
+      - keyword: INSERT
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: table_name_history
+      - bracketed:
+          start_bracket: (
+          column_reference:
+            naked_identifier: action
+          end_bracket: )
+      - values_clause:
+          keyword: VALUES
+          bracketed:
+            start_bracket: (
+            expression:
+              quoted_literal: "'UPDATE'"
+            end_bracket: )
     - statement_terminator: ;
     - keyword: END
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Changes the keyword `ACTION` from reserved to non-reserved.
- fixes #6965

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
