### PR TITLE
Support brackets in CASE statement condition

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -2520,7 +2520,7 @@ class CaseExpressionSegment(BaseSegment):
             "CASE",
             ImplicitIndent,
             AnyNumberOf(
-                Ref("WhenClauseSegment"),
+                Ref("WhenClauseSegment", terminators=[Ref.keyword("WHEN")]),
                 reset_terminators=True,
                 terminators=[Ref.keyword("ELSE"), Ref.keyword("END")],
             ),
@@ -2537,7 +2537,7 @@ class CaseExpressionSegment(BaseSegment):
             "CASE",
             ImplicitIndent,
             AnyNumberOf(
-                Ref("WhenClauseSegment"),
+                Ref("WhenClauseSegment", terminators=[Ref.keyword("WHEN")]),
                 reset_terminators=True,
                 terminators=[Ref.keyword("ELSE"), Ref.keyword("END")],
             ),
@@ -2560,7 +2560,7 @@ class CaseExpressionSegment(BaseSegment):
             ),
             ImplicitIndent,
             AnyNumberOf(
-                Ref("WhenClauseSegment"),
+                Ref("WhenClauseSegment", terminators=[Ref.keyword("WHEN")]),
                 reset_terminators=True,
                 terminators=[Ref.keyword("ELSE"), Ref.keyword("END")],
             ),

--- a/test/fixtures/dialects/oracle/case_expressions.sql
+++ b/test/fixtures/dialects/oracle/case_expressions.sql
@@ -280,3 +280,14 @@ SELECT
         ELSE 0
     END my_case AS result
 FROM abc;
+
+-- Test 28: CASE expression with bracketed condition
+SELECT 
+    CASE
+        WHEN abc = 1 THEN NULL
+        WHEN (
+            defg = 2
+            AND hijk = 3
+        ) THEN NULL
+    END AS result
+FROM abc;

--- a/test/fixtures/dialects/oracle/case_expressions.sql
+++ b/test/fixtures/dialects/oracle/case_expressions.sql
@@ -282,7 +282,7 @@ SELECT
 FROM abc;
 
 -- Test 28: CASE expression with bracketed condition
-SELECT 
+SELECT
     CASE
         WHEN abc = 1 THEN NULL
         WHEN (

--- a/test/fixtures/dialects/oracle/case_expressions.yml
+++ b/test/fixtures/dialects/oracle/case_expressions.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 3e97b082c60397a779fe8a11a12edd2b13365b238d4456fbdbac139747b6f76d
+_hash: 162ce31b0e333dc38b301e2cd94fff10314fd8eec6c2863fdd253212729da876
 file:
 - statement:
     select_statement:
@@ -1702,6 +1702,59 @@ file:
                   numeric_literal: '0'
             - keyword: END
             - naked_identifier: my_case
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: result
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: abc
+- statement_terminator: ;
+- statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          expression:
+            case_expression:
+            - keyword: CASE
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  column_reference:
+                    naked_identifier: abc
+                  comparison_operator:
+                    raw_comparison_operator: '='
+                  numeric_literal: '1'
+              - keyword: THEN
+              - expression:
+                  null_literal: 'NULL'
+            - when_clause:
+              - keyword: WHEN
+              - expression:
+                  bracketed:
+                    start_bracket: (
+                    expression:
+                    - column_reference:
+                        naked_identifier: defg
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - numeric_literal: '2'
+                    - binary_operator: AND
+                    - column_reference:
+                        naked_identifier: hijk
+                    - comparison_operator:
+                        raw_comparison_operator: '='
+                    - numeric_literal: '3'
+                    end_bracket: )
+              - keyword: THEN
+              - expression:
+                  null_literal: 'NULL'
+            - keyword: END
           alias_expression:
             alias_operator:
               keyword: AS


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fixes #7099 

Currently, valid CASE statements with a bracket in a WHEN clause will fail, such as

```sql
SELECT 
    CASE
        WHEN abc = 1 THEN NULL
        WHEN (
            defg = 2
            AND hijk = 3
        ) THEN NULL
    END AS result
FROM abc;
```

This PR fixes that.


### Are there any other side effects of this change that we should be aware of?

No, side effect free.


### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
