### PR TITLE
Per Issue 5567 update _common_directives_for_xml to AnyNumberOf (they…

### DIFF
--- a/src/sqlfluff/dialects/dialect_tsql.py
+++ b/src/sqlfluff/dialects/dialect_tsql.py
@@ -5670,7 +5670,7 @@ class ForClauseSegment(BaseSegment):
 
     type = "for_clause"
 
-    _common_directives_for_xml = Sequence(
+    _common_directives_for_xml = AnyNumberOf(
         Sequence(
             "BINARY",
             "BASE64",

--- a/test/fixtures/dialects/tsql/select_for.sql
+++ b/test/fixtures/dialects/tsql/select_for.sql
@@ -53,6 +53,12 @@ FOR XML PATH ('root');
 SELECT 0 ErrorCode
 FOR XML PATH('Result'), TYPE
 
+SELECT 0 ErrorCode
+FOR XML PATH('Result'), ROOT('RootName'), TYPE
+
+SELECT 0 ErrorCode
+FOR XML PATH('Result'), TYPE, ROOT('RootName')
+
 -- FOR BROWSE
 SELECT 1 AS a
 FOR BROWSE

--- a/test/fixtures/dialects/tsql/select_for.sql
+++ b/test/fixtures/dialects/tsql/select_for.sql
@@ -49,6 +49,10 @@ FROM Production.ProductModel
 WHERE ProductModelID=122 OR ProductModelID=119
 FOR XML PATH ('root');
 
+-- Per Issue #5567
+SELECT 0 ErrorCode
+FOR XML PATH('Result'), TYPE
+
 -- FOR BROWSE
 SELECT 1 AS a
 FOR BROWSE

--- a/test/fixtures/dialects/tsql/select_for.yml
+++ b/test/fixtures/dialects/tsql/select_for.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 73cba65618ffd7b7b376e8b950120ae69402f2886e4907418c56cda78a54dfb2
+_hash: 47a072e8ebd4a29ab9931979bd82178bd5475e916339440d64592b82401343fb
 file:
 - batch:
     statement:
@@ -328,6 +328,54 @@ file:
             end_bracket: )
         - comma: ','
         - keyword: TYPE
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            integer_literal: '0'
+            alias_expression:
+              naked_identifier: ErrorCode
+        for_clause:
+        - keyword: FOR
+        - keyword: XML
+        - keyword: PATH
+        - bracketed:
+            start_bracket: (
+            quoted_literal: "'Result'"
+            end_bracket: )
+        - comma: ','
+        - keyword: ROOT
+        - bracketed:
+            start_bracket: (
+            quoted_literal: "'RootName'"
+            end_bracket: )
+        - comma: ','
+        - keyword: TYPE
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            integer_literal: '0'
+            alias_expression:
+              naked_identifier: ErrorCode
+        for_clause:
+        - keyword: FOR
+        - keyword: XML
+        - keyword: PATH
+        - bracketed:
+            start_bracket: (
+            quoted_literal: "'Result'"
+            end_bracket: )
+        - comma: ','
+        - keyword: TYPE
+        - comma: ','
+        - keyword: ROOT
+        - bracketed:
+            start_bracket: (
+            quoted_literal: "'RootName'"
+            end_bracket: )
   - statement:
       select_statement:
         select_clause:

--- a/test/fixtures/dialects/tsql/select_for.yml
+++ b/test/fixtures/dialects/tsql/select_for.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: d343e4025573b7fae1ca3b4ad80a3a13cd4bc54f790f98c5b7ccd145e69e0281
+_hash: 73cba65618ffd7b7b376e8b950120ae69402f2886e4907418c56cda78a54dfb2
 file:
 - batch:
     statement:
@@ -310,6 +310,24 @@ file:
             quoted_literal: "'root'"
             end_bracket: )
   - statement_terminator: ;
+  - statement:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            integer_literal: '0'
+            alias_expression:
+              naked_identifier: ErrorCode
+        for_clause:
+        - keyword: FOR
+        - keyword: XML
+        - keyword: PATH
+        - bracketed:
+            start_bracket: (
+            quoted_literal: "'Result'"
+            end_bracket: )
+        - comma: ','
+        - keyword: TYPE
   - statement:
       select_statement:
         select_clause:


### PR DESCRIPTION
… Per Issue 5567 update _common_directives_for_xml to AnyNumberOf (they are optional, not a sequence)
Per (https://learn.microsoft.com/en-us/sql/t-sql/queries/select-for-clause-transact-sql?view=sql-server-ver16)


<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
fixes #5567

### Are there any other side effects of this change that we should be aware of?


### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
