### PR TITLE
Trino: support map data type

### DIFF
--- a/src/sqlfluff/dialects/dialect_trino.py
+++ b/src/sqlfluff/dialects/dialect_trino.py
@@ -284,13 +284,13 @@ trino_dialect.replace(
 )
 
 
-class DatatypeSegment(BaseSegment):
-    """Data type segment.
+class PrimitiveTypeSegment(BaseSegment):
+    """Primitive type segment.
 
     See https://trino.io/docs/current/language/types.html
     """
 
-    type = "data_type"
+    type = "primitive_type"
     match_grammar = OneOf(
         # Boolean
         "BOOLEAN",
@@ -318,13 +318,25 @@ class DatatypeSegment(BaseSegment):
         # Date and time
         "DATE",
         Ref("TimeWithTZGrammar"),
-        # Structural
-        Ref("ArrayTypeSegment"),
-        "MAP",
-        Ref("RowTypeSegment"),
         # Others
         "IPADDRESS",
         "UUID",
+    )
+
+
+class DatatypeSegment(BaseSegment):
+    """Data type segment.
+
+    See https://trino.io/docs/current/language/types.html
+    """
+
+    type = "data_type"
+    match_grammar = OneOf(
+        Ref("PrimitiveTypeSegment"),
+        # Structural
+        Ref("ArrayTypeSegment"),
+        Ref("MapTypeSegment"),
+        Ref("RowTypeSegment"),
     )
 
 
@@ -961,5 +973,41 @@ class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
                     optional=True,
                 ),
             ),
+        ),
+    )
+
+
+class MapTypeSegment(BaseSegment):
+    """Expression to construct a MAP datatype."""
+
+    type = "map_type"
+    match_grammar = Sequence(
+        "MAP",
+        Ref("MapTypeSchemaSegment", optional=True),
+    )
+
+
+class MapTypeSchemaSegment(BaseSegment):
+    """Expression to construct the schema of a MAP datatype."""
+
+    type = "map_type_schema"
+    match_grammar = OneOf(
+        Bracketed(
+            Sequence(
+                Ref("PrimitiveTypeSegment"),
+                Ref("CommaSegment"),
+                Ref("DatatypeSegment"),
+            ),
+            bracket_pairs_set="angle_bracket_pairs",
+            bracket_type="angle",
+        ),
+        Bracketed(
+            Sequence(
+                Ref("PrimitiveTypeSegment"),
+                Ref("CommaSegment"),
+                Ref("DatatypeSegment"),
+            ),
+            bracket_pairs_set="bracket_pairs",
+            bracket_type="round",
         ),
     )

--- a/test/fixtures/dialects/trino/alter_table.yml
+++ b/test/fixtures/dialects/trino/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: bda187ec3f0ea6b3bbdd96b0591804d07b326a24d0d9e4345e10ba56a7905f48
+_hash: 753fea3410ca662ecf3665053ad470c7bb0caae8b81e73be767cedf3f014df11
 file:
 - statement:
     alter_table_statement:
@@ -40,7 +40,8 @@ file:
     - column_definition:
         naked_identifier: col1
         data_type:
-          keyword: VARCHAR
+          primitive_type:
+            keyword: VARCHAR
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -56,7 +57,8 @@ file:
     - column_definition:
         naked_identifier: col1
         data_type:
-          keyword: VARCHAR
+          primitive_type:
+            keyword: VARCHAR
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -69,7 +71,8 @@ file:
     - column_definition:
       - naked_identifier: col1
       - data_type:
-          keyword: VARCHAR
+          primitive_type:
+            keyword: VARCHAR
       - keyword: NOT
       - keyword: 'NULL'
 - statement_terminator: ;
@@ -84,7 +87,8 @@ file:
     - column_definition:
         naked_identifier: col1
         data_type:
-          keyword: VARCHAR
+          primitive_type:
+            keyword: VARCHAR
         comment_clause:
           keyword: COMMENT
           quoted_literal: "'comment'"
@@ -100,7 +104,8 @@ file:
     - column_definition:
         naked_identifier: col1
         data_type:
-          keyword: VARCHAR
+          primitive_type:
+            keyword: VARCHAR
         keyword: WITH
         bracketed:
           start_bracket: (
@@ -123,7 +128,8 @@ file:
     - column_definition:
         naked_identifier: col1
         data_type:
-          keyword: VARCHAR
+          primitive_type:
+            keyword: VARCHAR
     - keyword: FIRST
 - statement_terminator: ;
 - statement:
@@ -137,7 +143,8 @@ file:
     - column_definition:
         naked_identifier: col1
         data_type:
-          keyword: VARCHAR
+          primitive_type:
+            keyword: VARCHAR
     - keyword: LAST
 - statement_terminator: ;
 - statement:
@@ -151,7 +158,8 @@ file:
     - column_definition:
         naked_identifier: col1
         data_type:
-          keyword: VARCHAR
+          primitive_type:
+            keyword: VARCHAR
     - keyword: AFTER
     - column_reference:
         naked_identifier: col2
@@ -224,7 +232,8 @@ file:
     - keyword: DATA
     - keyword: TYPE
     - data_type:
-        keyword: INTEGER
+        primitive_type:
+          keyword: INTEGER
 - statement_terminator: ;
 - statement:
     alter_table_statement:
@@ -240,12 +249,13 @@ file:
     - keyword: DATA
     - keyword: TYPE
     - data_type:
-        keyword: VARCHAR
-        bracketed_arguments:
-          bracketed:
-            start_bracket: (
-            numeric_literal: '100'
-            end_bracket: )
+        primitive_type:
+          keyword: VARCHAR
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              numeric_literal: '100'
+              end_bracket: )
 - statement_terminator: ;
 - statement:
     alter_table_statement:

--- a/test/fixtures/dialects/trino/array.yml
+++ b/test/fixtures/dialects/trino/array.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3a6b352e64b02f1f980732b97192496070288befe982266f03b65313ce40f506
+_hash: 935287f028b1aa720622e4d80c51a883770043026a7a0ad1107fd9c044a4155b
 file:
 - statement:
     select_statement:
@@ -228,7 +228,8 @@ file:
                     array_type_schema:
                       start_angle_bracket: <
                       data_type:
-                        keyword: DOUBLE
+                        primitive_type:
+                          keyword: DOUBLE
                       end_angle_bracket: '>'
                 end_bracket: )
 - statement_terminator: ;
@@ -261,7 +262,8 @@ file:
                       bracketed:
                         start_bracket: (
                         data_type:
-                          keyword: DOUBLE
+                          primitive_type:
+                            keyword: DOUBLE
                         end_bracket: )
                 end_bracket: )
 - statement_terminator: ;
@@ -293,7 +295,8 @@ file:
                     array_type_schema:
                       start_angle_bracket: <
                       data_type:
-                        keyword: DOUBLE
+                        primitive_type:
+                          keyword: DOUBLE
                       end_angle_bracket: '>'
                 end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/trino/create_table.sql
+++ b/test/fixtures/dialects/trino/create_table.sql
@@ -68,7 +68,9 @@ WITH NO DATA
 ;
 
 CREATE TABLE structural_types (
-  array_type array(integer),
-  map_type map(varchar(20), integer),
+  array_type_1 array(integer),
+  array_type_2 array<integer>,
+  map_type_1 map(varchar(20), integer),
+  map_type_2 map<varchar(20), integer>,
   row_type row(a integer, b varchar(20), c array(real))
 );

--- a/test/fixtures/dialects/trino/create_table.sql
+++ b/test/fixtures/dialects/trino/create_table.sql
@@ -67,7 +67,7 @@ FROM nation
 WITH NO DATA
 ;
 
-CREATE TABLE structual_types (
+CREATE TABLE structural_types (
   array_type array(integer),
   map_type map(varchar(20), integer),
   row_type row(a integer, b varchar(20), c array(real))

--- a/test/fixtures/dialects/trino/create_table.sql
+++ b/test/fixtures/dialects/trino/create_table.sql
@@ -66,3 +66,9 @@ SELECT *
 FROM nation
 WITH NO DATA
 ;
+
+CREATE TABLE structual_types (
+  array_of_ints array(integer),
+  map_of_ints map(integer, integer),
+  row_of_ints row(a integer, b integer, c integer)
+);

--- a/test/fixtures/dialects/trino/create_table.sql
+++ b/test/fixtures/dialects/trino/create_table.sql
@@ -68,7 +68,7 @@ WITH NO DATA
 ;
 
 CREATE TABLE structual_types (
-  array_of_ints array(integer),
-  map_of_ints map(integer, integer),
-  row_of_ints row(a integer, b integer, c integer)
+  array_type array(integer),
+  map_type map(varchar(20), integer),
+  row_type row(a integer, b varchar(20), c array(real))
 );

--- a/test/fixtures/dialects/trino/create_table.yml
+++ b/test/fixtures/dialects/trino/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9fec1b748fee758a5b704b2a453c2f9c13dffe90b88875e0896754da12f18aad
+_hash: 08ca8bd4658751a9e9f3e2654583e55345b24df9790e8cb4d33ae489c90c7676
 file:
 - statement:
     create_table_statement:
@@ -16,7 +16,8 @@ file:
         column_definition:
           naked_identifier: str
           data_type:
-            keyword: varchar
+            primitive_type:
+              keyword: varchar
         end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -37,27 +38,31 @@ file:
       - column_definition:
           naked_identifier: date_nk
           data_type:
-            keyword: date
+            primitive_type:
+              keyword: date
       - comma: ','
       - column_definition:
           naked_identifier: date_ts
           data_type:
-            keyword: timestamp
+            primitive_type:
+              keyword: timestamp
       - comma: ','
       - column_definition:
           naked_identifier: site
           data_type:
-            keyword: varchar
-            bracketed_arguments:
-              bracketed:
-                start_bracket: (
-                numeric_literal: '30'
-                end_bracket: )
+            primitive_type:
+              keyword: varchar
+              bracketed_arguments:
+                bracketed:
+                  start_bracket: (
+                  numeric_literal: '30'
+                  end_bracket: )
       - comma: ','
       - column_definition:
           naked_identifier: partition_date
           data_type:
-            keyword: date
+            primitive_type:
+              keyword: date
       - end_bracket: )
     - keyword: with
     - bracketed:
@@ -94,22 +99,26 @@ file:
       - column_definition:
           naked_identifier: orderkey
           data_type:
-            keyword: bigint
+            primitive_type:
+              keyword: bigint
       - comma: ','
       - column_definition:
           naked_identifier: orderstatus
           data_type:
-            keyword: varchar
+            primitive_type:
+              keyword: varchar
       - comma: ','
       - column_definition:
           naked_identifier: totalprice
           data_type:
-            keyword: double
+            primitive_type:
+              keyword: double
       - comma: ','
       - column_definition:
           naked_identifier: orderdate
           data_type:
-            keyword: date
+            primitive_type:
+              keyword: date
       - end_bracket: )
     - keyword: WITH
     - bracketed:
@@ -136,17 +145,20 @@ file:
       - column_definition:
           naked_identifier: orderkey
           data_type:
-            keyword: bigint
+            primitive_type:
+              keyword: bigint
       - comma: ','
       - column_definition:
           naked_identifier: orderstatus
           data_type:
-            keyword: varchar
+            primitive_type:
+              keyword: varchar
       - comma: ','
       - column_definition:
           naked_identifier: totalprice
           data_type:
-            keyword: double
+            primitive_type:
+              keyword: double
           comment_clause:
             keyword: COMMENT
             quoted_literal: "'Price in cents.'"
@@ -154,14 +166,16 @@ file:
       - column_definition:
         - naked_identifier: shipmentstatus
         - data_type:
-            keyword: varchar
+            primitive_type:
+              keyword: varchar
         - keyword: not
         - keyword: 'null'
       - comma: ','
       - column_definition:
           naked_identifier: orderdate
           data_type:
-            keyword: date
+            primitive_type:
+              keyword: date
       - end_bracket: )
     - comment_clause:
         keyword: COMMENT
@@ -178,7 +192,8 @@ file:
       - column_definition:
           naked_identifier: another_orderkey
           data_type:
-            keyword: bigint
+            primitive_type:
+              keyword: bigint
       - comma: ','
       - keyword: LIKE
       - table_reference:
@@ -187,7 +202,8 @@ file:
       - column_definition:
           naked_identifier: another_orderdate
           data_type:
-            keyword: date
+            primitive_type:
+              keyword: date
       - end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -347,4 +363,66 @@ file:
     - keyword: WITH
     - keyword: 'NO'
     - keyword: DATA
+- statement_terminator: ;
+- statement:
+    create_table_statement:
+    - keyword: CREATE
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: structual_types
+    - bracketed:
+      - start_bracket: (
+      - column_definition:
+          naked_identifier: array_of_ints
+          data_type:
+            array_type:
+              keyword: array
+              array_type_schema:
+                bracketed:
+                  start_bracket: (
+                  data_type:
+                    primitive_type:
+                      keyword: integer
+                  end_bracket: )
+      - comma: ','
+      - column_definition:
+          naked_identifier: map_of_ints
+          data_type:
+            map_type:
+              keyword: map
+              map_type_schema:
+                bracketed:
+                  start_bracket: (
+                  primitive_type:
+                    keyword: integer
+                  comma: ','
+                  data_type:
+                    primitive_type:
+                      keyword: integer
+                  end_bracket: )
+      - comma: ','
+      - column_definition:
+          naked_identifier: row_of_ints
+          data_type:
+            struct_type:
+              keyword: row
+              struct_type_schema:
+                bracketed:
+                - start_bracket: (
+                - parameter: a
+                - data_type:
+                    primitive_type:
+                      keyword: integer
+                - comma: ','
+                - parameter: b
+                - data_type:
+                    primitive_type:
+                      keyword: integer
+                - comma: ','
+                - parameter: c
+                - data_type:
+                    primitive_type:
+                      keyword: integer
+                - end_bracket: )
+      - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/trino/create_table.yml
+++ b/test/fixtures/dialects/trino/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 08ca8bd4658751a9e9f3e2654583e55345b24df9790e8cb4d33ae489c90c7676
+_hash: 5ea00be33730bd9fba636f1e027580b7ff048aba9030b0f642e1ed293ac90d5b
 file:
 - statement:
     create_table_statement:
@@ -373,7 +373,7 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-          naked_identifier: array_of_ints
+          naked_identifier: array_type
           data_type:
             array_type:
               keyword: array
@@ -386,7 +386,7 @@ file:
                   end_bracket: )
       - comma: ','
       - column_definition:
-          naked_identifier: map_of_ints
+          naked_identifier: map_type
           data_type:
             map_type:
               keyword: map
@@ -394,7 +394,12 @@ file:
                 bracketed:
                   start_bracket: (
                   primitive_type:
-                    keyword: integer
+                    keyword: varchar
+                    bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
+                        numeric_literal: '20'
+                        end_bracket: )
                   comma: ','
                   data_type:
                     primitive_type:
@@ -402,7 +407,7 @@ file:
                   end_bracket: )
       - comma: ','
       - column_definition:
-          naked_identifier: row_of_ints
+          naked_identifier: row_type
           data_type:
             struct_type:
               keyword: row
@@ -417,12 +422,24 @@ file:
                 - parameter: b
                 - data_type:
                     primitive_type:
-                      keyword: integer
+                      keyword: varchar
+                      bracketed_arguments:
+                        bracketed:
+                          start_bracket: (
+                          numeric_literal: '20'
+                          end_bracket: )
                 - comma: ','
                 - parameter: c
                 - data_type:
-                    primitive_type:
-                      keyword: integer
+                    array_type:
+                      keyword: array
+                      array_type_schema:
+                        bracketed:
+                          start_bracket: (
+                          data_type:
+                            primitive_type:
+                              keyword: real
+                          end_bracket: )
                 - end_bracket: )
       - end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/trino/create_table.yml
+++ b/test/fixtures/dialects/trino/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 5ea00be33730bd9fba636f1e027580b7ff048aba9030b0f642e1ed293ac90d5b
+_hash: 97882f36c2869ab5ddc3b2f2152b43a35f4122016e4b8b9aa93c19130d8160fd
 file:
 - statement:
     create_table_statement:
@@ -369,7 +369,7 @@ file:
     - keyword: CREATE
     - keyword: TABLE
     - table_reference:
-        naked_identifier: structual_types
+        naked_identifier: structural_types
     - bracketed:
       - start_bracket: (
       - column_definition:

--- a/test/fixtures/dialects/trino/create_table.yml
+++ b/test/fixtures/dialects/trino/create_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 97882f36c2869ab5ddc3b2f2152b43a35f4122016e4b8b9aa93c19130d8160fd
+_hash: d9ca4dc383cba48d778cc47b22712e45171aaf27ad6e37fa56d7979c2744c317
 file:
 - statement:
     create_table_statement:
@@ -373,7 +373,7 @@ file:
     - bracketed:
       - start_bracket: (
       - column_definition:
-          naked_identifier: array_type
+          naked_identifier: array_type_1
           data_type:
             array_type:
               keyword: array
@@ -386,7 +386,19 @@ file:
                   end_bracket: )
       - comma: ','
       - column_definition:
-          naked_identifier: map_type
+          naked_identifier: array_type_2
+          data_type:
+            array_type:
+              keyword: array
+              array_type_schema:
+                start_angle_bracket: <
+                data_type:
+                  primitive_type:
+                    keyword: integer
+                end_angle_bracket: '>'
+      - comma: ','
+      - column_definition:
+          naked_identifier: map_type_1
           data_type:
             map_type:
               keyword: map
@@ -405,6 +417,26 @@ file:
                     primitive_type:
                       keyword: integer
                   end_bracket: )
+      - comma: ','
+      - column_definition:
+          naked_identifier: map_type_2
+          data_type:
+            map_type:
+              keyword: map
+              map_type_schema:
+                start_angle_bracket: <
+                primitive_type:
+                  keyword: varchar
+                  bracketed_arguments:
+                    bracketed:
+                      start_bracket: (
+                      numeric_literal: '20'
+                      end_bracket: )
+                comma: ','
+                data_type:
+                  primitive_type:
+                    keyword: integer
+                end_angle_bracket: '>'
       - comma: ','
       - column_definition:
           naked_identifier: row_type

--- a/test/fixtures/dialects/trino/integer_types.yml
+++ b/test/fixtures/dialects/trino/integer_types.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: b6908cc207c828aa100f14d2e5527109c021eb95b5aa5cbbaa1ab27075c4943a
+_hash: cf985cf674bcb9341fc3eb33e8fe7058545690cc1aceaa15dcbbe3fa33fb34c5
 file:
 - statement:
     select_statement:
@@ -20,7 +20,8 @@ file:
                   numeric_literal: '1'
                 keyword: AS
                 data_type:
-                  keyword: TINYINT
+                  primitive_type:
+                    keyword: TINYINT
                 end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -38,7 +39,8 @@ file:
                   numeric_literal: '2'
                 keyword: AS
                 data_type:
-                  keyword: SMALLINT
+                  primitive_type:
+                    keyword: SMALLINT
                 end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -56,7 +58,8 @@ file:
                   numeric_literal: '3'
                 keyword: AS
                 data_type:
-                  keyword: INTEGER
+                  primitive_type:
+                    keyword: INTEGER
                 end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -74,7 +77,8 @@ file:
                   numeric_literal: '4'
                 keyword: AS
                 data_type:
-                  keyword: INT
+                  primitive_type:
+                    keyword: INT
                 end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -92,6 +96,7 @@ file:
                   numeric_literal: '5'
                 keyword: AS
                 data_type:
-                  keyword: BIGINT
+                  primitive_type:
+                    keyword: BIGINT
                 end_bracket: )
 - statement_terminator: ;

--- a/test/fixtures/dialects/trino/row_datatype.yml
+++ b/test/fixtures/dialects/trino/row_datatype.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 446c1e57c1da93b9914fab19ffa2a5749bb91c7b453e61296adc0d53a790adc9
+_hash: 1cf564a17627f9d44b2a1ff1df37c5703825b77823235b186fa17492b8985625
 file:
 - statement:
     select_statement:
@@ -44,11 +44,13 @@ file:
                       - start_bracket: (
                       - parameter: price
                       - data_type:
-                          keyword: REAL
+                          primitive_type:
+                            keyword: REAL
                       - comma: ','
                       - parameter: store
                       - data_type:
-                          keyword: VARCHAR
+                          primitive_type:
+                            keyword: VARCHAR
                       - end_bracket: )
                 end_bracket: )
           alias_expression:
@@ -97,11 +99,13 @@ file:
                         - start_bracket: (
                         - parameter: x
                         - data_type:
-                            keyword: BIGINT
+                            primitive_type:
+                              keyword: BIGINT
                         - comma: ','
                         - parameter: y
                         - data_type:
-                            keyword: DOUBLE
+                            primitive_type:
+                              keyword: DOUBLE
                         - end_bracket: )
                   end_bracket: )
             semi_structured_expression:

--- a/test/fixtures/dialects/trino/timestamp_resolutions.yml
+++ b/test/fixtures/dialects/trino/timestamp_resolutions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 351e0f55b3561e752332d82fa7478e3c75b97e39a1f457890aceb9c14db716e0
+_hash: e0a22b7ce9143a2851a299f9027668a2b1d7536047b11084c582603b19c81da4
 file:
 - statement:
     select_statement:
@@ -25,7 +25,8 @@ file:
                     end_bracket: )
                 keyword: AS
                 data_type:
-                  keyword: TIMESTAMP
+                  primitive_type:
+                    keyword: TIMESTAMP
                 end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -48,12 +49,13 @@ file:
                     end_bracket: )
                 keyword: AS
                 data_type:
-                  keyword: TIMESTAMP
-                  bracketed_arguments:
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '0'
-                      end_bracket: )
+                  primitive_type:
+                    keyword: TIMESTAMP
+                    bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
+                        numeric_literal: '0'
+                        end_bracket: )
                 end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -76,12 +78,13 @@ file:
                     end_bracket: )
                 keyword: AS
                 data_type:
-                  keyword: TIMESTAMP
-                  bracketed_arguments:
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '12'
-                      end_bracket: )
+                  primitive_type:
+                    keyword: TIMESTAMP
+                    bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
+                        numeric_literal: '12'
+                        end_bracket: )
                 end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -104,10 +107,11 @@ file:
                     end_bracket: )
                 keyword: AS
                 data_type:
-                - keyword: TIMESTAMP
-                - keyword: WITH
-                - keyword: TIME
-                - keyword: ZONE
+                  primitive_type:
+                  - keyword: TIMESTAMP
+                  - keyword: WITH
+                  - keyword: TIME
+                  - keyword: ZONE
                 end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -130,10 +134,11 @@ file:
                     end_bracket: )
                 keyword: AS
                 data_type:
-                - keyword: TIMESTAMP
-                - keyword: WITHOUT
-                - keyword: TIME
-                - keyword: ZONE
+                  primitive_type:
+                  - keyword: TIMESTAMP
+                  - keyword: WITHOUT
+                  - keyword: TIME
+                  - keyword: ZONE
                 end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -156,15 +161,16 @@ file:
                     end_bracket: )
                 keyword: AS
                 data_type:
-                - keyword: TIMESTAMP
-                - bracketed_arguments:
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '6'
-                      end_bracket: )
-                - keyword: WITH
-                - keyword: TIME
-                - keyword: ZONE
+                  primitive_type:
+                  - keyword: TIMESTAMP
+                  - bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
+                        numeric_literal: '6'
+                        end_bracket: )
+                  - keyword: WITH
+                  - keyword: TIME
+                  - keyword: ZONE
                 end_bracket: )
 - statement_terminator: ;
 - statement:
@@ -187,14 +193,15 @@ file:
                     end_bracket: )
                 keyword: AS
                 data_type:
-                - keyword: TIMESTAMP
-                - bracketed_arguments:
-                    bracketed:
-                      start_bracket: (
-                      numeric_literal: '6'
-                      end_bracket: )
-                - keyword: WITHOUT
-                - keyword: TIME
-                - keyword: ZONE
+                  primitive_type:
+                  - keyword: TIMESTAMP
+                  - bracketed_arguments:
+                      bracketed:
+                        start_bracket: (
+                        numeric_literal: '6'
+                        end_bracket: )
+                  - keyword: WITHOUT
+                  - keyword: TIME
+                  - keyword: ZONE
                 end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Add support for DataType like `MAP(VARCHAR, INTEGER)`.

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
