### PR TITLE
Snowflake: fix parsing `LIMIT` when not a limit clause

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -518,7 +518,7 @@ ansi_dialect.add(
         "FROM",
         "WHERE",
         Sequence("ORDER", "BY"),
-        "LIMIT",
+        Ref("LimitClauseSegment"),
         "OVERLAPS",
         Ref("SetOperatorSegment"),
         "FETCH",
@@ -530,7 +530,7 @@ ansi_dialect.add(
     CollateGrammar=Nothing(),
     FromClauseTerminatorGrammar=OneOf(
         "WHERE",
-        "LIMIT",
+        Ref("LimitClauseSegment"),
         Sequence("GROUP", "BY"),
         Sequence("ORDER", "BY"),
         "HAVING",
@@ -543,7 +543,7 @@ ansi_dialect.add(
         "OFFSET",
     ),
     WhereClauseTerminatorGrammar=OneOf(
-        "LIMIT",
+        Ref("LimitClauseSegment"),
         Sequence("GROUP", "BY"),
         Sequence("ORDER", "BY"),
         "HAVING",
@@ -554,7 +554,7 @@ ansi_dialect.add(
     ),
     GroupByClauseTerminatorGrammar=OneOf(
         Sequence("ORDER", "BY"),
-        "LIMIT",
+        Ref("LimitClauseSegment"),
         "HAVING",
         "QUALIFY",
         "WINDOW",
@@ -562,13 +562,13 @@ ansi_dialect.add(
     ),
     HavingClauseTerminatorGrammar=OneOf(
         Sequence("ORDER", "BY"),
-        "LIMIT",
+        Ref("LimitClauseSegment"),
         "QUALIFY",
         "WINDOW",
         "FETCH",
     ),
     OrderByClauseTerminators=OneOf(
-        "LIMIT",
+        Ref("LimitClauseSegment"),
         "HAVING",
         "QUALIFY",
         # For window functions
@@ -2521,7 +2521,7 @@ class OrderByClauseSegment(BaseSegment):
                 Sequence("NULLS", OneOf("FIRST", "LAST"), optional=True),
                 Ref("WithFillSegment", optional=True),
             ),
-            terminators=["LIMIT", Ref("FrameClauseUnitGrammar")],
+            terminators=[Ref("LimitClauseSegment"), Ref("FrameClauseUnitGrammar")],
         ),
         Dedent,
     )

--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -464,13 +464,7 @@ snowflake_dialect.add(
             Ref("ExpressionSegment"),
         ),
         terminators=[
-            "ORDER",
-            "LIMIT",
-            "FETCH",
-            "OFFSET",
-            "HAVING",
-            "QUALIFY",
-            "WINDOW",
+            Ref("GroupByClauseTerminatorGrammar"),
         ],
     ),
     LimitLiteralGrammar=OneOf(
@@ -745,16 +739,12 @@ snowflake_dialect.replace(
         "FROM",
         "WHERE",
         Sequence("ORDER", "BY"),
-        "LIMIT",
-        "FETCH",
-        "OFFSET",
+        Ref("LimitClauseSegment"),
         Ref("SetOperatorSegment"),
     ),
     FromClauseTerminatorGrammar=OneOf(
         "WHERE",
-        "LIMIT",
-        "FETCH",
-        "OFFSET",
+        Ref("LimitClauseSegment"),
         Sequence("GROUP", "BY"),
         Sequence("ORDER", "BY"),
         "HAVING",
@@ -765,9 +755,7 @@ snowflake_dialect.replace(
         Ref("WithDataClauseSegment"),
     ),
     WhereClauseTerminatorGrammar=OneOf(
-        "LIMIT",
-        "FETCH",
-        "OFFSET",
+        Ref("LimitClauseSegment"),
         Sequence("GROUP", "BY"),
         Sequence("ORDER", "BY"),
         "HAVING",
@@ -776,28 +764,24 @@ snowflake_dialect.replace(
         "OVERLAPS",
     ),
     OrderByClauseTerminators=OneOf(
-        "LIMIT",
+        Ref("LimitClauseSegment"),
         "HAVING",
         "QUALIFY",
         # For window functions
         "WINDOW",
         Ref("FrameClauseUnitGrammar"),
         "SEPARATOR",
-        "FETCH",
-        "OFFSET",
         "MEASURES",
     ),
     TrimParametersGrammar=Nothing(),
     GroupByClauseTerminatorGrammar=OneOf(
-        "ORDER", "LIMIT", "FETCH", "OFFSET", "HAVING", "QUALIFY", "WINDOW"
+        "ORDER", Ref("LimitClauseSegment"), "HAVING", "QUALIFY", "WINDOW"
     ),
     HavingClauseTerminatorGrammar=OneOf(
         Sequence("ORDER", "BY"),
-        "LIMIT",
+        Ref("LimitClauseSegment"),
         "QUALIFY",
         "WINDOW",
-        "FETCH",
-        "OFFSET",
     ),
     NonStandardJoinTypeKeywordsGrammar=OneOf("ASOF"),
     UnconditionalJoinKeywordsGrammar=OneOf(
@@ -8681,14 +8665,6 @@ class LimitClauseSegment(ansi.LimitClauseSegment):
     )
 
 
-class SelectClauseSegment(ansi.SelectClauseSegment):
-    """A group of elements in a select target statement."""
-
-    match_grammar = ansi.SelectClauseSegment.match_grammar.copy(
-        terminators=[Ref.keyword("FETCH"), Ref.keyword("OFFSET")],
-    )
-
-
 class OrderByClauseSegment(ansi.OrderByClauseSegment):
     """An `ORDER BY` clause.
 
@@ -8712,7 +8688,7 @@ class OrderByClauseSegment(ansi.OrderByClauseSegment):
                 OneOf("ASC", "DESC", optional=True),
                 Sequence("NULLS", OneOf("FIRST", "LAST"), optional=True),
             ),
-            terminators=["LIMIT", "FETCH", "OFFSET", Ref("FrameClauseUnitGrammar")],
+            terminators=[Ref("LimitClauseSegment"), Ref("FrameClauseUnitGrammar")],
         ),
         Dedent,
     )

--- a/test/fixtures/dialects/snowflake/select.sql
+++ b/test/fixtures/dialects/snowflake/select.sql
@@ -28,3 +28,7 @@ SELECT
 FROM mytable t
 ORDER BY TRUE
 ;
+
+select
+    limit as renamed
+from sometable;

--- a/test/fixtures/dialects/snowflake/select.yml
+++ b/test/fixtures/dialects/snowflake/select.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 7e91a615e51a9371171b3d61b6a68065aa569a024e7cd76ce5c91d2256b0f623
+_hash: 4bf524646ad3e14b1f139094c364904016c362aba7523876018300b6d76f69d2
 file:
 - statement:
     select_statement:
@@ -204,4 +204,23 @@ file:
       - keyword: ORDER
       - keyword: BY
       - boolean_literal: 'TRUE'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: select
+        select_clause_element:
+          column_reference:
+            naked_identifier: limit
+          alias_expression:
+            alias_operator:
+              keyword: as
+            naked_identifier: renamed
+      from_clause:
+        keyword: from
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: sometable
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes early termination of a number of clauses where a non-reserved keyword `LIMIT` may exist as a column name.
- fixes #5420
- fixes #6991

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
