### PR TITLE
Oracle: Add indent rules for basic control structures

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -2343,7 +2343,9 @@ class IfExpressionStatement(BaseSegment):
 
     match_grammar = Sequence(
         Ref("IfClauseSegment"),
+        Indent,
         Ref("OneOrMoreStatementsGrammar"),
+        Dedent,
         AnyNumberOf(
             Sequence(
                 "ELSIF",
@@ -2352,12 +2354,16 @@ class IfExpressionStatement(BaseSegment):
                     Ref("TriggerPredicatesGrammar"),
                 ),
                 "THEN",
+                Indent,
                 Ref("OneOrMoreStatementsGrammar"),
+                Dedent,
             ),
         ),
         Sequence(
             "ELSE",
+            Indent,
             Ref("OneOrMoreStatementsGrammar"),
+            Dedent,
             optional=True,
         ),
         "END",
@@ -2609,7 +2615,9 @@ class LoopStatementSegment(BaseSegment):
     match_grammar: Matchable = Sequence(
         Ref("SingleIdentifierGrammar", optional=True),
         "LOOP",
+        Indent,
         Ref("OneOrMoreStatementsGrammar"),
+        Dedent,
         "END",
         "LOOP",
         Ref("SingleIdentifierGrammar", optional=True),

--- a/test/fixtures/rules/std_rule_cases/LT02-indent-oracle.yml
+++ b/test/fixtures/rules/std_rule_cases/LT02-indent-oracle.yml
@@ -1,6 +1,130 @@
 rule: LT02
 
 # Test cases for conditionals and loops indentation scenarios
+test_fail_oracle_if_clause_indentation:
+  fail_str: |
+    BEGIN
+    IF 1 > 0 THEN
+    DBMS_OUTPUT.PUT_LINE('condition met');
+    ELSIF 2 > 1 THEN
+    DBMS_OUTPUT.PUT_LINE('alternative met');
+    ELSE
+    DBMS_OUTPUT.PUT_LINE('default case');
+    END IF;
+    END;
+  fix_str: |
+    BEGIN
+        IF 1 > 0 THEN
+            DBMS_OUTPUT.PUT_LINE('condition met');
+        ELSIF 2 > 1 THEN
+            DBMS_OUTPUT.PUT_LINE('alternative met');
+        ELSE
+            DBMS_OUTPUT.PUT_LINE('default case');
+        END IF;
+    END;
+  configs:
+    core:
+      dialect: oracle
+
+test_fail_oracle_for_loop_indentation:
+  fail_str: |
+    BEGIN
+    FOR i IN 1..10 LOOP
+    DBMS_OUTPUT.PUT_LINE('Counter: ' || i);
+    IF i < 5 THEN
+    DBMS_OUTPUT.PUT_LINE('Small number');
+    ELSE
+    DBMS_OUTPUT.PUT_LINE('Large number');
+    END IF;
+    END LOOP;
+    END;
+  fix_str: |
+    BEGIN
+        FOR i IN 1..10 LOOP
+            DBMS_OUTPUT.PUT_LINE('Counter: ' || i);
+            IF i < 5 THEN
+                DBMS_OUTPUT.PUT_LINE('Small number');
+            ELSE
+                DBMS_OUTPUT.PUT_LINE('Large number');
+            END IF;
+        END LOOP;
+    END;
+  configs:
+    core:
+      dialect: oracle
+
+test_fail_oracle_nested_control_structures:
+  fail_str: |
+    BEGIN
+    IF 1 > 0 THEN
+    FOR i IN 1..3 LOOP
+    IF i = 2 THEN
+    DBMS_OUTPUT.PUT_LINE('Found two: ' || i);
+    ELSIF i = 1 THEN
+    DBMS_OUTPUT.PUT_LINE('Found one: ' || i);
+    ELSE
+    DBMS_OUTPUT.PUT_LINE('Found other: ' || i);
+    END IF;
+    END LOOP;
+    END IF;
+    END;
+  fix_str: |
+    BEGIN
+        IF 1 > 0 THEN
+            FOR i IN 1..3 LOOP
+                IF i = 2 THEN
+                    DBMS_OUTPUT.PUT_LINE('Found two: ' || i);
+                ELSIF i = 1 THEN
+                    DBMS_OUTPUT.PUT_LINE('Found one: ' || i);
+                ELSE
+                    DBMS_OUTPUT.PUT_LINE('Found other: ' || i);
+                END IF;
+            END LOOP;
+        END IF;
+    END;
+  configs:
+    core:
+      dialect: oracle
+
+test_fail_oracle_simple_block_indentation:
+  fail_str: |
+    BEGIN
+    FOR i IN 1..5 LOOP
+    IF i < 3 THEN
+    DBMS_OUTPUT.PUT_LINE('Small: ' || i);
+    ELSE
+    DBMS_OUTPUT.PUT_LINE('Large: ' || i);
+    END IF;
+    END LOOP;
+    END;
+  fix_str: |
+    BEGIN
+        FOR i IN 1..5 LOOP
+            IF i < 3 THEN
+                DBMS_OUTPUT.PUT_LINE('Small: ' || i);
+            ELSE
+                DBMS_OUTPUT.PUT_LINE('Large: ' || i);
+            END IF;
+        END LOOP;
+    END;
+  configs:
+    core:
+      dialect: oracle
+
+test_pass_oracle_proper_indentation:
+  pass_str: |
+    BEGIN
+        FOR i IN 1..3 LOOP
+            IF i < 2 THEN
+                DBMS_OUTPUT.PUT_LINE('Small: ' || i);
+            ELSE
+                DBMS_OUTPUT.PUT_LINE('Large: ' || i);
+            END IF;
+        END LOOP;
+    END;
+  configs:
+    core:
+      dialect: oracle
 
 # Test cases for declare blocks indentation scenarios
 test_fail_declare_block_basic_declarations:


### PR DESCRIPTION
### Brief summary of the change made
Add basic Oracle PL/SQL indentation for control structures including IF/ELSIF/ELSE statements and FOR LOOP constructs.

Fixes #7057.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
