### PR TITLE
AL09: fix aliases without spaces after column name

### DIFF
--- a/src/sqlfluff/rules/aliasing/AL09.py
+++ b/src/sqlfluff/rules/aliasing/AL09.py
@@ -148,9 +148,18 @@ class Rule_AL09(BaseRule):
             alias_keyword_raw = getattr(
                 alias_expression.get_child("alias_operator"), "raw", None
             )
+
+            # If the column identifier is quoted, the whitespace between the column
+            # identifier and the `AS` keyword are optional. The `layout.spacing` rule
+            # should be the responsible rule for fixing this case, but we want to
+            # account for the situation here.
+            quoted_without_whitespace = (
+                column_identifier.is_type("quoted_identifier") and whitespace is None
+            )
+
             # If the alias keyword is '=', then no whitespace have to be present
             # between the alias_keyword and the alias_identifier
-            if alias_keyword_raw != "=":
+            if alias_keyword_raw != "=" and not quoted_without_whitespace:
                 if not (whitespace and alias_identifier):  # pragma: no cover
                     # We *should* expect all of these to be non-null, but some bug
                     # reports suggest that that isn't always the case for some

--- a/test/fixtures/rules/std_rule_cases/AL09.yml
+++ b/test/fixtures/rules/std_rule_cases/AL09.yml
@@ -256,3 +256,49 @@ test_pass_mysql_quoted_identifiers:
     configs:
         core:
             dialect: mysql
+
+test_pass_tsql_quoted_column_no_space_with_as:
+    pass_str: |
+        SELECT c.[name]as clientName
+        FROM clients as c
+    configs:
+        core:
+            dialect: tsql
+
+test_pass_bigquery_quoted_column_no_space_with_as:
+    pass_str: |
+        SELECT `col`as`renamed_col`
+        FROM clients as c
+    configs:
+        core:
+            dialect: bigquery
+
+test_fail_bigquery_quoted_column_no_space_with_as:
+    fail_str: |
+        SELECT `col`as`col`
+        FROM clients as c
+    fix_str: |
+        SELECT `col`
+        FROM clients as c
+    configs:
+        core:
+            dialect: bigquery
+
+test_pass_bigquery_quoted_column_no_space_without_as:
+    pass_str: |
+        SELECT `col``renamed_col`
+        FROM clients as c
+    configs:
+        core:
+            dialect: bigquery
+
+test_fail_bigquery_quoted_column_no_space_without_as:
+    fail_str: |
+        SELECT `col``col`
+        FROM clients as c
+    fix_str: |
+        SELECT `col`
+        FROM clients as c
+    configs:
+        core:
+            dialect: bigquery


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->
This resolves an issue with AL09 when a space between a quoted column reference and either the `AS` keyword or the alias itself does not exist. Previously this would throw a warning, but now this scenario is handled appropriately.
- fixes #6611

### Are there any other side effects of this change that we should be aware of?
None

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - Full autofix test cases in `test/fixtures/linter/autofix`.
  - Other.
- Added appropriate documentation for the change.
- Created GitHub issues for any relevant followup/future enhancements if appropriate.
