### PR TITLE
LT14: Ignore keywords in pipe operators

### DIFF
--- a/src/sqlfluff/core/default_config.cfg
+++ b/src/sqlfluff/core/default_config.cfg
@@ -249,6 +249,7 @@ line_position = alone
 [sqlfluff:layout:type:where_clause]
 line_position = alone
 keyword_line_position = leading
+keyword_line_position_exclusions = pipe_operator_clause
 
 [sqlfluff:layout:type:from_clause]
 line_position = alone
@@ -269,7 +270,8 @@ keyword_line_position = leading
 keyword_line_position_exclusions =
     window_specification,
     aggregate_order_by,
-    withingroup_clause
+    withingroup_clause,
+    pipe_operator_clause
 
 [sqlfluff:layout:type:having_clause]
 line_position = alone

--- a/test/fixtures/rules/std_rule_cases/LT14.yml
+++ b/test/fixtures/rules/std_rule_cases/LT14.yml
@@ -605,3 +605,12 @@ test_fail_leading_orderby_except_list_outer_orderby:
         orderby_clause:
           keyword_line_position: leading
           keyword_line_position_exclusions: window_specification, aggregate_order_by
+
+test_pass_bigquery_pipe_operator_where:
+  pass_str: |
+    FROM my_database.my_table
+    |> WHERE some_condition
+    |> ORDER BY my_column
+  configs:
+    core:
+      dialect: bigquery


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This prevents applying LT14 to `WHERE` and `ORDER BY` clauses within a pipe operator.
- makes progress on #6984, enforcing the leading pipe operator will require use of a different rule.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
