### PR TITLE
ANSI: Update `frame_clause` to support all `interval_expressions`

### DIFF
--- a/src/sqlfluff/dialects/dialect_ansi.py
+++ b/src/sqlfluff/dialects/dialect_ansi.py
@@ -1597,8 +1597,9 @@ class FrameClauseSegment(BaseSegment):
         Sequence(
             OneOf(
                 Ref("NumericLiteralSegment"),
-                Sequence("INTERVAL", Ref("QuotedLiteralSegment")),
+                Ref("IntervalExpressionSegment"),
                 "UNBOUNDED",
+                Ref("ColumnReferenceSegment"),
             ),
             OneOf("PRECEDING", "FOLLOWING"),
         ),

--- a/test/fixtures/dialects/greenplum/frame_clause.sql
+++ b/test/fixtures/dialects/greenplum/frame_clause.sql
@@ -1,0 +1,27 @@
+SELECT
+    SUM(field_1) OVER (
+        PARTITION BY field_2
+        ORDER BY
+            field_3
+        RANGE BETWEEN INTERVAL '1' MONTH PRECEDING AND CURRENT ROW
+    ) AS field_1
+FROM table_1;
+
+SELECT
+    SUM(field_1) OVER (
+        PARTITION BY field_2
+        ORDER BY
+            field_3
+        RANGE BETWEEN INTERVAL '1 month' PRECEDING AND CURRENT ROW
+    ) AS field_1
+FROM table_1;
+
+SELECT
+    COUNT(*) OVER (
+        PARTITION BY field_1
+        ORDER BY field_3
+        RANGE BETWEEN
+        field_2 PRECEDING AND
+        CURRENT ROW
+    )
+FROM table_1;

--- a/test/fixtures/dialects/greenplum/frame_clause.yml
+++ b/test/fixtures/dialects/greenplum/frame_clause.yml
@@ -1,0 +1,163 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: d10e5535650d36b0f0c9ec7d9881b5730cf03e6075f3d69f2e773ba7f762b322
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: SUM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: field_1
+                end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: field_2
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: field_3
+                  frame_clause:
+                  - keyword: RANGE
+                  - keyword: BETWEEN
+                  - interval_expression:
+                      keyword: INTERVAL
+                      quoted_literal: "'1'"
+                      date_part: MONTH
+                  - keyword: PRECEDING
+                  - keyword: AND
+                  - keyword: CURRENT
+                  - keyword: ROW
+                end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: field_1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table_1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: SUM
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                    naked_identifier: field_1
+                end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: field_2
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: field_3
+                  frame_clause:
+                  - keyword: RANGE
+                  - keyword: BETWEEN
+                  - interval_expression:
+                      keyword: INTERVAL
+                      quoted_literal: "'1 month'"
+                  - keyword: PRECEDING
+                  - keyword: AND
+                  - keyword: CURRENT
+                  - keyword: ROW
+                end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: field_1
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table_1
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: COUNT
+            function_contents:
+              bracketed:
+                start_bracket: (
+                star: '*'
+                end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                        naked_identifier: field_1
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                      naked_identifier: field_3
+                  frame_clause:
+                  - keyword: RANGE
+                  - keyword: BETWEEN
+                  - column_reference:
+                      naked_identifier: field_2
+                  - keyword: PRECEDING
+                  - keyword: AND
+                  - keyword: CURRENT
+                  - keyword: ROW
+                end_bracket: )
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: table_1
+- statement_terminator: ;

--- a/test/fixtures/dialects/postgres/select_frame_clause.yml
+++ b/test/fixtures/dialects/postgres/select_frame_clause.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: fc11622f2ead1ad581ae0729d6d0e9e42f0a750ecab773c992504e0418010f7e
+_hash: dcabe28ed50f2cde06ada224c3dcc904e98d398f2476505d0119874cd5fa4069
 file:
 - statement:
     select_statement:
@@ -162,12 +162,14 @@ file:
                   frame_clause:
                   - keyword: RANGE
                   - keyword: BETWEEN
-                  - keyword: INTERVAL
-                  - quoted_literal: "'1 YEAR - 1 DAYS'"
+                  - interval_expression:
+                      keyword: INTERVAL
+                      quoted_literal: "'1 YEAR - 1 DAYS'"
                   - keyword: PRECEDING
                   - keyword: AND
-                  - keyword: INTERVAL
-                  - quoted_literal: "'15 DAYS'"
+                  - interval_expression:
+                      keyword: INTERVAL
+                      quoted_literal: "'15 DAYS'"
                   - keyword: PRECEDING
                 end_bracket: )
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This allows for all types of the interval expressions and column references to be used in a `frame_clause`.
- fixes #6680

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
