### PR TITLE
oracle: Add support for utf8 identifiers

### DIFF
--- a/src/sqlfluff/dialects/dialect_oracle.py
+++ b/src/sqlfluff/dialects/dialect_oracle.py
@@ -281,7 +281,7 @@ oracle_dialect.sets("bare_functions").update(
 
 oracle_dialect.patch_lexer_matchers(
     [
-        RegexLexer("word", r"[a-zA-Z][0-9a-zA-Z_$#]*", WordSegment),
+        RegexLexer("word", r"[\p{L}][\p{L}\p{N}_$#]*", WordSegment),
         RegexLexer(
             "single_quote",
             r"'([^'\\]|\\|\\.|'')*'",
@@ -720,7 +720,7 @@ oracle_dialect.replace(
     ),
     NakedIdentifierSegment=SegmentGenerator(
         lambda dialect: RegexParser(
-            r"[A-Z0-9_]*[A-Z][A-Z0-9_#$]*",
+            r"[\p{L}\p{N}_]*[\p{L}][\p{L}\p{N}_#$]*",
             IdentifierSegment,
             type="naked_identifier",
             anti_template=r"^(" + r"|".join(dialect.sets("reserved_keywords")) + r")$",

--- a/test/fixtures/dialects/oracle/select_utf8.sql
+++ b/test/fixtures/dialects/oracle/select_utf8.sql
@@ -1,0 +1,4 @@
+SELECT
+    'Não' reativação
+FROM
+    TABLE1;

--- a/test/fixtures/dialects/oracle/select_utf8.yml
+++ b/test/fixtures/dialects/oracle/select_utf8.yml
@@ -1,0 +1,23 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: f1c3dffdf5a678de7b661f45cc8ce4680645faca1673ac871c1a4b916380ce07
+file:
+  statement:
+    select_statement:
+      select_clause:
+        keyword: SELECT
+        select_clause_element:
+          quoted_literal: "'Não'"
+          alias_expression:
+            naked_identifier: reativação
+      from_clause:
+        keyword: FROM
+        from_expression:
+          from_expression_element:
+            table_expression:
+              table_reference:
+                naked_identifier: TABLE1
+  statement_terminator: ;


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds support to the oracle dialect for utf8 characters in identifier names.
- fixes #7142

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
