### PR TITLE
fix(ST11): correct alias extraction for nested field references in Bi…

### DIFF
--- a/src/sqlfluff/rules/structure/ST11.py
+++ b/src/sqlfluff/rules/structure/ST11.py
@@ -120,7 +120,7 @@ class Rule_ST11(BaseRule):
                 else:
                     raise UnqualifiedReferenceError(ref.raw)
             # Remove any quoting characters when returning.
-            yield parts[-2].part.upper().strip("\"'`[]")
+            yield parts[0].part.upper().strip("\"'`[]")
 
     def _extract_references_from_select(
         self, segment: BaseSegment


### PR DESCRIPTION
This PR fixes a bug in rule ST11 where SQLFluff incorrectly reported false positives for unused joins when nested field references were used in BigQuery (e.g. g.a.b.c).

The root cause was incorrect alias extraction logic in _extract_referenced_tables(), which assumed aliases could be identified as the second-to-last part of the path. This fails in deeply nested structures.

This fix updates the logic to consistently extract the first part of the reference path as the alias, ensuring that references like g.a.b.c correctly identify g as the referenced alias.

No known side effects.
The change is scoped specifically to alias extraction logic used by ST11 and is expected to improve correctness for BigQuery without impacting other dialects or rule behavior.

Fixes #6997