### PR TITLE
feat(parser): Add support for T-SQL binary constants

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -390,10 +390,10 @@ tsql_dialect.add(
     # Here we add a special case for a DotSegment where we don't want to apply
     # LT01's respace rule.
     LeadingDotSegment=StringParser(".", SymbolSegment, type="leading_dot"),
-    HexadecimalLiteralSegment=RegexParser(
-        r"([xX]'([\da-fA-F][\da-fA-F])+'|0x[\da-fA-F]+)",
+    TsqlHexadecimalLiteralSegment=RegexParser(
+        r"(0x[\da-fA-F]*)",
         LiteralSegment,
-        type="numeric_literal",
+        type="binary_literal",
     ),
     PlusComparisonSegment=StringParser(
         "+", SymbolSegment, type="raw_comparison_operator"
@@ -455,6 +455,7 @@ tsql_dialect.replace(
     LiteralGrammar=ansi_dialect.get_grammar("LiteralGrammar")
     .copy(
         insert=[
+            Ref("TsqlHexadecimalLiteralSegment"),
             Ref("QuotedLiteralSegmentWithN"),
         ],
         before=Ref("NumericLiteralSegment"),

--- a/test/fixtures/dialects/tsql/binary_constant.sql
+++ b/test/fixtures/dialects/tsql/binary_constant.sql
@@ -1,0 +1,8 @@
+SELECT 0x0;
+SELECT 0x;
+SELECT 0xAE;
+SELECT 0x12Ef;
+SELECT 0x69048AEFDD010E;
+
+DECLARE @bin varbinary(1) = 0x0;
+SELECT CAST(0x0 as uniqueidentifier);

--- a/test/fixtures/dialects/tsql/binary_constant.yml
+++ b/test/fixtures/dialects/tsql/binary_constant.yml
@@ -1,0 +1,78 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: a11d4ea601181da712cb9b2bd24ec685cc5a737ca561ec82262371b0fcc17fc6
+file:
+  batch:
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            binary_literal: '0x0'
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            binary_literal: 0x
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            binary_literal: '0xAE'
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            binary_literal: '0x12Ef'
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            binary_literal: '0x69048AEFDD010E'
+        statement_terminator: ;
+  - statement:
+      declare_segment:
+        keyword: DECLARE
+        parameter: '@bin'
+        data_type:
+          data_type_identifier: varbinary
+          bracketed_arguments:
+            bracketed:
+              start_bracket: (
+              expression:
+                numeric_literal: '1'
+              end_bracket: )
+        comparison_operator:
+          raw_comparison_operator: '='
+        expression:
+          binary_literal: '0x0'
+        statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            function:
+              function_name:
+                keyword: CAST
+              function_contents:
+                bracketed:
+                  start_bracket: (
+                  expression:
+                    binary_literal: '0x0'
+                  keyword: as
+                  data_type:
+                    data_type_identifier: uniqueidentifier
+                  end_bracket: )
+        statement_terminator: ;


### PR DESCRIPTION
This change adds support for T-SQL binary constants, such as `0x0` and the empty binary string `0x`.

A new `TsqlHexadecimalLiteralSegment` is introduced to handle the T-SQL specific binary constant syntax, which allows for zero or more hexadecimal characters. This segment is then added to the `LiteralGrammar` for the T-SQL dialect.

A comprehensive set of test cases has been added to verify that binary constants are parsed correctly in various contexts, including `SELECT` statements, variable declarations, and function arguments.


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->


### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
