### PR TITLE
Oracle: Fix nested CASE expression parsing in SELECT statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -2525,6 +2525,23 @@ class CaseExpressionSegment(BaseSegment):
             ),
             Dedent,
             "END",
+        ),
+        Sequence(
+            "CASE",
+            ImplicitIndent,
+            AnyNumberOf(
+                Ref("WhenClauseSegment"),
+                reset_terminators=True,
+                terminators=[Ref.keyword("ELSE"), Ref.keyword("END")],
+            ),
+            Ref(
+                "ElseClauseSegment",
+                optional=True,
+                reset_terminators=True,
+                terminators=[Ref.keyword("END")],
+            ),
+            Dedent,
+            "END",
             Ref.keyword("CASE", optional=True),
             Ref("SingleIdentifierGrammar", optional=True),
         ),

--- a/test/fixtures/dialects/oracle/case_expressions.sql
+++ b/test/fixtures/dialects/oracle/case_expressions.sql
@@ -1,0 +1,282 @@
+-- Test 1: Simple CASE expression (CASE WHEN)
+SELECT
+    CASE
+        WHEN x = 5 THEN 1
+        WHEN x = 10 THEN 2
+        ELSE 0
+    END AS result
+FROM abc;
+
+-- Test 2: Simple CASE expression without ELSE
+SELECT
+    CASE
+        WHEN x = 5 THEN 1
+        WHEN x = 10 THEN 2
+    END AS result
+FROM abc;
+
+-- Test 3: Searched CASE expression with nested CASE
+SELECT
+    CASE
+        WHEN x = 5 THEN
+            CASE 
+                WHEN y = 6 THEN 999
+            END
+    END AS hi
+FROM abc;
+
+-- Test 4: Searched CASE with nested CASE and ELSE
+SELECT
+    CASE
+        WHEN x = 5 THEN
+            CASE 
+                WHEN y = 6 THEN 999
+                ELSE 888
+            END
+        ELSE 777
+    END AS result
+FROM abc;
+
+-- Test 5: Simple CASE expression (CASE expr WHEN)
+SELECT
+    CASE x
+        WHEN 5 THEN 1
+        WHEN 10 THEN 2
+        ELSE 0
+    END AS result
+FROM abc;
+
+-- Test 6: Simple CASE expression with nested CASE
+SELECT
+    CASE x
+        WHEN 5 THEN
+            CASE y
+                WHEN 6 THEN 999
+                ELSE 888
+            END
+        WHEN 10 THEN 2
+        ELSE 0
+    END AS result
+FROM abc;
+
+-- Test 7: Complex nested CASE expressions
+SELECT
+    CASE
+        WHEN x = 5 THEN
+            CASE
+                WHEN y = 6 THEN
+                    CASE z
+                        WHEN 7 THEN 777
+                        WHEN 8 THEN 888
+                        ELSE 999
+                    END
+                ELSE 666
+            END
+        WHEN x = 10 THEN
+            CASE y
+                WHEN 11 THEN 111
+                ELSE 222
+            END
+        ELSE 333
+    END AS complex_result
+FROM abc;
+
+-- Test 8: CASE expressions in WHERE clause
+SELECT *
+FROM abc
+WHERE CASE
+    WHEN x = 5 THEN 1
+    WHEN x = 10 THEN 2
+    ELSE 0
+END = 1;
+
+-- Test 9: CASE expressions in ORDER BY
+SELECT x, y, z
+FROM abc
+ORDER BY CASE
+    WHEN x = 5 THEN 1
+    WHEN x = 10 THEN 2
+    ELSE 3
+END;
+
+-- Test 10: CASE expressions with functions
+SELECT
+    CASE
+        WHEN LENGTH(name) > 10 THEN 'Long'
+        WHEN LENGTH(name) > 5 THEN 'Medium'
+        ELSE 'Short'
+    END AS name_length
+FROM abc;
+
+-- Test 11: CASE expressions with NULL handling
+SELECT
+    CASE
+        WHEN x IS NULL THEN 'NULL'
+        WHEN x = 0 THEN 'Zero'
+        WHEN x > 0 THEN 'Positive'
+        ELSE 'Negative'
+    END AS x_status
+FROM abc;
+
+-- Test 12: CASE expressions with multiple conditions
+SELECT
+    CASE
+        WHEN x = 5 AND y = 6 THEN 'Both match'
+        WHEN x = 5 OR y = 6 THEN 'One matches'
+        ELSE 'Neither matches'
+    END AS condition_result
+FROM abc;
+
+-- Test 13: CASE expressions with subqueries
+SELECT
+    CASE
+        WHEN x = 5 THEN (SELECT MAX(id) FROM def WHERE id = x)
+        WHEN x = 10 THEN (SELECT MIN(id) FROM def WHERE id = x)
+        ELSE 0
+    END AS subquery_result
+FROM abc;
+
+-- Test 14: CASE expressions with type conversion
+SELECT
+    CASE
+        WHEN x = 5 THEN TO_CHAR(x, '999')
+        WHEN x = 10 THEN TO_NUMBER('10')
+        ELSE 'Unknown'
+    END AS converted_result
+FROM abc;
+
+-- Test 15: CASE expressions in UPDATE statement
+UPDATE abc
+SET status = CASE
+    WHEN x = 5 THEN 'Active'
+    WHEN x = 10 THEN 'Inactive'
+    ELSE 'Unknown'
+END
+WHERE id = 1;
+
+-- Test 16: CASE expressions in INSERT statement
+INSERT INTO abc (id, status)
+SELECT id, CASE
+    WHEN x = 5 THEN 'Active'
+    WHEN x = 10 THEN 'Inactive'
+    ELSE 'Unknown'
+END
+FROM def;
+
+-- Test 17: CASE expressions with date handling
+SELECT
+    CASE
+        WHEN created_date > SYSDATE - 1 THEN 'Recent'
+        WHEN created_date > SYSDATE - 7 THEN 'This week'
+        WHEN created_date > SYSDATE - 30 THEN 'This month'
+        ELSE 'Old'
+    END AS age_category
+FROM abc;
+
+-- Test 18: CASE expressions with string operations
+SELECT
+    CASE
+        WHEN UPPER(name) LIKE '%TEST%' THEN 'Test record'
+        WHEN LOWER(name) LIKE '%prod%' THEN 'Production record'
+        ELSE 'Other'
+    END AS record_type
+FROM abc;
+
+-- Test 19: CASE expressions with numeric operations
+SELECT
+    CASE
+        WHEN x + y > 100 THEN 'High sum'
+        WHEN x * y > 50 THEN 'High product'
+        WHEN x - y < 0 THEN 'Negative difference'
+        ELSE 'Normal'
+    END AS calculation_result
+FROM abc;
+
+-- Test 20: CASE expressions with EXISTS subqueries
+SELECT
+    CASE
+        WHEN EXISTS (SELECT 1 FROM def WHERE def.id = abc.x) THEN 'Exists in def'
+        WHEN EXISTS (SELECT 1 FROM ghi WHERE ghi.id = abc.y) THEN 'Exists in ghi'
+        ELSE 'Not found'
+    END AS existence_check
+FROM abc;
+
+-- Test 21: CASE expressions with IN operator
+SELECT
+    CASE
+        WHEN x IN (1, 2, 3) THEN 'Low'
+        WHEN x IN (4, 5, 6) THEN 'Medium'
+        WHEN x IN (7, 8, 9) THEN 'High'
+        ELSE 'Unknown'
+    END AS range_category
+FROM abc;
+
+-- Test 22: CASE expressions with BETWEEN
+SELECT
+    CASE
+        WHEN x BETWEEN 1 AND 10 THEN 'First range'
+        WHEN x BETWEEN 11 AND 20 THEN 'Second range'
+        WHEN x BETWEEN 21 AND 30 THEN 'Third range'
+        ELSE 'Out of range'
+    END AS between_result
+FROM abc;
+
+-- Test 23: CASE expressions with REGEXP_LIKE
+SELECT
+    CASE
+        WHEN REGEXP_LIKE(name, '^[A-Z]') THEN 'Starts with uppercase'
+        WHEN REGEXP_LIKE(name, '[0-9]') THEN 'Contains number'
+        ELSE 'Other pattern'
+    END AS pattern_match
+FROM abc;
+
+-- Test 24: CASE expressions with DECODE equivalent
+SELECT
+    CASE x
+        WHEN 1 THEN 'One'
+        WHEN 2 THEN 'Two'
+        WHEN 3 THEN 'Three'
+        ELSE 'Other'
+    END AS decode_equivalent
+FROM abc;
+
+-- Test 25: Complex nested CASE with multiple levels
+SELECT
+    CASE
+        WHEN x = 1 THEN
+            CASE y
+                WHEN 10 THEN
+                    CASE z
+                        WHEN 100 THEN 'Level 3 - 100'
+                        WHEN 200 THEN 'Level 3 - 200'
+                        ELSE 'Level 3 - Other'
+                    END
+                WHEN 20 THEN 'Level 2 - 20'
+                ELSE 'Level 2 - Other'
+            END
+        WHEN x = 2 THEN
+            CASE y
+                WHEN 30 THEN 'Level 2 - 30'
+                ELSE 'Level 2 - Other'
+            END
+        ELSE 'Level 1 - Other'
+    END AS multi_level_result
+FROM abc;
+
+-- Test 26: CASE expression ending with END CASE
+SELECT
+    CASE
+        WHEN x = 5 THEN 1
+        WHEN x = 10 THEN 2
+        ELSE 0
+    END CASE AS result
+FROM abc;
+
+-- Test 27: CASE expression ending with END identifier
+SELECT
+    CASE
+        WHEN x = 5 THEN 1
+        WHEN x = 10 THEN 2
+        ELSE 0
+    END my_case AS result
+FROM abc;

