### PR TITLE
CV06: Skip non-semicolon terminators

### DIFF
--- a/src/sqlfluff/rules/convention/CV06.py
+++ b/src/sqlfluff/rules/convention/CV06.py
@@ -59,6 +59,11 @@ class Rule_CV06(BaseRule):
     is_fix_compatible = True
 
     @staticmethod
+    def _is_segment_semicolon(segment: BaseSegment) -> bool:
+        """Check if a segment is a semicolon statement terminator."""
+        return segment.is_type("statement_terminator") and segment.raw == ";"
+
+    @staticmethod
     def _handle_preceding_inline_comments(
         before_segment: Sequence[BaseSegment], anchor_segment: BaseSegment
     ):
@@ -391,7 +396,8 @@ class Rule_CV06(BaseRule):
         for idx, seg in enumerate(context.segment.segments):
             res = None
             # First we can simply handle the case of existing semi-colon alignment.
-            if seg.is_type("statement_terminator"):
+            # Only process actual semicolons, not other terminators like Oracle's /
+            if self._is_segment_semicolon(seg):
                 # If it's a terminator then we know it's a raw.
                 seg = cast(RawSegment, seg)
                 self.logger.debug("Handling semi-colon: %s", seg)

--- a/test/fixtures/rules/std_rule_cases/CV06.yml
+++ b/test/fixtures/rules/std_rule_cases/CV06.yml
@@ -516,3 +516,66 @@ test_pass_file_with_only_comments_with_require_final_semicolon:
     rules:
       convention.terminator:
         require_final_semicolon: true
+
+test_pass_ansi_block_with_slash_delimiter:
+  pass_str: |
+    CREATE PROCEDURE test_proc()
+    BEGIN
+        DECLARE my_var VARCHAR(100) DEFAULT 'Hello World';
+        SELECT my_var;
+    END;
+    /
+  configs:
+    rules:
+      convention.terminator:
+        require_final_semicolon: true
+
+test_pass_ansi_block_with_slash_delimiter_multiline:
+  pass_str: |
+    CREATE PROCEDURE test_proc()
+    BEGIN
+        DECLARE my_var VARCHAR(100) DEFAULT 'Hello World';
+        SELECT my_var;
+    END;
+    /
+  configs:
+    rules:
+      convention.terminator:
+        require_final_semicolon: true
+        multiline_newline: true
+
+test_pass_ansi_mixed_terminators:
+  pass_str: |
+    SELECT * FROM table1;
+    CREATE PROCEDURE test_proc()
+    BEGIN
+        SELECT 'Hello World';
+    END;
+    /
+    SELECT * FROM table2;
+  configs:
+    rules:
+      convention.terminator:
+        require_final_semicolon: true
+
+test_pass_ansi_slash_positioning_same_line:
+  pass_str: |
+    CREATE PROCEDURE test_proc()
+    BEGIN
+        SELECT NULL;
+    END; /
+
+test_pass_ansi_slash_positioning_newline:
+  pass_str: |
+    CREATE PROCEDURE test_proc()
+    BEGIN
+        SELECT NULL;
+    END;
+    /
+
+test_pass_ansi_slash_with_extra_spacing:
+  pass_str: |
+    CREATE PROCEDURE test_proc()
+    BEGIN
+        SELECT NULL;
+    END;   /


### PR DESCRIPTION
### Brief summary of the change made
Modified the CV06 rule to only process semicolon statement terminators (`;`) and completely ignore other terminators like Oracle's `/` delimiter.

Fixes #7053.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
