### PR TITLE
Postgres: Fix dialect to properly trigger RF04 for column names

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -2294,21 +2294,7 @@ class CreateTableStatementSegment(ansi.CreateTableStatementSegment):
                 Bracketed(
                     Delimited(
                         OneOf(
-                            Sequence(
-                                Ref("ColumnReferenceSegment"),
-                                Ref("DatatypeSegment"),
-                                AnyNumberOf(
-                                    # A single COLLATE segment can come before or
-                                    # after constraint segments
-                                    OneOf(
-                                        Ref("ColumnConstraintSegment"),
-                                        Sequence(
-                                            "COLLATE",
-                                            Ref("CollationReferenceSegment"),
-                                        ),
-                                    ),
-                                ),
-                            ),
+                            Ref("ColumnDefinitionSegment"),
                             Ref("TableConstraintSegment"),
                             Sequence(
                                 "LIKE",
@@ -6904,3 +6890,27 @@ class ResetSessionAuthorizationStatementSegment(BaseSegment):
     type = "reset_session_authorization_statement"
 
     match_grammar = Sequence("RESET", "SESSION", "AUTHORIZATION")
+
+
+class ColumnDefinitionSegment(ansi.ColumnDefinitionSegment):
+    """A column definition, e.g. for CREATE TABLE or ALTER TABLE.
+
+    As specified in https://www.postgresql.org/docs/current/sql-createtable.html
+    """
+
+    type = "column_definition"
+    match_grammar: Matchable = Sequence(
+        Ref("SingleIdentifierGrammar"),
+        Ref("DatatypeSegment"),
+        AnyNumberOf(
+            # A single COLLATE segment can come before or
+            # after constraint segments
+            OneOf(
+                Ref("ColumnConstraintSegment"),
+                Sequence(
+                    "COLLATE",
+                    Ref("CollationReferenceSegment"),
+                ),
+            ),
+        ),
+    )

--- a/test/fixtures/rules/std_rule_cases/RF04.yml
+++ b/test/fixtures/rules/std_rule_cases/RF04.yml
@@ -150,3 +150,9 @@ test_pass_one_character_identifier:
   configs:
     core:
       dialect: snowflake
+
+test_fail_keyword_as_column_name_postgres:
+  fail_str: CREATE TABLE test_table (type varchar(30) NOT NULL)
+  configs:
+    core:
+      dialect: postgres


### PR DESCRIPTION
### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fixes #6429.

**Problem**: RF04 (Keywords should not be used as identifiers) was inconsistent across SQL dialects. It correctly flagged keyword usage in CREATE TABLE column names for ANSI and MySQL dialects but failed to trigger for PostgreSQL dialect when using keywords like `type` as column names.

**Root Cause**: PostgreSQL dialect was incorrectly using `ColumnReferenceSegment` instead of `ColumnDefinitionSegment` for column definitions in CREATE TABLE statements, causing RF04's `identifiers_policy_applicable()` function to not recognize these as alias contexts.

**Solution**: 
- Created a proper PostgreSQL-specific `ColumnDefinitionSegment` that inherits from ANSI with additional COLLATE clause support
- Updated PostgreSQL CREATE TABLE grammar to use `ColumnDefinitionSegment` instead of the incorrect `ColumnReferenceSegment` 

### Are there any other side effects of this change that we should be aware of?

No negative side effects. This change actually improves consistency by making PostgreSQL dialect behavior match ANSI and MySQL dialects for RF04 rule enforcement while supporting PostgreSQL features.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [ ] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [x] Other: Manual testing across PostgreSQL, ANSI, and MySQL dialects to verify fix and prevent regressions.
- [x] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
