### PR TITLE
Postgres: Fix dialect to allow CTEs in COPY

### DIFF
--- a/src/sqlfluff/dialects/dialect_postgres.py
+++ b/src/sqlfluff/dialects/dialect_postgres.py
@@ -5795,9 +5795,7 @@ class CopyStatementSegment(BaseSegment):
                 _postgres9_compatible_stdin_options,
             ),
             Sequence(
-                OneOf(
-                    _table_definition, Bracketed(Ref("UnorderedSelectStatementSegment"))
-                ),
+                OneOf(_table_definition, Bracketed(Ref("SelectableGrammar"))),
                 "TO",
                 OneOf(
                     _target_subset,
@@ -5806,9 +5804,7 @@ class CopyStatementSegment(BaseSegment):
                 _option,
             ),
             Sequence(
-                OneOf(
-                    _table_definition, Bracketed(Ref("UnorderedSelectStatementSegment"))
-                ),
+                OneOf(_table_definition, Bracketed(Ref("SelectableGrammar"))),
                 "TO",
                 OneOf(
                     Ref("QuotedLiteralSegment"),

--- a/test/fixtures/dialects/postgres/copy.sql
+++ b/test/fixtures/dialects/postgres/copy.sql
@@ -8,6 +8,7 @@ COPY (Select * From my_table) TO '/tmp/dump.csv' WITH (FORMAT csv, ESCAPE '\', F
 COPY (Select * From my_table) TO '/tmp/dump.csv' WITH (FORMAT csv, ESCAPE '\', FORCE_NULL (col1, col2), FREEZE false);
 COPY (Select * From my_table) TO STDOUT WITH (FORMAT csv, ESCAPE '\', FORCE_NULL (col1, col2), FREEZE true);
 COPY (Select * From my_table) TO PROGRAM '/path/to/script' WITH (FORMAT csv, ESCAPE '\', FORCE_NULL (col1, col2), FREEZE false);
+COPY (WITH c AS (SELECT 1::int AS id) SELECT id FROM c) TO STDOUT WITH (FORMAT csv, HEADER);
 COPY my_table(col) TO '/tmp/dump.csv';
 COPY my_table TO '/tmp/dump.csv' WITH (FORMAT csv, HEADER true, FREEZE true, FORCE_NULL (col1, col2));
 COPY my_table(col1, col2) TO '/tmp/dump.csv' WITH (FORMAT csv, HEADER true);

--- a/test/fixtures/dialects/postgres/copy.yml
+++ b/test/fixtures/dialects/postgres/copy.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 4b115542ab2c94e730d6366b2cd172e0e8f7802ebe34ee63239b86b3346e1e96
+_hash: 7183a7dc7491c71f71cee5e900729ff0c5f0d5eb9d01884c0b76be0b066ad37c
 file:
 - statement:
     copy_statement:
@@ -369,6 +369,58 @@ file:
       - comma: ','
       - keyword: FREEZE
       - boolean_literal: 'false'
+      - end_bracket: )
+- statement_terminator: ;
+- statement:
+    copy_statement:
+    - keyword: COPY
+    - bracketed:
+        start_bracket: (
+        with_compound_statement:
+          keyword: WITH
+          common_table_expression:
+            naked_identifier: c
+            keyword: AS
+            bracketed:
+              start_bracket: (
+              select_statement:
+                select_clause:
+                  keyword: SELECT
+                  select_clause_element:
+                    expression:
+                      cast_expression:
+                        numeric_literal: '1'
+                        casting_operator: '::'
+                        data_type:
+                          keyword: int
+                    alias_expression:
+                      alias_operator:
+                        keyword: AS
+                      naked_identifier: id
+              end_bracket: )
+          select_statement:
+            select_clause:
+              keyword: SELECT
+              select_clause_element:
+                column_reference:
+                  naked_identifier: id
+            from_clause:
+              keyword: FROM
+              from_expression:
+                from_expression_element:
+                  table_expression:
+                    table_reference:
+                      naked_identifier: c
+        end_bracket: )
+    - keyword: TO
+    - keyword: STDOUT
+    - keyword: WITH
+    - bracketed:
+      - start_bracket: (
+      - keyword: FORMAT
+      - naked_identifier: csv
+      - comma: ','
+      - keyword: HEADER
       - end_bracket: )
 - statement_terminator: ;
 - statement:


### PR DESCRIPTION

<!--Thanks for contributing!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Fixes #7083

Fix Postgres parsing of `COPY (query) TO ...` where `query` includes a CTE (`WITH`). I just had t  update the bracketed query for the `TO` forms from `UnorderedSelectStatementSegment` to `SelectableGrammar` to enable CTEs inside `COPY (query)` per Postgres syntax.

### Are there any other side effects of this change that we should be aware of?
The scope limited to Postgres dialect `COPY (query) TO ...` parsing, and using `SelectableGrammar` allows any valid selectable (including `WITH`) in the bracketed query, which matches [Postgres behavior](https://www.postgresql.org/docs/16/sql-copy.html). `COPY FROM ...` is unaffected.

### Pull Request checklist
- [x] Included test cases to demonstrate the code changes
- [x] No documentation changes required (behavior now matches spec)
- [x] No follow-up issues required
