### PR TITLE
ST09: Handle mixed quoted table aliases

### DIFF
--- a/src/sqlfluff/rules/structure/ST09.py
+++ b/src/sqlfluff/rules/structure/ST09.py
@@ -2,6 +2,7 @@
 
 from typing import Optional, cast
 
+from sqlfluff.core.dialects.common import AliasInfo
 from sqlfluff.core.parser import BaseSegment, SymbolSegment
 from sqlfluff.core.rules import BaseRule, LintFix, LintResult, RuleContext
 from sqlfluff.core.rules.crawlers import SegmentSeekerCrawler
@@ -109,22 +110,36 @@ class Rule_ST09(BaseRule):
             return None
 
         # the first alias comes from the from clause
-        from_expression_alias: str = next(
+        from_expression_alias_info = next(
             cast(
                 FromExpressionElementSegment,
                 children.recursive_crawl("from_expression_element")[0],
             ).get_eventual_alias()
-        ).ref_str
+        )
+        from_expression_alias: str = (
+            from_expression_alias_info.segment.raw_normalized(False)
+            if from_expression_alias_info.segment
+            else from_expression_alias_info.ref_str
+        )
 
         table_aliases.append(from_expression_alias)
 
         # the rest of the aliases come from the different join clauses
-        join_clause_aliases: list[str] = [
-            cast(JoinClauseSegment, join_clause).get_eventual_aliases()[0][1].ref_str
+        join_clause_alias_infos: list[AliasInfo] = [
+            cast(JoinClauseSegment, join_clause).get_eventual_aliases()[0][1]
             for join_clause in [clause for clause in join_clauses]
         ]
 
-        table_aliases = table_aliases + join_clause_aliases
+        join_clause_aliases = [
+            (
+                alias_info.segment.raw_normalized(False)
+                if alias_info.segment
+                else alias_info.ref_str
+            )
+            for alias_info in join_clause_alias_infos
+        ]
+
+        table_aliases += join_clause_aliases
 
         table_aliases = [alias.upper() for alias in table_aliases]
 
@@ -186,8 +201,8 @@ class Rule_ST09(BaseRule):
                 "naked_identifier", "quoted_identifier"
             )
             assert first_table_seg and second_table_seg
-            first_table = first_table_seg.raw_upper
-            second_table = second_table_seg.raw_upper
+            first_table = first_table_seg.raw_normalized(False).upper()
+            second_table = second_table_seg.raw_normalized(False).upper()
 
             # if we swap the two column references around the comparison operator
             # we might have to replace the comparison operator with a different one

--- a/test/fixtures/rules/std_rule_cases/ST09.yml
+++ b/test/fixtures/rules/std_rule_cases/ST09.yml
@@ -474,3 +474,43 @@ test_fail_jinja_templated_issue_5506_reproduction:
     rules:
       structure.join_condition_order:
         preferred_first_table_in_join_clause: earlier
+
+test_fail_reorder_tsql_quoted:
+  fail_str: |
+    select 1
+    from t1
+    inner join  t2
+      on t1.name = t2.name
+      and t2.[col] = t1.[col]
+      and t2.id = [t1].id
+      and [t2].rec = t1.rec
+  fix_str: |
+    select 1
+    from t1
+    inner join  t2
+      on t1.name = t2.name
+      and t1.[col] = t2.[col]
+      and [t1].id = t2.id
+      and t1.rec = [t2].rec
+  configs:
+    core:
+      dialect: tsql
+
+test_fail_later_table_first_quoted_table_not_columns:
+  fail_str: |
+    select
+        "foo"."a",
+        "bar"."b"
+    from foo
+    left join "bar"
+        on "bar"."a" = "foo"."a"
+        and "bar"."b" = foo."b"
+
+  fix_str: |
+    select
+        "foo"."a",
+        "bar"."b"
+    from foo
+    left join "bar"
+        on "foo"."a" = "bar"."a"
+        and foo."b" = "bar"."b"


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This allows for quoted and non-quoted (naked) identifiers between tables or their aliases in the from/join clauses and the `join_on_condition`. Namely you can have `FROM foo JOIN bar on "bar".id = "foo".id` auto fixed.
- fixes #7016 

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
