### PR TITLE
Oracle: Add support for ** (power) and MOD operators in expressions

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -313,6 +313,13 @@ oracle_dialect.insert_lexer_matchers(
     before="equals",
 )
 
+oracle_dialect.insert_lexer_matchers(
+    [
+        StringLexer("power_operator", "**", CodeSegment),
+    ],
+    before="star",
+)
+
 oracle_dialect.add(
     SequenceNextValGrammar=Sequence(
         Ref("NakedIdentifierSegment"),
@@ -325,6 +332,8 @@ oracle_dialect.add(
     AssignmentOperatorSegment=StringParser(
         ":=", SymbolSegment, type="assignment_operator"
     ),
+    PowerOperatorSegment=StringParser("**", SymbolSegment, type="binary_operator"),
+    ModOperatorSegment=StringParser("MOD", WordSegment, type="binary_operator"),
     OnCommitGrammar=Sequence(
         "ON",
         "COMMIT",
@@ -849,6 +858,14 @@ oracle_dialect.replace(
     ),
     DelimiterGrammar=Sequence(
         Ref("SemicolonSegment"), Ref("SlashStatementTerminatorSegment", optional=True)
+    ),
+    ArithmeticBinaryOperatorGrammar=ansi_dialect.get_grammar(
+        "ArithmeticBinaryOperatorGrammar"
+    ).copy(
+        insert=[
+            Ref("ModOperatorSegment"),
+            Ref("PowerOperatorSegment"),
+        ]
     ),
     SelectClauseTerminatorGrammar=OneOf(
         "INTO",

--- a/test/fixtures/dialects/oracle/oracle_operators.sql
+++ b/test/fixtures/dialects/oracle/oracle_operators.sql
@@ -1,0 +1,73 @@
+-- Test Oracle-specific arithmetic operators: ** (power) and MOD
+
+BEGIN
+  -- Power operator in IF statements
+  IF i ** 2 > 50 THEN
+    DBMS_OUTPUT.PUT_LINE('i squared is greater than 50');
+  END IF;
+
+  -- MOD operator in IF statements
+  IF i MOD 2 = 0 THEN
+    DBMS_OUTPUT.PUT_LINE('i is even number');
+  ELSE
+    DBMS_OUTPUT.PUT_LINE('i is odd number');
+  END IF;
+
+  -- Combined operators in complex expressions
+  IF (x + y) ** 3 MOD 10 = 0 THEN
+    DBMS_OUTPUT.PUT_LINE('complex expression test');
+  END IF;
+
+  -- Power operator in SELECT expressions
+  SELECT
+    id,
+    value ** 2 AS value_squared,
+    amount ** 0.5 AS square_root
+  FROM test_table;
+
+  -- MOD operator in SELECT expressions
+  SELECT
+    id,
+    amount MOD 100 AS last_two_digits,
+    CASE WHEN id MOD 2 = 0 THEN 'Even' ELSE 'Odd' END AS parity
+  FROM test_table;
+
+  -- Power operator in WHERE clauses
+  SELECT * FROM test_table
+  WHERE value ** 2 BETWEEN 100 AND 400;
+
+  -- MOD operator in WHERE clauses
+  SELECT * FROM test_table
+  WHERE id MOD 5 = 0;
+
+  -- Combined operators in ORDER BY
+  SELECT id, value FROM test_table
+  ORDER BY value ** 2 DESC, id MOD 10;
+
+  -- Power operator in function calls
+  DBMS_OUTPUT.PUT_LINE('Result: ' || TO_CHAR(base ** exponent));
+
+  -- MOD operator in function calls
+  DBMS_OUTPUT.PUT_LINE('Remainder: ' || TO_CHAR(dividend MOD divisor));
+
+  -- Nested expressions with both operators
+  SELECT
+    ((a + b) ** 2) MOD 1000 AS complex_calc
+  FROM dual;
+
+  -- Power operator with parentheses for precedence
+  SELECT
+    2 ** (3 + 1) AS power_with_parens,
+    (2 ** 3) + 1 AS parens_around_power
+  FROM dual;
+
+  -- MOD operator chaining
+  SELECT
+    x MOD y MOD z AS chained_mod
+  FROM dual;
+
+  -- Mixed with other arithmetic operators
+  SELECT
+    a + b ** 2 - c MOD d * e AS mixed_arithmetic
+  FROM dual;
+END;

--- a/test/fixtures/dialects/oracle/oracle_operators.yml
+++ b/test/fixtures/dialects/oracle/oracle_operators.yml
@@ -1,0 +1,495 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 237b8bdde08c4e05a5f4d88f7ef991f25ada78ab77bdb123126f85d976e5d89b
+file:
+  statement:
+    begin_end_block:
+    - keyword: BEGIN
+    - statement:
+        if_then_statement:
+        - if_clause:
+          - keyword: IF
+          - expression:
+            - column_reference:
+                naked_identifier: i
+            - binary_operator: '**'
+            - numeric_literal: '2'
+            - comparison_operator:
+                raw_comparison_operator: '>'
+            - numeric_literal: '50'
+          - keyword: THEN
+        - statement:
+            function:
+              function_name:
+                naked_identifier: DBMS_OUTPUT
+                dot: .
+                function_name_identifier: PUT_LINE
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    quoted_literal: "'i squared is greater than 50'"
+                  end_bracket: )
+        - statement_terminator: ;
+        - keyword: END
+        - keyword: IF
+    - statement_terminator: ;
+    - statement:
+        if_then_statement:
+        - if_clause:
+          - keyword: IF
+          - expression:
+            - column_reference:
+                naked_identifier: i
+            - binary_operator: MOD
+            - numeric_literal: '2'
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - numeric_literal: '0'
+          - keyword: THEN
+        - statement:
+            function:
+              function_name:
+                naked_identifier: DBMS_OUTPUT
+                dot: .
+                function_name_identifier: PUT_LINE
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    quoted_literal: "'i is even number'"
+                  end_bracket: )
+        - statement_terminator: ;
+        - keyword: ELSE
+        - statement:
+            function:
+              function_name:
+                naked_identifier: DBMS_OUTPUT
+                dot: .
+                function_name_identifier: PUT_LINE
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    quoted_literal: "'i is odd number'"
+                  end_bracket: )
+        - statement_terminator: ;
+        - keyword: END
+        - keyword: IF
+    - statement_terminator: ;
+    - statement:
+        if_then_statement:
+        - if_clause:
+          - keyword: IF
+          - expression:
+            - bracketed:
+                start_bracket: (
+                expression:
+                - column_reference:
+                    naked_identifier: x
+                - binary_operator: +
+                - column_reference:
+                    naked_identifier: y
+                end_bracket: )
+            - binary_operator: '**'
+            - numeric_literal: '3'
+            - binary_operator: MOD
+            - numeric_literal: '10'
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - numeric_literal: '0'
+          - keyword: THEN
+        - statement:
+            function:
+              function_name:
+                naked_identifier: DBMS_OUTPUT
+                dot: .
+                function_name_identifier: PUT_LINE
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    quoted_literal: "'complex expression test'"
+                  end_bracket: )
+        - statement_terminator: ;
+        - keyword: END
+        - keyword: IF
+    - statement_terminator: ;
+    - statement:
+        select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                naked_identifier: id
+          - comma: ','
+          - select_clause_element:
+              expression:
+                column_reference:
+                  naked_identifier: value
+                binary_operator: '**'
+                numeric_literal: '2'
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: value_squared
+          - comma: ','
+          - select_clause_element:
+              expression:
+                column_reference:
+                  naked_identifier: amount
+                binary_operator: '**'
+                numeric_literal: '0.5'
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: square_root
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: test_table
+    - statement_terminator: ;
+    - statement:
+        select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                naked_identifier: id
+          - comma: ','
+          - select_clause_element:
+              expression:
+                column_reference:
+                  naked_identifier: amount
+                binary_operator: MOD
+                numeric_literal: '100'
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: last_two_digits
+          - comma: ','
+          - select_clause_element:
+              expression:
+                case_expression:
+                - keyword: CASE
+                - when_clause:
+                  - keyword: WHEN
+                  - expression:
+                    - column_reference:
+                        naked_identifier: id
+                    - binary_operator: MOD
+                    - numeric_literal: '2'
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - numeric_literal: '0'
+                  - keyword: THEN
+                  - expression:
+                      quoted_literal: "'Even'"
+                - else_clause:
+                    keyword: ELSE
+                    expression:
+                      quoted_literal: "'Odd'"
+                - keyword: END
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: parity
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: test_table
+    - statement_terminator: ;
+    - statement:
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: test_table
+          where_clause:
+            keyword: WHERE
+            expression:
+            - column_reference:
+                naked_identifier: value
+            - binary_operator: '**'
+            - numeric_literal: '2'
+            - keyword: BETWEEN
+            - numeric_literal: '100'
+            - keyword: AND
+            - numeric_literal: '400'
+    - statement_terminator: ;
+    - statement:
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              wildcard_expression:
+                wildcard_identifier:
+                  star: '*'
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: test_table
+          where_clause:
+            keyword: WHERE
+            expression:
+            - column_reference:
+                naked_identifier: id
+            - binary_operator: MOD
+            - numeric_literal: '5'
+            - comparison_operator:
+                raw_comparison_operator: '='
+            - numeric_literal: '0'
+    - statement_terminator: ;
+    - statement:
+        select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              column_reference:
+                naked_identifier: id
+          - comma: ','
+          - select_clause_element:
+              column_reference:
+                naked_identifier: value
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: test_table
+          orderby_clause:
+          - keyword: ORDER
+          - keyword: BY
+          - expression:
+              column_reference:
+                naked_identifier: value
+              binary_operator: '**'
+              numeric_literal: '2'
+          - keyword: DESC
+          - comma: ','
+          - expression:
+              column_reference:
+                naked_identifier: id
+              binary_operator: MOD
+              numeric_literal: '10'
+    - statement_terminator: ;
+    - statement:
+        function:
+          function_name:
+            naked_identifier: DBMS_OUTPUT
+            dot: .
+            function_name_identifier: PUT_LINE
+          function_contents:
+            bracketed:
+              start_bracket: (
+              expression:
+                quoted_literal: "'Result: '"
+                binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+                function:
+                  function_name:
+                    function_name_identifier: TO_CHAR
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - column_reference:
+                          naked_identifier: base
+                      - binary_operator: '**'
+                      - column_reference:
+                          naked_identifier: exponent
+                      end_bracket: )
+              end_bracket: )
+    - statement_terminator: ;
+    - statement:
+        function:
+          function_name:
+            naked_identifier: DBMS_OUTPUT
+            dot: .
+            function_name_identifier: PUT_LINE
+          function_contents:
+            bracketed:
+              start_bracket: (
+              expression:
+                quoted_literal: "'Remainder: '"
+                binary_operator:
+                - pipe: '|'
+                - pipe: '|'
+                function:
+                  function_name:
+                    function_name_identifier: TO_CHAR
+                  function_contents:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - column_reference:
+                          naked_identifier: dividend
+                      - binary_operator: MOD
+                      - column_reference:
+                          naked_identifier: divisor
+                      end_bracket: )
+              end_bracket: )
+    - statement_terminator: ;
+    - statement:
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    bracketed:
+                      start_bracket: (
+                      expression:
+                      - column_reference:
+                          naked_identifier: a
+                      - binary_operator: +
+                      - column_reference:
+                          naked_identifier: b
+                      end_bracket: )
+                    binary_operator: '**'
+                    numeric_literal: '2'
+                  end_bracket: )
+                binary_operator: MOD
+                numeric_literal: '1000'
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: complex_calc
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: dual
+    - statement_terminator: ;
+    - statement:
+        select_statement:
+          select_clause:
+          - keyword: SELECT
+          - select_clause_element:
+              expression:
+                numeric_literal: '2'
+                binary_operator: '**'
+                bracketed:
+                  start_bracket: (
+                  expression:
+                  - numeric_literal: '3'
+                  - binary_operator: +
+                  - numeric_literal: '1'
+                  end_bracket: )
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: power_with_parens
+          - comma: ','
+          - select_clause_element:
+              expression:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                  - numeric_literal: '2'
+                  - binary_operator: '**'
+                  - numeric_literal: '3'
+                  end_bracket: )
+                binary_operator: +
+                numeric_literal: '1'
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: parens_around_power
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: dual
+    - statement_terminator: ;
+    - statement:
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              expression:
+              - column_reference:
+                  naked_identifier: x
+              - binary_operator: MOD
+              - column_reference:
+                  naked_identifier: y
+              - binary_operator: MOD
+              - column_reference:
+                  naked_identifier: z
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: chained_mod
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: dual
+    - statement_terminator: ;
+    - statement:
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              expression:
+              - column_reference:
+                  naked_identifier: a
+              - binary_operator: +
+              - column_reference:
+                  naked_identifier: b
+              - binary_operator: '**'
+              - numeric_literal: '2'
+              - binary_operator: '-'
+              - column_reference:
+                  naked_identifier: c
+              - binary_operator: MOD
+              - column_reference:
+                  naked_identifier: d
+              - binary_operator: '*'
+              - column_reference:
+                  naked_identifier: e
+              alias_expression:
+                alias_operator:
+                  keyword: AS
+                naked_identifier: mixed_arithmetic
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: dual
+    - statement_terminator: ;
+    - keyword: END
+  statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Enable Oracle ** (power) and MOD operators in all expression contexts.

Fixes #7060.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
