### PR TITLE
CV12 and AL05: Prevent AL05 from deleting rewritten CV12 references

### DIFF
--- a/src/sqlfluff/utils/testing/rules.py
+++ b/src/sqlfluff/utils/testing/rules.py
@@ -71,7 +71,9 @@ def load_test_cases(
             for i in y:
                 if "configs" not in y[i].keys():
                     y[i].update({"configs": global_config})
-        ids.extend([rule + "_" + t for t in y])
+        # Replace any commas with underscores so we can reference specific tests.
+        # e.g. `pytest -k AL05_CV12`. Commas break as test keys.
+        ids.extend([rule.replace(",", "_") + "_" + t for t in y])
         test_cases.extend([RuleTestCase(rule=rule, **v) for k, v in y.items()])
 
     return ids, test_cases

--- a/test/fixtures/rules/std_rule_cases/AL05_CV12.yml
+++ b/test/fixtures/rules/std_rule_cases/AL05_CV12.yml
@@ -1,0 +1,18 @@
+rule: AL05,CV12
+
+test_rule_fix_conflict_deleted_where_reference:
+  fail_str: |
+    select a.a
+    from table_a as a
+    left join table_b as b
+    where a.id = b.id
+  fix_str: |
+    select a.a
+    from table_a as a
+    left join table_b as b ON a.id = b.id
+
+test_rule_fix_conflict_modified_where_reference:
+  fail_str: |
+    SELECT foo.a, bar.b FROM foo JOIN bar WHERE foo.x = bar.y AND foo.x = 3
+  fix_str: |
+    SELECT foo.a, bar.b FROM foo JOIN bar ON foo.x = bar.y WHERE foo.x = 3


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This stops AL05 from deleting references that may have been moved around from the `where_clause` into the `join_on_condition`.
- fixes #6946

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
