### PR TITLE
Redshift: Add `ENCODE` for `ALTER TABLE ADD COLUMN`

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -706,6 +706,7 @@ class AlterTableActionSegment(BaseSegment):
             Ref("ColumnReferenceSegment"),
             Ref("DatatypeSegment"),
             Sequence("DEFAULT", Ref("ExpressionSegment"), optional=True),
+            Sequence("ENCODE", Ref("ColumnEncodingGrammar"), optional=True),
             Sequence("COLLATE", Ref("CollationReferenceSegment"), optional=True),
             AnyNumberOf(Ref("ColumnConstraintSegment")),
         ),

--- a/test/fixtures/dialects/redshift/alter_table.sql
+++ b/test/fixtures/dialects/redshift/alter_table.sql
@@ -61,3 +61,5 @@ ALTER TABLE the_schema.the_table APPEND FROM the_schema.the_temp_table IGNOREEXT
 ALTER TABLE the_schema.the_table APPEND FROM the_schema.the_temp_table;
 
 ALTER TABLE the_schema.the_table SET LOCATION 's3://bucket/folder/';
+
+ALTER TABLE my_schema.my_table ADD COLUMN my_column BIGINT ENCODE ZSTD;

--- a/test/fixtures/dialects/redshift/alter_table.yml
+++ b/test/fixtures/dialects/redshift/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: de2269d68c7f114d0429b086bb24aaa20fa9bacbf4497d5291eb34615dc88365
+_hash: ff46dbbfa00e6b1b6358493fcd387bade51d7cf0cb7fe826125f44d984f3cb32
 file:
 - statement:
     alter_table_statement:
@@ -443,4 +443,22 @@ file:
       - keyword: SET
       - keyword: LOCATION
       - quoted_literal: "'s3://bucket/folder/'"
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+      - naked_identifier: my_schema
+      - dot: .
+      - naked_identifier: my_table
+    - alter_table_action_segment:
+      - keyword: ADD
+      - keyword: COLUMN
+      - column_reference:
+          naked_identifier: my_column
+      - data_type:
+          keyword: BIGINT
+      - keyword: ENCODE
+      - keyword: ZSTD
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds `ENCODE encoding` support within the `ALTER TABLE ADD COLUMN` segment
- fixes #6947

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
