### PR TITLE
Oracle: Support `ALTER TABLE ... RENAME CONSTRAINT`

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -968,7 +968,6 @@ class AlterTableConstraintClauses(BaseSegment):
             Ref("TableConstraintSegment"),
         ),
         # @TODO MODIFY
-        # @TODO RENAME
         # @TODO DROP
         # drop_constraint_clause
         Sequence(
@@ -994,6 +993,13 @@ class AlterTableConstraintClauses(BaseSegment):
                 optional=True,
             ),
             Ref.keyword("ONLINE", optional=True),
+        ),
+        Sequence(
+            "RENAME",
+            "CONSTRAINT",
+            Ref("ObjectReferenceSegment"),
+            "TO",
+            Ref("ObjectReferenceSegment"),
         ),
     )
 

--- a/test/fixtures/dialects/oracle/alter_table.sql
+++ b/test/fixtures/dialects/oracle/alter_table.sql
@@ -21,6 +21,9 @@ ALTER TABLE table_name
 ADD CONSTRAINT constraint_name
 FOREIGN KEY (column_name) REFERENCES other_table_name (other_column_name);
 
+-- rename_constraint_clause
+ALTER TABLE table_name RENAME CONSTRAINT source_constraint_name TO target_constraint_name;
+
 -- drop_constraint_clause
 ALTER TABLE table_name DROP CONSTRAINT constraint_name;
 

--- a/test/fixtures/dialects/oracle/alter_table.yml
+++ b/test/fixtures/dialects/oracle/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 9eec6cfe5e73ecdcee8624fae8b6172f082deb550dcb83cab053fe1e6500bf6e
+_hash: 5c301b233899fc491f600b1719b16ff28fc4c304f2fec5c16ef2c9e4d0225741
 file:
 - statement:
     alter_table_statement:
@@ -115,6 +115,21 @@ file:
             column_reference:
               naked_identifier: other_column_name
             end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: table_name
+    - alter_table_constraint_clauses:
+      - keyword: RENAME
+      - keyword: CONSTRAINT
+      - object_reference:
+          naked_identifier: source_constraint_name
+      - keyword: TO
+      - object_reference:
+          naked_identifier: target_constraint_name
 - statement_terminator: ;
 - statement:
     alter_table_statement:


### PR DESCRIPTION
### Brief summary of the change made

Add `ALTER TABLE ... RENAME CONSTRAINT` syntax for oracle
It makes progress on #7044.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
