### PR TITLE
Oracle: Fix BULK COLLECT INTO parsing in SELECT statements

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -201,9 +201,11 @@ oracle_dialect.sets("unreserved_keywords").update(
         "ACCESSIBLE",
         "AUTHID",
         "BODY",
+        "BULK",
         "BULK_EXCEPTIONS",
         "BULK_ROWCOUNT",
         "BYTE",
+        "COLLECT",
         "COMPILE",
         "COMPOUND",
         "CONSTANT",
@@ -882,6 +884,7 @@ oracle_dialect.replace(
         ]
     ),
     SelectClauseTerminatorGrammar=OneOf(
+        "BULK",
         "INTO",
         "FROM",
         "WHERE",
@@ -1508,7 +1511,11 @@ class UnorderedSelectStatementSegment(ansi.UnorderedSelectStatementSegment):
         ],
     ).copy(
         insert=[
-            Ref("IntoClauseSegment", optional=True),
+            OneOf(
+                Ref("IntoClauseSegment"),
+                Ref("BulkCollectIntoClauseSegment"),
+                optional=True,
+            ),
         ],
         before=Ref("FromClauseSegment", optional=True),
     )
@@ -2876,7 +2883,9 @@ class BulkCollectIntoClauseSegment(BaseSegment):
         "BULK",
         "COLLECT",
         "INTO",
+        ImplicitIndent,
         Delimited(OneOf(Ref("SingleIdentifierGrammar"), Ref("SqlplusVariableGrammar"))),
+        Dedent,
     )
 
 

--- a/test/fixtures/dialects/oracle/bulk_collect_into.sql
+++ b/test/fixtures/dialects/oracle/bulk_collect_into.sql
@@ -1,0 +1,80 @@
+-- Test 1: Basic BULK COLLECT INTO with single column
+SELECT foobar_table.foo
+BULK COLLECT INTO selected_foo_bars
+FROM foobar_table
+WHERE foobar_table.id = foobar_table.foo_bar_id;
+
+-- Test 2: BULK COLLECT INTO with multiple columns
+SELECT
+    foobar_table.foo,
+    foobar_table.bar
+BULK COLLECT INTO selected_foo_bars, selected_bar_bars
+FROM foobar_table
+WHERE foobar_table.id = foobar_table.foo_bar_id;
+
+-- Test 3: BULK COLLECT INTO with expressions and functions
+SELECT
+    foobar_table.foo * 2,
+    UPPER(foobar_table.bar),
+    LENGTH(foobar_table.foo)
+BULK COLLECT INTO selected_foo_bars, selected_bar_bars, selected_lengths
+FROM foobar_table
+WHERE foobar_table.id = foobar_table.foo_bar_id;
+
+-- Test 4: BULK COLLECT INTO with subquery and CASE expression
+SELECT
+    (
+        SELECT MAX(id) FROM other_table
+        WHERE other_table.ref_id = foobar_table.id
+    ),
+    CASE
+        WHEN foobar_table.foo = 'A' THEN 'Alpha'
+        WHEN foobar_table.foo = 'B' THEN 'Beta'
+        ELSE 'Other'
+    END
+BULK COLLECT INTO selected_max_ids, selected_categories
+FROM foobar_table
+WHERE foobar_table.id = foobar_table.foo_bar_id;
+
+-- Test 5: BULK COLLECT INTO with DISTINCT and ORDER BY
+SELECT DISTINCT foobar_table.foo
+BULK COLLECT INTO selected_unique_foos
+FROM foobar_table
+WHERE foobar_table.id = foobar_table.foo_bar_id
+ORDER BY foobar_table.foo;
+
+-- Test 6: BULK COLLECT INTO with window functions and aggregates
+SELECT
+    foobar_table.foo,
+    ROW_NUMBER() OVER (ORDER BY foobar_table.foo) AS row_num,
+    AVG(foobar_table.value) OVER (PARTITION BY foobar_table.category)
+BULK COLLECT INTO selected_foo_bars, selected_row_nums, selected_avgs
+FROM foobar_table
+WHERE foobar_table.id = foobar_table.foo_bar_id;
+
+-- Test 7: BULK COLLECT INTO with date and string functions
+SELECT
+    foobar_table.foo,
+    SYSDATE,
+    CONCAT(foobar_table.foo, '_suffix'),
+    SUBSTR(foobar_table.foo, 1, 3)
+BULK COLLECT INTO
+    selected_foos,
+    selected_sysdates,
+    selected_concat,
+    selected_substr
+FROM foobar_table
+WHERE foobar_table.id = foobar_table.foo_bar_id;
+
+-- Test 8: BULK COLLECT INTO with conditional logic and complex expressions
+SELECT
+    foobar_table.foo,
+    CASE
+        WHEN foobar_table.value > 100 THEN 'High'
+        WHEN foobar_table.value > 50 THEN 'Medium'
+        ELSE 'Low'
+    END AS value_category,
+    foobar_table.value * 1.1
+BULK COLLECT INTO selected_foos, selected_categories, selected_values
+FROM foobar_table
+WHERE foobar_table.id = foobar_table.foo_bar_id;

