### PR TITLE
ST05: Support dialects that use WITH, INSERT, SELECT order

### DIFF
--- a/src/sqlfluff/rules/structure/ST05.py
+++ b/src/sqlfluff/rules/structure/ST05.py
@@ -101,6 +101,12 @@ class Rule_ST05(BaseRule):
     }
     is_fix_compatible = True
 
+    # These are dialects that support WITH ... INSERT ... SELECT instead of
+    # INSERT ... WITH ... SELECT
+    # NOTE: this may be incomplete
+    # NOTE: postgres supports both ways, so I've not included it here.
+    _with_before_insert = {"tsql"}
+
     def _eval(self, context: RuleContext) -> EvalResultType:
         """Join/From clauses should not contain subqueries. Use CTEs instead."""
         self.forbid_subquery_in: str
@@ -109,6 +115,7 @@ class Rule_ST05(BaseRule):
         parent_stack = functional_context.parent_stack
         is_select = segment.all(is_type(*_SELECT_TYPES))
         is_select_child = parent_stack.any(is_type(*_SELECT_TYPES))
+        insert_parent = parent_stack.last(is_type("insert_statement"))
         if not is_select or is_select_child:
             # Nothing to do.
             return None
@@ -132,8 +139,14 @@ class Rule_ST05(BaseRule):
                 is_type(
                     "set_expression",
                     "select_statement",
+                    "insert_statement",
                 )
             )
+        elif insert_parent and context.dialect.name in self._with_before_insert:
+            # Here we select the parent `insert_statement` because it should be where
+            # we place the new CTE.
+            output_select = insert_parent
+            segment = insert_parent
 
         # Issue 3617: In T-SQL (and possibly other dialects) the automated fix
         # leaves parentheses in a location that causes a syntax error. This is an

--- a/test/fixtures/rules/std_rule_cases/ST05.yml
+++ b/test/fixtures/rules/std_rule_cases/ST05.yml
@@ -1141,3 +1141,76 @@ test_fail_mariadb_insert_cte_select:
   configs:
     core:
       dialect: mariadb
+
+test_fail_tsql_insert:
+  fail_str: |
+    INSERT INTO Table1 (Id,Name,Attribute)
+    SELECT
+    Main.Id
+    ,Main.Name
+    ,Subq.Attribute
+    FROM MainTable AS Main
+    LEFT JOIN
+    (SELECT
+    Id
+    ,Attribute
+    FROM Table2) Subq
+    ON Main.Id = Subq.Id
+  fix_str: |
+    WITH Subq AS (SELECT
+    Id
+    ,Attribute
+    FROM Table2)
+    INSERT INTO Table1 (Id,Name,Attribute)
+    SELECT
+    Main.Id
+    ,Main.Name
+    ,Subq.Attribute
+    FROM MainTable AS Main
+    LEFT JOIN
+    Subq
+    ON Main.Id = Subq.Id
+  configs:
+    core:
+      dialect: tsql
+
+test_fail_tsql_existing_cte_with_insert:
+  fail_str: |
+    WITH MainTable as (
+        select *
+        from sales
+    )
+
+    INSERT INTO Table1 (Id,Name,Attribute)
+    SELECT
+    Main.Id
+    ,Main.Name
+    ,Subq.Attribute
+    FROM MainTable AS Main
+    LEFT JOIN
+    (SELECT
+    Id
+    ,Attribute
+    FROM Table2) Subq
+    ON Main.Id = Subq.Id
+  fix_str: |
+    WITH MainTable as (
+        select *
+        from sales
+    ),
+    Subq AS (SELECT
+    Id
+    ,Attribute
+    FROM Table2)
+    INSERT INTO Table1 (Id,Name,Attribute)
+    SELECT
+    Main.Id
+    ,Main.Name
+    ,Subq.Attribute
+    FROM MainTable AS Main
+    LEFT JOIN
+    Subq
+    ON Main.Id = Subq.Id
+  configs:
+    core:
+      dialect: tsql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds support for dialects that use `WITH ... INSERT ... SELECT` ordering when using an `INSERT` with a CTE.
- fixes #5280

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
