### PR TITLE
Cancel outdated CI builds to save resources

### DIFF
--- a/.github/workflows/ci-test-dbt.yml
+++ b/.github/workflows/ci-test-dbt.yml
@@ -28,6 +28,10 @@ on:
       gh_token:
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.python-version }}-${{ inputs.dbt-version }}-${{ inputs.coverage }}
+  cancel-in-progress: true
+
 jobs:
   modular-python-test:
     name: py${{ inputs.python-version }}-${{ inputs.dbt-version }}

--- a/.github/workflows/ci-test-python.yml
+++ b/.github/workflows/ci-test-python.yml
@@ -29,6 +29,10 @@ on:
       gh_token:
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.python-version }}-${{ inputs.marks }}-${{ inputs.coverage }}
+  cancel-in-progress: true
+
 jobs:
   modular-python-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -26,6 +26,10 @@ on:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
     types: [checks_requested]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   linting:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,6 +3,11 @@ name: pre-commit
 on:
   pull_request:
   push:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Brief summary of the change made
This PR enforces the cancellation of outdated in-progress workflow runs as soon as new commits are pushed to the same branch, thereby optimizing resource usage.

Closes #7079.

### Are there any other side effects of this change that we should be aware of?
No.

### Pull Request checklist
- [X] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
