### PR TITLE
LT01: Fix alias alignment with templates

### DIFF
--- a/docs/source/configuration/layout.rst
+++ b/docs/source/configuration/layout.rst
@@ -192,14 +192,26 @@ up visually in the editor, regardless of the rendered length of
 Advanced: coordinate space override
 -----------------------------------
 
-You can optionally force the coordinate space via the alignment constraint by
-adding a final modifier to the align value (available for spacing_before and
-spacing_after):
+You can optionally force the coordinate space either:
+
+1) via the alignment constraint suffix (available for `spacing_before` and
+   `spacing_after`), or
+2) via the `alignment_coordinate_space` key in layout config for the target type.
 
 .. code-block:: ini
 
    [sqlfluff:layout:type:alias_expression]
    spacing_before = align:alias_expression:select_clause:bracketed:source
+
+Alternatively, the equivalent can be configured more declaratively:
+
+.. code-block:: ini
+
+   [sqlfluff:layout:type:alias_expression]
+   spacing_before = align
+   align_within = select_clause
+   align_scope = bracketed
+   alignment_coordinate_space = source
 
 Supported values are ``source`` and ``templated``. In most cases, ``source`` is
 the recommended choice for readability.

--- a/docs/source/configuration/layout.rst
+++ b/docs/source/configuration/layout.rst
@@ -167,6 +167,43 @@ the least obvious. The following example illustrates the impact it has.
    --    align_scope = file
    --    align_within = statement
 
