### PR TITLE
Oracle: Add basic support for `ALTER INDEX` statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -82,9 +82,11 @@ oracle_dialect.sets("reserved_keywords").update(
         "DELETE",
         "DELETING",
         "DESC",
+        "DISABLE",
         "DISTINCT",
         "DROP",
         "ELSE",
+        "ENABLE",
         "EXCLUSIVE",
         "EXISTS",
         "FILE",
@@ -107,10 +109,12 @@ oracle_dialect.sets("reserved_keywords").update(
         "INTEGER",
         "INTERSECT",
         "INTO",
+        "INVISIBLE",
         "IS",
         "LEVEL",
         "LIKE",
         "LOCK",
+        "LOGGING",
         "LONG",
         "LOOP",
         "MAXEXTENTS",
@@ -118,9 +122,13 @@ oracle_dialect.sets("reserved_keywords").update(
         "MLSLABEL",
         "MODE",
         "MODIFY",
+        "MONITORING",
         "NESTED_TABLE_ID",
         "NOAUDIT",
         "NOCOMPRESS",
+        "NOLOGGING",
+        "NOMONITORING",
+        "NOREVERSE",
         "NOT",
         "NOWAIT",
         "NULL",
@@ -133,6 +141,7 @@ oracle_dialect.sets("reserved_keywords").update(
         "OR",
         "ORDER",
         "OVERFLOW",
+        "PARAMETERS",
         "PCTFREE",
         "PIVOT",
         "PRIOR",
@@ -140,9 +149,11 @@ oracle_dialect.sets("reserved_keywords").update(
         "PROMPT",
         "PUBLIC",
         "RAW",
+        "REBUILD",
         "RENAME",
         "RESOURCE",
         "REVOKE",
+        "REVERSE",
         "ROW",
         "ROWID",
         "ROWNUM",
@@ -166,6 +177,7 @@ oracle_dialect.sets("reserved_keywords").update(
         "UNION",
         "UNIQUE",
         "UNPIVOT",
+        "UNUSABLE",
         "UPDATE",
         "UPDATING",
         "USER",
@@ -174,6 +186,7 @@ oracle_dialect.sets("reserved_keywords").update(
         "VARCHAR",
         "VARCHAR2",
         "VIEW",
+        "VISIBLE",
         "WHEN",
         "WHENEVER",
         "WHERE",
@@ -863,6 +876,43 @@ oracle_dialect.replace(
 )
 
 
+class AlterIndexStatementSegment(BaseSegment):
+    """An `ALTER INDEX` statement.
+
+    https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/ALTER-INDEX.html
+    If possible, please keep the order below the same as Oracle's doc:
+    """
+
+    type = "alter_index_statement"
+    match_grammar: Matchable = Sequence(
+        "ALTER",
+        "INDEX",
+        Ref("IndexReferenceSegment"),
+        OneOf(
+            Sequence(
+                "REBUILD",
+                OneOf(
+                    "REVERSE",
+                    "NOREVERSE",
+                    optional=True,
+                ),
+            ),
+            Sequence("MONITORING", "USAGE"),
+            Sequence("NOMONITORING", "USAGE"),
+            Sequence("PARAMETERS", Bracketed(Ref("QuotedLiteralSegment"))),
+            Sequence("RENAME", "TO", Ref("IndexReferenceSegment")),
+            "COMPILE",
+            "LOGGING",
+            "NOLOGGING",
+            "ENABLE",
+            "DISABLE",
+            "UNUSABLE",
+            "INVISIBLE",
+            "VISIBLE",
+        ),
+    )
+
+
 class AlterTableStatementSegment(ansi.AlterTableStatementSegment):
     """An `ALTER TABLE` statement.
 
@@ -1088,6 +1138,7 @@ class StatementSegment(ansi.StatementSegment):
             Ref("ContinueStatementSegment"),
             Ref("RaiseStatementSegment"),
             Ref("ReturnStatementSegment"),
+            Ref("AlterIndexStatementSegment"),
         ],
     )
 

--- a/test/fixtures/dialects/oracle/alter_index.sql
+++ b/test/fixtures/dialects/oracle/alter_index.sql
@@ -1,0 +1,23 @@
+ALTER INDEX some.idx_name REBUILD;
+ALTER INDEX some.idx_name REBUILD REVERSE;
+ALTER INDEX some.idx_name REBUILD NOREVERSE;
+
+ALTER INDEX some.idx_name PARAMETERS ('ODCI_OPTIMIZE=ALL');
+
+ALTER INDEX some.idx_name COMPILE;
+
+ALTER INDEX some.idx_name LOGGING;
+ALTER INDEX some.idx_name NOLOGGING;
+
+ALTER INDEX some.idx_name ENABLE;
+ALTER INDEX some.idx_name DISABLE;
+
+ALTER INDEX some.idx_name UNUSABLE;
+
+ALTER INDEX some.idx_name INVISIBLE;
+ALTER INDEX some.idx_name VISIBLE;
+
+ALTER INDEX some.idx_name RENAME TO some.new_idx_name;
+
+ALTER INDEX some.idx_name MONITORING USAGE;
+ALTER INDEX some.idx_name NOMONITORING USAGE;

--- a/test/fixtures/dialects/oracle/alter_index.yml
+++ b/test/fixtures/dialects/oracle/alter_index.yml
@@ -1,0 +1,170 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: e0823860f2d0f1ec5f74c5a9a1411ddc619b669824b86a6602ced70423211ac7
+file:
+- statement:
+    alter_index_statement:
+    - keyword: ALTER
+    - keyword: INDEX
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: idx_name
+    - keyword: REBUILD
+- statement_terminator: ;
+- statement:
+    alter_index_statement:
+    - keyword: ALTER
+    - keyword: INDEX
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: idx_name
+    - keyword: REBUILD
+    - keyword: REVERSE
+- statement_terminator: ;
+- statement:
+    alter_index_statement:
+    - keyword: ALTER
+    - keyword: INDEX
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: idx_name
+    - keyword: REBUILD
+    - keyword: NOREVERSE
+- statement_terminator: ;
+- statement:
+    alter_index_statement:
+    - keyword: ALTER
+    - keyword: INDEX
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: idx_name
+    - keyword: PARAMETERS
+    - bracketed:
+        start_bracket: (
+        quoted_literal: "'ODCI_OPTIMIZE=ALL'"
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_index_statement:
+    - keyword: ALTER
+    - keyword: INDEX
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: idx_name
+    - keyword: COMPILE
+- statement_terminator: ;
+- statement:
+    alter_index_statement:
+    - keyword: ALTER
+    - keyword: INDEX
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: idx_name
+    - keyword: LOGGING
+- statement_terminator: ;
+- statement:
+    alter_index_statement:
+    - keyword: ALTER
+    - keyword: INDEX
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: idx_name
+    - keyword: NOLOGGING
+- statement_terminator: ;
+- statement:
+    alter_index_statement:
+    - keyword: ALTER
+    - keyword: INDEX
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: idx_name
+    - keyword: ENABLE
+- statement_terminator: ;
+- statement:
+    alter_index_statement:
+    - keyword: ALTER
+    - keyword: INDEX
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: idx_name
+    - keyword: DISABLE
+- statement_terminator: ;
+- statement:
+    alter_index_statement:
+    - keyword: ALTER
+    - keyword: INDEX
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: idx_name
+    - keyword: UNUSABLE
+- statement_terminator: ;
+- statement:
+    alter_index_statement:
+    - keyword: ALTER
+    - keyword: INDEX
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: idx_name
+    - keyword: INVISIBLE
+- statement_terminator: ;
+- statement:
+    alter_index_statement:
+    - keyword: ALTER
+    - keyword: INDEX
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: idx_name
+    - keyword: VISIBLE
+- statement_terminator: ;
+- statement:
+    alter_index_statement:
+    - keyword: ALTER
+    - keyword: INDEX
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: idx_name
+    - keyword: RENAME
+    - keyword: TO
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: new_idx_name
+- statement_terminator: ;
+- statement:
+    alter_index_statement:
+    - keyword: ALTER
+    - keyword: INDEX
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: idx_name
+    - keyword: MONITORING
+    - keyword: USAGE
+- statement_terminator: ;
+- statement:
+    alter_index_statement:
+    - keyword: ALTER
+    - keyword: INDEX
+    - index_reference:
+      - naked_identifier: some
+      - dot: .
+      - naked_identifier: idx_name
+    - keyword: NOMONITORING
+    - keyword: USAGE
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
This commit adds basic parsing support for Oracle ALTER INDEX statements to SQLFluff, enabling proper formatting of index modification commands in Oracle SQL scripts.

It makes progress on #7044.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
