### PR TITLE
cli: support `.sqlfluffignore` when using `stdin-filename`

### DIFF
--- a/src/sqlfluff/cli/commands.py
+++ b/src/sqlfluff/cli/commands.py
@@ -645,7 +645,9 @@ def lint(
                 lnt.config = lnt.config.make_child_from_path(
                     stdin_filename, require_dialect=False
                 )
-            result = lnt.lint_string_wrapped(sys.stdin.read(), fname="stdin")
+            result = lnt.lint_string_wrapped(
+                sys.stdin.read(), fname="stdin", stdin_filename=stdin_filename
+            )
         else:
             result = lnt.lint_paths(
                 paths,
@@ -836,13 +838,18 @@ def _handle_unparsable(
 
 
 def _stdin_fix(
-    linter: Linter, formatter: OutputStreamFormatter, fix_even_unparsable: bool
+    linter: Linter,
+    formatter: OutputStreamFormatter,
+    fix_even_unparsable: bool,
+    stdin_filename: Optional[str] = None,
 ) -> None:
     """Handle fixing from stdin."""
     exit_code = EXIT_SUCCESS
     stdin = sys.stdin.read()
 
-    result = linter.lint_string_wrapped(stdin, fname="stdin", fix=True)
+    result = linter.lint_string_wrapped(
+        stdin, fname="stdin", fix=True, stdin_filename=stdin_filename
+    )
     templater_error = result.num_violations(types=SQLTemplaterError) > 0
     unfixable_error = result.num_violations(types=SQLLintError, fixable=False) > 0
 
@@ -1132,7 +1139,7 @@ def fix(
                 lnt.config = lnt.config.make_child_from_path(
                     stdin_filename, require_dialect=False
                 )
-            _stdin_fix(lnt, formatter, fix_even_unparsable)
+            _stdin_fix(lnt, formatter, fix_even_unparsable, stdin_filename)
         else:
             _paths_fix(
                 lnt,
@@ -1238,7 +1245,9 @@ def cli_format(
                 lnt.config = lnt.config.make_child_from_path(
                     stdin_filename, require_dialect=False
                 )
-            _stdin_fix(lnt, formatter, fix_even_unparsable=False)
+            _stdin_fix(
+                lnt, formatter, fix_even_unparsable=False, stdin_filename=stdin_filename
+            )
         else:
             _paths_fix(
                 lnt,

--- a/src/sqlfluff/core/linter/discovery.py
+++ b/src/sqlfluff/core/linter/discovery.py
@@ -239,6 +239,7 @@ def paths_from_path(
     ignore_files: bool = True,
     working_path: str = os.getcwd(),
     target_file_exts: Sequence[str] = (".sql",),
+    check_non_existent_file: bool = False,
 ) -> list[str]:
     """Return a set of sql file paths from a potentially more ambiguous path string.
 
@@ -255,7 +256,7 @@ def paths_from_path(
     of the two. This might be counterintuitive, but supports an appropriate solution
     for the dbt templater without having to additionally pass the project root path.
     """
-    if not os.path.exists(path):
+    if not os.path.exists(path) and not check_non_existent_file:
         if ignore_non_existent_files:
             return []
         else:
@@ -282,7 +283,7 @@ def paths_from_path(
                 outer_ignore_specs.append(ignore_spec)
 
     # Handle being passed an exact file first.
-    if os.path.isfile(path):
+    if os.path.isfile(path) or check_non_existent_file:
         return _process_exact_path(
             path, working_path, lower_file_exts, outer_ignore_specs
         )

--- a/src/sqlfluff/core/linter/linter.py
+++ b/src/sqlfluff/core/linter/linter.py
@@ -1008,11 +1008,23 @@ class Linter:
         string: str,
         fname: str = "<string input>",
         fix: bool = False,
+        stdin_filename: Optional[str] = None,
     ) -> LintingResult:
         """Lint strings directly."""
         result = LintingResult()
         linted_path = LintedDir(fname)
-        linted_path.add(self.lint_string(string, fname=fname, fix=fix))
+        if stdin_filename:
+            # This opens up additional files like `Untitled` in vscode where linting
+            # may be desired.
+            sql_exts = ("",)
+            for _ in paths_from_path(
+                stdin_filename, target_file_exts=sql_exts, check_non_existent_file=True
+            ):
+                linted_path.add(self.lint_string(string, fname=fname, fix=fix))
+                # Only return the first item, as stdin should only be one
+                break
+        else:
+            linted_path.add(self.lint_string(string, fname=fname, fix=fix))
         result.add(linted_path)
         result.stop_timer()
         return result

--- a/test/cli/commands_test.py
+++ b/test/cli/commands_test.py
@@ -308,6 +308,13 @@ stdin_cli_input = (
             "",
         ),
         (
+            lint,
+            "test/fixtures/cli/stdin_filename/ignored.sql",
+            0,
+            "re-run with `--disregard-sqlfluffignores`",
+            "",
+        ),
+        (
             cli_format,
             "test/fixtures/cli/stdin_filename/stdin_filename.sql",
             0,
@@ -329,6 +336,13 @@ stdin_cli_input = (
             "[1 templating/parsing errors found]",
         ),
         (
+            cli_format,
+            "test/fixtures/cli/stdin_filename/ignored.sql",
+            0,
+            stdin_cli_input,
+            "re-run with `--disregard-sqlfluffignores`",
+        ),
+        (
             fix,
             "test/fixtures/cli/stdin_filename/stdin_filename.sql",
             0,
@@ -348,6 +362,13 @@ stdin_cli_input = (
             1,
             "",
             "Unfixable violations detected.",
+        ),
+        (
+            fix,
+            "test/fixtures/cli/stdin_filename/ignored.sql",
+            0,
+            stdin_cli_input,
+            "re-run with `--disregard-sqlfluffignores`",
         ),
     ],
 )

--- a/test/fixtures/cli/stdin_filename/.sqlfluffignore
+++ b/test/fixtures/cli/stdin_filename/.sqlfluffignore
@@ -1,0 +1,1 @@
+ignored.sql


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This adds support for respecting `.sqlfluffignore` when using the `--stdin-filename` parameters.
- fixes #6449

### Are there any other side effects of this change that we should be aware of?
None, this works to maintain the current expectation of the filename being `stdin` for the sqlfluff vscode plugin.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
