### PR TITLE
Parallelize file rendering prior to linting/fixing

### DIFF
--- a/src/sqlfluff/core/linter/runner.py
+++ b/src/sqlfluff/core/linter/runner.py
@@ -132,6 +132,40 @@ class ParallelRunner(BaseRunner):
         super().__init__(linter, config)
         self.processes = processes
 
+    @staticmethod
+    def _render_file_static(args: tuple[str, Linter, FluffConfig]):
+        """Static helper for multiprocessing."""
+        fname, linter, config = args
+        try:
+            return fname, linter.render_file(fname, config)
+        except SQLFluffSkipFile as s:
+            linter_logger.warning(str(s))
+            return None
+
+    def iter_rendered(self, fnames: list[str]) -> Iterator[tuple[str, RenderedFile]]:
+        """Iterate through rendered files ready for linting."""
+        sequenced = list(self.linter.templater.sequence_files(
+            fnames, config=self.config, formatter=self.linter.formatter
+        ))
+        # Prepare arguments for each file
+        args_list = [(fname, self.linter, self.config) for fname in sequenced]
+
+        results = []
+        with self._create_pool(
+            self.processes,
+            self._init_global,
+        ) as pool:
+            for result in pool.imap_unordered(self._render_file_static, args_list, chunksize=10):
+                if result is not None:
+                    results.append(result)
+
+        # Instead of yielding in the loop above (which would double our number
+        # of spawned processes), render everything first (taking the memory hit
+        # of storing all rendered files) then yield.
+        for result in results:
+            yield result
+
+
     def run(self, fnames: list[str], fix: bool) -> Iterator[LintedFile]:
         """Parallel implementation.
 
@@ -254,7 +288,7 @@ class MultiProcessRunner(ParallelRunner):
         We use this so we can iterate through results as they arrive, and while other
         files are still being processed.
         """
-        return pool.imap_unordered(func=func, iterable=iterable)
+        return pool.imap_unordered(func=func, iterable=iterable, chunksize=10)
 
 
 class MultiThreadRunner(ParallelRunner):


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
Before this change, all SQL files are templated sequentially, causing slowness in projects using the Jinja templater with many macros, for instance. This change runs the templating function in parallel, using the same number of processes configured, to speed up the process.

This was the shortest path to getting a quick speedup for running sqlfluff against all files in a large project. Let me know if you'd like me to take an alternative approach.

### Are there any other side effects of this change that we should be aware of?

I suspect this will increase memory usage for most users who use parallel processing.

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
