### PR TITLE
extend databricks COMMENT ON to include columns

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -1567,6 +1567,10 @@ class CommentOnStatementSegment(BaseSegment):
                 "VOLUME",
                 Ref("VolumeReferenceSegment"),
             ),
+            Sequence(
+                "COLUMN",
+                Ref("ColumnReferenceSegment"),
+            ),
             # TODO: Split out individual items if they have references
             Sequence(
                 OneOf(

--- a/test/fixtures/dialects/databricks/comment_on.sql
+++ b/test/fixtures/dialects/databricks/comment_on.sql
@@ -17,3 +17,7 @@ COMMENT ON RECIPIENT my_recipient IS 'A good recipient';
 COMMENT ON PROVIDER my_provider IS 'A good provider';
 
 COMMENT ON VOLUME my_volume IS 'Huge volume';
+
+COMMENT ON COLUMN my_catalog.my_schema.my_table.my_column IS 'This is my column in a catalog';
+
+COMMENT ON COLUMN my_column IS 'This is my column';

--- a/test/fixtures/dialects/databricks/comment_on.yml
+++ b/test/fixtures/dialects/databricks/comment_on.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: dea3b1bd03043d9c632669f603ac0787f764a78efe1628003ee13b4440a1dfc0
+_hash: 3a83632ea31eb351e076a58321a5069d43dd578441f3a013480b4fba8b080feb
 file:
 - statement:
     comment_clause:
@@ -104,4 +104,30 @@ file:
         naked_identifier: my_volume
     - keyword: IS
     - quoted_literal: "'Huge volume'"
+- statement_terminator: ;
+- statement:
+    comment_clause:
+    - keyword: COMMENT
+    - keyword: 'ON'
+    - keyword: COLUMN
+    - column_reference:
+      - naked_identifier: my_catalog
+      - dot: .
+      - naked_identifier: my_schema
+      - dot: .
+      - naked_identifier: my_table
+      - dot: .
+      - naked_identifier: my_column
+    - keyword: IS
+    - quoted_literal: "'This is my column in a catalog'"
+- statement_terminator: ;
+- statement:
+    comment_clause:
+    - keyword: COMMENT
+    - keyword: 'ON'
+    - keyword: COLUMN
+    - column_reference:
+        naked_identifier: my_column
+    - keyword: IS
+    - quoted_literal: "'This is my column'"
 - statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made

Extends #6196 to also include COMMENT ON for COLUMNS.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [ ] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
