### PR TITLE
bigquery: fix `escape_replacements` control character value

### DIFF
--- a/src/sqlfluff/dialects/dialect_bigquery.py
+++ b/src/sqlfluff/dialects/dialect_bigquery.py
@@ -113,7 +113,7 @@ bigquery_dialect.patch_lexer_matchers(
                     r"|[^'])*(?<!\\)(?:\\{2})*)')",
                     "value",
                 ),
-                "escape_replacements": [(r"\\([\\`\"'?])", "\1")],
+                "escape_replacements": [(r"\\([\\`\"'?])", r"\1")],
             },
         ),
         RegexLexer(
@@ -130,7 +130,7 @@ bigquery_dialect.patch_lexer_matchers(
                     r'(\\{2})*\\"|[^"])*(?<!\\)(\\{2})*)")',
                     "value",
                 ),
-                "escape_replacements": [(r"\\([\\`\"'?])", "\1")],
+                "escape_replacements": [(r"\\([\\`\"'?])", r"\1")],
             },
         ),
     ]


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This fixes the replacement string for `escape_replacements`. Prior to this, it was producing a control character instead of returning the first group.

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