+Templating and alignment coordinate space
+-----------------------------------------
+
+When using templating (e.g. Jinja), alignment is for human readability and
+stable diffs. SQLFluff aligns based on the source (visible) positions whenever
+templated (non-literal) segments are involved in the alignment scope. This
+prevents excessive padding caused by the rendered output being longer than the
+source template. If all segments are literal (non-templated), alignment uses
+the regular templated working positions.
+
+Example (Jinja templating, align alias expressions within a select clause):
+
+.. code-block:: sql
+
+    select
+        {{ "longtemplated" }} as test_key,
+        b                     as b_col
+
+The alignment above is computed against the source text so that both lines line
+up visually in the editor, regardless of the rendered length of
+``{{ "longtemplated" }}``.
+
+Advanced: coordinate space override
+-----------------------------------
+
+You can optionally force the coordinate space via the alignment constraint by
+adding a final modifier to the align value (available for spacing_before and
+spacing_after):
+
+.. code-block:: ini
+
+   [sqlfluff:layout:type:alias_expression]
+   spacing_before = align:alias_expression:select_clause:bracketed:source
+
+Supported values are ``source`` and ``templated``. In most cases, ``source`` is
+the recommended choice for readability.
+
    WITH foo as (
       SELECT
          a,

--- a/src/sqlfluff/utils/reflow/config.py
+++ b/src/sqlfluff/utils/reflow/config.py
@@ -99,6 +99,11 @@ class ReflowConfig:
                         new_key += ":" + config_dict[seg_type]["align_within"]
                         if config_dict[seg_type].get("align_scope", None):
                             new_key += ":" + config_dict[seg_type]["align_scope"]
+                    # Optional coordinate space override
+                    if config_dict[seg_type].get("alignment_coordinate_space", None):
+                        new_key += ":" + config_dict[seg_type][
+                            "alignment_coordinate_space"
+                        ]
                     config_dict[seg_type][key] = new_key
         return cls(_config_dict=config_dict, config_types=config_types, **kwargs)
 

--- a/src/sqlfluff/utils/reflow/config.py
+++ b/src/sqlfluff/utils/reflow/config.py
@@ -101,9 +101,9 @@ class ReflowConfig:
                             new_key += ":" + config_dict[seg_type]["align_scope"]
                     # Optional coordinate space override
                     if config_dict[seg_type].get("alignment_coordinate_space", None):
-                        new_key += ":" + config_dict[seg_type][
-                            "alignment_coordinate_space"
-                        ]
+                        new_key += (
+                            ":" + config_dict[seg_type]["alignment_coordinate_space"]
+                        )
                     config_dict[seg_type][key] = new_key
         return cls(_config_dict=config_dict, config_types=config_types, **kwargs)
 

--- a/src/sqlfluff/utils/reflow/respace.py
+++ b/src/sqlfluff/utils/reflow/respace.py
@@ -28,6 +28,7 @@ reflow_logger = logging.getLogger("sqlfluff.rules.reflow")
 # Small helper functions
 # ---------------------------
 
+
 def _pos_line(pm: PositionMarker, use_source: bool) -> int:
     """Return the line number in the chosen coordinate space."""
     return pm.line_no if use_source else pm.working_line_no
@@ -38,10 +39,10 @@ def _pos_col(pm: PositionMarker, use_source: bool) -> int:
     return pm.line_pos if use_source else pm.working_line_pos
 
 
-def _should_align_by_source(
+def _has_templated_content(
     parent_segment: BaseSegment, siblings: list[BaseSegment], next_seg: RawSegment
 ) -> bool:
-    """Decide whether to align by source rather than templated coordinates.
+    """Check if any participating segments contain templated content.
 
     Returns True if any of the participating segments are non-literal (templated)
     or if any code tokens in the alignment parent are non-literal.
@@ -54,7 +55,8 @@ def _should_align_by_source(
         for rs in parent_segment.raw_segments:
             if rs.is_code and rs.pos_marker and not rs.pos_marker.is_literal():
                 return True
-    except Exception:  # pragma: no cover
+    except AttributeError:  # pragma: no cover
+        # Handle missing pos_marker attributes gracefully
         return False
     return False
 
@@ -68,8 +70,11 @@ def _group_siblings_by_line(
         _pos = sibling.pos_marker
         assert _pos
         grouped[_pos_line(_pos, use_source)].append(sibling)
+    # Sort each line's segments by column position in the chosen coordinate space
     for line_siblings in grouped.values():
-        line_siblings.sort(key=lambda s: cast(PositionMarker, s.pos_marker))
+        line_siblings.sort(
+            key=lambda s: _pos_col(cast(PositionMarker, s.pos_marker), use_source)
+        )
     return grouped
 
 
@@ -249,13 +254,28 @@ def _determine_aligned_inline_spacing(
     align_scope: Optional[str],
     align_space: Optional[str],
 ) -> str:
-    """Work out spacing for instance of an `align` constraint."""
-    # Find the level of segment that we're aligning.
-    # NOTE: Reverse slice
-    parent_segment = None
+    """Work out spacing for instance of an `align` constraint.
 
-    # Edge case: if next_seg has no position, we should use the position
-    # of the whitespace for searching.
+    Args:
+        root_segment: The root segment to search within.
+        whitespace_seg: The whitespace segment being modified.
+        next_seg: The segment immediately following the whitespace.
+        next_pos: Position marker for the next segment.
+        segment_type: Type of segments to align (e.g., 'alias_expression').
+        align_within: Parent segment type to limit alignment scope.
+        align_scope: Further scope limitation (e.g., 'bracketed').
+        align_space: Coordinate space override ('source', 'templated', or None).
+
+    Returns:
+        A string of spaces to achieve proper alignment.
+
+    Note:
+        When align_space is None, automatically chooses 'source' coordinates if
+        templated content is detected, otherwise uses 'templated' coordinates.
+        See https://github.com/sqlfluff/sqlfluff/issues/5429 for rationale.
+    """
+    # Find the parent segment within which we're aligning
+    parent_segment = None
     if align_within:
         for ps in root_segment.path_to(
             next_seg if next_seg.pos_marker else whitespace_seg
@@ -284,41 +304,56 @@ def _determine_aligned_inline_spacing(
                 sibling,
             )
 
-    # If the segment we're aligning, has position. Use that position.
-    # If it doesn't, then use the provided one. We can't do sibling analysis without it.
+    # Use the segment's position marker if available, fallback to provided position
     if next_seg.pos_marker:
         next_pos = next_seg.pos_marker
 
-    # Decide whether to align using templated positions (default) or source
-    # positions. See https://github.com/sqlfluff/sqlfluff/issues/5429.
+    # Choose coordinate space: source (visible) vs templated (rendered)
     if align_space == "source":
         use_source_positions = True
     elif align_space == "templated":
         use_source_positions = False
     else:
-        use_source_positions = _should_align_by_source(parent_segment, siblings, next_seg)
-    reflow_logger.debug("    Alignment coordinate space: %s", "source" if use_source_positions else "templated")
+        use_source_positions = _has_templated_content(
+            parent_segment, siblings, next_seg
+        )
+    reflow_logger.debug(
+        "    Alignment coordinate space: %s",
+        "source" if use_source_positions else "templated",
+    )
 
     # Group siblings by line using the chosen coordinate space
     siblings_by_line = _group_siblings_by_line(siblings, use_source_positions)
 
-    # Sort all segments by position to easily access index information
-    for line_siblings in siblings_by_line.values():
-        line_siblings.sort(
-            key=lambda s: cast(PositionMarker, s.pos_marker).working_line_pos
-        )
-
     # Identify the alignment column index for the current line
     current_line_key = _pos_line(next_pos, use_source_positions)
-    current_line_segments = siblings_by_line[current_line_key]
-    target_index = next(
-        idx
-        for idx, segment in enumerate(current_line_segments)
-        if (
-            _pos_col(cast(PositionMarker, segment.pos_marker), use_source_positions)
-            == _pos_col(next_pos, use_source_positions)
+    current_line_segments = siblings_by_line.get(current_line_key, [])
+
+    # Handle edge case where no segments are found on the current line
+    if not current_line_segments:
+        reflow_logger.debug(
+            "    No segments found on current line for alignment. Treat as single."
         )
+        return " "
+
+    target_index = next(
+        (
+            idx
+            for idx, segment in enumerate(current_line_segments)
+            if (
+                _pos_col(cast(PositionMarker, segment.pos_marker), use_source_positions)
+                == _pos_col(next_pos, use_source_positions)
+            )
+        ),
+        None,  # Default value if no match found
     )
+
+    # Handle case where target segment is not found
+    if target_index is None:
+        reflow_logger.debug(
+            "    Target segment not found in current line. Treat as single."
+        )
+        return " "
 
     # Now that we know the target index, we can extract the relevant segment from
     # all lines
@@ -355,7 +390,7 @@ def _determine_aligned_inline_spacing(
             ):
                 if use_source_positions:
                     end_pm = last_code.pos_marker.end_point_marker()
-                    loc = (end_pm.line_no, end_pm.line_pos)
+                    loc = (_pos_line(end_pm, True), _pos_col(end_pm, True))
                 else:
                     loc = last_code.pos_marker.working_loc_after(last_code.raw)
                 reflow_logger.debug(
@@ -369,9 +404,12 @@ def _determine_aligned_inline_spacing(
         if seg.is_code:
             last_code = seg
 
-    # Compute desired whitespace size in the chosen coordinate space
+    # Compute desired whitespace size in the chosen coordinate space.
+    # Ensure we always return at least a single space to avoid deleting
+    # whitespace when the current position already exceeds the target.
     current_ws_pos = _pos_col(whitespace_seg.pos_marker, use_source_positions)
-    desired_space = " " * (1 + max_desired_line_pos - current_ws_pos)
+    pad_width = max(1, 1 + max_desired_line_pos - current_ws_pos)
+    desired_space = " " * pad_width
     reflow_logger.debug(
         "    desired_space: %r (based on max line pos of %s)",
         desired_space,
@@ -385,14 +423,24 @@ def _extract_alignment_config(
 ) -> tuple[str, Optional[str], Optional[str], Optional[str]]:
     """Helper function to break apart an alignment config.
 
+    Returns:
+        Tuple of (segment_type, align_within, align_scope, align_space)
+
+        - segment_type: The type of segments to align
+        - align_within: Parent segment type to limit alignment scope
+        - align_scope: Further scope limitation (e.g., 'bracketed')
+        - align_space: Coordinate space ('source', 'templated', or None)
+
     >>> _extract_alignment_config("align:alias_expression")
     ('alias_expression', None, None, None)
     >>> _extract_alignment_config("align:alias_expression:statement")
     ('alias_expression', 'statement', None, None)
     >>> _extract_alignment_config("align:alias_expression:statement:bracketed")
     ('alias_expression', 'statement', 'bracketed', None)
-    >>> _extract_alignment_config("align:alias_expression:select_clause:bracketed:source")
+    >>> _extract_alignment_config("align:alias_expression:select_clause:bracketed:source")  # noqa: E501
     ('alias_expression', 'select_clause', 'bracketed', 'source')
+    >>> _extract_alignment_config("align:alias_expression:select_clause:bracketed:templated")  # noqa: E501
+    ('alias_expression', 'select_clause', 'bracketed', 'templated')
     """
     assert ":" in constraint
     alignment_config = constraint.split(":")
@@ -469,8 +517,8 @@ def handle_respace__inline_with_space(
     ) or pre_constraint == post_constraint == "single":
         # Determine the desired spacing, either as alignment or as a single.
         if post_constraint.startswith("align") and next_block:
-            seg_type, align_within, align_scope, align_space = _extract_alignment_config(
-                post_constraint
+            seg_type, align_within, align_scope, align_space = (
+                _extract_alignment_config(post_constraint)
             )
 
             next_pos: Optional[PositionMarker]

--- a/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
@@ -387,3 +387,25 @@ test_align_multiple_operators:
         binary_operator:
           spacing_before: align
           align_within: select_statement
+
+test_align_alias_with_jinja_source_positions:
+  # Alignment should respect source (visible) positions when templated content exists
+  # before the alias. The second line should align 'as' to the first, without
+  # padding to the length of the rendered template.
+  fail_str: |
+    select
+        {{ "longtemplated" }} as test_key,
+        b as b_col
+  fix_str: |
+    select
+        {{ "longtemplated" }} as test_key,
+        b                     as b_col
+  configs:
+    core:
+      templater: jinja
+    layout:
+      type:
+        alias_expression:
+          spacing_before: align
+          align_within: select_clause
+          align_scope: bracketed

--- a/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
@@ -409,3 +409,68 @@ test_align_alias_with_jinja_source_positions:
           spacing_before: align
           align_within: select_clause
           align_scope: bracketed
+
+test_align_alias_with_jinja_both_lines_templated:
+  # Both lines have templated content before the alias. Alignment should
+  # still respect source (visible) positions.
+  fail_str: |
+    select
+        {{ "templ_1" }} as a,
+        {{ "t2" }} as bb
+  fix_str: |
+    select
+        {{ "templ_1" }} as a,
+        {{ "t2" }}      as bb
+  configs:
+    core:
+      templater: jinja
+    layout:
+      type:
+        alias_expression:
+          spacing_before: align
+          align_within: select_clause
+          align_scope: bracketed
+
+test_align_alias_with_jinja_statement_scope:
+  # Alignment across a wider scope (select_statement) still uses source positions.
+  fail_str: |
+    select
+        {{ "xxx" }} as a,
+        col as b,
+        {{ "yyyyy" }} as c
+    from t
+  fix_str: |
+    select
+        {{ "xxx" }}   as a,
+        col           as b,
+        {{ "yyyyy" }} as c
+    from t
+  configs:
+    core:
+      templater: jinja
+    layout:
+      type:
+        alias_expression:
+          spacing_before: align
+          align_within: select_statement
+          align_scope: bracketed
+
+test_align_alias_with_jinja_force_templated_space:
+  # Force templated coordinate space via config override to ensure it is respected.
+  fail_str: |
+    select
+        {{ "templ" }} as a,
+        b as bb
+  # If we force templated, alignment should pad based on rendered lengths.
+  fix_str: |
+    select
+        {{ "templ" }} as a,
+        b            as bb
+  configs:
+    core:
+      templater: jinja
+    layout:
+      type:
+        alias_expression:
+          # Force templated coordinate space via align suffix
+          spacing_before: align:alias_expression:select_clause:bracketed:templated

--- a/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
+++ b/test/fixtures/rules/std_rule_cases/LT01-alignment.yml
@@ -465,7 +465,7 @@ test_align_alias_with_jinja_force_templated_space:
   fix_str: |
     select
         {{ "templ" }} as a,
-        b            as bb
+        b     as bb
   configs:
     core:
       templater: jinja

--- a/test/rules/std_LT01_jinja_alignment_test.py
+++ b/test/rules/std_LT01_jinja_alignment_test.py
@@ -1,0 +1,60 @@
+"""Tests for LT01 alias alignment with Jinja templating.
+
+This ensures alignment uses source positions when templated content is present
+so that alignment reflects what the user sees in the editor.
+"""
+
+from __future__ import annotations
+
+from sqlfluff.core.config import FluffConfig
+import sqlfluff
+
+
+def _count_lt01(results: list[dict]) -> int:
+    return sum(1 for r in results if r.get("code") == "LT01")
+
+
+def test_lt01_alias_alignment_with_jinja_uses_source_positions() -> None:
+    """Jinja before alias should not cause excessive padding (align by source)."""
+    sql = (
+        "select\n"
+        "    {{ generate_surrogate_key('test', ['a', 'b', 'c']) }} as test_key,\n"
+        "    b as b_col\n"
+        "from {{ ref('test') }}\n"
+    )
+
+    # First lint should report LT01 (spacing around select + alias alignment).
+    cfg = FluffConfig.from_kwargs(dialect="ansi")
+    # Inject settings not supported by from_kwargs via child config and update
+    cfg._configs["core"]["templater"] = "jinja"
+    cfg._configs.setdefault("layout", {}).setdefault("type", {}).setdefault(
+        "alias_expression", {}
+    ).update(
+        {
+            "spacing_before": "align",
+            "align_within": "select_clause",
+            "align_scope": "bracketed",
+        }
+    )
+    initial_results = sqlfluff.lint(sql, config=cfg, rules=["LT01"])
+    assert _count_lt01(initial_results) >= 1
+
+    # Apply fixes.
+    fixed = sqlfluff.fix(sql, config=cfg, rules=["LT01"])
+
+    # After fixing, there should be no LT01 violations.
+    post_results = sqlfluff.lint(fixed, config=cfg, rules=["LT01"])
+    assert _count_lt01(post_results) == 0
+
+    # Sanity: alignment should be reasonable. Check that both lines contain ' as '.
+    lines = fixed.splitlines()
+    assert any(" as " in line for line in lines)
+
+    # Find the two select lines and verify the 'as' columns align by source index.
+    select_lines = [l for l in lines if " as " in l]
+    assert len(select_lines) >= 2
+    first_as_col = select_lines[0].index(" as ")
+    second_as_col = select_lines[1].index(" as ")
+    assert first_as_col == second_as_col
+
+


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
Fixes alias alignment when using Jinja templating by automatically using source coordinate space when templated content is detected. This prevents excessive padding caused by long rendered templates while maintaining visual alignment in the editor.

Fixes #5429


### Problem
When using Jinja templates, alias alignment would:
- Generate false LT01 violations for visually aligned aliases  
- Apply excessive padding based on rendered macro length instead of visible template text
- Create unreadable code with aliases pushed far to the right

### Solution
Automatically detects templated content and switches to source-based alignment, ensuring aliases align based on what users see in their editor. Adds optional `alignment_coordinate_space` config for manual override.

### Examples

**Before (broken behavior):**
```sql
select
    {{ "longtemplated" }} as test_key,
    b as b_col  -- LT01 error despite visual alignment
```

After running `sqlfluff fix`, the old behavior would produce excessive padding:
```sql
select
    {{ generate_surrogate_key('test', ['a', 'b', 'c']) }} as test_key,
    b                                                                                                                                        as b_col  -- Excessive padding based on macro expansion
from {{ ref("test") }}
```

**After (fixed behavior):**
```sql
select
    {{ "longtemplated" }} as test_key,
    b                     as b_col  -- Properly aligned to visible template positions
```

### Are there any other side effects of this change that we should be aware of?
- **Backward compatible**: Existing behavior preserved for non-templated content
- **Transparent**: Automatic detection requires no user configuration  
- **Configurable**: New `alignment_coordinate_space` option for manual override
- **Scope**: Only affects alignment when templated content is detected

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases/LT01-alignment.yml`.
  - [x] Other: Integration tests in `test/rules/std_LT01_jinja_alignment_test.py`.
- [x] Added appropriate documentation for the change in `docs/source/configuration/layout.rst`.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>