### PR TITLE
Redshift: Adds EXCEPT set operator support

### DIFF
--- a/src/sqlfluff/dialects/dialect_redshift.py
+++ b/src/sqlfluff/dialects/dialect_redshift.py
@@ -2988,6 +2988,21 @@ class MergeStatementSegment(ansi.MergeStatementSegment):
     )
 
 
+class SetOperatorSegment(ansi.SetOperatorSegment):
+    """A set operator such as Union, Minus, Except or Intersect.
+
+    https://docs.aws.amazon.com/redshift/latest/dg/r_UNION.html#r_UNION-parameters
+    """
+
+    type = "set_operator"
+    match_grammar: Matchable = OneOf(
+        Ref("UnionGrammar"),
+        "INTERSECT",
+        "EXCEPT",
+        "MINUS",
+    )
+
+
 class PrepareStatementSegment(postgres.PrepareStatementSegment):
     """A `PREPARE` statement.
 

--- a/test/fixtures/dialects/redshift/set_operators.sql
+++ b/test/fixtures/dialects/redshift/set_operators.sql
@@ -1,0 +1,19 @@
+SELECT col FROM tab1
+MINUS
+(SELECT col FROM tab2);
+
+SELECT col FROM tab1
+EXCEPT
+(SELECT col FROM tab2);
+
+SELECT col FROM tab1
+UNION
+(SELECT col FROM tab2);
+
+SELECT col FROM tab1
+INTERSECT
+(SELECT col FROM tab2);
+
+SELECT col FROM tab1
+UNION ALL
+(SELECT col FROM tab2);

--- a/test/fixtures/dialects/redshift/set_operators.yml
+++ b/test/fixtures/dialects/redshift/set_operators.yml
@@ -1,0 +1,178 @@
+# YML test files are auto-generated from SQL files and should not be edited by
+# hand. To help enforce this, the "hash" field in the file must match a hash
+# computed by SQLFluff when running the tests. Please run
+# `python test/generate_parse_fixture_yml.py`  to generate them after adding or
+# altering SQL files.
+_hash: d76f4e0a0868e9c2beea3e1dd4a2e1b169552dfd5331ef6948a00f0f64fa3793
+file:
+- statement:
+    set_expression:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: col
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tab1
+      set_operator:
+        keyword: MINUS
+      bracketed:
+        start_bracket: (
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              column_reference:
+                naked_identifier: col
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: tab2
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    set_expression:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: col
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tab1
+      set_operator:
+        keyword: EXCEPT
+      bracketed:
+        start_bracket: (
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              column_reference:
+                naked_identifier: col
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: tab2
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    set_expression:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: col
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tab1
+      set_operator:
+        keyword: UNION
+      bracketed:
+        start_bracket: (
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              column_reference:
+                naked_identifier: col
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: tab2
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    set_expression:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: col
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tab1
+      set_operator:
+        keyword: INTERSECT
+      bracketed:
+        start_bracket: (
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              column_reference:
+                naked_identifier: col
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: tab2
+        end_bracket: )
+- statement_terminator: ;
+- statement:
+    set_expression:
+      select_statement:
+        select_clause:
+          keyword: SELECT
+          select_clause_element:
+            column_reference:
+              naked_identifier: col
+        from_clause:
+          keyword: FROM
+          from_expression:
+            from_expression_element:
+              table_expression:
+                table_reference:
+                  naked_identifier: tab1
+      set_operator:
+      - keyword: UNION
+      - keyword: ALL
+      bracketed:
+        start_bracket: (
+        select_statement:
+          select_clause:
+            keyword: SELECT
+            select_clause_element:
+              column_reference:
+                naked_identifier: col
+          from_clause:
+            keyword: FROM
+            from_expression:
+              from_expression_element:
+                table_expression:
+                  table_reference:
+                    naked_identifier: tab2
+        end_bracket: )
+- statement_terminator: ;


### PR DESCRIPTION
### Brief summary of the change made

Fixes https://github.com/sqlfluff/sqlfluff/issues/7169.

Fixes the issue where the `EXCEPT` keyword was not recognized as a valid set operator in the Redshift dialect, despite being documented as an exact synonym for `MINUS` in AWS Redshift.

#### Root Cause

The ANSI dialect's `SetOperatorSegment` includes an exclusion rule that prevents `EXCEPT` from being parsed as a set operator when followed by bracketed expressions:

```python
exclude=Sequence("EXCEPT", Bracketed(Anything()))
```

However, the Redshift dialect was inheriting this exclusion, which prevented `EXCEPT` from working as a set operator even though AWS Redshift documentation explicitly states that "MINUS and EXCEPT are exact synonyms."

#### Solution

This PR adds a custom `SetOperatorSegment` to the Redshift dialect that removes the ANSI exclusion for `EXCEPT` + bracketed expressions, allowing `EXCEPT` to work as a proper synonym for `MINUS`. 

Note: According to the [documentation](https://docs.aws.amazon.com/redshift/latest/dg/r_UNION.html#r_UNION-parameters),  INTERSECT ALL, EXCEPT ALL, and MINUS ALL aren't supported in Redshift.

#### Verification

**Before this fix**, `EXCEPT` would fail with a parsing error:

```sql
SELECT col FROM tab1
EXCEPT
(SELECT col FROM tab2);
```

```
sqlfluff parse test_except.sql --dialect redshift
[L:  1, P:  1]      |file:
[L:  1, P:  1]      |    statement:
[L:  1, P:  1]      |        select_statement:
[L:  1, P:  1]      |            select_clause:
[L:  1, P:  1]      |                keyword:                                      'SELECT'
[L:  1, P:  7]      |                [META] indent:
[L:  1, P:  7]      |                whitespace:                                   ' '
[L:  1, P:  8]      |                select_clause_element:
[L:  1, P:  8]      |                    column_reference:
[L:  1, P:  8]      |                        naked_identifier:                     'col'
[L:  1, P: 11]      |                [META] dedent:
[L:  1, P: 11]      |            whitespace:                                       ' '
[L:  1, P: 12]      |            from_clause:
[L:  1, P: 12]      |                keyword:                                      'FROM'
[L:  1, P: 16]      |                whitespace:                                   ' '
[L:  1, P: 17]      |                from_expression:
[L:  1, P: 17]      |                    [META] indent:
[L:  1, P: 17]      |                    from_expression_element:
[L:  1, P: 17]      |                        table_expression:
[L:  1, P: 17]      |                            table_reference:
[L:  1, P: 17]      |                                naked_identifier:             'tab1'
[L:  1, P: 21]      |                    [META] dedent:
[L:  1, P: 21]      |            newline:                                          '\n'
[L:  2, P:  1]      |            unparsable:                                       !! Expected: 'Nothing here.'
[L:  2, P:  1]      |                word:                                         'EXCEPT'
[L:  2, P:  7]      |                newline:                                      '\n'
[L:  3, P:  1]      |                start_bracket:                                '('
[L:  3, P:  2]      |                word:                                         'SELECT'
[L:  3, P:  8]      |                whitespace:                                   ' '
[L:  3, P:  9]      |                word:                                         'col'
[L:  3, P: 12]      |                whitespace:                                   ' '
[L:  3, P: 13]      |                word:                                         'FROM'
[L:  3, P: 17]      |                whitespace:                                   ' '
[L:  3, P: 18]      |                word:                                         'tab2'
[L:  3, P: 22]      |                end_bracket:                                  ')'
[L:  3, P: 23]      |    newline:                                                  '\n'
[L:  4, P:  1]      |    statement_terminator:                                     ';'
[L:  4, P:  2]      |    [META] end_of_file:

==== parsing violations ====
L:   2 | P:   1 |  PRS | Line 2, Position 1: Found unparsable section: 'EXCEPT\n(SELECT col
                       | FROM tab2)'
```

**After this fix**, `EXCEPT` is parsed correctly as a set operator, just like `MINUS`:

```
sqlfluff parse test_except.sql --dialect redshift
[L:  1, P:  1]      |file:
[L:  1, P:  1]      |    statement:
[L:  1, P:  1]      |        set_expression:
[L:  1, P:  1]      |            select_statement:
[L:  1, P:  1]      |                select_clause:
[L:  1, P:  1]      |                    keyword:                                  'SELECT'
[L:  1, P:  7]      |                    [META] indent:
[L:  1, P:  7]      |                    whitespace:                               ' '
[L:  1, P:  8]      |                    select_clause_element:
[L:  1, P:  8]      |                        column_reference:
[L:  1, P:  8]      |                            naked_identifier:                 'col'
[L:  1, P: 11]      |                    [META] dedent:
[L:  1, P: 11]      |                whitespace:                                   ' '
[L:  1, P: 12]      |                from_clause:
[L:  1, P: 12]      |                    keyword:                                  'FROM'
[L:  1, P: 16]      |                    whitespace:                               ' '
[L:  1, P: 17]      |                    from_expression:
[L:  1, P: 17]      |                        [META] indent:
[L:  1, P: 17]      |                        from_expression_element:
[L:  1, P: 17]      |                            table_expression:
[L:  1, P: 17]      |                                table_reference:
[L:  1, P: 17]      |                                    naked_identifier:         'tab1'
[L:  1, P: 21]      |                        [META] dedent:
[L:  1, P: 21]      |            newline:                                          '\n'
[L:  2, P:  1]      |            set_operator:
[L:  2, P:  1]      |                keyword:                                      'EXCEPT'
[L:  2, P:  7]      |            newline:                                          '\n'
[L:  3, P:  1]      |            bracketed:
[L:  3, P:  1]      |                start_bracket:                                '('
[L:  3, P:  2]      |                [META] indent:
[L:  3, P:  2]      |                select_statement:
[L:  3, P:  2]      |                    select_clause:
[L:  3, P:  2]      |                        keyword:                              'SELECT'
[L:  3, P:  8]      |                        [META] indent:
[L:  3, P:  8]      |                        whitespace:                           ' '
[L:  3, P:  9]      |                        select_clause_element:
[L:  3, P:  9]      |                            column_reference:
[L:  3, P:  9]      |                                naked_identifier:             'col'
[L:  3, P: 12]      |                        [META] dedent:
[L:  3, P: 12]      |                    whitespace:                               ' '
[L:  3, P: 13]      |                    from_clause:
[L:  3, P: 13]      |                        keyword:                              'FROM'
[L:  3, P: 17]      |                        whitespace:                           ' '
[L:  3, P: 18]      |                        from_expression:
[L:  3, P: 18]      |                            [META] indent:
[L:  3, P: 18]      |                            from_expression_element:
[L:  3, P: 18]      |                                table_expression:
[L:  3, P: 18]      |                                    table_reference:
[L:  3, P: 18]      |                                        naked_identifier:     'tab2'
[L:  3, P: 22]      |                            [META] dedent:
[L:  3, P: 22]      |                [META] dedent:
[L:  3, P: 22]      |                end_bracket:                                  ')'
[L:  3, P: 23]      |    newline:                                                  '\n'
[L:  4, P:  1]      |    statement_terminator:                                     ';'
[L:  4, P:  2]      |    [META] end_of_file:
```

The fix supports the correct Redshift syntax:
- `EXCEPT` (basic usage, synonym for `MINUS`)
- `UNION ALL` (only UNION supports ALL modifier in Redshift)
- `INTERSECT`, `EXCEPT`, and `MINUS` do NOT support ALL (per AWS documentation)

### Are there any other side effects of this change that we should be aware of?

There are no breaking changes. This change only affects the Redshift dialect and makes `EXCEPT` work as documented in AWS Redshift.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [ ] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [ ] Other.
- [x] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
