### PR TITLE
Databricks: Adds support for ALTER TABLE ADD COLUMN

### DIFF
--- a/src/sqlfluff/dialects/dialect_databricks.py
+++ b/src/sqlfluff/dialects/dialect_databricks.py
@@ -852,7 +852,7 @@ class AlterTableStatementSegment(sparksql.AlterTableStatementSegment):
                 "ADD",
                 OneOf("COLUMNS", "COLUMN"),
                 Indent,
-                Bracketed(
+                OptionallyBracketed(
                     Delimited(
                         Sequence(
                             Ref("ColumnFieldDefinitionSegment"),

--- a/test/fixtures/dialects/databricks/alter_table.sql
+++ b/test/fixtures/dialects/databricks/alter_table.sql
@@ -7,6 +7,22 @@ ALTER TABLE default.StudentInfo PARTITION (age='10') RENAME TO PARTITION (age='1
 
 ALTER TABLE StudentInfo ADD columns (LastName string, DOB timestamp);
 
+ALTER TABLE StudentInfo ADD COLUMN col_name string;
+
+ALTER TABLE StudentInfo ADD COLUMN col_name2 string AFTER col_name;
+
+ALTER TABLE StudentInfo ADD COLUMN col_name3 string COMMENT 'This is a comment';
+
+ALTER TABLE StudentInfo ADD COLUMN col_name4 string FIRST;
+
+ALTER TABLE StudentInfo ADD COLUMN col_name5 string COMMENT 'This is a comment' AFTER existing_col;
+
+ALTER TABLE StudentInfo ADD COLUMNS col1 string, col2 int;
+
+ALTER TABLE StudentInfo ADD COLUMN address.street string;
+
+ALTER TABLE StudentInfo ADD COLUMN complex_col STRUCT<name: STRING, age: INT>;
+
 ALTER TABLE StudentInfo DROP COLUMN (DOB);
 
 ALTER TABLE StudentInfo DROP COLUMNS IF EXISTS (LastName, DOB);

--- a/test/fixtures/dialects/databricks/alter_table.yml
+++ b/test/fixtures/dialects/databricks/alter_table.yml
@@ -3,7 +3,7 @@
 # computed by SQLFluff when running the tests. Please run
 # `python test/generate_parse_fixture_yml.py`  to generate them after adding or
 # altering SQL files.
-_hash: 24c2de61a1dd493f7fbc541af4a96afa39ed1e6475d8a6b76bac314c8349c9f4
+_hash: aebe4258aa537f3b5b85a9703a1740986c98062b5f6d4cc6b385feb15b2758e7
 file:
 - statement:
     alter_table_statement:
@@ -71,6 +71,162 @@ file:
             primitive_type:
               keyword: timestamp
       - end_bracket: )
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: StudentInfo
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        column_reference:
+          naked_identifier: col_name
+        data_type:
+          primitive_type:
+            keyword: string
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: StudentInfo
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        column_reference:
+          naked_identifier: col_name2
+        data_type:
+          primitive_type:
+            keyword: string
+    - keyword: AFTER
+    - column_reference:
+        naked_identifier: col_name
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: StudentInfo
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        column_reference:
+          naked_identifier: col_name3
+        data_type:
+          primitive_type:
+            keyword: string
+        column_properties_segment:
+          keyword: COMMENT
+          quoted_literal: "'This is a comment'"
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: StudentInfo
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        column_reference:
+          naked_identifier: col_name4
+        data_type:
+          primitive_type:
+            keyword: string
+    - keyword: FIRST
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: StudentInfo
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        column_reference:
+          naked_identifier: col_name5
+        data_type:
+          primitive_type:
+            keyword: string
+        column_properties_segment:
+          keyword: COMMENT
+          quoted_literal: "'This is a comment'"
+    - keyword: AFTER
+    - column_reference:
+        naked_identifier: existing_col
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: StudentInfo
+    - keyword: ADD
+    - keyword: COLUMNS
+    - column_definition:
+        column_reference:
+          naked_identifier: col1
+        data_type:
+          primitive_type:
+            keyword: string
+    - comma: ','
+    - column_definition:
+        column_reference:
+          naked_identifier: col2
+        data_type:
+          primitive_type:
+            keyword: int
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: StudentInfo
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        column_reference:
+        - naked_identifier: address
+        - dot: .
+        - naked_identifier: street
+        data_type:
+          primitive_type:
+            keyword: string
+- statement_terminator: ;
+- statement:
+    alter_table_statement:
+    - keyword: ALTER
+    - keyword: TABLE
+    - table_reference:
+        naked_identifier: StudentInfo
+    - keyword: ADD
+    - keyword: COLUMN
+    - column_definition:
+        column_reference:
+          naked_identifier: complex_col
+        data_type:
+          struct_type:
+            keyword: STRUCT
+            struct_type_schema:
+            - start_angle_bracket: <
+            - naked_identifier: name
+            - colon: ':'
+            - data_type:
+                primitive_type:
+                  keyword: STRING
+            - comma: ','
+            - naked_identifier: age
+            - colon: ':'
+            - data_type:
+                primitive_type:
+                  keyword: INT
+            - end_angle_bracket: '>'
 - statement_terminator: ;
 - statement:
     alter_table_statement:


### PR DESCRIPTION
<!--Thanks for adding this feature!-->

<!--Please give the Pull Request a meaningful title for the release notes-->

### Brief summary of the change made
<!--Please include `fixes #XXXX` to automatically close any corresponding issue when the pull request is merged. Alternatively if not fully closed you can say `makes progress on #XXXX`.-->

Fixes the first issue described in https://github.com/sqlfluff/sqlfluff/issues/7082.

Modifies the Databricks dialect to properly support the `ALTER TABLE ADD COLUMN` syntax as documented in the [Databricks documentation](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-ddl-alter-table-manage-column).

#### Root Cause

The Databricks dialect was not correctly parsing `ALTER TABLE ADD COLUMN` statements without brackets. According to the Databricks documentation, the syntax should support:

```sql
ALTER TABLE table_name ADD COLUMN column_name data_type [AFTER column_name];
```

However, SQLFluff was only parsing the bracketed version:

```sql
ALTER TABLE table_name ADD COLUMNS (column_name data_type);
```

This caused parsing failures for valid Databricks SQL statements like:
- `ALTER TABLE target_table ADD COLUMN col_name string`
- `ALTER TABLE target_table ADD COLUMN col_name string AFTER col_name_2`

#### Solution

Updated the `AlterTableStatementSegment` in the Databricks dialect to make brackets optional.

#### Verification

**Before this fix**, these statements would fail to parse:

```sql
ALTER TABLE target_table ADD COLUMN col_name string;
ALTER TABLE target_table ADD COLUMN col_name string AFTER col_name_2;
```

After this fix, all documented Databricks `ADD COLUMN` syntax patterns parse successfully. I also verified that all the commands added to the test cases are supported in Databricks.

<img width="847" height="716" alt="image" src="https://github.com/user-attachments/assets/778d6648-1e6b-43d5-9791-a79223b23367" />

### Are there any other side effects of this change that we should be aware of?

There are no breaking changes. This change only affects the Databricks dialect and extends support for valid Databricks SQL syntax.

### Pull Request checklist
- [x] Please confirm you have completed any of the necessary steps below.

- Included test cases to demonstrate any code changes, which may be one or more of the following:
  - [ ] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
  - [x] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
  - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
  - [ ] Other.
- [x] Added appropriate documentation for the change.
- [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