--- a/test/fixtures/dialects/oracle/bulk_collect_into.yml
+++ b/test/fixtures/dialects/oracle/bulk_collect_into.yml
@@ -1,0 +1,569 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 928bef33af267bfcc67afc5abc899f007347b774f34a9b6fecbf4f30007792d3
+file:
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: foo
+      bulk_collect_into_clause:
+      - keyword: BULK
+      - keyword: COLLECT
+      - keyword: INTO
+      - naked_identifier: selected_foo_bars
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foobar_table
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: foo_bar_id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: foo
+      - comma: ','
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: bar
+      bulk_collect_into_clause:
+      - keyword: BULK
+      - keyword: COLLECT
+      - keyword: INTO
+      - naked_identifier: selected_foo_bars
+      - comma: ','
+      - naked_identifier: selected_bar_bars
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foobar_table
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: foo_bar_id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+            column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: foo
+            binary_operator: '*'
+            numeric_literal: '2'
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: UPPER
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                  - naked_identifier: foobar_table
+                  - dot: .
+                  - naked_identifier: bar
+                end_bracket: )
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: LENGTH
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                  - naked_identifier: foobar_table
+                  - dot: .
+                  - naked_identifier: foo
+                end_bracket: )
+      bulk_collect_into_clause:
+      - keyword: BULK
+      - keyword: COLLECT
+      - keyword: INTO
+      - naked_identifier: selected_foo_bars
+      - comma: ','
+      - naked_identifier: selected_bar_bars
+      - comma: ','
+      - naked_identifier: selected_lengths
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foobar_table
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: foo_bar_id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          expression:
+            bracketed:
+              start_bracket: (
+              expression:
+                select_statement:
+                  select_clause:
+                    keyword: SELECT
+                    select_clause_element:
+                      function:
+                        function_name:
+                          function_name_identifier: MAX
+                        function_contents:
+                          bracketed:
+                            start_bracket: (
+                            expression:
+                              column_reference:
+                                naked_identifier: id
+                            end_bracket: )
+                  from_clause:
+                    keyword: FROM
+                    from_expression:
+                      from_expression_element:
+                        table_expression:
+                          table_reference:
+                            naked_identifier: other_table
+                  where_clause:
+                    keyword: WHERE
+                    expression:
+                    - column_reference:
+                      - naked_identifier: other_table
+                      - dot: .
+                      - naked_identifier: ref_id
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - column_reference:
+                      - naked_identifier: foobar_table
+                      - dot: .
+                      - naked_identifier: id
+              end_bracket: )
+      - comma: ','
+      - select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                  - naked_identifier: foobar_table
+                  - dot: .
+                  - naked_identifier: foo
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  quoted_literal: "'A'"
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Alpha'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                  - naked_identifier: foobar_table
+                  - dot: .
+                  - naked_identifier: foo
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  quoted_literal: "'B'"
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Beta'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Other'"
+            - keyword: END
+      bulk_collect_into_clause:
+      - keyword: BULK
+      - keyword: COLLECT
+      - keyword: INTO
+      - naked_identifier: selected_max_ids
+      - comma: ','
+      - naked_identifier: selected_categories
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foobar_table
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: foo_bar_id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_modifier:
+          keyword: DISTINCT
+        select_clause_element:
+          column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: foo
+      bulk_collect_into_clause:
+      - keyword: BULK
+      - keyword: COLLECT
+      - keyword: INTO
+      - naked_identifier: selected_unique_foos
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foobar_table
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: foo_bar_id
+      orderby_clause:
+      - keyword: ORDER
+      - keyword: BY
+      - column_reference:
+        - naked_identifier: foobar_table
+        - dot: .
+        - naked_identifier: foo
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: foo
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: ROW_NUMBER
+            function_contents:
+              bracketed:
+                start_bracket: (
+                end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  orderby_clause:
+                  - keyword: ORDER
+                  - keyword: BY
+                  - column_reference:
+                    - naked_identifier: foobar_table
+                    - dot: .
+                    - naked_identifier: foo
+                end_bracket: )
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: row_num
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: AVG
+            function_contents:
+              bracketed:
+                start_bracket: (
+                expression:
+                  column_reference:
+                  - naked_identifier: foobar_table
+                  - dot: .
+                  - naked_identifier: value
+                end_bracket: )
+            over_clause:
+              keyword: OVER
+              bracketed:
+                start_bracket: (
+                window_specification:
+                  partitionby_clause:
+                  - keyword: PARTITION
+                  - keyword: BY
+                  - expression:
+                      column_reference:
+                      - naked_identifier: foobar_table
+                      - dot: .
+                      - naked_identifier: category
+                end_bracket: )
+      bulk_collect_into_clause:
+      - keyword: BULK
+      - keyword: COLLECT
+      - keyword: INTO
+      - naked_identifier: selected_foo_bars
+      - comma: ','
+      - naked_identifier: selected_row_nums
+      - comma: ','
+      - naked_identifier: selected_avgs
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foobar_table
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: foo_bar_id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: foo
+      - comma: ','
+      - select_clause_element:
+          bare_function: SYSDATE
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: CONCAT
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                  - naked_identifier: foobar_table
+                  - dot: .
+                  - naked_identifier: foo
+              - comma: ','
+              - expression:
+                  quoted_literal: "'_suffix'"
+              - end_bracket: )
+      - comma: ','
+      - select_clause_element:
+          function:
+            function_name:
+              function_name_identifier: SUBSTR
+            function_contents:
+              bracketed:
+              - start_bracket: (
+              - expression:
+                  column_reference:
+                  - naked_identifier: foobar_table
+                  - dot: .
+                  - naked_identifier: foo
+              - comma: ','
+              - expression:
+                  numeric_literal: '1'
+              - comma: ','
+              - expression:
+                  numeric_literal: '3'
+              - end_bracket: )
+      bulk_collect_into_clause:
+      - keyword: BULK
+      - keyword: COLLECT
+      - keyword: INTO
+      - naked_identifier: selected_foos
+      - comma: ','
+      - naked_identifier: selected_sysdates
+      - comma: ','
+      - naked_identifier: selected_concat
+      - comma: ','
+      - naked_identifier: selected_substr
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foobar_table
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: foo_bar_id
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+      - keyword: SELECT
+      - select_clause_element:
+          column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: foo
+      - comma: ','
+      - select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                  - naked_identifier: foobar_table
+                  - dot: .
+                  - naked_identifier: value
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  numeric_literal: '100'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'High'"
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                  - naked_identifier: foobar_table
+                  - dot: .
+                  - naked_identifier: value
+                  comparison_operator:
+                    raw_comparison_operator: '>'
+                  numeric_literal: '50'
+              - keyword: THEN
+              - expression:
+                  quoted_literal: "'Medium'"
+            - else_clause:
+                keyword: ELSE
+                expression:
+                  quoted_literal: "'Low'"
+            - keyword: END
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: value_category
+      - comma: ','
+      - select_clause_element:
+          expression:
+            column_reference:
+            - naked_identifier: foobar_table
+            - dot: .
+            - naked_identifier: value
+            binary_operator: '*'
+            numeric_literal: '1.1'
+      bulk_collect_into_clause:
+      - keyword: BULK
+      - keyword: COLLECT
+      - keyword: INTO
+      - naked_identifier: selected_foos
+      - comma: ','
+      - naked_identifier: selected_categories
+      - comma: ','
+      - naked_identifier: selected_values
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: foobar_table
+      where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: id
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - column_reference:
+          - naked_identifier: foobar_table
+          - dot: .
+          - naked_identifier: foo_bar_id
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made
Allow the parser to recognize `BULK COLLECT INTO` as a valid clause after the SELECT list.

Fixes #7073.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
