### PR TITLE
feat(databricks): add support for single-line magics

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -83,6 +83,11 @@ databricks_dialect.insert_lexer_matchers(
         RegexLexer(
             "notebook_start", r"-- Databricks notebook source(\r?\n){1}", CommentSegment
         ),
+        RegexLexer(
+            "magic_single_line",
+            r"(-- MAGIC %)([^\n]{2,})( [^%]{1})([^\n]*)",
+            CodeSegment,
+        ),
         RegexLexer("magic_line", r"(-- MAGIC)( [^%]{1})([^\n]*)", CodeSegment),
         RegexLexer("magic_start", r"(-- MAGIC %)([^\n]{2,})(\r?\n)", CodeSegment),
     ],
@@ -236,6 +241,9 @@ databricks_dialect.add(
         ),
     ),
     NotebookStart=TypedParser("notebook_start", CommentSegment, type="notebook_start"),
+    MagicSingleLineGrammar=TypedParser(
+        "magic_single_line", CodeSegment, type="magic_single_line"
+    ),
     MagicLineGrammar=TypedParser("magic_line", CodeSegment, type="magic_line"),
     MagicStartGrammar=TypedParser("magic_start", CodeSegment, type="magic_start"),
     VariableNameIdentifierSegment=OneOf(
@@ -1603,8 +1611,13 @@ class MagicCellStatementSegment(BaseSegment):
     type = "magic_cell_segment"
     match_grammar = Sequence(
         Ref("NotebookStart", optional=True),
-        Ref("MagicStartGrammar"),
-        AnyNumberOf(Ref("MagicLineGrammar"), optional=True),
+        OneOf(
+            Sequence(
+                Ref("MagicStartGrammar", optional=True),
+                AnyNumberOf(Ref("MagicLineGrammar"), optional=True),
+            ),
+            Ref("MagicSingleLineGrammar", optional=True),
+        ),
         terminators=[Ref("CommandCellSegment", optional=True)],
         reset_terminators=True,
     )

--- a/test/fixtures/dialects/databricks/magic_single_line.sql
+++ b/test/fixtures/dialects/databricks/magic_single_line.sql
@@ -1,0 +1,11 @@
+-- Databricks notebook source
+-- MAGIC %md
+-- MAGIC # Dummy Notebook
+
+-- COMMAND ----------
+
+-- MAGIC %run ./Notebook
+
+-- COMMAND ----------
+
+SELECT a FROM b

--- a/test/fixtures/dialects/databricks/magic_single_line.yml
+++ b/test/fixtures/dialects/databricks/magic_single_line.yml
@@ -1,0 +1,30 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 7bd24732f4f263dec401f41cafbd4abf033c7c5bb082b2bbb171414bb1bf420a
+file:
+- statement:
+    magic_cell_segment:
+      magic_start: "-- MAGIC %md\n"
+      magic_line: '-- MAGIC # Dummy Notebook'
+- statement_terminator: "\n\n-- COMMAND ----------\n"
+- statement:
+    magic_cell_segment:
+      magic_single_line: -- MAGIC %run ./Notebook
+- statement_terminator: "\n\n-- COMMAND ----------\n"
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+            naked_identifier: a
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: b


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

This PR adds support for Databricks single-line magics (e.g., `-- MAGIC %run ./Notebook`) to the Databricks dialect.  
- Introduces a new `magic_single_line` regex lexer and grammar to correctly parse single-line magics as their own segment type.
- Updates the `MagicCellStatementSegment` to allow either multi-line or single-line magics.
- Adds test fixtures for single-line magics to ensure correct parsing and linting.

fixes #6998 

### Are there any other side effects of this change that we should be aware of?

No known side effects. This change is isolated to the Databricks dialect and only affects parsing of magic lines.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