--- a/test/fixtures/dialects/oracle/case_expressions.yml
+++ b/test/fixtures/dialects/oracle/case_expressions.yml
@@ -1,0 +1,1716 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 3e97b082c60397a779fe8a11a12edd2b13365b238d4456fbdbac139747b6f76d
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '5'
+              - keyword: THEN
+              - expression:
+                  numeric_literal: '1'
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '10'
+              - keyword: THEN
+              - expression:
+                  numeric_literal: '2'
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  numeric_literal: '0'
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '5'
+              - keyword: THEN
+              - expression:
+                  numeric_literal: '1'
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '10'
+              - keyword: THEN
+              - expression:
+                  numeric_literal: '2'
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '5'
+              - keyword: THEN
+              - expression:
+                  case_expression:
+                  - keyword: CASE
+                  - when_clause:
+                    - keyword: WHEN
+                    - expression:
+                        column_reference:
+                          naked_identifier: y
+                        comparison_operator:
+                          raw_comparison_operator: '='
+                        numeric_literal: '6'
+                    - keyword: THEN
+                    - expression:
+                        numeric_literal: '999'
+                  - keyword: END
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: hi
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '5'
+              - keyword: THEN
+              - expression:
+                  case_expression:
+                  - keyword: CASE
+                  - when_clause:
+                    - keyword: WHEN
+                    - expression:
+                        column_reference:
+                          naked_identifier: y
+                        comparison_operator:
+                          raw_comparison_operator: '='
+                        numeric_literal: '6'
+                    - keyword: THEN
+                    - expression:
+                        numeric_literal: '999'
+                  - else_clause:
+                      keyword: ELSE
+                      expression:
+                        numeric_literal: '888'
+                  - keyword: END
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  numeric_literal: '777'
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - expression:
+                column_reference:
+                  naked_identifier: x
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  numeric_literal: '5'
+              - keyword: THEN
+              - expression:
+                  numeric_literal: '1'
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  numeric_literal: '10'
+              - keyword: THEN
+              - expression:
+                  numeric_literal: '2'
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  numeric_literal: '0'
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - expression:
+                column_reference:
+                  naked_identifier: x
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  numeric_literal: '5'
+              - keyword: THEN
+              - expression:
+                  case_expression:
+                  - keyword: CASE
+                  - expression:
+                      column_reference:
+                        naked_identifier: y
+                  - when_clause:
+                    - keyword: WHEN
+                    - expression:
+                        numeric_literal: '6'
+                    - keyword: THEN
+                    - expression:
+                        numeric_literal: '999'
+                  - else_clause:
+                      keyword: ELSE
+                      expression:
+                        numeric_literal: '888'
+                  - keyword: END
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  numeric_literal: '10'
+              - keyword: THEN
+              - expression:
+                  numeric_literal: '2'
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  numeric_literal: '0'
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '5'
+              - keyword: THEN
+              - expression:
+                  case_expression:
+                  - keyword: CASE
+                  - when_clause:
+                    - keyword: WHEN
+                    - expression:
+                        column_reference:
+                          naked_identifier: y
+                        comparison_operator:
+                          raw_comparison_operator: '='
+                        numeric_literal: '6'
+                    - keyword: THEN
+                    - expression:
+                        case_expression:
+                        - keyword: CASE
+                        - expression:
+                            column_reference:
+                              naked_identifier: z
+                        - when_clause:
+                          - keyword: WHEN
+                          - expression:
+                              numeric_literal: '7'
+                          - keyword: THEN
+                          - expression:
+                              numeric_literal: '777'
+                        - when_clause:
+                          - keyword: WHEN
+                          - expression:
+                              numeric_literal: '8'
+                          - keyword: THEN
+                          - expression:
+                              numeric_literal: '888'
+                        - else_clause:
+                            keyword: ELSE
+                            expression:
+                              numeric_literal: '999'
+                        - keyword: END
+                  - else_clause:
+                      keyword: ELSE
+                      expression:
+                        numeric_literal: '666'
+                  - keyword: END
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '10'
+              - keyword: THEN
+              - expression:
+                  case_expression:
+                  - keyword: CASE
+                  - expression:
+                      column_reference:
+                        naked_identifier: y
+                  - when_clause:
+                    - keyword: WHEN
+                    - expression:
+                        numeric_literal: '11'
+                    - keyword: THEN
+                    - expression:
+                        numeric_literal: '111'
+                  - else_clause:
+                      keyword: ELSE
+                      expression:
+                        numeric_literal: '222'
+                  - keyword: END
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  numeric_literal: '333'
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: complex_result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          wildcard_expression:
+            wildcard_identifier:
+              star: '*'
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+      where_clause:
+        keyword: WHERE
+        expression:
+          case_expression:
+          - keyword: CASE
+          - when_clause:
+            - keyword: WHEN
+            - expression:
+                column_reference:
+                  naked_identifier: x
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '5'
+            - keyword: THEN
+            - expression:
+                numeric_literal: '1'
+          - when_clause:
+            - keyword: WHEN
+            - expression:
+                column_reference:
+                  naked_identifier: x
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '10'
+            - keyword: THEN
+            - expression:
+                numeric_literal: '2'
+          - else_clause:
+              keyword: ELSE
+              expression:
+                numeric_literal: '0'
+          - keyword: END
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+            naked_identifier: x
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: y
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+            naked_identifier: z
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - expression:
+          case_expression:
+          - keyword: CASE
+          - when_clause:
+            - keyword: WHEN
+            - expression:
+                column_reference:
+                  naked_identifier: x
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '5'
+            - keyword: THEN
+            - expression:
+                numeric_literal: '1'
+          - when_clause:
+            - keyword: WHEN
+            - expression:
+                column_reference:
+                  naked_identifier: x
+                comparison_operator:
+                  raw_comparison_operator: '='
+                numeric_literal: '10'
+            - keyword: THEN
+            - expression:
+                numeric_literal: '2'
+          - else_clause:
+              keyword: ELSE
+              expression:
+                numeric_literal: '3'
+          - keyword: END
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  function:
+                    function_name:
+                      function_name_identifier: LENGTH
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: name
+                        end_bracket: )
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  numeric_literal: '10'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Long'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  function:
+                    function_name:
+                      function_name_identifier: LENGTH
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: name
+                        end_bracket: )
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  numeric_literal: '5'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Medium'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Short'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: name_length
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  keyword: IS
+                  null_literal: 'NULL'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'NULL'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '0'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Zero'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  numeric_literal: '0'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Positive'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Negative'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: x_status
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                - column_reference:
+                    naked_identifier: x
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - numeric_literal: '5'
+                - binary_operator: AND
+                - column_reference:
+                    naked_identifier: y
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - numeric_literal: '6'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Both match'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                - column_reference:
+                    naked_identifier: x
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - numeric_literal: '5'
+                - binary_operator: OR
+                - column_reference:
+                    naked_identifier: y
+                - comparison_operator:
+                    raw_comparison_operator: '='
+                - numeric_literal: '6'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'One matches'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Neither matches'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: condition_result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '5'
+              - keyword: THEN
+              - expression:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      select_statement:
+                        select_clause:
+                          keyword: SELECT
+                          select_clause_element:
+                            function:
+                              function_name:
+                                function_name_identifier: MAX
+                              function_contents:
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                    column_reference:
+                                      naked_identifier: id
+                                  end_bracket: )
+                        from_clause:
+                          keyword: FROM
+                          from_expression:
+                            from_expression_element:
+                              table_expression:
+                                table_reference:
+                                  naked_identifier: def
+                        where_clause:
+                          keyword: WHERE
+                          expression:
+                          - column_reference:
+                              naked_identifier: id
+                          - comparison_operator:
+                              raw_comparison_operator: '='
+                          - column_reference:
+                              naked_identifier: x
+                    end_bracket: )
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '10'
+              - keyword: THEN
+              - expression:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                      select_statement:
+                        select_clause:
+                          keyword: SELECT
+                          select_clause_element:
+                            function:
+                              function_name:
+                                function_name_identifier: MIN
+                              function_contents:
+                                bracketed:
+                                  start_bracket: (
+                                  expression:
+                                    column_reference:
+                                      naked_identifier: id
+                                  end_bracket: )
+                        from_clause:
+                          keyword: FROM
+                          from_expression:
+                            from_expression_element:
+                              table_expression:
+                                table_reference:
+                                  naked_identifier: def
+                        where_clause:
+                          keyword: WHERE
+                          expression:
+                          - column_reference:
+                              naked_identifier: id
+                          - comparison_operator:
+                              raw_comparison_operator: '='
+                          - column_reference:
+                              naked_identifier: x
+                    end_bracket: )
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  numeric_literal: '0'
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: subquery_result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '5'
+              - keyword: THEN
+              - expression:
+                  function:
+                    function_name:
+                      function_name_identifier: TO_CHAR
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          column_reference:
+                            naked_identifier: x
+                      - comma: ','
+                      - expression:
+                          quoted_literal: "'999'"
+                      - end_bracket: )
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '10'
+              - keyword: THEN
+              - expression:
+                  function:
+                    function_name:
+                      function_name_identifier: TO_NUMBER
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          quoted_literal: "'10'"
+                        end_bracket: )
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Unknown'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: converted_result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    update_statement:
+      keyword: UPDATE
+      table_reference:
+        naked_identifier: abc
+      set_clause_list:
+        keyword: SET
+        set_clause:
+          column_reference:
+            naked_identifier: status
+          comparison_operator:
+            raw_comparison_operator: '='
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '5'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Active'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '10'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Inactive'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Unknown'"
+            - keyword: END
+      where_clause:
+        keyword: WHERE
+        expression:
+          column_reference:
+            naked_identifier: id
+          comparison_operator:
+            raw_comparison_operator: '='
+          numeric_literal: '1'
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: abc
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: id
+      - comma: ','
+      - column_reference:
+          naked_identifier: status
+      - end_bracket: )
+    - select_statement:
+        select_clause:
+        - keyword: SELECT
+        - select_clause_element:
+            column_reference:
+              naked_identifier: id
+        - comma: ','
+        - select_clause_element:
+            expression:
+              case_expression:
+              - keyword: CASE
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '5'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Active'"
+              - when_clause:
+                - keyword: WHEN
+                - expression:
+                    column_reference:
+                      naked_identifier: x
+                    comparison_operator:
+                      raw_comparison_operator: '='
+                    numeric_literal: '10'
+                - keyword: THEN
+                - expression:
+                    quoted_literal: "'Inactive'"
+              - else_clause:
+                  keyword: ELSE
+                  expression:
+                    quoted_literal: "'Unknown'"
+              - keyword: END
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: def
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: created_date
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  bare_function: SYSDATE
+                  binary_operator: '-'
+                  numeric_literal: '1'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Recent'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: created_date
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  bare_function: SYSDATE
+                  binary_operator: '-'
+                  numeric_literal: '7'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'This week'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: created_date
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  bare_function: SYSDATE
+                  binary_operator: '-'
+                  numeric_literal: '30'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'This month'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Old'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: age_category
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  function:
+                    function_name:
+                      function_name_identifier: UPPER
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: name
+                        end_bracket: )
+                  keyword: LIKE
+                  quoted_literal: "'%TEST%'"
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Test record'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  function:
+                    function_name:
+                      function_name_identifier: LOWER
+                    function_contents:
+                      bracketed:
+                        start_bracket: (
+                        expression:
+                          column_reference:
+                            naked_identifier: name
+                        end_bracket: )
+                  keyword: LIKE
+                  quoted_literal: "'%prod%'"
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Production record'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Other'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: record_type
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                - column_reference:
+                    naked_identifier: x
+                - binary_operator: +
+                - column_reference:
+                    naked_identifier: y
+                - comparison_operator:
+                    raw_comparison_operator: '>'
+                - numeric_literal: '100'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'High sum'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                - column_reference:
+                    naked_identifier: x
+                - binary_operator: '*'
+                - column_reference:
+                    naked_identifier: y
+                - comparison_operator:
+                    raw_comparison_operator: '>'
+                - numeric_literal: '50'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'High product'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                - column_reference:
+                    naked_identifier: x
+                - binary_operator: '-'
+                - column_reference:
+                    naked_identifier: y
+                - comparison_operator:
+                    raw_comparison_operator: <
+                - numeric_literal: '0'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Negative difference'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Normal'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: calculation_result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  keyword: EXISTS
+                  bracketed:
+                    start_bracket: (
+                    select_statement:
+                      select_clause:
+                        keyword: SELECT
+                        select_clause_element:
+                          numeric_literal: '1'
+                      from_clause:
+                        keyword: FROM
+                        from_expression:
+                          from_expression_element:
+                            table_expression:
+                              table_reference:
+                                naked_identifier: def
+                      where_clause:
+                        keyword: WHERE
+                        expression:
+                        - column_reference:
+                          - naked_identifier: def
+                          - dot: .
+                          - naked_identifier: id
+                        - comparison_operator:
+                            raw_comparison_operator: '='
+                        - column_reference:
+                          - naked_identifier: abc
+                          - dot: .
+                          - naked_identifier: x
+                    end_bracket: )
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Exists in def'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  keyword: EXISTS
+                  bracketed:
+                    start_bracket: (
+                    select_statement:
+                      select_clause:
+                        keyword: SELECT
+                        select_clause_element:
+                          numeric_literal: '1'
+                      from_clause:
+                        keyword: FROM
+                        from_expression:
+                          from_expression_element:
+                            table_expression:
+                              table_reference:
+                                naked_identifier: ghi
+                      where_clause:
+                        keyword: WHERE
+                        expression:
+                        - column_reference:
+                          - naked_identifier: ghi
+                          - dot: .
+                          - naked_identifier: id
+                        - comparison_operator:
+                            raw_comparison_operator: '='
+                        - column_reference:
+                          - naked_identifier: abc
+                          - dot: .
+                          - naked_identifier: y
+                    end_bracket: )
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Exists in ghi'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Not found'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: existence_check
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  keyword: IN
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '1'
+                  - comma: ','
+                  - numeric_literal: '2'
+                  - comma: ','
+                  - numeric_literal: '3'
+                  - end_bracket: )
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Low'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  keyword: IN
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '4'
+                  - comma: ','
+                  - numeric_literal: '5'
+                  - comma: ','
+                  - numeric_literal: '6'
+                  - end_bracket: )
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Medium'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  keyword: IN
+                  bracketed:
+                  - start_bracket: (
+                  - numeric_literal: '7'
+                  - comma: ','
+                  - numeric_literal: '8'
+                  - comma: ','
+                  - numeric_literal: '9'
+                  - end_bracket: )
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'High'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Unknown'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: range_category
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                - column_reference:
+                    naked_identifier: x
+                - keyword: BETWEEN
+                - numeric_literal: '1'
+                - keyword: AND
+                - numeric_literal: '10'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'First range'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                - column_reference:
+                    naked_identifier: x
+                - keyword: BETWEEN
+                - numeric_literal: '11'
+                - keyword: AND
+                - numeric_literal: '20'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Second range'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                - column_reference:
+                    naked_identifier: x
+                - keyword: BETWEEN
+                - numeric_literal: '21'
+                - keyword: AND
+                - numeric_literal: '30'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Third range'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Out of range'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: between_result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  function:
+                    function_name:
+                      function_name_identifier: REGEXP_LIKE
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          column_reference:
+                            naked_identifier: name
+                      - comma: ','
+                      - expression:
+                          quoted_literal: "'^[A-Z]'"
+                      - end_bracket: )
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Starts with uppercase'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  function:
+                    function_name:
+                      function_name_identifier: REGEXP_LIKE
+                    function_contents:
+                      bracketed:
+                      - start_bracket: (
+                      - expression:
+                          column_reference:
+                            naked_identifier: name
+                      - comma: ','
+                      - expression:
+                          quoted_literal: "'[0-9]'"
+                      - end_bracket: )
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Contains number'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Other pattern'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: pattern_match
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - expression:
+                column_reference:
+                  naked_identifier: x
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  numeric_literal: '1'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'One'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  numeric_literal: '2'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Two'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  numeric_literal: '3'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Three'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Other'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: decode_equivalent
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '1'
+              - keyword: THEN
+              - expression:
+                  case_expression:
+                  - keyword: CASE
+                  - expression:
+                      column_reference:
+                        naked_identifier: y
+                  - when_clause:
+                    - keyword: WHEN
+                    - expression:
+                        numeric_literal: '10'
+                    - keyword: THEN
+                    - expression:
+                        case_expression:
+                        - keyword: CASE
+                        - expression:
+                            column_reference:
+                              naked_identifier: z
+                        - when_clause:
+                          - keyword: WHEN
+                          - expression:
+                              numeric_literal: '100'
+                          - keyword: THEN
+                          - expression:
+                              quoted_literal: "'Level 3 - 100'"
+                        - when_clause:
+                          - keyword: WHEN
+                          - expression:
+                              numeric_literal: '200'
+                          - keyword: THEN
+                          - expression:
+                              quoted_literal: "'Level 3 - 200'"
+                        - else_clause:
+                            keyword: ELSE
+                            expression:
+                              quoted_literal: "'Level 3 - Other'"
+                        - keyword: END
+                  - when_clause:
+                    - keyword: WHEN
+                    - expression:
+                        numeric_literal: '20'
+                    - keyword: THEN
+                    - expression:
+                        quoted_literal: "'Level 2 - 20'"
+                  - else_clause:
+                      keyword: ELSE
+                      expression:
+                        quoted_literal: "'Level 2 - Other'"
+                  - keyword: END
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '2'
+              - keyword: THEN
+              - expression:
+                  case_expression:
+                  - keyword: CASE
+                  - expression:
+                      column_reference:
+                        naked_identifier: y
+                  - when_clause:
+                    - keyword: WHEN
+                    - expression:
+                        numeric_literal: '30'
+                    - keyword: THEN
+                    - expression:
+                        quoted_literal: "'Level 2 - 30'"
+                  - else_clause:
+                      keyword: ELSE
+                      expression:
+                        quoted_literal: "'Level 2 - Other'"
+                  - keyword: END
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Level 1 - Other'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: multi_level_result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '5'
+              - keyword: THEN
+              - expression:
+                  numeric_literal: '1'
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '10'
+              - keyword: THEN
+              - expression:
+                  numeric_literal: '2'
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  numeric_literal: '0'
+            - keyword: END
+            - keyword: CASE
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '5'
+              - keyword: THEN
+              - expression:
+                  numeric_literal: '1'
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: x
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '10'
+              - keyword: THEN
+              - expression:
+                  numeric_literal: '2'
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  numeric_literal: '0'
+            - keyword: END
+            - naked_identifier: my_case
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Fix Oracle dialect to parse nested CASE expressions in SELECT statements correctly.

The original issue was that Oracle's CaseExpressionSegment was not correctly handling nested CASE expressions like:

```sql
SELECT
    CASE
        WHEN x = 5 THEN
            CASE
                WHEN y = 6 THEN 999
            END
    END AS hi
FROM abc;
```

Added a comprehensive test suite with 27 test cases to ensure nested CASE expressions parse correctly.

Fixes #7074.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
