### PR TITLE
SQLite: Fix WHEN and BEGIN/END indentation

### DIFF
--- a/src/sqlfluff/dialects/dialect_sqlite.py
+++ b/src/sqlfluff/dialects/dialect_sqlite.py
@@ -641,6 +641,7 @@ class UpsertClauseSegment(BaseSegment):
             Sequence(
                 "UPDATE",
                 "SET",
+                Indent,
                 Delimited(
                     Sequence(
                         OneOf(
@@ -651,6 +652,7 @@ class UpsertClauseSegment(BaseSegment):
                         Ref("ExpressionSegment"),
                     ),
                 ),
+                Dedent,
                 Sequence(
                     "WHERE",
                     Ref("ExpressionSegment"),
@@ -874,7 +876,11 @@ class PragmaStatementSegment(BaseSegment):
     match_grammar = Sequence(
         "PRAGMA",
         Ref("PragmaReferenceSegment"),
-        Bracketed(_pragma_value, optional=True),
+        OneOf(
+            Bracketed(_pragma_value),
+            Bracketed(Ref("ObjectReferenceSegment")),
+            optional=True,
+        ),
         Sequence(
             Ref("EqualsSegment"), OptionallyBracketed(_pragma_value), optional=True
         ),
@@ -913,8 +919,15 @@ class CreateTriggerStatementSegment(ansi.CreateTriggerStatementSegment):
         "ON",
         Ref("TableReferenceSegment"),
         Sequence("FOR", "EACH", "ROW", optional=True),
-        Sequence("WHEN", OptionallyBracketed(Ref("ExpressionSegment")), optional=True),
+        Sequence(
+            "WHEN",
+            Indent,
+            OptionallyBracketed(Ref("ExpressionSegment")),
+            Dedent,
+            optional=True,
+        ),
         "BEGIN",
+        Indent,
         Delimited(
             Ref("UpdateStatementSegment"),
             Ref("InsertStatementSegment"),
@@ -924,6 +937,7 @@ class CreateTriggerStatementSegment(ansi.CreateTriggerStatementSegment):
             allow_gaps=True,
             allow_trailing=True,
         ),
+        Dedent,
         "END",
     )
 

--- a/test/fixtures/linter/autofix/sqlite/001_trigger_indentation/after.sql
+++ b/test/fixtures/linter/autofix/sqlite/001_trigger_indentation/after.sql
@@ -1,0 +1,9 @@
+CREATE TRIGGER trig
+AFTER UPDATE ON tab1
+WHEN
+    old.a IS NOT new.a
+    OR old.b IS NOT new.b
+    OR old.c IS NOT new.c
+BEGIN
+    INSERT INTO tab2 (x) VALUES ('UPDATE');
+END;

--- a/test/fixtures/linter/autofix/sqlite/001_trigger_indentation/before.sql
+++ b/test/fixtures/linter/autofix/sqlite/001_trigger_indentation/before.sql
@@ -1,0 +1,9 @@
+CREATE TRIGGER trig
+AFTER UPDATE ON tab1
+WHEN
+old.a IS NOT new.a
+OR old.b IS NOT new.b
+  OR old.c IS NOT new.c
+BEGIN
+INSERT INTO tab2 (x) VALUES ('UPDATE');
+END;

--- a/test/fixtures/linter/autofix/sqlite/001_trigger_indentation/test-config.yml
+++ b/test/fixtures/linter/autofix/sqlite/001_trigger_indentation/test-config.yml
@@ -1,0 +1,4 @@
+test-config:
+  dialect: sqlite
+  rules:
+    - LT02

--- a/test/fixtures/linter/autofix/sqlite/002_trigger_complex_indentation/after.sql
+++ b/test/fixtures/linter/autofix/sqlite/002_trigger_complex_indentation/after.sql
@@ -1,0 +1,22 @@
+CREATE TRIGGER update_trigger
+BEFORE UPDATE OF name, email ON users
+FOR EACH ROW
+WHEN
+    new.name IS NOT old.name
+    OR new.email IS NOT old.email
+BEGIN
+    UPDATE audit_log
+    SET last_modified = datetime('now')
+    WHERE user_id = NEW.id;
+    INSERT INTO change_history (
+        user_id,
+        old_name,
+        new_name,
+        change_date
+    ) VALUES (
+        NEW.id,
+        OLD.name,
+        NEW.name,
+        datetime('now')
+    );
+END;

--- a/test/fixtures/linter/autofix/sqlite/002_trigger_complex_indentation/before.sql
+++ b/test/fixtures/linter/autofix/sqlite/002_trigger_complex_indentation/before.sql
@@ -1,0 +1,22 @@
+CREATE TRIGGER update_trigger
+BEFORE UPDATE OF name, email ON users
+FOR EACH ROW
+WHEN
+new.name IS NOT old.name
+OR new.email IS NOT old.email
+BEGIN
+UPDATE audit_log
+SET last_modified = datetime('now')
+WHERE user_id = NEW.id;
+INSERT INTO change_history (
+user_id,
+old_name,
+new_name,
+change_date
+) VALUES (
+NEW.id,
+OLD.name,
+NEW.name,
+datetime('now')
+);
+END;

--- a/test/fixtures/linter/autofix/sqlite/002_trigger_complex_indentation/test-config.yml
+++ b/test/fixtures/linter/autofix/sqlite/002_trigger_complex_indentation/test-config.yml
@@ -1,0 +1,4 @@
+test-config:
+  dialect: sqlite
+  rules:
+    - LT02

--- a/test/fixtures/linter/autofix/sqlite/003_sqlite_specific_indentation/after.sql
+++ b/test/fixtures/linter/autofix/sqlite/003_sqlite_specific_indentation/after.sql
@@ -1,0 +1,21 @@
+-- SQLite specific features with indentation issues
+SELECT
+    data->>'name' AS name,
+    data->'age' AS age,
+    json_extract(data, '$.city') AS city
+FROM users
+WHERE
+    data IS NOT NULL
+    AND json_valid(data)
+    AND name IS NOT 'admin'
+ORDER BY
+    name,
+    age;
+
+-- UPSERT with conflict resolution
+INSERT INTO users (id, name, email)
+VALUES (1, 'John', 'john@example.com')
+ON CONFLICT(id) DO UPDATE SET
+    name = excluded.name,
+    email = excluded.email
+WHERE excluded.name IS NOT users.name;

--- a/test/fixtures/linter/autofix/sqlite/003_sqlite_specific_indentation/before.sql
+++ b/test/fixtures/linter/autofix/sqlite/003_sqlite_specific_indentation/before.sql
@@ -1,0 +1,20 @@
+-- SQLite specific features with indentation issues
+SELECT
+data->>'name' AS name,
+    data->'age' AS age,
+json_extract(data, '$.city') AS city
+FROM users
+WHERE data IS NOT NULL
+AND json_valid(data)
+AND name IS NOT 'admin'
+ORDER BY
+name,
+   age;
+
+-- UPSERT with conflict resolution
+INSERT INTO users (id, name, email)
+VALUES (1, 'John', 'john@example.com')
+ON CONFLICT(id) DO UPDATE SET
+name = excluded.name,
+  email = excluded.email
+WHERE excluded.name IS NOT users.name;

--- a/test/fixtures/linter/autofix/sqlite/003_sqlite_specific_indentation/test-config.yml
+++ b/test/fixtures/linter/autofix/sqlite/003_sqlite_specific_indentation/test-config.yml
@@ -1,0 +1,4 @@
+test-config:
+  dialect: sqlite
+  rules:
+    - LT02

--- a/test/fixtures/linter/autofix/sqlite/004_pragma_indentation/after.sql
+++ b/test/fixtures/linter/autofix/sqlite/004_pragma_indentation/after.sql
@@ -1,0 +1,17 @@
+-- Multiple PRAGMA statements with inconsistent indentation
+PRAGMA foreign_keys = ON;
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+PRAGMA cache_size = 10000;
+
+-- Multi-line statements with PRAGMA
+SELECT
+    name,
+    sql
+FROM sqlite_master
+WHERE
+    type = 'table'
+    AND name IS NOT 'sqlite_sequence'
+ORDER BY name;
+
+PRAGMA table_info(users);

--- a/test/fixtures/linter/autofix/sqlite/004_pragma_indentation/before.sql
+++ b/test/fixtures/linter/autofix/sqlite/004_pragma_indentation/before.sql
@@ -1,0 +1,16 @@
+-- Multiple PRAGMA statements with inconsistent indentation
+PRAGMA foreign_keys = ON;
+    PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+  PRAGMA cache_size = 10000;
+
+-- Multi-line statements with PRAGMA
+SELECT
+name,
+sql
+FROM sqlite_master
+WHERE type = 'table'
+AND name IS NOT 'sqlite_sequence'
+ORDER BY name;
+
+PRAGMA table_info(users);

--- a/test/fixtures/linter/autofix/sqlite/004_pragma_indentation/test-config.yml
+++ b/test/fixtures/linter/autofix/sqlite/004_pragma_indentation/test-config.yml
@@ -1,0 +1,4 @@
+test-config:
+  dialect: sqlite
+  rules:
+    - LT02

--- a/test/fixtures/linter/autofix/sqlite/005_virtual_table_indentation/after.sql
+++ b/test/fixtures/linter/autofix/sqlite/005_virtual_table_indentation/after.sql
@@ -1,0 +1,19 @@
+-- CREATE VIRTUAL TABLE with indentation issues
+CREATE VIRTUAL TABLE documents USING fts5(
+    title,
+    content,
+    author,
+    tags
+);
+
+-- Views with WHEN clause and IS NOT
+CREATE VIEW active_users AS
+SELECT
+    user_id,
+    name,
+    email
+FROM users
+WHERE
+    status IS NOT 'inactive'
+    AND last_login IS NOT NULL
+    AND email IS NOT '';

--- a/test/fixtures/linter/autofix/sqlite/005_virtual_table_indentation/before.sql
+++ b/test/fixtures/linter/autofix/sqlite/005_virtual_table_indentation/before.sql
@@ -1,0 +1,18 @@
+-- CREATE VIRTUAL TABLE with indentation issues
+CREATE VIRTUAL TABLE documents USING fts5(
+title,
+  content,
+author,
+    tags
+);
+
+-- Views with WHEN clause and IS NOT
+CREATE VIEW active_users AS
+SELECT
+user_id,
+name,
+email
+FROM users
+WHERE status IS NOT 'inactive'
+AND last_login IS NOT NULL
+AND email IS NOT '';

--- a/test/fixtures/linter/autofix/sqlite/005_virtual_table_indentation/test-config.yml
+++ b/test/fixtures/linter/autofix/sqlite/005_virtual_table_indentation/test-config.yml
@@ -1,0 +1,4 @@
+test-config:
+  dialect: sqlite
+  rules:
+    - LT02


### PR DESCRIPTION
### Brief summary of the change made
This PR addresses indentation issues in SQLite triggers by adding proper formatting for `WHEN` clauses and `BEGIN/END` blocks, along with comprehensive test coverage for SQLite-specific indentation scenarios.

Partially fixes #7062.
Partially fixes #7063.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
