### PR TITLE
Adds support for `json_object` syntax in Oracle.

### DIFF
--- a/test/fixtures/dialects/oracle/json_object.sql
+++ b/test/fixtures/dialects/oracle/json_object.sql
@@ -1,0 +1,39 @@
+SELECT JSON_OBJECT(
+'name' : first_name || ' ' || last_name,
+'email' : email,
+'phone' : phone_number,
+'hire_date' : hire_date
+)
+FROM employees
+WHERE employee_id = 140;
+
+SELECT JSON_OBJECT(*)
+FROM employees
+WHERE employee_id = 140;
+
+SELECT JSON_OBJECT('NAME' VALUE first_name)
+FROM employees e, departments d
+WHERE e.department_id = d.department_id
+AND e.employee_id = 140;
+
+SELECT JSON_ARRAYAGG(JSON_OBJECT(*))
+FROM departments;
+
+SELECT JSON_OBJECT ('name' value 'Foo') FROM DUAL;
+
+SELECT JSON_OBJECT ('name' value 'Foo' FORMAT JSON ) FROM DUAL;
+
+SELECT JSON_OBJECT (
+    KEY 'deptno' VALUE d.department_id,
+    KEY 'deptname' VALUE d.department_name
+    ) "Department Objects"
+FROM departments d
+ORDER BY d.department_id;
+
+SELECT JSON_OBJECT(first_name, last_name, email, hire_date)
+FROM employees
+WHERE employee_id = 140;
+
+SELECT JSON_OBJECT(eMail)
+FROM employees
+WHERE employee_id = 140;

--- a/test/fixtures/dialects/oracle/json_object.yml
+++ b/test/fixtures/dialects/oracle/json_object.yml
@@ -1,0 +1,357 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 9a8e4e050743f228c2747538c6facfef1c90a9fdf99b5a11036c10699d4d7f0f
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_OBJECT
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  quoted_literal: "'name'"
+              - colon: ':'
+              - expression:
+                - column_reference:
+                    naked_identifier: first_name
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - quoted_literal: "' '"
+                - binary_operator:
+                  - pipe: '|'
+                  - pipe: '|'
+                - column_reference:
+                    naked_identifier: last_name
+              - comma: ','
+              - expression:
+                  quoted_literal: "'email'"
+              - colon: ':'
+              - expression:
+                  column_reference:
+                    naked_identifier: email
+              - comma: ','
+              - expression:
+                  quoted_literal: "'phone'"
+              - colon: ':'
+              - expression:
+                  column_reference:
+                    naked_identifier: phone_number
+              - comma: ','
+              - expression:
+                  quoted_literal: "'hire_date'"
+              - colon: ':'
+              - expression:
+                  column_reference:
+                    naked_identifier: hire_date
+              - end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: employees
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: employee_id
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '140'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_OBJECT
+            function_contents:
+              bracketed:
+                start_bracket: (
+                star: '*'
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: employees
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: employee_id
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '140'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_OBJECT
+            function_contents:
+              bracketed:
+                start_bracket: (
+                quoted_literal: "'NAME'"
+                keyword: VALUE
+                expression:
+                  column_reference:
+                    naked_identifier: first_name
+                end_bracket: )
+      from_clause:
+      - keyword: FROM
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: employees
+            alias_expression:
+              naked_identifier: e
+      - comma: ','
+      - from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: departments
+            alias_expression:
+              naked_identifier: d
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: e
+          - dot: .
+          - naked_identifier: department_id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: d
+          - dot: .
+          - naked_identifier: department_id
+        - binary_operator: AND
+        - column_reference:
+          - naked_identifier: e
+          - dot: .
+          - naked_identifier: employee_id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '140'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_ARRAYAGG
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  function:
+                    function_name:
+                      function_name_identifier: JSON_OBJECT
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        star: '*'
+                        end_bracket: )
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: departments
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_OBJECT
+            function_contents:
+              bracketed:
+                start_bracket: (
+                quoted_literal: "'name'"
+                keyword: value
+                expression:
+                  quoted_literal: "'Foo'"
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: DUAL
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_OBJECT
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - quoted_literal: "'name'"
+              - keyword: value
+              - expression:
+                  quoted_literal: "'Foo'"
+              - keyword: FORMAT
+              - keyword: JSON
+              - end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: DUAL
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_OBJECT
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - keyword: KEY
+              - quoted_literal: "'deptno'"
+              - keyword: VALUE
+              - expression:
+                  column_reference:
+                  - naked_identifier: d
+                  - dot: .
+                  - naked_identifier: department_id
+              - comma: ','
+              - keyword: KEY
+              - quoted_literal: "'deptname'"
+              - keyword: VALUE
+              - expression:
+                  column_reference:
+                  - naked_identifier: d
+                  - dot: .
+                  - naked_identifier: department_name
+              - end_bracket: )
+          alias_expression:
+            quoted_identifier: '"Department Objects"'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: departments
+            alias_expression:
+              naked_identifier: d
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: d
+        - dot: .
+        - naked_identifier: department_id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_OBJECT
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                    naked_identifier: first_name
+              - comma: ','
+              - expression:
+                  column_reference:
+                    naked_identifier: last_name
+              - comma: ','
+              - expression:
+                  column_reference:
+                    naked_identifier: email
+              - comma: ','
+              - expression:
+                  column_reference:
+                    naked_identifier: hire_date
+              - end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: employees
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: employee_id
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '140'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: JSON_OBJECT
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: eMail
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: employees
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: employee_id
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '140'
+- statement_terminator: ;


### PR DESCRIPTION
Closes #6966 

Test examples from [Oracle docs](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/JSON_OBJECT.html)

<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
