### PR TITLE
Snowflake: Support `SET tuple` with a single expression

### DIFF
--- a/src/sqlfluff/dialects/dialect_snowflake.py
+++ b/src/sqlfluff/dialects/dialect_snowflake.py
@@ -1451,10 +1451,13 @@ class SetAssignmentStatementSegment(BaseSegment):
             "SET",
             Bracketed(Delimited(Ref("LocalVariableNameSegment"))),
             Ref("EqualsSegment"),
-            Bracketed(
-                Delimited(
-                    Ref("ExpressionSegment"),
+            OneOf(
+                Bracketed(
+                    Delimited(
+                        Ref("ExpressionSegment"),
+                    ),
                 ),
+                Ref("ExpressionSegment"),
             ),
         ),
     )

--- a/test/fixtures/dialects/snowflake/set_command.sql
+++ b/test/fixtures/dialects/snowflake/set_command.sql
@@ -11,3 +11,10 @@ set (min, max) = (40, 70);
 set (min, max) = (50, 2 * $min);
 
 SET THIS_ROLE=CURRENT_ROLE();
+
+SET (rec_updated_cutoff_orders, rec_updated_cutoff_deliverables) = (
+    SELECT
+        COALESCE(MAX(CASE WHEN entity_type = 'x' THEN rec_updated_at::DATE END), '2013-01-01')
+        , COALESCE(MAX(CASE WHEN entity_type = 'x' THEN rec_updated_at::DATE END), '2025-01-01')
+    FROM test.x
+);

--- a/test/fixtures/dialects/snowflake/set_command.yml
+++ b/test/fixtures/dialects/snowflake/set_command.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 8406aaf776583428fb10e8c4ffb8d33d7ad1d0ab00908336e579669bd1419ae7
+_hash: c4b55d920ebce0f003a5dfc2b56dafac5d1d9befac4eb99ee46084e6315868a7
 file:
 - statement:
     set_statement:
@@ -132,4 +132,111 @@ file:
             bracketed:
               start_bracket: (
               end_bracket: )
+- statement_terminator: ;
+- statement:
+    set_statement:
+      keyword: SET
+      bracketed:
+      - start_bracket: (
+      - variable: rec_updated_cutoff_orders
+      - comma: ','
+      - variable: rec_updated_cutoff_deliverables
+      - end_bracket: )
+      comparison_operator:
+        raw_comparison_operator: '='
+      expression:
+        bracketed:
+          start_bracket: (
+          select_statement:
+            select_clause:
+            - keyword: SELECT
+            - select_clause_element:
+                function:
+                  function_name:
+                    function_name_identifier: COALESCE
+                  function_contents:
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        function:
+                          function_name:
+                            function_name_identifier: MAX
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                case_expression:
+                                - keyword: CASE
+                                - when_clause:
+                                  - keyword: WHEN
+                                  - expression:
+                                      column_reference:
+                                        naked_identifier: entity_type
+                                      comparison_operator:
+                                        raw_comparison_operator: '='
+                                      quoted_literal: "'x'"
+                                  - keyword: THEN
+                                  - expression:
+                                      cast_expression:
+                                        column_reference:
+                                          naked_identifier: rec_updated_at
+                                        casting_operator: '::'
+                                        data_type:
+                                          data_type_identifier: DATE
+                                - keyword: END
+                              end_bracket: )
+                    - comma: ','
+                    - expression:
+                        quoted_literal: "'2013-01-01'"
+                    - end_bracket: )
+            - comma: ','
+            - select_clause_element:
+                function:
+                  function_name:
+                    function_name_identifier: COALESCE
+                  function_contents:
+                    bracketed:
+                    - start_bracket: (
+                    - expression:
+                        function:
+                          function_name:
+                            function_name_identifier: MAX
+                          function_contents:
+                            bracketed:
+                              start_bracket: (
+                              expression:
+                                case_expression:
+                                - keyword: CASE
+                                - when_clause:
+                                  - keyword: WHEN
+                                  - expression:
+                                      column_reference:
+                                        naked_identifier: entity_type
+                                      comparison_operator:
+                                        raw_comparison_operator: '='
+                                      quoted_literal: "'x'"
+                                  - keyword: THEN
+                                  - expression:
+                                      cast_expression:
+                                        column_reference:
+                                          naked_identifier: rec_updated_at
+                                        casting_operator: '::'
+                                        data_type:
+                                          data_type_identifier: DATE
+                                - keyword: END
+                              end_bracket: )
+                    - comma: ','
+                    - expression:
+                        quoted_literal: "'2025-01-01'"
+                    - end_bracket: )
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                    - naked_identifier: test
+                    - dot: .
+                    - naked_identifier: x
+          end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This allows for an expression that isn't delimited to be used for a tuple-style `SET` command.
- fixes #6986

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
