### PR TITLE
fix[sparksql]: Add support for INSERT INTO REPLACE WHERE/USING statements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
     rev: 7.1.1
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-black>=0.3.6]
+        additional_dependencies: [flake8-black>=0.3.7]
   - repo: https://github.com/pycqa/doc8
     rev: v1.1.2
     hooks:

--- a/test/fixtures/dialects/sparksql/insert_table.sql
+++ b/test/fixtures/dialects/sparksql/insert_table.sql
@@ -62,3 +62,31 @@ INSERT INTO students PARTITION (student_id = 11215017) (address, name) VALUES
 INSERT OVERWRITE students
 PARTITION (student_id = 11215017) (address, name)
 VALUES ('Hangzhou, China', 'Kent Yao Jr.');
+
+INSERT INTO students REPLACE USING (country)
+SELECT *
+FROM new_students;
+
+INSERT INTO students REPLACE USING (country, city)
+SELECT *
+FROM new_students;
+
+INSERT INTO students REPLACE USING (country, city)
+VALUES
+    ('Amy Smith', 1100),
+    ('Kent Yao', 2200);
+
+INSERT INTO sales REPLACE
+WHERE tx_date BETWEEN '2023-10-01' AND '2023-10-02'
+VALUES
+    ('2023-10-01', 1100),
+    ('2023-10-02', 2200),
+    ('2023-10-04', 4000);
+
+INSERT INTO sales REPLACE
+WHERE
+    tx_date BETWEEN '2023-10-01' AND '2023-10-02'
+    AND store_nbr = 1
+    AND item_nbr = 1
+SELECT *
+FROM new_sales;

--- a/test/fixtures/dialects/sparksql/insert_table.yml
+++ b/test/fixtures/dialects/sparksql/insert_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 968d5d3c702a1448221fa10c22f49b99596abfe28865007f84ec6b6eb8398fdb
+_hash: 7d1f784da0d1a5b69542c47e576be28a6593442bb78ea5a2ef95440385e8704f
 file:
 - statement:
     insert_statement:
@@ -407,4 +407,187 @@ file:
         - expression:
             quoted_literal: "'Kent Yao Jr.'"
         - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: students
+    - keyword: REPLACE
+    - keyword: USING
+    - bracketed:
+        start_bracket: (
+        column_reference:
+          naked_identifier: country
+        end_bracket: )
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: new_students
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: students
+    - keyword: REPLACE
+    - keyword: USING
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: country
+      - comma: ','
+      - column_reference:
+          naked_identifier: city
+      - end_bracket: )
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: new_students
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: students
+    - keyword: REPLACE
+    - keyword: USING
+    - bracketed:
+      - start_bracket: (
+      - column_reference:
+          naked_identifier: country
+      - comma: ','
+      - column_reference:
+          naked_identifier: city
+      - end_bracket: )
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            quoted_literal: "'Amy Smith'"
+        - comma: ','
+        - expression:
+            numeric_literal: '1100'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            quoted_literal: "'Kent Yao'"
+        - comma: ','
+        - expression:
+            numeric_literal: '2200'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: sales
+    - keyword: REPLACE
+    - where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: tx_date
+        - keyword: BETWEEN
+        - quoted_literal: "'2023-10-01'"
+        - keyword: AND
+        - quoted_literal: "'2023-10-02'"
+    - values_clause:
+      - keyword: VALUES
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            quoted_literal: "'2023-10-01'"
+        - comma: ','
+        - expression:
+            numeric_literal: '1100'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            quoted_literal: "'2023-10-02'"
+        - comma: ','
+        - expression:
+            numeric_literal: '2200'
+        - end_bracket: )
+      - comma: ','
+      - bracketed:
+        - start_bracket: (
+        - expression:
+            quoted_literal: "'2023-10-04'"
+        - comma: ','
+        - expression:
+            numeric_literal: '4000'
+        - end_bracket: )
+- statement_terminator: ;
+- statement:
+    insert_statement:
+    - keyword: INSERT
+    - keyword: INTO
+    - table_reference:
+        naked_identifier: sales
+    - keyword: REPLACE
+    - where_clause:
+        keyword: WHERE
+        expression:
+        - column_reference:
+            naked_identifier: tx_date
+        - keyword: BETWEEN
+        - quoted_literal: "'2023-10-01'"
+        - keyword: AND
+        - quoted_literal: "'2023-10-02'"
+        - binary_operator: AND
+        - column_reference:
+            naked_identifier: store_nbr
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '1'
+        - binary_operator: AND
+        - column_reference:
+            naked_identifier: item_nbr
+        - comparison_operator:
+            raw_comparison_operator: '='
+        - numeric_literal: '1'
+    - select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            wildcard_expression:
+              wildcard_identifier:
+                star: '*'
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: new_sales
 - statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

fixes #7138 

### Are there any other side effects of this change that we should be aware of?

No

### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
