### PR TITLE
CLI: Add support for the `NO_COLOR` environment variable

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -162,9 +162,8 @@ def common_options(f: Callable) -> Callable:
         ),
     )(f)
     f = click.option(
-        "-n",
-        "--nocolor",
-        is_flag=True,
+        "-n/ ",
+        "--nocolor/--color",
         default=None,
         help="No color - output will be without ANSI color codes.",
     )(f)

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -104,7 +104,9 @@ class OutputStreamFormatter(FormatterInterface):
     @staticmethod
     def should_produce_plain_output(nocolor: bool) -> bool:
         """Returns True if text output should be plain (not colored)."""
-        return nocolor or not sys.stdout.isatty() or os.environ.get("NO_COLOR") == "1"
+        # If `--color` is specified (nocolor is False), we ignore `NO_COLOR`
+        env_nocolor = bool(os.getenv("NO_COLOR")) and nocolor is not False
+        return nocolor or not sys.stdout.isatty() or env_nocolor
 
     def _dispatch(self, s: str) -> None:
         """Dispatch a string to the callback.

--- a/src/sqlfluff/cli/formatters.py
+++ b/src/sqlfluff/cli/formatters.py
@@ -1,5 +1,6 @@
 """Defines the formatters for the CLI."""
 
+import os
 import sys
 from io import StringIO
 from typing import Optional, Union
@@ -103,7 +104,7 @@ class OutputStreamFormatter(FormatterInterface):
     @staticmethod
     def should_produce_plain_output(nocolor: bool) -> bool:
         """Returns True if text output should be plain (not colored)."""
-        return nocolor or not sys.stdout.isatty()
+        return nocolor or not sys.stdout.isatty() or os.environ.get("NO_COLOR") == "1"
 
     def _dispatch(self, s: str) -> None:
         """Dispatch a string to the callback.

--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -2,7 +2,7 @@
 # verbose is an integer (0-2) indicating the level of log output
 verbose = 0
 # Turn off color formatting of output
-nocolor = False
+nocolor = None
 # Supported dialects https://docs.sqlfluff.com/en/stable/perma/dialects.html
 # Or run 'sqlfluff dialects'
 dialect = None

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1647,18 +1647,34 @@ def test__cli__command_fail_nice_not_found(command):
 
 @patch("click.utils.should_strip_ansi")
 @patch("sys.stdout.isatty")
-def test__cli__command_lint_nocolor(isatty, should_strip_ansi, capsys, tmpdir):
+@pytest.mark.parametrize(
+    "no_color",
+    [
+        ["flag"],
+        ["env_var"],
+    ],
+)
+def test__cli__command_lint_nocolor(
+    isatty, should_strip_ansi, capsys, tmpdir, no_color
+):
     """Test the --nocolor option prevents color output."""
     # Patch these two functions to make it think every output stream is a TTY.
     # In spite of this, the output should not contain ANSI color codes because
     # we specify "--nocolor" below.
+    if no_color == "flag":
+        no_color_flag = ["--nocolor"]
+        os.environ["NO_COLOR"] = "0"
+    else:
+        no_color_flag = []
+        os.environ["NO_COLOR"] = "1"
+
     isatty.return_value = True
     should_strip_ansi.return_value = False
     fpath = "test/fixtures/linter/indentation_errors.sql"
     output_file = str(tmpdir / "result.txt")
     cmd_args = [
         "--verbose",
-        "--nocolor",
+        *no_color_flag,
         "--dialect",
         "ansi",
         "--disable-progress-bar",

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -1648,25 +1648,32 @@ def test__cli__command_fail_nice_not_found(command):
 @patch("click.utils.should_strip_ansi")
 @patch("sys.stdout.isatty")
 @pytest.mark.parametrize(
-    "no_color",
+    "flag, env_var, has_color",
     [
-        ["flag"],
-        ["env_var"],
+        (None, None, True),
+        ("--nocolor", None, False),
+        ("--color", None, True),
+        (None, "1", False),
+        (None, "true", False),
+        (None, "True", False),
+        (None, "False", False),
+        (None, "anything", False),
+        (None, "", True),
+        ("--color", "1", True),
     ],
 )
 def test__cli__command_lint_nocolor(
-    isatty, should_strip_ansi, capsys, tmpdir, no_color
+    isatty, should_strip_ansi, capsys, tmpdir, flag, env_var, has_color
 ):
     """Test the --nocolor option prevents color output."""
     # Patch these two functions to make it think every output stream is a TTY.
     # In spite of this, the output should not contain ANSI color codes because
     # we specify "--nocolor" below.
-    if no_color == "flag":
-        no_color_flag = ["--nocolor"]
-        os.environ["NO_COLOR"] = "0"
-    else:
-        no_color_flag = []
-        os.environ["NO_COLOR"] = "1"
+    no_color_flag = [flag] if flag else []
+    if env_var is not None:
+        os.environ["NO_COLOR"] = env_var
+    elif "NO_COLOR" in os.environ:
+        os.environ.pop("NO_COLOR")
 
     isatty.return_value = True
     should_strip_ansi.return_value = False
@@ -1685,10 +1692,9 @@ def test__cli__command_lint_nocolor(
     with pytest.raises(SystemExit):
         lint(cmd_args)
     out = capsys.readouterr()[0]
-    assert not contains_ansi_escape(out)
     with open(output_file, "r") as f:
         file_contents = f.read()
-    assert not contains_ansi_escape(file_contents)
+    assert contains_ansi_escape(out + file_contents) == has_color
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds support for the no-color.org `NO_COLOR` environment variable to disable color output.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
