### PR TITLE
fix confusion between "toml" and "tomli"

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ import sys
 if sys.version_info >= (3, 11):
     import tomllib
 else:  # pragma: no cover
-    import toml as tomllib
+    import tomli as tomllib
 
 # -- Path setup --------------------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ dependencies = [
     # For returning exceptions from multiprocessing.Pool.map()
     "tblib",
     # For parsing pyproject.toml
-    "toml; python_version < '3.11'",
+    "tomli; python_version < '3.11'",
     # For handling progress bars
     "tqdm",
 ]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -30,7 +30,6 @@ tox
 # `types-*` dependencies here should be the same as in `.pre-commit-config.yaml`.
 # If you update these dependencies, make sure to update those too.
 mypy[mypyc]
-types-toml
 types-chardet
 types-appdirs
 types-colorama

--- a/src/sqlfluff/core/config/toml.py
+++ b/src/sqlfluff/core/config/toml.py
@@ -6,7 +6,7 @@ from typing import Any, TypeVar
 if sys.version_info >= (3, 11):
     import tomllib
 else:  # pragma: no cover
-    import toml as tomllib
+    import tomli as tomllib
 
 from sqlfluff.core.helpers.dict import (
     NestedDictRecord,

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -39,7 +39,7 @@ from sqlfluff.utils.testing.cli import invoke_assert_code
 if sys.version_info >= (3, 11):
     import tomllib
 else:  # pragma: no cover
-    import toml as tomllib
+    import tomli as tomllib
 
 
 re_ansi_escape = re.compile(r"\x1b[^m]*m")


### PR DESCRIPTION
Hi,

It was realy hard for me too to wrap my head around this, so I documented here: https://wiki.debian.org/Python/Backports

Here's the full evolution story of this library: pytoml -> toml -> tomli -> tomllib

tomli & tomllib should be 99% the same thing
