### PR TITLE
fix(ST06): prevent corruption of CREATE VIEW with explicit columns list

### DIFF
--- a/test/fixtures/rules/std_rule_cases/ST06.yml
+++ b/test/fixtures/rules/std_rule_cases/ST06.yml
@@ -299,3 +299,83 @@ test_fail_cte_used_in_select:
       FROM T
     )
     SELECT * FROM T1 INNER JOIN T2 ON T1.A = T2.A;
+
+test_pass_create_view_with_explicit_columns:
+  pass_str: |
+    CREATE OR REPLACE VIEW FRANCONNECT_REPORTING.GYM_ATTRIBUTES(
+      FRANCHISEENAME,
+      FRANCHISEID,
+      STORESTATUS,
+      GRANDSTOREOPENINGDATE,
+      SAME_GYM,
+      STATE
+    ) AS
+    SELECT
+      f.franchiseename,
+      TRY_TO_DOUBLE(f.franchiseename) AS franchiseid,
+      f.storestatus,
+      f.grandstoreopeningdate,
+      CASE WHEN f.grandstoreopeningdate < dateadd(month, -18, current_date) THEN 'Same Gym' ELSE NULL END as same_gym,
+      f.state
+    FROM FRANCONNECT_REPORTING.franchisee f
+
+test_fail_create_view_without_explicit_columns:
+  fail_str: |
+    CREATE OR REPLACE VIEW FRANCONNECT_REPORTING.GYM_ATTRIBUTES AS
+    SELECT
+      f.franchiseename,
+      TRY_TO_DOUBLE(f.franchiseename) AS franchiseid,
+      f.storestatus,
+      f.grandstoreopeningdate,
+      CASE WHEN f.grandstoreopeningdate < dateadd(month, -18, current_date) THEN 'Same Gym' ELSE NULL END as same_gym,
+      f.state
+    FROM FRANCONNECT_REPORTING.franchisee f
+  line_numbers: [2]
+
+  fix_str: |
+    CREATE OR REPLACE VIEW FRANCONNECT_REPORTING.GYM_ATTRIBUTES AS
+    SELECT
+      f.franchiseename,
+      f.storestatus,
+      f.grandstoreopeningdate,
+      f.state,
+      TRY_TO_DOUBLE(f.franchiseename) AS franchiseid,
+      CASE WHEN f.grandstoreopeningdate < dateadd(month, -18, current_date) THEN 'Same Gym' ELSE NULL END as same_gym
+    FROM FRANCONNECT_REPORTING.franchisee f
+
+test_pass_create_view_with_explicit_columns_tsql:
+  configs:
+    core:
+      dialect: tsql
+  pass_str: |
+    CREATE VIEW dbo.MyView (
+      EmployeeName,
+      EmployeeID,
+      Department
+    ) AS
+    SELECT
+      e.name,
+      TRY_CAST(e.id AS INT) AS employee_id,
+      e.department
+    FROM employees e
+
+test_fail_create_view_without_explicit_columns_tsql:
+  configs:
+    core:
+      dialect: tsql
+  fail_str: |
+    CREATE VIEW dbo.MyView AS
+    SELECT
+      e.name,
+      TRY_CAST(e.id AS INT) AS employee_id,
+      e.department
+    FROM employees e
+  line_numbers: [2]
+
+  fix_str: |
+    CREATE VIEW dbo.MyView AS
+    SELECT
+      e.name,
+      e.department,
+      TRY_CAST(e.id AS INT) AS employee_id
+    FROM employees e


### PR DESCRIPTION
### Brief summary of the change made
Fixes #7217

ST06 rule was reordering SELECT columns in CREATE VIEW statements with explicit column lists, causing view corruption by mismatching the declared columns with the selected columns.

When a CREATE VIEW includes an explicit column list like CREATE VIEW my_view(col1, col2, col3) AS SELECT ..., ST06 would reorder the SELECT columns but not update the column list, causing data to be mapped to wrong column names.

### Example:

-- Before (correct mapping)
CREATE VIEW v(NAME, ID, STATUS) AS
SELECT name, try_to_double(id), status FROM t;

-- After ST06 reordering (CORRUPTED - ID gets STATUS value!)
CREATE VIEW v(NAME, ID, STATUS) AS  
SELECT name, status, try_to_double(id) FROM t;
Solution: Added detection to skip reordering when explicit column lists are present, preserving the column-to-value mapping.

## Are there any other side effects of this change that we should be aware of?
No. The fix only affects CREATE VIEW with explicit column lists. Regular SELECT statements and CREATE VIEW without explicit columns continue to be reordered normally.

#### Pull Request checklist

- [x] Please confirm you have completed any of the necessary steps below.
  - Included test cases to demonstrate any code changes, which may be one or more of the following:
    - [x] `.yml` rule test cases in `test/fixtures/rules/std_rule_cases`.
    - [ ] `.sql`/`.yml` parser test cases in `test/fixtures/dialects` (note YML files can be auto generated with `tox -e generate-fixture-yml`).
    - [ ] Full autofix test cases in `test/fixtures/linter/autofix`.
    - [ ] Other.
  - [ ] Added appropriate documentation for the change.
  - [ ] Created GitHub issues for any relevant followup/future enhancements if appropriate.
