### PR TITLE
CV11: Ignore trino and athena dialects

### DIFF
--- a/src/sqlfluff/rules/convention/CV11.py
+++ b/src/sqlfluff/rules/convention/CV11.py
@@ -202,8 +202,11 @@ class Rule_CV11(BaseRule):
         # Config type hints
         self.preferred_type_casting_style: str
 
-        # Rule disabled for teradata.
-        if context.dialect.name == "teradata":
+        # Rule disabled for teradata, athena, or trino.
+        # They only support one of the options
+        # TODO: add additional dialects that only support a single option here.
+        # TODO: add a tier list for dialects support multiples, but not all.
+        if context.dialect.name in ("teradata", "athena", "trino"):
             return None
 
         # If we're in a templated section, don't consider the current location.

--- a/test/fixtures/rules/std_rule_cases/CV11.yml
+++ b/test/fixtures/rules/std_rule_cases/CV11.yml
@@ -336,6 +336,28 @@ test_pass_when_dialect_is_teradata:
     core:
       dialect: teradata
 
+test_pass_when_dialect_is_athena:
+  pass_str: |
+    select cast(1 as varchar(10)) as bar
+    from foo;
+  configs:
+    core:
+      dialect: athena
+    rules:
+      convention.casting_style:
+        preferred_type_casting_style: shorthand
+
+test_pass_when_dialect_is_trino:
+  pass_str: |
+    select cast(1 as varchar(10)) as bar
+    from foo;
+  configs:
+    core:
+      dialect: trino
+    rules:
+      convention.casting_style:
+        preferred_type_casting_style: shorthand
+
 test_fail_parenthesize_expression_when_config_shorthand_from_cast:
   fail_str: |
     select


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This ignores trino and athena dialects for CV11 where only `CAST(thing AS type)` is valid. There still exists an issue where some dialects may support two of the options, but the desired option is not supported in that dialect.
- fixes #7090

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
