### PR TITLE
oracle: Support `COLUMN_VALUE` as a bare function

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -268,7 +268,7 @@ oracle_dialect.sets("unreserved_keywords").update(
 oracle_dialect.sets("bare_functions").clear()
 oracle_dialect.sets("bare_functions").update(
     [
-        "COLUMN_VALUE",
+        "column_value",
         "current_date",
         "current_timestamp",
         "dbtimezone",

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -67,7 +67,6 @@ oracle_dialect.sets("reserved_keywords").update(
         "CHECK",
         "CLUSTER",
         "COLUMN",
-        "COLUMN_VALUE",
         "COMMENT",
         "COMPRESS",
         "CONNECT",
@@ -268,6 +267,7 @@ oracle_dialect.sets("unreserved_keywords").update(
 oracle_dialect.sets("bare_functions").clear()
 oracle_dialect.sets("bare_functions").update(
     [
+        "COLUMN_VALUE",
         "current_date",
         "current_timestamp",
         "dbtimezone",

--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -67,6 +67,7 @@ oracle_dialect.sets("reserved_keywords").update(
         "CHECK",
         "CLUSTER",
         "COLUMN",
+        "COLUMN_VALUE",
         "COMMENT",
         "COMPRESS",
         "CONNECT",

--- a/test/fixtures/dialects/oracle/column_value.sql
+++ b/test/fixtures/dialects/oracle/column_value.sql
@@ -1,0 +1,2 @@
+SELECT column_value AS mnth
+FROM sys.dbms_debug_vc2coll('01', '05', '09');

--- a/test/fixtures/dialects/oracle/column_value.yml
+++ b/test/fixtures/dialects/oracle/column_value.yml
@@ -1,0 +1,40 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: 27978468b93e9dba77b130443f65ee299dd445cf77d0644ba5f3bfacf393db49
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          bare_function: column_value
+          alias_expression:
+            alias_operator:
+              keyword: AS
+            naked_identifier: mnth
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              function:
+                function_name:
+                  naked_identifier: sys
+                  dot: .
+                  function_name_identifier: dbms_debug_vc2coll
+                function_contents:
+                  bracketed:
+                  - start_bracket: (
+                  - expression:
+                      quoted_literal: "'01'"
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'05'"
+                  - comma: ','
+                  - expression:
+                      quoted_literal: "'09'"
+                  - end_bracket: )
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This modifies `COLUMN_VALUE` to be used as a bare function. This allows it to be used without a reference in a select clause as well as generally used as needed, but the word is still reserved.
- fixes #7110

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
