### PR TITLE
LT15: Handle newlines that exists in templated areas

### DIFF
--- a/src/sqlfluff/rules/layout/LT15.py
+++ b/src/sqlfluff/rules/layout/LT15.py
@@ -63,16 +63,13 @@ class Rule_LT15(BaseRule):
         if len(context.raw_stack) < maximum_empty_lines:
             return None
 
-        if all(
-            raw_seg.is_type("newline")
-            for raw_seg in context.raw_stack[-maximum_empty_lines - 1 :]
-        ):
+        for raw_seg in context.raw_stack[-maximum_empty_lines - 1 :]:
+            if raw_seg.is_templated or not raw_seg.is_type("newline"):
+                return None
 
-            return [
-                LintResult(
-                    anchor=context_seg,
-                    fixes=[LintFix.delete(context_seg)],
-                )
-            ]
-
-        return None
+        return [
+            LintResult(
+                anchor=context_seg,
+                fixes=[LintFix.delete(context_seg)],
+            )
+        ]

--- a/test/fixtures/rules/std_rule_cases/LT15.yml
+++ b/test/fixtures/rules/std_rule_cases/LT15.yml
@@ -87,3 +87,70 @@ test_fail_bad_edge_case:
       layout.newlines:
         maximum_empty_lines_between_statements: 1
         maximum_empty_lines_within_statements: 0
+
+# yamllint disable rule:empty-lines
+# We need extra lines to test this rules!
+test_fail_macros_with_newlines:
+  fail_str: |
+    select {{ my_macro(5) }}
+    from t
+    where
+        x =
+
+
+
+
+
+
+        {{ my_macro(4) }}
+
+
+    and y = 2
+    ;
+  fix_str: |
+    select {{ my_macro(5) }}
+    from t
+    where
+        x =
+
+        {{ my_macro(4) }}
+
+    and y = 2
+    ;
+  configs:
+    templater:
+      jinja:
+        macros:
+          a_macro_def: |
+            {% macro my_macro(n) %}
+
+            {{ n }} + {{ n * 2 }}
+
+            {% endmacro %}
+
+test_pass_macros_with_embedded_newlines:
+  pass_str: |
+    select {{ my_macro(5) }}
+    from t
+    where
+
+        x = {{ my_macro(4) }}
+
+        and y = 2
+    ;
+  configs:
+    templater:
+      jinja:
+        macros:
+          a_macro_def: |
+            {% macro my_macro(n) %}
+
+
+
+
+
+
+            {{ n }} + {{ n * 2 }}
+
+            {% endmacro %}
+# yamllint enable


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This handles cases where both the jinja and dbt templater may introduce blank lines via macros or other sorcery. We want to prevent formatting based on the templated newlines, so we choose to ignore any newlines found in templated areas.
- fixes #6817

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
