### PR TITLE
ANSI: Support CTEs in Merge

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -2863,6 +2863,7 @@ ansi_dialect.add(
         Ref("UpdateStatementSegment"),
         Ref("InsertStatementSegment"),
         Ref("DeleteStatementSegment"),
+        Ref("MergeStatementSegment"),
     ),
     # Things that behave like select statements, which can form part of set expressions.
     NonSetSelectableGrammar=OneOf(
@@ -2945,7 +2946,7 @@ class WithCompoundStatementSegment(BaseSegment):
 
 
 class WithCompoundNonSelectStatementSegment(BaseSegment):
-    """A `UPDATE/INSERT/DELETE` statement preceded by a selection of `WITH` clauses.
+    """A `UPDATE/INSERT/DELETE/MERGE` statement preceded by `WITH` clauses.
 
     `WITH tab (col1,col2) AS (SELECT a,b FROM x)`
     """

--- a/test/fixtures/dialects/ansi/merge_into.sql
+++ b/test/fixtures/dialects/ansi/merge_into.sql
@@ -24,3 +24,15 @@ WHEN MATCHED AND a > b THEN
 UPDATE SET a = b
 WHEN MATCHED AND ( a < b AND c < d ) THEN DELETE
 WHEN NOT MATCHED THEN INSERT (a, c) VALUES (b, d);
+
+-- Merge using CTE
+WITH source AS (
+    SELECT
+        *
+    FROM u
+)
+MERGE INTO t USING source AS u ON (a = b)
+WHEN MATCHED THEN
+UPDATE SET a = b
+WHEN NOT MATCHED THEN
+INSERT (b) VALUES (c);

--- a/test/fixtures/dialects/ansi/merge_into.yml
+++ b/test/fixtures/dialects/ansi/merge_into.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 12b2866dcee4e144701a860bb381a3c8d3106abf8b3fa1a961543dd1fc0a4c95
+_hash: d097c8cf3f485d399b1f6e099f4b90408e94e376a61be78ddb017cba82634ad1
 file:
 - statement:
     merge_statement:
@@ -280,4 +280,87 @@ file:
                   column_reference:
                     naked_identifier: d
               - end_bracket: )
+- statement_terminator: ;
+- statement:
+    with_compound_statement:
+      keyword: WITH
+      common_table_expression:
+        naked_identifier: source
+        keyword: AS
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                wildcard_expression:
+                  wildcard_identifier:
+                    star: '*'
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: u
+          end_bracket: )
+      merge_statement:
+      - keyword: MERGE
+      - keyword: INTO
+      - table_reference:
+          naked_identifier: t
+      - keyword: USING
+      - table_reference:
+          naked_identifier: source
+      - alias_expression:
+          keyword: AS
+          naked_identifier: u
+      - join_on_condition:
+          keyword: 'ON'
+          bracketed:
+            start_bracket: (
+            expression:
+            - column_reference:
+                naked_identifier: a
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - column_reference:
+                naked_identifier: b
+            end_bracket: )
+      - merge_match:
+          merge_when_matched_clause:
+          - keyword: WHEN
+          - keyword: MATCHED
+          - keyword: THEN
+          - merge_update_clause:
+              keyword: UPDATE
+              set_clause_list:
+                keyword: SET
+                set_clause:
+                - column_reference:
+                    naked_identifier: a
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - column_reference:
+                    naked_identifier: b
+          merge_when_not_matched_clause:
+          - keyword: WHEN
+          - keyword: NOT
+          - keyword: MATCHED
+          - keyword: THEN
+          - merge_insert_clause:
+              keyword: INSERT
+              bracketed:
+                start_bracket: (
+                column_reference:
+                  naked_identifier: b
+                end_bracket: )
+              values_clause:
+                keyword: VALUES
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    column_reference:
+                      naked_identifier: c
+                  end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Fixes https://github.com/sqlfluff/sqlfluff/issues/6897. Adds `MERGE` to the supported list of statements that can come after a CTE. Added a test to verify the change.

Reference: https://www.datacamp.com/tutorial/cte-sql

I discovered this issue when trying to parse production Spark SQL code that is currently running.

### Are there any other side effects of this change that we should be aware of?
N/A

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
