### PR TITLE
In User Mapping ensure that PUBLIC doesn't get parsed as an identifier

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -6437,9 +6437,9 @@ class CreateUserMappingStatementSegment(BaseSegment):
         Ref("IfNotExistsGrammar", optional=True),
         "FOR",
         OneOf(
+            "PUBLIC",
             Ref("SingleIdentifierGrammar"),
             Ref("SessionInformationUserFunctionsGrammar"),
-            "PUBLIC",
         ),
         "SERVER",
         Ref("ServerReferenceSegment"),

--- a/test/fixtures/dialects/postgres/create_user_mapping.yml
+++ b/test/fixtures/dialects/postgres/create_user_mapping.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: e4b7bf32c9556794f7bc41d9292ef43e4b0804378e9bcb069042835912b4795e
+_hash: aa3d9916537fd4519c38d315f452a01e6a1acc23085673ce5330aede8d0e6bb4
 file:
 - statement:
     create_user_mapping_statement:
@@ -34,7 +34,7 @@ file:
     - keyword: NOT
     - keyword: EXISTS
     - keyword: FOR
-    - naked_identifier: PUBLIC
+    - keyword: PUBLIC
     - keyword: SERVER
     - server_reference:
         naked_identifier: foo


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Changed the precedence of `PUBLIC` so that it gets chosen first.  Otherwise it was getting parsed as an identifier, and I was getting warnings saying that it should be lower case.

I have a couple of unit tests that I used to check that it solved the problem, but it seemed overkill to push them for such a small change.  Happy to add them if desired.

### Are there any other side effects of this change that we should be aware of?

None that I can think of.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).