### PR TITLE
Add support for RENAME in ALTER FOREIGN TABLE in Postgres

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -6755,6 +6755,7 @@ class AlterForeignTableStatementSegment(BaseSegment):
                     "TO",
                     Ref("ColumnReferenceSegment"),
                 ),
+                Sequence("RENAME", "TO", Ref("TableReferenceSegment")),
             ),
         ),
     )

--- a/test/fixtures/dialects/postgres/alter_foreign_table.sql
+++ b/test/fixtures/dialects/postgres/alter_foreign_table.sql
@@ -9,3 +9,5 @@ ALTER FOREIGN TABLE myschema.distributors OPTIONS (ADD opt1 'value', SET opt2 'v
 ALTER FOREIGN TABLE test OPTIONS (SET table $$(select my_column from my_table)$$);
 
 ALTER FOREIGN TABLE test ADD COLUMN new_column int8, OPTIONS (SET table $$(select my_column from my_table)$$);
+
+ALTER FOREIGN TABLE test RENAME TO test_renamed;

--- a/test/fixtures/dialects/postgres/alter_foreign_table.yml
+++ b/test/fixtures/dialects/postgres/alter_foreign_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: c04f3f1caaed61735224ce3ab6ef577922471c3baa76a318b2f819daf9d5c087
+_hash: 22adfc000efda0003a1128b347d810eb75492828abc6309e7f4cb47a2b48218f
 file:
 - statement:
     alter_foreign_table_statement:
@@ -117,4 +117,16 @@ file:
           naked_identifier: table
           quoted_literal: $$(select my_column from my_table)$$
           end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_foreign_table_statement:
+    - keyword: ALTER
+    - keyword: FOREIGN
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: test
+    - keyword: RENAME
+    - keyword: TO
+    - table_reference:
+        naked_identifier: test_renamed
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Adds support for RENAME in ALTER FOREIGN TABLE in Postgres, which couldn't be parsed at all before.

https://www.postgresql.org/docs/current/sql-alterforeigntable.html

### Are there any other side effects of this change that we should be aware of?

I can't think of any.  This failed as unparseable before.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
